### PR TITLE
fix(sharing): Avoid (dead)locking during orphan deletion

### DIFF
--- a/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
+++ b/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,24 +27,45 @@
  */
 namespace OCA\Files_Sharing;
 
+use OCP\AppFramework\Db\TTransactional;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
-use OCP\Server;
+use PDO;
 use Psr\Log\LoggerInterface;
+use function array_map;
 
 /**
  * Delete all share entries that have no matching entries in the file cache table.
  */
 class DeleteOrphanedSharesJob extends TimedJob {
+
+	use TTransactional;
+
+	private const CHUNK_SIZE = 1000;
+
+	private const INTERVAL = 24 * 60 * 60; // 1 day
+
+	private IDBConnection $db;
+
+	private LoggerInterface $logger;
+
 	/**
 	 * sets the correct interval for this timed job
 	 */
-	public function __construct(ITimeFactory $time) {
+	public function __construct(
+		ITimeFactory $time,
+		IDBConnection $db,
+		LoggerInterface $logger
+	) {
 		parent::__construct($time);
 
-		$this->setInterval(24 * 60 * 60); // 1 day
+		$this->db = $db;
+
+		$this->setInterval(self::INTERVAL); // 1 day
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		$this->logger = $logger;
 	}
 
 	/**
@@ -50,15 +74,45 @@ class DeleteOrphanedSharesJob extends TimedJob {
 	 * @param array $argument unused argument
 	 */
 	public function run($argument) {
-		$connection = Server::get(IDBConnection::class);
-		$logger = Server::get(LoggerInterface::class);
+		$qbSelect = $this->db->getQueryBuilder();
+		$qbSelect->select('id')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'fc', $qbSelect->expr()->eq('s.file_source', 'fc.fileid'))
+			->where($qbSelect->expr()->isNull('fc.fileid'))
+			->setMaxResults(self::CHUNK_SIZE);
+		$deleteQb = $this->db->getQueryBuilder();
+		$deleteQb->delete('share')
+			->where(
+				$deleteQb->expr()->in('id', $deleteQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY)
+			);
 
-		$sql =
-			'DELETE FROM `*PREFIX*share` ' .
-			'WHERE `item_type` in (\'file\', \'folder\') ' .
-			'AND NOT EXISTS (SELECT `fileid` FROM `*PREFIX*filecache` WHERE `file_source` = `fileid`)';
-
-		$deletedEntries = $connection->executeStatement($sql);
-		$logger->debug("$deletedEntries orphaned share(s) deleted", ['app' => 'DeleteOrphanedSharesJob']);
+		/**
+		 * Read a chunk of orphan rows and delete them. Continue as long as the
+		 * chunk is filled and time before the next cron run does not run out.
+		 *
+		 * Note: With isolation level READ COMMITTED, the database will allow
+		 * other transactions to delete rows between our SELECT and DELETE. In
+		 * that (unlikely) case, our DELETE will have fewer affected rows than
+		 * IDs passed for the WHERE IN. If this happens while processing a full
+		 * chunk, the logic below will stop prematurely.
+		 * Note: The queries below are optimized for low database locking. They
+		 * could be combined into one single DELETE with join or sub query, but
+		 * that has shown to (dead)lock often.
+		 */
+		$cutOff = $this->time->getTime() + self::INTERVAL;
+		do {
+			$deleted = $this->atomic(function () use ($qbSelect, $deleteQb) {
+				$result = $qbSelect->executeQuery();
+				$ids = array_map('intval', $result->fetchAll(PDO::FETCH_COLUMN));
+				$result->closeCursor();
+				$deleteQb->setParameter('ids', $ids, IQueryBuilder::PARAM_INT_ARRAY);
+				$deleted = $deleteQb->executeStatement();
+				$this->logger->debug("{deleted} orphaned share(s) deleted", [
+					'app' => 'DeleteOrphanedSharesJob',
+					'deleted' => $deleted,
+				]);
+				return $deleted;
+			}, $this->db);
+		} while ($deleted >= self::CHUNK_SIZE && $this->time->getTime() <= $cutOff);
 	}
 }

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -27,7 +27,6 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\DeleteOrphanedSharesJob;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Share\IShare;
 
 /**
@@ -94,7 +93,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
 
-		$this->job = new DeleteOrphanedSharesJob(\OCP\Server::get(ITimeFactory::class));
+		$this->job = \OCP\Server::get(DeleteOrphanedSharesJob::class);
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/27695

## Summary

Concurrent modifications of shared entries in oc_filecache makes the share orphan background job lock. This is fine. If the row is UPDATED, we don't care. If the row is DELETEd, the next background job will catch it.

This replaces widely locking DELETE with SELECT+DELETE. See code comments.

## How to test

The real world (dead)lock is hard to reproduce in a lab setup. You have to simulate concurrent modifications of filecache.

1. Log into Nextcloud
2. Create two folders f1 and f2
3. Share both folders with another user
4. Delete f2
5. Go to trash bin and delete f2 permanently
6. Open a database shell
    1. Run `SELECT id FROM oc_jobs WHERE class = 'OCA\\Files_Sharing\\DeleteOrphanedSharesJob'`. Note down the job id.
    2. Run `SELECT file_target, file_source FROM oc_share ORDER BY id DESC LIMIT 2;`. These are your f1 and f2 shares. Note down the file_source of f1.
    3. Run `SELECT storage, path_hash FROM oc_filecache WHERE fileid=<file_source>;`. Note down storage and path_hash values.
    4. Run `START TRANSACTION;`
    5. Run ``UPDATE `oc_filecache` SET `mtime` = GREATEST(`mtime`, 1706777193), `etag` = '659cf751000cd' WHERE (`storage` = <storage>) AND (`path_hash` IN (<path_hash>));``
7. Run `php occ background-job:execute <id> --force-execute`

master: job will stall. Run `ROLLBACK;` in the datbase shell to unlock the occ command.
here: job will finish and clean up the oc_share entry of f2 despite the lock on f1's filecache entry. Run `ROLLBACK;` to unlock your dev env for other operations ;-)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
