### PR TITLE
[IAppConfig] format values based on type

### DIFF
--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -261,9 +261,11 @@ interface IAppConfig {
 	 * returns the type of config value
 	 *
 	 * **WARNING:** ignore lazy filtering, all config values are loaded from database
+	 *              unless lazy is set to false
 	 *
 	 * @param string $app id of the app
 	 * @param string $key config key
+	 * @param bool|null $lazy
 	 *
 	 * @return int
 	 * @throws AppConfigUnknownKeyException
@@ -274,7 +276,7 @@ interface IAppConfig {
 	 * @see VALUE_BOOL
 	 * @see VALUE_ARRAY
 	 */
-	public function getValueType(string $app, string $key): int;
+	public function getValueType(string $app, string $key, ?bool $lazy = null): int;
 
 	/**
 	 * Store a config key and its value in database


### PR DESCRIPTION
returns formated values based on type when calling `getAllValues()` and `searchValues()`

note: deprecated method `getValues()` use `getAllValues()` but if the config value is defined as MIXED (default), the value is kept as a string.


original:
```
{
    "key1": "value1",
    "key2": "value0",
    "key6": "1",
    "key7": "{\"test1\":1,\"test2\":2}",
    "test8": "1",
    "key3": "value0",
    "key4": "3",
    "key5": "3.14"
}
```

new:

```
{
    "key1": "value1",
    "key2": "value0",
    "key6": true,
    "key7": {
        "test1": 1,
        "test2": 2
    },
    "test8": true,
    "key3": "value0",
    "key4": 3,
    "key5": 3.14
}
```
