### PR TITLE
Cleanup versions entities in versions:clean command

### DIFF
--- a/apps/files_versions/lib/Command/CleanUp.php
+++ b/apps/files_versions/lib/Command/CleanUp.php
@@ -24,6 +24,7 @@
  */
 namespace OCA\Files_Versions\Command;
 
+use OCA\Files_Versions\Db\VersionsMapper;
 use OCP\Files\IRootFolder;
 use OCP\IUserBackend;
 use OCP\IUserManager;
@@ -37,6 +38,7 @@ class CleanUp extends Command {
 	public function __construct(
 		protected IRootFolder $rootFolder,
 		protected IUserManager $userManager,
+		protected VersionsMapper $versionMapper,
 	) {
 		parent::__construct();
 	}
@@ -118,6 +120,9 @@ class CleanUp extends Command {
 	protected function deleteVersions(string $user, ?string $path = null): void {
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($user);
+
+		$userHomeStorageId = $this->rootFolder->getUserFolder($user)->getStorage()->getCache()->getNumericStorageId();
+		$this->versionMapper->deleteAllVersionsForUser($userHomeStorageId, $path);
 
 		$fullPath = '/' . $user . '/files_versions' . ($path ? '/' . $path : '');
 		if ($this->rootFolder->nodeExists($fullPath)) {

--- a/apps/files_versions/lib/Db/VersionsMapper.php
+++ b/apps/files_versions/lib/Db/VersionsMapper.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Files_Versions\Db;
 
 use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 /**
@@ -82,5 +83,39 @@ class VersionsMapper extends QBMapper {
 		return $qb->delete($this->getTableName())
 			 ->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId)))
 			 ->executeStatement();
+	}
+
+	public function deleteAllVersionsForUser(int $storageId, string $path = null): void {
+		$fileIdsGenerator = $this->getFileIdsGenerator($storageId, $path);
+
+		$versionEntitiesDeleteQuery = $this->db->getQueryBuilder();
+		$versionEntitiesDeleteQuery->delete($this->getTableName())
+			->where($versionEntitiesDeleteQuery->expr()->in('file_id', $versionEntitiesDeleteQuery->createParameter('file_ids')));
+
+		foreach ($fileIdsGenerator as $fileIds) {
+			$versionEntitiesDeleteQuery->setParameter('file_ids', $fileIds, IQueryBuilder::PARAM_INT_ARRAY);
+			$versionEntitiesDeleteQuery->executeStatement();
+		}
+	}
+
+	private function getFileIdsGenerator(int $storageId, ?string $path): \Generator {
+		$offset = 0;
+		do {
+			$filesIdsSelect = $this->db->getQueryBuilder();
+			$filesIdsSelect->select('fileid')
+				->from('filecache')
+				->where($filesIdsSelect->expr()->eq('storage', $filesIdsSelect->createNamedParameter($storageId, IQueryBuilder::PARAM_STR)))
+				->andWhere($filesIdsSelect->expr()->like('path', $filesIdsSelect->createNamedParameter('files' . ($path ? '/' . $this->db->escapeLikeParameter($path) : '') . '/%', IQueryBuilder::PARAM_STR)))
+				->andWhere($filesIdsSelect->expr()->gt('fileid', $filesIdsSelect->createParameter('offset')))
+				->setMaxResults(1000)
+				->orderBy('fileid', 'ASC');
+
+			$filesIdsSelect->setParameter('offset', $offset, IQueryBuilder::PARAM_INT);
+			$result = $filesIdsSelect->executeQuery();
+			$fileIds = $result->fetchAll(\PDO::FETCH_COLUMN);
+			$offset = end($fileIds);
+
+			yield $fileIds;
+		} while (!empty($fileIds));
 	}
 }

--- a/tests/Core/Command/TwoFactorAuth/CleanupTest.php
+++ b/tests/Core/Command/TwoFactorAuth/CleanupTest.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace Core\Command\TwoFactorAuth;
 
 use OC\Core\Command\TwoFactorAuth\Cleanup;
+use OCA\Files_Versions\Db\VersionsMapper;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -40,6 +41,9 @@ class CleanupTest extends TestCase {
 	/** @var IUserManager|MockObject */
 	private $userManager;
 
+	/** @var VersionsMapper|MockObject */
+	private $versionMapper;
+
 	/** @var CommandTester */
 	private $cmd;
 
@@ -48,8 +52,9 @@ class CleanupTest extends TestCase {
 
 		$this->registry = $this->createMock(IRegistry::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->versionMapper = $this->createMock(VersionsMapper::class);
 
-		$cmd = new Cleanup($this->registry, $this->userManager);
+		$cmd = new Cleanup($this->registry, $this->userManager, $this->versionMapper);
 		$this->cmd = new CommandTester($cmd);
 	}
 


### PR DESCRIPTION
Forgoten place where we need to remove versions entities in the database.

Fix https://github.com/nextcloud/server/issues/39046
