### PR TITLE
fix(tests): Make the cypress apps management test more reliable

### DIFF
--- a/cypress/e2e/settings/apps.cy.ts
+++ b/cypress/e2e/settings/apps.cy.ts
@@ -40,7 +40,8 @@ describe('Settings: App management', { testIsolation: true }, () => {
 
 	it('Can enable an installed app', () => {
 		cy.get('#apps-list').should('be.visible')
-			.contains('tr', 'QA testing')
+			// Wait for the app list to load
+			.contains('tr', 'QA testing', { timeout: 10000 })
 			.should('exist')
 			.find('.actions')
 			// I enable the "QA testing" app
@@ -48,6 +49,14 @@ describe('Settings: App management', { testIsolation: true }, () => {
 			.click({ force: true })
 
 		handlePasswordConfirmation(admin.password)
+
+		// Wait until we see the disable button for the app
+		cy.get('#apps-list').should('be.visible')
+			.contains('tr', 'QA testing')
+			.should('exist')
+			.find('.actions')
+			// I see the disable button for the app
+			.contains('button', 'Disable', { timeout: 10000 })
 
 		// Change to enabled apps view
 		cy.get('#app-category-enabled a').click({ force: true })
@@ -58,7 +67,8 @@ describe('Settings: App management', { testIsolation: true }, () => {
 
 	it('Can disable an installed app', () => {
 		cy.get('#apps-list').should('be.visible')
-			.contains('tr', 'Update notification')
+			// Wait for the app list to load
+			.contains('tr', 'Update notification', { timeout: 10000 })
 			.should('exist')
 			.find('.actions')
 			// I disable the "Update notification" app
@@ -66,6 +76,14 @@ describe('Settings: App management', { testIsolation: true }, () => {
 			.click({ force: true })
 
 		handlePasswordConfirmation(admin.password)
+
+		// Wait until we see the disable button for the app
+		cy.get('#apps-list').should('be.visible')
+			.contains('tr', 'Update notification')
+			.should('exist')
+			.find('.actions')
+			// I see the enable button for the app
+			.contains('button', 'Enable', { timeout: 10000 })
 
 		// Change to disabled apps view
 		cy.get('#app-category-disabled a').click({ force: true })


### PR DESCRIPTION
## Summary

I was able to reproduce most failures that I found for the apps.cy.ts test by adding sleeps in the right places:
- The app could not be found in the app list
  - ![Settings App management -- Can disable an installed app (failed)](https://github.com/nextcloud/server/assets/213943/9b6d0795-4077-4159-88ec-ffcf50b90468)

  - Add `sleep(7);` as first line in https://github.com/nextcloud/server/blob/b64ab5fba86f55e59ebb8983a143d640d0c6a7a1/apps/settings/lib/Controller/AppSettingsController.php#L246
- Enabling the app took longer then loading the list of enabled apps
  - Add `sleep(7);` as first line in https://github.com/nextcloud/server/blob/b64ab5fba86f55e59ebb8983a143d640d0c6a7a1/apps/settings/lib/Controller/AppSettingsController.php#L438
- Disabling the app took longer then loading the list of disabled apps
  - Add `sleep(7);` as first line in https://github.com/nextcloud/server/blob/b64ab5fba86f55e59ebb8983a143d640d0c6a7a1/apps/settings/lib/Controller/AppSettingsController.php#L500

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
