### PR TITLE
enh: update desktop client unsupported version (403) error message

### DIFF
--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -15,7 +15,9 @@ use OCA\DAV\Connector\Sabre\CachingTree;
 use OCA\DAV\Connector\Sabre\DavAclPlugin;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\DAV\RootCollection;
+use OCA\Theming\ThemingDefaults;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\ITip\Message;
 
@@ -28,9 +30,8 @@ class InvitationResponseServer {
 	 */
 	public function __construct(bool $public = true) {
 		$baseUri = \OC::$WEBROOT . '/remote.php/dav/';
-		$logger = \OC::$server->get(LoggerInterface::class);
-		/** @var IEventDispatcher $dispatcher */
-		$dispatcher = \OC::$server->query(IEventDispatcher::class);
+		$logger = \OCP\Server::get(LoggerInterface::class);
+		$dispatcher = \OCP\Server::get(IEventDispatcher::class);
 
 		$root = new RootCollection();
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
@@ -42,7 +43,10 @@ class InvitationResponseServer {
 		$this->server->httpRequest->setUrl($baseUri);
 		$this->server->setBaseUri($baseUri);
 
-		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
+		$this->server->addPlugin(new BlockLegacyClientPlugin(
+			\OCP\Server::get(IConfig::class),
+			\OCP\Server::get(ThemingDefaults::class),
+		));
 		$this->server->addPlugin(new AnonymousOptionsPlugin());
 
 		// allow custom principal uri option

--- a/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\DAV\Connector\Sabre;
 
+use OCA\Theming\ThemingDefaults;
 use OCP\IConfig;
 use OCP\IRequest;
 use Sabre\DAV\Server;
@@ -21,10 +22,11 @@ use Sabre\HTTP\RequestInterface;
  */
 class BlockLegacyClientPlugin extends ServerPlugin {
 	protected ?Server $server = null;
-	protected IConfig $config;
 
-	public function __construct(IConfig $config) {
-		$this->config = $config;
+	public function __construct(
+		private IConfig $config,
+		private ThemingDefaults $themingDefaults,
+	) {
 	}
 
 	/**
@@ -51,8 +53,10 @@ class BlockLegacyClientPlugin extends ServerPlugin {
 		preg_match(IRequest::USER_AGENT_CLIENT_DESKTOP, $userAgent, $versionMatches);
 		if (isset($versionMatches[1]) &&
 			version_compare($versionMatches[1], $minimumSupportedDesktopVersion) === -1) {
-			$customClientDesktopLink = $this->config->getSystemValue('customclient_desktop', 'https://nextcloud.com/install/#install-clients');
-			throw new \Sabre\DAV\Exception\Forbidden('This version of the client is unsupported. Upgrade to <a href="'.$customClientDesktopLink.'">version '.$minimumSupportedDesktopVersion.' or later</a>.');
+			$customClientDesktopLink = htmlspecialchars($this->themingDefaults->getSyncClientUrl());
+			$minimumSupportedDesktopVersion = htmlspecialchars($minimumSupportedDesktopVersion);
+
+			throw new \Sabre\DAV\Exception\Forbidden("This version of the client is unsupported. Upgrade to <a href=\"$customClientDesktopLink\">version $minimumSupportedDesktopVersion or later</a>.");
 		}
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php
@@ -51,7 +51,8 @@ class BlockLegacyClientPlugin extends ServerPlugin {
 		preg_match(IRequest::USER_AGENT_CLIENT_DESKTOP, $userAgent, $versionMatches);
 		if (isset($versionMatches[1]) &&
 			version_compare($versionMatches[1], $minimumSupportedDesktopVersion) === -1) {
-			throw new \Sabre\DAV\Exception\Forbidden('Unsupported client version.');
+			$customClientDesktopLink = $this->config->getSystemValue('customclient_desktop', 'https://nextcloud.com/install/#install-clients');
+			throw new \Sabre\DAV\Exception\Forbidden('This version of the client is unsupported. Upgrade to <a href="'.$customClientDesktopLink.'">version '.$minimumSupportedDesktopVersion.' or later</a>.');
 		}
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -11,6 +11,7 @@ use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\DAV\ViewOnlyPlugin;
 use OCA\DAV\Files\ErrorPagePlugin;
+use OCA\Theming\ThemingDefaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IFilenameValidator;
@@ -78,7 +79,10 @@ class ServerFactory {
 
 		// Load plugins
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config, $this->l10n));
-		$server->addPlugin(new \OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin($this->config));
+		$server->addPlugin(new BlockLegacyClientPlugin(
+			\OCP\Server::get(IConfig::class),
+			\OCP\Server::get(ThemingDefaults::class),
+		));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin());
 		$server->addPlugin($authPlugin);
 		// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -50,6 +50,7 @@ use OCA\DAV\Provisioning\Apple\AppleProvisioningPlugin;
 use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
 use OCA\DAV\Upload\ChunkingV2Plugin;
+use OCA\Theming\ThemingDefaults;
 use OCP\AppFramework\Http\Response;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -110,7 +111,10 @@ class Server {
 		$this->server->setBaseUri($this->baseUri);
 
 		$this->server->addPlugin(new ProfilerPlugin($this->request));
-		$this->server->addPlugin(new BlockLegacyClientPlugin(\OC::$server->getConfig()));
+		$this->server->addPlugin(new BlockLegacyClientPlugin(
+			\OCP\Server::get(IConfig::class),
+			\OCP\Server::get(ThemingDefaults::class),
+		));
 		$this->server->addPlugin(new AnonymousOptionsPlugin());
 		$authPlugin = new Plugin();
 		$authPlugin->addBackend(new PublicAuth());

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -45,7 +45,20 @@ class BlockLegacyClientPluginTest extends TestCase {
 	 */
 	public function testBeforeHandlerException(string $userAgent): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
-		$this->expectExceptionMessage('Unsupported client version.');
+
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('customclient_desktop', 'https://nextcloud.com/install/#install-clients')
+			->willReturn('https://nextcloud.com/install/#install-clients');
+
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('minimum.supported.desktop.version', '2.3.0')
+			->willReturn('1.7.0');
+
+		$this->expectExceptionMessage('This version of the client is unsupported. Upgrade to <a href="https://nextcloud.com/install/#install-clients">version 1.7.0 or later</a>.');
 
 		/** @var RequestInterface|MockObject $request */
 		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
@@ -55,11 +68,6 @@ class BlockLegacyClientPluginTest extends TestCase {
 			->with('User-Agent')
 			->willReturn($userAgent);
 
-		$this->config
-			->expects($this->once())
-			->method('getSystemValue')
-			->with('minimum.supported.desktop.version', '2.3.0')
-			->willReturn('1.7.0');
 
 		$this->blockLegacyClientVersionPlugin->beforeHandler($request);
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
+use OCA\Theming\ThemingDefaults;
 use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\HTTP\RequestInterface;
@@ -21,19 +22,23 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
 class BlockLegacyClientPluginTest extends TestCase {
-	/** @var IConfig|MockObject */
-	private $config;
-	/** @var BlockLegacyClientPlugin */
-	private $blockLegacyClientVersionPlugin;
+
+	private IConfig&MockObject $config;
+	private ThemingDefaults&MockObject $themingDefaults;
+	private BlockLegacyClientPlugin $blockLegacyClientVersionPlugin;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->config = $this->createMock(IConfig::class);
-		$this->blockLegacyClientVersionPlugin = new BlockLegacyClientPlugin($this->config);
+		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
+		$this->blockLegacyClientVersionPlugin = new BlockLegacyClientPlugin(
+			$this->config,
+			$this->themingDefaults,
+		);
 	}
 
-	public function oldDesktopClientProvider(): array {
+	public static function oldDesktopClientProvider(): array {
 		return [
 			['Mozilla/5.0 (Windows) mirall/1.5.0'],
 			['Mozilla/5.0 (Bogus Text) mirall/1.6.9'],
@@ -46,10 +51,9 @@ class BlockLegacyClientPluginTest extends TestCase {
 	public function testBeforeHandlerException(string $userAgent): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
-		$this->config
+		$this->themingDefaults
 			->expects($this->once())
-			->method('getSystemValue')
-			->with('customclient_desktop', 'https://nextcloud.com/install/#install-clients')
+			->method('getSyncClientUrl')
 			->willReturn('https://nextcloud.com/install/#install-clients');
 
 		$this->config
@@ -59,6 +63,38 @@ class BlockLegacyClientPluginTest extends TestCase {
 			->willReturn('1.7.0');
 
 		$this->expectExceptionMessage('This version of the client is unsupported. Upgrade to <a href="https://nextcloud.com/install/#install-clients">version 1.7.0 or later</a>.');
+
+		/** @var RequestInterface|MockObject $request */
+		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
+		$request
+			->expects($this->once())
+			->method('getHeader')
+			->with('User-Agent')
+			->willReturn($userAgent);
+
+
+		$this->blockLegacyClientVersionPlugin->beforeHandler($request);
+	}
+
+	/**
+	 * Ensure that there is no room for XSS attack through configured URL / version
+	 * @dataProvider oldDesktopClientProvider
+	 */
+	public function testBeforeHandlerExceptionPreventXSSAttack(string $userAgent): void {
+		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
+
+		$this->themingDefaults
+			->expects($this->once())
+			->method('getSyncClientUrl')
+			->willReturn('https://example.com"><script>alter("hacked");</script>');
+
+		$this->config
+			->expects($this->once())
+			->method('getSystemValue')
+			->with('minimum.supported.desktop.version', '2.3.0')
+			->willReturn('1.7.0 <script>alert("unsafe")</script>');
+
+		$this->expectExceptionMessage('This version of the client is unsupported. Upgrade to <a href="https://example.com&quot;&gt;&lt;script&gt;alter(&quot;hacked&quot;);&lt;/script&gt;">version 1.7.0 &lt;script&gt;alert(&quot;unsafe&quot;)&lt;/script&gt; or later</a>.');
 
 		/** @var RequestInterface|MockObject $request */
 		$request = $this->createMock('\Sabre\HTTP\RequestInterface');


### PR DESCRIPTION
The user should get a more friendly warning when their desktop client version is not supported anymore by the server. See #nextcloud/desktop/issues/6273

### Before:

![before](https://github.com/nextcloud/server/assets/241266/103358ae-2f3d-404e-a9ea-4dcd552834c6)

###  After:

![after](https://github.com/nextcloud/server/assets/241266/4c89b379-de61-4791-bb11-36076183d395)

### Systray message
![systray](https://github.com/nextcloud/server/assets/241266/24a0fb27-c4b9-4dae-8a14-e9e35a6a35f0)

* Resolves: https://github.com/nextcloud/desktop/issues/6273

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
