### PR TITLE
fix(db): Give dirty read exception a message

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -282,7 +282,7 @@ class Connection extends PrimaryReadReplicaConnection {
 				[
 					'tables' => $this->tableDirtyWrites,
 					'reads' => $tables,
-					'exception' => new \Exception(),
+					'exception' => new \Exception('dirty table reads: ' . $sql),
 				],
 			);
 			// To prevent a dirty read on a replica that is slightly out of sync, we


### PR DESCRIPTION
## Summary

Avoids logging an exception that doesn't say anything. Sentry creates blank reports for them

![Bildschirmfoto vom 2024-02-02 12-57-30](https://github.com/nextcloud/server/assets/1374172/bbfba787-ed74-43c6-a4a4-8ebd719a0132)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
