### PR TITLE
fix kerberos test successfull authentication detection

### DIFF
--- a/apps/files_external/tests/sso-setup/test-sso-smb.sh
+++ b/apps/files_external/tests/sso-setup/test-sso-smb.sh
@@ -5,8 +5,9 @@ DC_IP="$1"
 SCRIPT_DIR="${0%/*}"
 
 echo -n "Checking that we can authenticate using kerberos: "
-LOGIN_CONTENT=$("$SCRIPT_DIR/client-cmd.sh" $DC_IP curl -i -s --negotiate -u testuser@DOMAIN.TEST: --delegation always http://httpd.domain.test/index.php/apps/user_saml/saml/login?originalUrl=success)
-if [[ "$LOGIN_CONTENT" =~ "Location: success" ]]; then
+LOGIN_CONTENT=$("$SCRIPT_DIR/client-cmd.sh" $DC_IP curl -i -s --negotiate -u testuser@DOMAIN.TEST: --delegation always http://httpd.domain.test/index.php/apps/user_saml/saml/login?originalUrl=http://localhost/success)
+
+if [[ "$LOGIN_CONTENT" =~ "Location: http://localhost/success" ]]; then
   echo "✔️"
 else
   echo "❌"


### PR DESCRIPTION
user_saml become more strict with the login redirect url that was breaking the login detection