### PR TITLE
fix(settings): `posix_getpwuid` can return `false` which should not be accessed like an array

### DIFF
--- a/apps/settings/lib/Settings/Admin/Server.php
+++ b/apps/settings/lib/Settings/Admin/Server.php
@@ -56,13 +56,17 @@ class Server implements IDelegatedSettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm() {
+		$ownerConfigFile = fileowner(\OC::$configDir . 'config.php');
+		$cliBasedCronPossible = function_exists('posix_getpwuid') && $ownerConfigFile !== false;
+		$cliBasedCronUser = $cliBasedCronPossible ? (posix_getpwuid($ownerConfigFile)['name'] ?? '') : '';
+
 		// Background jobs
 		$this->initialStateService->provideInitialState('backgroundJobsMode', $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax'));
 		$this->initialStateService->provideInitialState('lastCron', $this->appConfig->getValueInt('core', 'lastcron', 0));
 		$this->initialStateService->provideInitialState('cronMaxAge', $this->cronMaxAge());
 		$this->initialStateService->provideInitialState('cronErrors', $this->config->getAppValue('core', 'cronErrors'));
-		$this->initialStateService->provideInitialState('cliBasedCronPossible', function_exists('posix_getpwuid'));
-		$this->initialStateService->provideInitialState('cliBasedCronUser', function_exists('posix_getpwuid') ? posix_getpwuid(fileowner(\OC::$configDir . 'config.php'))['name'] : '');
+		$this->initialStateService->provideInitialState('cliBasedCronPossible', $cliBasedCronPossible);
+		$this->initialStateService->provideInitialState('cliBasedCronUser', $cliBasedCronUser);
 		$this->initialStateService->provideInitialState('backgroundJobsDocUrl', $this->urlGenerator->linkToDocs('admin-background-jobs'));
 
 		// Profile page


### PR DESCRIPTION
* Part of https://github.com/nextcloud/notifications/issues/2267

## Summary
When `fileowner` is *false* or the user can not read `/etc/passwd` (SELinux etc) then `posix_getpwuid` will fail and return `false` which of cause should not be accessed like `false['user']`.

This is one of the errors reported in the log of nextcloud/notifications#2267 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
