### PR TITLE
SMB: allow to list root directory when using case-insensitive option

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -683,7 +683,8 @@ class SMB extends Common implements INotifyStorage {
 
 	public function file_exists($path) {
 		try {
-			if ($this->caseSensitive === false) {
+			// Case sensitive filesystem doesn't matter for root directory
+			if ($this->caseSensitive === false && $path !== '') {
 				$filename = basename($path);
 				$siblings = $this->getDirectoryContent(dirname($this->buildPath($path)));
 				foreach ($siblings as $sibling) {


### PR DESCRIPTION
## Summary
Avoid `pending` status on root SMB root directory with case-insensitive support enabled.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
