### PR TITLE
fix(CI): Only run integration tests if needed

### DIFF
--- a/.github/workflows/integration-s3-primary.yml
+++ b/.github/workflows/integration-s3-primary.yml
@@ -1,27 +1,41 @@
 name: S3 primary storage integration tests
 on:
   pull_request:
-    paths:
-      - '.github/workflows/**'
-      - '3rdparty/**'
-      - 'build/integration/**'
-      - '**/*.php'
-      - '**/lib/**'
-      - '**/tests/**'
-      - '**/vendor-bin/**'
-      - '.php-cs-fixer.dist.php'
-      - 'composer.json'
-      - 'composer.lock'
 
 concurrency:
   group: integration-s3-primary-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+
+    outputs:
+      src: ${{ steps.changes.outputs.src}}
+
+    steps:
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - '3rdparty/**'
+              - '**/*.php'
+              - '**/lib/**'
+              - '**/tests/**'
+              - '**/vendor-bin/**'
+              - 'build/integration/**'
+              - '.php-cs-fixer.dist.php'
+              - 'composer.json'
+              - 'composer.lock'
+
   integration-s3-primary:
     runs-on: ubuntu-latest
+    needs: changes
 
-    if: ${{ github.repository_owner != 'nextcloud-gmbh' }}
+    if: needs.changes.outputs.src != 'false' && github.repository_owner != 'nextcloud-gmbh'
 
     strategy:
       # do not stop on another job's failure
@@ -91,11 +105,13 @@ jobs:
 
 
   s3-primary-integration-summary:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest-low
-    needs: [integration-s3-primary]
+    needs: [changes, integration-s3-primary]
 
     if: always()
 
     steps:
       - name: Summary status
-        run: if ${{ needs.integration-s3-primary.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.integration-s3-primary.result != 'success' }}; then exit 1; fi

--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -20,8 +20,7 @@ jobs:
     runs-on: ubuntu-latest-low
 
     outputs:
-      # FIXME src: ${{ steps.changes.outputs.src}}
-      src: 'true'
+      src: ${{ steps.changes.outputs.src}}
 
     steps:
       - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0


### PR DESCRIPTION
## Summary

Use the proper source file filter for integration tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
