### PR TITLE
fix(tests): Fix flaky cypress test

### DIFF
--- a/cypress/e2e/theming/navigation-bar-settings.cy.ts
+++ b/cypress/e2e/theming/navigation-bar-settings.cy.ts
@@ -201,7 +201,6 @@ describe('User theming set app order with default app', () => {
 
 	it('Change the order of the other apps', () => {
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').click()
-		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').click()
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').should('not.be.visible')
 
 		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {


### PR DESCRIPTION
This is a "Ctrl+D" instead of "Ctrl+S" fail from b2d999fd6835e5c59b6086c658330ce7360a780f
