### PR TITLE
chore: Add missing ArrayAccess template parameters

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -63,6 +63,7 @@ use Symfony\Component\HttpFoundation\IpUtils;
  * @property string method
  * @property mixed[] parameters
  * @property mixed[] server
+ * @template-implements \ArrayAccess<string,mixed>
  */
 class Request implements \ArrayAccess, \Countable, IRequest {
 	public const USER_AGENT_IE = '/(MSIE)|(Trident)/';

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -40,6 +40,9 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Mount\IMountPoint;
 use OCP\IUser;
 
+/**
+ * @template-implements \ArrayAccess<string,mixed>
+ */
 class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	private array|ICacheEntry $data;
 	/**

--- a/lib/private/Memcache/Cache.php
+++ b/lib/private/Memcache/Cache.php
@@ -24,6 +24,9 @@
  */
 namespace OC\Memcache;
 
+/**
+ * @template-implements \ArrayAccess<string,mixed>
+ */
 abstract class Cache implements \ArrayAccess, \OCP\ICache {
 	/**
 	 * @var string $prefix

--- a/lib/private/Memcache/ProfilerWrapperCache.php
+++ b/lib/private/Memcache/ProfilerWrapperCache.php
@@ -32,6 +32,7 @@ use OCP\IMemcacheTTL;
 
 /**
  * Cache wrapper that logs profiling information
+ * @template-implements \ArrayAccess<string,mixed>
  */
 class ProfilerWrapperCache extends AbstractDataCollector implements IMemcacheTTL, \ArrayAccess {
 	/** @var Redis  $wrappedCache*/

--- a/lib/private/Session/CryptoSessionData.php
+++ b/lib/private/Session/CryptoSessionData.php
@@ -39,6 +39,7 @@ use function OCP\Log\logger;
  * Class CryptoSessionData
  *
  * @package OC\Session
+ * @template-implements \ArrayAccess<string,mixed>
  */
 class CryptoSessionData implements \ArrayAccess, ISession {
 	/** @var ISession */

--- a/lib/private/Session/Session.php
+++ b/lib/private/Session/Session.php
@@ -29,6 +29,9 @@ namespace OC\Session;
 
 use OCP\ISession;
 
+/**
+ * @template-implements \ArrayAccess<string,mixed>
+ */
 abstract class Session implements \ArrayAccess, ISession {
 	/**
 	 * @var bool

--- a/lib/public/Cache/CappedMemoryCache.php
+++ b/lib/public/Cache/CappedMemoryCache.php
@@ -30,6 +30,7 @@ use OCP\ICache;
  *
  * @since 25.0.0
  * @template T
+ * @template-implements \ArrayAccess<string,T>
  */
 class CappedMemoryCache implements ICache, \ArrayAccess {
 	private int $capacity;

--- a/lib/public/Files/Cache/ICacheEntry.php
+++ b/lib/public/Files/Cache/ICacheEntry.php
@@ -28,6 +28,7 @@ use ArrayAccess;
  * meta data for a file or folder
  *
  * @since 9.0.0
+ * @template-extends ArrayAccess<string,mixed>
  *
  * This interface extends \ArrayAccess since v21.0.0, previous versions only
  * implemented it in the private implementation. Hence php would allow using the


### PR DESCRIPTION
## Summary

Add missing parameters for `ArrayAccess` template to have a smaller psalm baseline.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
