### PR TITLE
fix: added last two places for aria-labels on setting icons

### DIFF
--- a/apps/settings/templates/settings/admin/additional-mail.php
+++ b/apps/settings/templates/settings/admin/additional-mail.php
@@ -53,9 +53,11 @@ $mail_sendmailmode = [
 <div class="section" id="mail_general_settings">
 	<form id="mail_general_settings_form" class="mail_settings">
 		<h2><?php p($l->t('Email server'));?></h2>
-		<a target="_blank" rel="noreferrer noopener" class="icon-info"
-					title="<?php p($l->t('Open documentation'));?>"
-					href="<?php p(link_to_docs('admin-email')); ?>"></a>
+		<a 	target="_blank"
+			rel="noreferrer noopener" class="icon-info"
+			title="<?php p($l->t('Open documentation'));?>"
+			href="<?php p(link_to_docs('admin-email')); ?>"
+			aria-label="<?php p($l->t('Open documentation'));?>"></a>
 		<p class="settings-hint">
 			  <?php p($l->t('It is important to set up this server to be able to send emails, like for password reset and notifications.')); ?>
 		</p>

--- a/apps/settings/templates/settings/admin/overview.php
+++ b/apps/settings/templates/settings/admin/overview.php
@@ -30,7 +30,12 @@
 <div id="security-warning" class="section">
 	<div class="security-warning__heading">
 		<h2><?php p($l->t('Security & setup warnings'));?></h2>
-		<a target="_blank" rel="noreferrer" class="icon-info" title="<?php p($l->t('Open documentation'));?>" href="<?php p(link_to_docs('admin-warnings')); ?>"></a>
+		<a 	target="_blank"
+			rel="noreferrer"
+			class="icon-info"
+			title="<?php p($l->t('Open documentation'));?>"
+			href="<?php p(link_to_docs('admin-warnings')); ?>"
+			aria-label="<?php p($l->t('Open documentation')); ?>"></a>
 	</div>
 	<p class="settings-hint"><?php p($l->t('It\'s important for the security and performance of your instance that everything is configured correctly. To help you with that we are doing some automatic checks. Please see the linked documentation for more information.'));?></p>
 


### PR DESCRIPTION
* For: #42855

## Summary
After review, there was two places within the list mentioned in the original issue that still need to have their aria-label added. These places are places that still need to be translated to Vue, but for now, they will have their aria-label added here!

setttings/admin | settings/admin/overview
---|---
![image](https://github.com/nextcloud/server/assets/110193237/27b3e6ca-b7c6-4e36-a8fd-1cc490aca87f) | ![image](https://github.com/nextcloud/server/assets/110193237/1bb71afc-4d2b-4091-9919-7160679ec5c1)


## TODO

- [x] Add area label to these sections...
   - index.php/settings/admin
   - index.php/settings/admin/overview

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
