### PR TITLE
[Bug]: fix titles of pages (dashboard, apps-settings, users-settings) #43327

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardController.php
+++ b/apps/dashboard/lib/Controller/DashboardController.php
@@ -123,6 +123,7 @@ class DashboardController extends Controller {
 		$response = new TemplateResponse('dashboard', 'index', [
 			'id-app-content' => '#app-dashboard',
 			'id-app-navigation' => null,
+			'pageTitle' => $this->l10n->t('Dashboard'),
 		]);
 
 		// For the weather widget we should allow the geolocation

--- a/apps/dashboard/lib/Controller/DashboardController.php
+++ b/apps/dashboard/lib/Controller/DashboardController.php
@@ -123,7 +123,6 @@ class DashboardController extends Controller {
 		$response = new TemplateResponse('dashboard', 'index', [
 			'id-app-content' => '#app-dashboard',
 			'id-app-navigation' => null,
-			'pageTitle' => $this->l10n->t('Dashboard'),
 		]);
 
 		// For the weather widget we should allow the geolocation

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -139,7 +139,7 @@ class AppSettingsController extends Controller {
 		$params['bundles'] = $this->getBundles();
 		$this->navigationManager->setActiveEntry('core_apps');
 
-		$templateResponse = new TemplateResponse('settings', 'settings-vue', ['serverData' => $params, 'pageTitle' => $this->l10n->t('Apps')]);
+		$templateResponse = new TemplateResponse('settings', 'settings-vue', ['serverData' => $params, 'pageTitle' => $this->l10n->t('Settings')]);
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedImageDomain('https://usercontent.apps.nextcloud.com');
 		$templateResponse->setContentSecurityPolicy($policy);

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -280,7 +280,7 @@ class UsersController extends Controller {
 		$serverData['newUserRequireEmail'] = $this->config->getAppValue('core', 'newUser.requireEmail', 'no') === 'yes';
 		$serverData['newUserSendEmail'] = $this->config->getAppValue('core', 'newUser.sendEmail', 'yes') === 'yes';
 
-		return new TemplateResponse('settings', 'settings-vue', ['serverData' => $serverData, 'pageTitle' => $this->l10n->t('Users')]);
+		return new TemplateResponse('settings', 'settings-vue', ['serverData' => $serverData, 'pageTitle' => $this->l10n->t('Settings')]);
 	}
 
 	/**

--- a/apps/settings/tests/Controller/AppSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AppSettingsControllerTest.php
@@ -210,7 +210,7 @@ class AppSettingsControllerTest extends TestCase {
 					'bundles' => [],
 					'developerDocumentation' => ''
 				],
-				'pageTitle' => 'Apps'
+				'pageTitle' => 'Settings'
 			],
 			'user');
 		$expected->setContentSecurityPolicy($policy);
@@ -245,7 +245,7 @@ class AppSettingsControllerTest extends TestCase {
 					'bundles' => [],
 					'developerDocumentation' => ''
 				],
-				'pageTitle' => 'Apps'
+				'pageTitle' => 'Settings'
 			],
 			'user');
 		$expected->setContentSecurityPolicy($policy);

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -9,8 +9,8 @@
 		<title>
 			<?php
 				p(!empty($_['pageTitle']) ? $_['pageTitle'] . ' – ' : '');
-p($theme->getTitle());
-?>
+				p($theme->getTitle());
+			?>
 		</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 		<?php if ($theme->getiTunesAppId() !== '') { ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -18,8 +18,8 @@ $getUserAvatar = static function (int $size) use ($_): string {
 		<meta charset="utf-8">
 		<title>
 			<?php
-				p(!empty($_['pageTitle'])?$_['pageTitle'].' - ':'');
-				p(!empty($_['application'])?$_['application'].' - ':'');
+				p(!empty($_['pageTitle']) && $_['pageTitle'] !== $_['application'] ? $_['pageTitle'].' - ' : '');
+				p(!empty($_['application']) ? $_['application'].' - ' : '');
 				p($theme->getTitle());
 			?>
 		</title>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -19,9 +19,9 @@ $getUserAvatar = static function (int $size) use ($_): string {
 		<title>
 			<?php
 				p(!empty($_['pageTitle'])?$_['pageTitle'].' - ':'');
-p(!empty($_['application'])?$_['application'].' - ':'');
-p($theme->getTitle());
-?>
+				p(!empty($_['application'])?$_['application'].' - ':'');
+				p($theme->getTitle());
+			?>
 		</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 


### PR DESCRIPTION
* Resolves: #43327

## Summary

1. Remove pageTitle from Dashboard (remove duplication)
2. Changed on Settings/App from (Apps - Apps - Nextcloud) to (Settings - Apps - Nextcloud)
3. Changed on Users from (Users - Users - Nextcloud) to (Settings - Users - Nextcloud)