### PR TITLE
make storage directory test be a bit less strict about mtimes

### DIFF
--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -94,12 +94,13 @@ abstract class Storage extends \Test\TestCase {
 		$dirEntry = $content[0];
 		unset($dirEntry['scan_permissions']);
 		unset($dirEntry['etag']);
+		$this->assertLessThanOrEqual(1, abs($dirEntry['mtime'] - $this->instance->filemtime($directory)));
+		unset($dirEntry['mtime']);
+		unset($dirEntry['storage_mtime']);
 		$this->assertEquals([
 			'name' => $directory,
 			'mimetype' => $this->instance->getMimeType($directory),
-			'mtime' => $this->instance->filemtime($directory),
 			'size' => -1,
-			'storage_mtime' => $this->instance->filemtime($directory),
 			'permissions' => $this->instance->getPermissions($directory),
 		], $dirEntry);
 


### PR DESCRIPTION
sometimes the clock ticks over during the test

See for example https://github.com/nextcloud/server/actions/runs/7802691175/job/21281023435

Should hopefully reduce false negatives in CI