### PR TITLE
perf(dashboard): Stop loading the viewer on the dashboard

### DIFF
--- a/apps/dashboard/lib/Controller/DashboardController.php
+++ b/apps/dashboard/lib/Controller/DashboardController.php
@@ -30,8 +30,6 @@ declare(strict_types=1);
  */
 namespace OCA\Dashboard\Controller;
 
-use OCA\Files\Event\LoadSidebar;
-use OCA\Viewer\Event\LoadViewer;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
@@ -90,11 +88,6 @@ class DashboardController extends Controller {
 	public function index(): TemplateResponse {
 		\OCP\Util::addStyle('dashboard', 'dashboard');
 		\OCP\Util::addScript('dashboard', 'main', 'theming');
-
-		$this->eventDispatcher->dispatchTyped(new LoadSidebar());
-		if (class_exists(LoadViewer::class)) {
-			$this->eventDispatcher->dispatchTyped(new LoadViewer());
-		}
 
 		$this->eventDispatcher->dispatchTyped(new RegisterWidgetEvent($this->dashboardManager));
 


### PR DESCRIPTION
## Summary

Viewer is ~4MB of JS assets for loading, this is not needed on the dashboard and the sidebar is also not used on the dashboard - there is no sidebar at all.

before | after
---|---
![Screenshot_20240206_220934](https://github.com/nextcloud/server/assets/1855448/9f5329f8-650e-475a-bb81-6fdcf5537b95)|![Screenshot_20240206_221022](https://github.com/nextcloud/server/assets/1855448/d0f653cc-85b6-4887-b0b1-3d873c3f7afb)
![Screenshot_20240206_221121](https://github.com/nextcloud/server/assets/1855448/d25a3260-b6a7-48ca-a603-5f57f5b3c997)|![Screenshot_20240206_221059](https://github.com/nextcloud/server/assets/1855448/1f5779a7-69cd-45ae-8d2c-934f24b865ad)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
