### PR TITLE
only get the path for the users cached mount info when we use it

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1360,6 +1360,7 @@ return array(
     'OC\\Files\\Cache\\Wrapper\\JailPropagator' => $baseDir . '/lib/private/Files/Cache/Wrapper/JailPropagator.php',
     'OC\\Files\\Config\\CachedMountFileInfo' => $baseDir . '/lib/private/Files/Config/CachedMountFileInfo.php',
     'OC\\Files\\Config\\CachedMountInfo' => $baseDir . '/lib/private/Files/Config/CachedMountInfo.php',
+    'OC\\Files\\Config\\LazyPathCachedMountInfo' => $baseDir . '/lib/private/Files/Config/LazyPathCachedMountInfo.php',
     'OC\\Files\\Config\\LazyStorageMountInfo' => $baseDir . '/lib/private/Files/Config/LazyStorageMountInfo.php',
     'OC\\Files\\Config\\MountProviderCollection' => $baseDir . '/lib/private/Files/Config/MountProviderCollection.php',
     'OC\\Files\\Config\\UserMountCache' => $baseDir . '/lib/private/Files/Config/UserMountCache.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1393,6 +1393,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Files\\Cache\\Wrapper\\JailPropagator' => __DIR__ . '/../../..' . '/lib/private/Files/Cache/Wrapper/JailPropagator.php',
         'OC\\Files\\Config\\CachedMountFileInfo' => __DIR__ . '/../../..' . '/lib/private/Files/Config/CachedMountFileInfo.php',
         'OC\\Files\\Config\\CachedMountInfo' => __DIR__ . '/../../..' . '/lib/private/Files/Config/CachedMountInfo.php',
+        'OC\\Files\\Config\\LazyPathCachedMountInfo' => __DIR__ . '/../../..' . '/lib/private/Files/Config/LazyPathCachedMountInfo.php',
         'OC\\Files\\Config\\LazyStorageMountInfo' => __DIR__ . '/../../..' . '/lib/private/Files/Config/LazyStorageMountInfo.php',
         'OC\\Files\\Config\\MountProviderCollection' => __DIR__ . '/../../..' . '/lib/private/Files/Config/MountProviderCollection.php',
         'OC\\Files\\Config\\UserMountCache' => __DIR__ . '/../../..' . '/lib/private/Files/Config/UserMountCache.php',

--- a/lib/private/Files/Config/LazyPathCachedMountInfo.php
+++ b/lib/private/Files/Config/LazyPathCachedMountInfo.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\Files\Config;
+
+use OCP\IUser;
+
+class LazyPathCachedMountInfo extends CachedMountInfo {
+	// we don't allow \ in paths so it makes a great placeholder
+	private const PATH_PLACEHOLDER = '\\PLACEHOLDER\\';
+
+	/** @var callable(CachedMountInfo): string */
+	protected $rootInternalPathCallback;
+
+	/**
+	 * @param IUser $user
+	 * @param int $storageId
+	 * @param int $rootId
+	 * @param string $mountPoint
+	 * @param string $mountProvider
+	 * @param int|null $mountId
+	 * @param callable(CachedMountInfo): string $rootInternalPathCallback
+	 * @throws \Exception
+	 */
+	public function __construct(
+		IUser $user,
+		int $storageId,
+		int $rootId,
+		string $mountPoint,
+		string $mountProvider,
+		int $mountId = null,
+		callable $rootInternalPathCallback,
+	) {
+		parent::__construct($user, $storageId, $rootId, $mountPoint, $mountProvider, $mountId, self::PATH_PLACEHOLDER);
+		$this->rootInternalPathCallback = $rootInternalPathCallback;
+	}
+
+	public function getRootInternalPath(): string {
+		if ($this->rootInternalPath === self::PATH_PLACEHOLDER) {
+			$this->rootInternalPath = ($this->rootInternalPathCallback)($this);
+		}
+		return $this->rootInternalPath;
+	}
+}

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -84,8 +84,8 @@ class UserMountCacheTest extends TestCase {
 		}
 	}
 
-	private function getStorage($storageId) {
-		$rootId = $this->createCacheEntry('', $storageId);
+	private function getStorage($storageId, $rootInternalPath = '') {
+		$rootId = $this->createCacheEntry($rootInternalPath, $storageId);
 
 		$storageCache = $this->getMockBuilder('\OC\Files\Cache\Storage')
 			->disableOriginalConstructor()
@@ -237,7 +237,7 @@ class UserMountCacheTest extends TestCase {
 		$user3 = $this->userManager->get('u3');
 
 		[$storage1, $id1] = $this->getStorage(1);
-		[$storage2, $id2] = $this->getStorage(2);
+		[$storage2, $id2] = $this->getStorage(2, 'foo/bar');
 		$mount1 = new MountPoint($storage1, '/foo/');
 		$mount2 = new MountPoint($storage2, '/bar/');
 
@@ -256,11 +256,13 @@ class UserMountCacheTest extends TestCase {
 		$this->assertEquals($user1, $cachedMounts[$this->keyForMount($mount1)]->getUser());
 		$this->assertEquals($id1, $cachedMounts[$this->keyForMount($mount1)]->getRootId());
 		$this->assertEquals(1, $cachedMounts[$this->keyForMount($mount1)]->getStorageId());
+		$this->assertEquals('', $cachedMounts[$this->keyForMount($mount1)]->getRootInternalPath());
 
 		$this->assertEquals('/bar/', $cachedMounts[$this->keyForMount($mount2)]->getMountPoint());
 		$this->assertEquals($user1, $cachedMounts[$this->keyForMount($mount2)]->getUser());
 		$this->assertEquals($id2, $cachedMounts[$this->keyForMount($mount2)]->getRootId());
 		$this->assertEquals(2, $cachedMounts[$this->keyForMount($mount2)]->getStorageId());
+		$this->assertEquals('foo/bar', $cachedMounts[$this->keyForMount($mount2)]->getRootInternalPath());
 
 		$cachedMounts = $this->cache->getMountsForUser($user3);
 		$this->assertEmpty($cachedMounts);


### PR DESCRIPTION
most of the time we shouldn't need it so we can save joining on the filecache.

Note that for the other "getMountsFor..." calls the path is used more often but those calls are less often done in the first place.
