### PR TITLE
feat(share): save date and time for expiration

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -240,6 +240,7 @@ class ShareAPIController extends OCSController {
 
 		$expiration = $share->getExpirationDate();
 		if ($expiration !== null) {
+			$expiration->setTimezone($this->dateTimeZone->getTimeZone());
 			$result['expiration'] = $expiration->format('Y-m-d 00:00:00');
 		}
 
@@ -1695,12 +1696,14 @@ class ShareAPIController extends OCSController {
 	private function parseDate(string $expireDate): \DateTime {
 		try {
 			$date = new \DateTime(trim($expireDate, "\""), $this->dateTimeZone->getTimeZone());
+			// Make sure it expires at midnight in owner timezone
+			$date->setTime(0, 0, 0);
 		} catch (\Exception $e) {
 			throw new \Exception('Invalid date. Format must be YYYY-MM-DD');
 		}
 
+		// Use server timezone to store the date
 		$date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
-		$date->setTime(0, 0, 0);
 
 		return $date;
 	}

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -124,6 +124,7 @@ class ApiTest extends TestCase {
 		$userStatusManager = $this->createMock(IUserStatusManager::class);
 		$previewManager = $this->createMock(IPreview::class);
 		$dateTimeZone = $this->createMock(IDateTimeZone::class);
+		$dateTimeZone->method('getTimeZone')->willReturn(new \DateTimeZone(date_default_timezone_get()));
 
 		return new ShareAPIController(
 			self::APP_NAME,
@@ -1060,10 +1061,9 @@ class ApiTest extends TestCase {
 		$config->setAppValue('core', 'shareapi_enforce_expire_date', 'yes');
 
 		$dateWithinRange = new \DateTime();
-		$dateWithinRange->setTime(0, 0, 0);
-		$dateWithinRange->add(new \DateInterval('P5D'));
+		$dateWithinRange->add(new \DateInterval('P6D'));
+
 		$dateOutOfRange = new \DateTime();
-		$dateOutOfRange->setTime(0, 0, 0);
 		$dateOutOfRange->add(new \DateInterval('P8D'));
 
 		// update expire date to a valid value
@@ -1074,6 +1074,8 @@ class ApiTest extends TestCase {
 		$share1 = $this->shareManager->getShareById($share1->getFullId());
 
 		// date should be changed
+		$dateWithinRange->setTime(0, 0, 0);
+		$dateWithinRange->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 		$this->assertEquals($dateWithinRange, $share1->getExpirationDate());
 
 		// update expire date to a value out of range
@@ -1287,12 +1289,14 @@ class ApiTest extends TestCase {
 
 	public function datesProvider() {
 		$date = new \DateTime();
+		$date->setTime(0, 0);
 		$date->add(new \DateInterval('P5D'));
+		$date->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 		return [
-			[$date->format('Y-m-d'), true],
+			[$date->format('Y-m-d H:i:s'), true],
 			['abc', false],
-			[$date->format('Y-m-d') . 'xyz', false],
+			[$date->format('Y-m-d H:i:s') . 'xyz', false],
 		];
 	}
 
@@ -1318,7 +1322,7 @@ class ApiTest extends TestCase {
 
 		$data = $result->getData();
 		$this->assertTrue(is_string($data['token']));
-		$this->assertEquals($date, substr($data['expiration'], 0, 10));
+		$this->assertEquals(substr($date, 0, 10), substr($data['expiration'], 0, 10));
 
 		// check for correct link
 		$url = \OC::$server->getURLGenerator()->getAbsoluteURL('/index.php/s/' . $data['token']);
@@ -1326,7 +1330,7 @@ class ApiTest extends TestCase {
 
 		$share = $this->shareManager->getShareById('ocinternal:'.$data['id']);
 
-		$this->assertEquals($date, $share->getExpirationDate()->format('Y-m-d'));
+		$this->assertEquals($date, $share->getExpirationDate()->format('Y-m-d H:i:s'));
 
 		$this->shareManager->deleteShare($share);
 	}
@@ -1350,7 +1354,7 @@ class ApiTest extends TestCase {
 
 		$data = $result->getData();
 		$this->assertTrue(is_string($data['token']));
-		$this->assertEquals($date->format('Y-m-d') . ' 00:00:00', $data['expiration']);
+		$this->assertEquals($date->format('Y-m-d 00:00:00'), $data['expiration']);
 
 		// check for correct link
 		$url = \OC::$server->getURLGenerator()->getAbsoluteURL('/index.php/s/' . $data['token']);

--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -36,6 +36,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
+use OCP\IDateTimeZone;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -96,7 +97,8 @@ class CapabilitiesTest extends \Test\TestCase {
 			$this->createMock(IEventDispatcher::class),
 			$this->createMock(IUserSession::class),
 			$this->createMock(KnownUserService::class),
-			$this->createMock(ShareDisableChecker::class)
+			$this->createMock(ShareDisableChecker::class),
+			$this->createMock(IDateTimeZone::class),
 		);
 		$cap = new Capabilities($config, $shareManager);
 		$result = $this->getFilesSharingPart($cap->getCapabilities());

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -845,6 +845,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->groupManager->method('get')->willReturnMap([
 			['group', $group],
 		]);
+		$this->dateTimeZone->method('getTimezone')->willReturn(new \DateTimeZone('UTC'));
 
 		$d = $ocs->getShare($share->getId())->getData()[0];
 
@@ -4647,6 +4648,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturnSelf();
+		$this->dateTimeZone->method('getTimezone')->willReturn(new \DateTimeZone('UTC'));
 
 		if (!$exception) {
 			$this->rootFolder->method('getById')

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1266,7 +1266,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IEventDispatcher::class),
 				$c->get(IUserSession::class),
 				$c->get(KnownUserService::class),
-				$c->get(ShareDisableChecker::class)
+				$c->get(ShareDisableChecker::class),
+				$c->get(IDateTimeZone::class),
 			);
 
 			return $manager;

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -21,6 +21,7 @@
 
 namespace Test\Share20;
 
+use DateTimeZone;
 use OC\Files\Mount\MoveableMount;
 use OC\KnownUser\KnownUserService;
 use OC\Share20\DefaultShareProvider;
@@ -39,6 +40,7 @@ use OCP\Files\Node;
 use OCP\Files\Storage;
 use OCP\HintException;
 use OCP\IConfig;
+use OCP\IDateTimeZone;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -114,6 +116,9 @@ class ManagerTest extends \Test\TestCase {
 	protected $knownUserService;
 	/** @var ShareDisableChecker|MockObject  */
 	protected $shareDisabledChecker;
+	private DateTimeZone $timezone;
+	/** @var IDateTimeZone|MockObject  */
+	protected $dateTimeZone;
 
 	protected function setUp(): void {
 		$this->logger = $this->createMock(LoggerInterface::class);
@@ -132,6 +137,9 @@ class ManagerTest extends \Test\TestCase {
 		$this->knownUserService = $this->createMock(KnownUserService::class);
 
 		$this->shareDisabledChecker = new ShareDisableChecker($this->config, $this->userManager, $this->groupManager);
+		$this->dateTimeZone = $this->createMock(IDateTimeZone::class);
+		$this->timezone = new \DateTimeZone('Pacific/Auckland');
+		$this->dateTimeZone->method('getTimeZone')->willReturnCallback(fn () => $this->timezone);
 
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->l = $this->createMock(IL10N::class);
@@ -164,7 +172,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->dispatcher,
 			$this->userSession,
 			$this->knownUserService,
-			$this->shareDisabledChecker
+			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$this->defaultProvider = $this->createMock(DefaultShareProvider::class);
@@ -196,6 +205,7 @@ class ManagerTest extends \Test\TestCase {
 				$this->userSession,
 				$this->knownUserService,
 				$this->shareDisabledChecker,
+				$this->dateTimeZone,
 			]);
 	}
 
@@ -933,7 +943,7 @@ class ManagerTest extends \Test\TestCase {
 				]);
 		}
 
-		$expected = new \DateTime();
+		$expected = new \DateTime('now', $this->timezone);
 		$expected->setTime(0, 0, 0);
 		$expected->add(new \DateInterval('P3D'));
 
@@ -968,7 +978,7 @@ class ManagerTest extends \Test\TestCase {
 				]);
 		}
 
-		$expected = new \DateTime();
+		$expected = new \DateTime('now', $this->timezone);
 		$expected->setTime(0, 0, 0);
 		$expected->add(new \DateInterval('P1D'));
 
@@ -1015,7 +1025,7 @@ class ManagerTest extends \Test\TestCase {
 	 * @dataProvider validateExpirationDateInternalProvider
 	 */
 	public function testValidateExpirationDateInternalEnforceValid($shareType) {
-		$future = new \DateTime();
+		$future = new \DateTime('now', $this->dateTimeZone->getTimeZone());
 		$future->add(new \DateInterval('P2D'));
 		$future->setTime(1, 2, 3);
 
@@ -1057,7 +1067,7 @@ class ManagerTest extends \Test\TestCase {
 	 * @dataProvider validateExpirationDateInternalProvider
 	 */
 	public function testValidateExpirationDateInternalNoDefault($shareType) {
-		$date = new \DateTime();
+		$date = new \DateTime('now', $this->dateTimeZone->getTimeZone());
 		$date->add(new \DateInterval('P5D'));
 		$date->setTime(1, 2, 3);
 
@@ -1105,9 +1115,10 @@ class ManagerTest extends \Test\TestCase {
 		$share = $this->manager->newShare();
 		$share->setShareType($shareType);
 
-		$expected = new \DateTime();
+		$expected = new \DateTime('now', $this->timezone);
+		$expected->setTime(0, 0);
 		$expected->add(new \DateInterval('P3D'));
-		$expected->setTime(0, 0, 0);
+		$expected->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 		if ($shareType === IShare::TYPE_USER) {
 			$this->config->method('getAppValue')
@@ -1140,12 +1151,12 @@ class ManagerTest extends \Test\TestCase {
 	 * @dataProvider validateExpirationDateInternalProvider
 	 */
 	public function testValidateExpirationDateInternalDefault($shareType) {
-		$future = new \DateTime();
+		$future = new \DateTime('now', $this->timezone);
 		$future->add(new \DateInterval('P5D'));
 		$future->setTime(1, 2, 3);
 
 		$expected = clone $future;
-		$expected->setTime(0, 0, 0);
+		$expected->setTime(0, 0);
 
 		$share = $this->manager->newShare();
 		$share->setShareType($shareType);
@@ -1182,7 +1193,7 @@ class ManagerTest extends \Test\TestCase {
 	 * @dataProvider validateExpirationDateInternalProvider
 	 */
 	public function testValidateExpirationDateInternalHookModification($shareType) {
-		$nextWeek = new \DateTime();
+		$nextWeek = new \DateTime('now', $this->timezone);
 		$nextWeek->add(new \DateInterval('P7D'));
 		$nextWeek->setTime(0, 0, 0);
 
@@ -1311,7 +1322,7 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'link_defaultExpDays', '3', '3'],
 			]);
 
-		$expected = new \DateTime();
+		$expected = new \DateTime('now', $this->timezone);
 		$expected->setTime(0, 0, 0);
 		$expected->add(new \DateInterval('P3D'));
 
@@ -1332,7 +1343,7 @@ class ManagerTest extends \Test\TestCase {
 				['core', 'link_defaultExpDays', '3', '1'],
 			]);
 
-		$expected = new \DateTime();
+		$expected = new \DateTime('now', $this->timezone);
 		$expected->setTime(0, 0, 0);
 		$expected->add(new \DateInterval('P1D'));
 
@@ -1363,7 +1374,7 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateEnforceValid() {
-		$future = new \DateTime();
+		$future = new \DateTime('now', $this->timezone);
 		$future->add(new \DateInterval('P2D'));
 		$future->setTime(1, 2, 3);
 
@@ -1392,12 +1403,13 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateNoDefault() {
-		$date = new \DateTime();
+		$date = new \DateTime('now', $this->timezone);
 		$date->add(new \DateInterval('P5D'));
 		$date->setTime(1, 2, 3);
 
 		$expected = clone $date;
-		$expected->setTime(0, 0, 0);
+		$expected->setTime(0, 0);
+		$expected->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($date);
@@ -1431,9 +1443,10 @@ class ManagerTest extends \Test\TestCase {
 	public function testValidateExpirationDateNoDateDefault() {
 		$share = $this->manager->newShare();
 
-		$expected = new \DateTime();
+		$expected = new \DateTime('now', $this->timezone);
 		$expected->add(new \DateInterval('P3D'));
-		$expected->setTime(0, 0, 0);
+		$expected->setTime(0, 0);
+		$expected->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 		$this->config->method('getAppValue')
 			->willReturnMap([
@@ -1454,12 +1467,44 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateDefault() {
-		$future = new \DateTime();
+		$future = new \DateTime('now', $this->timezone);
 		$future->add(new \DateInterval('P5D'));
 		$future->setTime(1, 2, 3);
 
 		$expected = clone $future;
-		$expected->setTime(0, 0, 0);
+		$expected->setTime(0, 0);
+		$expected->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
+		$share = $this->manager->newShare();
+		$share->setExpirationDate($future);
+
+		$this->config->method('getAppValue')
+			->willReturnMap([
+				['core', 'shareapi_default_expire_date', 'no', 'yes'],
+				['core', 'shareapi_expire_after_n_days', '7', '3'],
+				['core', 'link_defaultExpDays', '3', '1'],
+			]);
+
+		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
+		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
+		$hookListener->expects($this->once())->method('listener')->with($this->callback(function ($data) use ($expected) {
+			return $data['expirationDate'] == $expected;
+		}));
+
+		self::invokePrivate($this->manager, 'validateExpirationDateLink', [$share]);
+
+		$this->assertEquals($expected, $share->getExpirationDate());
+	}
+
+	public function testValidateExpirationNegativeOffsetTimezone() {
+		$this->timezone = new \DateTimeZone('Pacific/Tahiti');
+		$future = new \DateTime();
+		$future->add(new \DateInterval('P5D'));
+
+		$expected = clone $future;
+		$expected->setTimezone($this->timezone);
+		$expected->setTime(0, 0);
+		$expected->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 		$share = $this->manager->newShare();
 		$share->setExpirationDate($future);
@@ -1483,11 +1528,12 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	public function testValidateExpirationDateHookModification() {
-		$nextWeek = new \DateTime();
+		$nextWeek = new \DateTime('now', $this->timezone);
 		$nextWeek->add(new \DateInterval('P7D'));
-		$nextWeek->setTime(0, 0, 0);
 
 		$save = clone $nextWeek;
+		$save->setTime(0, 0);
+		$save->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
 		\OCP\Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
@@ -2769,6 +2815,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->knownUserService,
 			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2817,6 +2864,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->knownUserService,
 			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -2872,6 +2920,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->knownUserService,
 			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$share = $this->createMock(IShare::class);
@@ -4272,6 +4321,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->knownUserService,
 			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 		$this->assertSame($expected,
 			$manager->shareProviderExists($shareType)
@@ -4307,6 +4357,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->knownUserService,
 			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4373,6 +4424,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->knownUserService,
 			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4491,6 +4543,7 @@ class ManagerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->knownUserService,
 			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$factory->setProvider($this->defaultProvider);
@@ -4617,7 +4670,8 @@ class ManagerTest extends \Test\TestCase {
 			$this->dispatcher,
 			$this->userSession,
 			$this->knownUserService,
-			$this->shareDisabledChecker
+			$this->shareDisabledChecker,
+			$this->dateTimeZone,
 		);
 
 		$factory->setProvider($this->defaultProvider);


### PR DESCRIPTION
## Summary

When we store an expiration date for a share, we store only the date, without time.
If an user is in UTC + 9 and share a file before 9am, the server will consider the expiration date to be one day earlier (ie. D+6 instead of D+7). Then, the display is wrong.

To fix that, we have to store time.

Fix #43457 
Fix https://github.com/nextcloud/server/issues/43243

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
