### PR TITLE
fix styling for input field in personal settings

### DIFF
--- a/apps/settings/src/components/PersonalInfo/shared/AccountPropertySection.vue
+++ b/apps/settings/src/components/PersonalInfo/shared/AccountPropertySection.vue
@@ -37,7 +37,7 @@
 				autocomplete="off"
 				spellcheck="false"
 				@input="onPropertyChange" />
-			<input v-else
+			<NcInputField v-else
 				:id="inputId"
 				ref="input"
 				:placeholder="placeholder"
@@ -47,7 +47,7 @@
 				autocapitalize="none"
 				spellcheck="false"
 				:autocomplete="autocomplete"
-				@input="onPropertyChange">
+				@input="onPropertyChange"/>
 
 			<div class="property__actions-container">
 				<Transition name="fade">
@@ -72,6 +72,7 @@
 <script>
 import debounce from 'debounce'
 
+import NcInputField from '@nextcloud/vue/dist/Components/NcInputField.js'
 import AlertCircle from 'vue-material-design-icons/AlertCircleOutline.vue'
 import AlertOctagon from 'vue-material-design-icons/AlertOctagon.vue'
 import Check from 'vue-material-design-icons/Check.vue'
@@ -89,6 +90,7 @@ export default {
 		AlertOctagon,
 		Check,
 		HeaderBar,
+		NcInputField,
 	},
 
 	props: {


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/42498

<details>
<summary>For my own testing</summary>

```
docker run -it --rm ^
--name nextcloud-easy-test1 ^
-p 8444:443 ^
-e SERVER_BRANCH=enh/42498/fix-input-field ^
-e COMPILE_SERVER=1 ^
-e VIEWER_BRANCH=master ^
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" ^
ghcr.io/szaimen/nextcloud-easy-test:latest

```

</details>


### Todo:

https://github.com/nextcloud/server/assets/42591237/05674a6a-8aa4-4731-8913-67e2862c039f

