### PR TITLE
fix(files_external) Redact sensitive S3 values

### DIFF
--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -125,12 +125,12 @@ class ListCommand extends Base {
 		}
 
 		if (!$input->getOption('show-password')) {
-			$hideKeys = ['password', 'refresh_token', 'token', 'client_secret', 'public_key', 'private_key'];
+			$hideKeys = ['key', 'bucket', 'secret', 'password', 'refresh_token', 'token', 'client_secret', 'public_key', 'private_key'];
 			foreach ($mounts as $mount) {
 				$config = $mount->getBackendOptions();
 				foreach ($config as $key => $value) {
 					if (in_array($key, $hideKeys)) {
-						$mount->setBackendOption($key, '***');
+						$mount->setBackendOption($key, '***REMOVED SENSITIVE VALUE***');
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

While troubleshooting another matter, noticed these weren't being redacted

* Adds S3 `key` / `secret` / `bucket` to list of values redacted automatically when dumping `files_external` config via `occ`
* Adjusted the redaction string to match the one we use for `occ config:list system` 

Probably not critical enough to backport to stable28.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
