### PR TITLE
feat: add `PATCH` HTTP Verb Support To `IClient` Interface & its HTTP Client Implementation

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -339,6 +339,41 @@ class Client implements IClient {
 	}
 
 	/**
+	 * Sends a PATCH request
+	 *
+	 * @param string $uri
+	 * @param array $options Array such as
+	 *              'body' => [
+	 *                  'field' => 'abc',
+	 *                  'other_field' => '123',
+	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              ],
+	 *              'headers' => [
+	 *                  'foo' => 'bar',
+	 *              ],
+	 *              'cookies' => [
+	 *                  'foo' => 'bar',
+	 *              ],
+	 *              'allow_redirects' => [
+	 *                   'max'       => 10,  // allow at most 10 redirects.
+	 *                   'strict'    => true,     // use "strict" RFC compliant redirects.
+	 *                   'referer'   => true,     // add a Referer header
+	 *                   'protocols' => ['https'] // only allow https URLs
+	 *              ],
+	 *              'sink' => '/path/to/file', // save to a file or a stream
+	 *              'verify' => true, // bool or string to CA file
+	 *              'debug' => true,
+	 *              'timeout' => 5,
+	 * @return IResponse
+	 * @throws \Exception If the request could not get completed
+	 */
+	public function patch(string $uri, array $options = []): IResponse {
+		$this->preventLocalAddress($uri, $options);
+		$response = $this->client->request('patch', $uri, $this->buildRequestOptions($options));
+		return new Response($response);
+	}
+
+	/**
 	 * Sends a DELETE request
 	 *
 	 * @param string $uri

--- a/lib/public/Http/Client/IClient.php
+++ b/lib/public/Http/Client/IClient.php
@@ -173,6 +173,7 @@ interface IClient {
 	 *              'debug' => true,
 	 * @return IResponse
 	 * @throws \Exception If the request could not get completed
+	 * @since 29.0.0
 	 */
 	public function patch(string $uri, array $options = []): IResponse;
 

--- a/lib/public/Http/Client/IClient.php
+++ b/lib/public/Http/Client/IClient.php
@@ -148,6 +148,35 @@ interface IClient {
 	public function put(string $uri, array $options = []): IResponse;
 
 	/**
+	 * Sends a PATCH request
+	 * @param string $uri
+	 * @param array $options Array such as
+	 *              'body' => [
+	 *                  'field' => 'abc',
+	 *                  'other_field' => '123',
+	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              ],
+	 *              'headers' => [
+	 *                  'foo' => 'bar',
+	 *              ],
+	 *              'cookies' => [
+	 *                  'foo' => 'bar',
+	 *              ],
+	 *              'allow_redirects' => [
+	 *                   'max'       => 10,  // allow at most 10 redirects.
+	 *                   'strict'    => true,     // use "strict" RFC compliant redirects.
+	 *                   'referer'   => true,     // add a Referer header
+	 *                   'protocols' => ['https'] // only allow https URLs
+	 *              ],
+	 *              'sink' => '/path/to/file', // save to a file or a stream
+	 *              'verify' => true, // bool or string to CA file
+	 *              'debug' => true,
+	 * @return IResponse
+	 * @throws \Exception If the request could not get completed
+	 */
+	public function patch(string $uri, array $options = []): IResponse;
+
+	/**
 	 * Sends a DELETE request
 	 * @param string $uri
 	 * @param array $options Array such as


### PR DESCRIPTION
## Summary

Added PATCH HTTP Verb Support To IClient Interface & its HTTP Client Implementation

Closes https://github.com/nextcloud/server/issues/43450

## TODO

- [ ] N/A

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
