### PR TITLE
Cleanup cron.php method calls

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -46,6 +46,7 @@ require_once __DIR__ . '/lib/versioncheck.php';
 
 use OC\SystemConfig;
 use OCP\BackgroundJob\IJobList;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\ISession;
 use OCP\ITempManager;
@@ -78,6 +79,7 @@ try {
 
 	$logger = Server::get(LoggerInterface::class);
 	$config = Server::get(IConfig::class);
+	$appConfig = Server::get(IAppConfig::class);
 	$tempManager = Server::get(ITempManager::class);
 
 	// Don't do anything if Nextcloud has not been installed
@@ -88,7 +90,7 @@ try {
 	$tempManager->cleanOld();
 
 	// Exit if background jobs are disabled!
-	$appMode = $config->getAppValue('core', 'backgroundjobs_mode', 'ajax');
+	$appMode = $appConfig->getValueString('core', 'backgroundjobs_mode', 'ajax');
 	if ($appMode === 'none') {
 		if (OC::$CLI) {
 			echo 'Background Jobs are disabled!' . PHP_EOL;
@@ -122,7 +124,7 @@ try {
 
 		// We call Nextcloud from the CLI (aka cron)
 		if ($appMode !== 'cron') {
-			$config->setAppValue('core', 'backgroundjobs_mode', 'cron');
+			$appConfig->setValueString('core', 'backgroundjobs_mode', 'cron');
 		}
 
 		// Low-load hours
@@ -211,7 +213,7 @@ try {
 	}
 
 	// Log the successful cron execution
-	$config->setAppValue('core', 'lastcron', time());
+	$appConfig->setValueInt('core', 'lastcron', time());
 	exit();
 } catch (Exception $ex) {
 	Server::get(LoggerInterface::class)->error(

--- a/cron.php
+++ b/cron.php
@@ -44,7 +44,6 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/lib/versioncheck.php';
 
-use OC\SystemConfig;
 use OCP\App\IAppManager;
 use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
@@ -62,12 +61,13 @@ try {
 		Server::get(LoggerInterface::class)->debug('Update required, skipping cron', ['app' => 'cron']);
 		exit;
 	}
-	if ((bool) Server::get(SystemConfig::class)->getValue('maintenance', false)) {
+
+	$config = Server::get(IConfig::class);
+
+	if ($config->getSystemValueBool('maintenance', false)) {
 		Server::get(LoggerInterface::class)->debug('We are in maintenance mode, skipping cron', ['app' => 'cron']);
 		exit;
 	}
-
-	$config = Server::get(IConfig::class);
 
 	// Don't do anything if Nextcloud has not been installed
 	if (!$config->getSystemValueBool('installed', false)) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1661,6 +1661,7 @@ class Server extends ServerContainer implements IServerContainer {
 
 	/**
 	 * @param \OCP\ISession $session
+	 * @return void
 	 */
 	public function setSession(\OCP\ISession $session) {
 		$this->get(SessionStorage::class)->setSession($session);

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -117,6 +117,8 @@ class OC_App {
 	 * exists.
 	 *
 	 * if $types is set to non-empty array, only apps of those types will be loaded
+	 *
+	 * @deprecated 29.0.0 use IAppManager::loadApps instead
 	 */
 	public static function loadApps(array $types = []): bool {
 		if (!\OC::$server->getSystemConfig()->getValue('installed', false)) {

--- a/psalm.xml
+++ b/psalm.xml
@@ -45,6 +45,7 @@
 		<directory name="lib"/>
 		<directory name="ocs"/>
 		<directory name="ocs-provider"/>
+		<file name="cron.php"/>
 		<file name="index.php"/>
 		<file name="public.php"/>
 		<file name="remote.php"/>


### PR DESCRIPTION
## Summary

Cleanup cron.php and bring it to the modern world. Added `strict_types` as well.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
