### PR TITLE
chore(index.php): Use strict_types and Server::get in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,8 +1,12 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
  * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
  * @author Joas Schilling <coding@schilljs.com>
  * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  * @author Lukas Reschke <lukas@statuscode.ch>
@@ -28,33 +32,39 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>
  *
  */
+
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\ServiceUnavailableException;
+use OC\User\LoginException;
+use OCP\HintException;
+use OCP\IRequest;
 use OCP\Security\Bruteforce\MaxDelayReached;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 try {
 	require_once __DIR__ . '/lib/base.php';
 
 	OC::handleRequest();
-} catch (\OC\ServiceUnavailableException $ex) {
-	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+} catch (ServiceUnavailableException $ex) {
+	Server::get(LoggerInterface::class)->error($ex->getMessage(), [
 		'app' => 'index',
 		'exception' => $ex,
 	]);
 
 	//show the user a detailed error page
 	OC_Template::printExceptionErrorPage($ex, 503);
-} catch (\OCP\HintException $ex) {
+} catch (HintException $ex) {
 	try {
 		OC_Template::printErrorPage($ex->getMessage(), $ex->getHint(), 503);
 	} catch (Exception $ex2) {
 		try {
-			\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+			Server::get(LoggerInterface::class)->error($ex->getMessage(), [
 				'app' => 'index',
 				'exception' => $ex,
 			]);
-			\OC::$server->get(LoggerInterface::class)->error($ex2->getMessage(), [
+			Server::get(LoggerInterface::class)->error($ex2->getMessage(), [
 				'app' => 'index',
 				'exception' => $ex2,
 			]);
@@ -65,8 +75,8 @@ try {
 		//show the user a detailed error page
 		OC_Template::printExceptionErrorPage($ex, 500);
 	}
-} catch (\OC\User\LoginException $ex) {
-	$request = \OC::$server->getRequest();
+} catch (LoginException $ex) {
+	$request = Server::get(IRequest::class);
 	/**
 	 * Routes with the @CORS annotation and other API endpoints should
 	 * not return a webpage, so we only print the error page when html is accepted,
@@ -80,7 +90,7 @@ try {
 	}
 	OC_Template::printErrorPage($ex->getMessage(), $ex->getMessage(), 401);
 } catch (MaxDelayReached $ex) {
-	$request = \OC::$server->getRequest();
+	$request = Server::get(IRequest::class);
 	/**
 	 * Routes with the @CORS annotation and other API endpoints should
 	 * not return a webpage, so we only print the error page when html is accepted,
@@ -95,7 +105,7 @@ try {
 	http_response_code(429);
 	OC_Template::printGuestPage('core', '429');
 } catch (Exception $ex) {
-	\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+	Server::get(LoggerInterface::class)->error($ex->getMessage(), [
 		'app' => 'index',
 		'exception' => $ex,
 	]);
@@ -104,7 +114,7 @@ try {
 	OC_Template::printExceptionErrorPage($ex, 500);
 } catch (Error $ex) {
 	try {
-		\OC::$server->get(LoggerInterface::class)->error($ex->getMessage(), [
+		Server::get(LoggerInterface::class)->error($ex->getMessage(), [
 			'app' => 'index',
 			'exception' => $ex,
 		]);


### PR DESCRIPTION
## Summary

Small followup for #43454 
`index.php` was already pretty clean so small PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
