### PR TITLE
feat: backported multi-file select

### DIFF
--- a/apps/files/src/components/FileEntry.vue
+++ b/apps/files/src/components/FileEntry.vue
@@ -564,11 +564,12 @@ export default Vue.extend({
 			}
 		},
 
-		onSelectionChange(selection) {
+		onSelectionChange(selected: boolean) {
 			const newSelectedIndex = this.index
 			const lastSelectedIndex = this.selectionStore.lastSelectedIndex
 
 			// Get the last selected and select all files in between
+			console.log("HUH")
 			if (this.keyboardStore?.shiftKey && lastSelectedIndex !== null) {
 				const isAlreadySelected = this.selectedFiles.includes(this.fileid)
 
@@ -577,18 +578,23 @@ export default Vue.extend({
 
 				const lastSelection = this.selectionStore.lastSelection
 				const filesToSelect = this.nodes
-					.map(file => file.fileid?.toString?.())
+					.map(file => file.fileid)
 					.slice(start, end + 1)
+					.filter(Boolean) as number[]
 
 				// If already selected, update the new selection _without_ the current file
 				const selection = [...lastSelection, ...filesToSelect]
-					.filter(fileId => !isAlreadySelected || fileId !== this.fileid)
+					.filter(fileid => !isAlreadySelected || fileid !== this.fileid)
 
 				logger.debug('Shift key pressed, selecting all files in between', { start, end, filesToSelect, isAlreadySelected })
 				// Keep previous lastSelectedIndex to be use for further shift selections
 				this.selectionStore.set(selection)
 				return
 			}
+
+			const selection = selected
+				? [...this.selectedFiles, this.fileid]
+				: this.selectedFiles.filter(fileid => fileid !== this.fileid)
 
 			logger.debug('Updating selection', { selection })
 			this.selectionStore.set(selection)

--- a/apps/files/src/store/keyboard.ts
+++ b/apps/files/src/store/keyboard.ts
@@ -19,7 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-/* eslint-disable */
 import { defineStore } from 'pinia'
 import Vue from 'vue'
 
@@ -28,9 +27,9 @@ import Vue from 'vue'
  * special keys states. Useful for checking the
  * current status of a key when executing a method.
  */
-export const useKeyboardStore = function() {
+export const useKeyboardStore = function(...args) {
 	const store = defineStore('keyboard', {
-		state: () => ({			
+		state: () => ({
 			altKey: false,
 			ctrlKey: false,
 			metaKey: false,
@@ -47,10 +46,10 @@ export const useKeyboardStore = function() {
 				Vue.set(this, 'metaKey', !!event.metaKey)
 				Vue.set(this, 'shiftKey', !!event.shiftKey)
 			},
-		}
+		},
 	})
 
-	const keyboardStore = store(...arguments)
+	const keyboardStore = store(...args)
 	// Make sure we only register the listeners once
 	if (!keyboardStore._initialized) {
 		window.addEventListener('keydown', keyboardStore.onEvent)

--- a/apps/files/src/store/selection.ts
+++ b/apps/files/src/store/selection.ts
@@ -19,7 +19,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-/* eslint-disable */
 import { defineStore } from 'pinia'
 import Vue from 'vue'
 import { FileId, SelectionStore } from '../types'
@@ -36,7 +35,7 @@ export const useSelectionStore = defineStore('selection', {
 		 * Set the selection of fileIds
 		 */
 		set(selection = [] as FileId[]) {
-			Vue.set(this, 'selected', selection)
+			Vue.set(this, 'selected', [...new Set(selection)])
 		},
 
 		/**
@@ -55,6 +54,6 @@ export const useSelectionStore = defineStore('selection', {
 			Vue.set(this, 'selected', [])
 			Vue.set(this, 'lastSelection', [])
 			Vue.set(this, 'lastSelectedIndex', null)
-		}
-	}
+		},
+	},
 })


### PR DESCRIPTION
## IS JUST A DRAFT RIGHT NOW - keyboardstore seems to not be working on stable27

# PR BODY WILL BE DONE LATER 👍🥹
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
