### PR TITLE
chore!: Remove global `autosize`

### DIFF
--- a/core/src/globals.js
+++ b/core/src/globals.js
@@ -35,7 +35,6 @@ import 'jquery-ui-dist/jquery-ui.js'
 import 'jquery-ui-dist/jquery-ui.css'
 import 'jquery-ui-dist/jquery-ui.theme.css'
 // END TODO
-import autosize from 'autosize'
 import Backbone from 'backbone'
 import './Polyfill/tooltip.js'
 import ClipboardJS from 'clipboard'
@@ -100,11 +99,11 @@ const setDeprecatedProp = (global, cb, msg) => {
 
 window._ = _
 setDeprecatedProp(['$', 'jQuery'], () => $, 'The global jQuery is deprecated. It will be removed in a later versions without another warning. Please ship your own.')
-setDeprecatedProp('autosize', () => autosize, 'please ship your own, this will be removed in Nextcloud 20')
 setDeprecatedProp('Backbone', () => Backbone, 'please ship your own, this will be removed in Nextcloud 20')
 setDeprecatedProp(['Clipboard', 'ClipboardJS'], () => ClipboardJS, 'please ship your own, this will be removed in Nextcloud 20')
 window.dav = dav
 setDeprecatedProp('Handlebars', () => Handlebars, 'please ship your own, this will be removed in Nextcloud 20')
+// Global md5 only required for: apps/files/js/file-upload.js
 setDeprecatedProp('md5', () => md5, 'please ship your own, this will be removed in Nextcloud 20')
 setDeprecatedProp('moment', () => moment, 'please ship your own, this will be removed in Nextcloud 20')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "@vueuse/components": "^10.7.2",
         "@vueuse/core": "^10.7.2",
         "@vueuse/integrations": "^10.7.2",
-        "autosize": "^6.0.1",
         "backbone": "^1.4.1",
         "blueimp-md5": "^2.19.0",
         "browserslist-useragent-regexp": "^4.0.0",
@@ -7000,11 +6999,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/autosize": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/autosize/-/autosize-6.0.1.tgz",
-      "integrity": "sha512-f86EjiUKE6Xvczc4ioP1JBlWG7FKrE13qe/DxBCpe8GCipCq2nFw73aO8QEBKHfSbYGDN5eB9jXWKen7tspDqQ=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@vueuse/components": "^10.7.2",
     "@vueuse/core": "^10.7.2",
     "@vueuse/integrations": "^10.7.2",
-    "autosize": "^6.0.1",
     "backbone": "^1.4.1",
     "blueimp-md5": "^2.19.0",
     "browserslist-useragent-regexp": "^4.0.0",


### PR DESCRIPTION
## Summary
It was deprecated for over 4 years and scheduled for removal with Nextcloud 20. Not used by server or any app anymore (except calendar but they ship their own version).


Docs: https://github.com/nextcloud/documentation/pull/11522
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
