### PR TITLE
re-do not break personal settings page is viewer is not there

### DIFF
--- a/apps/settings/lib/Settings/Personal/ServerDevNotice.php
+++ b/apps/settings/lib/Settings/Personal/ServerDevNotice.php
@@ -78,11 +78,11 @@ class ServerDevNotice implements ISettings {
 
 		$hasInitialState = false;
 
-		// viewer is default enabled and this makes a zero-cost assertion for Psalm
-		assert(class_exists(LoadViewer::class));
-
-		// If the Reasons to use Nextcloud.pdf file is here, let's init Viewer
-		if ($userFolder->nodeExists('Reasons to use Nextcloud.pdf')) {
+		// If the Reasons to use Nextcloud.pdf file is here, let's init Viewer, also check that Viewer is there
+		if (class_exists(LoadViewer::class) && $userFolder->nodeExists('Reasons to use Nextcloud.pdf')) {
+			/**
+			 * @psalm-suppress UndefinedClass, InvalidArgument
+			 */
 			$this->eventDispatcher->dispatch(LoadViewer::class, new LoadViewer());
 			$hasInitialState = true;
 		}


### PR DESCRIPTION
Re-do https://github.com/nextcloud/server/pull/43435

It looks like this was reverted in https://github.com/nextcloud/server/commit/898df41de968321926e10ad532a64c3915ddad29#diff-8dbbdb1612c79ff7409c0c43bd8ade4f433b8d66958e1453e714dcdc9b78e2d6 by mistake.