### PR TITLE
perf(sharing): Improve performance of share provider queries

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -79,10 +79,18 @@ class Application extends App {
 		$notificationManager->registerNotifierService(AuthenticationNotifier::class);
 
 		$eventDispatcher->addListener(AddMissingIndicesEvent::class, function (AddMissingIndicesEvent $event) {
+			/**
+			 * Replaced by the share_type_with index below
+			 * $event->addMissingIndex(
+			 * 'share',
+			 * 'share_with_index',
+			 * ['share_with']
+			 * );
+			 */
 			$event->addMissingIndex(
 				'share',
-				'share_with_index',
-				['share_with']
+				'share_type_with',
+				['share_type', 'share_with']
 			);
 			$event->addMissingIndex(
 				'share',

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -475,7 +475,9 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['item_type', 'share_type'], 'item_share_type_index');
 			$table->addIndex(['file_source'], 'file_source_index');
 			$table->addIndex(['token'], 'token_index');
-			$table->addIndex(['share_with'], 'share_with_index');
+			// Replaced by the share_type_with index below
+			// $table->addIndex(['share_with'], 'share_with_index');
+			$table->addIndex(['share_type', 'share_with'], 'share_type_with');
 			$table->addIndex(['parent'], 'parent_index');
 			$table->addIndex(['uid_owner'], 'owner_index');
 			$table->addIndex(['uid_initiator'], 'initiator_index');

--- a/core/Migrations/Version29000Date20240209123412.php
+++ b/core/Migrations/Version29000Date20240209123412.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Your name <your@email.com>
+ *
+ * @author Your name <your@email.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version29000Date20240209123412 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('share');
+		if ($table->hasIndex('share_with_index')) {
+			$table->dropIndex('share_with_index');
+			return $schema;
+		}
+		return null;
+	}
+
+}

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -886,11 +886,113 @@ class DefaultShareProvider implements IShareProvider {
 	 * @inheritdoc
 	 */
 	public function getSharedWith($userId, $shareType, $node, $limit, $offset) {
+		if ($shareType === IShare::TYPE_USER) {
+			if ($limit === -1 && $node === null && $offset === 0) {
+				return $this->getAllSharedWithUser((string) $userId);
+			}
+			return $this->getSharedWithUser($userId, $node, $limit, $offset);
+		}
+		if ($shareType === IShare::TYPE_GROUP) {
+			if ($limit === -1 && $node === null && $offset === 0) {
+				return $this->getAllSharedWithGroups((string) $userId);
+			}
+			return $this->getSharedWithGroups($userId, $node, $limit, $offset);
+		}
+		throw new BackendError('Invalid backend');
+	}
+
+	/**
+	 * Get limited user-shares shared with the given user
+	 *
+	 * @param string $userId get shares where this user is the recipient
+	 * @param Node|null $node
+	 * @param int $limit The max number of entries returned, -1 for all
+	 * @param int $offset
+	 * @return IShare[]
+	 */
+	public function getSharedWithUser($userId, $node, $limit, $offset): array {
 		/** @var Share[] $shares */
 		$shares = [];
 
-		if ($shareType === IShare::TYPE_USER) {
-			//Get shares directly with this user
+		//Get shares directly with this user
+		$qb = $this->dbConn->getQueryBuilder();
+		$qb->select('s.*',
+			'f.fileid', 'f.path', 'f.permissions AS f_permissions', 'f.storage', 'f.path_hash',
+			'f.parent AS f_parent', 'f.name', 'f.mimetype', 'f.mimepart', 'f.size', 'f.mtime', 'f.storage_mtime',
+			'f.encrypted', 'f.unencrypted_size', 'f.etag', 'f.checksum'
+		)
+			->selectAlias('st.id', 'storage_string_id')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
+			->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'));
+
+		// Order by id
+		$qb->orderBy('s.id');
+
+		// Set limit and offset
+		if ($limit !== -1) {
+			$qb->setMaxResults($limit);
+		}
+		$qb->setFirstResult($offset);
+
+		$qb->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_USER)))
+			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)))
+			->andWhere($qb->expr()->orX(
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
+				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
+			));
+
+		// Filter by node if provided
+		if ($node !== null) {
+			$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
+		}
+
+		$cursor = $qb->execute();
+
+		while ($data = $cursor->fetch()) {
+			if ($data['fileid'] && $data['path'] === null) {
+				$data['path'] = (string) $data['path'];
+				$data['name'] = (string) $data['name'];
+				$data['checksum'] = (string) $data['checksum'];
+			}
+			if ($this->isAccessibleResult($data)) {
+				$shares[] = $this->createShare($data);
+			}
+		}
+		$cursor->closeCursor();
+
+		return $shares;
+	}
+
+
+	/**
+	 * Get limited group-shares shared with the groups of a given user
+	 *
+	 * @param string $userId get shares where this user is the recipient
+	 * @param Node|null $node
+	 * @param int $limit The max number of entries returned, -1 for all
+	 * @param int $offset
+	 * @return IShare[]
+	 */
+	public function getSharedWithGroups($userId, $node, $limit, $offset): array {
+		/** @var Share[] $shares */
+		$shares = [];
+
+		$user = $this->userManager->get($userId);
+		$allGroups = ($user instanceof IUser) ? $this->groupManager->getUserGroupIds($user) : [];
+
+		/** @var Share[] $shares2 */
+		$shares2 = [];
+
+		$start = 0;
+		while (true) {
+			$groups = array_slice($allGroups, $start, 1000);
+			$start += 1000;
+
+			if ($groups === []) {
+				break;
+			}
+
 			$qb = $this->dbConn->getQueryBuilder();
 			$qb->select('s.*',
 				'f.fileid', 'f.path', 'f.permissions AS f_permissions', 'f.storage', 'f.path_hash',
@@ -900,117 +1002,206 @@ class DefaultShareProvider implements IShareProvider {
 				->selectAlias('st.id', 'storage_string_id')
 				->from('share', 's')
 				->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
-				->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'));
+				->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'))
+				->orderBy('s.id')
+				->setFirstResult(0);
 
-			// Order by id
-			$qb->orderBy('s.id');
-
-			// Set limit and offset
 			if ($limit !== -1) {
-				$qb->setMaxResults($limit);
+				$qb->setMaxResults($limit - count($shares));
 			}
-			$qb->setFirstResult($offset);
-
-			$qb->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_USER)))
-				->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($userId)))
-				->andWhere($qb->expr()->orX(
-					$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
-					$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
-				));
 
 			// Filter by node if provided
 			if ($node !== null) {
 				$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
 			}
 
-			$cursor = $qb->execute();
 
+			$groups = array_filter($groups);
+
+			$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
+				->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter(
+					$groups,
+					IQueryBuilder::PARAM_STR_ARRAY
+				)))
+				->andWhere($qb->expr()->orX(
+					$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
+					$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
+				));
+
+			$cursor = $qb->execute();
 			while ($data = $cursor->fetch()) {
-				if ($data['fileid'] && $data['path'] === null) {
-					$data['path'] = (string) $data['path'];
-					$data['name'] = (string) $data['name'];
-					$data['checksum'] = (string) $data['checksum'];
+				if ($offset > 0) {
+					$offset--;
+					continue;
 				}
+
 				if ($this->isAccessibleResult($data)) {
-					$shares[] = $this->createShare($data);
+					$shares2[] = $this->createShare($data);
 				}
 			}
 			$cursor->closeCursor();
-		} elseif ($shareType === IShare::TYPE_GROUP) {
-			$user = $this->userManager->get($userId);
-			$allGroups = ($user instanceof IUser) ? $this->groupManager->getUserGroupIds($user) : [];
-
-			/** @var Share[] $shares2 */
-			$shares2 = [];
-
-			$start = 0;
-			while (true) {
-				$groups = array_slice($allGroups, $start, 1000);
-				$start += 1000;
-
-				if ($groups === []) {
-					break;
-				}
-
-				$qb = $this->dbConn->getQueryBuilder();
-				$qb->select('s.*',
-					'f.fileid', 'f.path', 'f.permissions AS f_permissions', 'f.storage', 'f.path_hash',
-					'f.parent AS f_parent', 'f.name', 'f.mimetype', 'f.mimepart', 'f.size', 'f.mtime', 'f.storage_mtime',
-					'f.encrypted', 'f.unencrypted_size', 'f.etag', 'f.checksum'
-				)
-					->selectAlias('st.id', 'storage_string_id')
-					->from('share', 's')
-					->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.file_source', 'f.fileid'))
-					->leftJoin('f', 'storages', 'st', $qb->expr()->eq('f.storage', 'st.numeric_id'))
-					->orderBy('s.id')
-					->setFirstResult(0);
-
-				if ($limit !== -1) {
-					$qb->setMaxResults($limit - count($shares));
-				}
-
-				// Filter by node if provided
-				if ($node !== null) {
-					$qb->andWhere($qb->expr()->eq('file_source', $qb->createNamedParameter($node->getId())));
-				}
-
-
-				$groups = array_filter($groups);
-
-				$qb->andWhere($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
-					->andWhere($qb->expr()->in('share_with', $qb->createNamedParameter(
-						$groups,
-						IQueryBuilder::PARAM_STR_ARRAY
-					)))
-					->andWhere($qb->expr()->orX(
-						$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
-						$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
-					));
-
-				$cursor = $qb->execute();
-				while ($data = $cursor->fetch()) {
-					if ($offset > 0) {
-						$offset--;
-						continue;
-					}
-
-					if ($this->isAccessibleResult($data)) {
-						$shares2[] = $this->createShare($data);
-					}
-				}
-				$cursor->closeCursor();
-			}
-
-			/*
-			 * Resolve all group shares to user specific shares
-			 */
-			$shares = $this->resolveGroupShares($shares2, $userId);
-		} else {
-			throw new BackendError('Invalid backend');
 		}
 
+		/*
+		 * Resolve all group shares to user specific shares
+		 */
+		$shares = $this->resolveGroupShares($shares2, $userId);
 
 		return $shares;
+	}
+
+	/**
+	 * Get all user-shares shared with the given user
+	 *
+	 * @param string $userId get shares where this user is the recipient
+	 * @return IShare[]
+	 */
+	public function getAllSharedWithUser(string $userId): array {
+		//Get shares directly with this user
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select('*')
+			->from('share')
+			->where($query->expr()->eq('share_type', $query->createNamedParameter(IShare::TYPE_USER)))
+			->andWhere($query->expr()->eq('share_with', $query->createNamedParameter($userId)));
+
+		/** @var array<int, array> $shareRows */
+		$shareRows = [];
+
+		/** @var array<int, ?array> $fileData */
+		$fileData = [];
+
+		$result = $query->executeQuery();
+		while ($row = $result->fetch()) {
+			if ($row['item_type'] !== 'file' && $row['item_type'] !== 'folder') {
+				continue;
+			}
+
+			$shareRows[(int)$row['id']] = $row;
+			$fileData[(int)$row['file_source']] = null;
+		}
+		$result->closeCursor();
+
+		if (empty($fileData)) {
+			return [];
+		}
+
+		$queryFileCache = $this->dbConn->getQueryBuilder();
+		$queryFileCache->select('f.fileid', 'f.path', 'f.permissions AS f_permissions', 'f.storage', 'f.path_hash',
+			'f.parent AS f_parent', 'f.name', 'f.mimetype', 'f.mimepart', 'f.size', 'f.mtime', 'f.storage_mtime',
+			'f.encrypted', 'f.unencrypted_size', 'f.etag', 'f.checksum')
+			->selectAlias('st.id', 'storage_string_id')
+			->from('filecache', 'f')
+			->leftJoin('f', 'storages', 'st', $queryFileCache->expr()->eq('f.storage', 'st.numeric_id'))
+			->where($queryFileCache->expr()->in('f.fileid', $queryFileCache->createParameter('fileIds')));
+
+		$allFileIds = array_keys($fileData);
+		foreach (array_chunk($allFileIds, 1000) as $fileIds) {
+			// Filecache and storage info
+			$queryFileCache->setParameter('fileIds', $fileIds, IQueryBuilder::PARAM_INT_ARRAY);
+
+			$result = $queryFileCache->executeQuery();
+			while ($row = $result->fetch()) {
+				if (!$this->isAccessibleResult($row)) {
+					continue;
+				}
+
+				$fileData[(int) $row['fileid']] = $row;
+			}
+			$result->closeCursor();
+		}
+
+		/** @var IShare[] $shares */
+		$shares = [];
+		foreach ($shareRows as $row) {
+			if (empty($fileData[(int)$row['file_source']])) {
+				continue;
+			}
+			$shares[] = $this->createShare(array_merge($row, $fileData[(int)$row['file_source']]));
+		}
+
+		return $shares;
+	}
+
+
+	/**
+	 * Get all group-shares shared with the groups of a given user
+	 *
+	 * @param string $userId get shares where this user is the recipient
+	 * @return IShare[]
+	 */
+	public function getAllSharedWithGroups($userId): array {
+		$user = $this->userManager->get($userId);
+		$allGroups = ($user instanceof IUser) ? $this->groupManager->getUserGroupIds($user) : [];
+
+		$query = $this->dbConn->getQueryBuilder();
+		$query->select('s.*')
+			->from('share', 's')
+			->where($query->expr()->eq('s.share_type', $query->createNamedParameter(IShare::TYPE_GROUP)))
+			->andWhere($query->expr()->in('s.share_with', $query->createParameter('groups')));
+
+		/** @var array<int, array> $shareRows */
+		$shareRows = [];
+
+		/** @var array<int, ?array> $fileData */
+		$fileData = [];
+
+		foreach (array_chunk($allGroups, 1000) as $groups) {
+			$query->setParameter('groups', $groups, IQueryBuilder::PARAM_STR_ARRAY);
+
+			$result = $query->executeQuery();
+			while ($row = $result->fetch()) {
+				if ($row['item_type'] !== 'file' && $row['item_type'] !== 'folder') {
+					continue;
+				}
+
+				$shareRows[(int)$row['id']] = $row;
+				$fileData[(int)$row['file_source']] = null;
+			}
+			$result->closeCursor();
+		}
+
+		if (empty($fileData)) {
+			return [];
+		}
+
+		$queryFileCache = $this->dbConn->getQueryBuilder();
+		$queryFileCache->select('f.fileid', 'f.path', 'f.permissions AS f_permissions', 'f.storage', 'f.path_hash',
+			'f.parent AS f_parent', 'f.name', 'f.mimetype', 'f.mimepart', 'f.size', 'f.mtime', 'f.storage_mtime',
+			'f.encrypted', 'f.unencrypted_size', 'f.etag', 'f.checksum')
+			->selectAlias('st.id', 'storage_string_id')
+			->from('filecache', 'f')
+			->leftJoin('f', 'storages', 'st', $queryFileCache->expr()->eq('f.storage', 'st.numeric_id'))
+			->where($queryFileCache->expr()->in('f.fileid', $queryFileCache->createParameter('fileIds')));
+
+		$allFileIds = array_keys($fileData);
+		foreach (array_chunk($allFileIds, 1000) as $fileIds) {
+			// Filecache and storage info
+			$queryFileCache->setParameter('fileIds', $fileIds, IQueryBuilder::PARAM_INT_ARRAY);
+
+			$result = $queryFileCache->executeQuery();
+			while ($row = $result->fetch()) {
+				if (!$this->isAccessibleResult($row)) {
+					continue;
+				}
+
+				$fileData[(int) $row['fileid']] = $row;
+			}
+			$result->closeCursor();
+		}
+
+		/** @var IShare[] $shares */
+		$shares = [];
+		foreach ($shareRows as $row) {
+			if (empty($fileData[(int)$row['file_source']])) {
+				continue;
+			}
+			$shares[] = $this->createShare(array_merge($row, $fileData[(int)$row['file_source']]));
+		}
+
+		/**
+		 * Resolve all group shares to user specific shares
+		 */
+		return $this->resolveGroupShares($shares, $userId);
 	}
 
 	/**

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1115,16 +1115,16 @@ class DefaultShareProvider implements IShareProvider {
 	}
 
 	/**
-	 * @param Share[] $shares
+	 * @param IShare[] $shares
 	 * @param $userId
-	 * @return Share[] The updates shares if no update is found for a share return the original
+	 * @return IShare[] The updates shares if no update is found for a share return the original
 	 */
 	private function resolveGroupShares($shares, $userId) {
 		$result = [];
 
 		$start = 0;
 		while (true) {
-			/** @var Share[] $shareSlice */
+			/** @var IShare[] $shareSlice */
 			$shareSlice = array_slice($shares, $start, 100);
 			$start += 100;
 
@@ -1134,7 +1134,7 @@ class DefaultShareProvider implements IShareProvider {
 
 			/** @var int[] $ids */
 			$ids = [];
-			/** @var Share[] $shareMap */
+			/** @var IShare[] $shareMap */
 			$shareMap = [];
 
 			foreach ($shareSlice as $share) {

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -63,6 +63,8 @@ use function str_starts_with;
  * @package OC\Share20
  */
 class DefaultShareProvider implements IShareProvider {
+	protected int $chunkSize = 1000;
+
 	// Special share type for user modified group shares
 	public const SHARE_TYPE_USERGROUP = 2;
 
@@ -1095,7 +1097,7 @@ class DefaultShareProvider implements IShareProvider {
 			->where($queryFileCache->expr()->in('f.fileid', $queryFileCache->createParameter('fileIds')));
 
 		$allFileIds = array_keys($fileData);
-		foreach (array_chunk($allFileIds, 1000) as $fileIds) {
+		foreach (array_chunk($allFileIds, $this->chunkSize) as $fileIds) {
 			// Filecache and storage info
 			$queryFileCache->setParameter('fileIds', $fileIds, IQueryBuilder::PARAM_INT_ARRAY);
 
@@ -1145,7 +1147,7 @@ class DefaultShareProvider implements IShareProvider {
 		/** @var array<int, ?array> $fileData */
 		$fileData = [];
 
-		foreach (array_chunk($allGroups, 1000) as $groups) {
+		foreach (array_chunk($allGroups, $this->chunkSize) as $groups) {
 			$query->setParameter('groups', $groups, IQueryBuilder::PARAM_STR_ARRAY);
 
 			$result = $query->executeQuery();
@@ -1158,6 +1160,7 @@ class DefaultShareProvider implements IShareProvider {
 				$fileData[(int)$row['file_source']] = null;
 			}
 			$result->closeCursor();
+
 		}
 
 		if (empty($fileData)) {
@@ -1174,7 +1177,7 @@ class DefaultShareProvider implements IShareProvider {
 			->where($queryFileCache->expr()->in('f.fileid', $queryFileCache->createParameter('fileIds')));
 
 		$allFileIds = array_keys($fileData);
-		foreach (array_chunk($allFileIds, 1000) as $fileIds) {
+		foreach (array_chunk($allFileIds, $this->chunkSize) as $fileIds) {
 			// Filecache and storage info
 			$queryFileCache->setParameter('fileIds', $fileIds, IQueryBuilder::PARAM_INT_ARRAY);
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -994,6 +994,130 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals(IShare::TYPE_USER, $share->getShareType());
 	}
 
+	public function testGetAllSharedWithUser(): void {
+		$storageId = $this->createTestStorageEntry('home::shareOwner');
+		$fileIds = [];
+		for ($i = 0; $i < 50; $i++) {
+			$fileIds[] = $this->createTestFileEntry('files/test-' . $i . '.txt', $storageId);
+		}
+
+		$shareIds = [];
+		foreach ($fileIds as $fileId) {
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->insert('share')
+				->values([
+					'share_type' => $qb->expr()->literal(IShare::TYPE_USER),
+					'share_with' => $qb->expr()->literal('sharedWith'),
+					'uid_owner' => $qb->expr()->literal('shareOwner'),
+					'uid_initiator' => $qb->expr()->literal('sharedBy'),
+					'item_type' => $qb->expr()->literal('file'),
+					'file_source' => $qb->expr()->literal($fileId),
+					'file_target' => $qb->expr()->literal('myTarget'),
+					'permissions' => $qb->expr()->literal(13),
+				]);
+			$qb->executeStatement();
+			$shareIds[$fileId] = $qb->getLastInsertId();
+		}
+
+		$file = $this->createMock(File::class);
+		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
+		$this->rootFolder->method('getById')->willReturn([$file]);
+
+		self::invokePrivate($this->provider, 'chunkSize', [5]);
+		$shares = $this->provider->getSharedWith('sharedWith', IShare::TYPE_USER, null, -1, 0);
+		$this->assertCount(50, $shares);
+
+		foreach ($shares as $share) {
+			$this->assertEquals($shareIds[$share->getNodeId()], $share->getId());
+			$this->assertEquals('sharedWith', $share->getSharedWith());
+			$this->assertEquals('shareOwner', $share->getShareOwner());
+			$this->assertEquals('sharedBy', $share->getSharedBy());
+			$this->assertEquals(IShare::TYPE_USER, $share->getShareType());
+		}
+	}
+	public function testGetAllSharedWithGroup() {
+		$storageId = $this->createTestStorageEntry('home::shareOwner');
+		$fileIds = [];
+		for ($i = 0; $i < 50; $i++) {
+			$fileIds[] = $this->createTestFileEntry('files/test-' . $i . '.txt', $storageId);
+		}
+
+		$shareIdToFileIds = [];
+		$shareIdToGroupId = [];
+		for ($i = 0; $i < 50; $i++) {
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->insert('share')
+				->values([
+					'share_type' => $qb->expr()->literal(IShare::TYPE_GROUP),
+					'share_with' => $qb->expr()->literal('sharedWith'),
+					'uid_owner' => $qb->expr()->literal('shareOwner'),
+					'uid_initiator' => $qb->expr()->literal('sharedBy'),
+					'item_type' => $qb->expr()->literal('file'),
+					'file_source' => $qb->expr()->literal($fileIds[$i]),
+					'file_target' => $qb->expr()->literal('myTarget' . $i . 'shareWith'),
+					'permissions' => $qb->expr()->literal(13),
+				]);
+			$qb->executeStatement();
+			$shareId = $qb->getLastInsertId();
+			$shareIdToFileIds[$shareId] = $fileIds[$i];
+			$shareIdToGroupId[$shareId] = 'sharedWith';
+
+			$qb = $this->dbConn->getQueryBuilder();
+			$qb->insert('share')
+				->values([
+					'share_type' => $qb->expr()->literal(IShare::TYPE_GROUP),
+					'share_with' => $qb->expr()->literal('group' . $i),
+					'uid_owner' => $qb->expr()->literal('shareOwner'),
+					'uid_initiator' => $qb->expr()->literal('sharedBy'),
+					'item_type' => $qb->expr()->literal('file'),
+					'file_source' => $qb->expr()->literal($fileIds[$i]),
+					'file_target' => $qb->expr()->literal('myTarget' . $i . 'group'),
+					'permissions' => $qb->expr()->literal(13),
+				]);
+			$qb->executeStatement();
+			$shareId = $qb->getLastInsertId();
+			$shareIdToFileIds[$shareId] = $fileIds[$i];
+			$shareIdToGroupId[$shareId] = 'group' . $i;
+		}
+
+		$groups = [];
+		foreach (range(0, 100) as $i) {
+			$groups[] = 'group'.$i;
+		}
+
+		$groups[] = 'sharedWith';
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('sharedWith');
+		$owner = $this->createMock(IUser::class);
+		$owner->method('getUID')->willReturn('shareOwner');
+		$initiator = $this->createMock(IUser::class);
+		$initiator->method('getUID')->willReturn('sharedBy');
+
+		$this->userManager->method('get')->willReturnMap([
+			['sharedWith', $user],
+			['shareOwner', $owner],
+			['sharedBy', $initiator],
+		]);
+		$this->groupManager->method('getUserGroupIds')->with($user)->willReturn($groups);
+
+		$file = $this->createMock(File::class);
+		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
+		$this->rootFolder->method('getById')->willReturn([$file]);
+
+		self::invokePrivate($this->provider, 'chunkSize', [5]);
+		$shares = $this->provider->getSharedWith('sharedWith', IShare::TYPE_GROUP, null, -1, 0);
+		$this->assertCount(100, $shares);
+
+		foreach ($shares as $share) {
+			$this->assertEquals($shareIdToFileIds[$share->getId()], $share->getNodeId());
+			$this->assertEquals($shareIdToGroupId[$share->getId()], $share->getSharedWith());
+			$this->assertEquals('shareOwner', $share->getShareOwner());
+			$this->assertEquals('sharedBy', $share->getSharedBy());
+			$this->assertEquals(IShare::TYPE_GROUP, $share->getShareType());
+		}
+	}
+
 	/**
 	 * @dataProvider storageAndFileNameProvider
 	 */


### PR DESCRIPTION
## TODO

- [x] Remove the item_type from the query so other indices can be used
- [x] Split the getSharedWith() method
- [ ] The removed orderBy makes unit test flaky on Postgres...

### Split the getSharedWith() method

- User and group shares
- "get all" (mount logic) and "get some"

To improve the performance of the "get all" it was extracted into
yet another method, to allow to further optimize it.
E.g. the query was split into reading the shares and reading the
filecache, which will be required for future work with sharding anyway.
Without limits we also don't need to sort the entries.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
    - [ ] Could be considered partially