### PR TITLE
[stable28] fix(tests): Adjust mariadb testing matrix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1766,4 +1766,4 @@ trigger:
     - push
 ---
 kind: signature
-hmac: 8ffbbff9ef7aae684f6f1dc241390faf2fa336dac3b4773c42e9c04e17660e24
+hmac: f429112ae02a1b21b9d6b80e6558ed6ddf29819f04fae4a5790933eaf86ef414

--- a/.drone.yml
+++ b/.drone.yml
@@ -272,14 +272,14 @@ trigger:
 
 ---
 kind: pipeline
-name: mariadb10.2-php8.0
+name: mariadb10.3-php8.0
 
 steps:
 - name: submodules
   image: ghcr.io/nextcloud/continuous-integration-alpine-git:latest
   commands:
     - git submodule update --init
-- name: mariadb10.2-php8.0
+- name: mariadb10.3-php8.0
   image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
   commands:
     - bash tests/drone-run-php-tests.sh || exit 0
@@ -289,7 +289,7 @@ services:
 - name: cache
   image: ghcr.io/nextcloud/continuous-integration-redis:latest
 - name: mariadb
-  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.2:10.2
+  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.3:latest
   environment:
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: oc_autotest
@@ -310,14 +310,14 @@ trigger:
 
 ---
 kind: pipeline
-name: mariadb10.4-php8.0
+name: mariadb10.5-php8.0
 
 steps:
 - name: submodules
   image: ghcr.io/nextcloud/continuous-integration-alpine-git:latest
   commands:
     - git submodule update --init
-- name: mariadb10.4-php8.0
+- name: mariadb10.5-php8.0
   image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
   commands:
     - bash tests/drone-run-php-tests.sh || exit 0
@@ -327,7 +327,7 @@ services:
 - name: cache
   image: ghcr.io/nextcloud/continuous-integration-redis:latest
 - name: mariadb
-  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.4:10.4
+  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.5:latest
   environment:
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: oc_autotest
@@ -366,6 +366,44 @@ services:
   image: ghcr.io/nextcloud/continuous-integration-redis:latest
 - name: mariadb
   image: ghcr.io/nextcloud/continuous-integration-mariadb-10.6:latest
+  environment:
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: oc_autotest
+    MYSQL_PASSWORD: owncloud
+    MYSQL_DATABASE: oc_autotest
+  command:
+    - --sql-mode=ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION
+  tmpfs:
+    - /var/lib/mysql
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+
+---
+kind: pipeline
+name: mariadb10.11-php8.2
+
+steps:
+- name: submodules
+  image: ghcr.io/nextcloud/continuous-integration-alpine-git:latest
+  commands:
+    - git submodule update --init
+- name: mariadb10.11-php8.2
+  image: ghcr.io/nextcloud/continuous-integration-php8.2:latest
+  commands:
+    - bash tests/drone-run-php-tests.sh || exit 0
+    - NOCOVERAGE=true TEST_SELECTION=DB ./autotest.sh mariadb
+
+services:
+- name: cache
+  image: ghcr.io/nextcloud/continuous-integration-redis:latest
+- name: mariadb
+  image: ghcr.io/nextcloud/continuous-integration-mariadb-10.11:latest
   environment:
     MYSQL_ROOT_PASSWORD: owncloud
     MYSQL_USER: oc_autotest


### PR DESCRIPTION
* For https://github.com/nextcloud/documentation/pull/11517#pullrequestreview-1871430916

## Summary

Add current LTS 10.11 for testing and 10.3 as we support this for Ubuntu 20.04

## TODO

- [x] Requires https://github.com/nextcloud/docker-ci/pull/627
- [x] Sign drone config @nickvergessen 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
