### PR TITLE
[stable26] fix(sharing): Avoid (dead)locking during orphan deletion

### DIFF
--- a/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
+++ b/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2016, ownCloud, Inc.
  *
@@ -24,13 +27,29 @@
  */
 namespace OCA\Files_Sharing;
 
+use OCP\AppFramework\Db\TTransactional;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PDO;
+use Psr\Log\LoggerInterface;
+use function array_map;
 
 /**
  * Delete all share entries that have no matching entries in the file cache table.
  */
-class DeleteOrphanedSharesJob extends TimedJob {
+class DeleteOrphanedSharesJob extends TimedJob
+{
+
+	use TTransactional;
+
+	private const CHUNK_SIZE = 1000;
+
+	private IDBConnection $db;
+
+	private LoggerInterface $logger;
+
 	/**
 	 * Default interval in minutes
 	 *
@@ -41,10 +60,16 @@ class DeleteOrphanedSharesJob extends TimedJob {
 	/**
 	 * sets the correct interval for this timed job
 	 */
-	public function __construct(ITimeFactory $time) {
+	public function __construct(ITimeFactory    $time,
+								IDBConnection   $db,
+								LoggerInterface $logger)
+	{
 		parent::__construct($time);
 
+		$this->db = $db;
+
 		$this->interval = $this->defaultIntervalMin * 60;
+		$this->logger = $logger;
 	}
 
 	/**
@@ -53,15 +78,43 @@ class DeleteOrphanedSharesJob extends TimedJob {
 	 * @param array $argument unused argument
 	 */
 	public function run($argument) {
-		$connection = \OC::$server->getDatabaseConnection();
-		$logger = \OC::$server->getLogger();
-
-		$sql =
-			'DELETE FROM `*PREFIX*share` ' .
-			'WHERE `item_type` in (\'file\', \'folder\') ' .
-			'AND NOT EXISTS (SELECT `fileid` FROM `*PREFIX*filecache` WHERE `file_source` = `fileid`)';
-
-		$deletedEntries = $connection->executeUpdate($sql);
-		$logger->debug("$deletedEntries orphaned share(s) deleted", ['app' => 'DeleteOrphanedSharesJob']);
+		$qbSelect = $this->db->getQueryBuilder();
+		$qbSelect->select('id')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'fc', $qbSelect->expr()->eq('s.file_source', 'fc.fileid'))
+			->where($qbSelect->expr()->isNull('fc.fileid'))
+			->setMaxResults(self::CHUNK_SIZE);
+		$deleteQb = $this->db->getQueryBuilder();
+		$deleteQb->delete('share')
+			->where(
+				$deleteQb->expr()->in('id', $deleteQb->createParameter('ids'), IQueryBuilder::PARAM_INT_ARRAY)
+			);
+		/**
+		 * Read a chunk of orphan rows and delete them. Continue as long as the
+		 * chunk is filled.
+		 *
+		 * Note: With isolation level READ COMMITTED, the database will allow
+		 * other transactions to delete rows between our SELECT and DELETE. In
+		 * that (unlikely) case, our DELETE will have fewer affected rows than
+		 * IDs passed for the WHERE IN. If this happens while processing a full
+		 * chunk, the logic below will stop prematurely.
+		 * Note: The queries below are optimized for low database locking. They
+		 * could be combined into one single DELETE with join or sub query, but
+		 * that has shown to (dead)lock often.
+		 */
+		do {
+			$deleted = $this->atomic(function () use ($qbSelect, $deleteQb) {
+				$result = $qbSelect->executeQuery();
+				$ids = array_map('intval', $result->fetchAll(PDO::FETCH_COLUMN));
+				$result->closeCursor();
+				$deleteQb->setParameter('ids', $ids, IQueryBuilder::PARAM_INT_ARRAY);
+				$deleted = $deleteQb->executeStatement();
+				$this->logger->debug("{deleted} orphaned share(s) deleted", [
+					'app' => 'DeleteOrphanedSharesJob',
+					'deleted' => $deleted,
+				]);
+				return $deleted;
+			}, $this->db);
+		} while ($deleted >= self::CHUNK_SIZE);
 	}
 }

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -93,7 +93,8 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
 
-		$this->job = \OCP\Server::get(DeleteOrphanedSharesJob::class);	}
+		$this->job = \OCP\Server::get(DeleteOrphanedSharesJob::class);	
+	}
 
 	protected function tearDown(): void {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -27,7 +27,6 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\DeleteOrphanedSharesJob;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Share\IShare;
 
 /**
@@ -94,8 +93,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
 
-		$this->job = new DeleteOrphanedSharesJob(\OCP\Server::get(ITimeFactory::class));
-	}
+		$this->job = \OCP\Server::get(DeleteOrphanedSharesJob::class);	}
 
 	protected function tearDown(): void {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->
* backport of #43252

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
