### PR TITLE
chore(CI): Migrate autocheckers from Drone to GitHub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -164,4 +164,4 @@ trigger:
 
 ---
 kind: signature
-hmac: a4f9a3fec27fbd14dfb478902b7b5cbc155916a309f05fe6eb78961b3db18c3a
+hmac: e34c8c2ca36355a8dcaf01c7bd14c53bd42d25a4d631533e2c8109e2690c2a98

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,28 +1,5 @@
 ---
 kind: pipeline
-name: checkers
-
-steps:
-- name: submodules
-  image: ghcr.io/nextcloud/continuous-integration-alpine-git:latest
-  commands:
-    - git submodule update --init
-- name: checkers
-  image: ghcr.io/nextcloud/continuous-integration-php8.0:latest
-  commands:
-    - ./autotest-checkers.sh
-  secrets: [ github_token ]
-
-trigger:
-  branch:
-    - master
-    - stable*
-  event:
-    - pull_request
-    - push
-
----
-kind: pipeline
 name: litmus
 
 steps:

--- a/.github/workflows/autocheckers.yml
+++ b/.github/workflows/autocheckers.yml
@@ -1,0 +1,96 @@
+name: Code checkers
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: autocheckers-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest-low
+
+    outputs:
+      src: ${{ steps.changes.outputs.src }}
+
+    steps:
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '.github/workflows/**'
+              - '3rdparty/**'
+              - '**/appinfo/**'
+              - '**/lib/**'
+              - '**/templates/**'
+              - 'vendor/**'
+              - 'vendor-bin/**'
+              - 'composer.json'
+              - 'composer.lock'
+              - '**.php'
+
+  autocheckers:
+    runs-on: ubuntu-latest
+
+    needs: changes
+    if: needs.changes.outputs.src != 'false'
+
+    strategy:
+      matrix:
+        php-versions: ['8.3']
+
+    name: PHP checkers
+
+    steps:
+      - name: Checkout server
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        with:
+          submodules: true
+
+      - name: Set up php ${{ matrix.php-versions }}
+        uses: shivammathur/setup-php@7fdd3ece872ec7ec4c098ae5ab7637d5e0a96067 # v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: ctype, json, mbstring
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up dependencies
+        run: composer i
+
+      - name: Check auto loaders
+        run: bash ./build/autoloaderchecker.sh
+
+      - name: Check translations are JSON decodeable
+        run: php ./build/translation-checker.php
+
+      - name: Check translations do not contain triple dot but ellipsis
+        run: php ./build/triple-dot-checker.php
+
+      - name: Check .htaccess does not contain invalid changes
+        run: php ./build/htaccess-checker.php
+
+      - name: Check that all and only expected files are included
+        run: php ./build/files-checker.php
+
+  summary:
+    permissions:
+      contents: none
+    runs-on: ubuntu-latest-low
+    needs: [changes, autocheckers]
+
+    if: always()
+
+    name: autocheckers-summary
+
+    steps:
+      - name: Summary status
+        run: if ${{ needs.changes.outputs.src != 'false' && needs.autocheckers.result != 'success' }}; then exit 1; fi


### PR DESCRIPTION
* For #41187 

## Summary
Migrate the code checkers.

## TODO

- [x] @nickvergessen needs to sign the drone config.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
