### PR TITLE
fix(user_ldap): Do not block access to configuration page upon bad configuration

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -241,6 +241,7 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
+	 * @throws ServerNotAvailableException When connection failed or configuration is invalid
 	 * @return resource|\LDAP\Connection The LDAP resource
 	 */
 	public function getConnectionResource() {


### PR DESCRIPTION
- Resolve #43524

## Summary

It should be possible to access configuration page with the local admin
 user even when LDAP configuration is not valid.
This prevent ldap backend from throwing in countUsers to allow this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
