### PR TITLE
enh(log): exit log() earlier if no crashreport registered

### DIFF
--- a/lib/private/EventDispatcher/EventDispatcher.php
+++ b/lib/private/EventDispatcher/EventDispatcher.php
@@ -33,29 +33,17 @@ use OCP\Broadcast\Events\IBroadcastEvent;
 use OCP\EventDispatcher\ABroadcastedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IContainer;
 use OCP\IServerContainer;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyDispatcher;
 use function get_class;
 
 class EventDispatcher implements IEventDispatcher {
-	/** @var SymfonyDispatcher */
-	private $dispatcher;
-
-	/** @var IContainer */
-	private $container;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	public function __construct(SymfonyDispatcher $dispatcher,
-		IServerContainer $container,
-		LoggerInterface $logger) {
-		$this->dispatcher = $dispatcher;
-		$this->container = $container;
-		$this->logger = $logger;
-
+	public function __construct(
+		private SymfonyDispatcher $dispatcher,
+		private IServerContainer $container,
+		private LoggerInterface $logger,
+	) {
 		// inject the event dispatcher into the logger
 		// this is done here because there is a cyclic dependency between the event dispatcher and logger
 		if ($this->logger instanceof Log || $this->logger instanceof Log\PsrLoggerAdapter) {
@@ -84,6 +72,10 @@ class EventDispatcher implements IEventDispatcher {
 		);
 
 		$this->addListener($eventName, $listener, $priority);
+	}
+
+	public function hasListeners(string $eventName): bool {
+		return $this->dispatcher->hasListeners($eventName);
 	}
 
 	/**

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -62,24 +62,22 @@ use function strtr;
  * MonoLog is an example implementing this interface.
  */
 class Log implements ILogger, IDataLogger {
-	private IWriter $logger;
 	private ?SystemConfig $config;
 	private ?bool $logConditionSatisfied = null;
 	private ?Normalizer $normalizer;
-	private ?IRegistry $crashReporters;
 	private ?IEventDispatcher $eventDispatcher;
 
 	/**
 	 * @param IWriter $logger The logger that should be used
-	 * @param SystemConfig $config the system config object
+	 * @param SystemConfig|null $config the system config object
 	 * @param Normalizer|null $normalizer
-	 * @param IRegistry|null $registry
+	 * @param IRegistry|null $crashReporters
 	 */
 	public function __construct(
-		IWriter $logger,
+		private IWriter $logger,
 		SystemConfig $config = null,
 		Normalizer $normalizer = null,
-		IRegistry $registry = null
+		private	?IRegistry $crashReporters = null
 	) {
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if ($config === null) {
@@ -87,13 +85,11 @@ class Log implements ILogger, IDataLogger {
 		}
 
 		$this->config = $config;
-		$this->logger = $logger;
 		if ($normalizer === null) {
 			$this->normalizer = new Normalizer();
 		} else {
 			$this->normalizer = $normalizer;
 		}
-		$this->crashReporters = $registry;
 		$this->eventDispatcher = null;
 	}
 
@@ -211,6 +207,9 @@ class Log implements ILogger, IDataLogger {
 	 */
 	public function log(int $level, string $message, array $context = []) {
 		$minLevel = $this->getLogLevel($context);
+		if ($level < $minLevel && (($this->crashReporters?->hasReporters() ?? false) === false)) {
+			return; // we already know that log will be fully ignored
+		}
 
 		array_walk($context, [$this->normalizer, 'format']);
 
@@ -241,9 +240,7 @@ class Log implements ILogger, IDataLogger {
 					$this->crashReporters->delegateMessage($entry['message'], $messageContext);
 				}
 			} else {
-				if ($this->crashReporters !== null) {
-					$this->crashReporters->delegateBreadcrumb($entry['message'], 'log', $context);
-				}
+				$this->crashReporters?->delegateBreadcrumb($entry['message'], 'log', $context);
 			}
 		} catch (Throwable $e) {
 			// make sure we dont hard crash if logging fails
@@ -329,8 +326,8 @@ class Log implements ILogger, IDataLogger {
 		$level = $context['level'] ?? ILogger::ERROR;
 
 		$minLevel = $this->getLogLevel($context);
-		if ($level < $minLevel && ($this->crashReporters === null || !$this->crashReporters->hasReporters())) {
-			return;
+		if ($level < $minLevel && (($this->crashReporters?->hasReporters() ?? false) === false)) {
+			return; // we already know that log will be fully ignored
 		}
 
 		// if an error is raised before the autoloader is properly setup, we can't serialize exceptions

--- a/lib/public/EventDispatcher/IEventDispatcher.php
+++ b/lib/public/EventDispatcher/IEventDispatcher.php
@@ -71,6 +71,15 @@ interface IEventDispatcher {
 
 	/**
 	 * @template T of \OCP\EventDispatcher\Event
+	 * @param string $eventName preferably the fully-qualified class name of the Event sub class
+	 *
+	 * @return bool TRUE if event has registered listeners
+	 * @since 29.0.0
+	 */
+	public function hasListeners(string $eventName): bool;
+
+	/**
+	 * @template T of \OCP\EventDispatcher\Event
 	 * @param string $eventName
 	 * @psalm-param string|class-string<T> $eventName
 	 * @param Event $event


### PR DESCRIPTION
follow-up on the previous improvement from @juliushaertl : https://github.com/nextcloud/server/pull/35970

The idea is to avoid some formatting of the payload as soon as we know for sure that it will not be used