### PR TITLE
minor syntax update

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -62,38 +62,26 @@ use function strtr;
  * MonoLog is an example implementing this interface.
  */
 class Log implements ILogger, IDataLogger {
-	private ?SystemConfig $config;
 	private ?bool $logConditionSatisfied = null;
-	private ?Normalizer $normalizer;
-	private ?IEventDispatcher $eventDispatcher;
+	private ?IEventDispatcher $eventDispatcher = null;
 
-	/**
-	 * @param IWriter $logger The logger that should be used
-	 * @param SystemConfig|null $config the system config object
-	 * @param Normalizer|null $normalizer
-	 * @param IRegistry|null $crashReporters
-	 */
 	public function __construct(
 		private IWriter $logger,
-		SystemConfig $config = null,
-		Normalizer $normalizer = null,
-		private	?IRegistry $crashReporters = null
+		private ?SystemConfig $config = null,
+		private ?Normalizer $normalizer = null,
+		private ?IRegistry $crashReporters = null
 	) {
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if ($config === null) {
-			$config = \OC::$server->getSystemConfig();
+			$this->config = \OCP\Server::get(SystemConfig::class);
 		}
 
-		$this->config = $config;
 		if ($normalizer === null) {
 			$this->normalizer = new Normalizer();
-		} else {
-			$this->normalizer = $normalizer;
 		}
-		$this->eventDispatcher = null;
 	}
 
-	public function setEventDispatcher(IEventDispatcher $eventDispatcher) {
+	public function setEventDispatcher(IEventDispatcher $eventDispatcher): void {
 		$this->eventDispatcher = $eventDispatcher;
 	}
 
@@ -102,9 +90,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function emergency(string $message, array $context = []) {
+	public function emergency(string $message, array $context = []): void {
 		$this->log(ILogger::FATAL, $message, $context);
 	}
 
@@ -116,9 +103,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function alert(string $message, array $context = []) {
+	public function alert(string $message, array $context = []): void {
 		$this->log(ILogger::ERROR, $message, $context);
 	}
 
@@ -129,9 +115,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function critical(string $message, array $context = []) {
+	public function critical(string $message, array $context = []): void {
 		$this->log(ILogger::ERROR, $message, $context);
 	}
 
@@ -141,9 +126,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function error(string $message, array $context = []) {
+	public function error(string $message, array $context = []): void {
 		$this->log(ILogger::ERROR, $message, $context);
 	}
 
@@ -155,9 +139,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function warning(string $message, array $context = []) {
+	public function warning(string $message, array $context = []): void {
 		$this->log(ILogger::WARN, $message, $context);
 	}
 
@@ -166,9 +149,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function notice(string $message, array $context = []) {
+	public function notice(string $message, array $context = []): void {
 		$this->log(ILogger::INFO, $message, $context);
 	}
 
@@ -179,9 +161,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function info(string $message, array $context = []) {
+	public function info(string $message, array $context = []): void {
 		$this->log(ILogger::INFO, $message, $context);
 	}
 
@@ -190,9 +171,8 @@ class Log implements ILogger, IDataLogger {
 	 *
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function debug(string $message, array $context = []) {
+	public function debug(string $message, array $context = []): void {
 		$this->log(ILogger::DEBUG, $message, $context);
 	}
 
@@ -203,9 +183,8 @@ class Log implements ILogger, IDataLogger {
 	 * @param int $level
 	 * @param string $message
 	 * @param array $context
-	 * @return void
 	 */
-	public function log(int $level, string $message, array $context = []) {
+	public function log(int $level, string $message, array $context = []): void {
 		$minLevel = $this->getLogLevel($context);
 		if ($level < $minLevel
 			&& (($this->crashReporters?->hasReporters() ?? false) === false)
@@ -247,7 +226,7 @@ class Log implements ILogger, IDataLogger {
 		}
 	}
 
-	public function getLogLevel($context) {
+	public function getLogLevel($context): int {
 		$logCondition = $this->config->getValue('log.condition', []);
 
 		/**
@@ -297,20 +276,16 @@ class Log implements ILogger, IDataLogger {
 		}
 
 		if (isset($context['app'])) {
-			$app = $context['app'];
-
 			/**
 			 * check log condition based on the context of each log message
 			 * once this is met -> change the required log level to debug
 			 */
-			if (!empty($logCondition)
-				&& isset($logCondition['apps'])
-				&& in_array($app, $logCondition['apps'], true)) {
+			if (in_array($context['app'], $logCondition['apps'] ?? [], true)) {
 				return ILogger::DEBUG;
 			}
 		}
 
-		return min($this->config->getValue('loglevel', ILogger::WARN), ILogger::FATAL);
+		return min($this->config->getValue('loglevel', ILogger::WARN) ?? ILogger::WARN, ILogger::FATAL);
 	}
 
 	/**
@@ -321,7 +296,7 @@ class Log implements ILogger, IDataLogger {
 	 * @return void
 	 * @since 8.2.0
 	 */
-	public function logException(Throwable $exception, array $context = []) {
+	public function logException(Throwable $exception, array $context = []): void {
 		$app = $context['app'] ?? 'no app in context';
 		$level = $context['level'] ?? ILogger::ERROR;
 
@@ -395,7 +370,7 @@ class Log implements ILogger, IDataLogger {
 	 * @param string|array $entry
 	 * @param int $level
 	 */
-	protected function writeLog(string $app, $entry, int $level) {
+	protected function writeLog(string $app, $entry, int $level): void {
 		$this->logger->write($app, $entry, $level);
 	}
 

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -67,15 +67,11 @@ class Log implements ILogger, IDataLogger {
 
 	public function __construct(
 		private IWriter $logger,
-		private ?SystemConfig $config = null,
+		private SystemConfig $config,
 		private ?Normalizer $normalizer = null,
 		private ?IRegistry $crashReporters = null
 	) {
-		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
-		if ($config === null) {
-			$this->config = \OCP\Server::get(SystemConfig::class);
-		}
-
+		// FIXME: php8.1 allows "private Normalizer $normalizer = new Normalizer()," in initializer
 		if ($normalizer === null) {
 			$this->normalizer = new Normalizer();
 		}


### PR DESCRIPTION
Some small minor syntax update.

I have currently no idea how we can manage this FIXME:

https://github.com/nextcloud/server/blob/b8272ea51916cb8178edc55afbc3c51d4b48fa9d/lib/private/Log.php#L74-L77

It comes from a 9 years old commit https://github.com/nextcloud/server/commit/e79c255cabecb768061bb58ea508a38011ef6284
🫂 @MorrisJobke 

2 solutions: 
- removing the code and the null type of `$config`
- or removing the FIXME comment line.

 

