### PR TITLE
Backport PR "Add support for application/scim+json" to `stable25`

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -108,7 +108,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	protected $contentDecoded = false;
 
 	/** @var string */
-	protected string $jsonContentTypeRegex = '/application\/(\w+\+)?json/';
+	protected string $jsonContentTypeRegex = '{^application/(?:[a-z0-9.-]+\+)?json\b}';
 
 	/**
 	 * @param array $vars An associative array with the following optional values:

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -107,9 +107,6 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/** @var bool */
 	protected $contentDecoded = false;
 
-	/** @var string */
-	protected string $jsonContentTypeRegex = '{^application/(?:[a-z0-9.-]+\+)?json\b}';
-
 	/**
 	 * @param array $vars An associative array with the following optional values:
 	 *        - array 'urlParams' the parameters which were matched from the URL
@@ -444,7 +441,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		$params = [];
 
 		// 'application/json' and other JSON-related content types must be decoded manually.
-		if (preg_match($this->jsonContentTypeRegex, $this->getHeader('Content-Type')) === 1) {
+		if (preg_match(self::JSON_CONTENT_TYPE_REGEX, $this->getHeader('Content-Type')) === 1) {
 			$params = json_decode(file_get_contents($this->inputStream), true);
 			if ($params !== null && \count($params) > 0) {
 				$this->items['params'] = $params;

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -107,6 +107,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/** @var bool */
 	protected $contentDecoded = false;
 
+	protected $jsonContentTypeRegex = '/application\/(\w+\+)?json/';
+
 	/**
 	 * @param array $vars An associative array with the following optional values:
 	 *        - array 'urlParams' the parameters which were matched from the URL
@@ -407,13 +409,13 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			&& $this->getHeader('Content-Length') !== '0'
 			&& $this->getHeader('Content-Length') !== ''
 			&& strpos($this->getHeader('Content-Type'), 'application/x-www-form-urlencoded') === false
-			&& strpos($this->getHeader('Content-Type'), 'application/json') === false
-			&& strpos($this->getHeader('Content-Type'), 'application/scim+json') === false
+			&& preg_match($this->jsonContentTypeRegex, $this->getHeader('Content-Type')) === 0
 		) {
 			if ($this->content === false) {
 				throw new \LogicException(
 					'"put" can only be accessed once if not '
-					. 'application/x-www-form-urlencoded or application/json.'
+					. 'application/x-www-form-urlencoded, application/json '
+					. 'or other content type, related to JSON (like application/scim+json).'
 				);
 			}
 			$this->content = false;
@@ -441,9 +443,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 		$params = [];
 
-		// 'application/json' and 'application/scim+json' must be decoded manually.
-		if (strpos($this->getHeader('Content-Type'), 'application/json') !== false
-			|| strpos($this->getHeader('Content-Type'), 'application/scim+json') !== false) {
+		// 'application/json' and other JSON-related content types must be decoded manually.
+		if (preg_match($this->jsonContentTypeRegex, $this->getHeader('Content-Type')) === 1) {
 			$params = json_decode(file_get_contents($this->inputStream), true);
 			if ($params !== null && \count($params) > 0) {
 				$this->items['params'] = $params;

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -107,7 +107,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/** @var bool */
 	protected $contentDecoded = false;
 
-	protected $jsonContentTypeRegex = '/application\/(\w+\+)?json/';
+	/** @var string */
+	protected string $jsonContentTypeRegex = '/application\/(\w+\+)?json/';
 
 	/**
 	 * @param array $vars An associative array with the following optional values:
@@ -409,13 +410,12 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			&& $this->getHeader('Content-Length') !== '0'
 			&& $this->getHeader('Content-Length') !== ''
 			&& strpos($this->getHeader('Content-Type'), 'application/x-www-form-urlencoded') === false
-			&& preg_match($this->jsonContentTypeRegex, $this->getHeader('Content-Type')) === 0
+			&& strpos($this->getHeader('Content-Type'), 'application/json') === false
 		) {
 			if ($this->content === false) {
 				throw new \LogicException(
 					'"put" can only be accessed once if not '
-					. 'application/x-www-form-urlencoded, application/json '
-					. 'or other content type, related to JSON (like application/scim+json).'
+					. 'application/x-www-form-urlencoded or application/json.'
 				);
 			}
 			$this->content = false;

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -441,17 +441,9 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 		$params = [];
 
-		// 'application/json' must be decoded manually.
-		if (strpos($this->getHeader('Content-Type'), 'application/json') !== false) {
-			$params = json_decode(file_get_contents($this->inputStream), true);
-			if (\is_array($params) && \count($params) > 0) {
-				$this->items['params'] = $params;
-				if ($this->method === 'POST') {
-					$this->items['post'] = $params;
-				}
-			}
-		// 'application/scim+json' must be decoded manually.
-		} elseif (strpos($this->getHeader('Content-Type'), 'application/scim+json') !== false) {
+		// 'application/json' and 'application/scim+json' must be decoded manually.
+		if (strpos($this->getHeader('Content-Type'), 'application/json') !== false
+			|| strpos($this->getHeader('Content-Type'), 'application/scim+json') !== false) {
 			$params = json_decode(file_get_contents($this->inputStream), true);
 			if ($params !== null && \count($params) > 0) {
 				$this->items['params'] = $params;

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -99,8 +99,9 @@ interface IRequest {
 
 	/**
 	 * @var string
+	 * @since 26.0.0
 	 */
-	public const JSON_CONTENT_TYPE_REGEX = '{^application/(?:[a-z0-9.-]+\+)?json\b}';
+	public const JSON_CONTENT_TYPE_REGEX = '/^application\/(?:[a-z0-9.-]+\+)?json\b/';
 
 	/**
 	 * @param string $name

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -98,7 +98,6 @@ interface IRequest {
 	public const USER_AGENT_THUNDERBIRD_ADDON = '/^Mozilla\/5\.0 \([A-Za-z ]+\) Nextcloud\-Thunderbird v.*$/';
 
 	/**
-	 * @var string
 	 * @since 26.0.0
 	 */
 	public const JSON_CONTENT_TYPE_REGEX = '/^application\/(?:[a-z0-9.-]+\+)?json\b/';

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -98,6 +98,11 @@ interface IRequest {
 	public const USER_AGENT_THUNDERBIRD_ADDON = '/^Mozilla\/5\.0 \([A-Za-z ]+\) Nextcloud\-Thunderbird v.*$/';
 
 	/**
+	 * @var string
+	 */
+	public const JSON_CONTENT_TYPE_REGEX = '{^application/(?:[a-z0-9.-]+\+)?json\b}';
+
+	/**
 	 * @param string $name
 	 *
 	 * @psalm-taint-source input

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -208,14 +208,6 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('Joey', $request['nickname']);
 	}
 
-	public function notJsonDataProvider() {
-		return [
-			['this is not valid json'],
-			['"just a string"'],
-			['{"just a string"}'],
-		];
-	}
-
 	public function testScimJsonPost() {
 		global $data;
 		$data = '{"userName":"testusername", "displayName":"Example User"}';
@@ -264,9 +256,20 @@ class RequestTest extends \Test\TestCase {
 		$this->assertSame('someothertestvalue', $result['propertyB']);
 	}
 
-	public function testNotJsonPost() {
+	public function notJsonDataProvider() {
+		return [
+			['this is not valid json'],
+			['"just a string"'],
+			['{"just a string"}'],
+		];
+	}
+
+	/**
+	 * @dataProvider notJsonDataProvider
+	 */
+	public function testNotJsonPost($testData) {
 		global $data;
-		$data = 'this is not valid json';
+		$data = $testData;
 		$vars = [
 			'method' => 'POST',
 			'server' => ['CONTENT_TYPE' => 'application/json; utf-8']

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -2,6 +2,7 @@
 /**
  * @copyright 2013 Thomas Tanghus (thomas@tanghus.net)
  * @copyright 2016 Lukas Reschke lukas@owncloud.com
+ * @copyright 2022 Stanimir Bozhilov (stanimir@audriga.com)
  *
  * This file is licensed under the Affero General Public License version 3 or
  * later.
@@ -239,6 +240,51 @@ class RequestTest extends \Test\TestCase {
 		// ensure there's no error attempting to decode the content
 	}
 
+	public function testScimJsonPost() {
+		global $data;
+		$data = '{"userName":"testusername", "displayName":"Example User"}';
+		$vars = [
+			'method' => 'POST',
+			'server' => ['CONTENT_TYPE' => 'application/scim+json; utf-8']
+		];
+
+		$request = new Request(
+			$vars,
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame('POST', $request->method);
+		$result = $request->post;
+		$this->assertSame('testusername', $result['userName']);
+		$this->assertSame('Example User', $result['displayName']);
+		$this->assertSame('Example User', $request->params['displayName']);
+		$this->assertSame('Example User', $request['displayName']);
+	}
+
+	public function testNotScimJsonPost() {
+		global $data;
+		$data = 'this is not valid scim json';
+		$vars = [
+			'method' => 'POST',
+			'server' => ['CONTENT_TYPE' => 'application/scim+json; utf-8']
+		];
+
+		$request = new Request(
+			$vars,
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertEquals('POST', $request->method);
+		$result = $request->post;
+		// ensure there's no error attempting to decode the content
+	}
+
 	public function testPatch() {
 		global $data;
 		$data = http_build_query(['name' => 'John Q. Public', 'nickname' => 'Joey'], '', '&');
@@ -307,6 +353,52 @@ class RequestTest extends \Test\TestCase {
 
 		$this->assertSame('John Q. Public', $result['name']);
 		$this->assertSame(null, $result['nickname']);
+	}
+
+	public function testScimJsonPatchAndPut() {
+		global $data;
+
+		// PUT content
+		$data = '{"userName": "sometestusername", "displayName": "Example User"}';
+		$vars = [
+			'method' => 'PUT',
+			'server' => ['CONTENT_TYPE' => 'application/scim+json; utf-8'],
+		];
+
+		$request = new Request(
+			$vars,
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame('PUT', $request->method);
+		$result = $request->put;
+
+		$this->assertSame('sometestusername', $result['userName']);
+		$this->assertSame('Example User', $result['displayName']);
+
+		// PATCH content
+		$data = '{"userName": "sometestusername", "displayName": null}';
+		$vars = [
+			'method' => 'PATCH',
+			'server' => ['CONTENT_TYPE' => 'application/scim+json; utf-8'],
+		];
+
+		$request = new Request(
+			$vars,
+			$this->requestId,
+			$this->config,
+			$this->csrfTokenManager,
+			$this->stream
+		);
+
+		$this->assertSame('PATCH', $request->method);
+		$result = $request->patch;
+
+		$this->assertSame('sometestusername', $result['userName']);
+		$this->assertSame(null, $result['displayName']);
 	}
 
 	public function testPutStream() {


### PR DESCRIPTION
* Resolves: #33973 

## Summary
This PR is a backport of #34172 to `stable25` (cf. https://github.com/nextcloud/server/issues/33973#issuecomment-1705413738)

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
