### PR TITLE
Do not show full storage notification to users with 0 Bytes quota

### DIFF
--- a/apps/files/src/components/NavigationQuota.vue
+++ b/apps/files/src/components/NavigationQuota.vue
@@ -88,8 +88,8 @@ export default {
 	},
 
 	mounted() {
-		// Warn the user if the available storage is 0 on page load
-		if (this.storageStats?.free <= 0) {
+		// Warn the user if the available storage is 0 on page load, except for users with 0 B quota
+		if (this.storageStats?.free <= 0 && this.storageStats?.quota != 0) {
 			this.showStorageFullWarning()
 		}
 	},


### PR DESCRIPTION
* Resolves: #43535

## Summary

Do not show “Your storage is full, files can not be updated or synced anymore!” notification to users with quota set to 0 Bytes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
