### PR TITLE
Include error message in speech-to-text failure event

### DIFF
--- a/lib/private/SpeechToText/SpeechToTextManager.php
+++ b/lib/private/SpeechToText/SpeechToTextManager.php
@@ -141,6 +141,7 @@ class SpeechToTextManager implements ISpeechToTextManager {
 				return $provider->transcribeFile($file);
 			} catch (\Throwable $e) {
 				$this->logger->info('SpeechToText transcription using provider ' . $provider->getName() . ' failed', ['exception' => $e]);
+				throw new RuntimeException('SpeechToText transcription using provider "' . $provider->getName() . '" failed: ' . $e->getMessage());
 			}
 		}
 


### PR DESCRIPTION
Use the STT provider's exception message in the RuntimeException that will be caught by upper contexts.