### PR TITLE
[stable27] fix: checkbox now allows shift-click and multi-select

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -396,7 +396,7 @@
 				self.do_delete(filename, directory);
 			});
 
-			this.$fileList.on('change', 'td.selection>.selectCheckBox', _.bind(this._onClickFileCheckbox, this));
+			this.$fileList.on('click', 'td.selection', _.bind(this._onClickFileCheckbox, this));
 			this.$fileList.on('mouseover', 'td.selection', _.bind(this._onMouseOverCheckbox, this));
 			this.$el.on('show', _.bind(this._onShow, this));
 			this.$el.on('urlChanged', _.bind(this._onUrlChanged, this));
@@ -944,8 +944,10 @@
 		 * Event handler for when clicking on a file's checkbox
 		 */
 		_onClickFileCheckbox: function(e) {
+			// to prevent double click, prevent default
+			e.preventDefault()
 			var $tr = $(e.target).closest('tr');
-			if(this._getCurrentSelectionMode() === 'range') {
+			if(this._allowSelection && e.shiftKey) {
 				this._selectRange($tr);
 			} else {
 				this._selectSingle($tr);


### PR DESCRIPTION
* Resolves #42364

## Summary
PROBLEM: Shift clicking the files in the files app of stabl27 does not allow the functionality to select multiple files at once

* Originally, I thought that this was regression within the Vue #app-content components, but after testing, I found that it was due to the logic behind our legacy PHP templates and the JS that was bundled with it
*  To fix this, shift the event to the general select class. That means that the onChange behavior is not needed - we can now use onClick and prevent the default action that causes double clicking, as we do the clicking functionality ourselves
* The check used to see if we are choosing a range did not fall in line with the other shift-select logic, so I made them now similar

🏚️ Before | 🏡 After
---|---
https://github.com/nextcloud/server/assets/110193237/cb714e8f-ac41-484c-bf88-7351612c7286 | https://github.com/nextcloud/server/assets/110193237/db975ecc-e2c4-433c-a6a9-e389c47469d2


PS.. sorry for the weird links, but the gifs showing the difference are there^


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
