### PR TITLE
fix(settings): Disable SSL cert check for JavaScript modules SetupCheck

### DIFF
--- a/apps/settings/lib/SetupChecks/JavaScriptModules.php
+++ b/apps/settings/lib/SetupChecks/JavaScriptModules.php
@@ -66,6 +66,9 @@ class JavaScriptModules implements ISetupCheck {
 				$client = $this->clientService->newClient();
 				$response = $client->head($testURL, [
 					'connect_timeout' => 10,
+					// Disable SSL certificate checks to allow self signed certs
+					'verify' => false,
+					// Allow to connect to local server
 					'nextcloud' => [
 						'allow_local_address' => true,
 					],


### PR DESCRIPTION
* Resolves: #43153 

## Summary
Some users are using self signed certs without adding them as trusted - for this test we can disable the SSL check.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
