### PR TITLE
Fix for ignored `CSP_NONCE` in ContentSecurity Header

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -14,6 +14,7 @@
 		</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 		<meta name="theme-color" content="<?php p($theme->getColorPrimary()); ?>">
+		<meta name="csp-nonce" nonce="<?php p($_['cspNonce']); /* Do not pass into "content" to prevent exfiltration */ ?>">
 		<link rel="icon" href="<?php print_unescaped(image_path('core', 'favicon.ico')); /* IE11+ supports png */ ?>">
 		<link rel="apple-touch-icon" href="<?php print_unescaped(image_path('core', 'favicon-touch.png')); ?>">
 		<link rel="mask-icon" sizes="any" href="<?php print_unescaped(image_path('core', 'favicon-mask.svg')); ?>" color="<?php p($theme->getColorPrimary()); ?>">

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -19,6 +19,7 @@
 p($theme->getTitle());
 ?>
 		</title>
+		<meta name="csp-nonce" nonce="<?php p($_['cspNonce']); /* Do not pass into "content" to prevent exfiltration */ ?>">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 		<?php if ($theme->getiTunesAppId() !== '') { ?>
 		<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">

--- a/core/templates/layout.initial-state.php
+++ b/core/templates/layout.initial-state.php
@@ -5,7 +5,7 @@
  */
 ?>
 <div id="initial-state-container" style="display: none;">
-    <?php foreach ($_['initialStates'] as $app => $initialState) { ?>
-        <input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
-    <?php }?>
+	<?php foreach ($_['initialStates'] as $app => $initialState) { ?>
+		<input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
+	<?php }?>
 </div>

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -14,6 +14,7 @@
 p($theme->getTitle());
 ?>
 	</title>
+	<meta name="csp-nonce" nonce="<?php p($_['cspNonce']); /* Do not pass into "content" to prevent exfiltration */ ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
 	<?php if ($theme->getiTunesAppId() !== '') { ?>
 	<meta name="apple-itunes-app" content="app-id=<?php p($theme->getiTunesAppId()); ?>">

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -29,6 +29,7 @@ p(!empty($_['application']) ? $_['application'].' - ' : '');
 p($theme->getTitle());
 ?>
 		</title>
+		<meta name="csp-nonce" nonce="<?php p($_['cspNonce']); /* Do not pass into "content" to prevent exfiltration */ ?>">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 		<?php if ($theme->getiTunesAppId() !== '') { ?>

--- a/lib/private/AppFramework/Middleware/Security/CSPMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CSPMiddleware.php
@@ -53,7 +53,7 @@ class CSPMiddleware extends Middleware {
 		$defaultPolicy = $this->contentSecurityPolicyManager->mergePolicies($defaultPolicy, $policy);
 
 		if ($this->cspNonceManager->browserSupportsCspV3()) {
-			$defaultPolicy->useJsNonce($this->csrfTokenManager->getToken()->getEncryptedValue());
+			$defaultPolicy->useJsNonce($this->cspNonceManager->getNonce());
 		}
 
 		$response->setContentSecurityPolicy($defaultPolicy);

--- a/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
@@ -30,7 +30,10 @@ class ContentSecurityPolicyNonceManager {
 	public function getNonce(): string {
 		if ($this->nonce === '') {
 			if (empty($this->request->server['CSP_NONCE'])) {
-				$this->nonce = base64_encode($this->csrfTokenManager->getToken()->getEncryptedValue());
+				// Get the token from the CSRF token, we only use the "shared secret" part
+				// as the first part does not add any security / entropy to the token
+				// so it can be ignored to keep the nonce short while keeping the same randomness
+				$this->nonce = end(explode(':', ($this->csrfTokenManager->getToken()->getEncryptedValue())));
 			} else {
 				$this->nonce = $this->request->server['CSP_NONCE'];
 			}

--- a/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
@@ -33,7 +33,8 @@ class ContentSecurityPolicyNonceManager {
 				// Get the token from the CSRF token, we only use the "shared secret" part
 				// as the first part does not add any security / entropy to the token
 				// so it can be ignored to keep the nonce short while keeping the same randomness
-				$this->nonce = end(explode(':', ($this->csrfTokenManager->getToken()->getEncryptedValue())));
+				$csrfSecret = explode(':', ($this->csrfTokenManager->getToken()->getEncryptedValue()));
+				$this->nonce = end($csrfSecret);
 			} else {
 				$this->nonce = $this->request->server['CSP_NONCE'];
 			}

--- a/lib/private/Template/Base.php
+++ b/lib/private/Template/Base.php
@@ -24,11 +24,14 @@ class Base {
 	 * @param string $template
 	 * @param string $requestToken
 	 * @param \OCP\IL10N $l10n
+	 * @param string $cspNonce
 	 * @param Defaults $theme
 	 */
-	public function __construct($template, $requestToken, $l10n, $theme) {
-		$this->vars = [];
-		$this->vars['requesttoken'] = $requestToken;
+	public function __construct($template, $requestToken, $l10n, $theme, $cspNonce) {
+		$this->vars = [
+			'cspNonce' => $cspNonce,
+			'requesttoken' => $requestToken,
+		];
 		$this->l10n = $l10n;
 		$this->template = $template;
 		$this->theme = $theme;

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -43,6 +43,7 @@ class OC_Template extends \OC\Template\Base {
 		$theme = OC_Util::getTheme();
 
 		$requestToken = (OC::$server->getSession() && $registerCall) ? \OCP\Util::callRegister() : '';
+		$cspNonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
 
 		$parts = explode('/', $app); // fix translation when app is something like core/lostpassword
 		$l10n = \OC::$server->getL10N($parts[0]);
@@ -56,7 +57,13 @@ class OC_Template extends \OC\Template\Base {
 		$this->path = $path;
 		$this->app = $app;
 
-		parent::__construct($template, $requestToken, $l10n, $themeDefaults);
+		parent::__construct(
+			$template,
+			$requestToken,
+			$l10n,
+			$themeDefaults,
+			$cspNonce,
+		);
 	}
 
 

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -89,7 +89,7 @@ class EmptyContentSecurityPolicy {
 	}
 
 	/**
-	 * Use the according JS nonce
+	 * Use the according base64 encoded JS nonce
 	 * This method is only for CSPMiddleware, custom values are ignored in mergePolicies of ContentSecurityPolicyManager
 	 *
 	 * @param string $nonce
@@ -448,7 +448,7 @@ class EmptyContentSecurityPolicy {
 				if ($this->strictDynamicAllowed) {
 					$scriptSrc .= '\'strict-dynamic\' ';
 				}
-				$scriptSrc .= '\'nonce-'.base64_encode($this->jsNonce).'\'';
+				$scriptSrc .= '\'nonce-'.$this->jsNonce.'\'';
 				$allowedScriptDomains = array_flip($this->allowedScriptDomains);
 				unset($allowedScriptDomains['\'self\'']);
 				$this->allowedScriptDomains = array_flip($allowedScriptDomains);

--- a/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
+++ b/lib/public/AppFramework/Http/EmptyContentSecurityPolicy.php
@@ -89,7 +89,7 @@ class EmptyContentSecurityPolicy {
 	}
 
 	/**
-	 * Use the according base64 encoded JS nonce
+	 * The base64 encoded nonce to be used for script source.
 	 * This method is only for CSPMiddleware, custom values are ignored in mergePolicies of ContentSecurityPolicyManager
 	 *
 	 * @param string $nonce

--- a/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/ContentSecurityPolicyTest.php
@@ -29,41 +29,41 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.owncloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.nextcloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.owncloud.com www.owncloud.org;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.nextcloud.com www.nextcloud.org;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowScriptDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.owncloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self' www.nextcloud.com;style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultipleStacked() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.nextcloud.org')->disallowScriptDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -75,41 +75,41 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.nextcloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com www.owncloud.org 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.nextcloud.com www.nextcloud.org 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowStyleDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.nextcloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultipleStacked() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.nextcloud.org')->disallowStyleDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -121,9 +121,9 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.owncloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' www.nextcloud.com 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -135,275 +135,275 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyImageDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.nextcloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com www.owncloud.org;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.nextcloud.com www.nextcloud.org;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowImageDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowImageDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.owncloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob: www.nextcloud.com;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowImageDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.nextcloud.org')->disallowImageDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.nextcloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com www.owncloud.org;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.nextcloud.com www.nextcloud.org;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFontDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFontDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.owncloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data: www.nextcloud.com;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFontDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.nextcloud.org')->disallowFontDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.nextcloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com www.owncloud.org;media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.nextcloud.com www.nextcloud.org;media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowConnectDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.owncloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self' www.nextcloud.com;media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.nextcloud.org')->disallowConnectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.nextcloud.com www.nextcloud.org;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowMediaDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self' www.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.nextcloud.org')->disallowMediaDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowObjectDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';object-src www.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.nextcloud.org')->disallowObjectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetAllowedFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com www.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFrameDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-src www.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.nextcloud.org')->disallowFrameDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetAllowedChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.owncloud.com child.owncloud.org;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src child.nextcloud.com child.nextcloud.org;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowChildSrcDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src www.owncloud.com;frame-ancestors 'self';form-action 'self'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';child-src www.nextcloud.com;frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.nextcloud.org')->disallowChildSrcDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -443,8 +443,8 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	public function testGetPolicyDisallowFrameAncestorDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'self';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.nextcloud.org')->disallowChildSrcDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -463,8 +463,8 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyNonce() {
-		$nonce = 'my-nonce';
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$nonce = base64_encode('my-nonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-$nonce';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->contentSecurityPolicy->useStrictDynamicOnScripts(false);
@@ -472,16 +472,16 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyNonceDefault() {
-		$nonce = 'my-nonce';
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-".base64_encode($nonce) . "';script-src-elem 'strict-dynamic' 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$nonce = base64_encode('my-nonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-$nonce';script-src-elem 'strict-dynamic' 'nonce-$nonce';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyNonceStrictDynamic() {
-		$nonce = 'my-nonce';
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$nonce = base64_encode('my-nonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-$nonce';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->contentSecurityPolicy->useStrictDynamic(true);
@@ -490,8 +490,8 @@ class ContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyNonceStrictDynamicDefault() {
-		$nonce = 'my-nonce';
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-".base64_encode($nonce) . "';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
+		$nonce = base64_encode('my-nonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-$nonce';style-src 'self' 'unsafe-inline';img-src 'self' data: blob:;font-src 'self' data:;connect-src 'self';media-src 'self';frame-ancestors 'self';form-action 'self'";
 
 		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->contentSecurityPolicy->useStrictDynamic(true);

--- a/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
+++ b/tests/lib/AppFramework/Http/EmptyContentSecurityPolicyTest.php
@@ -29,41 +29,41 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyScriptDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyScriptDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowScriptDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowScriptDomainMultipleStacked() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedScriptDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowScriptDomain('www.owncloud.org')->disallowScriptDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowScriptDomain('www.nextcloud.org')->disallowScriptDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -82,41 +82,41 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyStyleDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowStyleDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowStyleDomainMultipleStacked() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowStyleDomain('www.owncloud.org')->disallowStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowStyleDomain('www.nextcloud.org')->disallowStyleDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -128,9 +128,9 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyStyleAllowInlineWithDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.owncloud.com 'unsafe-inline';frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';style-src www.nextcloud.com 'unsafe-inline';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedStyleDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedStyleDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->allowInlineStyle(true);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
@@ -143,313 +143,317 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyImageDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyImageDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowImageDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowImageDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';img-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowImageDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedImageDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowImageDomain('www.owncloud.org')->disallowImageDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedImageDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowImageDomain('www.nextcloud.org')->disallowImageDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFontDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFontDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFontDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';font-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFontDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFontDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFontDomain('www.owncloud.org')->disallowFontDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFontDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFontDomain('www.nextcloud.org')->disallowFontDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyConnectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowConnectDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';connect-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowConnectDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedConnectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowConnectDomain('www.owncloud.org')->disallowConnectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedConnectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowConnectDomain('www.nextcloud.org')->disallowConnectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyMediaDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowMediaDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';media-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowMediaDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedMediaDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowMediaDomain('www.owncloud.org')->disallowMediaDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedMediaDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowMediaDomain('www.nextcloud.org')->disallowMediaDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValid() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyObjectDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowObjectDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';object-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowObjectDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedObjectDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowObjectDomain('www.owncloud.org')->disallowObjectDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedObjectDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowObjectDomain('www.nextcloud.org')->disallowObjectDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetAllowedFrameDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyFrameDomainValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com www.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFrameDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowFrameDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedFrameDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowFrameDomain('www.owncloud.org')->disallowFrameDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedFrameDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowFrameDomain('www.nextcloud.org')->disallowFrameDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetAllowedChildSrcDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyChildSrcValidMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.owncloud.com child.owncloud.org;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src child.nextcloud.com child.nextcloud.org;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.com');
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.nextcloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('child.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowChildSrcDomain() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultiple() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src www.owncloud.com;frame-ancestors 'none'";
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';child-src www.nextcloud.com;frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyDisallowChildSrcDomainMultipleStakes() {
 		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.owncloud.com');
-		$this->contentSecurityPolicy->disallowChildSrcDomain('www.owncloud.org')->disallowChildSrcDomain('www.owncloud.com');
+		$this->contentSecurityPolicy->addAllowedChildSrcDomain('www.nextcloud.com');
+		$this->contentSecurityPolicy->disallowChildSrcDomain('www.nextcloud.org')->disallowChildSrcDomain('www.nextcloud.com');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithJsNonceAndScriptDomains() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl' www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
+		$nonce = base64_encode('MyJsNonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-$nonce' www.nextcloud.com www.nextcloud.org;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
-		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
+		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.org');
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithJsNonceAndStrictDynamic() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-TXlKc05vbmNl' www.nextcloud.com;frame-ancestors 'none'";
+		$nonce = base64_encode('MyJsNonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-$nonce' www.nextcloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->useStrictDynamic(true);
-		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
+		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithJsNonceAndStrictDynamicAndStrictDynamicOnScripts() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-TXlKc05vbmNl' www.nextcloud.com;frame-ancestors 'none'";
+		$nonce = base64_encode('MyJsNonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'strict-dynamic' 'nonce-$nonce' www.nextcloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->useStrictDynamic(true);
 		$this->contentSecurityPolicy->useStrictDynamicOnScripts(true);
-		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
+		$this->contentSecurityPolicy->useJsNonce($nonce);
 		// Should be same as `testGetPolicyWithJsNonceAndStrictDynamic` because of fallback
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
 	public function testGetPolicyWithJsNonceAndStrictDynamicOnScripts() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl' www.nextcloud.com;script-src-elem 'strict-dynamic' 'nonce-TXlKc05vbmNl' www.nextcloud.com;frame-ancestors 'none'";
+		$nonce = base64_encode('MyJsNonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-$nonce' www.nextcloud.com;script-src-elem 'strict-dynamic' 'nonce-$nonce' www.nextcloud.com;frame-ancestors 'none'";
 
 		$this->contentSecurityPolicy->addAllowedScriptDomain('www.nextcloud.com');
 		$this->contentSecurityPolicy->useStrictDynamicOnScripts(true);
-		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
+		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}
 
@@ -461,9 +465,10 @@ class EmptyContentSecurityPolicyTest extends \Test\TestCase {
 	}
 
 	public function testGetPolicyWithJsNonceAndSelfScriptDomain() {
-		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-TXlKc05vbmNl';frame-ancestors 'none'";
+		$nonce = base64_encode('MyJsNonce');
+		$expectedPolicy = "default-src 'none';base-uri 'none';manifest-src 'self';script-src 'nonce-$nonce';frame-ancestors 'none'";
 
-		$this->contentSecurityPolicy->useJsNonce('MyJsNonce');
+		$this->contentSecurityPolicy->useJsNonce($nonce);
 		$this->contentSecurityPolicy->addAllowedScriptDomain("'self'");
 		$this->assertSame($expectedPolicy, $this->contentSecurityPolicy->buildPolicy());
 	}

--- a/tests/lib/AppFramework/Middleware/Security/CSPMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CSPMiddlewareTest.php
@@ -20,15 +20,15 @@ use OCP\AppFramework\Http\Response;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class CSPMiddlewareTest extends \Test\TestCase {
-	/** @var CSPMiddleware|MockObject */
+	/** @var CSPMiddleware&MockObject */
 	private $middleware;
-	/** @var Controller|MockObject */
+	/** @var Controller&MockObject */
 	private $controller;
-	/** @var ContentSecurityPolicyManager|MockObject */
+	/** @var ContentSecurityPolicyManager&MockObject */
 	private $contentSecurityPolicyManager;
-	/** @var CsrfTokenManager|MockObject */
+	/** @var CsrfTokenManager&MockObject */
 	private $csrfTokenManager;
-	/** @var ContentSecurityPolicyNonceManager|MockObject */
+	/** @var ContentSecurityPolicyNonceManager&MockObject */
 	private $cspNonceManager;
 
 	protected function setUp(): void {
@@ -94,14 +94,10 @@ class CSPMiddlewareTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('browserSupportsCspV3')
 			->willReturn(true);
-		$token = $this->createMock(CsrfToken::class);
-		$token
+		$token = base64_encode('the-nonce');
+		$this->cspNonceManager
 			->expects($this->once())
-			->method('getEncryptedValue')
-			->willReturn('MyEncryptedToken');
-		$this->csrfTokenManager
-			->expects($this->once())
-			->method('getToken')
+			->method('getNonce')
 			->willReturn($token);
 		$response = $this->createMock(Response::class);
 		$defaultPolicy = new ContentSecurityPolicy();

--- a/tests/lib/AppFramework/Middleware/Security/CSPMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CSPMiddlewareTest.php
@@ -12,7 +12,6 @@ use OC\AppFramework\Middleware\Security\CSPMiddleware;
 use OC\Security\CSP\ContentSecurityPolicy;
 use OC\Security\CSP\ContentSecurityPolicyManager;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
-use OC\Security\CSRF\CsrfToken;
 use OC\Security\CSRF\CsrfTokenManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\EmptyContentSecurityPolicy;

--- a/tests/lib/Security/CSP/ContentSecurityPolicyNonceManagerTest.php
+++ b/tests/lib/Security/CSP/ContentSecurityPolicyNonceManagerTest.php
@@ -13,39 +13,43 @@ use OC\AppFramework\Http\Request;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
 use OC\Security\CSRF\CsrfToken;
 use OC\Security\CSRF\CsrfTokenManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ContentSecurityPolicyNonceManagerTest extends TestCase {
-	/** @var CsrfTokenManager */
-	private $csrfTokenManager;
-	/** @var Request */
+	/** @var CsrfTokenManager&MockObject */
+	private $CSRFTokenManager;
+	/** @var Request&MockObject */
 	private $request;
 	/** @var ContentSecurityPolicyNonceManager */
 	private $nonceManager;
 
 	protected function setUp(): void {
-		$this->csrfTokenManager = $this->createMock(CsrfTokenManager::class);
+		$this->CSRFTokenManager = $this->createMock(CsrfTokenManager::class);
 		$this->request = $this->createMock(Request::class);
 		$this->nonceManager = new ContentSecurityPolicyNonceManager(
-			$this->csrfTokenManager,
+			$this->CSRFTokenManager,
 			$this->request
 		);
 	}
 
 	public function testGetNonce() {
+		$secret = base64_encode('secret');
+		$tokenValue = base64_encode('secret' ^ 'value_') . ':' . $secret;
 		$token = $this->createMock(CsrfToken::class);
 		$token
 			->expects($this->once())
 			->method('getEncryptedValue')
-			->willReturn('MyToken');
+			->willReturn($tokenValue);
 
-		$this->csrfTokenManager
+		$this->CSRFTokenManager
 			->expects($this->once())
 			->method('getToken')
 			->willReturn($token);
 
-		$this->assertSame('TXlUb2tlbg==', $this->nonceManager->getNonce());
-		$this->assertSame('TXlUb2tlbg==', $this->nonceManager->getNonce());
+		$this->assertSame($secret, $this->nonceManager->getNonce());
+		// call it twice but `getEncryptedValue` is expected to be called only once
+		$this->assertSame($secret, $this->nonceManager->getNonce());
 	}
 
 	public function testGetNonceServerVar() {
@@ -61,6 +65,7 @@ class ContentSecurityPolicyNonceManagerTest extends TestCase {
 			->willReturn(['CSP_NONCE' => $token]);
 
 		$this->assertSame($token, $this->nonceManager->getNonce());
+		// call it twice but `CSP_NONCE` variable is expected to be loaded only once
 		$this->assertSame($token, $this->nonceManager->getNonce());
 	}
 }


### PR DESCRIPTION
We should use 'cspNonceManager' for requesting the NONCE value, because it is doing the same as before, except that it honors a CPS_NONCE environment variable if available.

If a CSP_NONCE env var is defined, it is used nearly everywhere, except for setting the correct ContentSecurityPolicy Header.

This commit fixes this.