### PR TITLE
fix(settings): Deprecate old things for real

### DIFF
--- a/lib/public/Accounts/IAccountManager.php
+++ b/lib/public/Accounts/IAccountManager.php
@@ -72,6 +72,7 @@ interface IAccountManager {
 	/**
 	 * Contact details only visible locally
 	 *
+	 * @since 15.0.0
 	 * @deprecated 21.0.1
 	 */
 	public const VISIBILITY_PRIVATE = 'private';
@@ -79,6 +80,7 @@ interface IAccountManager {
 	/**
 	 * Contact details visible on trusted federated servers.
 	 *
+	 * @since 15.0.0
 	 * @deprecated 21.0.1
 	 */
 	public const VISIBILITY_CONTACTS_ONLY = 'contacts';
@@ -86,6 +88,7 @@ interface IAccountManager {
 	/**
 	 * Contact details visible on trusted federated servers and in the public lookup server.
 	 *
+	 * @since 15.0.0
 	 * @deprecated 21.0.1
 	 */
 	public const VISIBILITY_PUBLIC = 'public';
@@ -105,14 +108,49 @@ interface IAccountManager {
 		self::VISIBILITY_PUBLIC,
 	];
 
+	/**
+	 * @since 15.0.0
+	 */
 	public const PROPERTY_AVATAR = 'avatar';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const PROPERTY_DISPLAYNAME = 'displayname';
+
+	/**
+	 * @since 27.0.0
+	 */
 	public const PROPERTY_DISPLAYNAME_LEGACY = 'display-name';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const PROPERTY_PHONE = 'phone';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const PROPERTY_EMAIL = 'email';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const PROPERTY_WEBSITE = 'website';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const PROPERTY_ADDRESS = 'address';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const PROPERTY_TWITTER = 'twitter';
+
+	/**
+	 * @since 26.0.0
+	 */
 	public const PROPERTY_FEDIVERSE = 'fediverse';
 
 	/**
@@ -161,10 +199,25 @@ interface IAccountManager {
 		self::PROPERTY_PROFILE_ENABLED,
 	];
 
+
+	/**
+	 * @since 22.0.0
+	 */
 	public const COLLECTION_EMAIL = 'additional_mail';
 
+	/**
+	 * @since 15.0.0
+	 */
 	public const NOT_VERIFIED = '0';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const VERIFICATION_IN_PROGRESS = '1';
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const VERIFIED = '2';
 
 	/**

--- a/lib/public/Activity/IExtension.php
+++ b/lib/public/Activity/IExtension.php
@@ -31,13 +31,43 @@ namespace OCP\Activity;
  * @since 8.0.0
  */
 interface IExtension {
+	/**
+	 * @since 8.0.0
+	 */
 	public const METHOD_STREAM = 'stream';
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const METHOD_MAIL = 'email';
+
+	/**
+	 * @since 20.0.0
+	 */
 	public const METHOD_NOTIFICATION = 'notification';
 
+	/**
+	 * @since 8.0.0
+	 */
 	public const PRIORITY_VERYLOW = 10;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PRIORITY_LOW = 20;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PRIORITY_MEDIUM = 30;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PRIORITY_HIGH = 40;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PRIORITY_VERYHIGH = 50;
 }

--- a/lib/public/App/ManagerEvent.php
+++ b/lib/public/App/ManagerEvent.php
@@ -32,16 +32,19 @@ use OCP\EventDispatcher\Event;
  */
 class ManagerEvent extends Event {
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_APP_ENABLE = 'OCP\App\IAppManager::enableApp';
 
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_APP_ENABLE_FOR_GROUPS = 'OCP\App\IAppManager::enableAppForGroups';
 
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_APP_DISABLE = 'OCP\App\IAppManager::disableApp';

--- a/lib/public/AppFramework/Http.php
+++ b/lib/public/AppFramework/Http.php
@@ -29,63 +29,298 @@ namespace OCP\AppFramework;
  * @since 6.0.0
  */
 class Http {
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_CONTINUE = 100;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_SWITCHING_PROTOCOLS = 101;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_PROCESSING = 102;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_OK = 200;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_CREATED = 201;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_ACCEPTED = 202;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NON_AUTHORATIVE_INFORMATION = 203;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NO_CONTENT = 204;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_RESET_CONTENT = 205;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_PARTIAL_CONTENT = 206;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_MULTI_STATUS = 207;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_ALREADY_REPORTED = 208;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_IM_USED = 226;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_MULTIPLE_CHOICES = 300;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_MOVED_PERMANENTLY = 301;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_FOUND = 302;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_SEE_OTHER = 303;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NOT_MODIFIED = 304;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_USE_PROXY = 305;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_RESERVED = 306;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_TEMPORARY_REDIRECT = 307;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_BAD_REQUEST = 400;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_UNAUTHORIZED = 401;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_PAYMENT_REQUIRED = 402;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_FORBIDDEN = 403;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NOT_FOUND = 404;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_METHOD_NOT_ALLOWED = 405;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NOT_ACCEPTABLE = 406;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_PROXY_AUTHENTICATION_REQUIRED = 407;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_REQUEST_TIMEOUT = 408;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_CONFLICT = 409;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_GONE = 410;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_LENGTH_REQUIRED = 411;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_PRECONDITION_FAILED = 412;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_REQUEST_ENTITY_TOO_LARGE = 413;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_REQUEST_URI_TOO_LONG = 414;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_UNSUPPORTED_MEDIA_TYPE = 415;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_REQUEST_RANGE_NOT_SATISFIABLE = 416;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_EXPECTATION_FAILED = 417;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_IM_A_TEAPOT = 418;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_UNPROCESSABLE_ENTITY = 422;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_LOCKED = 423;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_FAILED_DEPENDENCY = 424;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_UPGRADE_REQUIRED = 426;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_PRECONDITION_REQUIRED = 428;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_TOO_MANY_REQUESTS = 429;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_INTERNAL_SERVER_ERROR = 500;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NOT_IMPLEMENTED = 501;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_BAD_GATEWAY = 502;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_SERVICE_UNAVAILABLE = 503;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_GATEWAY_TIMEOUT = 504;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_HTTP_VERSION_NOT_SUPPORTED = 505;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_VARIANT_ALSO_NEGOTIATES = 506;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_INSUFFICIENT_STORAGE = 507;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_LOOP_DETECTED = 508;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_BANDWIDTH_LIMIT_EXCEEDED = 509;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NOT_EXTENDED = 510;
+
+	/**
+	 * @since 6.0.0
+	 */
 	public const STATUS_NETWORK_AUTHENTICATION_REQUIRED = 511;
 }

--- a/lib/public/AppFramework/OCSController.php
+++ b/lib/public/AppFramework/OCSController.php
@@ -36,9 +36,24 @@ use OCP\IRequest;
  * @since 8.1.0
  */
 abstract class OCSController extends ApiController {
+	/**
+	 * @since 22.0.0
+	 */
 	public const RESPOND_UNAUTHORISED = 997;
+
+	/**
+	 * @since 22.0.0
+	 */
 	public const RESPOND_SERVER_ERROR = 996;
+
+	/**
+	 * @since 22.0.0
+	 */
 	public const RESPOND_NOT_FOUND = 998;
+
+	/**
+	 * @since 22.0.0
+	 */
 	public const RESPOND_UNKNOWN_ERROR = 999;
 
 	/** @var int */

--- a/lib/public/Authentication/TwoFactorAuth/IRegistry.php
+++ b/lib/public/Authentication/TwoFactorAuth/IRegistry.php
@@ -39,11 +39,13 @@ use OCP\IUser;
  */
 interface IRegistry {
 	/**
+	 * @since 15.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_PROVIDER_ENABLED = self::class . '::enable';
 
 	/**
+	 * @since 15.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_PROVIDER_DISABLED = self::class . '::disable';

--- a/lib/public/Comments/CommentsEntityEvent.php
+++ b/lib/public/Comments/CommentsEntityEvent.php
@@ -33,6 +33,7 @@ use OCP\EventDispatcher\Event;
  */
 class CommentsEntityEvent extends Event {
 	/**
+	 * @since 9.1.0
 	 * @deprecated 22.0.0 - Listen to the typed event instead.
 	 */
 	public const EVENT_ENTITY = 'OCP\Comments\ICommentsManager::registerEntity';

--- a/lib/public/Comments/CommentsEvent.php
+++ b/lib/public/Comments/CommentsEvent.php
@@ -32,21 +32,25 @@ use OCP\EventDispatcher\Event;
  */
 class CommentsEvent extends Event {
 	/**
+	 * @since 11.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_ADD = 'OCP\Comments\ICommentsManager::addComment';
 
 	/**
+	 * @since 11.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_PRE_UPDATE = 'OCP\Comments\ICommentsManager::preUpdateComment';
 
 	/**
+	 * @since 11.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_UPDATE = 'OCP\Comments\ICommentsManager::updateComment';
 
 	/**
+	 * @since 11.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_DELETE = 'OCP\Comments\ICommentsManager::deleteComment';

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -33,6 +33,9 @@ namespace OCP\Comments;
  * @since 9.0.0
  */
 interface IComment {
+	/**
+	 * @since 9.0.0
+	 */
 	public const MAX_MESSAGE_LENGTH = 1000;
 
 	/**

--- a/lib/public/Console/ConsoleEvent.php
+++ b/lib/public/Console/ConsoleEvent.php
@@ -32,6 +32,7 @@ use OCP\EventDispatcher\Event;
  */
 class ConsoleEvent extends Event {
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_RUN = 'OC\Console\Application::run';

--- a/lib/public/Constants.php
+++ b/lib/public/Constants.php
@@ -43,10 +43,30 @@ class Constants {
 	 * @since 8.0.0
 	 */
 	public const PERMISSION_CREATE = 4;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PERMISSION_READ = 1;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PERMISSION_UPDATE = 2;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PERMISSION_DELETE = 8;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PERMISSION_SHARE = 16;
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const PERMISSION_ALL = 31;
 
 	/**

--- a/lib/public/Dashboard/Model/WidgetButton.php
+++ b/lib/public/Dashboard/Model/WidgetButton.php
@@ -29,8 +29,19 @@ namespace OCP\Dashboard\Model;
  * @since 25.0.0
  */
 class WidgetButton {
+	/**
+	 * @since 25.0.0
+	 */
 	public const TYPE_NEW = 'new';
+
+	/**
+	 * @since 25.0.0
+	 */
 	public const TYPE_MORE = 'more';
+
+	/**
+	 * @since 25.0.0
+	 */
 	public const TYPE_SETUP = 'setup';
 
 	private string $type;

--- a/lib/public/Files/Cache/ICache.php
+++ b/lib/public/Files/Cache/ICache.php
@@ -38,9 +38,24 @@ use OCP\Files\Search\ISearchQuery;
  * @since 9.0.0
  */
 interface ICache {
+	/**
+	 * @since 9.0.0
+	 */
 	public const NOT_FOUND = 0;
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const PARTIAL = 1; //only partial data available, file not cached in the database
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const SHALLOW = 2; //folder in cache, but not all child files are completely scanned
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const COMPLETE = 3;
 
 	/**

--- a/lib/public/Files/Cache/ICacheEntry.php
+++ b/lib/public/Files/Cache/ICacheEntry.php
@@ -35,6 +35,9 @@ use ArrayAccess;
  * object as array, while strictly speaking it didn't support this.
  */
 interface ICacheEntry extends ArrayAccess {
+	/**
+	 * @since 9.0.0
+	 */
 	public const DIRECTORY_MIMETYPE = 'httpd/unix-directory';
 
 	/**

--- a/lib/public/Files/Cache/IScanner.php
+++ b/lib/public/Files/Cache/IScanner.php
@@ -28,12 +28,34 @@ namespace OCP\Files\Cache;
  * @since 9.0.0
  */
 interface IScanner {
+	/**
+	 * @since 9.0.0
+	 */
 	public const SCAN_RECURSIVE_INCOMPLETE = 2; // only recursive into not fully scanned folders
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const SCAN_RECURSIVE = true;
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const SCAN_SHALLOW = false;
 
+	/**
+	 * @since 12.0.0
+	 */
 	public const REUSE_NONE = 0;
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const REUSE_ETAG = 1;
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const REUSE_SIZE = 2;
 
 	/**

--- a/lib/public/Files/Cache/IWatcher.php
+++ b/lib/public/Files/Cache/IWatcher.php
@@ -28,8 +28,19 @@ namespace OCP\Files\Cache;
  * @since 9.0.0
  */
 interface IWatcher {
+	/**
+	 * @since 9.0.0
+	 */
 	public const CHECK_NEVER = 0; // never check the underlying filesystem for updates
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const CHECK_ONCE = 1; // check the underlying filesystem for updates once every request for each file
+
+	/**
+	 * @since 9.0.0
+	 */
 	public const CHECK_ALWAYS = 2; // always check the underlying filesystem for updates
 
 	/**

--- a/lib/public/Files/Notify/IChange.php
+++ b/lib/public/Files/Notify/IChange.php
@@ -29,9 +29,24 @@ namespace OCP\Files\Notify;
  * @since 12.0.0
  */
 interface IChange {
+	/**
+	 * @since 12.0.0
+	 */
 	public const ADDED = 1;
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const REMOVED = 2;
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const MODIFIED = 3;
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const RENAMED = 4;
 
 	/**

--- a/lib/public/Files/Search/ISearchBinaryOperator.php
+++ b/lib/public/Files/Search/ISearchBinaryOperator.php
@@ -27,8 +27,19 @@ namespace OCP\Files\Search;
  * @since 12.0.0
  */
 interface ISearchBinaryOperator extends ISearchOperator {
+	/**
+	 * @since 12.0.0
+	 */
 	public const OPERATOR_AND = 'and';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const OPERATOR_OR = 'or';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const OPERATOR_NOT = 'not';
 
 	/**

--- a/lib/public/Files/Search/ISearchComparison.php
+++ b/lib/public/Files/Search/ISearchComparison.php
@@ -28,15 +28,49 @@ namespace OCP\Files\Search;
  * @since 12.0.0
  */
 interface ISearchComparison extends ISearchOperator {
+	/**
+	 * @since 12.0.0
+	 */
 	public const COMPARE_EQUAL = 'eq';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const COMPARE_GREATER_THAN = 'gt';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const COMPARE_GREATER_THAN_EQUAL = 'gte';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const COMPARE_LESS_THAN = 'lt';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const COMPARE_LESS_THAN_EQUAL = 'lte';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const COMPARE_LIKE = 'like';
+
+	/**
+	 * @since 23.0.0
+	 */
 	public const COMPARE_LIKE_CASE_SENSITIVE = 'clike';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const COMPARE_DEFINED = 'is-defined';
 
+	/**
+	 * @since 23.0.0
+	 */
 	public const HINT_PATH_EQ_HASH = 'path_eq_hash'; // transform `path = "$path"` into `path_hash = md5("$path")`, on by default
 
 	/**

--- a/lib/public/Files/Search/ISearchOrder.php
+++ b/lib/public/Files/Search/ISearchOrder.php
@@ -30,7 +30,14 @@ use OCP\Files\FileInfo;
  * @since 12.0.0
  */
 interface ISearchOrder {
+	/**
+	 * @since 12.0.0
+	 */
 	public const DIRECTION_ASCENDING = 'asc';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const DIRECTION_DESCENDING = 'desc';
 
 	/**

--- a/lib/public/Files/Storage/INotifyStorage.php
+++ b/lib/public/Files/Storage/INotifyStorage.php
@@ -31,9 +31,24 @@ use OCP\Files\Notify\INotifyHandler;
  * @since 9.1.0
  */
 interface INotifyStorage {
+	/**
+	 * @since 9.1.0
+	 */
 	public const NOTIFY_ADDED = 1;
+
+	/**
+	 * @since 9.1.0
+	 */
 	public const NOTIFY_REMOVED = 2;
+
+	/**
+	 * @since 9.1.0
+	 */
 	public const NOTIFY_MODIFIED = 3;
+
+	/**
+	 * @since 9.1.0
+	 */
 	public const NOTIFY_RENAMED = 4;
 
 	/**

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -36,15 +36,43 @@ use OCP\HintException;
 
 /**
  * Storage is temporarily not available
- * @since 6.0.0 - since 8.2.1 based on HintException
+ * @since 6.0.0
+ * @since 8.2.1 based on HintException
  */
 class StorageNotAvailableException extends HintException {
+	/**
+	 * @since 8.2.0
+	 */
 	public const STATUS_SUCCESS = 0;
+
+	/**
+	 * @since 8.2.0
+	 */
 	public const STATUS_ERROR = 1;
+
+	/**
+	 * @since 8.2.0
+	 */
 	public const STATUS_INDETERMINATE = 2;
+
+	/**
+	 * @since 8.2.0
+	 */
 	public const STATUS_INCOMPLETE_CONF = 3;
+
+	/**
+	 * @since 8.2.0
+	 */
 	public const STATUS_UNAUTHORIZED = 4;
+
+	/**
+	 * @since 8.2.0
+	 */
 	public const STATUS_TIMEOUT = 5;
+
+	/**
+	 * @since 8.2.0
+	 */
 	public const STATUS_NETWORK_ERROR = 6;
 
 	/**

--- a/lib/public/FullTextSearch/Model/IIndex.php
+++ b/lib/public/FullTextSearch/Model/IIndex.php
@@ -43,24 +43,84 @@ namespace OCP\FullTextSearch\Model;
  *
  */
 interface IIndex {
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_OK = 1;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_IGNORE = 2;
 
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_META = 4;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_CONTENT = 8;
+
+	/**
+	 * @since 16.0.0
+	 */
 	public const INDEX_PARTS = 16;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_FULL = 28;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_REMOVE = 32;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_DONE = 64;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const INDEX_FAILED = 128;
 
+	/**
+	 * @since 15.0.0
+	 */
 	public const ERROR_FAILED = 1;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const ERROR_FAILED2 = 2;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const ERROR_FAILED3 = 4;
 
+	/**
+	 * @since 15.0.0
+	 */
 	public const ERROR_SEV_1 = 1;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const ERROR_SEV_2 = 2;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const ERROR_SEV_3 = 3;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const ERROR_SEV_4 = 4;
 
 

--- a/lib/public/FullTextSearch/Model/IIndexDocument.php
+++ b/lib/public/FullTextSearch/Model/IIndexDocument.php
@@ -41,7 +41,14 @@ namespace OCP\FullTextSearch\Model;
  * @since 15.0.0
  */
 interface IIndexDocument {
+	/**
+	 * @since 15.0.0
+	 */
 	public const NOT_ENCODED = 0;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const ENCODED_BASE64 = 1;
 
 

--- a/lib/public/FullTextSearch/Model/IRunner.php
+++ b/lib/public/FullTextSearch/Model/IRunner.php
@@ -40,8 +40,19 @@ namespace OCP\FullTextSearch\Model;
  *
  */
 interface IRunner {
+	/**
+	 * @since 15.0.0
+	 */
 	public const RESULT_TYPE_SUCCESS = 1;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const RESULT_TYPE_WARNING = 4;
+
+	/**
+	 * @since 15.0.0
+	 */
 	public const RESULT_TYPE_FAIL = 9;
 
 

--- a/lib/public/FullTextSearch/Model/ISearchRequestSimpleQuery.php
+++ b/lib/public/FullTextSearch/Model/ISearchRequestSimpleQuery.php
@@ -38,16 +38,59 @@ namespace OCP\FullTextSearch\Model;
  *
  */
 interface ISearchRequestSimpleQuery {
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_TEXT = 1;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_KEYWORD = 2;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_INT_EQ = 3;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_INT_GTE = 4;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_INT_GT = 5;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_INT_LTE = 6;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_INT_LT = 7;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_BOOL = 8;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_ARRAY = 9;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_REGEX = 10;
+
+	/**
+	 * @since 17.0.0
+	 */
 	public const COMPARE_TYPE_WILDCARD = 11;
 
 

--- a/lib/public/GroupInterface.php
+++ b/lib/public/GroupInterface.php
@@ -38,15 +38,44 @@ namespace OCP;
 interface GroupInterface {
 	/**
 	 * actions that user backends can define
+	 *
+	 * @since 12.0.0
 	 */
 	public const CREATE_GROUP = 0x00000001;
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const DELETE_GROUP = 0x00000010;
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const ADD_TO_GROUP = 0x00000100;
+
+	/**
+	 * @since 12.0.0
+	 * @deprecated  29.0.0
+	 */
 	public const REMOVE_FROM_GOUP = 0x00001000; // oops
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const REMOVE_FROM_GROUP = 0x00001000;
+
 	//OBSOLETE const GET_DISPLAYNAME	= 0x00010000;
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const COUNT_USERS = 0x00100000;
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const GROUP_DETAILS = 0x01000000;
+
 	/**
 	 * @since 13.0.0
 	 */

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -45,16 +45,24 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
  * @since 6.0.0
  */
 interface IDBConnection {
-	/* @since 28.0.0 */
+	/**
+	 * @since 28.0.0
+	 */
 	public const PLATFORM_MYSQL = 'mysql';
 
-	/* @since 28.0.0 */
+	/**
+	 * @since 28.0.0
+	 */
 	public const PLATFORM_ORACLE = 'oracle';
 
-	/* @since 28.0.0 */
+	/**
+	 * @since 28.0.0
+	 */
 	public const PLATFORM_POSTGRES = 'postgres';
 
-	/* @since 28.0.0 */
+	/**
+	 * @since 28.0.0
+	 */
 	public const PLATFORM_SQLITE = 'sqlite';
 
 	/**

--- a/lib/public/IPreview.php
+++ b/lib/public/IPreview.php
@@ -38,7 +38,14 @@ use OCP\Files\SimpleFS\ISimpleFile;
  * @since 6.0.0
  */
 interface IPreview {
+	/**
+	 * @since 11.0.0
+	 */
 	public const MODE_FILL = 'fill';
+
+	/**
+	 * @since 11.0.0
+	 */
 	public const MODE_COVER = 'cover';
 
 	/**

--- a/lib/public/Search/FilterDefinition.php
+++ b/lib/public/Search/FilterDefinition.php
@@ -35,14 +35,49 @@ use InvalidArgumentException;
  * @since 28.0.0
  */
 class FilterDefinition {
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_BOOL = 'bool';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_INT = 'int';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_FLOAT = 'float';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_STRING = 'string';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_STRINGS = 'strings';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_DATETIME = 'datetime';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_PERSON = 'person';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_NC_USER = 'nc-user';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const TYPE_NC_GROUP = 'nc-group';
 
 	/**

--- a/lib/public/Security/ISecureRandom.php
+++ b/lib/public/Security/ISecureRandom.php
@@ -41,17 +41,36 @@ namespace OCP\Security;
 interface ISecureRandom {
 	/**
 	 * Flags for characters that can be used for <code>generate($length, $characters)</code>
+	 * @since 8.0.0
 	 */
 	public const CHAR_UPPER = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const CHAR_LOWER = 'abcdefghijklmnopqrstuvwxyz';
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const CHAR_DIGITS = '0123456789';
+
+	/**
+	 * @since 8.0.0
+	 */
 	public const CHAR_SYMBOLS = '!\"#$%&\\\'()*+,-./:;<=>?@[\]^_`{|}~';
+
+	/**
+	 * @since 12.0.0
+	 */
 	public const CHAR_ALPHANUMERIC = self::CHAR_UPPER . self::CHAR_LOWER . self::CHAR_DIGITS;
 
 	/**
 	 * Characters that can be used for <code>generate($length, $characters)</code>, to
-	 * generate human readable random strings. Lower- and upper-case characters and digits
+	 * generate human-readable random strings. Lower- and upper-case characters and digits
 	 * are included. Characters which are ambiguous are excluded, such as I, l, and 1 and so on.
+	 *
+	 * @since 23.0.0
 	 */
 	public const CHAR_HUMAN_READABLE = 'abcdefgijkmnopqrstwxyzABCDEFGHJKLMNPQRSTWXYZ23456789';
 

--- a/lib/public/Settings/IManager.php
+++ b/lib/public/Settings/IManager.php
@@ -35,25 +35,25 @@ use OCP\IUser;
 interface IManager {
 	/**
 	 * @since 9.1.0
-	 * @depreacted 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
+	 * @deprecated 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
 	 */
 	public const KEY_ADMIN_SETTINGS = 'admin';
 
 	/**
 	 * @since 9.1.0
-	 * @depreacted 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
+	 * @deprecated 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
 	 */
 	public const KEY_ADMIN_SECTION = 'admin-section';
 
 	/**
 	 * @since 13.0.0
-	 * @depreacted 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
+	 * @deprecated 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
 	 */
 	public const KEY_PERSONAL_SETTINGS = 'personal';
 
 	/**
 	 * @since 13.0.0
-	 * @depreacted 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
+	 * @deprecated 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
 	 */
 	public const KEY_PERSONAL_SECTION = 'personal-section';
 

--- a/lib/public/SetupCheck/SetupResult.php
+++ b/lib/public/SetupCheck/SetupResult.php
@@ -34,9 +34,24 @@ use OCP\RichObjectStrings\IValidator;
  * @since 28.0.0
  */
 class SetupResult implements \JsonSerializable {
+	/**
+	 * @since 28.0.0
+	 */
 	public const SUCCESS = 'success';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const INFO = 'info';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const WARNING = 'warning';
+
+	/**
+	 * @since 28.0.0
+	 */
 	public const ERROR = 'error';
 
 	/**

--- a/lib/public/SystemTag/ManagerEvent.php
+++ b/lib/public/SystemTag/ManagerEvent.php
@@ -37,16 +37,19 @@ use OCP\EventDispatcher\Event;
  */
 class ManagerEvent extends Event {
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_CREATE = 'OCP\SystemTag\ISystemTagManager::createTag';
 
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_UPDATE = 'OCP\SystemTag\ISystemTagManager::updateTag';
 
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_DELETE = 'OCP\SystemTag\ISystemTagManager::deleteTag';

--- a/lib/public/SystemTag/MapperEvent.php
+++ b/lib/public/SystemTag/MapperEvent.php
@@ -36,11 +36,13 @@ use OCP\EventDispatcher\Event;
  */
 class MapperEvent extends Event {
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_ASSIGN = 'OCP\SystemTag\ISystemTagObjectMapper::assignTags';
 
 	/**
+	 * @since 9.0.0
 	 * @deprecated 22.0.0
 	 */
 	public const EVENT_UNASSIGN = 'OCP\SystemTag\ISystemTagObjectMapper::unassignTags';

--- a/lib/public/SystemTag/SystemTagsEntityEvent.php
+++ b/lib/public/SystemTag/SystemTagsEntityEvent.php
@@ -37,6 +37,7 @@ use OCP\EventDispatcher\Event;
  */
 class SystemTagsEntityEvent extends Event {
 	/**
+	 * @since 9.1.0
 	 * @deprecated 22.0.0 Listen to the typed event instead
 	 */
 	public const EVENT_ENTITY = 'OCP\SystemTag\ISystemTagManager::registerEntity';

--- a/lib/public/UserMigration/IImportSource.php
+++ b/lib/public/UserMigration/IImportSource.php
@@ -32,6 +32,9 @@ use OCP\Files\Folder;
  * @since 24.0.0
  */
 interface IImportSource {
+	/**
+	 * @since 24.0.0
+	 */
 	public const PATH_USER = 'user.json';
 
 	/**

--- a/lib/public/WorkflowEngine/IManager.php
+++ b/lib/public/WorkflowEngine/IManager.php
@@ -31,7 +31,14 @@ namespace OCP\WorkflowEngine;
  * @since 9.1
  */
 interface IManager {
+	/**
+	 * @since 18.0.0
+	 */
 	public const SCOPE_ADMIN = 0;
+
+	/**
+	 * @since 18.0.0
+	 */
 	public const SCOPE_USER = 1;
 
 	/**


### PR DESCRIPTION
Psalm output before:
```
ERROR: InvalidDocblock - lib/public/Settings/IManager.php:40:2 - Typo in @deprecated for const in OCP. (see https://psalm.dev/008)
	/**
	 * @since 9.1.0
	 * @depreacted 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
	 */
	public const KEY_ADMIN_SETTINGS = 'admin';


ERROR: InvalidDocblock - lib/public/Settings/IManager.php:46:2 - Typo in @deprecated for const in OCP. (see https://psalm.dev/008)
	/**
	 * @since 9.1.0
	 * @depreacted 29.0.0 Use {@see self::SETTINGS_ADMIN} instead
	 */
	public const KEY_ADMIN_SECTION = 'admin-section';


ERROR: InvalidDocblock - lib/public/Settings/IManager.php:52:2 - Typo in @deprecated for const in OCP. (see https://psalm.dev/008)
	/**
	 * @since 13.0.0
	 * @depreacted 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
	 */
	public const KEY_PERSONAL_SETTINGS = 'personal';


ERROR: InvalidDocblock - lib/public/Settings/IManager.php:58:2 - Typo in @deprecated for const in OCP. (see https://psalm.dev/008)
	/**
	 * @since 13.0.0
	 * @depreacted 29.0.0 Use {@see self::SETTINGS_PERSONAL} instead
	 */
	public const KEY_PERSONAL_SECTION = 'personal-section';


------------------------------
4 errors found
------------------------------
```

## Follow up

- Also enforce the `@since` for constants in OCP => Follow up PR as there are 223 failures 😱 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
