### PR TITLE
fix(OCP): Add since tag to all constants

### DIFF
--- a/lib/public/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/public/Collaboration/Reference/LinkReferenceProvider.php
@@ -45,10 +45,16 @@ use Psr\Log\LoggerInterface;
  */
 class LinkReferenceProvider implements IReferenceProvider {
 
-	/* for image size and webpage header */
-	private const MAX_CONTENT_LENGTH = 5 * 1024 * 1024;
+	/**
+	 * for image size and webpage header
+	 * @since 29.0.0
+	 */
+	public const MAX_CONTENT_LENGTH = 5 * 1024 * 1024;
 
-	private const ALLOWED_CONTENT_TYPES = [
+	/**
+	 * @since 29.0.0
+	 */
+	public const ALLOWED_CONTENT_TYPES = [
 		'image/png',
 		'image/jpg',
 		'image/jpeg',


### PR DESCRIPTION
Red CI due to parallel merges of
- https://github.com/nextcloud/server/pull/43355
- https://github.com/nextcloud/server/pull/43581

PS: I find private constants weird on public API. Any problem with exposing them? Would allowing apps to create their own providers on top of it.