### PR TITLE
only cleanup orphaned shared daily

### DIFF
--- a/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
+++ b/apps/files_sharing/lib/DeleteOrphanedSharesJob.php
@@ -35,17 +35,13 @@ use Psr\Log\LoggerInterface;
  */
 class DeleteOrphanedSharesJob extends TimedJob {
 	/**
-	 * Default interval in minutes
-	 **/
-	protected int $defaultIntervalMin = 15;
-
-	/**
 	 * sets the correct interval for this timed job
 	 */
 	public function __construct(ITimeFactory $time) {
 		parent::__construct($time);
 
-		$this->interval = $this->defaultIntervalMin * 60;
+		$this->setInterval(24 * 60 * 60); // 1 day
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	/**


### PR DESCRIPTION
Since we filter out the shares with no matching files when loading them already there is no real downsides to leaving them in the db a bit longer.

Reducing the interval should decrease the db load a bit