### PR TITLE
fix: fallback from guessing the owner from path in versioning

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -367,6 +367,16 @@ class FileEventsListener implements IEventListener {
 		}
 
 		$owner = $node->getOwner()?->getUid();
+
+		// If no owner, extract it from the path.
+		// e.g. /user/files/foobar.txt
+		if (!$owner) {
+			$parts = explode('/', $node->getPath(), 4);
+			if (count($parts) === 4) {
+				$owner = $parts[1];
+			}
+		}
+
 		if ($owner) {
 			$path = $this->rootFolder
 				->getUserFolder($owner)


### PR DESCRIPTION
Fixes version hook for files without owner (groupfolders, external storage) when the write is from a context without user (cli, cron).