### PR TITLE
Allow + character for usernames as allowed in mail addresses via rfc5233

### DIFF
--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -733,10 +733,10 @@ class Manager extends PublicEmitter implements IUserManager {
 		$l = Server::get(IFactory::class)->get('lib');
 
 		// Check the name for bad characters
-		// Allowed are: "a-z", "A-Z", "0-9", spaces and "_.@-'"
-		if (preg_match('/[^a-zA-Z0-9 _.@\-\']/', $uid)) {
+		// Allowed are: "a-z", "A-Z", "0-9", spaces and "_.@-'+"
+		if (preg_match('/[^a-zA-Z0-9 _.@\-\'\+]/', $uid)) {
 			throw new \InvalidArgumentException($l->t('Only the following characters are allowed in an Login:'
-				. ' "a-z", "A-Z", "0-9", spaces and "_.@-\'"'));
+				. ' "a-z", "A-Z", "0-9", spaces and "_.@-\'+"'));
 		}
 
 		// No empty username


### PR DESCRIPTION
## Summary
This should allow usage of '+' character in usernames as allowed for mail addresses via rfc5233.
