### PR TITLE
Move away from deprecated utf8_encode() on PHP 8.2+

### DIFF
--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -106,7 +106,7 @@ abstract class LogDetails {
 			if (is_string($value)) {
 				$testEncode = json_encode($value, JSON_UNESCAPED_SLASHES);
 				if ($testEncode === false) {
-					$entry[$key] = utf8_encode($value);
+					$entry[$key] = mb_convert_encoding($value, 'UTF-8', mb_detect_encoding($value));
 				}
 			}
 		}


### PR DESCRIPTION
Fix: https://github.com/nextcloud/server/issues/43602

## Summary

https://www.php.net/manual/en/function.mb-convert-encoding.php

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)