### PR TITLE
Add user:keys:verify command

### DIFF
--- a/core/Command/User/Keys/Verify.php
+++ b/core/Command/User/Keys/Verify.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024, Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @author Marcel Müller <marcel.mueller@nextcloud.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Command\User\Keys;
+
+use OC\Security\IdentityProof\Manager;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Verify extends Command {
+	public function __construct(
+		protected IUserManager $userManager,
+		protected Manager $keyManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('user:keys:verify')
+			->setDescription('Verify if the stored public key matches the stored private key')
+			->addArgument(
+				'user-id',
+				InputArgument::REQUIRED,
+				'User ID of the user to verify'
+			)
+		;
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$userId = $input->getArgument('user-id');
+
+		$user = $this->userManager->get($userId);
+		if (!$user instanceof IUser) {
+			$output->writeln('Unknown user');
+			return static::FAILURE;
+		}
+
+		$key = $this->keyManager->getKey($user);
+		$publicKey = $key->getPublic();
+		$privateKey = $key->getPrivate();
+
+		$output->writeln('User public key size: ' . strlen($publicKey));
+		$output->writeln('User private key size: ' . strlen($privateKey));
+
+		// Derive the public key from the private key again to validate the stored public key
+		$opensslPrivateKey = openssl_pkey_get_private($privateKey);
+		$publicKeyDerived = openssl_pkey_get_details($opensslPrivateKey);
+		$publicKeyDerived = $publicKeyDerived['key'];
+		$output->writeln('User derived public key size: ' . strlen($publicKeyDerived));
+
+		$output->writeln('');
+
+		$output->writeln('Stored public key:');
+		$output->writeln($publicKey);
+		$output->writeln('Derived public key:');
+		$output->writeln($publicKeyDerived);
+
+		if ($publicKey != $publicKeyDerived) {
+			$output->writeln('<error>Stored public key does not match stored private key</error>');
+			return static::FAILURE;
+		}
+
+		$output->writeln('<info>Stored public key matches stored private key</info>');
+
+		return static::SUCCESS;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -161,6 +161,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\User\AuthTokens\Add::class));
 	$application->add(Server::get(Command\User\AuthTokens\ListCommand::class));
 	$application->add(Server::get(Command\User\AuthTokens\Delete::class));
+	$application->add(Server::get(Command\User\Keys\Verify::class));
 
 	$application->add(Server::get(Command\Group\Add::class));
 	$application->add(Server::get(Command\Group\Delete::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1124,6 +1124,7 @@ return array(
     'OC\\Core\\Command\\User\\Disable' => $baseDir . '/core/Command/User/Disable.php',
     'OC\\Core\\Command\\User\\Enable' => $baseDir . '/core/Command/User/Enable.php',
     'OC\\Core\\Command\\User\\Info' => $baseDir . '/core/Command/User/Info.php',
+    'OC\\Core\\Command\\User\\Keys\\Verify' => $baseDir . '/core/Command/User/Keys/Verify.php',
     'OC\\Core\\Command\\User\\LastSeen' => $baseDir . '/core/Command/User/LastSeen.php',
     'OC\\Core\\Command\\User\\ListCommand' => $baseDir . '/core/Command/User/ListCommand.php',
     'OC\\Core\\Command\\User\\Report' => $baseDir . '/core/Command/User/Report.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1157,6 +1157,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\User\\Disable' => __DIR__ . '/../../..' . '/core/Command/User/Disable.php',
         'OC\\Core\\Command\\User\\Enable' => __DIR__ . '/../../..' . '/core/Command/User/Enable.php',
         'OC\\Core\\Command\\User\\Info' => __DIR__ . '/../../..' . '/core/Command/User/Info.php',
+        'OC\\Core\\Command\\User\\Keys\\Verify' => __DIR__ . '/../../..' . '/core/Command/User/Keys/Verify.php',
         'OC\\Core\\Command\\User\\LastSeen' => __DIR__ . '/../../..' . '/core/Command/User/LastSeen.php',
         'OC\\Core\\Command\\User\\ListCommand' => __DIR__ . '/../../..' . '/core/Command/User/ListCommand.php',
         'OC\\Core\\Command\\User\\Report' => __DIR__ . '/../../..' . '/core/Command/User/Report.php',


### PR DESCRIPTION
## Summary

This occ command checks if the stored public key belongs to the stored private key. In case of a mismatch, some nextcloud functionality is broken (e.g. push proxy registration fails). While this should not happen, it is hard to debug when we end up in such a situation. The command is for verification only, in a next step we could add a second command to update the stored public key.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
