### PR TITLE
Log host/ip for access violation

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -192,7 +192,7 @@ class Client implements IClient {
 			throw new LocalServerException('Could not detect any host');
 		}
 		if (!$this->remoteHostValidator->isValid($host)) {
-			throw new LocalServerException('Host violates local access rules');
+			throw new LocalServerException('Host "'.$host.'" violates local access rules');
 		}
 	}
 

--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -147,7 +147,7 @@ class DnsPinMiddleware {
 					foreach ($targetIps as $ip) {
 						if ($this->ipAddressClassifier->isLocalAddress($ip)) {
 							// TODO: continue with all non-local IPs?
-							throw new LocalServerException('Host violates local access rules');
+							throw new LocalServerException('Host "'.$ip.'" violates local access rules');
 						}
 						$curlResolves["$hostName:$port"][] = $ip;
 					}

--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -147,7 +147,7 @@ class DnsPinMiddleware {
 					foreach ($targetIps as $ip) {
 						if ($this->ipAddressClassifier->isLocalAddress($ip)) {
 							// TODO: continue with all non-local IPs?
-							throw new LocalServerException('Host "'.$ip.'" violates local access rules');
+							throw new LocalServerException('Host "'.$ip.'" ('.$hostName.':'.$port.') violates local access rules');
 						}
 						$curlResolves["$hostName:$port"][] = $ip;
 					}

--- a/tests/lib/Http/Client/DnsPinMiddlewareTest.php
+++ b/tests/lib/Http/Client/DnsPinMiddlewareTest.php
@@ -287,7 +287,7 @@ class DnsPinMiddlewareTest extends TestCase {
 
 	public function testRejectIPv4() {
 		$this->expectException(LocalServerException::class);
-		$this->expectExceptionMessage('Host violates local access rules');
+		$this->expectExceptionMessage('violates local access rules');
 
 		$mockHandler = new MockHandler([
 			static function (RequestInterface $request, array $options) {
@@ -334,7 +334,7 @@ class DnsPinMiddlewareTest extends TestCase {
 
 	public function testRejectIPv6() {
 		$this->expectException(LocalServerException::class);
-		$this->expectExceptionMessage('Host violates local access rules');
+		$this->expectExceptionMessage('violates local access rules');
 
 		$mockHandler = new MockHandler([
 			static function (RequestInterface $request, array $options) {
@@ -381,7 +381,7 @@ class DnsPinMiddlewareTest extends TestCase {
 
 	public function testRejectCanonicalName() {
 		$this->expectException(LocalServerException::class);
-		$this->expectExceptionMessage('Host violates local access rules');
+		$this->expectExceptionMessage('violates local access rules');
 
 		$mockHandler = new MockHandler([
 			static function (RequestInterface $request, array $options) {


### PR DESCRIPTION
## Summary

During checking some `Host violates local access rules` I noticed, that there is no value being logged. This PR adds the affected Host/IP to the Exception.



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
