### PR TITLE
fix(security): Describe `occ security:bruteforce:attempts` accurately

### DIFF
--- a/core/Command/Security/BruteforceAttempts.php
+++ b/core/Command/Security/BruteforceAttempts.php
@@ -41,11 +41,11 @@ class BruteforceAttempts extends Base {
 		parent::configure();
 		$this
 			->setName('security:bruteforce:attempts')
-			->setDescription('resets bruteforce attempts for given IP address')
+			->setDescription('Show bruteforce attempts status for a given IP address')
 			->addArgument(
 				'ipaddress',
 				InputArgument::REQUIRED,
-				'IP address for which the attempts are to be reset',
+				'IP address for which the attempts status is to be shown',
 			)
 			->addArgument(
 				'action',


### PR DESCRIPTION
## Summary

This command is used to list a summary of brute force protection attempts associated with a given IP address and, optionally, a specific action. It does not reset attempts (there's already another command for that).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
