### PR TITLE
fix: ignore error when removing "is writable" test file

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -453,7 +453,7 @@ class OC_Util {
 					];
 				} else {
 					fclose($handle);
-					unlink($testFile);
+					@unlink($testFile);
 				}
 			} else {
 				$errors = array_merge($errors, self::checkDataDirectoryPermissions($CONFIG_DATADIRECTORY));


### PR DESCRIPTION
the error is safe to ignore