### PR TITLE
feat(tests): Test that mtime is the same after move or rename

### DIFF
--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -573,7 +573,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function copy($source, $target, $isFile = null) {
+	public function copy($source, $target, bool $preserveMtime = false, ?bool $isFile = null): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -607,7 +607,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 			foreach ($this->getDirectoryContent($source) as $item) {
 				$childSource = $source . '/' . $item['name'];
 				$childTarget = $target . '/' . $item['name'];
-				$this->copy($childSource, $childTarget, $item['mimetype'] !== FileInfo::MIMETYPE_FOLDER);
+				$this->copy($childSource, $childTarget, $preserveMtime, $item['mimetype'] !== FileInfo::MIMETYPE_FOLDER);
 			}
 		}
 

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -573,6 +573,10 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
+	/**
+	 * @param string $source
+	 * @param string $target
+	 */
 	public function copy($source, $target, bool $preserveMtime = false, ?bool $isFile = null): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -519,6 +519,10 @@ class SFTP extends Common {
 		}
 	}
 
+	/**
+	 * @param string $source
+	 * @param string $target
+	 */
 	public function copy($source, $target, bool $preserveMtime = false): bool {
 		if ($this->is_dir($source) || $this->is_dir($target)) {
 			return parent::copy($source, $target, $preserveMtime);

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -519,9 +519,9 @@ class SFTP extends Common {
 		}
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		if ($this->is_dir($source) || $this->is_dir($target)) {
-			return parent::copy($source, $target);
+			return parent::copy($source, $target, $preserveMtime);
 		} else {
 			$absSource = $this->absPath($source);
 			$absTarget = $this->absPath($target);

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -483,7 +483,7 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -502,6 +502,12 @@ class Swift extends \OC\Files\Storage\Common {
 				// invalidate target object to force repopulation on fetch
 				$this->objectCache->remove($target);
 				$this->objectCache->remove($target . '/');
+				if ($preserveMtime) {
+					$mTime = $this->filemtime($source);
+					if (is_int($mTime)) {
+						$this->touch($target, $mTime);
+					}
+				}
 			} catch (BadResponseError $e) {
 				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), [
 					'exception' => $e,
@@ -534,7 +540,7 @@ class Swift extends \OC\Files\Storage\Common {
 
 				$source = $source . '/' . $file;
 				$target = $target . '/' . $file;
-				$this->copy($source, $target);
+				$this->copy($source, $target, $preserveMtime);
 			}
 		} else {
 			//file does not exist

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -483,6 +483,10 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 	}
 
+	/**
+	 * @param string $source
+	 * @param string $target
+	 */
 	public function copy($source, $target, bool $preserveMtime = false): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -54,7 +54,7 @@ use Psr\Log\LoggerInterface;
 use Test\Traits\MountProviderTrait;
 
 class TemporaryNoCross extends Temporary {
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, bool $preserveMtime = false): bool {
 		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -413,6 +413,7 @@ return array(
     'OCP\\Files\\Storage\\IChunkedFileWrite' => $baseDir . '/lib/public/Files/Storage/IChunkedFileWrite.php',
     'OCP\\Files\\Storage\\IDisableEncryptionStorage' => $baseDir . '/lib/public/Files/Storage/IDisableEncryptionStorage.php',
     'OCP\\Files\\Storage\\ILockingStorage' => $baseDir . '/lib/public/Files/Storage/ILockingStorage.php',
+    'OCP\\Files\\Storage\\IMtimePreserving' => $baseDir . '/lib/public/Files/Storage/IMtimePreserving.php',
     'OCP\\Files\\Storage\\INotifyStorage' => $baseDir . '/lib/public/Files/Storage/INotifyStorage.php',
     'OCP\\Files\\Storage\\IReliableEtagStorage' => $baseDir . '/lib/public/Files/Storage/IReliableEtagStorage.php',
     'OCP\\Files\\Storage\\IStorage' => $baseDir . '/lib/public/Files/Storage/IStorage.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -446,6 +446,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\Storage\\IChunkedFileWrite' => __DIR__ . '/../../..' . '/lib/public/Files/Storage/IChunkedFileWrite.php',
         'OCP\\Files\\Storage\\IDisableEncryptionStorage' => __DIR__ . '/../../..' . '/lib/public/Files/Storage/IDisableEncryptionStorage.php',
         'OCP\\Files\\Storage\\ILockingStorage' => __DIR__ . '/../../..' . '/lib/public/Files/Storage/ILockingStorage.php',
+        'OCP\\Files\\Storage\\IMtimePreserving' => __DIR__ . '/../../..' . '/lib/public/Files/Storage/IMtimePreserving.php',
         'OCP\\Files\\Storage\\INotifyStorage' => __DIR__ . '/../../..' . '/lib/public/Files/Storage/INotifyStorage.php',
         'OCP\\Files\\Storage\\IReliableEtagStorage' => __DIR__ . '/../../..' . '/lib/public/Files/Storage/IReliableEtagStorage.php',
         'OCP\\Files\\Storage\\IStorage' => __DIR__ . '/../../..' . '/lib/public/Files/Storage/IStorage.php',

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -596,7 +596,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$sourceInternalPath,
 		$targetInternalPath,
 		$preserveMtime = false
-	) {
+	): bool {
 		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class)) {
 			/** @var ObjectStoreStorage $sourceStorage */
 			if ($sourceStorage->getObjectStore()->getStorageId() === $this->getObjectStore()->getStorageId()) {
@@ -614,10 +614,10 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			}
 		}
 
-		return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -60,6 +60,7 @@ use OCP\Files\InvalidDirectoryException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\ReservedWordException;
 use OCP\Files\Storage\ILockingStorage;
+use OCP\Files\Storage\IMtimePreserving;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IWriteStreamStorage;
 use OCP\Lock\ILockingProvider;
@@ -78,7 +79,7 @@ use Psr\Log\LoggerInterface;
  * Some \OC\Files\Storage\Common methods call functions which are first defined
  * in classes which extend it, e.g. $this->stat() .
  */
-abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
+abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, IMtimePreserving {
 	use LocalTempFileTrait;
 
 	protected $cache;
@@ -222,17 +223,17 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		$this->remove($target);
 
 		$this->removeCachedFile($source);
-		return $this->copy($source, $target) and $this->remove($source);
+		return $this->copy($source, $target, true) && $this->remove($source);
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		if ($this->is_dir($source)) {
 			$this->remove($target);
 			$dir = $this->opendir($source);
 			$this->mkdir($target);
 			while ($file = readdir($dir)) {
 				if (!Filesystem::isIgnoredDir($file)) {
-					if (!$this->copy($source . '/' . $file, $target . '/' . $file)) {
+					if (!$this->copy($source . '/' . $file, $target . '/' . $file, $preserveMtime)) {
 						closedir($dir);
 						return false;
 					}
@@ -246,6 +247,9 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			[, $result] = \OC_Helper::streamCopy($sourceStream, $targetStream);
 			if (!$result) {
 				\OCP\Server::get(LoggerInterface::class)->warning("Failed to write data while copying $source to $target");
+			} elseif ($preserveMtime) {
+				$mtime = $this->filemtime($source);
+				$this->touch($target, is_int($mtime) ? $mtime : null);
 			}
 			$this->removeCachedFile($target);
 			return $result;
@@ -615,19 +619,22 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 	 * @param bool $preserveMtime
 	 * @return bool
 	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, bool $preserveMtime = false): bool {
 		if ($sourceStorage === $this) {
-			return $this->copy($sourceInternalPath, $targetInternalPath);
+			return $this->copy($sourceInternalPath, $targetInternalPath, $preserveMtime);
 		}
 
 		if ($sourceStorage->is_dir($sourceInternalPath)) {
 			$dh = $sourceStorage->opendir($sourceInternalPath);
-			$result = $this->mkdir($targetInternalPath);
 			if (is_resource($dh)) {
-				$result = true;
-				while ($result and ($file = readdir($dh)) !== false) {
+				if (!$this->is_dir($targetInternalPath)) {
+					$result = $this->mkdir($targetInternalPath);
+				} else {
+					$result = true;
+				}
+				while ($result && ($file = readdir($dh)) !== false) {
 					if (!Filesystem::isIgnoredDir($file)) {
-						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file);
+						$result = $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, $preserveMtime);
 					}
 				}
 			}
@@ -655,7 +662,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 				$this->getCache()->remove($targetInternalPath);
 			}
 		}
-		return (bool)$result;
+		return $result;
 	}
 
 	/**

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -240,6 +240,10 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 				}
 			}
 			closedir($dir);
+			if ($preserveMtime) {
+				$mtime = $this->filemtime($source);
+				$this->touch($target, is_int($mtime) ? $mtime : null);
+			}
 			return true;
 		} else {
 			$sourceStream = $this->fopen($source, 'r');
@@ -636,6 +640,10 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 					if (!Filesystem::isIgnoredDir($file)) {
 						$result = $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, $preserveMtime);
 					}
+				}
+				if ($result && $preserveMtime) {
+					$mtime = $sourceStorage->filemtime($sourceInternalPath);
+					$this->touch($targetInternalPath, is_int($mtime) ? $mtime : null);
 				}
 			}
 		} else {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -565,7 +565,7 @@ class DAV extends Common {
 	}
 
 	/** {@inheritdoc} */
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		$this->init();
 		$source = $this->cleanPath($source);
 		$target = $this->cleanPath($target);

--- a/lib/private/Files/Storage/FailedStorage.php
+++ b/lib/private/Files/Storage/FailedStorage.php
@@ -132,7 +132,7 @@ class FailedStorage extends Common {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
@@ -180,7 +180,7 @@ class FailedStorage extends Common {
 		return true;
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, bool $preserveMtime = false): bool {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -398,20 +398,26 @@ class Local extends \OC\Files\Storage\Common {
 		return $this->copy($source, $target) && $this->unlink($source);
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		if ($this->is_dir($source)) {
-			return parent::copy($source, $target);
+			return parent::copy($source, $target, $preserveMtime);
 		} else {
 			$oldMask = umask($this->defUMask);
 			if ($this->unlinkOnTruncate) {
 				$this->unlink($target);
 			}
-			$result = copy($this->getSourcePath($source), $this->getSourcePath($target));
+			$sourceInternalPath = $this->getSourcePath($source);
+			$targetInternalPath = $this->getSourcePath($target);
+			$result = copy($sourceInternalPath, $targetInternalPath);
 			umask($oldMask);
 			if ($this->caseInsensitive) {
 				if (mb_strtolower($target) === mb_strtolower($source) && !$this->file_exists($target)) {
 					return false;
 				}
+			}
+			if ($result && $preserveMtime) {
+				$mtime = $this->filemtime($sourceInternalPath);
+				$this->touch($targetInternalPath, is_int($mtime) ? $mtime : null);
 			}
 			return $result;
 		}
@@ -590,13 +596,10 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * @param IStorage $sourceStorage
 	 * @param string $sourceInternalPath
 	 * @param string $targetInternalPath
-	 * @param bool $preserveMtime
-	 * @return bool
 	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, bool $preserveMtime = false): bool {
 		if ($this->canDoCrossStorageMove($sourceStorage)) {
 			if ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**
@@ -608,9 +611,9 @@ class Local extends \OC\Files\Storage\Common {
 			 * @var \OC\Files\Storage\Local $sourceStorage
 			 */
 			$rootStorage = new Local(['datadir' => '/']);
-			return $rootStorage->copy($sourceStorage->getSourcePath($sourceInternalPath), $this->getSourcePath($targetInternalPath));
+			return $rootStorage->copy($sourceStorage->getSourcePath($sourceInternalPath), $this->getSourcePath($targetInternalPath), $preserveMtime);
 		} else {
-			return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+			return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 		}
 	}
 

--- a/lib/private/Files/Storage/PolyFill/CopyDirectory.php
+++ b/lib/private/Files/Storage/PolyFill/CopyDirectory.php
@@ -64,35 +64,37 @@ trait CopyDirectory {
 	 */
 	abstract public function mkdir($path);
 
-	public function copy($source, $target) {
+	/**
+	 * Copy file or folder
+	 *
+	 * @param string $source
+	 * @param string $target
+	 */
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		if ($this->is_dir($source)) {
 			if ($this->file_exists($target)) {
 				$this->unlink($target);
 			}
 			$this->mkdir($target);
-			return $this->copyRecursive($source, $target);
+			return $this->copyRecursive($source, $target, $preserveMtime);
 		} else {
-			return parent::copy($source, $target);
+			return parent::copy($source, $target, $preserveMtime);
 		}
 	}
 
 	/**
 	 * For adapters that don't support copying folders natively
-	 *
-	 * @param $source
-	 * @param $target
-	 * @return bool
 	 */
-	protected function copyRecursive($source, $target) {
+	protected function copyRecursive(string $source, string $target, bool $preserveMtime = false): bool {
 		$dh = $this->opendir($source);
 		$result = true;
 		while ($file = readdir($dh)) {
 			if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
 				if ($this->is_dir($source . '/' . $file)) {
 					$this->mkdir($target . '/' . $file);
-					$result = $this->copyRecursive($source . '/' . $file, $target . '/' . $file);
+					$result = $this->copyRecursive($source . '/' . $file, $target . '/' . $file, $preserveMtime);
 				} else {
-					$result = parent::copy($source . '/' . $file, $target . '/' . $file);
+					$result = parent::copy($source . '/' . $file, $target . '/' . $file, $preserveMtime);
 				}
 				if (!$result) {
 					break;

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -824,9 +824,9 @@ class Encryption extends Wrapper {
 				$result = true;
 			}
 			if (is_resource($dh)) {
-				while ($result and ($file = readdir($dh)) !== false) {
+				while ($result && ($file = readdir($dh)) !== false) {
 					if (!Filesystem::isIgnoredDir($file)) {
-						$result &= $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, false, $isRename);
+						$result = $this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, $preserveMtime, $isRename);
 					}
 				}
 			}

--- a/lib/private/Files/Storage/Wrapper/KnownMtime.php
+++ b/lib/private/Files/Storage/Wrapper/KnownMtime.php
@@ -86,7 +86,7 @@ class KnownMtime extends Wrapper {
 	public function rename($source, $target) {
 		$result = parent::rename($source, $target);
 		if ($result) {
-			$this->knowMtimes->set($target, $this->clock->now()->getTimestamp());
+			$this->knowMtimes->set($target, $this->filemtime($source));
 			$this->knowMtimes->set($source, $this->clock->now()->getTimestamp());
 		}
 		return $result;
@@ -125,9 +125,10 @@ class KnownMtime extends Wrapper {
 	}
 
 	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+		$mTime = $sourceStorage->filemtime($sourceInternalPath);
 		$result = parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		if ($result) {
-			$this->knowMtimes->set($targetInternalPath, $this->clock->now()->getTimestamp());
+			$this->knowMtimes->set($targetInternalPath, $mTime);
 		}
 		return $result;
 	}

--- a/lib/private/Lockdown/Filesystem/NullStorage.php
+++ b/lib/private/Lockdown/Filesystem/NullStorage.php
@@ -117,7 +117,7 @@ class NullStorage extends Common {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
@@ -161,7 +161,7 @@ class NullStorage extends Common {
 		return false;
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, bool $preserveMtime = false): bool {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 

--- a/lib/public/Files/Storage/IMtimePreserving.php
+++ b/lib/public/Files/Storage/IMtimePreserving.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright Copyright (c) 2024 Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @author Côme Chilliet <come.chilliet@nextcloud.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+namespace OCP\Files\Storage;
+
+/**
+ * @since 29.0.0
+ */
+interface IMtimePreserving extends IStorage {
+
+	/**
+	 * see https://www.php.net/manual/en/function.copy.php
+	 *
+	 * @param string $source
+	 * @param string $target
+	 * @return bool
+	 * @since 9.0.0
+	 * @deprecated 29.0.0 see copyWithMtime
+	 */
+	public function copy($source, $target, bool $preserveMtime = false): bool;
+
+	/**
+	 * @param string $sourceInternalPath
+	 * @param string $targetInternalPath
+	 * @since 29.0.0
+	 */
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, bool $preserveMtime = false): bool;
+
+	/**
+	 * see https://www.php.net/manual/en/function.copy.php
+	 *
+	 * @since 29.0.0
+	 */
+	// public function copyWithMtime(string $source, string $target, bool $preserveMtime = false): bool;
+
+	/**
+	 * @since 29.0.0
+	 */
+	// public function copyFromStorageWithMtime(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool;
+}

--- a/tests/lib/Files/Storage/CopyDirectoryTest.php
+++ b/tests/lib/Files/Storage/CopyDirectoryTest.php
@@ -24,11 +24,11 @@ namespace Test\Files\Storage;
 use OC\Files\Storage\Temporary;
 
 class StorageNoRecursiveCopy extends Temporary {
-	public function copy($path1, $path2) {
-		if ($this->is_dir($path1)) {
+	public function copy($source, $target, bool $preserveMtime = false): bool {
+		if ($this->is_dir($source)) {
 			return false;
 		}
-		return copy($this->getSourcePath($path1), $this->getSourcePath($path2));
+		return copy($this->getSourcePath($source), $this->getSourcePath($target));
 	}
 }
 

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -730,6 +730,13 @@ abstract class Storage extends \Test\TestCase {
 			->method('filemtime')
 			->with($source)
 			->willReturn($mTime);
+		$instance->expects(static::any())
+			->method('getId')
+			->willReturn('fakeid');
+		$cache = $this->createMock(\OCP\Files\Cache\ICache::class);
+		$instance->expects(static::any())
+			->method('getCache')
+			->willReturn($cache);
 
 		$this->assertFalse($this->instance->file_exists($target));
 		$this->instance->moveFromStorage($instance, $source, $target);

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -243,12 +243,14 @@ abstract class Storage extends \Test\TestCase {
 	public function testMove($source, $target) {
 		$this->initSourceAndTarget($source);
 
+		$mTime = $this->instance->filemtime($source);
 		$this->instance->rename($source, $target);
 
 		$this->wait();
 		$this->assertTrue($this->instance->file_exists($target), $target . ' was not created');
 		$this->assertFalse($this->instance->file_exists($source), $source . ' still exists');
 		$this->assertSameAsLorem($target);
+		$this->assertEquals($mTime, $this->instance->filemtime($target), 'mtime was not preserved by move');
 	}
 
 	/**
@@ -271,11 +273,13 @@ abstract class Storage extends \Test\TestCase {
 	public function testMoveOverwrite($source, $target) {
 		$this->initSourceAndTarget($source, $target);
 
+		$mTime = $this->instance->filemtime($source);
 		$this->instance->rename($source, $target);
 
 		$this->assertTrue($this->instance->file_exists($target), $target . ' was not created');
 		$this->assertFalse($this->instance->file_exists($source), $source . ' still exists');
 		$this->assertSameAsLorem($target);
+		$this->assertEquals($mTime, $this->instance->filemtime($target), 'mtime was not preserved by move');
 	}
 
 	public function testLocal() {
@@ -485,6 +489,10 @@ abstract class Storage extends \Test\TestCase {
 		$this->instance->file_put_contents('source/test2.txt', 'qwerty');
 		$this->instance->mkdir('source/subfolder');
 		$this->instance->file_put_contents('source/subfolder/test.txt', 'bar');
+
+		$mTimeDirectory = $this->instance->filemtime('source');
+		$mTimeTestFile = $this->instance->filemtime('source/subfolder/test.txt');
+
 		$this->instance->rename('source', 'target');
 
 		$this->assertFalse($this->instance->file_exists('source'));
@@ -505,6 +513,8 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertEquals('foo', $this->instance->file_get_contents('target/test1.txt'));
 		$this->assertEquals('qwerty', $this->instance->file_get_contents('target/test2.txt'));
 		$this->assertEquals('bar', $this->instance->file_get_contents('target/subfolder/test.txt'));
+		$this->assertEquals($mTimeDirectory, $this->instance->filemtime('target'), 'directory mtime was not preserved by rename');
+		$this->assertEquals($mTimeTestFile, $this->instance->filemtime('target/subfolder/test.txt'), 'file mtime was not preserved by rename');
 	}
 
 	public function testRenameOverWriteDirectory() {

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -224,6 +224,15 @@ abstract class Storage extends \Test\TestCase {
 		);
 	}
 
+	protected function getAlteredMtime($path): int {
+		/* Save mtime, but also change it so that it differs from current timestamp */
+		$mTime = $this->instance->filemtime($path);
+		$mTime -= 100;
+		$this->instance->touch($path, $mTime);
+		$this->assertEquals($mTime, $this->instance->filemtime($path), 'Failed to set mtime with touch');
+		return $mTime;
+	}
+
 	/**
 	 * @dataProvider copyAndMoveProvider
 	 */
@@ -243,7 +252,7 @@ abstract class Storage extends \Test\TestCase {
 	public function testMove($source, $target) {
 		$this->initSourceAndTarget($source);
 
-		$mTime = $this->instance->filemtime($source);
+		$mTime = $this->getAlteredMtime($source);
 		$this->instance->rename($source, $target);
 
 		$this->wait();
@@ -273,7 +282,7 @@ abstract class Storage extends \Test\TestCase {
 	public function testMoveOverwrite($source, $target) {
 		$this->initSourceAndTarget($source, $target);
 
-		$mTime = $this->instance->filemtime($source);
+		$mTime = $this->getAlteredMtime($source);
 		$this->instance->rename($source, $target);
 
 		$this->assertTrue($this->instance->file_exists($target), $target . ' was not created');
@@ -490,8 +499,8 @@ abstract class Storage extends \Test\TestCase {
 		$this->instance->mkdir('source/subfolder');
 		$this->instance->file_put_contents('source/subfolder/test.txt', 'bar');
 
-		$mTimeDirectory = $this->instance->filemtime('source');
-		$mTimeTestFile = $this->instance->filemtime('source/subfolder/test.txt');
+		$mTimeDirectory = $this->getAlteredMtime('source');
+		$mTimeTestFile = $this->getAlteredMtime('source/subfolder/test.txt');
 
 		$this->instance->rename('source', 'target');
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -39,7 +39,7 @@ class TemporaryNoTouch extends Temporary {
 }
 
 class TemporaryNoCross extends Temporary {
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, bool $preserveMtime = false): bool {
 		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 


### PR DESCRIPTION


## Summary

There is no clear consensus on whether copy should preserve mtime, but rename or move should definetly preserve it.
So adding some tests for this, and if failure are found I may fix some of them in the PR as well.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
