### PR TITLE
fix(notifications): Help finding missing notifications by logging it

### DIFF
--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -366,6 +366,7 @@ class Manager implements IManager {
 		}
 
 		if (!$notification->isValidParsed()) {
+			$this->logger->info('Notification was not parsed by any notifier [app: ' . $notification->getApp() . ', subject: ' . $notification->getSubject() . ']');
 			throw new \InvalidArgumentException('The given notification has not been handled');
 		}
 


### PR DESCRIPTION
* Used this to find https://github.com/nextcloud/spreed/pull/11610

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
