### PR TITLE
fix(db): Remove duplicate missing index check for `cards`

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -165,13 +165,6 @@ class Application extends App {
 
 			$event->addMissingIndex(
 				'cards',
-				'cards_abiduri',
-				['addressbookid', 'uri'],
-				[],
-				true
-			);
-			$event->addMissingIndex(
-				'cards',
 				'cards_abid',
 				['addressbookid'],
 				[],


### PR DESCRIPTION
## Summary

Just looks like it was duplicated during #39487.

Probably not backport worthy since I'm not aware of any real side effects.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
