### PR TITLE
fix(AppFramework): Correctly implement CSRF checks

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -451,8 +451,10 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 
 
 	/**
-	 * Checks if the CSRF check was correct
-	 * @return bool true if CSRF check passed
+	 * Checks if the request passes the CSRF checks.
+	 *
+	 * A request must always pass the strict cookie check, unless it has the OCS-APIRequest set or no session (@see cookieCheckRequired).
+	 * If the OCS-APIRequest is set or a valid CSRF token is sent the request will to pass.
 	 */
 	public function passesCSRFCheck(): bool {
 		if ($this->csrfTokenManager === null) {

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -463,6 +463,10 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			return false;
 		}
 
+		if ($this->getHeader('OCS-APIRequest') !== '') {
+			return true;
+		}
+
 		if (isset($this->items['get']['requesttoken'])) {
 			$token = $this->items['get']['requesttoken'];
 		} elseif (isset($this->items['post']['requesttoken'])) {

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -481,17 +481,12 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/**
 	 * Whether the cookie checks are required
 	 *
+	 * In case the OCS-APIRequest header is set or the user has no session, we don't to check the cookies because the client is not a browser and thus doesn't need CSRF checks.
+	 *
 	 * @return bool
 	 */
 	private function cookieCheckRequired(): bool {
-		if ($this->getHeader('OCS-APIREQUEST')) {
-			return false;
-		}
-		if ($this->getCookie(session_name()) === null && $this->getCookie('nc_token') === null) {
-			return false;
-		}
-
-		return true;
+		return $this->getHeader('OCS-APIRequest') === '' && ($this->getCookie(session_name()) !== null || $this->getCookie('nc_token') !== null);
 	}
 
 	/**

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -487,7 +487,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	/**
 	 * Whether the cookie checks are required
 	 *
-	 * In case the OCS-APIRequest header is set or the user has no session, we don't to check the cookies because the client is not a browser and thus doesn't need CSRF checks.
+	 * In case the OCS-APIRequest header is set or the user has no session, we don't need to check the cookies because the client is not a browser and thus doesn't need CSRF checks.
 	 *
 	 * @return bool
 	 */

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -454,7 +454,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * Checks if the request passes the CSRF checks.
 	 *
 	 * A request must always pass the strict cookie check, unless it has the OCS-APIRequest set or no session (@see cookieCheckRequired).
-	 * If the OCS-APIRequest is set or a valid CSRF token is sent the request will to pass.
+	 * If the OCS-APIRequest is set or a valid CSRF token is sent the check will succeed.
 	 */
 	public function passesCSRFCheck(): bool {
 		if ($this->csrfTokenManager === null) {

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -532,11 +532,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 
 		$cookieName = $this->getProtectedCookieName('nc_sameSiteCookiestrict');
-		if ($this->getCookie($cookieName) === 'true'
-			&& $this->passesLaxCookieCheck()) {
-			return true;
-		}
-		return false;
+		return $this->getCookie($cookieName) === 'true' && $this->passesLaxCookieCheck();
 	}
 
 	/**
@@ -552,10 +548,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		}
 
 		$cookieName = $this->getProtectedCookieName('nc_sameSiteCookielax');
-		if ($this->getCookie($cookieName) === 'true') {
-			return true;
-		}
-		return false;
+		return $this->getCookie($cookieName) === 'true';
 	}
 
 

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -2261,4 +2261,24 @@ class RequestTest extends \Test\TestCase {
 
 		$this->assertFalse($request->passesCSRFCheck());
 	}
+
+	public function testPassesCSRFCheckWithOCSAPIRequestHeader() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_OCS_APIREQUEST' => 'true',
+					],
+				],
+				$this->requestId,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+
+		$this->assertTrue($request->passesCSRFCheck());
+	}
 }


### PR DESCRIPTION
## Summary

These changes ensure that actually all the CSRF protection methods can be correctly used.
I improved the existing codes and allowed requests with OCS-APIRequest headers to pass which was not possible before and a bug.
As far as I can see there were no security problems before and this does not open any new ones :tm:

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
