### PR TITLE
enh(updatenotification): Try to make legacy-notification smart(er)

### DIFF
--- a/apps/updatenotification/js/legacy-notification.js
+++ b/apps/updatenotification/js/legacy-notification.js
@@ -11,11 +11,24 @@
  */
 
 /**
- * This only gets loaded if an update is available and the notifications app is not enabled for the user.
+ * This only gets loaded if an update is available, but the notifications app has been disabled (but updatechecker isn't disabled).
+ * The goal here is to make sure admins still get an indication there is an update available even if push notifications are disabled.
+ *
+ * Since this is a fallback method that only gets used when the notifications app is disabled, we use toasts to notify, but there's no 
+ * intelligence. To avoid constant nagging upon every page reload, we only generate the toasts one day a week on the half hour. This tries to strike 
+ * a balance for an admin that disables push notifications. The idea is they still get a periodic reminder of an update being available, 
+ * without constant nagging every day upon every page reload. This hopefully reduces likelihood of needing to disable update 
+ * checks outright (e.g. by setting `updatechecker => false` in their `config.php` or disabling this app outright too).
+ *
  */
 window.addEventListener('DOMContentLoaded', function(){
 	var text = t('core', '{version} is available. Get more information on how to update.', {version: oc_updateState.updateVersion}),
 		element = $('<a>').attr('href', oc_updateState.updateLink).attr('target','_blank').text(text);
-
-	OC.Notification.showHtml(element.prop('outerHTML'), { type: 'error' });
+	
+    today = new Date();
+	dayOfMonth = today.getDate();
+	minuteOfHour = today.getMinutes();
+	if (dayOfMonth % 7 === 0 && minuteOfHour % 30 === 0) {	// only toast once a week on the half hour
+		OC.Notification.showHtml(element.prop('outerHTML'), { type: 'error' });
+	}
 });


### PR DESCRIPTION
* Resolves: #43645 <!-- related github issue -->

## Summary

If `updatenotification` app is enabled (the default), but the `notifications` (push notifications) app is disabled, we [load](https://github.com/nextcloud/server/blob/1731d3154a8e9c8d3692c6c73f5a6b91b9bc17a5/apps/updatenotification/lib/AppInfo/Application.php#L75-L87) a so-called [legacy-notification](https://github.com/nextcloud/server/blob/master/apps/updatenotification/js/legacy-notification.js) as a toast message as a fallback to inform admins about new available updates. If there is a new version of Server available, a new _toast_ is generated upon _every DOM reload_. An admin (effectively) can't dismiss it:

<img width="601" alt="image" src="https://github.com/nextcloud/server/assets/1560121/9c597d24-cab2-4550-8d6e-1cfd7a65647c">

If a user that disables push notifications still wishes to periodically be notified in the Web UI about new updates they _must_ tolerate the constant toasts all day long every day without the ability to dismiss them beyond the next page load. 

Example: Joe User is happily running Server v27, but doesn't plan to update to v28 soon. They don't want to be told about the latest v28 release all day long every day long in a new toast.

Alternatives from the user's perspective:

- Re-enable the `notifications` app even if they won't really want to
- Don't use an account with admin privileges for everyday work
- Decide it's not worth it and disable _all_ update notifications (by either disabling the `updatenotification` app outright or setting `updatechecker: false` in `config.php`) [likely not an action we want to encourage if it's merely out of frustration with the constant toasts]

This PR tries to make this legacy code a tiny bit smart, by only sending the notification one day a week and on the half hour only.

Currently it's set to every 7th day, but maybe every 4th or something makes more sense (in order to be less likely to skip a weekday/etc.).

Keep in mind this doesn't have to be perfect. It's already only a fallback that is *only* utilized when the `notifications` app is disabled.

## TODO

- [ ] Confirm hard coded *every X day* makes sense

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
