### PR TITLE
fix(cypress): more stable `navigation-bar-settings` and `versions` cypress tests

### DIFF
--- a/cypress/e2e/files_versions/filesVersionsUtils.ts
+++ b/cypress/e2e/files_versions/filesVersionsUtils.ts
@@ -20,10 +20,10 @@
  *
  */
 
-import path from "path"
-import type { User } from "@nextcloud/cypress"
+import type { User } from '@nextcloud/cypress'
+import path from 'path'
 
-export function uploadThreeVersions(user: User, fileName: string) {
+export const uploadThreeVersions = (user: User, fileName: string) => {
 	// A new version will not be created if the changes occur
 	// within less than one second of each other.
 	// eslint-disable-next-line cypress/no-unnecessary-waiting
@@ -35,23 +35,22 @@ export function uploadThreeVersions(user: User, fileName: string) {
 	cy.login(user)
 }
 
-export function openVersionsPanel(fileName: string) {
-	cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${fileName}"]`).within(() => {
-		cy.get('[data-cy-files-list-row-actions] .action-item__menutoggle')
-			.click()
+export const openVersionsPanel = (fileName: string) =>{
+	// Detect the versions list fetch
+	cy.intercept('PROPFIND', '**/dav/versions/*/versions/**').as('getVersions')
+
+	// Open the versions tab
+	cy.window().then(win => {
+		win.OCA.Files.Sidebar.setActiveTab('version_vue')
+		win.OCA.Files.Sidebar.open(`/${fileName}`)
 	})
 
-	cy.get('.action-item__popper')
-		.get('[data-cy-files-list-row-action="details"]')
-		.click()
-
-	cy.get('#app-sidebar-vue')
-		.get('[aria-controls="tab-version_vue"]')
-		.click()
-
+	// Wait for the versions list to be fetched
+	cy.wait('@getVersions')
+	cy.get('#tab-version_vue').should('be.visible', { timeout: 10000 })
 }
 
-export function openVersionMenu(index: number) {
+export const openVersionMenu = (index: number) => {
 	cy.get('#tab-version_vue').within(() => {
 		cy.get('[data-files-versions-version]')
 			.eq(index).within(() => {
@@ -61,19 +60,19 @@ export function openVersionMenu(index: number) {
 	})
 }
 
-export function clickPopperAction(actionName: string) {
+export const clickPopperAction = (actionName: string) => {
 	cy.get('.v-popper__popper').filter(':visible')
 		.contains(actionName)
 		.click()
 }
 
-export function nameVersion(index: number, name: string) {
+export const nameVersion = (index: number, name: string) => {
 	openVersionMenu(index)
 	clickPopperAction('Name this version')
 	cy.get(':focused').type(`${name}{enter}`)
 }
 
-export function assertVersionContent(filename: string, index: number, expectedContent: string) {
+export const assertVersionContent = (filename: string, index: number, expectedContent: string) => {
 	const downloadsFolder = Cypress.config('downloadsFolder')
 
 	openVersionMenu(index)

--- a/cypress/e2e/files_versions/version_restoration.cy.ts
+++ b/cypress/e2e/files_versions/version_restoration.cy.ts
@@ -22,9 +22,11 @@
 
 import { assertVersionContent, clickPopperAction, openVersionMenu, openVersionsPanel, uploadThreeVersions } from './filesVersionsUtils'
 
-function restoreVersion(index: number) {
+const restoreVersion = (index: number) => {
+	cy.intercept('MOVE', '**/dav/versions/*/versions/**').as('restoreVersion')
 	openVersionMenu(index)
 	clickPopperAction('Restore version')
+	cy.wait('@restoreVersion')
 }
 
 describe('Versions restoration', () => {

--- a/cypress/e2e/theming/navigation-bar-settings.cy.ts
+++ b/cypress/e2e/theming/navigation-bar-settings.cy.ts
@@ -35,6 +35,8 @@ describe('Admin theming set default apps', () => {
 	it('See the current default app is the dashboard', () => {
 		cy.visit('/')
 		cy.url().should('match', /apps\/dashboard/)
+
+		// Also check the top logo link
 		cy.get('#nextcloud').click()
 		cy.url().should('match', /apps\/dashboard/)
 	})
@@ -54,9 +56,9 @@ describe('Admin theming set default apps', () => {
 	})
 
 	it('See the default app order selector', () => {
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['dashboard', 'files'])
 		})
 	})
 
@@ -70,13 +72,17 @@ describe('Admin theming set default apps', () => {
 	})
 
 	it('See the default app is changed', () => {
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['files', 'dashboard'])
 		})
 
-		cy.get('#nextcloud').click()
-		cy.url().should('match', /apps\/files/)
+		// Check the redirect to the default app works
+		cy.request({ url: '/', followRedirect: false }).then((response) => {
+			expect(response.status).to.eq(302)
+			expect(response).to.have.property('headers')
+			expect(response.headers.location).to.contain('/apps/files')
+		})
 	})
 
 	it('Toggle the "use custom default app" switch back to reset the default apps', () => {
@@ -89,9 +95,12 @@ describe('Admin theming set default apps', () => {
 	})
 
 	it('See the default app is changed back to default', () => {
-		cy.reload()
-		cy.get('#nextcloud').click()
-		cy.url().should('match', /apps\/dashboard/)
+		// Check the redirect to the default app works
+		cy.request({ url: '/', followRedirect: false }).then((response) => {
+			expect(response.status).to.eq(302)
+			expect(response).to.have.property('headers')
+			expect(response.headers.location).to.contain('/apps/dashboard')
+		})
 	})
 })
 
@@ -117,14 +126,16 @@ describe('User theming set app order', () => {
 	})
 
 	it('See that the dashboard app is the first one', () => {
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
+		// Check the app order settings UI
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['dashboard', 'files'])
 		})
 
-		cy.get('.app-menu-main .app-menu-entry').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'dashboard')
-			else cy.wrap($el).should('have.attr', 'data-app-id', 'files')
+		// Check the top app menu order
+		cy.get('.app-menu-main .app-menu-entry').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-app-id')).get()
+			expect(appIDs).to.deep.eq(['dashboard', 'files'])
 		})
 	})
 
@@ -133,17 +144,17 @@ describe('User theming set app order', () => {
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').click()
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').should('not.be.visible')
 
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['files', 'dashboard'])
 		})
 	})
 
 	it('See the app menu order is changed', () => {
 		cy.reload()
-		cy.get('.app-menu-main .app-menu-entry').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'files')
-			else cy.wrap($el).should('have.attr', 'data-app-id', 'dashboard')
+		cy.get('.app-menu-main .app-menu-entry').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-app-id')).get()
+			expect(appIDs).to.deep.eq(['files', 'dashboard'])
 		})
 	})
 })
@@ -171,20 +182,21 @@ describe('User theming set app order with default app', () => {
 	})
 
 	it('See files is the default app', () => {
-		cy.visit('/')
-		cy.url().should('match', /apps\/files/)
-
-		cy.get('.app-menu-main .app-menu-entry').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'files')
+		// Check the redirect to the default app works
+		cy.request({ url: '/', followRedirect: false }).then((response) => {
+			expect(response.status).to.eq(302)
+			expect(response).to.have.property('headers')
+			expect(response.headers.location).to.contain('/apps/files')
 		})
 	})
 
 	it('See the app order settings: files is the first one', () => {
 		cy.visit('/settings/user/theming')
 		cy.get('[data-cy-app-order]').scrollIntoView()
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').should('have.length', 4).each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
-			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			expect(elements).to.have.length(4)
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['files', 'dashboard', 'testapp1', 'testapp'])
 		})
 	})
 
@@ -200,22 +212,31 @@ describe('User theming set app order with default app', () => {
 	})
 
 	it('Change the order of the other apps', () => {
+		cy.intercept('POST', '**/apps/provisioning_api/api/v1/config/users/core/apporder').as('setAppOrder')
+
+		// Move the testapp up twice, it should be the first one after files
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').click()
+		cy.wait('@setAppOrder')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').click()
+		cy.wait('@setAppOrder')
+
+		// Can't get up anymore, files is enforced as default app
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="testapp"] [data-cy-app-order-button="up"]').should('not.be.visible')
 
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
-			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'testapp')
-			else if (idx === 2) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
+		// Check the final list order
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			expect(elements).to.have.length(4)
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['files', 'testapp', 'dashboard', 'testapp1'])
 		})
 	})
 
 	it('See the app menu order is changed', () => {
 		cy.reload()
-		cy.get('.app-menu-main .app-menu-entry').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'files')
-			else if (idx === 1) cy.wrap($el).should('have.attr', 'data-app-id', 'testapp')
-			else if (idx === 2) cy.wrap($el).should('have.attr', 'data-app-id', 'dashboard')
+		cy.get('.app-menu-main .app-menu-entry').then(elements => {
+			expect(elements).to.have.length(4)
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-app-id')).get()
+			expect(appIDs).to.deep.eq(['files', 'testapp', 'dashboard', 'testapp1'])
 		})
 	})
 })
@@ -289,14 +310,16 @@ describe('User theming reset app order', () => {
 	})
 
 	it('See that the dashboard app is the first one', () => {
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
+		// Check the app order settings UI
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['dashboard', 'files'])
 		})
 
-		cy.get('.app-menu-main .app-menu-entry').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-app-id', 'dashboard')
-			else cy.wrap($el).should('have.attr', 'data-app-id', 'files')
+		// Check the top app menu order
+		cy.get('.app-menu-main .app-menu-entry').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-app-id')).get()
+			expect(appIDs).to.deep.eq(['dashboard', 'files'])
 		})
 	})
 
@@ -310,9 +333,10 @@ describe('User theming reset app order', () => {
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').click()
 		cy.get('[data-cy-app-order] [data-cy-app-order-element="files"] [data-cy-app-order-button="up"]').should('not.be.visible')
 
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
+		// Check the app order settings UI
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['files', 'dashboard'])
 		})
 	})
 
@@ -326,9 +350,9 @@ describe('User theming reset app order', () => {
 	})
 
 	it('See the app order is restored', () => {
-		cy.get('[data-cy-app-order] [data-cy-app-order-element]').each(($el, idx) => {
-			if (idx === 0) cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'dashboard')
-			else cy.wrap($el).should('have.attr', 'data-cy-app-order-element', 'files')
+		cy.get('[data-cy-app-order] [data-cy-app-order-element]').then(elements => {
+			const appIDs = elements.map((idx, el) => el.getAttribute('data-cy-app-order-element')).get()
+			expect(appIDs).to.deep.eq(['dashboard', 'files'])
 		})
 	})
 

--- a/cypress/fixtures/testapp/appinfo/info.xml
+++ b/cypress/fixtures/testapp/appinfo/info.xml
@@ -16,7 +16,7 @@
     <category>games</category>
     <bugs>https://github.com/nextcloud/server/issues</bugs>
     <dependencies>
-        <nextcloud min-version="28" max-version="28"/>
+        <nextcloud min-version="28" max-version="29"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/cypress/support/commonUtils.ts
+++ b/cypress/support/commonUtils.ts
@@ -46,7 +46,7 @@ export function installTestApp() {
 		cy.wrap(version).should('not.be.undefined')
 		cy.exec(`docker cp '${testAppPath}' nextcloud-cypress-tests-server:/var/www/html/apps`, { log: true })
 		cy.exec(`docker exec nextcloud-cypress-tests-server sed -i -e 's|-version="[0-9]\\+|-version="${version}|g' apps/testapp/appinfo/info.xml`)
-		cy.runOccCommand('app:enable testapp')
+		cy.runOccCommand('app:enable --force testapp')
 	})
 }
 


### PR DESCRIPTION
After https://github.com/nextcloud/server/pull/43360

`testapp` DO have to be moved up twice
![image](https://github.com/nextcloud/server/assets/14975046/2d6ea3e6-0ec1-4f05-bd2e-7d25f0197d82)
