### PR TITLE
fix(user_ldap): Ignore unserialize error in group membership migration

### DIFF
--- a/apps/user_ldap/lib/Migration/Version1190Date20230706134108.php
+++ b/apps/user_ldap/lib/Migration/Version1190Date20230706134108.php
@@ -99,6 +99,10 @@ class Version1190Date20230706134108 extends SimpleMigrationStep {
 		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$knownUsers = unserialize($row['owncloudusers']);
+			if (!is_array($knownUsers)) {
+				/* Unserialize failed or data was incorrect in database, ignore */
+				continue;
+			}
 			$knownUsers = array_unique($knownUsers);
 			foreach ($knownUsers as $knownUser) {
 				try {


### PR DESCRIPTION
* Resolves: #43584 

## Summary

The memberships will be checked by the background job later and data will be added to the table anyway.
This avoids blocking migration when there is invalid data in the ldap_group_members table, whatever the reason.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
