### PR TITLE
fix: Throw instead of yielding nothing when listing local directories

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -62,6 +62,7 @@ use OCP\Files\ReservedWordException;
 use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IWriteStreamStorage;
+use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Server;
@@ -898,6 +899,11 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 
 	public function getDirectoryContent($directory): \Traversable {
 		$dh = $this->opendir($directory);
+
+		if ($dh === false) {
+			throw new StorageNotAvailableException('Directory listing failed');
+		}
+
 		if (is_resource($dh)) {
 			$basePath = rtrim($directory, '/');
 			while (($file = readdir($dh)) !== false) {


### PR DESCRIPTION
I've been poking around in code trying to replicate scenarios where out of a sudden file ids were changed. Due to one case where we have seen this with a temporary storage failure I tried making the __groupfolders directory not readable by changing filesystem permissions. Now when we hit file scanning logic we may end up calling the directory listing from the Local storage class which on an error does not fail but instead yields nothing which means that the scanner will handle the given directory as if it would be empty.

Note I'm not sure this actually fixes the issue and also not what could cause a scan on the folder out of a sudden (in testing i manually set the size to -1 to trigger this).

@icewind1991 Maybe you can have a look, i think from a code perspective is sensible and should avoid unnecessary file cache entry drops if the opendir fails. However I also cannot really exclude possible side-effects of a scanner then not removing a missing directory on the filesystem.

Related to https://github.com/nextcloud/groupfolders/issues/1468

I also remember issues in the past where the size was always pending on some group folders (not sure if that was fixed meanwhile), but could then probably trigger such cases if the scan never finishes or happens regularly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
