### PR TITLE
fix(files): handle multidimensional arrays in scanner 

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -221,8 +221,9 @@ class Scanner extends BasicEmitter implements IScanner {
 						}
 
 						// Only update metadata that has changed
-						$newData = array_diff_assoc($data, $cacheData->getData());
-
+						// i.e. get all the values in $data that are not present in the cache already
+						$newData = $this->array_diff_assoc_multi($data, $cacheData->getData());
+						
 						// make it known to the caller that etag has been changed and needs propagation
 						if (isset($newData['etag'])) {
 							$data['etag_changed'] = true;
@@ -367,6 +368,50 @@ class Scanner extends BasicEmitter implements IScanner {
 			}
 		}
 		return $data;
+	}
+
+	/**
+	 * Compares $array1 against $array2 and returns all the values in $array1 that are not in $array2
+	 * Note this is a one-way check - i.e. we don't care about things that are in $array2 that aren't in $array1
+	 *
+	 * Supports multi-dimensional arrays
+	 * Also checks keys/indexes
+	 * Comparisons are strict just like array_diff_assoc
+	 * Order of keys/values does not matter
+	 *
+	 * @param array $array1
+	 * @param array $array2
+	 * @return array with the differences between $array1 and $array1
+	 * @throws \InvalidArgumentException if $array1 isn't an actual array
+	 *
+	 */
+	protected function array_diff_assoc_multi(array $array1, array $array2) {
+		
+		$result = [];
+
+		foreach ($array1 as $key => $value) {
+		
+			// if $array2 doesn't have the same key, that's a result
+			if (!array_key_exists($key, $array2)) {
+				$result[$key] = $value;
+				continue;
+			}
+		
+			// if $array2's value for the same key is different, that's a result
+			if ($array2[$key] !== $value && !is_array($value)) {
+				$result[$key] = $value;
+				continue;
+			}
+		
+			if (is_array($value)) {
+				$nestedDiff = $this->array_diff_assoc_multi($value, $array2[$key]);
+				if (!empty($nestedDiff)) {
+					$result[$key] = $nestedDiff;
+					continue;
+				}
+			}
+		}
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: #43408 <!-- related github issue -->
* Also likely fixes #45082 and #43642

## Summary

`array_diff_assoc()` doesn't  support multidimensional arrays on its own (and, when attempted, it internally casts any embedded array elements to strings to attempt to compare them - not only generating warnings like "Array to string conversion" but also then overlooking differences).

_But sometimes we're passing it a multidimensional array._

I *think* the reason this became a new problem in v28 is because the `metadata` (#40761 / etc) gets embedded as a second level array here. It happens that triggering a scan on an Object Store is one way to trigger this code path just right to see the behavior found in #43408. (In other words: there *may* be other cases where an n-level array ends up here, but I don't know of one off-hand; and this should accommodate any of them in any case). 

## TODO

- Housekeeping 
  - [x] Fix code formatting
  - [x] Fix docblock
  - [x] Fix commits (squash, change message)
- [ ] Confirm whether also fixes/closes #45082 
- [ ] Confirm whether also fixes/closes #43642


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
