### PR TITLE
fix: wrap text on exception page

### DIFF
--- a/core/css/exception.css
+++ b/core/css/exception.css
@@ -1,0 +1,1 @@
+li{word-wrap:break-word}pre{white-space:pre-wrap;word-wrap:break-word}/*# sourceMappingURL=exception.css.map */

--- a/core/css/exception.css.map
+++ b/core/css/exception.css.map
@@ -1,0 +1,1 @@
+{"version":3,"sourceRoot":"","sources":["exception.scss"],"names":[],"mappings":"AAsBA,GACC,qBAGD,IACC,qBACA","file":"exception.css"}

--- a/core/css/exception.scss
+++ b/core/css/exception.scss
@@ -1,0 +1,30 @@
+/**
+ * @copyright Copyright (c) 2024 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+li {
+	word-wrap: break-word;
+}
+
+pre {
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}

--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -2,7 +2,7 @@
 /** @var array $_ */
 /** @var \OCP\IL10N $l */
 
-style('core', ['styles', 'header']);
+style('core', ['styles', 'header', 'exception']);
 
 function print_exception(Throwable $e, \OCP\IL10N $l): void {
 	print_unescaped('<pre>');


### PR DESCRIPTION
* Resolves: _none_

## Summary

| Before | After |
| --- | --- |
| ![grafik](https://github.com/nextcloud/server/assets/1479486/fe48f351-85ec-489a-ba9a-913d71e59eed) | ![grafik](https://github.com/nextcloud/server/assets/1479486/9610471a-b7b8-4d7e-a36d-e2bbb3fb7bd9) |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
