### PR TITLE
chore(deps): Bump calendar-availability-vue from 2.1.0 to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@nextcloud/axios": "^2.3.0",
         "@nextcloud/browser-storage": "^0.3.0",
         "@nextcloud/browserslist-config": "^3.0.0",
-        "@nextcloud/calendar-availability-vue": "^2.1.0",
+        "@nextcloud/calendar-availability-vue": "^2.2.0",
         "@nextcloud/capabilities": "^1.0.4",
         "@nextcloud/dialogs": "^5.1.2",
         "@nextcloud/event-bus": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nextcloud/axios": "^2.3.0",
     "@nextcloud/browser-storage": "^0.3.0",
     "@nextcloud/browserslist-config": "^3.0.0",
-    "@nextcloud/calendar-availability-vue": "^2.1.0",
+    "@nextcloud/calendar-availability-vue": "^2.2.0",
     "@nextcloud/capabilities": "^1.0.4",
     "@nextcloud/dialogs": "^5.1.2",
     "@nextcloud/event-bus": "^3.1.0",


### PR DESCRIPTION
Bump `calendar-availability-vue` from `2.1.0` to `2.2.0`
