### PR TITLE
feat(search): allows to search files by path

### DIFF
--- a/apps/files/lib/Search/FilesSearchProvider.php
+++ b/apps/files/lib/Search/FilesSearchProvider.php
@@ -116,6 +116,7 @@ class FilesSearchProvider implements IFilteringProvider {
 			'max-size',
 			'mime',
 			'type',
+			'path',
 			'is-favorite',
 			'title-only',
 		];
@@ -131,6 +132,7 @@ class FilesSearchProvider implements IFilteringProvider {
 			new FilterDefinition('max-size', FilterDefinition::TYPE_INT),
 			new FilterDefinition('mime', FilterDefinition::TYPE_STRING),
 			new FilterDefinition('type', FilterDefinition::TYPE_STRING),
+			new FilterDefinition('path', FilterDefinition::TYPE_STRING),
 			new FilterDefinition('is-favorite', FilterDefinition::TYPE_BOOL),
 		];
 	}
@@ -182,6 +184,7 @@ class FilesSearchProvider implements IFilteringProvider {
 				'max-size' => new SearchComparison(ISearchComparison::COMPARE_LESS_THAN_EQUAL, 'size', $filter->get()),
 				'mime' => new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'mimetype', $filter->get()),
 				'type' => new SearchComparison(ISearchComparison::COMPARE_LIKE, 'mimetype', $filter->get() . '/%'),
+				'path' => new SearchComparison(ISearchComparison::COMPARE_LIKE, 'path', 'files/' . ltrim($filter->get(), '/') . '%'),
 				'person' => $this->buildPersonSearchQuery($filter),
 				default => throw new InvalidArgumentException('Unsupported comparison'),
 			};


### PR DESCRIPTION
Ref: #42915

## Summary

Allows to search files in a specific directory.

Usage: `GET search/providers/files/search?path=<path>` with beginning of the path.
Example: `GET search/providers/files/search?path=/Media` will search all files within `/Media` directory


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
