### PR TITLE
Add ability to cancel a scheduled transcription

### DIFF
--- a/lib/private/SpeechToText/SpeechToTextManager.php
+++ b/lib/private/SpeechToText/SpeechToTextManager.php
@@ -112,6 +112,24 @@ class SpeechToTextManager implements ISpeechToTextManager {
 		}
 	}
 
+	public function cancelScheduledFileTranscription(File $file, ?string $userId, string $appId): void {
+		try {
+			$jobArguments = [
+				'fileId' => $file->getId(),
+				'owner' => $file->getOwner()->getUID(),
+				'userId' => $userId,
+				'appId' => $appId,
+			];
+			if (!$this->jobList->has(TranscriptionJob::class, $jobArguments)) {
+				$this->logger->debug('Failed to cancel a Speech-to-text job for file ' . $file->getId() . '. No related job was found.');
+				return;
+			}
+			$this->jobList->remove(TranscriptionJob::class, $jobArguments);
+		} catch (NotFoundException|InvalidPathException $e) {
+			throw new InvalidArgumentException('Invalid file provided to cancel file transcription: ' . $e->getMessage());
+		}
+	}
+
 	public function transcribeFile(File $file): string {
 		if (!$this->hasProviders()) {
 			throw new PreConditionNotMetException('No SpeechToText providers have been registered');

--- a/lib/public/SpeechToText/ISpeechToTextManager.php
+++ b/lib/public/SpeechToText/ISpeechToTextManager.php
@@ -62,6 +62,17 @@ interface ISpeechToTextManager {
 	public function scheduleFileTranscription(File $file, ?string $userId, string $appId): void;
 
 	/**
+	 * Will cancel a scheduled transcription process
+	 *
+	 * @param File $file The media file involved in the transcription
+	 * @param ?string $userId The user that triggered this request
+	 * @param string $appId The app that triggered this request
+	 * @throws InvalidArgumentException If the file could not be found or is not of a supported type
+	 * @since 29.0.0
+	 */
+	public function cancelScheduledFileTranscription(File $file, ?string $userId, string $appId): void;
+
+	/**
 	 * @param File $file The media file to transcribe
 	 * @returns string The transcription of the passed media file
 	 * @throws PreConditionNotMetException If no provider was registered but this method was still called


### PR DESCRIPTION
This makes it possible to cancel a scheduled transcription given the same information provided to schedule it.

We don't get the job ID when adding the job in the jobList. Even if we did, it is not possible to use job IDs to remove a job from the list.