### PR TITLE
fix(federation): Allow cloud federation providers to handle unsuccess…

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -408,6 +408,22 @@ class Client implements IClient {
 		return new Response($response);
 	}
 
+	/**
+	 * Get the response of a Throwable thrown by the request methods when possible
+	 *
+	 * @param \Throwable $e
+	 * @return IResponse
+	 * @throws \Throwable When $e did not have a response
+	 * @since 29.0.0
+	 */
+	public function getResponseFromThrowable(\Throwable $e): IResponse {
+		if (method_exists($e, 'hasResponse') && method_exists($e, 'getResponse') && $e->hasResponse()) {
+			return new Response($e->getResponse());
+		}
+
+		throw $e;
+	}
+
 	protected function wrapGuzzlePromise(PromiseInterface $promise): IPromise {
 		return new GuzzlePromiseAdapter(
 			$promise,

--- a/lib/public/Federation/ICloudFederationProviderManager.php
+++ b/lib/public/Federation/ICloudFederationProviderManager.php
@@ -23,6 +23,9 @@
  */
 namespace OCP\Federation;
 
+use OCP\Http\Client\IResponse;
+use OCP\OCM\Exceptions\OCMProviderException;
+
 /**
  * Class ICloudFederationProviderManager
  *
@@ -80,8 +83,17 @@ interface ICloudFederationProviderManager {
 	 * @return mixed
 	 *
 	 * @since 14.0.0
+	 * @deprecated 29.0.0 - Use {@see sendCloudShare()} instead and handle errors manually
 	 */
 	public function sendShare(ICloudFederationShare $share);
+
+	/**
+	 * @param ICloudFederationShare $share
+	 * @return IResponse
+	 * @throws OCMProviderException
+	 * @since 29.0.0
+	 */
+	public function sendCloudShare(ICloudFederationShare $share): IResponse;
 
 	/**
 	 * send notification about existing share
@@ -91,8 +103,18 @@ interface ICloudFederationProviderManager {
 	 * @return array|false
 	 *
 	 * @since 14.0.0
+	 * @deprecated 29.0.0 - Use {@see sendCloudNotification()} instead and handle errors manually
 	 */
 	public function sendNotification($url, ICloudFederationNotification $notification);
+
+	/**
+	 * @param string $url
+	 * @param ICloudFederationNotification $notification
+	 * @return IResponse
+	 * @throws OCMProviderException
+	 * @since 29.0.0
+	 */
+	public function sendCloudNotification(string $url, ICloudFederationNotification $notification): IResponse;
 
 	/**
 	 * check if the new cloud federation API is ready to be used

--- a/lib/public/Http/Client/IClient.php
+++ b/lib/public/Http/Client/IClient.php
@@ -208,6 +208,16 @@ interface IClient {
 	public function options(string $uri, array $options = []): IResponse;
 
 	/**
+	 * Get the response of a Throwable thrown by the request methods when possible
+	 *
+	 * @param \Throwable $e
+	 * @return IResponse
+	 * @throws \Throwable When $e did not have a response
+	 * @since 29.0.0
+	 */
+	public function getResponseFromThrowable(\Throwable $e): IResponse;
+
+	/**
 	 * Sends an asynchronous GET request
 	 * @param string $uri
 	 * @param array $options Array such as


### PR DESCRIPTION
…ful return codes

Otherwise they are put to retry and will immediately trigger bruteforce protection infinitely. This is currently easily producable when a federated user leaves a room during a "netsplit", maintenance mode or with a temporary error and afterwards people posting in the normal chat room.

* Required for https://github.com/nextcloud/spreed/issues/11278

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
