### PR TITLE
fix(JSResourceLocator): Consider configured app roots for files

### DIFF
--- a/tests/lib/Template/JSResourceLocatorTest.php
+++ b/tests/lib/Template/JSResourceLocatorTest.php
@@ -127,9 +127,9 @@ class JSResourceLocatorTest extends \Test\TestCase {
 		$webRoot = $resource[1];
 		$file = $resource[2];
 
-		$expectedRoot = $new_apps_path . '/test-js-app';
-		$expectedWebRoot = \OC::$WEBROOT . '/js-apps-test/test-js-app';
-		$expectedFile = 'test-file.js';
+		$expectedRoot = $new_apps_path;
+		$expectedWebRoot = \OC::$WEBROOT . '/js-apps-test';
+		$expectedFile = $appName . '/test-file.js';
 
 		$this->assertEquals($expectedRoot, $root,
 			'Ensure the app path symlink is resolved into the real path');
@@ -145,7 +145,7 @@ class JSResourceLocatorTest extends \Test\TestCase {
 			->method('getAppPath')
 			->with('core')
 			->willThrowException(new AppPathNotFoundException());
-		$this->appManager->expects($this->once())
+		$this->appManager->expects($this->atMost(1))
 			->method('getAppWebPath')
 			->with('core')
 			->willThrowException(new AppPathNotFoundException());


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/42671
* Resolved: https://github.com/nextcloud/server/issues/42493

## Summary
https://github.com/nextcloud/server/pull/40898 introduced an issue when loading scripts from other app roots,
the problem is that the app roots are manually queried and then tried, but if the apps directory path is not a child of the server root the webroot could not be guessed.

The solution I propose is also simplifying the code I think:
Instead of looking into app roots after all other queries we load the app path and app webroot for the requested script in the beginning.
Then we try all paths like before, except for `apps/...` we now use `{apppath}/...` directly as this also works for the native `apps` root.
Here we also pass the matching app webroot so we do not need to fallback to the ResourceLocator guessing function.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
