### PR TITLE
fix(IUrlGenerator): Add `throws` documentation for `imagePath` function

### DIFF
--- a/lib/public/IURLGenerator.php
+++ b/lib/public/IURLGenerator.php
@@ -95,6 +95,7 @@ interface IURLGenerator {
 	 * @param string $appName the name of the app
 	 * @param string $file the name of the file
 	 * @return string the url
+	 * @throws \RuntimeException If the image does not exist
 	 * @since 6.0.0
 	 */
 	public function imagePath(string $appName, string $file): string;


### PR DESCRIPTION
## Summary

The implementation of the URL generator can throw on `imagePath`, this is documented for the private class in OC but not for the interface in OCP.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
