### PR TITLE
fix: Fetch custom app store url without internet connection

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -44,6 +44,7 @@ use Psr\Log\LoggerInterface;
 abstract class Fetcher {
 	public const INVALIDATE_AFTER_SECONDS = 3600;
 	public const RETRY_AFTER_FAILURE_SECONDS = 300;
+	public const APP_STORE_URL = 'https://apps.nextcloud.com/api/v1';
 
 	/** @var IAppData */
 	protected $appData;
@@ -96,7 +97,7 @@ abstract class Fetcher {
 			];
 		}
 
-		if ($this->config->getSystemValueString('appstoreurl', 'https://apps.nextcloud.com/api/v1') === 'https://apps.nextcloud.com/api/v1') {
+		if ($this->config->getSystemValueString('appstoreurl', self::APP_STORE_URL) === self::APP_STORE_URL) {
 			// If we have a valid subscription key, send it to the appstore
 			$subscriptionKey = $this->config->getAppValue('support', 'subscription_key');
 			if ($this->registry->delegateHasValidSubscription() && $subscriptionKey) {
@@ -140,8 +141,9 @@ abstract class Fetcher {
 	public function get($allowUnstable = false) {
 		$appstoreenabled = $this->config->getSystemValueBool('appstoreenabled', true);
 		$internetavailable = $this->config->getSystemValueBool('has_internet_connection', true);
+		$isDefaultAppStore = $this->config->getSystemValueString('appstoreurl', self::APP_STORE_URL) === self::APP_STORE_URL;
 
-		if (!$appstoreenabled || !$internetavailable) {
+		if (!$appstoreenabled || (!$internetavailable && $isDefaultAppStore)) {
 			return [];
 		}
 

--- a/tests/lib/App/AppStore/Fetcher/CategoryFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/CategoryFetcherTest.php
@@ -64,6 +64,11 @@ class CategoryFetcherTest extends FetcherBase {
 				}
 				return $default;
 			});
+		$this->config
+			->method('getSystemValueString')
+			->willReturnCallback(function ($var, $default) {
+				return $default;
+			});
 		$this->appData
 			->expects($this->never())
 			->method('getFolder');

--- a/tests/lib/App/AppStore/Fetcher/FetcherBase.php
+++ b/tests/lib/App/AppStore/Fetcher/FetcherBase.php
@@ -76,10 +76,13 @@ abstract class FetcherBase extends TestCase {
 
 	public function testGetWithAlreadyExistingFileAndUpToDateTimestampAndVersion() {
 		$this->config
-			->expects($this->exactly(1))
 			->method('getSystemValueString')
-			->with($this->equalTo('version'), $this->anything())
-			->willReturn('11.0.0.2');
+			->willReturnCallback(function ($var, $default) {
+				if ($var === 'version') {
+					return '11.0.0.2';
+				}
+				return $default;
+			});
 		$this->config->method('getSystemValueBool')
 			->willReturnArgument(1);
 


### PR DESCRIPTION
We should still fetch custom app store urls even when having has_internet_connection configured to false as the app store might be in the internal network.
