### PR TITLE
Handle more cases in the MergeDistributive search query optimizer

### DIFF
--- a/lib/private/Files/Search/QueryOptimizer/ReplacingOptimizerStep.php
+++ b/lib/private/Files/Search/QueryOptimizer/ReplacingOptimizerStep.php
@@ -20,7 +20,9 @@ class ReplacingOptimizerStep extends QueryOptimizerStep {
 			$modified = false;
 			$arguments = $operator->getArguments();
 			foreach ($arguments as &$argument) {
-				$modified = $modified || $this->processOperator($argument);
+				if ($this->processOperator($argument)) {
+					$modified = true;
+				}
 			}
 			if ($modified) {
 				$operator->setArguments($arguments);

--- a/tests/lib/Files/Search/QueryOptimizer/CombinedTests.php
+++ b/tests/lib/Files/Search/QueryOptimizer/CombinedTests.php
@@ -42,4 +42,150 @@ class CombinedTests extends TestCase {
 
 		$this->assertEquals('(storage eq 1 and path in ["foo","bar","asd"])', $operator->__toString());
 	}
+
+	public function testComplexSearchPattern1() {
+		$operator = new SearchBinaryOperator(
+			ISearchBinaryOperator::OPERATOR_OR,
+			[
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 1),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 2),
+					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+						new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "201"),
+						new SearchComparison(ISearchComparison::COMPARE_LIKE, "path", "201/%"),
+					]),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "301"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 4),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "401"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "302"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 4),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "402"),
+				]),
+			]
+		);
+		$this->assertEquals('((storage eq 1) or (storage eq 2 and (path eq "201" or path like "201\/%")) or (storage eq 3 and path eq "301") or (storage eq 4 and path eq "401") or (storage eq 3 and path eq "302") or (storage eq 4 and path eq "402"))', $operator->__toString());
+
+		$this->optimizer->processOperator($operator);
+
+		$this->assertEquals('(storage eq 1 or (storage eq 2 and (path eq "201" or path like "201\/%")) or (storage eq 3 and path in ["301","302"]) or (storage eq 4 and path in ["401","402"]))', $operator->__toString());
+	}
+
+	public function testComplexSearchPattern2() {
+		$operator = new SearchBinaryOperator(
+			ISearchBinaryOperator::OPERATOR_OR,
+			[
+				new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 1),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 2),
+					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+						new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "201"),
+						new SearchComparison(ISearchComparison::COMPARE_LIKE, "path", "201/%"),
+					]),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "301"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 4),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "401"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "302"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 4),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "402"),
+				]),
+			]
+		);
+		$this->assertEquals('(storage eq 1 or (storage eq 2 and (path eq "201" or path like "201\/%")) or (storage eq 3 and path eq "301") or (storage eq 4 and path eq "401") or (storage eq 3 and path eq "302") or (storage eq 4 and path eq "402"))', $operator->__toString());
+
+		$this->optimizer->processOperator($operator);
+
+		$this->assertEquals('(storage eq 1 or (storage eq 2 and (path eq "201" or path like "201\/%")) or (storage eq 3 and path in ["301","302"]) or (storage eq 4 and path in ["401","402"]))', $operator->__toString());
+	}
+
+	public function testApplySearchConstraints1() {
+		$operator = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+			new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "mimetype", "image/png"),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "mimetype", "image/jpeg"),
+				]),
+			]),
+			new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 1),
+					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+						new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "files"),
+						new SearchComparison(ISearchComparison::COMPARE_LIKE, "path", "files/%"),
+					]),
+				]),
+				new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 2),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "files/301"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "files/302"),
+				]),
+			]),
+		]);
+		$this->assertEquals('(((mimetype eq "image\/png" or mimetype eq "image\/jpeg")) and ((storage eq 1 and (path eq "files" or path like "files\/%")) or storage eq 2 or (storage eq 3 and path eq "files\/301") or (storage eq 3 and path eq "files\/302")))', $operator->__toString());
+
+		$this->optimizer->processOperator($operator);
+
+		$this->assertEquals('(mimetype in ["image\/png","image\/jpeg"] and ((storage eq 1 and (path eq "files" or path like "files\/%")) or storage eq 2 or (storage eq 3 and path in ["files\/301","files\/302"])))', $operator->__toString());
+	}
+
+	public function testApplySearchConstraints2() {
+		$operator = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+			new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "mimetype", "image/png"),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "mimetype", "image/jpeg"),
+				]),
+			]),
+			new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 1),
+					new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, [
+						new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "files"),
+						new SearchComparison(ISearchComparison::COMPARE_LIKE, "path", "files/%"),
+					]),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 2),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "files/301"),
+				]),
+				new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "storage", 3),
+					new SearchComparison(ISearchComparison::COMPARE_EQUAL, "path", "files/302"),
+				]),
+			]),
+		]);
+		$this->assertEquals('(((mimetype eq "image\/png" or mimetype eq "image\/jpeg")) and ((storage eq 1 and (path eq "files" or path like "files\/%")) or (storage eq 2) or (storage eq 3 and path eq "files\/301") or (storage eq 3 and path eq "files\/302")))', $operator->__toString());
+
+		$this->optimizer->processOperator($operator);
+
+		$this->assertEquals('(mimetype in ["image\/png","image\/jpeg"] and ((storage eq 1 and (path eq "files" or path like "files\/%")) or storage eq 2 or (storage eq 3 and path in ["files\/301","files\/302"])))', $operator->__toString());
+	}
 }


### PR DESCRIPTION
If an `AND`/`OR` operator contains more than just `AND`/`OR` arguments it was previously skipped. Now those parts are factored out properly and the rest is still optimized.