### PR TITLE
fix: fall back to creating a temp file on NFS mounts

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -25,6 +25,7 @@
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  * @author Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>
  * @author Vincent Petry <vincent@nextcloud.com>
+ * @author Richard Steinmetz <richard@steinmetz.cloud>
  *
  * @license AGPL-3.0
  *
@@ -229,6 +230,14 @@ class Local extends \OC\Files\Storage\Common {
 			$parent = dirname($stat['full_path']);
 			if (is_writable($parent)) {
 				$permissions += Constants::PERMISSION_DELETE;
+			} else {
+				// is_writable() is not reliable on NFS mounts -> try creating a random file
+				$testFile = implode('/', [$parent, bin2hex(random_bytes(16))]);
+				$writtenBytes = @file_put_contents($testFile, "TEST");
+				if ($writtenBytes !== false) {
+					$permissions += Constants::PERMISSION_DELETE;
+				}
+				@unlink($testFile);
 			}
 		}
 


### PR DESCRIPTION
* Resolves: _none_

## Summary

The built-in method `is_writable()` is not reliable on NFS mounts so we should fall back to creating a random file to check for delete permissions.

This might have an impact on performance as we create, write to a file and unlink it again.

Ref https://stackoverflow.com/a/50801358
Ref https://github.com/nextcloud/server/pull/13237

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
