### PR TITLE
fix(filecache): Move from array_merge to avoid memory exhaustion on large scans

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -585,8 +585,13 @@ class Cache implements ICache {
 				return $cacheEntry->getPath();
 			}, $children);
 
-			$deletedIds = array_merge($deletedIds, $childIds);
-			$deletedPaths = array_merge($deletedPaths, $childPaths);
+			foreach ($childIds as $childId) {
+				$deletedIds[] = $childId;
+			}
+
+			foreach ($childPaths as $childPath) {
+				$deletedPaths[] = $childPath;
+			}
 
 			$query = $this->getQueryBuilder();
 			$query->delete('filecache_extended')


### PR DESCRIPTION
* Resolves part of https://github.com/nextcloud/server/issues/43964#issuecomment-1976976837

## Summary

When merging large arrays, PHP may require a significant amount of memory, especially if the arrays contain a lot of data.
This can be the case in file scans of large filesystems.

To avoid using `array_merge` and reduce memory consumption, concatenate the arrays using a loop instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
