### PR TITLE
Use the proper path to check if a file needs to be copied/moved to the actual target storage

### DIFF
--- a/apps/dav/lib/Upload/ChunkingV2Plugin.php
+++ b/apps/dav/lib/Upload/ChunkingV2Plugin.php
@@ -344,7 +344,7 @@ class ChunkingV2Plugin extends ServerPlugin {
 
 		// If the file was not uploaded to the user storage directly we need to copy/move it
 		try {
-			$uploadFileAbsolutePath = Filesystem::getRoot() . $uploadFile->getPath();
+			$uploadFileAbsolutePath = $uploadFile->getFileInfo()->getPath();
 			if ($uploadFileAbsolutePath !== $targetAbsolutePath) {
 				$uploadFile = $rootFolder->get($uploadFile->getFileInfo()->getPath());
 				if ($exists) {


### PR DESCRIPTION
This resolves issues where after an s3 multipart upload we run into issues with shared locks while trying to copy as we're actually copying the file to the same path again.

Confirmed to fix issues where a file upload >10MB caused conflicting shared lock issues during the MOVE of chunked upload parts.