### PR TITLE
Fix default text processing provider in AI settings

### DIFF
--- a/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
+++ b/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
@@ -86,7 +86,9 @@ class ArtificialIntelligence implements IDelegatedSettings {
 				'name' => $provider->getName(),
 				'taskType' => $provider->getTaskType(),
 			];
-			$textProcessingSettings[$provider->getTaskType()] = $provider instanceof IProviderWithId ? $provider->getId() : $provider::class;
+			if (!isset($textProcessingSettings[$provider->getTaskType()])) {
+				$textProcessingSettings[$provider->getTaskType()] = $provider instanceof IProviderWithId ? $provider->getId() : $provider::class;
+			}
 		}
 		$textProcessingTaskTypes = [];
 		foreach ($textProcessingSettings as $taskTypeClass => $providerClass) {

--- a/apps/testing/lib/Provider/FakeTextProcessingProvider.php
+++ b/apps/testing/lib/Provider/FakeTextProcessingProvider.php
@@ -34,7 +34,7 @@ class FakeTextProcessingProvider implements IProvider {
 	}
 
 	public function process(string $prompt): string {
-		return strrev($prompt);
+		return strrev($prompt) . ' (done with FakeTextProcessingProvider)';
 	}
 
 	public function getTaskType(): string {

--- a/apps/testing/lib/Provider/FakeTextProcessingProviderSync.php
+++ b/apps/testing/lib/Provider/FakeTextProcessingProviderSync.php
@@ -36,7 +36,7 @@ class FakeTextProcessingProviderSync implements IProviderWithExpectedRuntime {
 	}
 
 	public function process(string $prompt): string {
-		return strrev($prompt);
+		return strrev($prompt) . ' (done with FakeTextProcessingProviderSync)';
 	}
 
 	public function getTaskType(): string {


### PR DESCRIPTION
When no AI setting has been set, make sure the selected text processing provider is the same as the one that will be actually used by the manager.

The manager takes the first available provider from its `getProviders` method result. The settings were showing the last in this list.

refs https://github.com/nextcloud/text/pull/5269#issuecomment-1906713610

Also, add provider name in results of fake providers (in the testing app).

I didn't check but we might have the same problem for STT, text2image and translation.