### PR TITLE
fix: Remove unused endpoint from base.php

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -1018,21 +1018,6 @@ class OC {
 			}
 		}
 
-		// emergency app disabling
-		if ($requestPath === '/disableapp'
-			&& $request->getMethod() === 'POST'
-		) {
-			\OC_JSON::callCheck();
-			\OC_JSON::checkAdminUser();
-			$appIds = (array)$request->getParam('appid');
-			foreach ($appIds as $appId) {
-				$appId = \OC_App::cleanAppId($appId);
-				Server::get(\OCP\App\IAppManager::class)->disableApp($appId);
-			}
-			\OC_JSON::success();
-			exit();
-		}
-
 		// Always load authentication apps
 		OC_App::loadApps(['authentication']);
 		OC_App::loadApps(['extended_authentication']);


### PR DESCRIPTION
It’s not called anymore, and app loading cannot break boot anymore

It was added in https://github.com/nextcloud/server/commit/1dbe240b0e5b0a0b32d0e0eca596bf4e510f980e but the frontend code calling it was removed long ago. Also it’s pretty hard for an app to break the files app because Throwables at boot are catched.
It’s still possible to crash /app/files by listening to sidebar loading and crashing for instance, and there are some message about it in the UI but it does not seem to disable. This should be fixed in a follow-up and use the standard disable app route.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
