### PR TITLE
fix: Remove calls to deprecated OC_JSON::encode

### DIFF
--- a/lib/private/legacy/OC_API.php
+++ b/lib/private/legacy/OC_API.php
@@ -171,7 +171,7 @@ class OC_API {
 			],
 		];
 		if ($format == 'json') {
-			return OC_JSON::encode($response);
+			return json_encode($response, JSON_HEX_TAG);
 		}
 
 		$writer = new XMLWriter();

--- a/lib/private/legacy/OC_EventSource.php
+++ b/lib/private/legacy/OC_EventSource.php
@@ -113,13 +113,13 @@ class OC_EventSource implements \OCP\IEventSource {
 		}
 		if ($this->fallback) {
 			$response = '<script type="text/javascript">window.parent.OC.EventSource.fallBackCallBack('
-				. $this->fallBackId . ',"' . $type . '",' . OC_JSON::encode($data) . ')</script>' . PHP_EOL;
+				. $this->fallBackId . ',"' . ($type ?? '') . '",' . json_encode($data, JSON_HEX_TAG) . ')</script>' . PHP_EOL;
 			echo $response;
 		} else {
 			if ($type) {
 				echo 'event: ' . $type . PHP_EOL;
 			}
-			echo 'data: ' . OC_JSON::encode($data) . PHP_EOL;
+			echo 'data: ' . json_encode($data, JSON_HEX_TAG) . PHP_EOL;
 		}
 		echo PHP_EOL;
 		flush();

--- a/lib/private/legacy/OC_JSON.php
+++ b/lib/private/legacy/OC_JSON.php
@@ -114,22 +114,10 @@ class OC_JSON {
 	}
 
 	/**
-	 * Convert OC_L10N_String to string, for use in json encodings
-	 */
-	protected static function to_string(&$value) {
-		if ($value instanceof \OC\L10N\L10NString) {
-			$value = (string)$value;
-		}
-	}
-
-	/**
 	 * Encode JSON
 	 * @deprecated Use a AppFramework JSONResponse instead
 	 */
-	public static function encode($data) {
-		if (is_array($data)) {
-			array_walk_recursive($data, ['OC_JSON', 'to_string']);
-		}
+	private static function encode($data) {
 		return json_encode($data, JSON_HEX_TAG);
 	}
 }


### PR DESCRIPTION
* Related to: #8568 

## Summary

to_string was useless because L10N string is json serializable now and serialize to string correctly. Removed all external calls to OC_JSON::encode to ease removing the rest of it later.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
