### PR TITLE
Fix/caldav/eventcomparisionservice uses wrong array comparison

### DIFF
--- a/apps/dav/lib/CalDAV/EventComparisonService.php
+++ b/apps/dav/lib/CalDAV/EventComparisonService.php
@@ -65,7 +65,7 @@ class EventComparisonService {
 				$eventToFilterData[] = IMipService::readPropertyWithDefault($eventToFilter, $eventDiff, '');
 			}
 			// events are identical and can be removed
-			if (empty(array_diff($filterEventData, $eventToFilterData))) {
+			if ($filterEventData === $eventToFilterData) {
 				unset($eventsToFilter[$k]);
 				return true;
 			}

--- a/apps/dav/tests/unit/CalDAV/EventComparisonServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/EventComparisonServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 /**
  * @copyright 2023 Daniel Kesselberg <mail@danielkesselberg.de>
+ * @copyright 2024 Robert C. Schaller <gtbc_robert.schaller@rsxc.de>
  *
  * @author 2023 Daniel Kesselberg <mail@danielkesselberg.de>
  *
@@ -137,4 +138,70 @@ class EventComparisonServiceTest extends TestCase {
 		$this->assertEquals([$vEventOld2], $result['old']);
 		$this->assertEquals([$vEventNew2], $result['new']);
 	}
+
+	// First test to certify fix for issue nextcloud/server#41084
+	public function testSequenceNumberIncrementDetectedForFirstModificationToEventWithoutZeroInit(): void {
+		$vCalendarOld = new VCalendar();
+		$vCalendarNew = new VCalendar();
+
+		$vEventOld = $vCalendarOld->add('VEVENT', [
+			'UID' => 'uid-1234',
+			'LAST-MODIFIED' => 123456,
+			// 'SEQUENCE' => 0,			// sequence number may not be set to zero during event creation and instead fully omitted
+			'SUMMARY' => 'Fellowship meeting',
+			'DTSTART' => new \DateTime('2016-01-01 00:00:00'),
+			'RRULE' => 'FREQ=DAILY;INTERVAL=1;UNTIL=20160201T000000Z',
+		]);
+		$vEventOld->add('ORGANIZER', 'mailto:gandalf@wiz.ard');
+		$vEventOld->add('ATTENDEE', 'mailto:' . 'frodo@hobb.it', ['RSVP' => 'TRUE', 'CN' => 'Frodo']);
+
+		$vEventNew = $vCalendarNew->add('VEVENT', [
+			'UID' => 'uid-1234',
+			'LAST-MODIFIED' => 123456,
+			'SEQUENCE' => 1,
+			'SUMMARY' => 'Fellowship meeting',
+			'DTSTART' => new \DateTime('2016-01-01 00:00:00'),
+			'RRULE' => 'FREQ=DAILY;INTERVAL=1;UNTIL=20160201T000000Z',
+		]);
+		$vEventNew->add('ORGANIZER', 'mailto:gandalf@wiz.ard');
+		$vEventNew->add('ATTENDEE', 'mailto:' . 'frodo@hobb.it', ['RSVP' => 'TRUE', 'CN' => 'Frodo']);
+
+		$result = $this->eventComparisonService->findModified($vCalendarNew, $vCalendarOld);
+		$this->assertEquals([$vEventOld], $result['old']);
+		$this->assertEquals([$vEventNew], $result['new']);
+	}
+
+	// Second test to certify fix for issue nextcloud/server#41084
+	public function testSequenceNumberIncrementDetectedForFirstModificationToEventWithZeroInit(): void {
+		$vCalendarOld = new VCalendar();
+		$vCalendarNew = new VCalendar();
+
+		$vEventOld = $vCalendarOld->add('VEVENT', [
+			'UID' => 'uid-1234',
+			'LAST-MODIFIED' => 123456,
+			'SEQUENCE' => 0,
+			'SUMMARY' => 'Fellowship meeting',
+			'DTSTART' => new \DateTime('2016-01-01 00:00:00'),
+			'RRULE' => 'FREQ=DAILY;INTERVAL=1;UNTIL=20160201T000000Z',
+		]);
+		$vEventOld->add('ORGANIZER', 'mailto:gandalf@wiz.ard');
+		$vEventOld->add('ATTENDEE', 'mailto:' . 'frodo@hobb.it', ['RSVP' => 'TRUE', 'CN' => 'Frodo']);
+
+		$vEventNew = $vCalendarNew->add('VEVENT', [
+			'UID' => 'uid-1234',
+			'LAST-MODIFIED' => 123456,
+			'SEQUENCE' => 1,
+			'SUMMARY' => 'Fellowship meeting',
+			'DTSTART' => new \DateTime('2016-01-01 00:00:00'),
+			'RRULE' => 'FREQ=DAILY;INTERVAL=1;UNTIL=20160201T000000Z',
+		]);
+		$vEventNew->add('ORGANIZER', 'mailto:gandalf@wiz.ard');
+		$vEventNew->add('ATTENDEE', 'mailto:' . 'frodo@hobb.it', ['RSVP' => 'TRUE', 'CN' => 'Frodo']);
+
+		$result = $this->eventComparisonService->findModified($vCalendarNew, $vCalendarOld);
+		$this->assertEquals([$vEventOld], $result['old']);
+		$this->assertEquals([$vEventNew], $result['new']);
+	}
+
+
 }


### PR DESCRIPTION
* Resolves: Partially nextcloud/server#41084 

## Summary
Fixes the comparison of two arrays that contain relevant differences between two events.

Old comparison implementation compares each element of the array against each other with no respect for the associated array label, which leads to wrongful removals because one value is accidentally present in a completely different label. New comparison works 'by-label' individually.
Refer to php manual https://www.php.net/manual/en/function.array-diff.php

Partly fixes nextcloud/server#41084 because changes between 'SEQUENCE' not present, 'SEQUENCE:0' and 'SEQUENCE:1' were not detected in the old implementation and thus no email update sent.

@miaulalala please inspect. Small fix for your otherwise comprehensive contribution for nextcloud/calendar#3919

## TODO
nextcloud/server#41084 needs to remain open as there is a second issue, which prevents the SEQUENCE evaluation in certain cases.

/backport to stable28
/backport to stable27
/backport to stable26