### PR TITLE
refactor: make share manager buildable

### DIFF
--- a/apps/files_sharing/tests/CapabilitiesTest.php
+++ b/apps/files_sharing/tests/CapabilitiesTest.php
@@ -38,7 +38,6 @@ use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
 use OCP\IDateTimeZone;
 use OCP\IGroupManager;
-use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -86,7 +85,6 @@ class CapabilitiesTest extends \Test\TestCase {
 			$this->createMock(IHasher::class),
 			$this->createMock(IMountManager::class),
 			$this->createMock(IGroupManager::class),
-			$this->createMock(IL10N::class),
 			$this->createMock(IFactory::class),
 			$this->createMock(IProviderFactory::class),
 			$this->createMock(IUserManager::class),

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -152,7 +152,6 @@ use OC\Security\VerificationToken\VerificationToken;
 use OC\Session\CryptoWrapper;
 use OC\SetupCheck\SetupCheckManager;
 use OC\Share20\ProviderFactory;
-use OC\Share20\ShareDisableChecker;
 use OC\Share20\ShareHelper;
 use OC\SpeechToText\SpeechToTextManager;
 use OC\SystemTag\ManagerFactory as SystemTagManagerFactory;
@@ -261,6 +260,7 @@ use OCP\Security\ITrustedDomainHelper;
 use OCP\Security\RateLimiting\ILimiter;
 use OCP\Security\VerificationToken\IVerificationToken;
 use OCP\SetupCheck\ISetupCheckManager;
+use OCP\Share\IProviderFactory;
 use OCP\Share\IShareHelper;
 use OCP\SpeechToText\ISpeechToTextManager;
 use OCP\SystemTag\ISystemTagManager;
@@ -1247,36 +1247,14 @@ class Server extends ServerContainer implements IServerContainer {
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ContentSecurityPolicyManager', ContentSecurityPolicyManager::class);
 
-		$this->registerService(\OCP\Share\IManager::class, function (IServerContainer $c) {
+		$this->registerService(IProviderFactory::class, function (ContainerInterface $c) {
 			$config = $c->get(\OCP\IConfig::class);
 			$factoryClass = $config->getSystemValue('sharing.managerFactory', ProviderFactory::class);
 			/** @var \OCP\Share\IProviderFactory $factory */
-			$factory = new $factoryClass($this);
-
-			$manager = new \OC\Share20\Manager(
-				$c->get(LoggerInterface::class),
-				$c->get(\OCP\IConfig::class),
-				$c->get(ISecureRandom::class),
-				$c->get(IHasher::class),
-				$c->get(IMountManager::class),
-				$c->get(IGroupManager::class),
-				$c->getL10N('lib'),
-				$c->get(IFactory::class),
-				$factory,
-				$c->get(IUserManager::class),
-				$c->get(IRootFolder::class),
-				$c->get(IMailer::class),
-				$c->get(IURLGenerator::class),
-				$c->get('ThemingDefaults'),
-				$c->get(IEventDispatcher::class),
-				$c->get(IUserSession::class),
-				$c->get(KnownUserService::class),
-				$c->get(ShareDisableChecker::class),
-				$c->get(IDateTimeZone::class),
-			);
-
-			return $manager;
+			return new $factoryClass($this);
 		});
+
+		$this->registerAlias(\OCP\Share\IManager::class, \OC\Share20\Manager::class);
 		/** @deprecated 19.0.0 */
 		$this->registerDeprecatedAlias('ShareManager', \OCP\Share\IManager::class);
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -130,7 +130,6 @@ class Manager implements IManager {
 		IHasher $hasher,
 		IMountManager $mountManager,
 		IGroupManager $groupManager,
-		IL10N $l,
 		IFactory $l10nFactory,
 		IProviderFactory $factory,
 		IUserManager $userManager,
@@ -150,7 +149,7 @@ class Manager implements IManager {
 		$this->hasher = $hasher;
 		$this->mountManager = $mountManager;
 		$this->groupManager = $groupManager;
-		$this->l = $l;
+		$this->l = $l10nFactory->get('lib');
 		$this->l10nFactory = $l10nFactory;
 		$this->factory = $factory;
 		$this->userManager = $userManager;

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -151,19 +151,27 @@ class ManagerTest extends \Test\TestCase {
 			->willReturnCallback(function ($singular, $plural, $count, $parameters = []) {
 				return vsprintf(str_replace('%n', $count, ($count === 1) ? $singular : $plural), $parameters);
 			});
+		$this->l10nFactory->method('get')->willReturn($this->l);
 
 		$this->factory = new DummyFactory(\OC::$server);
 
-		$this->manager = new Manager(
+		$this->manager = $this->createManager($this->factory);
+
+		$this->defaultProvider = $this->createMock(DefaultShareProvider::class);
+		$this->defaultProvider->method('identifier')->willReturn('default');
+		$this->factory->setProvider($this->defaultProvider);
+	}
+
+	private function createManager(IProviderFactory $factory): Manager {
+		return new Manager(
 			$this->logger,
 			$this->config,
 			$this->secureRandom,
 			$this->hasher,
 			$this->mountManager,
 			$this->groupManager,
-			$this->l,
 			$this->l10nFactory,
-			$this->factory,
+			$factory,
 			$this->userManager,
 			$this->rootFolder,
 			$this->mailer,
@@ -175,10 +183,6 @@ class ManagerTest extends \Test\TestCase {
 			$this->shareDisabledChecker,
 			$this->dateTimeZone,
 		);
-
-		$this->defaultProvider = $this->createMock(DefaultShareProvider::class);
-		$this->defaultProvider->method('identifier')->willReturn('default');
-		$this->factory->setProvider($this->defaultProvider);
 	}
 
 	/**
@@ -193,7 +197,6 @@ class ManagerTest extends \Test\TestCase {
 				$this->hasher,
 				$this->mountManager,
 				$this->groupManager,
-				$this->l,
 				$this->l10nFactory,
 				$this->factory,
 				$this->userManager,
@@ -2796,27 +2799,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$factory = $this->createMock(IProviderFactory::class);
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 
 		$share = $this->createMock(IShare::class);
 
@@ -2845,27 +2828,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$factory = $this->createMock(IProviderFactory::class);
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 
 		$share = $this->createMock(IShare::class);
 
@@ -2901,27 +2864,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$factory = $this->createMock(IProviderFactory::class);
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 
 		$share = $this->createMock(IShare::class);
 
@@ -4302,27 +4245,7 @@ class ManagerTest extends \Test\TestCase {
 				throw new Exception\ProviderException();
 			});
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 		$this->assertSame($expected,
 			$manager->shareProviderExists($shareType)
 		);
@@ -4338,27 +4261,7 @@ class ManagerTest extends \Test\TestCase {
 	public function testGetSharesInFolder() {
 		$factory = new DummyFactory2($this->createMock(IServerContainer::class));
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 
 		$factory->setProvider($this->defaultProvider);
 		$extraProvider = $this->createMock(IShareProvider::class);
@@ -4405,27 +4308,7 @@ class ManagerTest extends \Test\TestCase {
 	public function testGetAccessList() {
 		$factory = new DummyFactory2($this->createMock(IServerContainer::class));
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 
 		$factory->setProvider($this->defaultProvider);
 		$extraProvider = $this->createMock(IShareProvider::class);
@@ -4524,27 +4407,7 @@ class ManagerTest extends \Test\TestCase {
 	public function testGetAccessListWithCurrentAccess() {
 		$factory = new DummyFactory2($this->createMock(IServerContainer::class));
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 
 		$factory->setProvider($this->defaultProvider);
 		$extraProvider = $this->createMock(IShareProvider::class);
@@ -4652,27 +4515,7 @@ class ManagerTest extends \Test\TestCase {
 	public function testGetAllShares() {
 		$factory = new DummyFactory2($this->createMock(IServerContainer::class));
 
-		$manager = new Manager(
-			$this->logger,
-			$this->config,
-			$this->secureRandom,
-			$this->hasher,
-			$this->mountManager,
-			$this->groupManager,
-			$this->l,
-			$this->l10nFactory,
-			$factory,
-			$this->userManager,
-			$this->rootFolder,
-			$this->mailer,
-			$this->urlGenerator,
-			$this->defaults,
-			$this->dispatcher,
-			$this->userSession,
-			$this->knownUserService,
-			$this->shareDisabledChecker,
-			$this->dateTimeZone,
-		);
+		$manager = $this->createManager($factory);
 
 		$factory->setProvider($this->defaultProvider);
 		$extraProvider = $this->createMock(IShareProvider::class);


### PR DESCRIPTION
Make it less of a pain to touch the constructor