### PR TITLE
fix: regression with updating read-only config

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -153,8 +153,6 @@ class Config {
 	 * @throws HintException
 	 */
 	protected function set($key, $value) {
-		$this->checkReadOnly();
-
 		if (!isset($this->cache[$key]) || $this->cache[$key] !== $value) {
 			// Add change
 			$this->cache[$key] = $value;
@@ -185,8 +183,6 @@ class Config {
 	 * @throws HintException
 	 */
 	protected function delete($key) {
-		$this->checkReadOnly();
-
 		if (isset($this->cache[$key])) {
 			// Delete key from cache
 			unset($this->cache[$key]);


### PR DESCRIPTION
Revert some changes for #29901.

Old behaviour before those changes (and again, after this PR):
Nextcloud calls set('theme', '') etc. Because the existing config has the same values, it does not attempt to write anything to the config file. If the config file would get changed, then it gives an error if the read-only option is set.

Regression behaviour:
The same call is made and immediately errors despite the fact that the config file will not be changed.


The set()/delete() methods are clearly written in a way that they skip writing changes if the value is already the same, but the previous changes make a check before those checks, thus erroring when there are no changes to write. The same PR also adds this check to writeData(), which is called by both of these methods, making them redundant.