### PR TITLE
fix(user_ldap): Early failure for empty password login attempt

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1593,17 +1593,15 @@ class Access extends LDAPUtility {
 		return $filter;
 	}
 
-	/**
-	 * @param string $name
-	 * @param string $password
-	 * @return bool
-	 */
-	public function areCredentialsValid($name, $password) {
+	public function areCredentialsValid(string $name, string $password): bool {
+		if ($name === '' || $password === '') {
+			return false;
+		}
 		$name = $this->helper->DNasBaseParameter($name);
 		$testConnection = clone $this->connection;
 		$credentials = [
 			'ldapAgentName' => $name,
-			'ldapAgentPassword' => $password
+			'ldapAgentPassword' => $password,
 		];
 		if (!$testConnection->setConfiguration($credentials)) {
 			return false;


### PR DESCRIPTION
## Summary

This avoids user_ldap logging about an invalid configuration with an
 empty password when the empty password actually comes from a login
 attempt.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
