### PR TITLE
Revert "don't perform an explicit setup when using the file cache"

### DIFF
--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -29,6 +29,7 @@
  */
 namespace OC\Cache;
 
+use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\ICache;
 use OCP\Security\ISecureRandom;
@@ -52,6 +53,7 @@ class File implements ICache {
 		if (\OC::$server->getUserSession()->isLoggedIn()) {
 			$rootView = new View();
 			$user = \OC::$server->getUserSession()->getUser();
+			Filesystem::initMountPoints($user->getUID());
 			if (!$rootView->file_exists('/' . $user->getUID() . '/cache')) {
 				$rootView->mkdir('/' . $user->getUID() . '/cache');
 			}

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -95,7 +95,7 @@ class UserMountCache implements IUserMountCache {
 
 		$cachedMounts = $this->getMountsForUser($user);
 		if (is_array($mountProviderClasses)) {
-			$cachedMounts = array_filter($cachedMounts, function (ICachedMountInfo $mountInfo) use ($mountProviderClasses, $newMounts): bool {
+			$cachedMounts = array_filter($cachedMounts, function (ICachedMountInfo $mountInfo) use ($mountProviderClasses, $newMounts) {
 				// for existing mounts that didn't have a mount provider set
 				// we still want the ones that map to new mounts
 				if ($mountInfo->getMountProvider() === '' && isset($newMounts[$mountInfo->getKey()])) {

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -82,14 +82,6 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		if (isset($params['validateWrites'])) {
 			$this->validateWrites = (bool)$params['validateWrites'];
 		}
-
-		// home storage is setup in the SetupManager
-		if (!$this instanceof HomeObjectStoreStorage) {
-			//initialize cache with root directory in cache
-			if (!$this->is_dir('/')) {
-				$this->mkdir('/');
-			}
-		}
 		$this->handleCopiesAsOwned = (bool)($params['handleCopiesAsOwned'] ?? false);
 
 		$this->logger = \OCP\Server::get(LoggerInterface::class);

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -257,20 +257,9 @@ class SetupManager {
 
 			if ($homeMount->getStorageRootId() === -1) {
 				$this->eventLogger->start('fs:setup:user:home:scan', 'Scan home filesystem for user');
-				$homeStorage = $homeMount->getStorage();
-				$homeStorage->mkdir('');
-				$homeStorage->mkdir('files');
-				$homeStorage->getScanner()->scan('');
+				$homeMount->getStorage()->mkdir('');
+				$homeMount->getStorage()->getScanner()->scan('');
 				$this->eventLogger->end('fs:setup:user:home:scan');
-			}
-
-			$provider = $homeMount->getMountProvider();
-			$this->userMountCache->registerMounts($user, [$homeMount], [$provider]);
-			if (!isset($this->setupUserMountProviders[$user->getUID()])) {
-				$this->setupUserMountProviders[$user->getUID()] = [];
-			}
-			if (!in_array($provider, $this->setupUserMountProviders[$user->getUID()])) {
-				$this->setupUserMountProviders[$user->getUID()][] = $provider;
 			}
 			$this->eventLogger->end('fs:setup:user:home');
 		} else {


### PR DESCRIPTION
Reverts nextcloud/server#32163
This broke the `Talk/` folder and testing a manual revert in https://github.com/nextcloud/spreed/actions/runs/8188740603/job/22392077005?pr=11738 has green tests again.