### PR TITLE
refactor: depricate getNumberOfUnreadCommentsForFolder and redo it's …

### DIFF
--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -29,6 +29,7 @@
 namespace OC\Comments;
 
 use Doctrine\DBAL\Exception\DriverException;
+use OCA\DAV\Connector\Sabre\File;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\CommentsEvent;
 use OCP\Comments\IComment;
@@ -36,6 +37,9 @@ use OCP\Comments\ICommentsEventHandler;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\FileInfo;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IEmojiHelper;
@@ -46,12 +50,6 @@ use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class Manager implements ICommentsManager {
-	protected IDBConnection $dbConn;
-	protected LoggerInterface $logger;
-	protected IConfig $config;
-	protected ITimeFactory $timeFactory;
-	protected IEmojiHelper $emojiHelper;
-	protected IInitialStateService $initialStateService;
 	/** @var IComment[] */
 	protected array $commentsCache = [];
 
@@ -64,18 +62,15 @@ class Manager implements ICommentsManager {
 	/** @var \Closure[] */
 	protected array $displayNameResolvers = [];
 
-	public function __construct(IDBConnection $dbConn,
-		LoggerInterface $logger,
-		IConfig $config,
-		ITimeFactory $timeFactory,
-		IEmojiHelper $emojiHelper,
-		IInitialStateService $initialStateService) {
-		$this->dbConn = $dbConn;
-		$this->logger = $logger;
-		$this->config = $config;
-		$this->timeFactory = $timeFactory;
-		$this->emojiHelper = $emojiHelper;
-		$this->initialStateService = $initialStateService;
+	public function __construct(
+		protected IDBConnection $dbConn,
+		protected LoggerInterface $logger,
+		protected IConfig $config,
+		protected ITimeFactory $timeFactory,
+		protected IEmojiHelper $emojiHelper,
+		protected IInitialStateService $initialStateService,
+		protected IRootFolder $rootFolder,
+	) {
 	}
 
 	/**
@@ -820,54 +815,25 @@ class Manager implements ICommentsManager {
 	/**
 	 * Get the number of unread comments for all files in a folder
 	 *
+	 * This is unused since 8bd39fccf411195839f2dadee085fad18ec52c23
+	 *
 	 * @param int $folderId
 	 * @param IUser $user
 	 * @return array [$fileId => $unreadCount]
 	 */
 	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user) {
-		$qb = $this->dbConn->getQueryBuilder();
-
-		$query = $qb->select('f.fileid')
-			->addSelect($qb->func()->count('c.id', 'num_ids'))
-			->from('filecache', 'f')
-			->leftJoin('f', 'comments', 'c', $qb->expr()->andX(
-				$qb->expr()->eq('f.fileid', $qb->expr()->castColumn('c.object_id', IQueryBuilder::PARAM_INT)),
-				$qb->expr()->eq('c.object_type', $qb->createNamedParameter('files'))
-			))
-			->leftJoin('c', 'comments_read_markers', 'm', $qb->expr()->andX(
-				$qb->expr()->eq('c.object_id', 'm.object_id'),
-				$qb->expr()->eq('m.object_type', $qb->createNamedParameter('files'))
-			))
-			->where(
-				$qb->expr()->andX(
-					$qb->expr()->eq('f.parent', $qb->createNamedParameter($folderId)),
-					$qb->expr()->orX(
-						$qb->expr()->eq('c.object_type', $qb->createNamedParameter('files')),
-						$qb->expr()->isNull('c.object_type')
-					),
-					$qb->expr()->orX(
-						$qb->expr()->eq('m.object_type', $qb->createNamedParameter('files')),
-						$qb->expr()->isNull('m.object_type')
-					),
-					$qb->expr()->orX(
-						$qb->expr()->eq('m.user_id', $qb->createNamedParameter($user->getUID())),
-						$qb->expr()->isNull('m.user_id')
-					),
-					$qb->expr()->orX(
-						$qb->expr()->gt('c.creation_timestamp', 'm.marker_datetime'),
-						$qb->expr()->isNull('m.marker_datetime')
-					)
-				)
-			)->groupBy('f.fileid');
-
-		$resultStatement = $query->execute();
-
-		$results = [];
-		while ($row = $resultStatement->fetch()) {
-			$results[$row['fileid']] = (int) $row['num_ids'];
+		$directory = $this->rootFolder->getFirstNodeById($folderId);
+		if (!$directory instanceof Folder) {
+			return [];
 		}
-		$resultStatement->closeCursor();
-		return $results;
+		$children = $directory->getDirectoryListing();
+		$ids = array_map(fn (FileInfo $child) => (string) $child->getId(), $children);
+
+		$ids[] = (string) $directory->getId();
+		$counts = $this->getNumberOfUnreadCommentsForObjects('files', $ids, $user);
+		return array_filter($counts, function (int $count) {
+			return $count > 0;
+		});
 	}
 
 	/**

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -271,6 +271,7 @@ interface ICommentsManager {
 	 * @param IUser $user
 	 * @return array [$fileId => $unreadCount]
 	 * @since 12.0.0
+	 * @deprecated 29.0.0 use getNumberOfUnreadCommentsForObjects instead
 	 */
 	public function getNumberOfUnreadCommentsForFolder($folderId, IUser $user);
 

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -10,6 +10,8 @@ use OCP\Comments\IComment;
 use OCP\Comments\ICommentsEventHandler;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IInitialStateService;
@@ -26,11 +28,14 @@ use Test\TestCase;
 class ManagerTest extends TestCase {
 	/** @var IDBConnection */
 	private $connection;
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IRootFolder */
+	private $rootFolder;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->rootFolder = $this->createMock(IRootFolder::class);
 
 		$sql = $this->connection->getDatabasePlatform()->getTruncateTableSQL('`*PREFIX*comments`');
 		$this->connection->prepare($sql)->execute();
@@ -80,7 +85,8 @@ class ManagerTest extends TestCase {
 			$this->createMock(IConfig::class),
 			$this->createMock(ITimeFactory::class),
 			new EmojiHelper($this->connection),
-			$this->createMock(IInitialStateService::class)
+			$this->createMock(IInitialStateService::class),
+			$this->rootFolder,
 		);
 	}
 
@@ -329,23 +335,19 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGetNumberOfUnreadCommentsForFolder() {
-		$query = $this->connection->getQueryBuilder();
-		$query->insert('filecache')
-			->values([
-				'parent' => $query->createNamedParameter(1000),
-				'size' => $query->createNamedParameter(10),
-				'mtime' => $query->createNamedParameter(10),
-				'storage_mtime' => $query->createNamedParameter(10),
-				'path' => $query->createParameter('path'),
-				'path_hash' => $query->createParameter('path'),
-			]);
-
-		$fileIds = [];
-		for ($i = 0; $i < 4; $i++) {
-			$query->setParameter('path', 'path_' . $i);
-			$query->execute();
-			$fileIds[] = $query->getLastInsertId();
-		}
+		$folder = $this->createMock(Folder::class);
+		$fileIds = range(1111, 1114);
+		$children = array_map(function (int $id) {
+			$file = $this->createMock(Folder::class);
+			$file->method('getId')
+				->willReturn($id);
+			return $file;
+		}, $fileIds);
+		$folder->method('getId')->willReturn(1000);
+		$folder->method('getDirectoryListing')->willReturn($children);
+		$this->rootFolder->method('getFirstNodeById')
+			->with($folder->getId())
+			->willReturn($folder);
 
 		// 2 comment for 1111 with 1 before read marker
 		// 2 comments for 1112 with no read marker
@@ -367,7 +369,7 @@ class ManagerTest extends TestCase {
 		$manager->setReadMark('files', (string) $fileIds[0], (new \DateTime())->modify('-1 days'), $user);
 		$manager->setReadMark('files', (string) $fileIds[2], (new \DateTime()), $user);
 
-		$amount = $manager->getNumberOfUnreadCommentsForFolder(1000, $user);
+		$amount = $manager->getNumberOfUnreadCommentsForFolder($folder->getId(), $user);
 		$this->assertEquals([
 			$fileIds[0] => 1,
 			$fileIds[1] => 2,
@@ -750,7 +752,8 @@ class ManagerTest extends TestCase {
 			$this->createMock(IConfig::class),
 			Server::get(ITimeFactory::class),
 			new EmojiHelper($this->connection),
-			$this->createMock(IInitialStateService::class)
+			$this->createMock(IInitialStateService::class),
+			$this->rootFolder,
 		);
 
 		// just to make sure they are really set, with correct actor data
@@ -795,7 +798,8 @@ class ManagerTest extends TestCase {
 			$this->createMock(IConfig::class),
 			Server::get(ITimeFactory::class),
 			new EmojiHelper($this->connection),
-			$this->createMock(IInitialStateService::class)
+			$this->createMock(IInitialStateService::class),
+			$this->rootFolder,
 		);
 
 		$deleted = $manager->deleteCommentsExpiredAtObject('files');


### PR DESCRIPTION
…implementation based on getNumberOfUnreadCommentsForObjects

This seems to be unused since https://github.com/nextcloud/server/pull/23792