### PR TITLE
files_versions: add missing null check

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -194,6 +194,11 @@ class FileEventsListener implements IEventListener {
 		}
 
 		$path = $this->getPathForNode($node);
+
+		if ($path === null) {
+			return;
+		}
+
 		$result = Storage::store($path);
 
 		// Store the result of the version creation so it can be used in post_write_hook.


### PR DESCRIPTION
The fact that this can be null could indicate a deeper problem.

See https://github.com/pulsejet/memories/issues/1053