### PR TITLE
fix(AppManager): Allow to query dark **or** bright icon

### DIFF
--- a/apps/updatenotification/lib/Notification/AppUpdateNotifier.php
+++ b/apps/updatenotification/lib/Notification/AppUpdateNotifier.php
@@ -84,9 +84,9 @@ class AppUpdateNotifier implements INotifier {
 		// Prepare translation factory for requested language
 		$l = $this->l10nFactory->get(Application::APP_NAME, $languageCode);
 		
-		$icon = $this->appManager->getAppIcon($appId);
+		$icon = $this->appManager->getAppIcon($appId, true);
 		if ($icon === null) {
-			$icon = $this->urlGenerator->imagePath('core', 'default-app-icon');
+			$icon = $this->urlGenerator->imagePath('core', 'actions/change.svg');
 		}
 
 		$action = $notification->createAction();

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -109,8 +109,8 @@ class AppManager implements IAppManager {
 	) {
 	}
 
-	public function getAppIcon(string $appId): ?string {
-		$possibleIcons = [$appId . '.svg', 'app.svg', $appId . '-dark.svg', 'app-dark.svg'];
+	public function getAppIcon(string $appId, bool $dark = false): ?string {
+		$possibleIcons = $dark ? [$appId . '-dark.svg', 'app-dark.svg'] : [$appId . '.svg', 'app.svg'];
 		$icon = null;
 		foreach ($possibleIcons as $iconName) {
 			try {

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -65,10 +65,11 @@ interface IAppManager {
 	 * Returns the app icon or null if none is found
 	 *
 	 * @param string $appId
+	 * @param bool $dark Enable to request a dark icon variant, default is a white icon
 	 * @return string|null
 	 * @since 29.0.0
 	 */
-	public function getAppIcon(string $appId): string|null;
+	public function getAppIcon(string $appId, bool $dark = false): string|null;
 
 	/**
 	 * Check if an app is enabled for user

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -135,12 +135,16 @@ class AppManagerTest extends TestCase {
 	/**
 	 * @dataProvider dataGetAppIcon
 	 */
-	public function testGetAppIcon($callback, string|null $expected) {
+	public function testGetAppIcon($callback, ?bool $dark, string|null $expected) {
 		$this->urlGenerator->expects($this->atLeastOnce())
 			->method('imagePath')
 			->willReturnCallback($callback);
 
-		$this->assertEquals($expected, $this->manager->getAppIcon('test'));
+		if ($dark !== null) {
+			$this->assertEquals($expected, $this->manager->getAppIcon('test', $dark));
+		} else {
+			$this->assertEquals($expected, $this->manager->getAppIcon('test'));
+		}
 	}
 
 	public function dataGetAppIcon(): array {
@@ -162,35 +166,58 @@ class AppManagerTest extends TestCase {
 		return [
 			'does not find anything' => [
 				$nothing,
+				false,
 				null,
 			],
-			'only app.svg' => [
+			'nothing if request dark but only bright available' => [
 				$createCallback(['app.svg']),
+				true,
+				null,
+			],
+			'nothing if request bright but only dark available' => [
+				$createCallback(['app-dark.svg']),
+				false,
+				null,
+			],
+			'bright and only app.svg' => [
+				$createCallback(['app.svg']),
+				false,
 				'/path/app.svg',
 			],
-			'only app-dark.svg' => [
+			'dark and only app-dark.svg' => [
 				$createCallback(['app-dark.svg']),
+				true,
 				'/path/app-dark.svg',
 			],
-			'only appname -dark.svg' => [
+			'dark only appname -dark.svg' => [
 				$createCallback(['test-dark.svg']),
+				true,
 				'/path/test-dark.svg',
 			],
-			'only appname.svg' => [
+			'bright and only appname.svg' => [
 				$createCallback(['test.svg']),
+				false,
 				'/path/test.svg',
 			],
 			'priotize custom over default' => [
 				$createCallback(['app.svg', 'test.svg']),
+				false,
 				'/path/test.svg',
 			],
-			'priotize default over dark' => [
-				$createCallback(['test-dark.svg', 'app-dark.svg', 'app.svg']),
-				'/path/app.svg',
-			],
-			'priotize custom over default' => [
-				$createCallback(['test.svg', 'test-dark.svg', 'app-dark.svg']),
+			'defaults to bright' => [
+				$createCallback(['test-dark.svg', 'test.svg']),
+				null,
 				'/path/test.svg',
+			],
+			'no dark icon on default' => [
+				$createCallback(['test-dark.svg', 'test.svg', 'app-dark.svg', 'app.svg']),
+				false,
+				'/path/test.svg',
+			],
+			'no bright icon on dark' => [
+				$createCallback(['test-dark.svg', 'test.svg', 'app-dark.svg', 'app.svg']),
+				true,
+				'/path/test-dark.svg',
 			],
 		];
 	}


### PR DESCRIPTION
* Follow up on #43967

## Summary
The navigation needs the bright icon, while the notifications and activity need a dark icon.
This fixes the notification to have also a bright one -> no contrast.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
