### PR TITLE
fix(updatenotification): Adjust tests for changed IAppConfig

### DIFF
--- a/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
+++ b/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
@@ -218,7 +218,8 @@ class UpdateAvailableNotifications extends TimedJob {
 			}
 		}
 
-		return array_unique($this->users);
+		$this->users = array_values(array_unique($this->users));
+		return $this->users;
 	}
 
 	/**

--- a/apps/updatenotification/tests/BackgroundJob/ResetTokenTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/ResetTokenTest.php
@@ -57,9 +57,9 @@ class ResetTokenTest extends TestCase {
 			->expects($this->atLeastOnce())
 			->method('getTime')
 			->willReturn(123);
-		$this->config
+		$this->appConfig
 			->expects($this->once())
-			->method('getAppValue')
+			->method('getValueInt')
 			->with('core', 'updater.secret.created', 123);
 		$this->config
 			->expects($this->once())
@@ -75,13 +75,14 @@ class ResetTokenTest extends TestCase {
 
 	public function testRunWithExpiredToken() {
 		$this->timeFactory
-			->expects($this->exactly(2))
-			->method('getTime')
-			->willReturnOnConsecutiveCalls(1455131633, 1455045234);
-		$this->config
 			->expects($this->once())
-			->method('getAppValue')
-			->with('core', 'updater.secret.created', 1455045234);
+			->method('getTime')
+			->willReturn(1455045234);
+		$this->appConfig
+			->expects($this->once())
+			->method('getValueInt')
+			->with('core', 'updater.secret.created', 1455045234)
+			->willReturn(2 * 24 * 60 * 60 + 1); // over 2 days
 		$this->config
 			->expects($this->once())
 			->method('deleteSystemValue')
@@ -94,9 +95,9 @@ class ResetTokenTest extends TestCase {
 		$this->timeFactory
 			->expects($this->never())
 			->method('getTime');
-		$this->config
+		$this->appConfig
 			->expects($this->never())
-			->method('getAppValue');
+			->method('getValueInt');
 		$this->config
 			->expects($this->once())
 			->method('getSystemValueBool')

--- a/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
@@ -211,19 +211,19 @@ class UpdateAvailableNotificationsTest extends TestCase {
 			$job->expects($this->never())
 				->method('clearErrorNotifications');
 
-			$this->config->expects($this->once())
-				->method('getAppValue')
-				->willReturn($errorDays);
-			$this->config->expects($this->once())
-				->method('setAppValue')
-				->with('updatenotification', 'update_check_errors', $errorDays + 1);
+			$this->appConfig->expects($this->once())
+				->method('getAppValueInt')
+				->willReturn($errorDays ?? 0);
+			$this->appConfig->expects($this->once())
+				->method('setAppValueInt')
+				->with('update_check_errors', $errorDays + 1);
 			$job->expects($errorDays !== null ? $this->once() : $this->never())
 				->method('sendErrorNotifications')
 				->with($errorDays + 1);
 		} else {
-			$this->config->expects($this->once())
-				->method('setAppValue')
-				->with('updatenotification', 'update_check_errors', 0);
+			$this->appConfig->expects($this->once())
+				->method('setAppValueInt')
+				->with('update_check_errors', 0);
 			$job->expects($this->once())
 				->method('clearErrorNotifications');
 			$job->expects($this->once())
@@ -302,15 +302,15 @@ class UpdateAvailableNotificationsTest extends TestCase {
 			'getUsersToNotify',
 		]);
 
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('updatenotification', $app, false)
-			->willReturn($lastNotification);
+		$this->appConfig->expects($this->once())
+			->method('getAppValueString')
+			->with($app, '')
+			->willReturn($lastNotification ? $lastNotification : '');
 
 		if ($lastNotification !== $version) {
-			$this->config->expects($this->once())
-				->method('setAppValue')
-				->with('updatenotification', $app, $version);
+			$this->appConfig->expects($this->once())
+				->method('setAppValueString')
+				->with($app, $version);
 		}
 
 		if ($callDelete === false) {
@@ -386,10 +386,10 @@ class UpdateAvailableNotificationsTest extends TestCase {
 	public function testGetUsersToNotify(array $groups, array $groupUsers, array $expected) {
 		$job = $this->getJob();
 
-		$this->config->expects($this->once())
-			->method('getAppValue')
-			->with('updatenotification', 'notify_groups', '["admin"]')
-			->willReturn(json_encode($groups));
+		$this->appConfig->expects($this->once())
+			->method('getAppValueArray')
+			->with('notify_groups', ['admin'])
+			->willReturn($groups);
 
 		$groupMap = [];
 		foreach ($groupUsers as $gid => $uids) {

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -92,9 +92,9 @@ class AdminControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getTime')
 			->willReturn(12345);
-		$this->config
+		$this->appConfig
 			->expects($this->once())
-			->method('setAppValue')
+			->method('setValueInt')
 			->with('core', 'updater.secret.created', 12345);
 
 		$expected = new DataResponse('MyGeneratedToken');


### PR DESCRIPTION
* Follow up on #43967 - This was already fixed there but probably lost in last rebase.

## Summary

Fix unit tests to use correct app config.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
