### PR TITLE
fix(settings): Adjust order of parameters for `runRequest`

### DIFF
--- a/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
+++ b/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
@@ -74,8 +74,8 @@ trait CheckServerResponseTrait {
 
 	/**
 	 * Run a HTTP request to check header
-	 * @param string $url The relative URL to check
 	 * @param string $method The HTTP method to use
+	 * @param string $url The relative URL to check
 	 * @param array{ignoreSSL?: bool, httpErrors?: bool, options?: array} $options Additional options, like
 	 *                                                 [
 	 *                                                  // Ignore invalid SSL certificates (e.g. self signed)
@@ -86,7 +86,7 @@ trait CheckServerResponseTrait {
 	 *
 	 * @return Generator<int, IResponse>
 	 */
-	protected function runRequest(string $url, string $method, array $options = []): Generator {
+	protected function runRequest(string $method, string $url, array $options = []): Generator {
 		$options = array_merge(['ignoreSSL' => true, 'httpErrors' => true], $options);
 
 		$client = $this->clientService->newClient();
@@ -95,7 +95,7 @@ trait CheckServerResponseTrait {
 
 		foreach ($this->getTestUrls($url) as $testURL) {
 			try {
-				yield $client->request($testURL, $method, $requestOptions);
+				yield $client->request($method, $testURL, $requestOptions);
 			} catch (\Throwable $e) {
 				$this->logger->debug('Can not connect to local server for running setup checks', ['exception' => $e, 'url' => $testURL]);
 			}
@@ -110,7 +110,7 @@ trait CheckServerResponseTrait {
 	 * @return Generator<int, IResponse>
 	 */
 	protected function runHEAD(string $url, bool $ignoreSSL = true, bool $httpErrors = true): Generator {
-		return $this->runRequest($url, 'HEAD', ['ignoreSSL' => $ignoreSSL, 'httpErrors' => $httpErrors]);
+		return $this->runRequest('HEAD', $url, ['ignoreSSL' => $ignoreSSL, 'httpErrors' => $httpErrors]);
 	}
 
 	protected function getRequestOptions(bool $ignoreSSL, bool $httpErrors): array {

--- a/apps/settings/lib/SetupChecks/WellKnownUrls.php
+++ b/apps/settings/lib/SetupChecks/WellKnownUrls.php
@@ -70,7 +70,7 @@ class WellKnownUrls implements ISetupCheck {
 
 		foreach ($urls as [$verb,$url,$validStatuses,$checkCustomHeader]) {
 			$works = null;
-			foreach ($this->runRequest($url, $verb, ['httpErrors' => false, 'options' => ['allow_redirects' => ['track_redirects' => true]]]) as $response) {
+			foreach ($this->runRequest($verb, $url, ['httpErrors' => false, 'options' => ['allow_redirects' => ['track_redirects' => true]]]) as $response) {
 				// Check that the response status matches
 				$works = in_array($response->getStatusCode(), $validStatuses);
 				// and (if needed) the custom Nextcloud header is set


### PR DESCRIPTION
* Regression of https://github.com/nextcloud/server/pull/43939

## Summary

Fixing invalid request to host `HEAD`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
