### PR TITLE
fix(2fa): Handle twofactor_enforced configuration parameter as boolean

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/MandatoryTwoFactor.php
+++ b/lib/private/Authentication/TwoFactorAuth/MandatoryTwoFactor.php
@@ -46,7 +46,7 @@ class MandatoryTwoFactor {
 	 */
 	public function getState(): EnforcementState {
 		return new EnforcementState(
-			$this->config->getSystemValue('twofactor_enforced', 'false') === 'true',
+			$this->config->getSystemValueBool('twofactor_enforced', false),
 			$this->config->getSystemValue('twofactor_enforced_groups', []),
 			$this->config->getSystemValue('twofactor_enforced_excluded_groups', [])
 		);
@@ -56,7 +56,7 @@ class MandatoryTwoFactor {
 	 * Set the state of enforced two-factor auth
 	 */
 	public function setState(EnforcementState $state) {
-		$this->config->setSystemValue('twofactor_enforced', $state->isEnforced() ? 'true' : 'false');
+		$this->config->setSystemValueBool('twofactor_enforced', $state->isEnforced());
 		$this->config->setSystemValue('twofactor_enforced_groups', $state->getEnforcedGroups());
 		$this->config->setSystemValue('twofactor_enforced_excluded_groups', $state->getExcludedGroups());
 	}

--- a/tests/lib/Authentication/TwoFactorAuth/MandatoryTwoFactorTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/MandatoryTwoFactorTest.php
@@ -55,9 +55,13 @@ class MandatoryTwoFactorTest extends TestCase {
 
 	public function testIsNotEnforced() {
 		$this->config
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', false, false],
+			]);
+		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'false', 'false'],
 				['twofactor_enforced_groups', [], []],
 				['twofactor_enforced_excluded_groups', [], []],
 			]);
@@ -69,9 +73,13 @@ class MandatoryTwoFactorTest extends TestCase {
 
 	public function testIsEnforced() {
 		$this->config
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', false, true],
+			]);
+		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'false', 'true'],
 				['twofactor_enforced_groups', [], []],
 				['twofactor_enforced_excluded_groups', [], []],
 			]);
@@ -85,9 +93,13 @@ class MandatoryTwoFactorTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user123');
 		$this->config
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', false, false],
+			]);
+		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'false', 'false'],
 				['twofactor_enforced_groups', [], []],
 				['twofactor_enforced_excluded_groups', [], []],
 			]);
@@ -101,9 +113,13 @@ class MandatoryTwoFactorTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user123');
 		$this->config
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', false, true],
+			]);
+		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'false', 'true'],
 				['twofactor_enforced_groups', [], ['twofactorers']],
 				['twofactor_enforced_excluded_groups', [], []],
 			]);
@@ -121,9 +137,13 @@ class MandatoryTwoFactorTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user123');
 		$this->config
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', false, true],
+			]);
+		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'false', 'true'],
 				['twofactor_enforced_groups', [], ['twofactorers']],
 				['twofactor_enforced_excluded_groups', [], []],
 			]);
@@ -139,9 +159,13 @@ class MandatoryTwoFactorTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user123');
 		$this->config
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', false, true],
+			]);
+		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'false', 'true'],
 				['twofactor_enforced_groups', [], []],
 				['twofactor_enforced_excluded_groups', [], ['yoloers']],
 			]);
@@ -157,10 +181,15 @@ class MandatoryTwoFactorTest extends TestCase {
 
 	public function testSetEnforced() {
 		$this->config
-			->expects($this->exactly(3))
+			->expects($this->exactly(1))
+			->method('setSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', true],
+			]);
+		$this->config
+			->expects($this->exactly(2))
 			->method('setSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'true'],
 				['twofactor_enforced_groups', []],
 				['twofactor_enforced_excluded_groups', []],
 			]);
@@ -170,10 +199,15 @@ class MandatoryTwoFactorTest extends TestCase {
 
 	public function testSetEnforcedForGroups() {
 		$this->config
-			->expects($this->exactly(3))
+			->expects($this->exactly(1))
+			->method('setSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', true],
+			]);
+		$this->config
+			->expects($this->exactly(2))
 			->method('setSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'true'],
 				['twofactor_enforced_groups', ['twofactorers']],
 				['twofactor_enforced_excluded_groups', ['yoloers']],
 			]);
@@ -183,10 +217,15 @@ class MandatoryTwoFactorTest extends TestCase {
 
 	public function testSetNotEnforced() {
 		$this->config
-			->expects($this->exactly(3))
+			->expects($this->exactly(1))
+			->method('setSystemValueBool')
+			->willReturnMap([
+				['twofactor_enforced', false],
+			]);
+		$this->config
+			->expects($this->exactly(2))
 			->method('setSystemValue')
 			->willReturnMap([
-				['twofactor_enforced', 'false'],
 				['twofactor_enforced_groups', []],
 				['twofactor_enforced_excluded_groups', []],
 			]);


### PR DESCRIPTION
## Summary
The `twofactor_enforced` configuration parameter should be handled as a boolean value like all the other boolean configuration parameters. This reduces configuration errors at least for those, who might edit config.php directly.

## TODO

- Should we migrate the string values to boolean on current installations? Or make `getSystemValueBool` return the correct value regardless if it's e.g. `'true'` or `true`?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
