### PR TITLE
fix(UpdateNotifications): Handle numeric user ids

### DIFF
--- a/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
+++ b/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
@@ -121,7 +121,7 @@ class UpdateAvailableNotifications extends TimedJob {
 				->setSubject('connection_error', ['days' => $numDays]);
 
 			foreach ($this->getUsersToNotify() as $uid) {
-				$notification->setUser($uid);
+				$notification->setUser((string) $uid);
 				$this->notificationManager->notify($notification);
 			}
 		} catch (\InvalidArgumentException $e) {
@@ -189,7 +189,7 @@ class UpdateAvailableNotifications extends TimedJob {
 			}
 
 			foreach ($this->getUsersToNotify() as $uid) {
-				$notification->setUser($uid);
+				$notification->setUser((string) $uid);
 				$this->notificationManager->notify($notification);
 			}
 		} catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
* Resolves: #44051 <!-- related github issue -->

## Summary

`getUsersToNotify()` uses `array_key` so when `$uid` happens to be numeric it ends up needing to be cast here (similar to #15912).

Backports will need to be done manually due to restructure that occurred in >v28 (I'll follow-up with those).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
