### PR TITLE
fix(cron): Fix Cron misrepresenting itself as console

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -117,7 +117,7 @@ try {
 		$user = posix_getuid();
 		$dataDirectoryUser = fileowner($config->getSystemValueString('datadirectory', \OC::$SERVERROOT . '/data'));
 		if ($user !== $dataDirectoryUser) {
-			echo "Console has to be executed with the user that owns the data directory" . PHP_EOL;
+			echo "Cron has to be executed with the user that owns the data directory" . PHP_EOL;
 			echo "Current user id: " . $user . PHP_EOL;
 			echo "Owner id of the data directory: " . $dataDirectoryUser . PHP_EOL;
 			exit(1);


### PR DESCRIPTION

## Summary

While working on #42449 I noticed that a log string was incorrect. And since that is now resolved via another PR I've spun this off into a separate branch.

console.php and cron.php logging the same name was a bit confusing at one time. So this is the fix.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
