### PR TITLE
[stable28] fix(UpdateNotifications): Handle numeric user ids

### DIFF
--- a/apps/updatenotification/lib/Notification/BackgroundJob.php
+++ b/apps/updatenotification/lib/Notification/BackgroundJob.php
@@ -118,7 +118,7 @@ class BackgroundJob extends TimedJob {
 				->setSubject('connection_error', ['days' => $numDays]);
 
 			foreach ($this->getUsersToNotify() as $uid) {
-				$notification->setUser($uid);
+				$notification->setUser((string) $uid);
 				$this->notificationManager->notify($notification);
 			}
 		} catch (\InvalidArgumentException $e) {
@@ -186,7 +186,7 @@ class BackgroundJob extends TimedJob {
 			}
 
 			foreach ($this->getUsersToNotify() as $uid) {
-				$notification->setUser($uid);
+				$notification->setUser((string) $uid);
 				$this->notificationManager->notify($notification);
 			}
 		} catch (\InvalidArgumentException $e) {


### PR DESCRIPTION

* Resolves: #44051 <!-- related github issue -->

## Summary

Manual backport of #44093 for <=v28. Same change just a different file since things got moved around in master.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
