### PR TITLE
fix(theming): fix incorrectly inverted favicons

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -181,7 +181,7 @@ class IconBuilder {
 			 * invert app icons for bright primary colors
 			 * the default nextcloud logo will not be inverted to black
 			 */
-			if ($this->util->invertTextColor($color)
+			if ($this->util->isBrightColor($color)
 				&& !$appIcon instanceof ISimpleFile
 				&& $app !== "core"
 			) {


### PR DESCRIPTION
Reason: invertTextColor has changed and is not now incorrectly inverting icons even with the default primary color. This now switches to isBrightColor which more correctly returns what we need here.

| Before | After with default primary color | After with white as primary color | After with black as primary color |
|---|---|---|---|
| ![image](https://github.com/nextcloud/server/assets/42591237/437dae74-fe60-4c43-bcc2-059153dabcda) | ![image](https://github.com/nextcloud/server/assets/42591237/c8496fea-66bc-4626-a4b1-fce7e6feff4b) | ![image](https://github.com/nextcloud/server/assets/42591237/0abe29ad-d275-4e7d-b3d2-01b5bf23bd6a) | ![image](https://github.com/nextcloud/server/assets/42591237/000d0226-2f4b-442c-a98d-3a43151eaca8) |