### PR TITLE
fix(settings): Fix always empty disabled users list for subadmins

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -256,7 +256,7 @@ class UsersController extends AUserData {
 						fn (IUser $user): string => $user->getUID(),
 						array_filter(
 							$group->searchUsers('', ($tempLimit === null ? null : $tempLimit - count($users))),
-							fn (IUser $user): bool => $user->isEnabled()
+							fn (IUser $user): bool => !$user->isEnabled()
 						)
 					)
 				);


### PR DESCRIPTION
## Summary

- Fix https://github.com/nextcloud/server/issues/44099

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)