### PR TITLE
fix: Call execute until it is removed for Job class

### DIFF
--- a/core/Command/Background/Job.php
+++ b/core/Command/Background/Job.php
@@ -84,7 +84,8 @@ class Job extends Command {
 			$output->writeln('<error>Something went wrong when trying to retrieve Job with ID ' . $jobId . ' from database</error>');
 			return 1;
 		}
-		$job->start($this->jobList);
+		/** Calling execute until it is removed, then will switch to start */
+		$job->execute($this->jobList);
 		$job = $this->jobList->getById($jobId);
 
 		if (($job === null) || ($lastRun !== $job->getLastRun())) {

--- a/core/Command/Background/Job.php
+++ b/core/Command/Background/Job.php
@@ -84,7 +84,7 @@ class Job extends Command {
 			$output->writeln('<error>Something went wrong when trying to retrieve Job with ID ' . $jobId . ' from database</error>');
 			return 1;
 		}
-		/** Calling execute until it is removed, then will switch to start */
+		/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
 		$job->execute($this->jobList);
 		$job = $this->jobList->getById($jobId);
 

--- a/cron.php
+++ b/cron.php
@@ -172,7 +172,8 @@ try {
 			$memoryBefore = memory_get_usage();
 			$memoryPeakBefore = memory_get_peak_usage();
 
-			$job->start($jobList);
+			/** Calling execute until it is removed, then will switch to start */
+			$job->execute($jobList);
 
 			$memoryAfter = memory_get_usage();
 			$memoryPeakAfter = memory_get_peak_usage();
@@ -207,7 +208,8 @@ try {
 			$job = $jobList->getNext();
 			if ($job != null) {
 				$logger->debug('WebCron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);
-				$job->start($jobList);
+				/** Calling execute until it is removed, then will switch to start */
+				$job->execute($jobList);
 				$jobList->setLastJob($job);
 			}
 			OC_JSON::success();

--- a/cron.php
+++ b/cron.php
@@ -172,7 +172,7 @@ try {
 			$memoryBefore = memory_get_usage();
 			$memoryPeakBefore = memory_get_peak_usage();
 
-			/** Calling execute until it is removed, then will switch to start */
+			/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
 			$job->execute($jobList);
 
 			$memoryAfter = memory_get_usage();
@@ -208,7 +208,7 @@ try {
 			$job = $jobList->getNext();
 			if ($job != null) {
 				$logger->debug('WebCron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);
-				/** Calling execute until it is removed, then will switch to start */
+				/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
 				$job->execute($jobList);
 				$jobList->setLastJob($job);
 			}


### PR DESCRIPTION
## Summary

Because if an application extends `execute` it will change behavior
 without warning otherwise.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
