### PR TITLE
Added rate limit bypass for app_api requests

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -302,7 +302,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 					$c->get(IRequest::class),
 					$c->get(IUserSession::class),
 					$c->get(IControllerMethodReflector::class),
-					$c->get(OC\Security\RateLimiting\Limiter::class)
+					$c->get(OC\Security\RateLimiting\Limiter::class),
+					$c->get(ISession::class)
 				)
 			);
 			$dispatcher->registerMiddleware(

--- a/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/RateLimitingMiddlewareTest.php
@@ -37,6 +37,7 @@ use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserSession;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -77,6 +78,7 @@ class RateLimitingMiddlewareTest extends TestCase {
 	private IUserSession|MockObject $userSession;
 	private ControllerMethodReflector $reflector;
 	private Limiter|MockObject $limiter;
+	private ISession|MockObject $session;
 	private RateLimitingMiddleware $rateLimitingMiddleware;
 
 	protected function setUp(): void {
@@ -86,12 +88,14 @@ class RateLimitingMiddlewareTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->reflector = new ControllerMethodReflector();
 		$this->limiter = $this->createMock(Limiter::class);
+		$this->session = $this->createMock(ISession::class);
 
 		$this->rateLimitingMiddleware = new RateLimitingMiddleware(
 			$this->request,
 			$this->userSession,
 			$this->reflector,
-			$this->limiter
+			$this->limiter,
+			$this->session
 		);
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

When doing a request via app_api the rate limiting prevents more than 5 requests per 2 minutes, with checking if the app_api session exsists we bypass the rate limiting for app_api requests.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)


* Resolves: # <!-- related github issue -->