### PR TITLE
fix(updatenotification): spread the use of new iappconfig

### DIFF
--- a/apps/settings/lib/Settings/Admin/Server.php
+++ b/apps/settings/lib/Settings/Admin/Server.php
@@ -30,6 +30,7 @@ use OC\Profile\TProfileHelper;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -39,28 +40,16 @@ use OCP\Settings\IDelegatedSettings;
 class Server implements IDelegatedSettings {
 	use TProfileHelper;
 
-	private IDBConnection $connection;
-	private IInitialState $initialStateService;
-	private ProfileManager $profileManager;
-	private ITimeFactory $timeFactory;
-	private IConfig $config;
-	private IL10N $l;
-	private IURLGenerator $urlGenerator;
-
-	public function __construct(IDBConnection $connection,
-		IInitialState $initialStateService,
-		ProfileManager $profileManager,
-		ITimeFactory $timeFactory,
-		IURLGenerator $urlGenerator,
-		IConfig $config,
-		IL10N $l) {
-		$this->connection = $connection;
-		$this->initialStateService = $initialStateService;
-		$this->profileManager = $profileManager;
-		$this->timeFactory = $timeFactory;
-		$this->config = $config;
-		$this->l = $l;
-		$this->urlGenerator = $urlGenerator;
+	public function __construct(
+		private IDBConnection $connection,
+		private IInitialState $initialStateService,
+		private ProfileManager $profileManager,
+		private ITimeFactory $timeFactory,
+		private IURLGenerator $urlGenerator,
+		private IConfig $config,
+		private IAppConfig $appConfig,
+		private IL10N $l,
+	) {
 	}
 
 	/**
@@ -69,7 +58,7 @@ class Server implements IDelegatedSettings {
 	public function getForm() {
 		// Background jobs
 		$this->initialStateService->provideInitialState('backgroundJobsMode', $this->config->getAppValue('core', 'backgroundjobs_mode', 'ajax'));
-		$this->initialStateService->provideInitialState('lastCron', (int)$this->config->getAppValue('core', 'lastcron', '0'));
+		$this->initialStateService->provideInitialState('lastCron', $this->appConfig->getValueInt('core', 'lastcron', 0));
 		$this->initialStateService->provideInitialState('cronMaxAge', $this->cronMaxAge());
 		$this->initialStateService->provideInitialState('cronErrors', $this->config->getAppValue('core', 'cronErrors'));
 		$this->initialStateService->provideInitialState('cliBasedCronPossible', function_exists('posix_getpwuid'));

--- a/apps/settings/lib/SetupChecks/CronInfo.php
+++ b/apps/settings/lib/SetupChecks/CronInfo.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 
 namespace OCA\Settings\SetupChecks;
 
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IL10N;
@@ -37,6 +38,7 @@ class CronInfo implements ISetupCheck {
 	public function __construct(
 		private IL10N $l10n,
 		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IURLGenerator $urlGenerator,
 		private IDateTimeFormatter $dateTimeFormatter,
 	) {
@@ -51,7 +53,7 @@ class CronInfo implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		$lastCronRun = (int)$this->config->getAppValue('core', 'lastcron', '0');
+		$lastCronRun = $this->appConfig->getValueInt('core', 'lastcron', 0);
 		$relativeTime = $this->dateTimeFormatter->formatTimeSpan($lastCronRun);
 
 		if ((time() - $lastCronRun) > 3600) {

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -36,6 +36,7 @@ use OCA\Settings\Settings\Admin\Server;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -59,6 +60,8 @@ class ServerTest extends TestCase {
 	private $timeFactory;
 	/** @var IConfig|MockObject */
 	private $config;
+	/** @var IAppConfig|MockObject */
+	private $appConfig;
 	/** @var IL10N|MockObject */
 	private $l10n;
 	/** @var IUrlGenerator|MockObject */
@@ -71,6 +74,7 @@ class ServerTest extends TestCase {
 		$this->profileManager = $this->createMock(ProfileManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->urlGenerator = $this->createMock(IUrlGenerator::class);
 
@@ -83,6 +87,7 @@ class ServerTest extends TestCase {
 				$this->timeFactory,
 				$this->urlGenerator,
 				$this->config,
+				$this->appConfig,
 				$this->l10n,
 			])
 			->getMock();

--- a/apps/updatenotification/lib/Settings/Admin.php
+++ b/apps/updatenotification/lib/Settings/Admin.php
@@ -33,6 +33,7 @@ use OC\User\Backend;
 use OCA\UpdateNotification\UpdateChecker;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IGroupManager;
@@ -45,40 +46,22 @@ use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class Admin implements ISettings {
-	private IConfig $config;
-	private UpdateChecker $updateChecker;
-	private IGroupManager $groupManager;
-	private IDateTimeFormatter $dateTimeFormatter;
-	private IFactory $l10nFactory;
-	private IRegistry $subscriptionRegistry;
-	private IUserManager $userManager;
-	private LoggerInterface $logger;
-	private IInitialState $initialState;
-
 	public function __construct(
-		IConfig $config,
-		UpdateChecker $updateChecker,
-		IGroupManager $groupManager,
-		IDateTimeFormatter $dateTimeFormatter,
-		IFactory $l10nFactory,
-		IRegistry $subscriptionRegistry,
-		IUserManager $userManager,
-		LoggerInterface $logger,
-		IInitialState $initialState
+		private IConfig $config,
+		private IAppConfig $appConfig,
+		private UpdateChecker $updateChecker,
+		private IGroupManager $groupManager,
+		private IDateTimeFormatter $dateTimeFormatter,
+		private IFactory $l10nFactory,
+		private IRegistry $subscriptionRegistry,
+		private IUserManager $userManager,
+		private LoggerInterface $logger,
+		private IInitialState $initialState
 	) {
-		$this->config = $config;
-		$this->updateChecker = $updateChecker;
-		$this->groupManager = $groupManager;
-		$this->dateTimeFormatter = $dateTimeFormatter;
-		$this->l10nFactory = $l10nFactory;
-		$this->subscriptionRegistry = $subscriptionRegistry;
-		$this->userManager = $userManager;
-		$this->logger = $logger;
-		$this->initialState = $initialState;
 	}
 
 	public function getForm(): TemplateResponse {
-		$lastUpdateCheckTimestamp = (int)$this->config->getAppValue('core', 'lastupdatedat');
+		$lastUpdateCheckTimestamp = $this->appConfig->getValueInt('core', 'lastupdatedat');
 		$lastUpdateCheck = $this->dateTimeFormatter->formatDateTime($lastUpdateCheckTimestamp);
 
 		$channels = [

--- a/apps/updatenotification/tests/Settings/AdminTest.php
+++ b/apps/updatenotification/tests/Settings/AdminTest.php
@@ -34,6 +34,7 @@ use OCA\UpdateNotification\Settings\Admin;
 use OCA\UpdateNotification\UpdateChecker;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDateTimeFormatter;
 use OCP\IGroup;
@@ -55,6 +56,8 @@ class AdminTest extends TestCase {
 	private $admin;
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
+	/** @var IAppConfig|\PHPUnit\Framework\MockObject\MockObject */
+	private $appConfig;
 	/** @var UpdateChecker|\PHPUnit\Framework\MockObject\MockObject */
 	private $updateChecker;
 	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
@@ -74,6 +77,7 @@ class AdminTest extends TestCase {
 		parent::setUp();
 
 		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->updateChecker = $this->createMock(UpdateChecker::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->dateTimeFormatter = $this->createMock(IDateTimeFormatter::class);
@@ -85,6 +89,7 @@ class AdminTest extends TestCase {
 
 		$this->admin = new Admin(
 			$this->config,
+			$this->appConfig,
 			$this->updateChecker,
 			$this->groupManager,
 			$this->dateTimeFormatter,
@@ -143,14 +148,16 @@ class AdminTest extends TestCase {
 		if ($currentChannel === 'git') {
 			$channels[] = 'git';
 		}
-
+		$this->appConfig
+			->expects($this->once())
+			->method('getValueInt')
+			->with('core', 'lastupdatedat', 0)
+			->willReturn(12345);
 		$this->config
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getAppValue')
-			->willReturnMap([
-				['core', 'lastupdatedat', '', '12345'],
-				['updatenotification', 'notify_groups', '["admin"]', '["admin"]'],
-			]);
+			->with('updatenotification', 'notify_groups', '["admin"]')
+			->willReturn('["admin"]');
 		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
@@ -160,7 +167,7 @@ class AdminTest extends TestCase {
 		$this->dateTimeFormatter
 			->expects($this->once())
 			->method('formatDateTime')
-			->with('12345')
+			->with(12345)
 			->willReturn('LastCheckedReturnValue');
 		$this->updateChecker
 			->expects($this->once())
@@ -268,13 +275,16 @@ class AdminTest extends TestCase {
 			$channels[] = 'git';
 		}
 
+		$this->appConfig
+			->expects($this->once())
+			->method('getValueInt')
+			->with('core', 'lastupdatedat', 0)
+			->willReturn(12345);
 		$this->config
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getAppValue')
-			->willReturnMap([
-				['core', 'lastupdatedat', '', '12345'],
-				['updatenotification', 'notify_groups', '["admin"]', '["admin"]'],
-			]);
+			->with('updatenotification', 'notify_groups', '["admin"]')
+			->willReturn('["admin"]');
 		$this->config
 			->method('getSystemValue')
 			->willReturnMap([
@@ -392,13 +402,16 @@ class AdminTest extends TestCase {
 			$channels[] = 'git';
 		}
 
+		$this->appConfig
+			->expects($this->once())
+			->method('getValueInt')
+			->with('core', 'lastupdatedat', 0)
+			->willReturn(12345);
 		$this->config
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('getAppValue')
-			->willReturnMap([
-				['core', 'lastupdatedat', '', '12345'],
-				['updatenotification', 'notify_groups', '["admin"]', '["admin"]'],
-			]);
+			->with('updatenotification', 'notify_groups', '["admin"]')
+			->willReturn('["admin"]');
 		$this->config
 			->method('getSystemValue')
 			->willReturnMap([

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -40,10 +40,13 @@ use OC\Repair\Events\RepairStepEvent;
 use OC\Repair\Events\RepairWarningEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
+use OCP\IConfig;
 use OCP\IEventSource;
 use OCP\IEventSourceFactory;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 if (!str_contains(@ini_get('disable_functions'), 'set_time_limit')) {
@@ -111,13 +114,13 @@ if (\OCP\Util::needUpgrade()) {
 	// avoid side effects
 	\OC_User::setIncognitoMode(true);
 
-	$logger = \OC::$server->get(\Psr\Log\LoggerInterface::class);
-	$config = \OC::$server->getConfig();
+	$config = Server::get(IConfig::class);
 	$updater = new \OC\Updater(
 		$config,
+		Server::get(IAppConfig::class),
 		\OC::$server->getIntegrityCodeChecker(),
-		$logger,
-		\OC::$server->query(\OC\Installer::class)
+		Server::get(LoggerInterface::class),
+		Server::get(\OC\Installer::class)
 	);
 	$incompatibleApps = [];
 	$incompatibleOverwrites = $config->getSystemValue('app_install_overwrite', []);
@@ -189,7 +192,7 @@ if (\OCP\Util::needUpgrade()) {
 	try {
 		$updater->upgrade();
 	} catch (\Exception $e) {
-		\OCP\Server::get(LoggerInterface::class)->error(
+		Server::get(LoggerInterface::class)->error(
 			$e->getMessage(),
 			[
 				'exception' => $e,

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -62,6 +62,7 @@ use OC\TextProcessing\RemoveOldTasksBackgroundJob;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\Defaults;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -382,7 +383,8 @@ class Setup {
 
 		$config = Server::get(IConfig::class);
 		$config->setAppValue('core', 'installedat', (string)microtime(true));
-		$config->setAppValue('core', 'lastupdatedat', (string)microtime(true));
+		$appConfig = Server::get(IAppConfig::class);
+		$appConfig->setValueInt('core', 'lastupdatedat', time());
 
 		$vendorData = $this->getVendorData();
 		$config->setAppValue('core', 'vendor', $vendorData['vendor']);

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -59,6 +59,7 @@ use OCP\App\IAppManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\ILogger;
 use OCP\Util;
@@ -74,19 +75,7 @@ use Psr\Log\LoggerInterface;
  *  - failure(string $message)
  */
 class Updater extends BasicEmitter {
-	/** @var LoggerInterface */
-	private $log;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var Checker */
-	private $checker;
-
-	/** @var Installer */
-	private $installer;
-
-	private $logLevelNames = [
+	private array $logLevelNames = [
 		0 => 'Debug',
 		1 => 'Info',
 		2 => 'Warning',
@@ -94,14 +83,13 @@ class Updater extends BasicEmitter {
 		4 => 'Fatal',
 	];
 
-	public function __construct(IConfig $config,
-		Checker $checker,
-		?LoggerInterface $log,
-		Installer $installer) {
-		$this->log = $log;
-		$this->config = $config;
-		$this->checker = $checker;
-		$this->installer = $installer;
+	public function __construct(
+		private IConfig $config,
+		private IAppConfig $appConfig,
+		private Checker $checker,
+		private ?LoggerInterface $log,
+		private Installer $installer
+	) {
 	}
 
 	/**
@@ -303,7 +291,7 @@ class Updater extends BasicEmitter {
 		$repair->run();
 
 		//Invalidate update feed
-		$this->config->setAppValue('core', 'lastupdatedat', '0');
+		$this->appConfig->setValueInt('core', 'lastupdatedat', 0);
 
 		// Check for code integrity if not disabled
 		if (\OC::$server->getIntegrityCodeChecker()->isCodeCheckEnforced()) {

--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -27,6 +27,7 @@
 namespace OC\Updater;
 
 use OCP\Http\Client\IClientService;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\Support\Subscription\IRegistry;
@@ -37,6 +38,7 @@ class VersionCheck {
 	public function __construct(
 		private IClientService $clientService,
 		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IUserManager $userManager,
 		private IRegistry $registry,
 		private LoggerInterface $logger,
@@ -56,13 +58,13 @@ class VersionCheck {
 		}
 
 		// Look up the cache - it is invalidated all 30 minutes
-		if (((int)$this->config->getAppValue('core', 'lastupdatedat') + 1800) > time()) {
+		if (($this->appConfig->getValueInt('core', 'lastupdatedat') + 1800) > time()) {
 			return json_decode($this->config->getAppValue('core', 'lastupdateResult'), true);
 		}
 
 		$updaterUrl = $this->config->getSystemValueString('updater.server.url', 'https://updates.nextcloud.com/updater_server/');
 
-		$this->config->setAppValue('core', 'lastupdatedat', (string)time());
+		$this->appConfig->setValueInt('core', 'lastupdatedat', time());
 
 		if ($this->config->getAppValue('core', 'installedat', '') === '') {
 			$this->config->setAppValue('core', 'installedat', (string)microtime(true));
@@ -70,7 +72,7 @@ class VersionCheck {
 
 		$version = Util::getVersion();
 		$version['installed'] = $this->config->getAppValue('core', 'installedat');
-		$version['updated'] = $this->config->getAppValue('core', 'lastupdatedat');
+		$version['updated'] = $this->appConfig->getValueInt('core', 'lastupdatedat');
 		$version['updatechannel'] = \OC_Util::getChannel();
 		$version['edition'] = '';
 		$version['build'] = \OC_Util::getBuild();

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -25,6 +25,7 @@ namespace Test;
 use OC\Installer;
 use OC\IntegrityCheck\Checker;
 use OC\Updater;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -32,6 +33,8 @@ use Psr\Log\LoggerInterface;
 class UpdaterTest extends TestCase {
 	/** @var IConfig|MockObject */
 	private $config;
+	/** @var IAppConfig|MockObject */
+	private $appConfig;
 	/** @var LoggerInterface|MockObject */
 	private $logger;
 	/** @var Updater */
@@ -46,6 +49,9 @@ class UpdaterTest extends TestCase {
 		$this->config = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$this->appConfig = $this->getMockBuilder(IAppConfig::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -58,6 +64,7 @@ class UpdaterTest extends TestCase {
 
 		$this->updater = new Updater(
 			$this->config,
+			$this->appConfig,
 			$this->checker,
 			$this->logger,
 			$this->installer


### PR DESCRIPTION

This PR fix a regression from #43967 and #43454 where new appconfig's api were used to type values while the old API was still used in some other place

### Context

It has been decided that once a config value is set as anything other than `mixed` (default type for config value pre-29) it cannot be set back to mixed. 

Meaning that once `IAppConfig::setValueString()` have been called on a config key, any line of code using the old API to set a value for this config key would returns an exception like this one: 

```
{
  "reqId": "aOMsS5ZTlMntl6lNG1g8",
  "level": 3,
  "time": "2024-03-12T15:34:05+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "cult",
  "app": "index",
  "method": "GET",
  "url": "/index.php/settings/admin/overview",
  "message": "conflict between new type (mixed) and old type (integer)",
  "userAgent": "Mozilla/5.0 (X11; Linux x86_64; rv:122.0) Gecko/20100101 Firefox/122.0",
  "version": "29.0.0.7",
  "exception": {
    "Exception": "OCP\\Exceptions\\AppConfigTypeConflictException",
    "Message": "conflict between new type (mixed) and old type (integer)",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/private/AppConfig.php",
        "line": 1340,
        "function": "setTypedValue",
        "class": "OC\\AppConfig",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/private/AllConfig.php",
        "line": 208,
        "function": "setValue",
        "class": "OC\\AppConfig",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/private/Updater/VersionCheck.php",
        "line": 65,
        "function": "setAppValue",
        "class": "OC\\AllConfig",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/apps/updatenotification/lib/UpdateChecker.php",
        "line": 52,
        "function": "check",
        "class": "OC\\Updater\\VersionCheck",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/apps/updatenotification/lib/Settings/Admin.php",
        "line": 95,
        "function": "getUpdateState",
        "class": "OCA\\UpdateNotification\\UpdateChecker",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/apps/settings/lib/Controller/CommonSettingsTrait.php",
        "line": 129,
        "function": "getForm",
        "class": "OCA\\UpdateNotification\\Settings\\Admin",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/apps/settings/lib/Controller/AdminSettingsController.php",
        "line": 86,
        "function": "formatSettings",
        "class": "OCA\\Settings\\Controller\\AdminSettingsController",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/apps/settings/lib/Controller/CommonSettingsTrait.php",
        "line": 149,
        "function": "getSettings",
        "class": "OCA\\Settings\\Controller\\AdminSettingsController",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/apps/settings/lib/Controller/AdminSettingsController.php",
        "line": 71,
        "function": "getIndexResponse",
        "class": "OCA\\Settings\\Controller\\AdminSettingsController",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 232,
        "function": "index",
        "class": "OCA\\Settings\\Controller\\AdminSettingsController",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 138,
        "function": "executeController",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/private/AppFramework/App.php",
        "line": 184,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/private/Route/Router.php",
        "line": 338,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/lib/base.php",
        "line": 1050,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->"
      },
      {
        "file": "/home/maxence/sites/nc29/nextcloud/index.php",
        "line": 49,
        "function": "handleRequest",
        "class": "OC",
        "type": "::"
      }
    ],
    "File": "/home/maxence/sites/nc29/nextcloud/lib/private/AppConfig.php",
    "Line": 809,
    "message": "conflict between new type (mixed) and old type (integer)",
    "exception": {},
    "CustomMessage": "conflict between new type (mixed) and old type (integer)"
  }
}
```
