### PR TITLE
fix(Navigation): ensure NavManager is inited when adding an entry

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -94,6 +94,7 @@ class NavigationManager implements INavigationManager {
 			$this->closureEntries[] = $entry;
 			return;
 		}
+		$this->init();
 
 		$id = $entry['id'];
 
@@ -234,10 +235,6 @@ class NavigationManager implements INavigationManager {
 				'name' => $l->t('Help'),
 				'icon' => $this->urlGenerator->imagePath('settings', 'help.svg'),
 			]);
-		}
-
-		if ($this->appManager === 'null') {
-			return;
 		}
 
 		$this->defaultApp = $this->appManager->getDefaultAppForUser($this->userSession->getUser(), false);


### PR DESCRIPTION
## Summary

otherwise custom order cannot be applied

Needed by https://github.com/nextcloud/tables/pull/904

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
