### PR TITLE
Do not throw an exception if the etag is not set in metadata

### DIFF
--- a/lib/private/FilesMetadata/Model/FilesMetadata.php
+++ b/lib/private/FilesMetadata/Model/FilesMetadata.php
@@ -159,7 +159,7 @@ class FilesMetadata implements IFilesMetadata {
 
 	public function getEtag(string $key): string {
 		if (!array_key_exists($key, $this->metadata)) {
-			throw new FilesMetadataNotFoundException();
+			return '';
 		}
 
 		return $this->metadata[$key]->getEtag();


### PR DESCRIPTION
Currently, if no `etag` is set for the metadata, the caller need to wrap `getEtag` in a `try/catch`, else, the provider will always fail at the same place. This returns an empty string instead of throwing.