### PR TITLE
fix: avoid scanning a non existing directory

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -282,7 +282,11 @@ class Local extends \OC\Files\Storage\Common {
 	public function file_exists($path) {
 		if ($this->caseInsensitive) {
 			$fullPath = $this->getSourcePath($path);
-			$content = scandir(dirname($fullPath), SCANDIR_SORT_NONE);
+			$parentPath = dirname($fullPath);
+			if (!is_dir($parentPath)) {
+				return false;
+			}
+			$content = scandir($parentPath, SCANDIR_SORT_NONE);
 			return is_array($content) && array_search(basename($fullPath), $content) !== false;
 		} else {
 			return file_exists($this->getSourcePath($path));


### PR DESCRIPTION
## Summary
Avoid some warning when scanning: sometimes the parent directory don't exists

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
