### PR TITLE
config: fix correctness issues in reading

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -215,13 +215,24 @@ class Config {
 
 		// Include file and merge config
 		foreach ($configFiles as $file) {
-			$fileExistsAndIsReadable = file_exists($file) && is_readable($file);
-			$filePointer = $fileExistsAndIsReadable ? fopen($file, 'r') : false;
-			if ($file === $this->configFilePath &&
-				$filePointer === false) {
-				// Opening the main config might not be possible, e.g. if the wrong
-				// permissions are set (likely on a new installation)
-				continue;
+			unset($CONFIG);
+
+			// Invalidate opcache (only if the timestamp changed)
+			if (function_exists('opcache_invalidate')) {
+				opcache_invalidate($file, false);
+			}
+
+			$filePointer = @fopen($file, 'r');
+			if ($filePointer === false) {
+				// e.g. wrong permissions are set
+				if ($file === $this->configFilePath) {
+					// opening the main config file might not be possible
+					// (likely on a new installation)
+					continue;
+				}
+
+				http_response_code(500);
+				die(sprintf('FATAL: Could not open the config file %s', $file));
 			}
 
 			// Try to acquire a file lock
@@ -229,8 +240,14 @@ class Config {
 				throw new \Exception(sprintf('Could not acquire a shared lock on the config file %s', $file));
 			}
 
-			unset($CONFIG);
-			include $file;
+			try {
+				include $file;
+			} finally {
+				// Close the file pointer and release the lock
+				flock($filePointer, LOCK_UN);
+				fclose($filePointer);
+			}
+
 			if (!defined('PHPUNIT_RUN') && headers_sent()) {
 				// syntax issues in the config file like leading spaces causing PHP to send output
 				$errorMessage = sprintf('Config file has leading content, please remove everything before "<?php" in %s', basename($file));
@@ -242,10 +259,6 @@ class Config {
 			if (isset($CONFIG) && is_array($CONFIG)) {
 				$this->cache = array_merge($this->cache, $CONFIG);
 			}
-
-			// Close the file pointer and release the lock
-			flock($filePointer, LOCK_UN);
-			fclose($filePointer);
 		}
 
 		$this->envCache = getenv();


### PR DESCRIPTION
Multiple fixes here.

1. Checking readability is pointless, since fopen is guaranteed to not throw and return false if the file doesn't exist or is not readable ~~(it even logs a warning when the file isn't readable, which is very nice)~~ 
2. ~~Skip even for non-main fails when we can't open it (it'll crash later anyway otherwise)~~ Show the admin a better error message when a config file cannot be opened instead of throwing a TypeError (see https://github.com/nextcloud/server/pull/44230#issuecomment-2013126704)
3. Reduce the size of the critical block
4. Make sure to unlock the file even if something fails
5. Check opcache on every request. This is low overhead since it only revalidates the timestamp for `config.php` (even if timestamp validation is disabled in the opcache config) and actually fixes a _lot_ of correctness issues. Some actions such as upgrading an app make it obvious that the opcache may need to be refreshed, but config changes might happen more subtly, and opcache defeats the whole point of locking the file to begin with.

Side note: while `Config::writeData` does invalidate the opcache anyway, this is not sufficient since
1. It may be called from the CLI
2. It only affects a single PHP-FPM instance; other hosts wont be affected