### PR TITLE
fix(Logger): Warn on invalid `loglevel` configuration option

### DIFF
--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -282,7 +282,13 @@ class Log implements ILogger, IDataLogger {
 		}
 
 		$configLogLevel = $this->config->getValue('loglevel', ILogger::WARN);
-		return min(is_int($configLogLevel) ? $configLogLevel : ILogger::WARN, ILogger::FATAL);
+		if (is_numeric($configLogLevel)) {
+			return min((int)$configLogLevel, ILogger::FATAL);
+		}
+
+		// Invalid configuration, warn the user and fall back to default level of WARN
+		error_log('Nextcloud configuration: "loglevel" is not a valid integer');
+		return ILogger::WARN;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When the configuration is not a valid integer do not silently fallback to warn, instead try to cast it (might be more what the admin wanted to configure, e.g. allows `'0'` when `0` was meant).
And if the value is invalid do handle it not silently but at least put a warning in the log (even we do not have access to the logger we can put it in the error log.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
