### PR TITLE
fix(files_external): Remove invalid jQuery Tooltip usage

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1327,9 +1327,6 @@ MountConfigListView.prototype = _.extend({
 		}
 		if (typeof message === 'string') {
 			$statusSpan.attr('title', message);
-			$statusSpan.tooltip();
-		} else {
-			$statusSpan.tooltip('dispose');
 		}
 	},
 


### PR DESCRIPTION
* Resolves: #44204 

## Summary

The tooltip methods were remove long ago but we removed the "polyfill" (try-catch) so this caused the UI to throw an error causing it to be unusable.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
