### PR TITLE
fix(setupcheck): Catch Throwables from setup checks and show them to the admin

### DIFF
--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -51,6 +51,7 @@ class SetupCheckManager implements ISetupCheckManager {
 				$setupResult = $setupCheckObject->run();
 			} catch (\Throwable $t) {
 				$setupResult = SetupResult::error("An exception occured while running the setup check:\n$t");
+				$this->logger->error('Exception running check '.get_class($setupCheckObject).': '.$t->getMessage(), ['exception' => $t]);
 			}
 			$setupResult->setName($setupCheckObject->getName());
 			$category = $setupCheckObject->getCategory();

--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -30,6 +30,7 @@ use OC\AppFramework\Bootstrap\Coordinator;
 use OCP\Server;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\ISetupCheckManager;
+use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;
 
 class SetupCheckManager implements ISetupCheckManager {
@@ -46,7 +47,11 @@ class SetupCheckManager implements ISetupCheckManager {
 			/** @var ISetupCheck $setupCheckObject */
 			$setupCheckObject = Server::get($setupCheck->getService());
 			$this->logger->debug('Running check '.get_class($setupCheckObject));
-			$setupResult = $setupCheckObject->run();
+			try {
+				$setupResult = $setupCheckObject->run();
+			} catch (\Throwable $t) {
+				$setupResult = SetupResult::error("An exception occured while running the setup check:\n$t");
+			}
 			$setupResult->setName($setupCheckObject->getName());
 			$category = $setupCheckObject->getCategory();
 			$results[$category] ??= [];


### PR DESCRIPTION
## Summary

This avoids letting a buggy setup check from an application crash the
 setupcheck system. The throwable is shown instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
