### PR TITLE
Fixes incorrect "free" value in stat

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -522,6 +522,13 @@ class OC_Helper {
 			$total = $free + $used;
 		} else {
 			$total = $free; //either unknown or unlimited
+
+			// So that the front does not react to a negative free space value and does not show appropriate warnings
+			if ($free === \OCP\Files\FileInfo::SPACE_UNKNOWN
+				|| $free === \OCP\Files\FileInfo::SPACE_UNLIMITED
+				|| $free === \OCP\Files\FileInfo::SPACE_NOT_COMPUTED) {
+				$free = PHP_INT_MAX;
+			}
 		}
 		if ($total > 0) {
 			if ($quota > 0 && $total > $quota) {


### PR DESCRIPTION
## Summary
Fixed the problem with incorrect output of "free" when receiving stat

## Use case
If you connect an ObjectStore, for example S3, and do not set a quota for the user, then NextCloud returns the total free space, and since the ObjectStore is connected, "-2" (SPACE_UNKNOWN) is returned. When the frontend receives data, it relies on the "free" field to display a warning about the lack of disk space, which is not correct, because there is disk space, but it cannot be obtained due to the connected ObjectStore.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
