### PR TITLE
fix(config): Make sure user keys are strings

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -339,7 +339,7 @@ class AllConfig implements IConfig {
 	public function getUserKeys($userId, $appName) {
 		$data = $this->getAllUserValues($userId);
 		if (isset($data[$appName])) {
-			return array_keys($data[$appName]);
+			return array_map('strval', array_keys($data[$appName]));
 		} else {
 			return [];
 		}

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -277,6 +277,31 @@ class AllConfigTest extends \Test\TestCase {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
 	}
 
+	public function testGetUserKeysAllInts() {
+		$config = $this->getConfig();
+
+		// preparation - add something to the database
+		$data = [
+			['userFetch', 'appFetch1', '123', 'value'],
+			['userFetch', 'appFetch1', '456', 'value'],
+		];
+		foreach ($data as $entry) {
+			$this->connection->executeUpdate(
+				'INSERT INTO `*PREFIX*preferences` (`userid`, `appid`, ' .
+				'`configkey`, `configvalue`) VALUES (?, ?, ?, ?)',
+				$entry
+			);
+		}
+
+		$value = $config->getUserKeys('userFetch', 'appFetch1');
+		$this->assertEquals(['123', '456'], $value);
+		$this->assertIsString($value[0]);
+		$this->assertIsString($value[1]);
+
+		// cleanup
+		$this->connection->executeUpdate('DELETE FROM `*PREFIX*preferences`');
+	}
+
 	public function testGetUserValueDefault() {
 		$config = $this->getConfig();
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

array_keys returns string[]|int[] and out API should only return string[].

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
