### PR TITLE
fix: ensure nested mount points are handled in the correct order

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1481,6 +1481,13 @@ class View {
 
 		//add a folder for any mountpoint in this directory and add the sizes of other mountpoints to the folders
 		$mounts = Filesystem::getMountManager()->findIn($path);
+
+		// make sure nested mounts are sorted after their parent mounts
+		// otherwise doesn't propagate the etag across storage boundaries correctly
+		usort($mounts, function (IMountPoint $a, IMountPoint $b) {
+			return $a->getMountPoint() <=> $b->getMountPoint();
+		});
+
 		$dirLength = strlen($path);
 		foreach ($mounts as $mount) {
 			$mountPoint = $mount->getMountPoint();


### PR DESCRIPTION
Otherwise etag propagation across nested mountpoints won't behave correctly.

To test:

- Create groupfolders `gf1`, `gf1/gf2` and `gf1/gf2/gf3`
- Apply the patch, but change the order of `$a` and `$b` around to change the sort order to be intentionally wrong
- do a propfind with `Depth: 1` on `gf1` and on `gf1/gf2`
  - Note that the etag for `gf1/gf2` differs between the two requests
- Restore the correct sort order by changing `$a` and `$b` back
- do a propfind with `Depth: 1` on `gf1` and on `gf1/gf2`
  - The etag for `gf1/gf2` should now be the same between the two requests