### PR TITLE
enh(UpdateNotification): Clarify update option paths

### DIFF
--- a/apps/updatenotification/src/components/UpdateNotification.vue
+++ b/apps/updatenotification/src/components/UpdateNotification.vue
@@ -50,11 +50,13 @@
 					<a v-if="updaterEnabled && webUpdaterEnabled"
 						href="#"
 						class="button primary"
-						@click="clickUpdaterButton">{{ t('updatenotification', 'Open updater') }}</a>
-					<a v-if="downloadLink"
+						@click="clickUpdaterButton">{{ t('updatenotification', 'Update via web') }}</a>
+					<a v-if="updaterEnabled"
+						href="https://docs.nextcloud.com/server/latest/admin_manual/maintenance/update.html#using-the-command-line-based-updater"
+						class="button primary">{{ t('updatenotification', 'Update via command line`) }}</a>						
+					<a v-if="downloadLink && updaterEnabled"
 						:href="downloadLink"
-						class="button"
-						:class="{ hidden: !updaterEnabled }">{{ t('updatenotification', 'Download now') }}</a>
+						class="button">{{ t('updatenotification', 'Update manually') }}</a>
 					<span v-if="updaterEnabled && !webUpdaterEnabled">
 						{{ t('updatenotification', 'Web updater is disabled. Please use the command line updater or the appropriate update mechanism for your installation method (e.g. Docker pull) to update.') }}
 					</span>

--- a/apps/updatenotification/src/components/UpdateNotification.vue
+++ b/apps/updatenotification/src/components/UpdateNotification.vue
@@ -53,10 +53,13 @@
 						@click="clickUpdaterButton">{{ t('updatenotification', 'Update via web') }}</a>
 					<a v-if="updaterEnabled"
 						href="https://docs.nextcloud.com/server/latest/admin_manual/maintenance/update.html#using-the-command-line-based-updater"
-						class="button primary">{{ t('updatenotification', 'Update via command line`) }}</a>						
+						class="button primary">{{ t('updatenotification', 'Update via command line`) }}</a>
+					<a v-if="updaterEnabled"
+						href="https://docs.nextcloud.com/server/latest/admin_manual/maintenance/manual_upgrade.html"
+						class="button primary">{{ t('updatenotification', 'Update manually`) }}</a>
 					<a v-if="downloadLink && updaterEnabled"
 						:href="downloadLink"
-						class="button">{{ t('updatenotification', 'Update manually') }}</a>
+						class="button">{{ t('updatenotification', 'Download the Archive (.zip) file') }}</a>
 					<span v-if="updaterEnabled && !webUpdaterEnabled">
 						{{ t('updatenotification', 'Web updater is disabled. Please use the command line updater or the appropriate update mechanism for your installation method (e.g. Docker pull) to update.') }}
 					</span>


### PR DESCRIPTION
## Summary

* Changes label on button that triggers the web updater from **Open updater** to **Update via web**
* Adds a new button **Update via the command line** which links to the CLI updater documentation
* Adds a new button **Update manually** which links to the manual update process documentation
* Changes label on button that currently says **Download now** to **Download the Archive (.zip) file** <-- this option is only used in two scenarios: a manual update scenario (but other steps are necessary - hence the documentation link being the primary button) and if someone wishes to inspect the contents of the update on their own prior to using their favorite update approach (which may be none of the above - e.g. `docker pull`, `snap`, etc)

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
