### PR TITLE
fix: Pass the mountpoint target user to storages without owner

### DIFF
--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -140,6 +140,7 @@ class ConfigAdapter implements IMountProvider {
 		}, $storages, $storageConfigs);
 
 		$mounts = array_map(function (StorageConfig $storageConfig, Storage\IStorage $storage) use ($user, $loader) {
+			$storage->setOwner($user->getUID());
 			if ($storageConfig->getType() === StorageConfig::MOUNT_TYPE_PERSONAL) {
 				return new PersonalMount(
 					$this->userStoragesService,

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -868,6 +868,19 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 	}
 
 	/**
+	 * Allow setting the storage owner
+	 *
+	 * This can be used for storages that do not have a dedicated owner, where we want to
+	 * pass the user that we setup the mountpoint for along to the storage layer
+	 *
+	 * @param string|null $user
+	 * @return void
+	 */
+	public function setOwner(?string $user): void {
+		$this->owner = $user;
+	}
+
+	/**
 	 * @return bool
 	 */
 	public function needsPartFile() {

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -674,4 +674,8 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		}
 		return false;
 	}
+
+	public function setOwner(?string $user): void {
+		$this->getWrapperStorage()->setOwner($user);
+	}
 }

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -460,4 +460,16 @@ interface IStorage {
 	 * @since 9.0.0
 	 */
 	public function getWatcher();
+
+	/**
+	 * Allow setting the storage owner
+	 *
+	 * This can be used for storages that do not have a dedicated owner, where we want to
+	 * pass the user that we setup the mountpoint for along to the storage layer
+	 *
+	 * @param string|null $user Owner user id
+	 * @return void
+	 * @since 29.0.0
+	 */
+	public function setOwner(?string $user): void;
 }


### PR DESCRIPTION
Storages that do not have a dedicated owner (e.g. groupfolders, external
storages) currently always assume the current session user as the owner.
This leads to several issues when there is no user session but a node is
obtained through a user folder.

In order to have the correct user available we need to pass the user
that is used to setup a mountpoint along to the storage layer as we
generally assume that an owner is available for those.

Steps to see the issue:

## Text

- Setup a local global external storage
- As a user with access to it
  - Have text enabled
  - Create a share link with edit permissions
  - Access the share link in a private browser window
  - Try to save the file which fails because file hooks like the version backend or files metadata extractors try to operate with the storage owner
