### PR TITLE
Allow injecting the user temporarily for direct editing

### DIFF
--- a/apps/files_external/lib/Migration/DummyUserSession.php
+++ b/apps/files_external/lib/Migration/DummyUserSession.php
@@ -29,10 +29,7 @@ use OCP\IUserSession;
 
 class DummyUserSession implements IUserSession {
 
-	/**
-	 * @var IUser
-	 */
-	private $user;
+	private ?IUser $user = null;
 
 	public function login($uid, $password) {
 	}
@@ -41,6 +38,10 @@ class DummyUserSession implements IUserSession {
 	}
 
 	public function setUser($user) {
+		$this->user = $user;
+	}
+
+	public function setVolatileActiveUser(?IUser $user): void {
 		$this->user = $user;
 	}
 

--- a/lib/private/DirectEditing/Manager.php
+++ b/lib/private/DirectEditing/Manager.php
@@ -272,13 +272,11 @@ class Manager implements IManager {
 	}
 
 	public function invokeTokenScope($userId): void {
-		\OC_User::setIncognitoMode(true);
 		\OC_User::setUserId($userId);
 	}
 
 	public function revertTokenScope(): void {
 		$this->userSession->setUser(null);
-		\OC_User::setIncognitoMode(false);
 	}
 
 	public function createToken($editorId, File $file, string $filePath, IShare $share = null): string {

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -212,6 +212,15 @@ class Session implements IUserSession, Emitter {
 	}
 
 	/**
+	 * Temporarily set the currently active user without persisting in the session
+	 *
+	 * @param IUser|null $user
+	 */
+	public function setVolatileActiveUser(?IUser $user): void {
+		$this->activeUser = $user;
+	}
+
+	/**
 	 * get the current active user
 	 *
 	 * @return IUser|null Current user, otherwise null

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -41,6 +41,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Server;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\UserLoggedInEvent;
@@ -338,7 +339,7 @@ class OC_User {
 	 * @return string|false uid or false
 	 */
 	public static function getUser() {
-		$uid = \OC::$server->getSession() ? \OC::$server->getSession()->get('user_id') : null;
+		$uid = Server::get(IUserSession::class)->getUser()?->getUID();
 		if (!is_null($uid) && self::$incognitoMode === false) {
 			return $uid;
 		} else {

--- a/lib/public/IUserSession.php
+++ b/lib/public/IUserSession.php
@@ -64,6 +64,14 @@ interface IUserSession {
 	public function setUser($user);
 
 	/**
+	 * Temporarily set the currently active user without persisting in the session
+	 *
+	 * @param IUser|null $user
+	 * @since 29.0.0
+	 */
+	public function setVolatileActiveUser(?IUser $user): void;
+
+	/**
 	 * get the current active user
 	 *
 	 * @return \OCP\IUser|null Current user, otherwise null


### PR DESCRIPTION
- Drop usage of incognito mode
- Allow to inject the current user into the session without writing it to the php session itself for direct editing


## Groupfolders

Fix https://github.com/ONLYOFFICE/onlyoffice-nextcloud/issues/900 with https://github.com/ONLYOFFICE/onlyoffice-nextcloud/pull/967

- Setup a groupfolder that has read only ACL set on a child folder (without share permission)
- Try to open a file with a mobile app
- The mobile app uses a webview without user session
- Now the onlyoffice codebase uses getUserFolder()->getById() which is fine as they handle authentication internally, however the getById will fail as groupfolders is not aware of the current user the mountpoint is setup with and assumes that the file is a share (requiring share acls)
