### PR TITLE
fix(federatedfilesharing): Use correct language file to render notifi…

### DIFF
--- a/apps/federatedfilesharing/lib/Notifier.php
+++ b/apps/federatedfilesharing/lib/Notifier.php
@@ -94,7 +94,7 @@ class Notifier implements INotifier {
 		}
 
 		// Read the language from the notification
-		$l = $this->factory->get('files_sharing', $languageCode);
+		$l = $this->factory->get('federatedfilesharing', $languageCode);
 
 		switch ($notification->getSubject()) {
 			// Deal with known subjects

--- a/apps/files_sharing/lib/Notification/Notifier.php
+++ b/apps/files_sharing/lib/Notification/Notifier.php
@@ -249,7 +249,7 @@ class Notifier implements INotifier {
 		$notification->addParsedAction($acceptAction);
 
 		$rejectAction = $notification->createAction();
-		$rejectAction->setParsedLabel($l->t('Reject'))
+		$rejectAction->setParsedLabel($l->t('Decline'))
 			->setLink($this->url->linkToOCSRouteAbsolute('files_sharing.ShareAPI.deleteShare', ['id' => $share->getId()]), 'DELETE')
 			->setPrimary(false);
 		$notification->addParsedAction($rejectAction);


### PR DESCRIPTION
…cation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
