### PR TITLE
fix(settings): show warning for indexToReplace as part of missing indices

### DIFF
--- a/apps/settings/lib/SetupChecks/DatabaseHasMissingIndices.php
+++ b/apps/settings/lib/SetupChecks/DatabaseHasMissingIndices.php
@@ -56,6 +56,7 @@ class DatabaseHasMissingIndices implements ISetupCheck {
 		$event = new AddMissingIndicesEvent();
 		$this->dispatcher->dispatchTyped($event);
 		$missingIndices = $event->getMissingIndices();
+		$indicesToReplace = $event->getIndicesToReplace();
 
 		if (!empty($missingIndices)) {
 			$schema = new SchemaWrapper($this->connection);
@@ -64,6 +65,18 @@ class DatabaseHasMissingIndices implements ISetupCheck {
 					$table = $schema->getTable($missingIndex['tableName']);
 					if (!$table->hasIndex($missingIndex['indexName'])) {
 						$indexInfo->addHintForMissingIndex($missingIndex['tableName'], $missingIndex['indexName']);
+					}
+				}
+			}
+		}
+
+		if (!empty($indicesToReplace)) {
+			$schema = new SchemaWrapper($this->connection);
+			foreach ($indicesToReplace as $indexToReplace) {
+				if ($schema->hasTable($indexToReplace['tableName'])) {
+					$table = $schema->getTable($indexToReplace['tableName']);
+					if (!$table->hasIndex($indexToReplace['newIndexName'])) {
+						$indexInfo->addHintForMissingIndex($indexToReplace['tableName'], $indexToReplace['newIndexName']);
 					}
 				}
 			}


### PR DESCRIPTION
Follow-up to: https://github.com/nextcloud/server/pull/43209

## Summary

Warning of missing indices is extended to show indicesToReplace as well. https://github.com/nextcloud/mail/pull/9295 as example:

![Screenshot from 2024-03-19 11-33-42](https://github.com/nextcloud/server/assets/74607597/9502b76d-96d6-4812-9528-6f9dae254a2b)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
