### PR TITLE
meta(ISSUE_TEMPLATE): Search both open and closed issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -23,13 +23,15 @@ body:
       label: "⚠️ This issue respects the following points: ⚠️"
       description: All conditions are **required**. Your issue can be closed if these are checked incorrectly.
       options:
-        - label: This is a **bug**, not a question or a configuration/webserver/proxy issue.
+        - label: This is **not** a troubleshooting question, general support matter, or webserver/proxy problem, but likely a bug _(if unsure, ask the [Community Help Forum](https://help.nextcloud.com))_.
           required: true
-        - label: This issue is **not** already reported on [Github](https://github.com/nextcloud/server/issues?q=is%3Aopen+is%3Aissue+label%3Abug) OR [Nextcloud Community Forum](https://help.nextcloud.com/) _(I've searched it)_.
+        - label: This issue is **not** already reported on [Github](https://github.com/nextcloud/server/issues?q=is%3Aissue+label%3Abug) OR solved at the [Community Help Forum](https://help.nextcloud.com/) _(I've searched!)_.
           required: true
-        - label: Nextcloud Server **is** up to date. See [Maintenance and Release Schedule](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule) for supported versions.
+        - label: I'm using a maintained major version of Nextcloud Server **and** tested against the latest patch level. _([Supported major versions and current patch levels](https://github.com/nextcloud/server/wiki/Maintenance-and-Release-Schedule))_.
           required: true
         - label: I agree to follow Nextcloud's [Code of Conduct](https://nextcloud.com/contribute/code-of-conduct/).
+          required: true
+        - label: I've tried my best to provide clear reproduction steps that someone unfamiliar with this bug could use to reproduce it.
           required: true
   - type: textarea
     id: bug-description


### PR DESCRIPTION
## Summary

Change GitHub search link to include not only `open`, but also `closed` issues (to catch items already fixed, but not necessarily released yet or backported). Also, change the wording about reporting bugs already noted on the search forum, in order to clarify its okay to report a bug brought up on the Help Forum.

Also:

* Reword "This is a bug" line so that examples that aren't bugs are pointed out first (since "bug" is still misinterpreted to mean "anything not functioning even if it's a config matter" and a quick skimmer will always simply check that box) + added additional hint to utilize the help forum first if unsure
* Minor rewording line about checking against maintained major + latest patch level
* New stipulation line to further encourage as clear/simple reproduction steps as possible (to streamline triaging/resolution)


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
