### PR TITLE
fix(db): remove redundant index in cards

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -165,13 +165,6 @@ class Application extends App {
 
 			$event->addMissingIndex(
 				'cards',
-				'cards_abid',
-				['addressbookid'],
-				[],
-				true
-			);
-			$event->addMissingIndex(
-				'cards',
 				'cards_abiduri',
 				['addressbookid', 'uri'],
 				[],


### PR DESCRIPTION
## Summary

On a fresh Nextcloud 29 installation, a warning is shown that the index cards_abid is missing.

![Screenshot from 2024-03-19 17-22-44](https://github.com/nextcloud/server/assets/3902676/33f1438a-950c-4755-9431-9f9f6e2ed9ea)

The index was removed with https://github.com/nextcloud/server/pull/43340 and therefore the warning can also go. 


## TODO


- [x] CI
- [x] Review
- [ ] Merge

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
