### PR TITLE
Add occ command for getting User ID(s) for a given email addr…

### DIFF
--- a/core/Command/User/GetUserFromEmail.php
+++ b/core/Command/User/GetUserFromEmail.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ *
+ * @author Andreas Fischer <bantu@owncloud.com>
+ * @author Christopher Schäpers <kondou@ts.unde.re>
+ * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Laurens Post <lkpost@scept.re>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Sujith H <sharidasan@owncloud.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCP\App\IAppManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+class GetUserFromEmail extends Base {
+	public function __construct(
+		protected IUserManager $userManager,
+		private IAppManager $appManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('user:getfromemail')
+			->setDescription('Find the user ID for the user with a given email')
+			->addArgument(
+				'email',
+				InputArgument::REQUIRED,
+				'Email address'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$email = $input->getArgument('email');
+
+		$users = $this->userManager->getByEmail($email);
+		if (count($users) == 0) {
+			$output->writeln('<error>User with given email not found</error>');
+			return 1;
+
+		}
+		foreach ($users as $user) {
+			$output->writeln($user->getUID());
+		}
+		return 0;
+	}
+
+	/**
+	 * @param string $argumentName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeArgumentValues($argumentName, CompletionContext $context) {
+		if ($argumentName === 'email') {
+			return array_map(static fn (IUser $user) => $user->getEmail(), $this->userManager->search($context->getCurrentWord()));
+		}
+		return [];
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -151,6 +151,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\User\Delete::class));
 	$application->add(Server::get(Command\User\Disable::class));
 	$application->add(Server::get(Command\User\Enable::class));
+	$application->add(Server::get(Command\User\GetUserFromEmail::class)); // Tested with $application->add(new OC\Core\Command\User\GetUserFromEmail(\OC::$server->getUserManager()));
 	$application->add(Server::get(Command\User\LastSeen::class));
 	$application->add(Server::get(Command\User\Report::class));
 	$application->add(Server::get(Command\User\ResetPassword::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1136,6 +1136,7 @@ return array(
     'OC\\Core\\Command\\User\\Delete' => $baseDir . '/core/Command/User/Delete.php',
     'OC\\Core\\Command\\User\\Disable' => $baseDir . '/core/Command/User/Disable.php',
     'OC\\Core\\Command\\User\\Enable' => $baseDir . '/core/Command/User/Enable.php',
+    'OC\\Core\\Command\\User\\GetUserFromEmail' => $baseDir . '/core/Command/User/GetUserFromEmail.php',
     'OC\\Core\\Command\\User\\Info' => $baseDir . '/core/Command/User/Info.php',
     'OC\\Core\\Command\\User\\Keys\\Verify' => $baseDir . '/core/Command/User/Keys/Verify.php',
     'OC\\Core\\Command\\User\\LastSeen' => $baseDir . '/core/Command/User/LastSeen.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1169,6 +1169,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\User\\Delete' => __DIR__ . '/../../..' . '/core/Command/User/Delete.php',
         'OC\\Core\\Command\\User\\Disable' => __DIR__ . '/../../..' . '/core/Command/User/Disable.php',
         'OC\\Core\\Command\\User\\Enable' => __DIR__ . '/../../..' . '/core/Command/User/Enable.php',
+        'OC\\Core\\Command\\User\\GetUserFromEmail' => __DIR__ . '/../../..' . '/core/Command/User/GetUserFromEmail.php',
         'OC\\Core\\Command\\User\\Info' => __DIR__ . '/../../..' . '/core/Command/User/Info.php',
         'OC\\Core\\Command\\User\\Keys\\Verify' => __DIR__ . '/../../..' . '/core/Command/User/Keys/Verify.php',
         'OC\\Core\\Command\\User\\LastSeen' => __DIR__ . '/../../..' . '/core/Command/User/LastSeen.php',


### PR DESCRIPTION

## Summary
Adds an occ command for getting the user ID(s) from an email address. Uses the user manager to lookup the email address, and returns a list of users if they have this address listed.

Uploading so that the community can benefit from contributions, but please do feel free to pull into a feature branch and rework or modify heavily and use as a springboard. This solved a particular usecase I had so figured may be useful.

## TODO
- [ ] I'm by no means a PHP developer, so there may be significant defects.
- [ ] Don't have the ability to test against current master; slight modifications and it appears to work on my installed server, running NC 21, but would need to be tested properly against master code.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
