### PR TITLE
Add occ command for checking the password for a given user ID.

### DIFF
--- a/core/Command/User/CheckPassword.php
+++ b/core/Command/User/CheckPassword.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ *
+ * @author Andreas Fischer <bantu@owncloud.com>
+ * @author Christopher Schäpers <kondou@ts.unde.re>
+ * @author Clark Tomlinson <fallen013@gmail.com>
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Laurens Post <lkpost@scept.re>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Sujith H <sharidasan@owncloud.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Core\Command\User;
+
+use OC\Core\Command\Base;
+use OCP\App\IAppManager;
+use OCP\IUser;
+use OCP\IUserManager;
+use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+
+class CheckPassword extends Base {
+	public function __construct(
+		protected IUserManager $userManager,
+		private IAppManager $appManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('user:checkpassword')
+			->setDescription('Look up the user by ID and check the given password')
+			->addArgument(
+				'user',
+				InputArgument::REQUIRED,
+				'User ID'
+			)
+			->addArgument(
+				'password',
+				InputArgument::OPTIONAL,
+				'User\'s password - if not provided, will be prompted interactively if a TTY is available or read from STDIN'
+			)
+			->addOption(
+				'password-from-env',
+				null,
+				InputOption::VALUE_NONE,
+				'read password from environment variable OC_PASS'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$userID = $input->getArgument('user');
+
+		$user = $this->userManager->get($userID);
+		
+		if (is_null($user)) {
+			$output->writeln('<error>User does not exist</error>');
+			return 1;
+		}
+
+		// Get from the environment variable
+		if ($input->getOption('password-from-env')) {
+			$password = getenv('OC_PASS');
+			if (!$password) {
+				$output->writeln('<error>--password-from-env given, but OC_PASS is empty!</error>');
+				return 2;
+			}
+		} else {
+		// Was an argument provided?
+			$password = $input->getArgument('password');
+
+			if (is_null($password)) {
+				// It was not.
+
+				//If interactive, we prompt
+				if ($input->isInteractive()) {
+					/** @var QuestionHelper $helper */
+					$helper = $this->getHelper('question');
+		
+					$question = new Question('Enter user\'s password: ');
+					$question->setHidden(true);
+					$password = $helper->ask($input, $output, $question);
+		
+					if ($password === null) {
+						$output->writeln("<error>Password cannot be empty!</error>");
+						return 2;
+					}
+				} else {
+					// FIXME:
+					// isInteractive seems to return true even when data are piped in
+					// We want to detect if we are in a pipeline and not prompt for the question
+
+					// Else, we try readin from stdin if the user piped it
+					$password  = fgets(STDIN);
+					if ($password === false) {
+						// STDIN was closed.
+						// No password provided, and not interactive, so we can't do anything.
+						$output->writeln('<error>--Password not given but TTY is not interactive and no data on STDIN!</error>');
+						return 2;
+					}
+					
+				}
+			}
+
+		} // argument not provided
+
+		if ($this->userManager->checkPassword($userID, $password)) {
+			$output->writeln('<info>Password okay</info>');
+			return 0;
+		} else {
+			$output->writeln('<error>Password is incorrect</error>');
+			return 1;
+		}
+
+
+	}
+
+
+	/**
+	 * @param string $argumentName
+	 * @param CompletionContext $context
+	 * @return string[]
+	 */
+	public function completeArgumentValues($argumentName, CompletionContext $context) {
+		if ($argumentName === 'user') {
+			return array_map(static fn (IUser $user) => $user->getUID(), $this->userManager->search($context->getCurrentWord()));
+		}
+		return [];
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -148,6 +148,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\Preview\ResetRenderedTexts::class));
 
 	$application->add(Server::get(Command\User\Add::class));
+	$application->add(Server::get(Command\User\CheckPassword::class)); // Tested with $application->add(new OC\Core\Command\User\CheckPassword(\OC::$server->getUserManager()));
 	$application->add(Server::get(Command\User\Delete::class));
 	$application->add(Server::get(Command\User\Disable::class));
 	$application->add(Server::get(Command\User\Enable::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1133,6 +1133,7 @@ return array(
     'OC\\Core\\Command\\User\\AuthTokens\\Add' => $baseDir . '/core/Command/User/AuthTokens/Add.php',
     'OC\\Core\\Command\\User\\AuthTokens\\Delete' => $baseDir . '/core/Command/User/AuthTokens/Delete.php',
     'OC\\Core\\Command\\User\\AuthTokens\\ListCommand' => $baseDir . '/core/Command/User/AuthTokens/ListCommand.php',
+    'OC\\Core\\Command\\User\\CheckPassword' => $baseDir . '/core/Command/User/CheckPassword.php',
     'OC\\Core\\Command\\User\\Delete' => $baseDir . '/core/Command/User/Delete.php',
     'OC\\Core\\Command\\User\\Disable' => $baseDir . '/core/Command/User/Disable.php',
     'OC\\Core\\Command\\User\\Enable' => $baseDir . '/core/Command/User/Enable.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1166,6 +1166,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\User\\AuthTokens\\Add' => __DIR__ . '/../../..' . '/core/Command/User/AuthTokens/Add.php',
         'OC\\Core\\Command\\User\\AuthTokens\\Delete' => __DIR__ . '/../../..' . '/core/Command/User/AuthTokens/Delete.php',
         'OC\\Core\\Command\\User\\AuthTokens\\ListCommand' => __DIR__ . '/../../..' . '/core/Command/User/AuthTokens/ListCommand.php',
+        'OC\\Core\\Command\\User\\CheckPassword' => __DIR__ . '/../../..' . '/core/Command/User/CheckPassword.php',
         'OC\\Core\\Command\\User\\Delete' => __DIR__ . '/../../..' . '/core/Command/User/Delete.php',
         'OC\\Core\\Command\\User\\Disable' => __DIR__ . '/../../..' . '/core/Command/User/Disable.php',
         'OC\\Core\\Command\\User\\Enable' => __DIR__ . '/../../..' . '/core/Command/User/Enable.php',


### PR DESCRIPTION
* Resolves: https://help.nextcloud.com/t/check-credentials-programatically-server-side/185703

## Summary

Adds an occ command for checking the password for the given user ID. The user can provide the password literally in the CLI arguments (less secure but other applications don't prevent this), using `OC_PASS`, through stdin or interactively.

I have a small self-contained application that needs to authenticate users. Rather than maintain a separate set of credentials, or set up something like LDAP (would be overkill), adding a command like this seems the best way to achieve what I needed - the application is server-side and can then look up the user and password, and the exit status is used to determine if the user was authenticated or not.


Uploading so that the community can benefit from contributions, but please do feel free to pull into a feature branch and rework or modify heavily and use as a springboard. This solved a particular usecase I had so figured may be useful.

## TODO
- [ ] Tried to make the interactive prompt detect if it's in a TTY or a pipe, but this seems to return true in either case
- [ ] People may want to modify this heavily or not add it for security implications for what code is in here. I've thought about some basics, but am not a security expert, nor do I know much about nextcloud's design. I started from the password reset command; so this seems comparable, but someone should review and consider the implications
- [ ] I'm by no means a PHP developer, so there may be significant defects.
- [ ] Don't have the ability to test against current master; slight modifications and it appears to work on my installed server, running NC 21, but would need to be tested properly against master code.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
