### PR TITLE
fix(ProvisioningApi): only return verified additional mails per user

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -149,6 +149,9 @@ abstract class AUserData extends OCSController {
 			$additionalEmails = $additionalEmailScopes = [];
 			$emailCollection = $userAccount->getPropertyCollection(IAccountManager::COLLECTION_EMAIL);
 			foreach ($emailCollection->getProperties() as $property) {
+				if ($property->getLocallyVerified() !== IAccountManager::VERIFIED) {
+					continue;
+				}
 				$additionalEmails[] = $property->getValue();
 				if ($includeScopes) {
 					$additionalEmailScopes[] = $property->getScope();

--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -63,5 +63,10 @@ return [
 				'type' => null
 			]
 		],
+		[
+			'name' => 'MailVerificationTest',
+			'url' => '/api/v1/mailverification',
+			'verb' => 'POST',
+		]
 	],
 ];

--- a/apps/testing/lib/Controller/MailVerificationTestController.php
+++ b/apps/testing/lib/Controller/MailVerificationTestController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OCA\Testing\Controller;
+
+use InvalidArgumentException;
+use OCP\Accounts\IAccountManager;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserManager;
+
+class MailVerificationTestController extends OCSController {
+	public function __construct(
+		$appName,
+		IRequest $request,
+		protected IAccountManager $accountManager,
+		protected IUserManager $userManager,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	public function verify(string $userId, string $email): DataResponse {
+		$user = $this->userManager->get($userId);
+		$userAccount = $this->accountManager->getAccount($user);
+		$emailProperty = $userAccount->getPropertyCollection(IAccountManager::COLLECTION_EMAIL)
+			->getPropertyByValue($email);
+		if ($emailProperty === null) {
+			throw new InvalidArgumentException('Email not available in account.');
+		}
+		$emailProperty->setLocallyVerified(IAccountManager::VERIFIED);
+		return new DataResponse();
+	}
+}

--- a/build/integration/features/bootstrap/Provisioning.php
+++ b/build/integration/features/bootstrap/Provisioning.php
@@ -980,4 +980,28 @@ trait Provisioning {
 			}
 		}
 	}
+
+	/**
+	 * @Then user :user verifies email :email
+	 */
+	public function userVerifiesEmail(string $userId, string $email): void {
+		$fullUrl = $this->baseUrl . "v{$this->apiVersion}.php/apps/testing/api/v1/mailverification";
+		$client = new Client();
+		$options = [];
+		if ($this->currentUser === 'admin') {
+			$options['auth'] = $this->adminUser;
+		}
+
+		$options['form_params'] = [
+			'userid' => $userId,
+			'email' => $email,
+		];
+
+		$options['headers'] = [
+			'OCS-APIREQUEST' => 'true',
+		];
+
+		$this->response = $client->post($fullUrl, $options);
+	}
 }
+

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -129,11 +129,13 @@ Feature: provisioning
       | value | no.reply@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
+    And user "brand-new-user" verifies email "no.reply@nextcloud.com"
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
       | value | noreply@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
+    And user "brand-new-user" verifies email "noreply@nextcloud.com"
 		And sending "PUT" to "/cloud/users/brand-new-user" with
 			| key | phone |
 			| value | +49 711 / 25 24 28-90 |
@@ -302,11 +304,13 @@ Feature: provisioning
       | value | no.reply6@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
+    And user "brand-new-user" verifies email "no.reply6@nextcloud.com"
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
       | value | noreply7@nextcloud.com |
     And the OCS status code should be "100"
     And the HTTP status code should be "200"
+    And user "brand-new-user" verifies email "no.reply7@nextcloud.com"
     When sending "PUT" to "/cloud/users/brand-new-user/additional_mail" with
       | key | no.reply6@nextcloud.com |
       | value | |


### PR DESCRIPTION
## Summary

…it would not per se be bad to return all of them, however the meta data about the verified state is missing. Since the information may go out to connected clients, those may have wrong trust the returned email addresses.

Email verification still works with this change.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
