### PR TITLE
fix(LDAP): escape DN on check-user

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -279,6 +279,8 @@ class Access extends LDAPUtility {
 	 * Normalizes a result grom getAttributes(), i.e. handles DNs and binary
 	 * data if present.
 	 *
+	 * DN values are escaped as per RFC 2253
+	 *
 	 * @param array $result from ILDAPWrapper::getAttributes()
 	 * @param string $attribute the attribute name that was read
 	 * @return string[]
@@ -1259,6 +1261,8 @@ class Access extends LDAPUtility {
 
 	/**
 	 * Executes an LDAP search
+	 *
+	 * DN values in the result set are escaped as per RFC 2253
 	 *
 	 * @throws ServerNotAvailableException
 	 */

--- a/apps/user_ldap/lib/Command/CheckUser.php
+++ b/apps/user_ldap/lib/Command/CheckUser.php
@@ -138,7 +138,8 @@ class CheckUser extends Command {
 			$attrs = $access->userManager->getAttributes();
 			$user = $access->userManager->get($uid);
 			$avatarAttributes = $access->getConnection()->resolveRule('avatar');
-			$result = $access->search('objectclass=*', $user->getDN(), $attrs, 1, 0);
+			$baseDn = $this->helper->DNasBaseParameter($user->getDN());
+			$result = $access->search('objectclass=*', $baseDn, $attrs, 1, 0);
 			foreach ($result[0] as $attribute => $valueSet) {
 				$output->writeln('  ' . $attribute . ': ');
 				foreach ($valueSet as $value) {

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -206,6 +206,21 @@ class Helper {
 	/**
 	 * sanitizes a DN received from the LDAP server
 	 *
+	 * This is used and done to have a stable format of DNs that can be compared
+	 * and identified again. The input DN value is modified as following:
+	 *
+	 * 1) whitespaces after commas are removed
+	 * 2) the DN is turned to lower-case
+	 * 3) the DN is escaped according to RFC 2253
+	 *
+	 * When a future DN is supposed to be used as a base parameter, it has to be
+	 * run through DNasBaseParameter() first, to recode \5c into a backslash
+	 * again, otherwise the search or read operation will fail with LDAP error
+	 * 32, NO_SUCH_OBJECT. Regular usage in LDAP filters requires the backslash
+	 * being escaped, however.
+	 *
+	 * Internally, DNs are stored in their sanitized form.
+	 *
 	 * @param array|string $dn the DN in question
 	 * @return array|string the sanitized DN
 	 */


### PR DESCRIPTION
## Summary

the DN has to be escaped differently when used as a base and we were missing it here in the search method call in the check-user command.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
