### PR TITLE
log error when default getWrapperStorage would return null

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -569,6 +569,16 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 
 	public function getWrapperStorage() {
 		$this->init();
+
+		/**
+		 * @psalm-suppress DocblockTypeContradiction
+		 */
+		if (!$this->storage) {
+			$message = "no storage set after init for share " . $this->getShareId();
+			$this->logger->error($message);
+			$this->storage = new FailedStorage(['exception' => new \Exception($message)]);
+		}
+
 		return $this->storage;
 	}
 

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -31,11 +31,14 @@
  */
 namespace OC\Files\Storage\Wrapper;
 
+use OC\Files\Storage\FailedStorage;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IWriteStreamStorage;
 use OCP\Lock\ILockingProvider;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStreamStorage {
 	/**
@@ -60,6 +63,12 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 	 * @return \OC\Files\Storage\Storage
 	 */
 	public function getWrapperStorage() {
+		if (!$this->storage) {
+			$message = "storage wrapper " . get_class($this) . " doesn't have a wrapped storage set";
+			$logger = Server::get(LoggerInterface::class);
+			$logger->error($message);
+			$this->storage = new FailedStorage(['exception' => new \Exception($message)]);
+		}
 		return $this->storage;
 	}
 


### PR DESCRIPTION
 and return a `FailedStorage` instead of `null`.

This should hopefully make things more resistant against wrapper issues.