### PR TITLE
fix(caldav): add EXDATE and EXRULE to confidential object

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarObject.php
+++ b/apps/dav/lib/CalDAV/CalendarObject.php
@@ -116,9 +116,13 @@ class CalendarObject extends \Sabre\CalDAV\CalendarObject {
 					case 'CREATED':
 					case 'DTSTART':
 					case 'RRULE':
+					case 'RECURRENCE-ID':
+					case 'RDATE':
 					case 'DURATION':
 					case 'DTEND':
 					case 'CLASS':
+					case 'EXRULE':
+					case 'EXDATE':
 					case 'UID':
 						break;
 					case 'SUMMARY':


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/calendar/issues/5860

## Summary

The EXDATE / EXRULE properties are lost when a confidential object is created.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
