### PR TITLE
fix(dav): ACLs for shared addressbooks

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBook.php
+++ b/apps/dav/lib/CardDAV/AddressBook.php
@@ -118,7 +118,7 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable, IMov
 			],
 			[
 				'privilege' => '{DAV:}write-properties',
-				'principal' => '{DAV:}authenticated',
+				'principal' => $this->getOwner(),
 				'protected' => true,
 			],
 		];
@@ -126,6 +126,11 @@ class AddressBook extends \Sabre\CardDAV\AddressBook implements IShareable, IMov
 		if ($this->getOwner() === 'principals/system/system') {
 			$acl[] = [
 				'privilege' => '{DAV:}read',
+				'principal' => '{DAV:}authenticated',
+				'protected' => true,
+			];
+			$acl[] = [
+				'privilege' => '{DAV:}write-properties',
 				'principal' => '{DAV:}authenticated',
 				'protected' => true,
 			];

--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -214,7 +214,7 @@ abstract class Backend {
 					'principal' => $share['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}principal'],
 					'protected' => true,
 				];
-			} elseif ($this->service->getResourceType() === 'calendar') {
+			} elseif (in_array($this->service->getResourceType(), ['calendar','addressbook'])) {
 				// Allow changing the properties of read only calendars,
 				// so users can change the visibility.
 				$acl[] = [

--- a/apps/dav/tests/unit/CardDAV/AddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookTest.php
@@ -169,7 +169,7 @@ class AddressBookTest extends TestCase {
 			'protected' => true
 		], [
 			'privilege' => '{DAV:}write-properties',
-			'principal' => '{DAV:}authenticated',
+			'principal' => $hasOwnerSet ? 'user1' : 'user2',
 			'protected' => true
 		]];
 		if ($hasOwnerSet) {


### PR DESCRIPTION
## Summary

Grant write-properties permission to shared addressbooks (to disable, change the local name, etc)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
