### PR TITLE
feat(command): Print a success message with the add/remove use occ command

### DIFF
--- a/core/Command/Group/AddUser.php
+++ b/core/Command/Group/AddUser.php
@@ -49,7 +49,10 @@ class AddUser extends Base {
 			$output->writeln('<error>user not found</error>');
 			return 1;
 		}
+
 		$group->addUser($user);
+		$output->writeln('<info>success</info>');
+
 		return 0;
 	}
 

--- a/core/Command/Group/RemoveUser.php
+++ b/core/Command/Group/RemoveUser.php
@@ -50,6 +50,9 @@ class RemoveUser extends Base {
 			return 1;
 		}
 		$group->removeUser($user);
+
+		$output->writeln('<info>success</info>');
+
 		return 0;
 	}
 


### PR DESCRIPTION
## Summary

**Before**

When we add or remove an user from a group. The end-user doesn't know if the command was successful or not.

![image](https://github.com/nextcloud/server/assets/28636549/0fb9f04d-5b90-4a8c-9b3f-3eac23c64f74)
![image](https://github.com/nextcloud/server/assets/28636549/ff82b541-de87-4ec1-915d-4e6db992c3a5)


**After**

Now, the end-user is informed when he/she adds or removes an user from a group with the occ command.

![image](https://github.com/nextcloud/server/assets/28636549/2ddfd103-e045-4903-ab2b-14f4c6e4d213)
![image](https://github.com/nextcloud/server/assets/28636549/68db9442-e458-4994-8809-f55f2b415cd9)

## TODO

- [ ] Install your Nextcloud instance
- [ ] Create a few users
- [ ] Create a few groups
- [ ] From the terminal, run the following commands : 
  - [ ] `php occ group:adduser <groupname> <uid>`
  - [ ] `php occ group:remove <groupname> <uid>`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
