### PR TITLE
feat(dav): Track calendar object changes in admin audit log

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -268,6 +268,7 @@ return array(
     'OCA\\DAV\\HookManager' => $baseDir . '/../lib/HookManager.php',
     'OCA\\DAV\\Listener\\ActivityUpdaterListener' => $baseDir . '/../lib/Listener/ActivityUpdaterListener.php',
     'OCA\\DAV\\Listener\\AddressbookListener' => $baseDir . '/../lib/Listener/AddressbookListener.php',
+    'OCA\\DAV\\Listener\\AdminAuditListener' => $baseDir . '/../lib/Listener/AdminAuditListener.php',
     'OCA\\DAV\\Listener\\BirthdayListener' => $baseDir . '/../lib/Listener/BirthdayListener.php',
     'OCA\\DAV\\Listener\\CalendarContactInteractionListener' => $baseDir . '/../lib/Listener/CalendarContactInteractionListener.php',
     'OCA\\DAV\\Listener\\CalendarDeletionDefaultUpdaterListener' => $baseDir . '/../lib/Listener/CalendarDeletionDefaultUpdaterListener.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -283,6 +283,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\HookManager' => __DIR__ . '/..' . '/../lib/HookManager.php',
         'OCA\\DAV\\Listener\\ActivityUpdaterListener' => __DIR__ . '/..' . '/../lib/Listener/ActivityUpdaterListener.php',
         'OCA\\DAV\\Listener\\AddressbookListener' => __DIR__ . '/..' . '/../lib/Listener/AddressbookListener.php',
+        'OCA\\DAV\\Listener\\AdminAuditListener' => __DIR__ . '/..' . '/../lib/Listener/AdminAuditListener.php',
         'OCA\\DAV\\Listener\\BirthdayListener' => __DIR__ . '/..' . '/../lib/Listener/BirthdayListener.php',
         'OCA\\DAV\\Listener\\CalendarContactInteractionListener' => __DIR__ . '/..' . '/../lib/Listener/CalendarContactInteractionListener.php',
         'OCA\\DAV\\Listener\\CalendarDeletionDefaultUpdaterListener' => __DIR__ . '/..' . '/../lib/Listener/CalendarDeletionDefaultUpdaterListener.php',

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -72,6 +72,7 @@ use OCA\DAV\Events\SubscriptionDeletedEvent;
 use OCA\DAV\HookManager;
 use OCA\DAV\Listener\ActivityUpdaterListener;
 use OCA\DAV\Listener\AddressbookListener;
+use OCA\DAV\Listener\AdminAuditListener;
 use OCA\DAV\Listener\BirthdayListener;
 use OCA\DAV\Listener\CalendarContactInteractionListener;
 use OCA\DAV\Listener\CalendarDeletionDefaultUpdaterListener;
@@ -153,6 +154,7 @@ class Application extends App implements IBootstrap {
 		 */
 		$context->registerEventListener(CalendarCreatedEvent::class, ActivityUpdaterListener::class);
 		$context->registerEventListener(CalendarDeletedEvent::class, ActivityUpdaterListener::class);
+		$context->registerEventListener(CalendarDeletedEvent::class, AdminAuditListener::class);
 		$context->registerEventListener(CalendarDeletedEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarDeletedEvent::class, CalendarDeletionDefaultUpdaterListener::class);
 		$context->registerEventListener(CalendarMovedToTrashEvent::class, ActivityUpdaterListener::class);
@@ -161,16 +163,20 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(CalendarRestoredEvent::class, ActivityUpdaterListener::class);
 		$context->registerEventListener(CalendarRestoredEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectCreatedEvent::class, ActivityUpdaterListener::class);
+		$context->registerEventListener(CalendarObjectCreatedEvent::class, AdminAuditListener::class);
 		$context->registerEventListener(CalendarObjectCreatedEvent::class, CalendarContactInteractionListener::class);
 		$context->registerEventListener(CalendarObjectCreatedEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectUpdatedEvent::class, ActivityUpdaterListener::class);
+		$context->registerEventListener(CalendarObjectUpdatedEvent::class, AdminAuditListener::class);
 		$context->registerEventListener(CalendarObjectUpdatedEvent::class, CalendarContactInteractionListener::class);
 		$context->registerEventListener(CalendarObjectUpdatedEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectDeletedEvent::class, ActivityUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectDeletedEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectMovedEvent::class, ActivityUpdaterListener::class);
+		$context->registerEventListener(CalendarObjectMovedEvent::class, AdminAuditListener::class);
 		$context->registerEventListener(CalendarObjectMovedEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectMovedToTrashEvent::class, ActivityUpdaterListener::class);
+		$context->registerEventListener(CalendarObjectMovedToTrashEvent::class, AdminAuditListener::class);
 		$context->registerEventListener(CalendarObjectMovedToTrashEvent::class, CalendarObjectReminderUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectRestoredEvent::class, ActivityUpdaterListener::class);
 		$context->registerEventListener(CalendarObjectRestoredEvent::class, CalendarObjectReminderUpdaterListener::class);

--- a/apps/dav/lib/Listener/AdminAuditListener.php
+++ b/apps/dav/lib/Listener/AdminAuditListener.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * @copyright 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @author 2024 Christoph Wurst <christoph@winzerhof-wurst.at>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\DAV\Listener;
+
+use OCA\DAV\Events\CalendarObjectCreatedEvent;
+use OCA\DAV\Events\CalendarObjectDeletedEvent;
+use OCA\DAV\Events\CalendarObjectMovedEvent;
+use OCA\DAV\Events\CalendarObjectMovedToTrashEvent;
+use OCA\DAV\Events\CalendarObjectUpdatedEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Log\Audit\CriticalActionPerformedEvent;
+
+/**
+ * @template-extends IEventListener<CalendarObjectCreatedEvent|CalendarObjectUpdatedEvent|CalendarObjectMovedEvent|CalendarObjectDeletedEvent|Event>
+ */
+class AdminAuditListener implements IEventListener {
+
+	private IEventDispatcher $eventDispatcher;
+
+	public function __construct(IEventDispatcher $eventDispatcher) {
+		$this->eventDispatcher = $eventDispatcher;
+	}
+
+	public function handle(Event $event): void {
+		if ($event instanceof CalendarObjectCreatedEvent) {
+			$this->eventDispatcher->dispatchTyped(
+				new CriticalActionPerformedEvent(
+					'Calendar event %s created in calendar %s of principal %s',
+					[
+						$event->getObjectData()['uri'] ?? '?',
+						$event->getCalendarData()['uri'] ?? '?',
+						$event->getCalendarData()['principaluri'] ?? '?',
+					],
+				)
+			);
+		}
+		if ($event instanceof CalendarObjectUpdatedEvent) {
+			$this->eventDispatcher->dispatchTyped(
+				new CriticalActionPerformedEvent(
+					'Calendar event %s in calendar %s of principal %s updated',
+					[
+						$event->getObjectData()['uri'] ?? '?',
+						$event->getCalendarData()['uri'] ?? '?',
+						$event->getCalendarData()['principaluri'] ?? '?',
+					],
+				)
+			);
+		}
+		if ($event instanceof CalendarObjectMovedEvent) {
+			$this->eventDispatcher->dispatchTyped(
+				new CriticalActionPerformedEvent(
+					'Calendar event %s moved from calendar %s of principal %s updated to calendar %s of principal %s',
+					[
+						$event->getObjectData()['uri'] ?? '?',
+						$event->getSourceCalendarData()['uri'] ?? '?',
+						$event->getSourceCalendarData()['principaluri'] ?? '?',
+						$event->getTargetCalendarData()['uri'] ?? '?',
+						$event->getTargetCalendarData()['principaluri'] ?? '?',
+					],
+				)
+			);
+		}
+		if ($event instanceof CalendarObjectMovedToTrashEvent) {
+			$this->eventDispatcher->dispatchTyped(
+				new CriticalActionPerformedEvent(
+					'Calendar event %s in calendar %s of principal %s moved to trash',
+					[
+						$event->getObjectData()['uri'] ?? '?',
+						$event->getCalendarData()['uri'] ?? '?',
+						$event->getCalendarData()['principaluri'] ?? '?',
+					],
+				)
+			);
+		}
+		if ($event instanceof CalendarObjectDeletedEvent) {
+			$this->eventDispatcher->dispatchTyped(
+				new CriticalActionPerformedEvent(
+					'Calendar event %s moved from calendar %s of principal %s updated to calendar %s of principal %s',
+					[
+						$event->getObjectData()['uri'] ?? '?',
+						$event->getSourceCalendarData()['uri'] ?? '?',
+						$event->getSourceCalendarData()['principaluri'] ?? '?',
+						$event->getTargetCalendarData()['uri'] ?? '?',
+						$event->getTargetCalendarData()['principaluri'] ?? '?',
+					],
+				)
+			);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Makes it possible for admins to keep a log of (critical) changes in user calendars, e.g. if a suspicious activity has happened.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
