### PR TITLE
fix(JSRecourceLocator): Add missing slash after server root

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -52,7 +52,7 @@ class JSResourceLocator extends ResourceLocator {
 		$app = substr($script, 0, strpos($script, '/'));
 		$scriptName = basename($script);
 		// Get the app root path
-		$appRoot = $this->serverroot . 'apps/';
+		$appRoot = $this->serverroot . '/apps/';
 		$appWebRoot = null;
 		try {
 			// We need the dir name as getAppPath appends the appid


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/44358

## Summary

The `OC::$SERVERROOT` is always returned without a trailing slash, so we need to add a slash between server root and apps directory.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
