### PR TITLE
fix(AppStore\Fetcher): Ensure `get` returns an array

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -181,7 +181,7 @@ abstract class Fetcher {
 		try {
 			$responseJson = $this->fetch($ETag, $content, $allowUnstable);
 
-			if (empty($responseJson)) {
+			if (empty($responseJson) || empty($responseJson['data'])) {
 				return [];
 			}
 


### PR DESCRIPTION
## Summary

When fetch fails and the `data` prop contains null (e.g. `json_decode` failed), then we should return an empty array instead of null.

Resolves: 
```
Technical details
    • Remote Address: 172.17.0.1 
    • Request ID: Bf943uVmxB3yrn7SILRi 
    • Type: Exception 
    • Code: 0 
    • Message: array_map(): Argument #2 ($array) must be of type array, null given in file '/var/www/html/apps/settings/lib/Controller/AppSettingsController.php' line 253 
    • File: /var/www/html/lib/private/AppFramework/Http/Dispatcher.php 
    • Line: 170 
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
