### PR TITLE
fix(CSP): Add CSP nonce by default and convert `browserSupportsCspV3` to blacklist

### DIFF
--- a/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
+++ b/lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php
@@ -65,17 +65,14 @@ class ContentSecurityPolicyNonceManager {
 	 * Check if the browser supports CSP v3
 	 */
 	public function browserSupportsCspV3(): bool {
-		$browserWhitelist = [
-			Request::USER_AGENT_CHROME,
-			Request::USER_AGENT_FIREFOX,
-			Request::USER_AGENT_SAFARI,
-			Request::USER_AGENT_MS_EDGE,
+		$browserBlocklist = [
+			Request::USER_AGENT_IE,
 		];
 
-		if ($this->request->isUserAgent($browserWhitelist)) {
-			return true;
+		if ($this->request->isUserAgent($browserBlocklist)) {
+			return false;
 		}
 
-		return false;
+		return true;
 	}
 }


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/10207

## Summary

Every modern browser ("modern" like every version since 2013 (over 10 years now!)) support the nonce src.
So we should add it by default and only keep a blacklist instead.

This way even users with for us unknown user agents get the more secure version.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
