### PR TITLE
chore: Switch to `@nextcloud/cypress` for common dockerode config

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,15 +1,15 @@
-import {
-	applyChangesToNextcloud,
-	configureNextcloud,
-	startNextcloud,
-	stopNextcloud,
-	waitOnNextcloud,
-} from './cypress/dockerNode'
-import { defineConfig } from 'cypress'
-import cypressSplit from 'cypress-split'
-import webpackPreprocessor from '@cypress/webpack-preprocessor'
 import type { Configuration } from 'webpack'
 
+import {
+	configureNextcloud,
+	stopNextcloud,
+	waitOnNextcloud,
+} from '@nextcloud/cypress/docker'
+import webpackPreprocessor from '@cypress/webpack-preprocessor'
+
+import { defineConfig } from 'cypress'
+import { applyChangesToNextcloud, startDockerServer } from './cypress/dockerNode'
+import cypressSplit from 'cypress-split'
 import webpackConfig from './webpack.config.js'
 
 export default defineConfig({
@@ -83,13 +83,13 @@ export default defineConfig({
 
 			// Before the browser launches
 			// starting Nextcloud testing container
-			const ip = await startNextcloud(process.env.BRANCH)
+			const ip = await startDockerServer(process.env.BRANCH)
 
 			// Setting container's IP as base Url
 			config.baseUrl = `http://${ip}/index.php`
 			await waitOnNextcloud(ip)
-			await configureNextcloud()
 			await applyChangesToNextcloud()
+			await configureNextcloud()
 
 			// IMPORTANT: return the config otherwise cypress-split will not work
 			return config

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -288,5 +288,5 @@ Cypress.Commands.add('resetUserTheming', (user?: User) => {
 
 Cypress.Commands.add('runOccCommand', (command: string, options?: Partial<Cypress.ExecOptions>) => {
 	const env = Object.entries(options?.env ?? {}).map(([name, value]) => `-e '${name}=${value}'`).join(' ')
-	return cy.exec(`docker exec --user www-data ${env} nextcloud-cypress-tests-server php ./occ ${command}`, options)
+	return cy.exec(`docker exec --user www-data ${env} nextcloud-cypress-tests php ./occ ${command}`, options)
 })


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
