### PR TITLE
Add user verification to webauthn challenges

### DIFF
--- a/core/Migrations/Version29000Date20240324113502.php
+++ b/core/Migrations/Version29000Date20240324113502.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright 2024 S1m <git@sgougeon.fr>
+ *
+ * @author 2024 S1m <git@sgougeon.fr>
+ * @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version29000Date20240324113502 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('webauthn');
+		$table->addColumn('user_verification', Types::BOOLEAN, ['notnull' => false, 'default' => false]);
+		return $schema;
+	}
+}

--- a/core/Migrations/Version29000Date20240324113502.php
+++ b/core/Migrations/Version29000Date20240324113502.php
@@ -2,26 +2,9 @@
 
 declare(strict_types=1);
 /**
- * @copyright 2024 S1m <git@sgougeon.fr>
- *
- * @author 2024 S1m <git@sgougeon.fr>
- * @author 2024 Richard Steinmetz <richard@steinmetz.cloud>
- *
- * @license AGPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2024 S1m <git@sgougeon.fr>
+ * SPDX-FileCopyrightText: 2024 Richard Steinmetz <richard@steinmetz.cloud>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OC\Core\Migrations;

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1276,6 +1276,7 @@ return array(
     'OC\\Core\\Migrations\\Version29000Date20240124132201' => $baseDir . '/core/Migrations/Version29000Date20240124132201.php',
     'OC\\Core\\Migrations\\Version29000Date20240124132202' => $baseDir . '/core/Migrations/Version29000Date20240124132202.php',
     'OC\\Core\\Migrations\\Version29000Date20240131122720' => $baseDir . '/core/Migrations/Version29000Date20240131122720.php',
+    'OC\\Core\\Migrations\\Version29000Date20240324113502' => $baseDir . '/core/Migrations/Version29000Date20240324113502.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',
     'OC\\DB\\Adapter' => $baseDir . '/lib/private/DB/Adapter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1309,6 +1309,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version29000Date20240124132201' => __DIR__ . '/../../..' . '/core/Migrations/Version29000Date20240124132201.php',
         'OC\\Core\\Migrations\\Version29000Date20240124132202' => __DIR__ . '/../../..' . '/core/Migrations/Version29000Date20240124132202.php',
         'OC\\Core\\Migrations\\Version29000Date20240131122720' => __DIR__ . '/../../..' . '/core/Migrations/Version29000Date20240131122720.php',
+        'OC\\Core\\Migrations\\Version29000Date20240324113502' => __DIR__ . '/../../..' . '/core/Migrations/Version29000Date20240324113502.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',
         'OC\\DB\\Adapter' => __DIR__ . '/../../..' . '/lib/private/DB/Adapter.php',

--- a/lib/private/Authentication/WebAuthn/CredentialRepository.php
+++ b/lib/private/Authentication/WebAuthn/CredentialRepository.php
@@ -61,7 +61,7 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository {
 		}, $entities);
 	}
 
-	public function saveAndReturnCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource, ?string $name = null): PublicKeyCredentialEntity {
+	public function saveAndReturnCredentialSource(PublicKeyCredentialSource $publicKeyCredentialSource, ?string $name = null, bool $userVerification = false): PublicKeyCredentialEntity {
 		$oldEntity = null;
 
 		try {
@@ -75,12 +75,17 @@ class CredentialRepository implements PublicKeyCredentialSourceRepository {
 			$name = 'default';
 		}
 
-		$entity = PublicKeyCredentialEntity::fromPublicKeyCrendentialSource($name, $publicKeyCredentialSource);
+		$entity = PublicKeyCredentialEntity::fromPublicKeyCrendentialSource($name, $publicKeyCredentialSource, $userVerification);
 
 		if ($oldEntity) {
 			$entity->setId($oldEntity->getId());
 			if ($defaultName) {
 				$entity->setName($oldEntity->getName());
+			}
+
+			// Don't downgrade UV just because it was skipped during a login due to another key
+			if ($oldEntity->getUserVerification()) {
+				$entity->setUserVerification(true);
 			}
 		}
 

--- a/lib/private/Authentication/WebAuthn/Db/PublicKeyCredentialEntity.php
+++ b/lib/private/Authentication/WebAuthn/Db/PublicKeyCredentialEntity.php
@@ -41,6 +41,9 @@ use Webauthn\PublicKeyCredentialSource;
  * @method void setPublicKeyCredentialId(string $id);
  * @method string getData();
  * @method void setData(string $data);
+ * @since 30.0.0
+ * @method bool|null getUserVerification();
+ * @method void setUserVerification(bool $userVerification);
  */
 class PublicKeyCredentialEntity extends Entity implements JsonSerializable {
 	/** @var string */
@@ -55,20 +58,25 @@ class PublicKeyCredentialEntity extends Entity implements JsonSerializable {
 	/** @var string */
 	protected $data;
 
+	/** @var bool|null */
+	protected $userVerification;
+
 	public function __construct() {
 		$this->addType('name', 'string');
 		$this->addType('uid', 'string');
 		$this->addType('publicKeyCredentialId', 'string');
 		$this->addType('data', 'string');
+		$this->addType('userVerification', 'boolean');
 	}
 
-	public static function fromPublicKeyCrendentialSource(string $name, PublicKeyCredentialSource $publicKeyCredentialSource): PublicKeyCredentialEntity {
+	public static function fromPublicKeyCrendentialSource(string $name, PublicKeyCredentialSource $publicKeyCredentialSource, bool $userVerification): PublicKeyCredentialEntity {
 		$publicKeyCredentialEntity = new self();
 
 		$publicKeyCredentialEntity->setName($name);
 		$publicKeyCredentialEntity->setUid($publicKeyCredentialSource->getUserHandle());
 		$publicKeyCredentialEntity->setPublicKeyCredentialId(base64_encode($publicKeyCredentialSource->getPublicKeyCredentialId()));
 		$publicKeyCredentialEntity->setData(json_encode($publicKeyCredentialSource));
+		$publicKeyCredentialEntity->setUserVerification($userVerification);
 
 		return $publicKeyCredentialEntity;
 	}

--- a/lib/private/Authentication/WebAuthn/Db/PublicKeyCredentialEntity.php
+++ b/lib/private/Authentication/WebAuthn/Db/PublicKeyCredentialEntity.php
@@ -41,7 +41,8 @@ use Webauthn\PublicKeyCredentialSource;
  * @method void setPublicKeyCredentialId(string $id);
  * @method string getData();
  * @method void setData(string $data);
- * @since 30.0.0
+ *
+ * @since 30.0.0 Add userVerification attribute
  * @method bool|null getUserVerification();
  * @method void setUserVerification(bool $userVerification);
  */

--- a/version.php
+++ b/version.php
@@ -30,7 +30,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [30, 0, 0, 0];
+$OC_Version = [30, 0, 0, 1];
 
 // The human-readable string
 $OC_VersionString = '30.0.0 dev';


### PR DESCRIPTION
Require user verification if all tokens are registered with UV flag, else discourage it


* Resolves: #41599
* Previously work on #34389 (by @ChristophWurst)

## Summary


## TODO
- [x] Recommend UV (user verification with a PIN) during device registration
- [x] Require UV during authentication if all tokens are registered with UV
- [x] Discourage UV during authentication if any token is registered without UV \*
- [x] Previously registered token are considered without UV to avoid locking out a user

\* Currently, this is always discouraged

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
