### PR TITLE
fix(federation): Fix creating local cloudIds with http:// protocol

### DIFF
--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -195,9 +195,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('myFile'),
 				$this->anything(),
 				'shareOwner',
-				'shareOwner@http://localhost/',
+				'shareOwner@http://localhost',
 				'sharedBy',
-				'sharedBy@http://localhost/'
+				'sharedBy@http://localhost'
 			)
 			->willReturn(true);
 
@@ -276,9 +276,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('myFile'),
 				$this->anything(),
 				'shareOwner',
-				'shareOwner@http://localhost/',
+				'shareOwner@http://localhost',
 				'sharedBy',
-				'sharedBy@http://localhost/'
+				'sharedBy@http://localhost'
 			)->willReturn(false);
 
 		$this->rootFolder->method('getById')
@@ -337,9 +337,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('myFile'),
 				$this->anything(),
 				'shareOwner',
-				'shareOwner@http://localhost/',
+				'shareOwner@http://localhost',
 				'sharedBy',
-				'sharedBy@http://localhost/'
+				'sharedBy@http://localhost'
 			)->willThrowException(new \Exception('dummy'));
 
 		$this->rootFolder->method('getById')
@@ -443,9 +443,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('myFile'),
 				$this->anything(),
 				'shareOwner',
-				'shareOwner@http://localhost/',
+				'shareOwner@http://localhost',
 				'sharedBy',
-				'sharedBy@http://localhost/'
+				'sharedBy@http://localhost'
 			)->willReturn(true);
 
 		$this->rootFolder->expects($this->never())->method($this->anything());
@@ -514,9 +514,9 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				$this->equalTo('myFile'),
 				$this->anything(),
 				$owner,
-				$owner . '@http://localhost/',
+				$owner . '@http://localhost',
 				$sharedBy,
-				$sharedBy . '@http://localhost/'
+				$sharedBy . '@http://localhost'
 			)->willReturn(true);
 
 		if ($owner === $sharedBy) {

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -124,11 +124,15 @@ class CloudIdManagerTest extends TestCase {
 		$this->cloudIdManager->resolveCloudId($cloudId);
 	}
 
-	public function getCloudIdProvider() {
+	public function getCloudIdProvider(): array {
 		return [
 			['test', 'example.com', 'test@example.com'],
+			['test', 'http://example.com', 'test@http://example.com', 'test@example.com'],
+			['test', null, 'test@http://example.com', 'test@example.com', 'http://example.com'],
 			['test@example.com', 'example.com', 'test@example.com@example.com'],
+			['test@example.com', 'https://example.com', 'test@example.com@example.com'],
 			['test@example.com', null, 'test@example.com@example.com'],
+			['test@example.com', 'https://example.com/index.php/s/shareToken', 'test@example.com@example.com'],
 		];
 	}
 
@@ -136,24 +140,24 @@ class CloudIdManagerTest extends TestCase {
 	 * @dataProvider getCloudIdProvider
 	 *
 	 * @param string $user
-	 * @param string $remote
+	 * @param null|string $remote
 	 * @param string $id
 	 */
-	public function testGetCloudId($user, $remote, $id) {
+	public function testGetCloudId(string $user, ?string $remote, string $id, ?string $searchCloudId = null, ?string $localHost = 'https://example.com'): void {
 		if ($remote !== null) {
 			$this->contactsManager->expects($this->any())
 				->method('search')
-				->with($id, ['CLOUD'])
+				->with($searchCloudId ?? $id, ['CLOUD'])
 				->willReturn([
 					[
-						'CLOUD' => [$id],
+						'CLOUD' => [$searchCloudId ?? $id],
 						'FN' => 'Ample Ex',
 					]
 				]);
 		} else {
 			$this->urlGenerator->expects(self::once())
 				->method('getAbsoluteUrl')
-				->willReturn('https://example.com');
+				->willReturn($localHost);
 		}
 
 		$cloudId = $this->cloudIdManager->getCloudId($user, $remote);


### PR DESCRIPTION
* Required for https://github.com/nextcloud/spreed/issues/11888

## Summary

As per the already existing comment in the code:
```
		// note that for remote id's we don't strip the protocol for the remote we use to construct the CloudId
		// this way if a user has an explicit non-https cloud id this will be preserved
		// we do still use the version without protocol for looking up the display name
```

However this was not applied correctly when generating a local cloudId with `remote === null`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
