### PR TITLE
fix(contactsinteraction): Allow vCard download

### DIFF
--- a/apps/contactsinteraction/lib/Card.php
+++ b/apps/contactsinteraction/lib/Card.php
@@ -96,7 +96,7 @@ class Card implements ICard, IACL {
 	 * @inheritDoc
 	 */
 	public function getSize(): int {
-		throw new NotImplemented();
+		return strlen($this->contact->getCard());
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Sabre calculates a header for the size of a vcard, therefore we have to implement the size method.

## How to test

1. Share a file to an email address
2. Open Contacts and find a generated contact for the email address
3. Open the contact details
4. Click on the actions menu in the top right
5. Click *Download*

Master: nothing happens (URL is opened in a new tab and kind of silently fails).
Here: vcard is downloaded.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
