### PR TITLE
fix: Allow using replica config with split databases

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -233,7 +233,7 @@ class ConnectionFactory {
 			$connectionParams['persistent'] = true;
 		}
 
-		$replica = $this->config->getValue('dbreplica', []) ?: [$connectionParams];
+		$replica = $this->config->getValue($configPrefix . 'dbreplica', $this->config->getValue('dbreplica', [])) ?: [$connectionParams];
 		return array_merge($connectionParams, [
 			'primary' => $connectionParams,
 			'replica' => $replica,


### PR DESCRIPTION
Otherwise using [Replication](https://docs.nextcloud.com/server/latest/admin_manual/configuration_database/replication.html) with [Splitting databases](https://docs.nextcloud.com/server/latest/admin_manual/configuration_database/splitting.html) would be incompatible as the split database would pick up the replica of the regular database.

With this change there is also the possibility to configure dedicated replicas for each config prefix of a database.