### PR TITLE
fix(dns): detect disabled IPv6 support in DNS pinning

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -75,7 +75,9 @@ class DnsPinMiddleware {
 		$soaDnsEntry = $this->soaRecord($target);
 		$dnsNegativeTtl = $soaDnsEntry['minimum-ttl'] ?? null;
 
-		$dnsTypes = [DNS_A, DNS_AAAA, DNS_CNAME];
+		$dnsTypes = \defined('AF_INET6') || @inet_pton('::1')
+			? [DNS_A, DNS_AAAA, DNS_CNAME]
+			: [DNS_A, DNS_CNAME];
 		foreach ($dnsTypes as $dnsType) {
 			if ($this->negativeDnsCache->isNegativeCached($target, $dnsType)) {
 				continue;


### PR DESCRIPTION
* Resolves: #33567
* Closes: #40821 (inactive but contains good fix)

## Summary
If IPv6 isn't supported (PHP compiled with `--disable-ipv6` flag), don't try to resolve AAAA records

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
