### PR TITLE
fix(settings): Also verify that `trusted_proxies` only contains IP addresses (with range)

### DIFF
--- a/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
+++ b/apps/settings/lib/SetupChecks/ForwardedForHeaders.php
@@ -59,6 +59,16 @@ class ForwardedForHeaders implements ISetupCheck {
 			return SetupResult::error($this->l10n->t('Your "trusted_proxies" setting is not correctly set, it should be an array.'));
 		}
 
+		foreach ($trustedProxies as $proxy) {
+			$addressParts = explode('/', $proxy, 2);
+			if (filter_var($addressParts[0], FILTER_VALIDATE_IP) === false || !ctype_digit($addressParts[1] ?? '24')) {
+				return SetupResult::error(
+					$this->l10n->t('Your "trusted_proxies" setting is not correctly set, it should be an array of IP addresses - optionally with range in CIDR notation.'),
+					$this->urlGenerator->linkToDocs('admin-reverse-proxy'),
+				);
+			}
+		}
+
 		if (($remoteAddress === '') && ($detectedRemoteAddress === '')) {
 			if (\OC::$CLI) {
 				/* We were called from CLI */


### PR DESCRIPTION
## Summary

`trusted_proxies` only handles IPv4 and IPv6 addresses, optionally with CIDR range notation, so we should validate this too. As it is a common mistake to put host names into this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
