### PR TITLE
Get success when try to create a folder that already exists

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -159,7 +159,9 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $fullPath);
 			$this->sendHooks(['preWrite', 'preCreate'], [$nonExisting]);
 			if (!$this->view->mkdir($fullPath)) {
-				throw new NotPermittedException('Could not create folder "' . $fullPath . '"');
+				if (!$this->view->is_dir($fullPath)) {
+					throw new NotPermittedException('Could not create folder "' . $fullPath . '"');
+				}
 			}
 			$parent = dirname($fullPath) === $this->getPath() ? $this : null;
 			$node = new Folder($this->root, $this->view, $fullPath, null, $parent);

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -178,6 +178,34 @@ class FolderTest extends NodeTest {
 		$this->assertEquals($child, $result);
 	}
 
+	public function testNewFolderWhenFolderAlreadyExists() {
+		$manager = $this->createMock(Manager::class);
+		$view = $this->getRootViewMock();
+		$root = $this->getMockBuilder(Root::class)
+			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache, $this->logger, $this->userManager, $this->eventDispatcher, $this->cacheFactory])
+			->getMock();
+		$root->expects($this->any())
+			->method('getUser')
+			->willReturn($this->user);
+
+		$view->method('getFileInfo')
+			->with('/bar/foo')
+			->willReturn($this->getFileInfo(['permissions' => \OCP\Constants::PERMISSION_ALL]));
+
+		$view->method('mkdir')
+			->with('/bar/foo/asd')
+			->willReturn(false);
+
+		$view->method('is_dir')
+			->with('/bar/foo/asd')
+			->willReturn(true);
+
+		$node = new Folder($root, $view, '/bar/foo');
+		$child = new Folder($root, $view, '/bar/foo/asd', null, $node);
+		$result = $node->newFolder('asd');
+		$this->assertEquals($child, $result);
+	}
+
 	public function testNewFolderDeepParent() {
 		$manager = $this->createMock(Manager::class);
 		$view = $this->getRootViewMock();


### PR DESCRIPTION
The PHP function mkdir return false when the directory already exists:

https://www.php.net/manual/en/function.mkdir.php#refsect1-function.mkdir-returnvalues

If the directory that we is trying to create already exists, would be good to return success and consider that the folder exists to prevent fatal error because the scenario about existing folder is not covered now.

How to reproduce this:

Try to create a folder that already exists.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes (not required)
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
