### PR TITLE
perf(dav): skip non-calendar requests in webcal caching plugin

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
@@ -98,6 +98,10 @@ class Plugin extends ServerPlugin {
 		}
 
 		$path = $request->getPath();
+		if (!str_starts_with($path, 'calendars/')) {
+			return;
+		}
+
 		$pathParts = explode('/', ltrim($path, '/'));
 		if (\count($pathParts) < 2) {
 			return;

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/PluginTest.php
@@ -25,6 +25,10 @@ namespace OCA\DAV\Tests\unit\CalDAV\WebcalCaching;
 
 use OCA\DAV\CalDAV\WebcalCaching\Plugin;
 use OCP\IRequest;
+use Sabre\DAV\Server;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\Request;
+use Sabre\HTTP\Response;
 
 class PluginTest extends \Test\TestCase {
 	public function testDisabled(): void {
@@ -59,5 +63,59 @@ class PluginTest extends \Test\TestCase {
 		$plugin = new Plugin($request);
 
 		$this->assertEquals(true, $plugin->isCachingEnabledForThisRequest());
+	}
+
+	public function testSkipNonCalendarRequest(): void {
+		$request = $this->createMock(IRequest::class);
+		$request->expects($this->once())
+			->method('isUserAgent')
+			->with(Plugin::ENABLE_FOR_CLIENTS)
+			->willReturn(false);
+
+		$request->expects($this->once())
+			->method('getHeader')
+			->with('X-NC-CalDAV-Webcal-Caching')
+			->willReturn('On');
+
+		$sabreRequest = new Request('REPORT', '/remote.php/dav/principals/users/admin/');
+		$sabreRequest->setBaseUrl('/remote.php/dav/');
+
+		$tree = $this->createMock(Tree::class);
+		$tree->expects($this->never())
+			->method('getNodeForPath');
+
+		$server = new Server($tree);
+
+		$plugin = new Plugin($request);
+		$plugin->initialize($server);
+
+		$plugin->beforeMethod($sabreRequest, new Response());
+	}
+
+	public function testProcessCalendarRequest(): void {
+		$request = $this->createMock(IRequest::class);
+		$request->expects($this->once())
+			->method('isUserAgent')
+			->with(Plugin::ENABLE_FOR_CLIENTS)
+			->willReturn(false);
+
+		$request->expects($this->once())
+			->method('getHeader')
+			->with('X-NC-CalDAV-Webcal-Caching')
+			->willReturn('On');
+
+		$sabreRequest = new Request('REPORT', '/remote.php/dav/calendars/admin/personal/');
+		$sabreRequest->setBaseUrl('/remote.php/dav/');
+
+		$tree = $this->createMock(Tree::class);
+		$tree->expects($this->once())
+			->method('getNodeForPath');
+
+		$server = new Server($tree);
+
+		$plugin = new Plugin($request);
+		$plugin->initialize($server);
+
+		$plugin->beforeMethod($sabreRequest, new Response());
 	}
 }


### PR DESCRIPTION
## Summary

The webcal caching plugin is active when the X-NC-CalDAV-Webcal-Caching header is there.

findPrincipalByUrl sends a request for /remote.php/dav/principals/users/admin/ using the caldavService which sets the header by default.[^1]

As X-NC-CalDAV-Webcal-Caching only impacts calendar requests, we can skip non-calendar requests.

[^1]: https://github.com/nextcloud/calendar/blob/b3670f1805ef9ef952d6abe4e5334e37b5a14133/src/services/caldavService.js#L43


## TODO

- [x] CI
- [x] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
