### PR TITLE
fix(logger): Make the handling of SensitiveParameters consistent

### DIFF
--- a/lib/private/Log/ExceptionSerializer.php
+++ b/lib/private/Log/ExceptionSerializer.php
@@ -220,7 +220,9 @@ class ExceptionSerializer {
 	private function removeValuesFromArgs($args, $values): array {
 		$workArgs = [];
 		foreach ($args as $arg) {
-			if (in_array($arg, $values, true)) {
+			if (isset($arg['__class__']) && $arg['__class__'] === \SensitiveParameterValue::class) {
+				$arg = self::SENSITIVE_VALUE_PLACEHOLDER;
+			} elseif (in_array($arg, $values, true)) {
 				$arg = self::SENSITIVE_VALUE_PLACEHOLDER;
 			} elseif (is_array($arg)) {
 				$arg = $this->removeValuesFromArgs($arg, $values);

--- a/tests/lib/Log/ExceptionSerializerTest.php
+++ b/tests/lib/Log/ExceptionSerializerTest.php
@@ -52,6 +52,14 @@ class ExceptionSerializerTest extends TestCase {
 		throw new \Exception('expected custom auth exception');
 	}
 
+	private function usingSensitiveParameterAttribute(
+		string $login,
+		#[\SensitiveParameter]
+		string $parole,
+	): void {
+		throw new \Exception('SensitiveParameter attribute');
+	}
+
 	/**
 	 * this test ensures that the serializer does not overwrite referenced
 	 * variables. It is crafted after a scenario we experienced: the DAV server
@@ -79,6 +87,17 @@ class ExceptionSerializerTest extends TestCase {
 			$this->assertSame('customMagicAuthThing', $serializedData['Trace'][0]['function']);
 			$this->assertSame(ExceptionSerializer::SENSITIVE_VALUE_PLACEHOLDER, $serializedData['Trace'][0]['args'][0]);
 			$this->assertFalse(isset($serializedData['Trace'][0]['args'][1]));
+		}
+	}
+
+	public function testSensitiveParameterAttribute(): void {
+		try {
+			$this->usingSensitiveParameterAttribute('u57474', 'Secret');
+		} catch (\Exception $e) {
+			$serializedData = $this->serializer->serializeException($e);
+			$this->assertSame('usingSensitiveParameterAttribute', $serializedData['Trace'][0]['function']);
+			$this->assertSame('u57474', $serializedData['Trace'][0]['args'][0]);
+			$this->assertSame('*** sensitive parameters replaced ***', $serializedData['Trace'][0]['args'][1]);
 		}
 	}
 }


### PR DESCRIPTION
## TODO

- [ ] Add support for 8.1 and 8.0

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
