### PR TITLE
Fix federated group shares when no longer found in remote server

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -599,7 +599,18 @@ class Manager {
 		return $result;
 	}
 
-	public function removeShare($mountPoint): bool {
+	/**
+	 * Remove a share based on its mountpoint.
+	 *
+	 * User shares are always fully removed; group shares by default are just
+	 * marked again as pending for the current user, unless explicitly forced
+	 * to be fully removed (parent group share and all its sub-shares).
+	 *
+	 * @param bool $force True to fully removed a group share, false to mark it
+	 *        as pending for the current user
+	 * @return bool True if the share could be removed, false otherwise
+	 */
+	public function removeShare(string $mountPoint, bool $force = false): bool {
 		try {
 			$mountPointObj = $this->mountManager->find($mountPoint);
 		} catch (NotFoundException $e) {
@@ -617,7 +628,7 @@ class Manager {
 
 		try {
 			$getShare = $this->connection->prepare('
-				SELECT `remote`, `share_token`, `remote_id`, `share_type`, `id`
+				SELECT `remote`, `share_token`, `remote_id`, `share_type`, `id`, `parent`
 				FROM  `*PREFIX*share_external`
 				WHERE `mountpoint_hash` = ? AND `user` = ?');
 			$result = $getShare->execute([$hash, $this->uid]);
@@ -638,7 +649,22 @@ class Manager {
 				$deleteResult = $query->execute([(int)$share['id']]);
 				$deleteResult->closeCursor();
 			} elseif ($share !== false && (int)$share['share_type'] === IShare::TYPE_GROUP) {
-				$this->updateAccepted((int)$share['id'], false);
+				if ($force) {
+					$qb = $this->connection->getQueryBuilder();
+					// delete group share entry and matching sub-entries
+					$qb->delete('share_external')
+					->where(
+						$qb->expr()->orX(
+							$qb->expr()->eq('id', $qb->createParameter('share_parent_id')),
+							$qb->expr()->eq('parent', $qb->createParameter('share_parent_id'))
+						)
+					);
+
+					$qb->setParameter('share_parent_id', $share['parent']);
+					$qb->executeStatement();
+				} else {
+					$this->updateAccepted((int)$share['id'], false);
+				}
 			}
 
 			$this->removeReShares($id);

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -239,7 +239,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 				// valid Nextcloud instance means that the public share no longer exists
 				// since this is permanent (re-sharing the file will create a new token)
 				// we remove the invalid storage
-				$this->manager->removeShare($this->mountPoint);
+				$this->manager->removeShare($this->mountPoint, true);
 				$this->manager->getMountManager()->removeMount($this->mountPoint);
 				throw new StorageInvalidException("Remote share not found", 0, $e);
 			} else {
@@ -248,7 +248,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 			}
 		} catch (ForbiddenException $e) {
 			// auth error, remove share for now (provide a dialog in the future)
-			$this->manager->removeShare($this->mountPoint);
+			$this->manager->removeShare($this->mountPoint, true);
 			$this->manager->getMountManager()->removeMount($this->mountPoint);
 			throw new StorageInvalidException("Auth error when getting remote share");
 		} catch (\GuzzleHttp\Exception\ConnectException $e) {

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -498,24 +498,24 @@ class ManagerTest extends TestCase {
 
 		return $shareData;
 	}
-	private function createTestGroupShare($groupId = 'group1') {
+	private function createTestGroupShare($groupId = 'group1', $token = 'token1', $name = '/SharedFolder', $remoteId = '2342') {
 		$shareData = [
 			'remote' => 'http://localhost',
-			'token' => 'token1',
+			'token' => $token,
 			'password' => '',
-			'name' => '/SharedFolder',
+			'name' => $name,
 			'owner' => 'foobar',
 			'shareType' => IShare::TYPE_GROUP,
 			'accepted' => false,
 			'user' => $groupId,
-			'remoteId' => '2342'
+			'remoteId' => $remoteId
 		];
 
 		$this->assertSame(null, call_user_func_array([$this->manager, 'addShare'], $shareData));
 
 		$allShares = self::invokePrivate($this->manager, 'getShares', [null]);
 		foreach ($allShares as $share) {
-			if ($share['user'] === $groupId) {
+			if ($share['user'] === $groupId && $share['share_token'] == $token && $share['name'] == $name && $share['remote_id'] == $remoteId) {
 				// this will hold the main group entry
 				$groupShare = $share;
 				break;

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -498,7 +498,9 @@ class ManagerTest extends TestCase {
 
 		return $shareData;
 	}
-	private function createTestGroupShare($groupId = 'group1', $token = 'token1', $name = '/SharedFolder', $remoteId = '2342') {
+	private function createTestGroupShare($groupId = 'group1', $token = 'token1', $name = '/SharedFolder', $remoteId = '2342', $manager = null) {
+		$manager ??= $this->manager;
+
 		$shareData = [
 			'remote' => 'http://localhost',
 			'token' => $token,
@@ -511,9 +513,9 @@ class ManagerTest extends TestCase {
 			'remoteId' => $remoteId
 		];
 
-		$this->assertSame(null, call_user_func_array([$this->manager, 'addShare'], $shareData));
+		$this->assertSame(null, call_user_func_array([$manager, 'addShare'], $shareData));
 
-		$allShares = self::invokePrivate($this->manager, 'getShares', [null]);
+		$allShares = self::invokePrivate($manager, 'getShares', [null]);
 		foreach ($allShares as $share) {
 			if ($share['user'] === $groupId && $share['share_token'] == $token && $share['name'] == $name && $share['remote_id'] == $remoteId) {
 				// this will hold the main group entry

--- a/apps/testing/appinfo/routes.php
+++ b/apps/testing/appinfo/routes.php
@@ -80,5 +80,10 @@ return [
 				'type' => null
 			]
 		],
+		[
+			'name' => 'RemoteShares#delete',
+			'url' => '/api/v1/remote_shares',
+			'verb' => 'DELETE',
+		],
 	],
 ];

--- a/apps/testing/composer/composer/autoload_classmap.php
+++ b/apps/testing/composer/composer/autoload_classmap.php
@@ -12,6 +12,7 @@ return array(
     'OCA\\Testing\\Controller\\ConfigController' => $baseDir . '/../lib/Controller/ConfigController.php',
     'OCA\\Testing\\Controller\\LockingController' => $baseDir . '/../lib/Controller/LockingController.php',
     'OCA\\Testing\\Controller\\RateLimitTestController' => $baseDir . '/../lib/Controller/RateLimitTestController.php',
+    'OCA\\Testing\\Controller\\RemoteSharesController' => $baseDir . '/../lib/Controller/RemoteSharesController.php',
     'OCA\\Testing\\Listener\\GetDeclarativeSettingsValueListener' => $baseDir . '/../lib/Listener/GetDeclarativeSettingsValueListener.php',
     'OCA\\Testing\\Listener\\RegisterDeclarativeSettingsListener' => $baseDir . '/../lib/Listener/RegisterDeclarativeSettingsListener.php',
     'OCA\\Testing\\Listener\\SetDeclarativeSettingsValueListener' => $baseDir . '/../lib/Listener/SetDeclarativeSettingsValueListener.php',

--- a/apps/testing/composer/composer/autoload_static.php
+++ b/apps/testing/composer/composer/autoload_static.php
@@ -27,6 +27,7 @@ class ComposerStaticInitTesting
         'OCA\\Testing\\Controller\\ConfigController' => __DIR__ . '/..' . '/../lib/Controller/ConfigController.php',
         'OCA\\Testing\\Controller\\LockingController' => __DIR__ . '/..' . '/../lib/Controller/LockingController.php',
         'OCA\\Testing\\Controller\\RateLimitTestController' => __DIR__ . '/..' . '/../lib/Controller/RateLimitTestController.php',
+        'OCA\\Testing\\Controller\\RemoteSharesController' => __DIR__ . '/..' . '/../lib/Controller/RemoteSharesController.php',
         'OCA\\Testing\\Listener\\GetDeclarativeSettingsValueListener' => __DIR__ . '/..' . '/../lib/Listener/GetDeclarativeSettingsValueListener.php',
         'OCA\\Testing\\Listener\\RegisterDeclarativeSettingsListener' => __DIR__ . '/..' . '/../lib/Listener/RegisterDeclarativeSettingsListener.php',
         'OCA\\Testing\\Listener\\SetDeclarativeSettingsValueListener' => __DIR__ . '/..' . '/../lib/Listener/SetDeclarativeSettingsValueListener.php',

--- a/apps/testing/lib/Controller/RemoteSharesController.php
+++ b/apps/testing/lib/Controller/RemoteSharesController.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright Copyright (c) 2024, Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @author Daniel Calviño Sánchez <danxuliu@gmail.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Testing\Controller;
+
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
+use OCP\IDBConnection;
+use OCP\IRequest;
+
+class RemoteSharesController extends OCSController {
+
+	/** @var IDBConnection */
+	protected $connection;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 */
+	public function __construct($appName,
+		IRequest $request,
+		IDBConnection $connection) {
+		parent::__construct($appName, $request);
+		$this->connection = $connection;
+	}
+
+	/**
+	 * Deletes all remote shares.
+	 *
+	 * Note that neither storages nor mountpoints are deleted. This is meant to
+	 * be used to get rid of dangling group shares after the users and groups
+	 * were deleted.
+	 *
+	 * @return DataResponse
+	 */
+	public function delete() {
+		// For simplicity the database table is cleared directly in the
+		// controller :see-no-evil:
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('share_external');
+
+		$query->executeStatement();
+
+		return new DataResponse();
+	}
+}

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -401,6 +401,58 @@ Feature: federated
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
 
+	Scenario: Delete federated group share with another server
+		Given Using server "LOCAL"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user0" exists
+		Given Using server "REMOTE"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group1-user0" exists
+		And user "group1-user1" exists
+		And group "group1" exists
+		And user "group1-user0" belongs to group "group1"
+		And user "group1-user1" belongs to group "group1"
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user0" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user0" from server "LOCAL" shares "/remote-share.txt" with group "group1" from server "REMOTE"
+		And Using server "LOCAL"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+		And Using server "REMOTE"
+		And User "group1-user0" from server "REMOTE" accepts last pending share
+		And as "group1-user0" the file "/remote-share.txt" exists
+		And As an "group1-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group1-user1" from server "REMOTE" accepts last pending share
+		And as "group1-user1" the file "/remote-share.txt" exists
+		And As an "group1-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And Using server "LOCAL"
+		When As an "user0"
+		And Deleting last share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 0 shares
+		And Using server "REMOTE"
+		And as "group1-user0" the file "/remote-share.txt" does not exist
+		And As an "group1-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 0 shares
+		And as "group1-user1" the file "/remote-share.txt" does not exist
+		And As an "group1-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 0 shares
+
 	Scenario: Delete federated share with another server no longer reachable
 		Given Using server "LOCAL"
 		And user "user0" exists
@@ -418,6 +470,46 @@ Feature: federated
 		And User "user1" from server "REMOTE" accepts last pending share
 		And as "user1" the file "/remote-share.txt" exists
 		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		And Using server "LOCAL"
+		When As an "user0"
+		And Deleting last share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 0 shares
+
+	Scenario: Delete federated group share with another server no longer reachable
+		Given Using server "LOCAL"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user0" exists
+		Given Using server "REMOTE"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group1-user0" exists
+		And user "group1-user1" exists
+		And group "group1" exists
+		And user "group1-user0" belongs to group "group1"
+		And user "group1-user1" belongs to group "group1"
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user0" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user0" from server "LOCAL" shares "/remote-share.txt" with group "group1" from server "REMOTE"
+		And Using server "LOCAL"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+		And Using server "REMOTE"
+		And User "group1-user0" from server "REMOTE" accepts last pending share
+		And as "group1-user0" the file "/remote-share.txt" exists
+		And As an "group1-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group1-user1" from server "REMOTE" accepts last pending share
+		And as "group1-user1" the file "/remote-share.txt" exists
+		And As an "group1-user1"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 1 shares
 		And remote server is stopped
@@ -463,6 +555,60 @@ Feature: federated
 		And as "user1" the file "/remote-share.txt" does not exist
 		And As an "user1"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+
+	Scenario: Delete federated group share with another server when temporary unreachable
+		Given Using server "LOCAL"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user0" exists
+		Given Using server "REMOTE"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group1-user0" exists
+		And user "group1-user1" exists
+		And group "group1" exists
+		And user "group1-user0" belongs to group "group1"
+		And user "group1-user1" belongs to group "group1"
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user0" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user0" from server "LOCAL" shares "/remote-share.txt" with group "group1" from server "REMOTE"
+		And Using server "LOCAL"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+		And Using server "REMOTE"
+		And User "group1-user0" from server "REMOTE" accepts last pending share
+		And as "group1-user0" the file "/remote-share.txt" exists
+		And As an "group1-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group1-user1" from server "REMOTE" accepts last pending share
+		And as "group1-user1" the file "/remote-share.txt" exists
+		And As an "group1-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		And Using server "LOCAL"
+		When As an "user0"
+		And Deleting last share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 0 shares
+		And remote server is started
+		And Using server "REMOTE"
+		And as "group1-user0" the file "/remote-share.txt" does not exist
+		And As an "group1-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 0 shares
+		And as "group1-user1" the file "/remote-share.txt" does not exist
+		And As an "group1-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
 		And the list of returned shares has 0 shares
 
 	Scenario: Delete federated share from another server

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -401,6 +401,35 @@ Feature: federated
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
 
+	Scenario: Delete federated share with another server no longer reachable
+		Given Using server "LOCAL"
+		And user "user0" exists
+		Given Using server "REMOTE"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user0" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user0" from server "LOCAL" shares "/remote-share.txt" with user "user1" from server "REMOTE"
+		And Using server "LOCAL"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+		And Using server "REMOTE"
+		And User "user1" from server "REMOTE" accepts last pending share
+		And as "user1" the file "/remote-share.txt" exists
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		And Using server "LOCAL"
+		When As an "user0"
+		And Deleting last share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 0 shares
+
 	Scenario: Delete federated share from another server
 		Given Using server "LOCAL"
 		And user "user0" exists

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -519,6 +519,35 @@ Feature: federated
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
 
+	Scenario: Delete federated share from another server when temporary unreachable
+		Given Using server "LOCAL"
+		And user "user0" exists
+		Given Using server "REMOTE"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with user "user0" from server "LOCAL"
+		And Using server "LOCAL"
+		And User "user0" from server "LOCAL" accepts last pending share
+		And as "user0" the file "/remote-share.txt" exists
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		When user "user0" deletes last accepted remote share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And remote server is started
+		And as "user0" the file "/remote-share.txt" does not exist
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And Using server "REMOTE"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+
 	Scenario: Delete federated share file from another server
 		Given Using server "LOCAL"
 		And user "user0" exists
@@ -570,3 +599,31 @@ Feature: federated
 		And As an "user0"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
+
+	Scenario: Delete federated share file from another server when temporary unreachable
+		Given Using server "LOCAL"
+		And user "user0" exists
+		Given Using server "REMOTE"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with user "user0" from server "LOCAL"
+		And Using server "LOCAL"
+		And User "user0" from server "LOCAL" accepts last pending share
+		And as "user0" the file "/remote-share.txt" exists
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		When User "user0" deletes file "/remote-share.txt"
+		Then the HTTP status code should be "204"
+		And remote server is started
+		And as "user0" the file "/remote-share.txt" does not exist
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And Using server "REMOTE"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -375,28 +375,29 @@ Feature: federated
 		And user "user1" exists
 		# Rename file so it has a unique name in the target server (as the target
 		# server may have its own /textfile0.txt" file)
-		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
-		And User "user1" from server "REMOTE" shares "/remote-share.txt" with user "user0" from server "LOCAL"
-		And As an "user1"
+		And User "user0" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user0" from server "LOCAL" shares "/remote-share.txt" with user "user1" from server "REMOTE"
+		And Using server "LOCAL"
+		And As an "user0"
 		And sending "GET" to "/apps/files_sharing/api/v1/shares"
 		And the list of returned shares has 1 shares
-		And Using server "LOCAL"
-		And User "user0" from server "LOCAL" accepts last pending share
-		And as "user0" the file "/remote-share.txt" exists
-		And As an "user0"
+		And Using server "REMOTE"
+		And User "user1" from server "REMOTE" accepts last pending share
+		And as "user1" the file "/remote-share.txt" exists
+		And As an "user1"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 1 shares
-		And Using server "REMOTE"
-		When As an "user1"
+		And Using server "LOCAL"
+		When As an "user0"
 		And Deleting last share
 		Then the OCS status code should be "100"
 		And the HTTP status code should be "200"
-		And As an "user1"
+		And As an "user0"
 		And sending "GET" to "/apps/files_sharing/api/v1/shares"
 		And the list of returned shares has 0 shares
-		And Using server "LOCAL"
-		And as "user0" the file "/remote-share.txt" does not exist
-		And As an "user0"
+		And Using server "REMOTE"
+		And as "user1" the file "/remote-share.txt" does not exist
+		And As an "user1"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
 

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -495,6 +495,53 @@ Feature: federated
 		And sending "GET" to "/apps/files_sharing/api/v1/shares"
 		And the list of returned shares has 0 shares
 
+	Scenario: Delete federated group share from another server
+		Given Using server "LOCAL"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group0-user0" exists
+		And user "group0-user1" exists
+		And group "group0" exists
+		And user "group0-user0" belongs to group "group0"
+		And user "group0-user1" belongs to group "group0"
+		Given Using server "REMOTE"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with group "group0" from server "LOCAL"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+		And Using server "LOCAL"
+		And User "group0-user1" from server "LOCAL" accepts last pending share
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group0-user0" from server "LOCAL" accepts last pending share
+		And as "group0-user0" the file "/remote-share.txt" exists
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		When user "group0-user0" deletes last accepted remote group share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And as "group0-user0" the file "/remote-share.txt" does not exist
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 1 shares
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And Using server "REMOTE"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+
 	Scenario: Delete federated share from another server no longer reachable
 		Given Using server "LOCAL"
 		And user "user0" exists
@@ -518,6 +565,47 @@ Feature: federated
 		And As an "user0"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
+
+	Scenario: Delete federated group share from another server no longer reachable
+		Given Using server "LOCAL"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group0-user0" exists
+		And user "group0-user1" exists
+		And group "group0" exists
+		And user "group0-user0" belongs to group "group0"
+		And user "group0-user1" belongs to group "group0"
+		Given Using server "REMOTE"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with group "group0" from server "LOCAL"
+		And Using server "LOCAL"
+		And User "group0-user1" from server "LOCAL" accepts last pending share
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group0-user0" from server "LOCAL" accepts last pending share
+		And as "group0-user0" the file "/remote-share.txt" exists
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		When user "group0-user0" deletes last accepted remote group share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And as "group0-user0" the file "/remote-share.txt" does not exist
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 1 shares
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
 
 	Scenario: Delete federated share from another server when temporary unreachable
 		Given Using server "LOCAL"
@@ -543,6 +631,52 @@ Feature: federated
 		And As an "user0"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
+		And Using server "REMOTE"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+
+	Scenario: Delete federated group share from another server when temporary unreachable
+		Given Using server "LOCAL"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group0-user0" exists
+		And user "group0-user1" exists
+		And group "group0" exists
+		And user "group0-user0" belongs to group "group0"
+		And user "group0-user1" belongs to group "group0"
+		Given Using server "REMOTE"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with group "group0" from server "LOCAL"
+		And Using server "LOCAL"
+		And User "group0-user1" from server "LOCAL" accepts last pending share
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group0-user0" from server "LOCAL" accepts last pending share
+		And as "group0-user0" the file "/remote-share.txt" exists
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		When user "group0-user0" deletes last accepted remote group share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And remote server is started
+		And as "group0-user0" the file "/remote-share.txt" does not exist
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 1 shares
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
 		And Using server "REMOTE"
 		And As an "user1"
 		And sending "GET" to "/apps/files_sharing/api/v1/shares"
@@ -577,6 +711,52 @@ Feature: federated
 		And sending "GET" to "/apps/files_sharing/api/v1/shares"
 		And the list of returned shares has 0 shares
 
+	Scenario: Delete federated group share file from another server
+		Given Using server "LOCAL"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group0-user0" exists
+		And user "group0-user1" exists
+		And group "group0" exists
+		And user "group0-user0" belongs to group "group0"
+		And user "group0-user1" belongs to group "group0"
+		Given Using server "REMOTE"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with group "group0" from server "LOCAL"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+		And Using server "LOCAL"
+		And User "group0-user1" from server "LOCAL" accepts last pending share
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group0-user0" from server "LOCAL" accepts last pending share
+		And as "group0-user0" the file "/remote-share.txt" exists
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		When User "group0-user0" deletes file "/remote-share.txt"
+		Then the HTTP status code should be "204"
+		And as "group0-user0" the file "/remote-share.txt" does not exist
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 1 shares
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And Using server "REMOTE"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+
 	Scenario: Delete federated share file from another server no longer reachable
 		Given Using server "LOCAL"
 		And user "user0" exists
@@ -599,6 +779,46 @@ Feature: federated
 		And As an "user0"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
+
+	Scenario: Delete federated group share file from another server no longer reachable
+		Given Using server "LOCAL"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group0-user0" exists
+		And user "group0-user1" exists
+		And group "group0" exists
+		And user "group0-user0" belongs to group "group0"
+		And user "group0-user1" belongs to group "group0"
+		Given Using server "REMOTE"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with group "group0" from server "LOCAL"
+		And Using server "LOCAL"
+		And User "group0-user1" from server "LOCAL" accepts last pending share
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group0-user0" from server "LOCAL" accepts last pending share
+		And as "group0-user0" the file "/remote-share.txt" exists
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		When User "group0-user0" deletes file "/remote-share.txt"
+		Then the HTTP status code should be "204"
+		And as "group0-user0" the file "/remote-share.txt" does not exist
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 1 shares
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
 
 	Scenario: Delete federated share file from another server when temporary unreachable
 		Given Using server "LOCAL"
@@ -623,6 +843,51 @@ Feature: federated
 		And As an "user0"
 		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
 		And the list of returned shares has 0 shares
+		And Using server "REMOTE"
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+
+	Scenario: Delete federated group share file from another server when temporary unreachable
+		Given Using server "LOCAL"
+		And parameter "incoming_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "group0-user0" exists
+		And user "group0-user1" exists
+		And group "group0" exists
+		And user "group0-user0" belongs to group "group0"
+		And user "group0-user1" belongs to group "group0"
+		Given Using server "REMOTE"
+		And parameter "outgoing_server2server_group_share_enabled" of app "files_sharing" is set to "yes"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user1" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user1" from server "REMOTE" shares "/remote-share.txt" with group "group0" from server "LOCAL"
+		And Using server "LOCAL"
+		And User "group0-user1" from server "LOCAL" accepts last pending share
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And User "group0-user0" from server "LOCAL" accepts last pending share
+		And as "group0-user0" the file "/remote-share.txt" exists
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		When User "group0-user0" deletes file "/remote-share.txt"
+		Then the HTTP status code should be "204"
+		And remote server is started
+		And as "group0-user0" the file "/remote-share.txt" does not exist
+		And As an "group0-user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares/pending"
+		And the list of returned shares has 1 shares
+		And as "group0-user1" the file "/remote-share.txt" exists
+		And As an "group0-user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
 		And Using server "REMOTE"
 		And As an "user1"
 		And sending "GET" to "/apps/files_sharing/api/v1/shares"

--- a/build/integration/federation_features/federated.feature
+++ b/build/integration/federation_features/federated.feature
@@ -430,6 +430,41 @@ Feature: federated
 		And sending "GET" to "/apps/files_sharing/api/v1/shares"
 		And the list of returned shares has 0 shares
 
+	Scenario: Delete federated share with another server when temporary unreachable
+		Given Using server "LOCAL"
+		And user "user0" exists
+		Given Using server "REMOTE"
+		And user "user1" exists
+		# Rename file so it has a unique name in the target server (as the target
+		# server may have its own /textfile0.txt" file)
+		And User "user0" copies file "/textfile0.txt" to "/remote-share.txt"
+		And User "user0" from server "LOCAL" shares "/remote-share.txt" with user "user1" from server "REMOTE"
+		And Using server "LOCAL"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 1 shares
+		And Using server "REMOTE"
+		And User "user1" from server "REMOTE" accepts last pending share
+		And as "user1" the file "/remote-share.txt" exists
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 1 shares
+		And remote server is stopped
+		And Using server "LOCAL"
+		When As an "user0"
+		And Deleting last share
+		Then the OCS status code should be "100"
+		And the HTTP status code should be "200"
+		And As an "user0"
+		And sending "GET" to "/apps/files_sharing/api/v1/shares"
+		And the list of returned shares has 0 shares
+		And remote server is started
+		And Using server "REMOTE"
+		And as "user1" the file "/remote-share.txt" does not exist
+		And As an "user1"
+		And sending "GET" to "/apps/files_sharing/api/v1/remote_shares"
+		And the list of returned shares has 0 shares
+
 	Scenario: Delete federated share from another server
 		Given Using server "LOCAL"
 		And user "user0" exists


### PR DESCRIPTION
When a federated group share with another server is deleted a notification is sent to the remote server to delete the share. If that notification is not received then when the remote server tries to access the share again it will not be found in the sharer server, so it will be locally unshared in the remote server.

This works fine for user shares, as in that case the share is deleted in the remote server, but locally unsharing a received federated group share only marks it as pending again for the user that tried to access it. Due to that the received federated group share is left dangling in the remote server, and it is kept forever in the list of pending shares for the users in the group.

To solve that now the received federated group share is fully removed instead of simply unshared when no longer available in the sharer server; if the share was a user share it will be locally unshared like before, but if it is a group share it will be fully deleted.

Note that all of the above applies only when the sharer server is still available and it returns a "not found" error when the remote server tries to access the share. If the sharer server is not available accessing the received share just fails, as in that case it is not possible to know if the sharer server is temporarily unavailable or gone forever.

Besides the fix this pull request also adds an integration test to verify the behaviour (_Delete federated group share with another server when temporary unreachable_) as well as several other integration tests for deletion scenarios. Unit tests were also added for `removeShare` with group shares.

TODO / Open questions:
- [ ] Besides when no longer found in the sharer server the received group share is also removed if a `ForbiddenException` is received. I did that for consistency with the behaviour of user shares, but is that right or should the removal be limited to `NotFoundException`?
- [ ] Right now for simplicity `removeShare` was reused by adding a boolean `$force` parameter (which I am not a fan of). Should a different, explicit method be introduced instead?
- [ ] In the integration tests, although groups are removed after each scenario it seems that their remote group shares are not, which causes weird issues in (some) following tests due to the existing remote group shares in the database. To address that the `share_external` table is explicitly cleared before running a scenario. But... could that be a bug in itself? Should the remote group shares be automatically removed if the group they belong to is removed?
- [ ] Should there be (or does it exist but I am not aware of it) an OCC command or something similar to clear remote shares from a specific server to remove them if the remote server is gone forever?
- [ ] Reshares do not seem to be properly removed when a federated share is removed, even if both instances are up (it happens also with user shares, it is unrelated to the changes in this pull request)
