### PR TITLE
feat: drop support for php 8.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,12 +8,12 @@ steps:
   commands:
     - git submodule update --init
 - name: litmus-v1
-  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.0:latest
+  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.3:latest
   commands:
     - bash tests/travis/install.sh sqlite
     - bash apps/dav/tests/travis/litmus-v1/script.sh
 - name: litmus-v2
-  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.0:latest
+  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.3:latest
   commands:
     - bash tests/travis/install.sh sqlite
     - bash apps/dav/tests/travis/litmus-v2/script.sh
@@ -36,7 +36,7 @@ steps:
   commands:
     - git submodule update --init
 - name: caldavtester-new-endpoint
-  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.0:latest
+  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.3:latest
   commands:
     - bash tests/travis/install.sh sqlite
     - bash apps/dav/tests/travis/caldav/install.sh
@@ -60,7 +60,7 @@ steps:
   commands:
     - git submodule update --init
 - name: caldavtester-old-endpoint
-  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.0:latest
+  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.3:latest
   commands:
     - bash tests/travis/install.sh sqlite
     - bash apps/dav/tests/travis/caldav/install.sh
@@ -84,7 +84,7 @@ steps:
   commands:
     - git submodule update --init
 - name: carddavtester-new-endpoint
-  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.0:latest
+  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.3:latest
   commands:
     - bash tests/travis/install.sh sqlite
     - bash apps/dav/tests/travis/carddav/install.sh
@@ -108,7 +108,7 @@ steps:
   commands:
     - git submodule update --init
 - name: carddavtester-old-endpoint
-  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.0:latest
+  image: ghcr.io/nextcloud/continuous-integration-litmus-php8.3:latest
   commands:
     - bash tests/travis/install.sh sqlite
     - bash apps/dav/tests/travis/carddav/install.sh

--- a/.drone.yml
+++ b/.drone.yml
@@ -124,4 +124,4 @@ trigger:
 
 ---
 kind: signature
-hmac: f1a7a4774aef02c37a06ec6189d0acfefd847b66661ac4f6aab243f12f979158
+hmac: 1c487e85d1dba3fec3151868f8f94fc46b4ecb0f821c35516c193700cdbc2a9c

--- a/.github/workflows/files-external-ftp.yml
+++ b/.github/workflows/files-external-ftp.yml
@@ -41,10 +41,10 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.3']
+        php-versions: ['8.1', '8.3']
         ftpd: ['proftpd', 'vsftpd', 'pure-ftpd']
         include:
-          - php-versions: '8.0'
+          - php-versions: '8.1'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.ftpd }}

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}
@@ -115,7 +115,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/files-external-sftp.yml
+++ b/.github/workflows/files-external-sftp.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   schedule:
     - cron: "5 2 * * *"
-  
+
 concurrency:
   group: files-external-sftp-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -41,10 +41,10 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.0', '8.3']
+        php-versions: ['8.1', '8.3']
         sftpd: ['openssh']
         include:
-          - php-versions: '8.0'
+          - php-versions: '8.1'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-${{ matrix.sftpd }}

--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -39,9 +39,9 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.3']
+        php-versions: ['8.1', '8.3']
         include:
-          - php-versions: '8.0'
+          - php-versions: '8.1'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-smb

--- a/.github/workflows/files-external-webdav.yml
+++ b/.github/workflows/files-external-webdav.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -38,7 +38,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/integration-s3-primary.yml
+++ b/.github/workflows/integration-s3-primary.yml
@@ -41,7 +41,7 @@ jobs:
       # do not stop on another job's failure
       fail-fast: false
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         key: ['objectstore', 'objectstore_multibucket']
 
     name: php${{ matrix.php-versions }}-${{ matrix.key }}-minio

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: [ "8.0", "8.1", "8.2", "8.3" ]
+        php-versions: [ "8.1", "8.2", "8.3" ]
 
     name: php-lint
 

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -43,7 +43,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
 
     name: performance-${{ matrix.php-versions }}
 

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0','8.3']
+        php-versions: ['8.1','8.3']
 
     steps:
       - name: Checkout server

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         mariadb-versions: ['10.3', '10.4', '10.5', '10.6', '10.11']
         include:
           - php-versions: '8.3'

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         mysql-versions: ['8.0', '8.3']
         include:
           - mysql-versions: '8.0'

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -53,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         oracle-versions: ['11']
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.1']
         # To keep the matrix smaller we ignore PostgreSQL '11', '13', '14' as we already test 10 and 15 as lower and upper bound
         postgres-versions: ['10', '15', '16']
         include:

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.1'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:
@@ -56,7 +56,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@master
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: ctype,curl,dom,fileinfo,ftp,gd,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
 
@@ -84,7 +84,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: ctype,curl,dom,fileinfo,gd,intl,json,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:

--- a/.github/workflows/update-psalm-baseline.yml
+++ b/.github/workflows/update-psalm-baseline.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: apcu,ctype,curl,dom,fileinfo,ftp,gd,intl,json,ldap,mbstring,openssl,pdo_sqlite,posix,sqlite,xml,zip
           coverage: none
         env:

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2347,7 +2347,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @param int $syncLevel
 	 * @param int|null $limit
 	 * @param int $calendarType
-	 * @return array
+	 * @return ?array
 	 */
 	public function getChangesForCalendar($calendarId, $syncToken, $syncLevel, $limit = null, $calendarType = self::CALENDAR_TYPE_CALENDAR) {
 		$table = $calendarType === self::CALENDAR_TYPE_CALENDAR ? 'calendars': 'calendarsubscriptions';

--- a/apps/settings/lib/SetupChecks/PhpOutdated.php
+++ b/apps/settings/lib/SetupChecks/PhpOutdated.php
@@ -46,8 +46,8 @@ class PhpOutdated implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		if (PHP_VERSION_ID < 80100) {
-			return SetupResult::warning($this->l10n->t('You are currently running PHP %s. PHP 8.0 is now deprecated in Nextcloud 27. Nextcloud 28 may require at least PHP 8.1. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [PHP_VERSION]), 'https://secure.php.net/supported-versions.php');
+		if (PHP_VERSION_ID < 80200) {
+			return SetupResult::warning($this->l10n->t('You are currently running PHP %s. PHP 8.1 is now deprecated in Nextcloud 30. Nextcloud 31 may require at least PHP 8.2. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [PHP_VERSION]), 'https://secure.php.net/supported-versions.php');
 		}
 		return SetupResult::success($this->l10n->t('You are currently running PHP %s.', [PHP_VERSION]));
 	}

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -38,6 +38,11 @@
       <code>array</code>
     </LessSpecificImplementedReturnType>
   </file>
+  <file src="3rdparty/symfony/routing/Route.php">
+    <MethodSignatureMustProvideReturnType>
+      <code>unserialize</code>
+    </MethodSignatureMustProvideReturnType>
+  </file>
   <file src="apps/comments/lib/Notification/Listener.php">
     <LessSpecificReturnStatement>
       <code>$uids</code>
@@ -109,7 +114,6 @@
   <file src="apps/dav/lib/CalDAV/CalDavBackend.php">
     <InvalidNullableReturnType>
       <code>array</code>
-      <code>array</code>
     </InvalidNullableReturnType>
     <LessSpecificReturnStatement>
       <code>Reader::read($objectData)</code>
@@ -123,86 +127,6 @@
       <code>VCalendar</code>
     </MoreSpecificReturnType>
     <NullableReturnStatement>
-      <code><![CDATA[$this->atomic(function () use ($calendarId, $syncToken, $syncLevel, $limit, $calendarType) {
-			// Current synctoken
-			$qb = $this->db->getQueryBuilder();
-			$qb->select('synctoken')
-				->from('calendars')
-				->where(
-					$qb->expr()->eq('id', $qb->createNamedParameter($calendarId))
-				);
-			$stmt = $qb->executeQuery();
-			$currentToken = $stmt->fetchOne();
-
-			if ($currentToken === false) {
-				return null;
-			}
-
-			$result = [
-				'syncToken' => $currentToken,
-				'added' => [],
-				'modified' => [],
-				'deleted' => [],
-			];
-
-			if ($syncToken) {
-				$qb = $this->db->getQueryBuilder();
-
-				$qb->select('uri', 'operation')
-					->from('calendarchanges')
-					->where(
-						$qb->expr()->andX(
-							$qb->expr()->gte('synctoken', $qb->createNamedParameter($syncToken)),
-							$qb->expr()->lt('synctoken', $qb->createNamedParameter($currentToken)),
-							$qb->expr()->eq('calendarid', $qb->createNamedParameter($calendarId)),
-							$qb->expr()->eq('calendartype', $qb->createNamedParameter($calendarType))
-						)
-					)->orderBy('synctoken');
-				if (is_int($limit) && $limit > 0) {
-					$qb->setMaxResults($limit);
-				}
-
-				// Fetching all changes
-				$stmt = $qb->executeQuery();
-				$changes = [];
-
-				// This loop ensures that any duplicates are overwritten, only the
-				// last change on a node is relevant.
-				while ($row = $stmt->fetch()) {
-					$changes[$row['uri']] = $row['operation'];
-				}
-				$stmt->closeCursor();
-
-				foreach ($changes as $uri => $operation) {
-					switch ($operation) {
-						case 1:
-							$result['added'][] = $uri;
-							break;
-						case 2:
-							$result['modified'][] = $uri;
-							break;
-						case 3:
-							$result['deleted'][] = $uri;
-							break;
-					}
-				}
-			} else {
-				// No synctoken supplied, this is the initial sync.
-				$qb = $this->db->getQueryBuilder();
-				$qb->select('uri')
-					->from('calendarobjects')
-					->where(
-						$qb->expr()->andX(
-							$qb->expr()->eq('calendarid', $qb->createNamedParameter($calendarId)),
-							$qb->expr()->eq('calendartype', $qb->createNamedParameter($calendarType))
-						)
-					);
-				$stmt = $qb->executeQuery();
-				$result['added'] = $stmt->fetchAll(\PDO::FETCH_COLUMN);
-				$stmt->closeCursor();
-			}
-			return $result;
-		}, $this->db)]]></code>
       <code>null</code>
     </NullableReturnStatement>
   </file>
@@ -312,7 +236,7 @@
     </RedundantCast>
     <RedundantCondition>
       <code><![CDATA[!empty($modified['old']) && is_array($modified['old'])]]></code>
-      <code>is_array($modified['old'])</code>
+      <code><![CDATA[is_array($modified['old'])]]></code>
     </RedundantCondition>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipService.php">
@@ -323,8 +247,8 @@
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/Plugin.php">
     <InvalidArgument>
-      <code>[$aclPlugin, 'propFind']</code>
-      <code>[$aclPlugin, 'propFind']</code>
+      <code><![CDATA[[$aclPlugin, 'propFind']]]></code>
+      <code><![CDATA[[$aclPlugin, 'propFind']]]></code>
     </InvalidArgument>
     <LessSpecificReturnStatement>
       <code><![CDATA[$vevent->DTEND]]></code>
@@ -359,12 +283,12 @@
   </file>
   <file src="apps/dav/lib/CalDAV/Search/Xml/Request/CalendarSearchReport.php">
     <TypeDoesNotContainType>
-      <code>!is_array($newProps['filters']['comps'])</code>
-      <code>!is_array($newProps['filters']['params'])</code>
-      <code>!is_array($newProps['filters']['props'])</code>
-      <code>!isset($newProps['filters']['comps']) || !is_array($newProps['filters']['comps'])</code>
-      <code>!isset($newProps['filters']['params']) || !is_array($newProps['filters']['params'])</code>
-      <code>!isset($newProps['filters']['props']) || !is_array($newProps['filters']['props'])</code>
+      <code><![CDATA[!is_array($newProps['filters']['comps'])]]></code>
+      <code><![CDATA[!is_array($newProps['filters']['params'])]]></code>
+      <code><![CDATA[!is_array($newProps['filters']['props'])]]></code>
+      <code><![CDATA[!isset($newProps['filters']['comps']) || !is_array($newProps['filters']['comps'])]]></code>
+      <code><![CDATA[!isset($newProps['filters']['params']) || !is_array($newProps['filters']['params'])]]></code>
+      <code><![CDATA[!isset($newProps['filters']['props']) || !is_array($newProps['filters']['props'])]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php">
@@ -400,7 +324,7 @@
       <code>VCard</code>
     </MoreSpecificReturnType>
     <TypeDoesNotContainType>
-      <code>$addressBooks[$row['id']][$readOnlyPropertyName] === 0</code>
+      <code><![CDATA[$addressBooks[$row['id']][$readOnlyPropertyName] === 0]]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="apps/dav/lib/CardDAV/MultiGetExportPlugin.php">
@@ -502,7 +426,7 @@
       <code>bool</code>
     </InvalidNullableReturnType>
     <TooManyArguments>
-      <code>new PreconditionFailed('Cannot filter by non-existing tag', 0, $e)</code>
+      <code><![CDATA[new PreconditionFailed('Cannot filter by non-existing tag', 0, $e)]]></code>
     </TooManyArguments>
     <UndefinedClass>
       <code>\OCA\Circles\Api\v1\Circles</code>
@@ -767,7 +691,7 @@
   </file>
   <file src="apps/encryption/lib/Crypto/Crypt.php">
     <TypeDoesNotContainType>
-      <code>get_class($res) === 'OpenSSLAsymmetricKey'</code>
+      <code><![CDATA[get_class($res) === 'OpenSSLAsymmetricKey']]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="apps/encryption/lib/Crypto/Encryption.php">
@@ -782,7 +706,7 @@
   </file>
   <file src="apps/encryption/lib/Session.php">
     <TooManyArguments>
-      <code>new Exceptions\PrivateKeyMissingException('please try to log-out and log-in again', 0)</code>
+      <code><![CDATA[new Exceptions\PrivateKeyMissingException('please try to log-out and log-in again', 0)]]></code>
     </TooManyArguments>
   </file>
   <file src="apps/encryption/lib/Util.php">
@@ -810,7 +734,7 @@
       <code>$shareId</code>
       <code>$shareId</code>
       <code>$shareId</code>
-      <code>(int)$data['id']</code>
+      <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
   </file>
   <file src="apps/federatedfilesharing/lib/Notifications.php">
@@ -834,7 +758,7 @@
       <code>string</code>
     </InvalidReturnType>
     <InvalidScalarArgument>
-      <code>(int)$share['id']</code>
+      <code><![CDATA[(int)$share['id']]]></code>
     </InvalidScalarArgument>
   </file>
   <file src="apps/federation/lib/DbHandler.php">
@@ -1063,7 +987,7 @@
   </file>
   <file src="apps/files_sharing/templates/public.php">
     <RedundantCondition>
-      <code>$_['hideFileList'] !== true</code>
+      <code><![CDATA[$_['hideFileList'] !== true]]></code>
       <code><![CDATA[isset($_['hideFileList']) && $_['hideFileList'] !== true]]></code>
     </RedundantCondition>
   </file>
@@ -1193,7 +1117,7 @@
   <file src="apps/sharebymail/lib/ShareByMailProvider.php">
     <InvalidArgument>
       <code><![CDATA[$share->getId()]]></code>
-      <code>(int)$data['id']</code>
+      <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
   </file>
   <file src="apps/systemtags/lib/Activity/Listener.php">
@@ -1201,11 +1125,6 @@
       <code><![CDATA[$event->getObjectId()]]></code>
       <code><![CDATA[$event->getObjectId()]]></code>
     </InvalidArgument>
-  </file>
-  <file src="apps/theming/lib/Jobs/MigrateBackgroundImages.php">
-    <OverriddenInterfaceConstant>
-      <code>TIME_SENSITIVE</code>
-    </OverriddenInterfaceConstant>
   </file>
   <file src="apps/theming/lib/Util.php">
     <InvalidReturnStatement>
@@ -1512,7 +1431,6 @@
   <file src="core/routes.php">
     <InvalidScope>
       <code>$this</code>
-      <code>$this</code>
       <code><![CDATA[$this->create('core_ajax_update', '/core/ajax/update.php')]]></code>
     </InvalidScope>
   </file>
@@ -1682,7 +1600,7 @@
   </file>
   <file src="lib/private/AppFramework/Routing/RouteConfig.php">
     <InvalidArrayOffset>
-      <code>$action['url-postfix']</code>
+      <code><![CDATA[$action['url-postfix']]]></code>
     </InvalidArrayOffset>
   </file>
   <file src="lib/private/AppFramework/Services/AppConfig.php">
@@ -1771,20 +1689,6 @@
       <code>setToken</code>
       <code>setType</code>
     </UndefinedMagicMethod>
-  </file>
-  <file src="lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[array_map(function (array $row) {
-			return [
-				'provider_id' => $row['provider_id'],
-				'uid' => $row['uid'],
-				'enabled' => 1 === (int) $row['enabled'],
-			];
-		}, $rows)]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[list<array{provider_id: string, uid: string, enabled: bool}>]]></code>
-    </MoreSpecificReturnType>
   </file>
   <file src="lib/private/Authentication/TwoFactorAuth/ProviderSet.php">
     <InvalidArgument>
@@ -1906,7 +1810,7 @@
       <code>getParams</code>
     </InternalMethod>
     <InvalidArrayOffset>
-      <code>$params['collation']</code>
+      <code><![CDATA[$params['collation']]]></code>
     </InvalidArrayOffset>
   </file>
   <file src="lib/private/DB/Connection.php">
@@ -1917,8 +1821,8 @@
       <code>$params</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$params['adapter']</code>
-      <code>$params['tablePrefix']</code>
+      <code><![CDATA[$params['adapter']]]></code>
+      <code><![CDATA[$params['tablePrefix']]]></code>
     </InvalidArrayOffset>
   </file>
   <file src="lib/private/DB/Exceptions/DbalException.php">
@@ -1951,7 +1855,7 @@
       <code>getParams</code>
     </InternalMethod>
     <InvalidArrayOffset>
-      <code>$params['collation']</code>
+      <code><![CDATA[$params['collation']]]></code>
     </InvalidArrayOffset>
   </file>
   <file src="lib/private/DB/QueryBuilder/QueryBuilder.php">
@@ -1980,10 +1884,6 @@
 			'width' => $format,
 		])]]></code>
     </FalsableReturnStatement>
-    <InvalidDocblock>
-      <code>public function formatDateSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null) {</code>
-      <code>public function formatTimeSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null) {</code>
-    </InvalidDocblock>
     <InvalidReturnStatement>
       <code><![CDATA[$l->l($type, $timestamp, [
 			'width' => $format,
@@ -2146,10 +2046,10 @@
       <code>$user</code>
     </InvalidOperand>
     <RedundantCondition>
-      <code>get_class($provider) !== 'OCA\Files_Sharing\MountProvider'</code>
+      <code><![CDATA[get_class($provider) !== 'OCA\Files_Sharing\MountProvider']]></code>
     </RedundantCondition>
     <TypeDoesNotContainType>
-      <code>get_class($provider) === 'OCA\Files_Sharing\MountProvider'</code>
+      <code><![CDATA[get_class($provider) === 'OCA\Files_Sharing\MountProvider']]></code>
     </TypeDoesNotContainType>
   </file>
   <file src="lib/private/Files/Config/UserMountCache.php">
@@ -2215,7 +2115,6 @@
     </MoreSpecificImplementedParamType>
     <MoreSpecificReturnType>
       <code>\OC\Files\Node\Node</code>
-      <code>\OC\Files\Node\Node[]</code>
       <code>\OC\Files\Node\Node[]</code>
     </MoreSpecificReturnType>
   </file>
@@ -2313,7 +2212,7 @@
       <code>Promise\promise_for(
 					new Credentials($key, $secret)
 				)</code>
-      <code>\Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider())</code>
+      <code><![CDATA[\Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider())]]></code>
     </UndefinedFunction>
   </file>
   <file src="lib/private/Files/ObjectStore/S3ObjectTrait.php">
@@ -2561,8 +2460,8 @@
       <code>false</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$app['path']</code>
-      <code>$app['path']</code>
+      <code><![CDATA[$app['path']]]></code>
+      <code><![CDATA[$app['path']]]></code>
     </InvalidArrayOffset>
     <NullArgument>
       <code>null</code>
@@ -2884,7 +2783,7 @@
   </file>
   <file src="lib/private/Setup.php">
     <RedundantCondition>
-      <code>$type === 'pdo'</code>
+      <code><![CDATA[$type === 'pdo']]></code>
     </RedundantCondition>
     <UndefinedVariable>
       <code>$vendor</code>
@@ -2905,7 +2804,7 @@
     <InvalidArgument>
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[$share->getId()]]></code>
-      <code>(int)$data['id']</code>
+      <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
     <TooManyArguments>
       <code>set</code>
@@ -3097,8 +2996,8 @@
       <code>$groupsList</code>
     </InvalidArgument>
     <InvalidArrayOffset>
-      <code>$dir['path']</code>
-      <code>$dir['url']</code>
+      <code><![CDATA[$dir['path']]]></code>
+      <code><![CDATA[$dir['url']]]></code>
     </InvalidArrayOffset>
     <NullArgument>
       <code>null</code>

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "8.0"
+			"php": "8.1"
 		},
 		"allow-plugins": {
 			"bamarni/composer-bin-plugin": true
@@ -23,7 +23,7 @@
 		}
 	},
 	"require": {
-		"php": "^8.0",
+		"php": "^8.1",
 		"ext-ctype": "*",
 		"ext-curl": "*",
 		"ext-dom": "*",

--- a/lib/composer/composer/platform_check.php
+++ b/lib/composer/composer/platform_check.php
@@ -4,8 +4,8 @@
 
 $issues = array();
 
-if (!(PHP_VERSION_ID >= 80000)) {
-    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.0.0". You are running ' . PHP_VERSION . '.';
+if (!(PHP_VERSION_ID >= 80100)) {
+    $issues[] = 'Your Composer dependencies require a PHP version ">= 8.1.0". You are running ' . PHP_VERSION . '.';
 }
 
 if ($issues) {

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -60,7 +60,7 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 	 * @psalm-param S $id
 	 * @psalm-return (S is class-string<T> ? T : mixed)
 	 */
-	public function get(string $id) {
+	public function get(string $id): mixed {
 		return $this->query($id);
 	}
 

--- a/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
+++ b/lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php
@@ -91,8 +91,6 @@ class ProviderUserAssignmentDao {
 	/**
 	 * Delete all provider states of a user and return the provider IDs
 	 *
-	 * @param string $uid
-	 *
 	 * @return list<array{provider_id: string, uid: string, enabled: bool}>
 	 */
 	public function deleteByUser(string $uid): array {
@@ -100,7 +98,7 @@ class ProviderUserAssignmentDao {
 		$selectQuery = $qb1->select('*')
 			->from(self::TABLE_NAME)
 			->where($qb1->expr()->eq('uid', $qb1->createNamedParameter($uid)));
-		$selectResult = $selectQuery->execute();
+		$selectResult = $selectQuery->executeQuery();
 		$rows = $selectResult->fetchAll();
 		$selectResult->closeCursor();
 
@@ -108,15 +106,15 @@ class ProviderUserAssignmentDao {
 		$deleteQuery = $qb2
 			->delete(self::TABLE_NAME)
 			->where($qb2->expr()->eq('uid', $qb2->createNamedParameter($uid)));
-		$deleteQuery->execute();
+		$deleteQuery->executeStatement();
 
-		return array_map(function (array $row) {
+		return array_values(array_map(function (array $row) {
 			return [
-				'provider_id' => $row['provider_id'],
-				'uid' => $row['uid'],
-				'enabled' => (int) $row['enabled'] === 1,
+				'provider_id' => (string)$row['provider_id'],
+				'uid' => (string)$row['uid'],
+				'enabled' => ((int) $row['enabled']) === 1,
 			];
-		}, $rows);
+		}, $rows));
 	}
 
 	public function deleteAll(string $providerId): void {

--- a/lib/private/DB/QueryBuilder/Literal.php
+++ b/lib/private/DB/QueryBuilder/Literal.php
@@ -32,10 +32,7 @@ class Literal implements ILiteral {
 		$this->literal = $literal;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function __toString() {
+	public function __toString(): string {
 		return (string) $this->literal;
 	}
 }

--- a/lib/private/DB/QueryBuilder/Parameter.php
+++ b/lib/private/DB/QueryBuilder/Parameter.php
@@ -31,10 +31,7 @@ class Parameter implements IParameter {
 		$this->name = $name;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function __toString() {
+	public function __toString(): string {
 		return (string) $this->name;
 	}
 }

--- a/lib/private/DB/QueryBuilder/QueryFunction.php
+++ b/lib/private/DB/QueryBuilder/QueryFunction.php
@@ -31,10 +31,7 @@ class QueryFunction implements IQueryFunction {
 		$this->function = $function;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function __toString() {
+	public function __toString(): string {
 		return (string) $this->function;
 	}
 }

--- a/lib/private/Diagnostics/Event.php
+++ b/lib/private/Diagnostics/Event.php
@@ -101,7 +101,7 @@ class Event implements IEvent {
 		return $this->end - $this->start;
 	}
 
-	public function __toString() {
+	public function __toString(): string {
 		return $this->getId() . ' ' . $this->getDescription() . ' ' . $this->getDuration();
 	}
 }

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -419,7 +419,7 @@ class OC_Image implements \OCP\IImage {
 	/**
 	 * @return string - base64 encoded, which is suitable for embedding in a VCard.
 	 */
-	public function __toString() {
+	public function __toString(): string {
 		return base64_encode($this->data());
 	}
 

--- a/lib/public/Files/LockNotAcquiredException.php
+++ b/lib/public/Files/LockNotAcquiredException.php
@@ -50,10 +50,9 @@ class LockNotAcquiredException extends \Exception {
 	/**
 	 * custom string representation of object
 	 *
-	 * @return string
 	 * @since 7.0.0
 	 */
-	public function __toString() {
+	public function __toString(): string {
 		return __CLASS__ . ": [{$this->code}]: {$this->message}\n";
 	}
 }

--- a/lib/versioncheck.php
+++ b/lib/versioncheck.php
@@ -25,10 +25,10 @@ declare(strict_types=1);
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-// Show warning if a PHP version below 8.0 is used,
-if (PHP_VERSION_ID < 80000) {
+// Show warning if a PHP version below 8.1 is used,
+if (PHP_VERSION_ID < 80100) {
 	http_response_code(500);
-	echo 'This version of Nextcloud requires at least PHP 8.0<br/>';
+	echo 'This version of Nextcloud requires at least PHP 8.1<br/>';
 	echo 'You are currently running ' . PHP_VERSION . '. Please update your PHP version.';
 	exit(1);
 }


### PR DESCRIPTION
## Summary

PHP 8.0 has been EOL for a long time now. Even debian stable is on PHP 8.2[^1].

This change should also be reflected in the documentation and workflow template repository.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

[^1]: https://packages.debian.org/bookworm/php
