### PR TITLE
[stable26] fix(auth): Log when authtoken activity is updated in a transaction

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\Token;
 
+use Exception;
 use OC\Authentication\Exceptions\ExpiredTokenException;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Exceptions\TokenPasswordExpiredException;
@@ -296,6 +297,9 @@ class PublicKeyTokenProvider implements IProvider {
 		$now = $this->time->getTime();
 		if ($token->getLastActivity() < ($now - $activityInterval)) {
 			$token->setLastActivity($now);
+			if ($this->db->inTransaction()) {
+				$this->logger->error('Auth token update is executed in a transaction', ['exception' => new Exception('Auth token update is executed in a transaction')]);
+			}
 			$this->mapper->updateActivity($token, $now);
 		}
 	}

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -280,6 +280,9 @@ class PublicKeyTokenProvider implements IProvider {
 		if (!($token instanceof PublicKeyToken)) {
 			throw new InvalidTokenException("Invalid token type");
 		}
+		if ($this->db->inTransaction()) {
+			$this->logger->error('Auth token update is executed in a transaction', ['exception' => new Exception('Auth token update is executed in a transaction')]);
+		}
 		$this->mapper->update($token);
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
