### PR TITLE
fix(tests): Fix tests when daytime saving time change happened recently

### DIFF
--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -1536,6 +1536,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$save = clone $nextWeek;
 		$save->setTime(0, 0);
+		$save->sub(new \DateInterval('P2D'));
 		$save->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
 		$hookListener = $this->getMockBuilder('Dummy')->setMethods(['listener'])->getMock();
@@ -1549,7 +1550,6 @@ class ManagerTest extends \Test\TestCase {
 
 		self::invokePrivate($this->manager, 'validateExpirationDateLink', [$share]);
 
-		$save->sub(new \DateInterval('P2D'));
 		$this->assertEquals($save, $share->getExpirationDate());
 	}
 


### PR DESCRIPTION
## Summary

Fix the quite corner case we are currently having in CI: recent daytime saving time change in Europe is making the share date expiration test fail.
Somehow the tests are also not correctly independent and having this one fail messed up 6 others, by leaving behind a hook expectation it seems.

The bug comes from the order of timezone change and day removal, if you change timezone first and remove 2 days after you do not get the same hours as if you do it the other way around.
Can be tested with this:
```php
<?php

$timezone = new \DateTimeZone('Pacific/Auckland');
$nextWeek = new \DateTime('now', $timezone);
$nextWeek->add(new \DateInterval('P7D'));

$save = clone $nextWeek;
$save->setTime(0, 0);
$save->sub(new \DateInterval('P2D'));
$save->setTimezone(new \DateTimeZone(date_default_timezone_get()));

$save2 = clone $nextWeek;
$save2->setTime(0, 0);
$save2->setTimezone(new \DateTimeZone(date_default_timezone_get()));
$save2->sub(new \DateInterval('P2D'));
		
var_dump(
    $nextWeek,
    $save,
    $save2,
);
```

Current output (on 2024-04-02):
```
object(DateTime)#2 (3) {
  ["date"]=>
  string(26) "2024-04-09 22:29:22.491335"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(16) "Pacific/Auckland"
}
object(DateTime)#3 (3) {
  ["date"]=>
  string(26) "2024-04-06 13:00:00.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(16) "Europe/Amsterdam"
}
object(DateTime)#4 (3) {
  ["date"]=>
  string(26) "2024-04-06 14:00:00.000000"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(16) "Europe/Amsterdam"
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
