### PR TITLE
fix(federation): ICloudId->getRemote() should contain the protocol

### DIFF
--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -174,7 +174,6 @@ class CloudIdManager implements ICloudIdManager {
 		// note that for remote id's we don't strip the protocol for the remote we use to construct the CloudId
 		// this way if a user has an explicit non-https cloud id this will be preserved
 		// we do still use the version without protocol for looking up the display name
-		$remote = $this->removeProtocolFromUrl($remote, true);
 		$remote = $this->fixRemoteURL($remote);
 		$host = $this->removeProtocolFromUrl($remote);
 
@@ -191,7 +190,9 @@ class CloudIdManager implements ICloudIdManager {
 		} else {
 			$displayName = $this->getDisplayNameFromContact($user . '@' . $host);
 		}
-		$id = $user . '@' . $remote;
+
+		// For the visible cloudID we only strip away https
+		$id = $user . '@' . $this->removeProtocolFromUrl($remote, true);
 
 		$data = [
 			'id' => $id,

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -128,11 +128,11 @@ class CloudIdManagerTest extends TestCase {
 		return [
 			['test', 'example.com', 'test@example.com'],
 			['test', 'http://example.com', 'test@http://example.com', 'test@example.com'],
-			['test', null, 'test@http://example.com', 'test@example.com', 'http://example.com'],
+			['test', null, 'test@http://example.com', 'test@example.com', 'http://example.com', 'http://example.com'],
 			['test@example.com', 'example.com', 'test@example.com@example.com'],
 			['test@example.com', 'https://example.com', 'test@example.com@example.com'],
-			['test@example.com', null, 'test@example.com@example.com'],
-			['test@example.com', 'https://example.com/index.php/s/shareToken', 'test@example.com@example.com'],
+			['test@example.com', null, 'test@example.com@example.com', null, 'https://example.com', 'https://example.com'],
+			['test@example.com', 'https://example.com/index.php/s/shareToken', 'test@example.com@example.com', null, 'https://example.com', 'https://example.com'],
 		];
 	}
 
@@ -143,7 +143,7 @@ class CloudIdManagerTest extends TestCase {
 	 * @param null|string $remote
 	 * @param string $id
 	 */
-	public function testGetCloudId(string $user, ?string $remote, string $id, ?string $searchCloudId = null, ?string $localHost = 'https://example.com'): void {
+	public function testGetCloudId(string $user, ?string $remote, string $id, ?string $searchCloudId = null, ?string $localHost = 'https://example.com', ?string $expectedRemoteId = null): void {
 		if ($remote !== null) {
 			$this->contactsManager->expects($this->any())
 				->method('search')
@@ -159,9 +159,11 @@ class CloudIdManagerTest extends TestCase {
 				->method('getAbsoluteUrl')
 				->willReturn($localHost);
 		}
+		$expectedRemoteId ??= $remote;
 
 		$cloudId = $this->cloudIdManager->getCloudId($user, $remote);
 
-		$this->assertEquals($id, $cloudId->getId());
+		$this->assertEquals($id, $cloudId->getId(), 'Cloud ID');
+		$this->assertEquals($expectedRemoteId, $cloudId->getRemote(), 'Remote URL');
 	}
 }


### PR DESCRIPTION
* Resolves: #44608 
* Regression from #44453 

## Summary

the `getRemote()` field should always contain the protocol as it's used directly in web requests, only the visible cloudId should have `https://` stripped out.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
