### PR TITLE
fix(appconfig): returns correct value on details

### DIFF
--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -173,8 +173,8 @@ class SetConfig extends Base {
 			 */
 			$sensitive = $input->getOption('sensitive');
 			try {
-				$currSensitive = $this->appConfig->isLazy($appName, $configName);
-				if ($sensitive === null || $sensitive === $currSensitive || !$this->ask($input, $output, ($sensitive) ? 'LAZY' : 'NOT LAZY')) {
+				$currSensitive = $this->appConfig->isSensitive($appName, $configName, null);
+				if ($sensitive === null || $sensitive === $currSensitive || !$this->ask($input, $output, ($sensitive) ? 'SENSITIVE' : 'NOT SENSITIVE')) {
 					$sensitive = $currSensitive;
 				}
 			} catch (AppConfigUnknownKeyException) {

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1034,14 +1034,20 @@ class AppConfig implements IAppConfig {
 			throw new AppConfigUnknownKeyException('unknown config key');
 		}
 
+		$value = $cache[$app][$key];
+		$sensitive = $this->isSensitive($app, $key, null);
+		if ($sensitive && str_starts_with($value, self::ENCRYPTION_PREFIX)) {
+			$value = $this->crypto->decrypt(substr($value, self::ENCRYPTION_PREFIX_LENGTH));
+		}
+
 		return [
 			'app' => $app,
 			'key' => $key,
-			'value' => $cache[$app][$key],
+			'value' => $value,
 			'type' => $type,
 			'lazy' => $lazy,
 			'typeString' => $typeString,
-			'sensitive' => $this->isSensitive($app, $key, null)
+			'sensitive' => $sensitive
 		];
 	}
 

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -1253,7 +1253,7 @@ class AppConfigTest extends TestCase {
 			[
 				'app' => 'sensitive-app',
 				'key' => 'lazy-key',
-				'value' => $this->baseStruct['sensitive-app']['lazy-key']['encrypted'],
+				'value' => 'value',
 				'type' => 4,
 				'lazy' => true,
 				'typeString' => 'string',


### PR DESCRIPTION
fixing 2 issues:

- `--sensitive`/`--no-sensitive` were not well processed when running `occ config:app:set`
- `getDetails()` now returns correct (decrypted) value on sensitive data


**Before**
```
$ ./occ config:app:set myapp key2 --value 12343cc --sensitive 
Config value 'key2' for app 'myapp' is now set to '$AppConfigEncryption$71598bcf15f456ba7d37e4a80b04baa4|e8b8d16786364e91d65333c2456919c5|55769ff0d438c6fb261b70a7c211ab899c88cce9b472b5efe42e98db7abfe1c59900bd60a111769935bccedb7fc1ec9f1d66ba66d9ee38a13de8730a119826ba|3', stored as string in fast cache
```

**After**
```
$ ./occ config:app:set myapp key2 --value 12343cc --sensitive 
Config value 'key2' for app 'myapp' is now set to '12343cc', stored as string in fast cache
```

### Also, when displaying details

**Before**
```
$ ./occ config:app:get myapp key2  --details 
  - app: myapp
  - key: key2
  - value: $AppConfigEncryption$f7caf4b86c21e1a4c6d8558ac031e71d|dfb2aafbc1390e938f71fed742527cf1|4c7622db35fc58e4ed620324ad2a0d16c19569cc7adb5099cb971f889217539423b9297bdbff5ce38ca57e688b575264c2bbe96442b7820944fe1bd7918eabdb|3
  - type: string
  - lazy: false
  - sensitive: true
```

**After**
```
$ ./occ config:app:get myapp key2  --details 
  - app: myapp
  - key: key2
  - value: 12343cc
  - type: string
  - lazy: false
  - sensitive: true
```
