### PR TITLE
feat(trashbin): Add deleted by properties

### DIFF
--- a/apps/files_trashbin/composer/composer/autoload_classmap.php
+++ b/apps/files_trashbin/composer/composer/autoload_classmap.php
@@ -26,6 +26,7 @@ return array(
     'OCA\\Files_Trashbin\\Listeners\\LoadAdditionalScripts' => $baseDir . '/../lib/Listeners/LoadAdditionalScripts.php',
     'OCA\\Files_Trashbin\\Listeners\\SyncLivePhotosListener' => $baseDir . '/../lib/Listeners/SyncLivePhotosListener.php',
     'OCA\\Files_Trashbin\\Migration\\Version1010Date20200630192639' => $baseDir . '/../lib/Migration/Version1010Date20200630192639.php',
+    'OCA\\Files_Trashbin\\Migration\\Version1020Date20240403003535' => $baseDir . '/../lib/Migration/Version1020Date20240403003535.php',
     'OCA\\Files_Trashbin\\Sabre\\AbstractTrash' => $baseDir . '/../lib/Sabre/AbstractTrash.php',
     'OCA\\Files_Trashbin\\Sabre\\AbstractTrashFile' => $baseDir . '/../lib/Sabre/AbstractTrashFile.php',
     'OCA\\Files_Trashbin\\Sabre\\AbstractTrashFolder' => $baseDir . '/../lib/Sabre/AbstractTrashFolder.php',

--- a/apps/files_trashbin/composer/composer/autoload_static.php
+++ b/apps/files_trashbin/composer/composer/autoload_static.php
@@ -41,6 +41,7 @@ class ComposerStaticInitFiles_Trashbin
         'OCA\\Files_Trashbin\\Listeners\\LoadAdditionalScripts' => __DIR__ . '/..' . '/../lib/Listeners/LoadAdditionalScripts.php',
         'OCA\\Files_Trashbin\\Listeners\\SyncLivePhotosListener' => __DIR__ . '/..' . '/../lib/Listeners/SyncLivePhotosListener.php',
         'OCA\\Files_Trashbin\\Migration\\Version1010Date20200630192639' => __DIR__ . '/..' . '/../lib/Migration/Version1010Date20200630192639.php',
+        'OCA\\Files_Trashbin\\Migration\\Version1020Date20240403003535' => __DIR__ . '/..' . '/../lib/Migration/Version1020Date20240403003535.php',
         'OCA\\Files_Trashbin\\Sabre\\AbstractTrash' => __DIR__ . '/..' . '/../lib/Sabre/AbstractTrash.php',
         'OCA\\Files_Trashbin\\Sabre\\AbstractTrashFile' => __DIR__ . '/..' . '/../lib/Sabre/AbstractTrashFile.php',
         'OCA\\Files_Trashbin\\Sabre\\AbstractTrashFolder' => __DIR__ . '/..' . '/../lib/Sabre/AbstractTrashFolder.php',

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -60,7 +60,7 @@ class Helper {
 		$absoluteDir = $view->getAbsolutePath($dir);
 		$internalPath = $mount->getInternalPath($absoluteDir);
 
-		$originalLocations = \OCA\Files_Trashbin\Trashbin::getLocations($user);
+		$extraData = \OCA\Files_Trashbin\Trashbin::getExtraData($user);
 		$dirContent = $storage->getCache()->getFolderContents($mount->getInternalPath($view->getAbsolutePath($dir)));
 		foreach ($dirContent as $entry) {
 			$entryName = $entry->getName();
@@ -76,8 +76,8 @@ class Helper {
 			}
 			$originalPath = '';
 			$originalName = substr($entryName, 0, -strlen($timestamp) - 2);
-			if (isset($originalLocations[$originalName][$timestamp])) {
-				$originalPath = $originalLocations[$originalName][$timestamp];
+			if (isset($extraData[$originalName][$timestamp]['location'])) {
+				$originalPath = $extraData[$originalName][$timestamp]['location'];
 				if (substr($originalPath, -1) === '/') {
 					$originalPath = substr($originalPath, 0, -1);
 				}
@@ -101,6 +101,7 @@ class Helper {
 					$i['extraData'] = $originalName;
 				}
 			}
+			$i['deletedBy'] = $extraData[$originalName][$timestamp]['deletedBy'] ?? null;
 			$result[] = new FileInfo($absoluteDir . '/' . $i['name'], $storage, $internalPath . '/' . $i['name'], $i, $mount);
 		}
 

--- a/apps/files_trashbin/lib/Migration/Version1020Date20240403003535.php
+++ b/apps/files_trashbin/lib/Migration/Version1020Date20240403003535.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright 2024 Christopher Ng <chrng8@gmail.com>
+ *
+ * @author Christopher Ng <chrng8@gmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Trashbin\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1020Date20240403003535 extends SimpleMigrationStep {
+
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('files_trash')) {
+			return null;
+		}
+
+		$table = $schema->getTable('files_trash');
+		$table->addColumn('deleted_by', Types::STRING, [
+			'notnull' => false,
+			'length' => 64,
+		]);
+
+		return $schema;
+	}
+}

--- a/apps/files_trashbin/lib/Sabre/AbstractTrash.php
+++ b/apps/files_trashbin/lib/Sabre/AbstractTrash.php
@@ -28,6 +28,7 @@ namespace OCA\Files_Trashbin\Sabre;
 use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\Files\FileInfo;
+use OCP\IUser;
 
 abstract class AbstractTrash implements ITrash {
 	/** @var ITrashItem */
@@ -87,6 +88,10 @@ abstract class AbstractTrash implements ITrash {
 
 	public function getTitle(): string {
 		return $this->data->getTitle();
+	}
+
+	public function getDeletedBy(): ?IUser {
+		return $this->data->getDeletedBy();
 	}
 
 	public function delete() {

--- a/apps/files_trashbin/lib/Sabre/ITrash.php
+++ b/apps/files_trashbin/lib/Sabre/ITrash.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 namespace OCA\Files_Trashbin\Sabre;
 
 use OCP\Files\FileInfo;
+use OCP\IUser;
 
 interface ITrash {
 	public function restore(): bool;
@@ -38,6 +39,8 @@ interface ITrash {
 	public function getTitle(): string;
 
 	public function getDeletionTime(): int;
+
+	public function getDeletedBy(): ?IUser;
 
 	public function getSize(): int|float;
 

--- a/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
@@ -41,6 +41,8 @@ class TrashbinPlugin extends ServerPlugin {
 	public const TRASHBIN_ORIGINAL_LOCATION = '{http://nextcloud.org/ns}trashbin-original-location';
 	public const TRASHBIN_DELETION_TIME = '{http://nextcloud.org/ns}trashbin-deletion-time';
 	public const TRASHBIN_TITLE = '{http://nextcloud.org/ns}trashbin-title';
+	public const TRASHBIN_DELETED_BY_ID = '{http://nextcloud.org/ns}trashbin-deleted-by-id';
+	public const TRASHBIN_DELETED_BY_DISPLAY_NAME = '{http://nextcloud.org/ns}trashbin-deleted-by-display-name';
 
 	/** @var Server */
 	private $server;
@@ -81,6 +83,14 @@ class TrashbinPlugin extends ServerPlugin {
 
 		$propFind->handle(self::TRASHBIN_DELETION_TIME, function () use ($node) {
 			return $node->getDeletionTime();
+		});
+
+		$propFind->handle(self::TRASHBIN_DELETED_BY_ID, function () use ($node) {
+			return $node->getDeletedBy()?->getUID();
+		});
+
+		$propFind->handle(self::TRASHBIN_DELETED_BY_DISPLAY_NAME, function () use ($node) {
+			return $node->getDeletedBy()?->getDisplayName();
 		});
 
 		$propFind->handle(FilesPlugin::SIZE_PROPERTYNAME, function () use ($node) {

--- a/apps/files_trashbin/lib/Trash/ITrashItem.php
+++ b/apps/files_trashbin/lib/Trash/ITrashItem.php
@@ -77,5 +77,10 @@ interface ITrashItem extends FileInfo {
 	 */
 	public function getUser(): IUser;
 
+	/**
+	 * @since 30.0.0
+	 */
+	public function getDeletedBy(): ?IUser;
+
 	public function getTitle(): string;
 }

--- a/apps/files_trashbin/lib/Trash/TrashItem.php
+++ b/apps/files_trashbin/lib/Trash/TrashItem.php
@@ -27,33 +27,16 @@ use OCP\Files\FileInfo;
 use OCP\IUser;
 
 class TrashItem implements ITrashItem {
-	/** @var ITrashBackend */
-	private $backend;
-	/** @var string */
-	private $orignalLocation;
-	/** @var int */
-	private $deletedTime;
-	/** @var string */
-	private $trashPath;
-	/** @var FileInfo */
-	private $fileInfo;
-	/** @var IUser */
-	private $user;
 
 	public function __construct(
-		ITrashBackend $backend,
-		string $originalLocation,
-		int $deletedTime,
-		string $trashPath,
-		FileInfo $fileInfo,
-		IUser $user
+		private ITrashBackend $backend,
+		private string $originalLocation,
+		private int $deletedTime,
+		private string $trashPath,
+		private FileInfo $fileInfo,
+		private IUser $user,
+		private ?IUser $deletedBy,
 	) {
-		$this->backend = $backend;
-		$this->orignalLocation = $originalLocation;
-		$this->deletedTime = $deletedTime;
-		$this->trashPath = $trashPath;
-		$this->fileInfo = $fileInfo;
-		$this->user = $user;
 	}
 
 	public function getTrashBackend(): ITrashBackend {
@@ -61,7 +44,7 @@ class TrashItem implements ITrashItem {
 	}
 
 	public function getOriginalLocation(): string {
-		return $this->orignalLocation;
+		return $this->originalLocation;
 	}
 
 	public function getDeletedTime(): int {
@@ -190,6 +173,10 @@ class TrashItem implements ITrashItem {
 
 	public function getParentId(): int {
 		return $this->fileInfo->getParentId();
+	}
+
+	public function getDeletedBy(): ?IUser {
+		return $this->deletedBy;
 	}
 
 	/**

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -228,7 +228,8 @@ class Trashbin {
 				->setValue('id', $query->createNamedParameter($targetFilename))
 				->setValue('timestamp', $query->createNamedParameter($timestamp))
 				->setValue('location', $query->createNamedParameter($targetLocation))
-				->setValue('user', $query->createNamedParameter($user));
+				->setValue('user', $query->createNamedParameter($user))
+				->setValue('deleted_by', $query->createNamedParameter($user));
 			$result = $query->executeStatement();
 			if (!$result) {
 				\OC::$server->get(LoggerInterface::class)->error('trash bin database couldn\'t be updated for the files owner', ['app' => 'files_trashbin']);
@@ -358,7 +359,8 @@ class Trashbin {
 				->setValue('id', $query->createNamedParameter($filename))
 				->setValue('timestamp', $query->createNamedParameter($timestamp))
 				->setValue('location', $query->createNamedParameter($location))
-				->setValue('user', $query->createNamedParameter($owner));
+				->setValue('user', $query->createNamedParameter($owner))
+				->setValue('deleted_by', $query->createNamedParameter($user));
 			$result = $query->executeStatement();
 			if (!$result) {
 				\OC::$server->get(LoggerInterface::class)->error('trash bin database couldn\'t be updated', ['app' => 'files_trashbin']);

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -126,24 +126,23 @@ class Trashbin {
 	}
 
 	/**
-	 * get original location of files for user
+	 * get original location and deleted by of files for user
 	 *
 	 * @param string $user
-	 * @return array (filename => array (timestamp => original location))
+	 * @return array<string, array<string, array{location: string, deletedBy: string}>>
 	 */
-	public static function getLocations($user) {
+	public static function getExtraData($user) {
 		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
-		$query->select('id', 'timestamp', 'location')
+		$query->select('id', 'timestamp', 'location', 'deleted_by')
 			->from('files_trash')
 			->where($query->expr()->eq('user', $query->createNamedParameter($user)));
 		$result = $query->executeQuery();
 		$array = [];
 		while ($row = $result->fetch()) {
-			if (isset($array[$row['id']])) {
-				$array[$row['id']][$row['timestamp']] = $row['location'];
-			} else {
-				$array[$row['id']] = [$row['timestamp'] => $row['location']];
-			}
+			$array[$row['id']][$row['timestamp']] = [
+				'location' => (string)$row['location'],
+				'deletedBy' => (string)$row['deleted_by'],
+			];
 		}
 		$result->closeCursor();
 		return $array;

--- a/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
+++ b/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
@@ -96,7 +96,15 @@ class TrashbinMigrator implements IMigrator, ISizeEstimationMigrator {
 			}
 			$output->writeln("Exporting trashbin files…");
 			$exportDestination->copyFolder($trashbinFolder, static::PATH_FILES_FOLDER);
-			$originalLocations = \OCA\Files_Trashbin\Trashbin::getLocations($uid);
+			$originalLocations = [];
+			// TODO Export all extra data and bump migrator to v2
+			foreach (\OCA\Files_Trashbin\Trashbin::getExtraData($uid) as $filename => $extraData) {
+				$locationData = [];
+				foreach ($extraData as $timestamp => ['location' => $location]) {
+					$locationData[$timestamp] = $location;
+				}
+				$originalLocations[$filename] = $locationData;
+			}
 			$exportDestination->addFileContents(static::PATH_LOCATIONS_FILE, json_encode($originalLocations));
 		} catch (NotFoundException $e) {
 			$output->writeln("No trashbin to export…");


### PR DESCRIPTION
- Part of https://github.com/nextcloud/server/issues/14917

## Summary

- Store and provide a new `trashbin-deleted-by-id` and `trashbin-deleted-by-display-name` DAV properties

- Example PROPFIND request data
```xml
<?xml version="1.0"?>
<d:propfind xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
  <d:prop>
    <oc:fileid />
    <d:displayname />
    <d:getlastmodified />
    <d:getcontenttype />
    <oc:size />
    <oc:owner-id />
    <oc:share-types />
    <nc:sharees />
    <nc:share-download-limits />
    <nc:trashbin-filename />
    <nc:trashbin-deletion-time />
    <nc:trashbin-original-location />
    <nc:trashbin-title />
    <nc:trashbin-deleted-by />
  </d:prop>
</d:propfind>
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)