### PR TITLE
fix(appconfig): format app values

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -219,8 +219,9 @@ class AppConfig implements IAppConfig {
 		// if we want to filter values, we need to get sensitivity
 		$this->loadConfigAll();
 		// array_merge() will remove numeric keys (here config keys), so addition arrays instead
+		$values = $this->formatAppValues($app, ($this->fastCache[$app] ?? []) + ($this->lazyCache[$app] ?? []));
 		$values = array_filter(
-			(($this->fastCache[$app] ?? []) + ($this->lazyCache[$app] ?? [])),
+			$values,
 			function (string $key) use ($prefix): bool {
 				return str_starts_with($key, $prefix); // filter values based on $prefix
 			}, ARRAY_FILTER_USE_KEY
@@ -271,7 +272,8 @@ class AppConfig implements IAppConfig {
 
 		foreach (array_keys($cache) as $app) {
 			if (isset($cache[$app][$key])) {
-				$values[$app] = $cache[$app][$key];
+				$appCache = $this->formatAppValues((string)$app, $cache[$app], $lazy);
+				$values[$app] = $appCache[$key];
 			}
 		}
 
@@ -510,9 +512,9 @@ class AppConfig implements IAppConfig {
 	 * @see VALUE_BOOL
 	 * @see VALUE_ARRAY
 	 */
-	public function getValueType(string $app, string $key): int {
+	public function getValueType(string $app, string $key, ?bool $lazy = null): int {
 		$this->assertParams($app, $key);
-		$this->loadConfigAll();
+		$this->loadConfig($lazy);
 
 		if (!isset($this->valueTypes[$app][$key])) {
 			throw new AppConfigUnknownKeyException('unknown config key');
@@ -1385,6 +1387,48 @@ class AppConfig implements IAppConfig {
 	 */
 	public function getFilteredValues($app) {
 		return $this->getAllValues($app, filtered: true);
+	}
+
+
+	/**
+	 * **Warning:** avoid default NULL value for $lazy as this will
+	 * load all lazy values from the database
+	 *
+	 * @param string $app
+	 * @param array $values
+	 * @param bool|null $lazy
+	 *
+	 * @return array
+	 */
+	private function formatAppValues(string $app, array $values, ?bool $lazy = null): array {
+		foreach($values as $key => $value) {
+			try {
+				$type = $this->getValueType($app, $key, $lazy);
+			} catch (AppConfigUnknownKeyException $e) {
+				continue;
+			}
+
+			switch ($type) {
+				case self::VALUE_INT:
+					$values[$key] = (int)$value;
+					break;
+				case self::VALUE_FLOAT:
+					$values[$key] = (float)$value;
+					break;
+				case self::VALUE_BOOL:
+					$values[$key] = in_array(strtolower($value), ['1', 'true', 'yes', 'on']);
+					break;
+				case self::VALUE_ARRAY:
+					try {
+						$values[$key] = json_decode($value, true, flags: JSON_THROW_ON_ERROR);
+					} catch (JsonException $e) {
+						// ignoreable
+					}
+					break;
+			}
+		}
+
+		return $values;
 	}
 
 	/**

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -97,7 +97,7 @@ class AppConfig implements IAppConfig {
 	 * @param string $key config keys prefix to search
 	 * @param bool $filtered TRUE to hide sensitive config values. Value are replaced by {@see IConfig::SENSITIVE_VALUE}
 	 *
-	 * @return array<string, string> [configKey => configValue]
+	 * @return array<string, string|int|float|bool|array> [configKey => configValue]
 	 * @since 29.0.0
 	 */
 	public function getAllAppValues(string $key = '', bool $filtered = false): array {

--- a/lib/public/AppFramework/Services/IAppConfig.php
+++ b/lib/public/AppFramework/Services/IAppConfig.php
@@ -88,7 +88,7 @@ interface IAppConfig {
 	 * @param string $key config keys prefix to search, can be empty.
 	 * @param bool $filtered filter sensitive config values
 	 *
-	 * @return array<string, string> [configKey => configValue]
+	 * @return array<string, string|int|float|bool|array> [configKey => configValue]
 	 * @since 29.0.0
 	 */
 	public function getAllAppValues(string $key = '', bool $filtered = false): array;

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -140,7 +140,7 @@ interface IAppConfig {
 	 * @param string $prefix config keys prefix to search, can be empty.
 	 * @param bool $filtered filter sensitive config values
 	 *
-	 * @return array<string, string> [configKey => configValue]
+	 * @return array<string, string|int|float|bool|array> [configKey => configValue]
 	 * @since 29.0.0
 	 */
 	public function getAllValues(string $app, string $prefix = '', bool $filtered = false): array;
@@ -151,11 +151,12 @@ interface IAppConfig {
 	 *
 	 * @param string $key config key
 	 * @param bool $lazy search within lazy loaded config
+	 * @param int|null $typedAs enforce type for the returned values {@see self::VALUE_STRING} and others
 	 *
 	 * @return array<string, string|int|float|bool|array> [appId => configValue]
 	 * @since 29.0.0
 	 */
-	public function searchValues(string $key, bool $lazy = false): array;
+	public function searchValues(string $key, bool $lazy = false, ?int $typedAs = null): array;
 
 	/**
 	 * Get config value assigned to a config key.

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -261,9 +261,11 @@ interface IAppConfig {
 	 * returns the type of config value
 	 *
 	 * **WARNING:** ignore lazy filtering, all config values are loaded from database
+	 *              unless lazy is set to false
 	 *
 	 * @param string $app id of the app
 	 * @param string $key config key
+	 * @param bool|null $lazy
 	 *
 	 * @return int
 	 * @throws AppConfigUnknownKeyException
@@ -274,7 +276,7 @@ interface IAppConfig {
 	 * @see VALUE_BOOL
 	 * @see VALUE_ARRAY
 	 */
-	public function getValueType(string $app, string $key): int;
+	public function getValueType(string $app, string $key, ?bool $lazy = null): int;
 
 	/**
 	 * Store a config key and its value in database

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -386,6 +386,21 @@ class AppConfigTest extends TestCase {
 		$config->isLazy('unknown-app', 'inexistant-key');
 	}
 
+	public function testGetAllValues(): void {
+		$config = $this->generateAppConfig();
+		$this->assertEquals(
+			[
+				'array' => ['test' => 1],
+				'bool' => true,
+				'float' => 3.14,
+				'int' => 42,
+				'mixed' => 'mix',
+				'string' => 'value',
+			],
+			$config->getAllValues('typed')
+		);
+	}
+
 	public function testGetAllValuesWithEmptyApp(): void {
 		$config = $this->generateAppConfig();
 		$this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
returns formated values based on type when calling `getAllValues()` and `searchValues()`

note: deprecated method `getValues()` use `getAllValues()` but if the config value is defined as MIXED (default), the value is kept as a string.


original:
```
{
    "key1": "value1",
    "key2": "value0",
    "key6": "1",
    "key7": "{\"test1\":1,\"test2\":2}",
    "test8": "1",
    "key3": "value0",
    "key4": "3",
    "key5": "3.14"
}
```

new:

```
{
    "key1": "value1",
    "key2": "value0",
    "key6": true,
    "key7": {
        "test1": 1,
        "test2": 2
    },
    "test8": true,
    "key3": "value0",
    "key4": 3,
    "key5": 3.14
}
```

same as #43258 with tests