### PR TITLE
fix(files): Do not show files from hidden folders in "Recent"-view if hidden files are disabled by user

### DIFF
--- a/apps/files/src/views/FilesList.vue
+++ b/apps/files/src/views/FilesList.vue
@@ -476,7 +476,7 @@ export default defineComponent({
 			}
 
 			// Fetch the current dir contents
-			this.promise = currentView.getContents(dir) as Promise<ContentsWithRoot>
+			this.promise = currentView.getContents(dir, this.fetchContent) as Promise<ContentsWithRoot>
 			try {
 				const { folder, contents } = await this.promise
 				logger.debug('Fetched contents', { dir, folder, contents })

--- a/cypress/e2e/files/files-settings.cy.ts
+++ b/cypress/e2e/files/files-settings.cy.ts
@@ -1,0 +1,81 @@
+import type { User } from '@nextcloud/cypress'
+import { getRowForFile } from './FilesUtils'
+
+const showHiddenFiles = () => {
+	// Open the files settings
+	cy.get('[data-cy-files-navigation-settings-button] a').click({ force: true })
+	// Toggle the hidden files setting
+	cy.get('[data-cy-files-settings-setting="show_hidden"]').within(() => {
+		cy.get('input').should('not.be.checked')
+		cy.get('input').check({ force: true })
+	})
+	// Close the dialog
+	cy.get('[data-cy-files-navigation-settings] button[aria-label="Close"]').click()
+}
+
+describe('files: Hide or show hidden files', { testIsolation: true }, () => {
+	let user: User
+
+	beforeEach(() => {
+		cy.createRandomUser().then(($user) => {
+			user = $user
+
+			cy.uploadContent(user, new Blob([]), 'text/plain', '/.file')
+			cy.mkdir(user, '/.folder')
+			cy.login(user)
+		})
+	})
+
+	context('view: All files', { testIsolation: false }, () => {
+		it('hides dot-files by default', () => {
+			cy.visit('/apps/files')
+
+			getRowForFile('.file').should('not.exist')
+			getRowForFile('.folder').should('not.exist')
+		})
+
+		it('can show hidden files', () => {
+			showHiddenFiles()
+			// Now the files should be visible
+			getRowForFile('.file').should('be.visible')
+			getRowForFile('.folder').should('be.visible')
+		})
+	})
+
+	context('view: Personal files', { testIsolation: false }, () => {
+		it('hides dot-files by default', () => {
+			cy.visit('/apps/files/personal')
+
+			getRowForFile('.file').should('not.exist')
+			getRowForFile('.folder').should('not.exist')
+		})
+
+		it('can show hidden files', () => {
+			showHiddenFiles()
+			// Now the files should be visible
+			getRowForFile('.file').should('be.visible')
+			getRowForFile('.folder').should('be.visible')
+		})
+	})
+
+	context('view: Recent files', { testIsolation: false }, () => {
+		it('hides dot-files by default', () => {
+			// also add hidden file in hidden folder
+			cy.uploadContent(user, new Blob([]), 'text/plain', '/.folder/other-file')
+			cy.login(user)
+			cy.visit('/apps/files/recent')
+
+			getRowForFile('.file').should('not.exist')
+			getRowForFile('.folder').should('not.exist')
+			getRowForFile('other-file').should('not.exist')
+		})
+
+		it('can show hidden files', () => {
+			showHiddenFiles()
+			// Now the files should be visible
+			getRowForFile('.file').should('be.visible')
+			getRowForFile('.folder').should('be.visible')
+			getRowForFile('other-file').should('be.visible')
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Have a hidden folder `.foo` and create a file inside (`.foo/bar`) then the file `bar` is shown in recent even if it is basically hidden.

## TODO

- [ ] Requires https://github.com/nextcloud-libraries/nextcloud-files/pull/918

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
