### PR TITLE
fix: Remove obsolete resource typing

### DIFF
--- a/apps/files_external/lib/Lib/Storage/FtpConnection.php
+++ b/apps/files_external/lib/Lib/Storage/FtpConnection.php
@@ -50,10 +50,7 @@ class FtpConnection {
 	}
 
 	public function __destruct() {
-		if ($this->connection) {
-			ftp_close($this->connection);
-		}
-		$this->connection = null;
+		ftp_close($this->connection);
 	}
 
 	public function setUtf8Mode(): bool {

--- a/apps/files_external/lib/Lib/Storage/FtpConnection.php
+++ b/apps/files_external/lib/Lib/Storage/FtpConnection.php
@@ -1,6 +1,7 @@
 <?php
 
 declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2020 Robin Appelman <robin@icewind.nl>
  *
@@ -27,8 +28,7 @@ namespace OCA\Files_External\Lib\Storage;
  * Low level wrapper around the ftp functions that smooths over some difference between servers
  */
 class FtpConnection {
-	/** @var resource|\FTP\Connection */
-	private $connection;
+	private \FTP\Connection $connection;
 
 	public function __construct(bool $secure, string $hostname, int $port, string $username, string $password) {
 		if ($secure) {

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -240,7 +240,7 @@ class ImageManager {
 				imagesavealpha($newImage, true);
 				imagealphablending($newImage, true);
 
-				$newWidth = (int)(imagesx($newImage) < 4096 ? imagesx($newImage) : 4096);
+				$newWidth = (imagesx($newImage) < 4096 ? imagesx($newImage) : 4096);
 				$newHeight = (int)(imagesy($newImage) / (imagesx($newImage) / $newWidth));
 				$outputImage = imagescale($newImage, $newWidth, $newHeight);
 				if ($outputImage === false) {
@@ -248,7 +248,7 @@ class ImageManager {
 				}
 
 				$newTmpFile = $this->tempManager->getTemporaryFile();
-				imageinterlace($outputImage, 1);
+				imageinterlace($outputImage, true);
 				// Keep jpeg images encoded as jpeg
 				if (str_contains($detectedMimeType, 'image/jpeg')) {
 					if (!imagejpeg($outputImage, $newTmpFile, 90)) {

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1136,7 +1136,7 @@ class Access extends LDAPUtility {
 	/**
 	 * processes an LDAP paged search operation
 	 *
-	 * @param resource|\LDAP\Result|resource[]|\LDAP\Result[] $sr the array containing the LDAP search resources
+	 * @param \LDAP\Result|\LDAP\Result[] $sr the array containing the LDAP search resources
 	 * @param int $foundItems number of results in the single search operation
 	 * @param int $limit maximum results to be counted
 	 * @param bool $pagedSearchOK whether a paged search has been executed
@@ -1249,7 +1249,7 @@ class Access extends LDAPUtility {
 	}
 
 	/**
-	 * @param resource|\LDAP\Result|resource[]|\LDAP\Result[] $sr
+	 * @param \LDAP\Result|\LDAP\Result[] $sr
 	 * @return int
 	 * @throws ServerNotAvailableException
 	 */

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -188,11 +188,6 @@ class Access extends LDAPUtility {
 			return false;
 		}
 		$cr = $this->connection->getConnectionResource();
-		if (!$this->ldap->isResource($cr)) {
-			//LDAP not available
-			$this->logger->debug('LDAP resource not available.', ['app' => 'user_ldap']);
-			return false;
-		}
 		$attr = mb_strtolower($attr, 'UTF-8');
 		// the actual read attribute later may contain parameters on a ranged
 		// request, e.g. member;range=99-199. Depends on server reply.
@@ -344,11 +339,6 @@ class Access extends LDAPUtility {
 			throw new \Exception('LDAP password changes are disabled.');
 		}
 		$cr = $this->connection->getConnectionResource();
-		if (!$this->ldap->isResource($cr)) {
-			//LDAP not available
-			$this->logger->debug('LDAP resource not available.', ['app' => 'user_ldap']);
-			return false;
-		}
 		try {
 			// try PASSWD extended operation first
 			return @$this->invokeLDAPMethod('exopPasswd', $userDN, '', $password) ||
@@ -1108,12 +1098,6 @@ class Access extends LDAPUtility {
 	) {
 		// See if we have a resource, in case not cancel with message
 		$cr = $this->connection->getConnectionResource();
-		if (!$this->ldap->isResource($cr)) {
-			// Seems like we didn't find any resource.
-			// Return an empty array just like before.
-			$this->logger->debug('Could not search, because resource is missing.', ['app' => 'user_ldap']);
-			return false;
-		}
 
 		//check whether paged search should be attempted
 		try {

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -231,9 +231,6 @@ class Connection extends LDAPUtility {
 	public function getConnectionResource(): \LDAP\Connection {
 		if (!$this->ldapConnectionRes) {
 			$this->init();
-		} elseif (!$this->ldap->isResource($this->ldapConnectionRes)) {
-			$this->ldapConnectionRes = null;
-			$this->establishConnection();
 		}
 		if (is_null($this->ldapConnectionRes)) {
 			$this->logger->error(

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -650,7 +650,11 @@ class Connection extends LDAPUtility {
 			return false;
 		}
 
-		$this->ldapConnectionRes = $this->ldap->connect($host, $port);
+		$this->ldapConnectionRes = $this->ldap->connect($host, $port) ?: null;
+
+		if ($this->ldapConnectionRes === null) {
+			throw new ServerNotAvailableException('Connection failed');
+		}
 
 		if (!$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
 			throw new ServerNotAvailableException('Could not set required LDAP Protocol version.');

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -86,30 +86,15 @@ use Psr\Log\LoggerInterface;
  * @property string ldapAdminGroup
  */
 class Connection extends LDAPUtility {
-	/**
-	 * @var resource|\LDAP\Connection|null
-	 */
-	private $ldapConnectionRes = null;
-
-	/**
-	 * @var string
-	 */
-	private $configPrefix;
-
-	/**
-	 * @var ?string
-	 */
-	private $configID;
-
-	/**
-	 * @var bool
-	 */
-	private $configured = false;
+	private ?\LDAP\Connection $ldapConnectionRes = null;
+	private string $configPrefix;
+	private ?string $configID;
+	private bool $configured = false;
 
 	/**
 	 * @var bool whether connection should be kept on __destruct
 	 */
-	private $dontDestruct = false;
+	private bool $dontDestruct = false;
 
 	/**
 	 * @var bool runtime flag that indicates whether supported primary groups are available
@@ -241,9 +226,9 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
-	 * @return resource|\LDAP\Connection The LDAP resource
+	 * @return \LDAP\Connection The LDAP resource
 	 */
-	public function getConnectionResource() {
+	public function getConnectionResource(): \LDAP\Connection {
 		if (!$this->ldapConnectionRes) {
 			$this->init();
 		} elseif (!$this->ldap->isResource($this->ldapConnectionRes)) {
@@ -263,7 +248,7 @@ class Connection extends LDAPUtility {
 	/**
 	 * resets the connection resource
 	 */
-	public function resetConnectionResource() {
+	public function resetConnectionResource(): void {
 		if (!is_null($this->ldapConnectionRes)) {
 			@$this->ldap->unbind($this->ldapConnectionRes);
 			$this->ldapConnectionRes = null;
@@ -273,9 +258,8 @@ class Connection extends LDAPUtility {
 
 	/**
 	 * @param string|null $key
-	 * @return string
 	 */
-	private function getCacheKey($key) {
+	private function getCacheKey($key): string {
 		$prefix = 'LDAP-'.$this->configID.'-'.$this->configPrefix.'-';
 		if (is_null($key)) {
 			return $prefix;
@@ -332,9 +316,8 @@ class Connection extends LDAPUtility {
 	 * Caches the general LDAP configuration.
 	 * @param bool $force optional. true, if the re-read should be forced. defaults
 	 * to false.
-	 * @return null
 	 */
-	private function readConfiguration($force = false) {
+	private function readConfiguration(bool $force = false): void {
 		if ((!$this->configured || $force) && !is_null($this->configID)) {
 			$this->configuration->readConfiguration();
 			$this->configured = $this->validateConfiguration();
@@ -406,7 +389,7 @@ class Connection extends LDAPUtility {
 		return $result;
 	}
 
-	private function doSoftValidation() {
+	private function doSoftValidation(): void {
 		//if User or Group Base are not set, take over Base DN setting
 		foreach (['ldapBaseUsers', 'ldapBaseGroups'] as $keyBase) {
 			$val = $this->configuration->$keyBase;
@@ -461,10 +444,7 @@ class Connection extends LDAPUtility {
 		}
 	}
 
-	/**
-	 * @return bool
-	 */
-	private function doCriticalValidation() {
+	private function doCriticalValidation(): bool {
 		$configurationOK = true;
 		$errorStr = 'Configuration Error (prefix '.
 			(string)$this->configPrefix .'): ';
@@ -552,7 +532,7 @@ class Connection extends LDAPUtility {
 	 * Validates the user specified configuration
 	 * @return bool true if configuration seems OK, false otherwise
 	 */
-	private function validateConfiguration() {
+	private function validateConfiguration(): bool {
 		if ($this->doNotValidate) {
 			//don't do a validation if it is a new configuration with pure
 			//default values. Will be allowed on changes via __set or
@@ -575,7 +555,7 @@ class Connection extends LDAPUtility {
 	 *
 	 * @throws ServerNotAvailableException
 	 */
-	private function establishConnection() {
+	private function establishConnection(): ?bool {
 		if (!$this->configuration->ldapConfigurationActive) {
 			return null;
 		}
@@ -663,10 +643,9 @@ class Connection extends LDAPUtility {
 	/**
 	 * @param string $host
 	 * @param string $port
-	 * @return bool
 	 * @throws \OC\ServerNotAvailableException
 	 */
-	private function doConnect($host, $port) {
+	private function doConnect($host, $port): bool {
 		if ($host === '') {
 			return false;
 		}

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -446,8 +446,7 @@ class Connection extends LDAPUtility {
 
 	private function doCriticalValidation(): bool {
 		$configurationOK = true;
-		$errorStr = 'Configuration Error (prefix '.
-			(string)$this->configPrefix .'): ';
+		$errorStr = 'Configuration Error (prefix ' . $this->configPrefix . '): ';
 
 		//options that shall not be empty
 		$options = ['ldapHost', 'ldapUserDisplayName',

--- a/apps/user_ldap/lib/Group_LDAP.php
+++ b/apps/user_ldap/lib/Group_LDAP.php
@@ -1374,10 +1374,10 @@ class Group_LDAP extends ABackend implements GroupInterface, IGroupLDAP, IGetDis
 	 * of the current access.
 	 *
 	 * @param string $gid
-	 * @return resource|\LDAP\Connection The LDAP connection
+	 * @return \LDAP\Connection The LDAP connection
 	 * @throws ServerNotAvailableException
 	 */
-	public function getNewLDAPConnection($gid) {
+	public function getNewLDAPConnection($gid): \LDAP\Connection {
 		$connection = clone $this->access->getConnection();
 		return $connection->getConnectionResource();
 	}

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -371,9 +371,9 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGet
 	 * The connection needs to be closed manually.
 	 *
 	 * @param string $gid
-	 * @return resource|\LDAP\Connection The LDAP connection
+	 * @return \LDAP\Connection The LDAP connection
 	 */
-	public function getNewLDAPConnection($gid) {
+	public function getNewLDAPConnection($gid): \LDAP\Connection {
 		return $this->handleRequest($gid, 'getNewLDAPConnection', [$gid]);
 	}
 

--- a/apps/user_ldap/lib/IGroupLDAP.php
+++ b/apps/user_ldap/lib/IGroupLDAP.php
@@ -36,7 +36,7 @@ interface IGroupLDAP {
 	/**
 	 * Return a new LDAP connection for the specified group.
 	 * @param string $gid
-	 * @return resource|\LDAP\Connection The LDAP connection
+	 * @return \LDAP\Connection The LDAP connection
 	 */
 	public function getNewLDAPConnection($gid);
 }

--- a/apps/user_ldap/lib/ILDAPWrapper.php
+++ b/apps/user_ldap/lib/ILDAPWrapper.php
@@ -205,6 +205,7 @@ interface ILDAPWrapper {
 	/**
 	 * Checks whether the submitted parameter is a resource
 	 * @param mixed $resource the resource variable to check
+	 * @psalm-assert-if-true object $resource
 	 * @return bool true if it is a resource or LDAP object, false otherwise
 	 */
 	public function isResource($resource);

--- a/apps/user_ldap/lib/ILDAPWrapper.php
+++ b/apps/user_ldap/lib/ILDAPWrapper.php
@@ -34,7 +34,7 @@ interface ILDAPWrapper {
 
 	/**
 	 * Bind to LDAP directory
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @param string $dn an RDN to log in with
 	 * @param string $password the password
 	 * @return bool true on success, false otherwise
@@ -47,14 +47,14 @@ interface ILDAPWrapper {
 	 * connect to an LDAP server
 	 * @param string $host The host to connect to
 	 * @param string $port The port to connect to
-	 * @return resource|\LDAP\Connection|false a link resource on success, otherwise false
+	 * @return \LDAP\Connection|false a link resource on success, otherwise false
 	 */
 	public function connect($host, $port);
 
 	/**
 	 * Retrieve the LDAP pagination cookie
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @param resource|\LDAP\Result $result LDAP result resource
+	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Result $result LDAP result resource
 	 * @param string &$cookie structure sent by LDAP server
 	 * @return bool true on success, false otherwise
 	 *
@@ -64,22 +64,22 @@ interface ILDAPWrapper {
 
 	/**
 	 * Count the number of entries in a search
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @param resource|\LDAP\Result $result LDAP result resource
+	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Result $result LDAP result resource
 	 * @return int|false number of results on success, false otherwise
 	 */
 	public function countEntries($link, $result);
 
 	/**
 	 * Return the LDAP error number of the last LDAP command
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @return int error code
 	 */
 	public function errno($link);
 
 	/**
 	 * Return the LDAP error message of the last LDAP command
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @return string error message
 	 */
 	public function error($link);
@@ -95,69 +95,69 @@ interface ILDAPWrapper {
 
 	/**
 	 * Return first result id
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @param resource|\LDAP\Result $result LDAP result resource
-	 * @return resource|\LDAP\ResultEntry an LDAP entry resource
+	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Result $result LDAP result resource
+	 * @return \LDAP\ResultEntry an LDAP entry resource
 	 * */
 	public function firstEntry($link, $result);
 
 	/**
 	 * Get attributes from a search result entry
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @param resource|\LDAP\ResultEntry $result LDAP result resource
+	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\ResultEntry $result LDAP result resource
 	 * @return array|false containing the results, false on error
 	 * */
 	public function getAttributes($link, $result);
 
 	/**
 	 * Get the DN of a result entry
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @param resource|\LDAP\ResultEntry $result LDAP result resource
+	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\ResultEntry $result LDAP result resource
 	 * @return string|false containing the DN, false on error
 	 */
 	public function getDN($link, $result);
 
 	/**
 	 * Get all result entries
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @param resource|\LDAP\Result $result LDAP result resource
+	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Result $result LDAP result resource
 	 * @return array|false containing the results, false on error
 	 */
 	public function getEntries($link, $result);
 
 	/**
 	 * Return next result id
-	 * @param resource|\LDAP\Connection $link LDAP link resource
-	 * @param resource|\LDAP\ResultEntry $result LDAP result resource
-	 * @return resource|\LDAP\ResultEntry an LDAP entry resource
+	 * @param \LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\ResultEntry $result LDAP result resource
+	 * @return \LDAP\ResultEntry an LDAP entry resource
 	 * */
 	public function nextEntry($link, $result);
 
 	/**
 	 * Read an entry
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @param string $baseDN The DN of the entry to read from
 	 * @param string $filter An LDAP filter
 	 * @param array $attr array of the attributes to read
-	 * @return resource|\LDAP\Result an LDAP search result resource
+	 * @return \LDAP\Result an LDAP search result resource
 	 */
 	public function read($link, $baseDN, $filter, $attr);
 
 	/**
 	 * Search LDAP tree
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @param string $baseDN The DN of the entry to read from
 	 * @param string $filter An LDAP filter
 	 * @param array $attr array of the attributes to read
 	 * @param int $attrsOnly optional, 1 if only attribute types shall be returned
 	 * @param int $limit optional, limits the result entries
-	 * @return resource|\LDAP\Result|false an LDAP search result resource, false on error
+	 * @return \LDAP\Result|false an LDAP search result resource, false on error
 	 */
 	public function search($link, string $baseDN, string $filter, array $attr, int $attrsOnly = 0, int $limit = 0, int $pageSize = 0, string $cookie = '');
 
 	/**
 	 * Replace the value of a userPassword by $password
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @param string $userDN the DN of the user whose password is to be replaced
 	 * @param string $password the new value for the userPassword
 	 * @return bool true on success, false otherwise
@@ -166,14 +166,14 @@ interface ILDAPWrapper {
 
 	/**
 	 * Performs a PASSWD extended operation.
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @return bool|string The generated password if new_password is empty or omitted. Otherwise true on success and false on failure.
 	 */
 	public function exopPasswd($link, string $userDN, string $oldPassword, string $password);
 
 	/**
 	 * Sets the value of the specified option to be $value
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @param int $option a defined LDAP Server option
 	 * @param mixed $value the new value for the option
 	 * @return bool true on success, false otherwise
@@ -182,14 +182,14 @@ interface ILDAPWrapper {
 
 	/**
 	 * establish Start TLS
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @return bool true on success, false otherwise
 	 */
 	public function startTls($link);
 
 	/**
 	 * Unbind from LDAP directory
-	 * @param resource|\LDAP\Connection $link LDAP link resource
+	 * @param \LDAP\Connection $link LDAP link resource
 	 * @return bool true on success, false otherwise
 	 */
 	public function unbind($link);

--- a/apps/user_ldap/lib/IUserLDAP.php
+++ b/apps/user_ldap/lib/IUserLDAP.php
@@ -37,7 +37,7 @@ interface IUserLDAP {
 	/**
 	 * Return a new LDAP connection for the specified user.
 	 * @param string $uid
-	 * @return resource|\LDAP\Connection of the LDAP connection
+	 * @return \LDAP\Connection of the LDAP connection
 	 */
 	public function getNewLDAPConnection($uid);
 

--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -360,7 +360,7 @@ class LDAP implements ILDAPWrapper {
 	/**
 	 * Analyzes the returned LDAP error and acts accordingly if not 0
 	 *
-	 * @param resource|\LDAP\Connection $resource the LDAP Connection resource
+	 * @param \LDAP\Connection $resource the LDAP Connection resource
 	 * @throws ConstraintViolationException
 	 * @throws ServerNotAvailableException
 	 * @throws \Exception

--- a/apps/user_ldap/lib/LDAPProvider.php
+++ b/apps/user_ldap/lib/LDAPProvider.php
@@ -149,7 +149,7 @@ class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
 	 * Return a new LDAP connection resource for the specified user.
 	 * The connection must be closed manually.
 	 * @param string $uid user id
-	 * @return resource|\LDAP\Connection The LDAP connection
+	 * @return \LDAP\Connection The LDAP connection
 	 * @throws \Exception if user id was not found in LDAP
 	 */
 	public function getLDAPConnection($uid) {
@@ -163,7 +163,7 @@ class LDAPProvider implements ILDAPProvider, IDeletionFlagSupport {
 	 * Return a new LDAP connection resource for the specified user.
 	 * The connection must be closed manually.
 	 * @param string $gid group id
-	 * @return resource|\LDAP\Connection The LDAP connection
+	 * @return \LDAP\Connection The LDAP connection
 	 * @throws \Exception if group id was not found in LDAP
 	 */
 	public function getGroupLDAPConnection($gid) {

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -622,7 +622,7 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	 * The cloned connection needs to be closed manually.
 	 * of the current access.
 	 * @param string $uid
-	 * @return resource|\LDAP\Connection The LDAP connection
+	 * @return \LDAP\Connection The LDAP connection
 	 */
 	public function getNewLDAPConnection($uid) {
 		$connection = clone $this->access->getConnection();

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -438,7 +438,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 	 * The connection needs to be closed manually.
 	 *
 	 * @param string $uid
-	 * @return resource|\LDAP\Connection The LDAP connection
+	 * @return \LDAP\Connection The LDAP connection
 	 */
 	public function getNewLDAPConnection($uid) {
 		return $this->handleRequest($uid, 'getNewLDAPConnection', [$uid]);

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -48,8 +48,7 @@ use Psr\Log\LoggerInterface;
 class Wizard extends LDAPUtility {
 	protected static ?IL10N $l = null;
 	protected Access $access;
-	/** @var resource|\LDAP\Connection|null */
-	protected $cr;
+	protected ?\LDAP\Connection $cr = null;
 	protected Configuration $configuration;
 	protected WizardResult $result;
 	protected LoggerInterface $logger;
@@ -361,7 +360,7 @@ class Wizard extends LDAPUtility {
 		if (!$this->ldap->isResource($rr)) {
 			return false;
 		}
-		/** @var resource|\LDAP\Result $rr */
+		/** @var \LDAP\Result $rr */
 		$er = $this->ldap->firstEntry($cr, $rr);
 		$attributes = $this->ldap->getAttributes($cr, $er);
 		if ($attributes === false) {
@@ -649,7 +648,7 @@ class Wizard extends LDAPUtility {
 		if (!$this->ldap->isResource($cr)) {
 			throw new \Exception('connection error');
 		}
-		/** @var resource|\LDAP\Connection $cr */
+		/** @var \LDAP\Connection $cr */
 
 		if (mb_strpos($this->access->connection->ldapLoginFilter, '%uid', 0, 'UTF-8')
 			=== false) {
@@ -819,7 +818,7 @@ class Wizard extends LDAPUtility {
 		if (!$this->ldap->isResource($rr)) {
 			return false;
 		}
-		/** @var resource|\LDAP\Result $rr */
+		/** @var \LDAP\Result $rr */
 		$er = $this->ldap->firstEntry($cr, $rr);
 		while ($this->ldap->isResource($er)) {
 			$this->ldap->getDN($cr, $er);
@@ -866,7 +865,7 @@ class Wizard extends LDAPUtility {
 			);
 			return false;
 		}
-		/** @var resource|\LDAP\Result $rr */
+		/** @var \LDAP\Result $rr */
 		$entries = $this->ldap->countEntries($cr, $rr);
 		return ($entries !== false) && ($entries > 0);
 	}
@@ -929,7 +928,7 @@ class Wizard extends LDAPUtility {
 							if (!$this->ldap->isResource($rr)) {
 								continue;
 							}
-							/** @var resource|\LDAP\Result $rr */
+							/** @var \LDAP\Result $rr */
 							$er = $this->ldap->firstEntry($cr, $rr);
 							$attrs = $this->ldap->getAttributes($cr, $er);
 							$dn = $this->ldap->getDN($cr, $er);
@@ -1073,7 +1072,7 @@ class Wizard extends LDAPUtility {
 		if (!$this->ldap->isResource($cr)) {
 			throw new \Exception(self::$l->t('Invalid Host'));
 		}
-		/** @var resource|\LDAP\Connection $cr */
+		/** @var \LDAP\Connection $cr */
 
 		//set LDAP options
 		$this->ldap->setOption($cr, LDAP_OPT_PROTOCOL_VERSION, 3);
@@ -1169,7 +1168,7 @@ class Wizard extends LDAPUtility {
 		if (!$this->ldap->isResource($cr)) {
 			return false;
 		}
-		/** @var resource|\LDAP\Connection $cr */
+		/** @var \LDAP\Connection $cr */
 		$lastFilter = null;
 		if (isset($filters[count($filters) - 1])) {
 			$lastFilter = $filters[count($filters) - 1];
@@ -1184,7 +1183,7 @@ class Wizard extends LDAPUtility {
 			if (!$this->ldap->isResource($rr)) {
 				continue;
 			}
-			/** @var resource|\LDAP\Result $rr */
+			/** @var \LDAP\Result $rr */
 			$entries = $this->ldap->countEntries($cr, $rr);
 			$getEntryFunc = 'firstEntry';
 			if (($entries !== false) && ($entries > 0)) {
@@ -1310,9 +1309,9 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * @return resource|\LDAP\Connection|false a link resource on success, otherwise false
+	 * @return \LDAP\Connection|false a link resource on success, otherwise false
 	 */
-	private function getConnection() {
+	private function getConnection(): \LDAP\Connection|false {
 		if (!is_null($this->cr)) {
 			return $this->cr;
 		}

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -645,10 +645,6 @@ class Wizard extends LDAPUtility {
 		}
 
 		$cr = $this->access->connection->getConnectionResource();
-		if (!$this->ldap->isResource($cr)) {
-			throw new \Exception('connection error');
-		}
-		/** @var \LDAP\Connection $cr */
 
 		if (mb_strpos($this->access->connection->ldapLoginFilter, '%uid', 0, 'UTF-8')
 			=== false) {
@@ -1213,9 +1209,7 @@ class Wizard extends LDAPUtility {
 					$dnReadCount++;
 					$foundItems = array_merge($foundItems, $newItems);
 					$dnRead[] = $dn;
-				} while (($state === self::LRESULT_PROCESSED_SKIP
-						|| $this->ldap->isResource($entry))
-						&& ($dnReadLimit === 0 || $dnReadCount < $dnReadLimit));
+				} while ($dnReadLimit === 0 || $dnReadCount < $dnReadLimit);
 			}
 		}
 

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -481,15 +481,14 @@ class AccessTest extends TestCase {
 		$this->connection
 			->expects($this->once())
 			->method('getConnectionResource')
-			->willReturn($connection);
+			->willThrowException(new \OC\ServerNotAvailableException('Connection to LDAP server could not be established'));
 		$this->ldap
-			->expects($this->once())
-			->method('isResource')
-			->with($connection)
-			->willReturn(false);
+			->expects($this->never())
+			->method('isResource');
 
-		/** @noinspection PhpUnhandledExceptionInspection */
-		$this->assertFalse($this->access->setPassword('CN=foo', 'MyPassword'));
+		$this->expectException(\OC\ServerNotAvailableException::class);
+		$this->expectExceptionMessage('Connection to LDAP server could not be established');
+		$this->access->setPassword('CN=foo', 'MyPassword');
 	}
 
 
@@ -505,11 +504,6 @@ class AccessTest extends TestCase {
 			->expects($this->any())
 			->method('getConnectionResource')
 			->willReturn($connection);
-		$this->ldap
-			->expects($this->once())
-			->method('isResource')
-			->with($connection)
-			->willReturn(true);
 		$this->ldap
 			->expects($this->once())
 			->method('modReplace')
@@ -529,11 +523,6 @@ class AccessTest extends TestCase {
 			->expects($this->any())
 			->method('getConnectionResource')
 			->willReturn($connection);
-		$this->ldap
-			->expects($this->once())
-			->method('isResource')
-			->with($connection)
-			->willReturn(true);
 		$this->ldap
 			->expects($this->once())
 			->method('modReplace')
@@ -567,7 +556,7 @@ class AccessTest extends TestCase {
 			->expects($this->any())
 			->method('isResource')
 			->willReturnCallback(function ($resource) {
-				return is_resource($resource) || is_object($resource);
+				return is_object($resource);
 			});
 		$this->ldap
 			->expects($this->any())

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -114,6 +114,9 @@ class AccessTest extends TestCase {
 		$connector = $this->getMockBuilder(Connection::class)
 			->setConstructorArgs([$lw, '', null])
 			->getMock();
+		$connector->expects($this->any())
+			->method('getConnectionResource')
+			->willReturn(ldap_connect('ldap://example.com'));
 		$um = $this->getMockBuilder(Manager::class)
 			->setConstructorArgs([
 				$this->createMock(IConfig::class),
@@ -286,6 +289,11 @@ class AccessTest extends TestCase {
 		$this->ldap->expects($this->any())
 			->method('isResource')
 			->willReturn(true);
+
+		$this->connection
+			->expects($this->any())
+			->method('getConnectionResource')
+			->willReturn(ldap_connect('ldap://example.com'));
 
 		$this->ldap->expects($this->any())
 			->method('getAttributes')
@@ -469,7 +477,7 @@ class AccessTest extends TestCase {
 		$this->connection
 			->method('__get')
 			->willReturn(true);
-		$connection = $this->createMock(LDAP::class);
+		$connection = ldap_connect('ldap://example.com');
 		$this->connection
 			->expects($this->once())
 			->method('getConnectionResource')
@@ -492,7 +500,7 @@ class AccessTest extends TestCase {
 		$this->connection
 			->method('__get')
 			->willReturn(true);
-		$connection = $this->createMock(LDAP::class);
+		$connection = ldap_connect('ldap://example.com');
 		$this->connection
 			->expects($this->any())
 			->method('getConnectionResource')
@@ -516,7 +524,7 @@ class AccessTest extends TestCase {
 		$this->connection
 			->method('__get')
 			->willReturn(true);
-		$connection = $this->createMock(LDAP::class);
+		$connection = ldap_connect('ldap://example.com');
 		$this->connection
 			->expects($this->any())
 			->method('getConnectionResource')

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -114,7 +114,7 @@ class ConnectionTest extends \Test\TestCase {
 
 		$this->ldap->expects($this->exactly(3))
 			->method('connect')
-			->willReturn('ldapResource');
+			->willReturn(ldap_connect('ldap://example.com'));
 
 		$this->ldap->expects($this->any())
 			->method('errno')
@@ -173,7 +173,7 @@ class ConnectionTest extends \Test\TestCase {
 
 		$this->ldap->expects($this->once())
 			->method('connect')
-			->willReturn('ldapResource');
+			->willReturn(ldap_connect('ldap://example.com'));
 
 		$this->ldap->expects($this->any())
 			->method('errno')
@@ -221,7 +221,7 @@ class ConnectionTest extends \Test\TestCase {
 
 		$this->ldap->expects($this->any())
 			->method('connect')
-			->willReturn('ldapResource');
+			->willReturn(ldap_connect('ldap://example.com'));
 
 		$this->ldap->expects($this->once())
 			->method('bind')
@@ -264,7 +264,7 @@ class ConnectionTest extends \Test\TestCase {
 
 		$this->ldap->expects($this->any())
 			->method('connect')
-			->willReturn('ldapResource');
+			->willReturn(ldap_connect('ldap://example.com'));
 
 		$this->ldap->expects($this->any())
 			->method('setOption')

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -271,14 +271,15 @@ class LDAPProviderTest extends \Test\TestCase {
 		$userBackend->expects($this->any())
 			->method('userExists')
 			->willReturn(true);
+		$ldapConnection = ldap_connect('ldap://example.com');
 		$userBackend->expects($this->any())
 			->method('getNewLDAPConnection')
-			->willReturn(true);
+			->willReturn($ldapConnection);
 
 		$server = $this->getServerMock($userBackend, $this->getDefaultGroupBackendMock());
 
 		$ldapProvider = $this->getLDAPProvider($server);
-		$this->assertTrue($ldapProvider->getLDAPConnection('existing_user'));
+		$this->assertEquals($ldapConnection, $ldapProvider->getLDAPConnection('existing_user'));
 	}
 
 
@@ -317,14 +318,15 @@ class LDAPProviderTest extends \Test\TestCase {
 			->method('groupExists')
 			->willReturn(true);
 
+		$ldapConnection = ldap_connect('ldap://example.com');
 		$groupBackend->expects($this->any())
 			->method('getNewLDAPConnection')
-			->willReturn(true);
+			->willReturn($ldapConnection);
 
 		$server = $this->getServerMock($userBackend, $groupBackend);
 
 		$ldapProvider = $this->getLDAPProvider($server);
-		$this->assertTrue($ldapProvider->getGroupLDAPConnection('existing_group'));
+		$this->assertEquals($ldapConnection, $ldapProvider->getGroupLDAPConnection('existing_group'));
 	}
 
 

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -320,7 +320,7 @@ class User_LDAPTest extends TestCase {
 			->willReturn($mapping);
 		$this->connection->expects($this->any())
 			->method('getConnectionResource')
-			->willReturn('this is an ldap link');
+			->willReturn(ldap_connect('ldap://example.com'));
 
 		$this->deletedUsersIndex->expects($this->once())
 		->method('isUserMarked')

--- a/apps/user_ldap/tests/WizardTest.php
+++ b/apps/user_ldap/tests/WizardTest.php
@@ -84,8 +84,8 @@ class WizardTest extends TestCase {
 	private function prepareLdapWrapperForConnections(MockObject &$ldap) {
 		$ldap->expects($this->once())
 			->method('connect')
-			//dummy value, usually invalid
-			->willReturn(true);
+			//dummy value
+			->willReturn(ldap_connect('ldap://example.com'));
 
 		$ldap->expects($this->exactly(3))
 			->method('setOption')
@@ -173,7 +173,7 @@ class WizardTest extends TestCase {
 		$ldap->expects($this->any())
 			->method('isResource')
 			->willReturnCallback(function ($r) {
-				if ($r === true) {
+				if ($r instanceof \LDAP\Connection) {
 					return true;
 				}
 				if ($r % 24 === 0) {

--- a/build/stubs/ftp.php
+++ b/build/stubs/ftp.php
@@ -16,59 +16,80 @@ namespace FTP {
 
 namespace {
 
-    function ftp_connect(string $hostname, int $port = 21, int $timeout = 90): FTP\Connection|resource|false {}
+    function ftp_connect(string $hostname, int $port = 21, int $timeout = 90): FTP\Connection|false {}
 
     #ifdef HAVE_FTP_SSL
-    function ftp_ssl_connect(string $hostname, int $port = 21, int $timeout = 90): FTP\Connection|resource|false {}
+    function ftp_ssl_connect(string $hostname, int $port = 21, int $timeout = 90): FTP\Connection|false {}
     #endif
 
-    function ftp_login(FTP\Connection|resource $ftp, string $username, string $password): bool {}
-    function ftp_pwd(FTP\Connection|resource $ftp): string|false {}
-    function ftp_cdup(FTP\Connection|resource $ftp): bool {}
-    function ftp_chdir(FTP\Connection|resource $ftp, string $directory): bool {}
-    function ftp_exec(FTP\Connection|resource $ftp, string $command): bool {}
-    function ftp_raw(FTP\Connection|resource $ftp, string $command): ?array {}
-    function ftp_mkdir(FTP\Connection|resource $ftp, string $directory): string|false {}
-    function ftp_rmdir(FTP\Connection|resource $ftp, string $directory): bool {}
-    function ftp_chmod(FTP\Connection|resource $ftp, int $permissions, string $filename): int|false {}
+    function ftp_login(FTP\Connection $ftp, string $username, string $password): bool {}
+    function ftp_pwd(FTP\Connection $ftp): string|false {}
+    function ftp_cdup(FTP\Connection $ftp): bool {}
+    function ftp_chdir(FTP\Connection $ftp, string $directory): bool {}
+    function ftp_exec(FTP\Connection $ftp, string $command): bool {}
+
+    /**
+     * @return array<int, string>|null
+     * @refcount 1
+     */
+    function ftp_raw(FTP\Connection $ftp, string $command): ?array {}
+    function ftp_mkdir(FTP\Connection $ftp, string $directory): string|false {}
+    function ftp_rmdir(FTP\Connection $ftp, string $directory): bool {}
+    function ftp_chmod(FTP\Connection $ftp, int $permissions, string $filename): int|false {}
 
     /** @param string $response */
-    function ftp_alloc(FTP\Connection|resource $ftp, int $size, &$response = null): bool {}
-    function ftp_nlist(FTP\Connection|resource $ftp, string $directory): array|false {}
-    function ftp_rawlist(FTP\Connection|resource $ftp, string $directory, bool $recursive = false): array|false {}
-    function ftp_mlsd(FTP\Connection|resource $ftp, string $directory): array|false {}
-    function ftp_systype(FTP\Connection|resource $ftp): string|false {}
+    function ftp_alloc(FTP\Connection $ftp, int $size, &$response = null): bool {}
+
+    /**
+     * @return array<int, string>|false
+     * @refcount 1
+     */
+    function ftp_nlist(FTP\Connection $ftp, string $directory): array|false {}
+
+    /**
+     * @return array<int, string>|false
+     * @refcount 1
+     */
+    function ftp_rawlist(FTP\Connection $ftp, string $directory, bool $recursive = false): array|false {}
+
+    /**
+     * @return array<int, array>|false
+     * @refcount 1
+     */
+    function ftp_mlsd(FTP\Connection $ftp, string $directory): array|false {}
+
+    function ftp_systype(FTP\Connection $ftp): string|false {}
 
     /** @param resource $stream */
-    function ftp_fget(FTP\Connection|resource $ftp, $stream, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): bool {}
+    function ftp_fget(FTP\Connection $ftp, $stream, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): bool {}
 
     /** @param resource $stream */
-    function ftp_nb_fget(FTP\Connection|resource $ftp, $stream, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): int {}
-    function ftp_pasv(FTP\Connection|resource $ftp, bool $enable): bool {}
-    function ftp_get(FTP\Connection|resource $ftp, string $local_filename, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): bool {}
-    function ftp_nb_get(FTP\Connection|resource $ftp, string $local_filename, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): int {}
-    function ftp_nb_continue(FTP\Connection|resource $ftp): int {}
+    function ftp_nb_fget(FTP\Connection $ftp, $stream, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): int {}
+    function ftp_pasv(FTP\Connection $ftp, bool $enable): bool {}
+    function ftp_get(FTP\Connection $ftp, string $local_filename, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): bool {}
+    function ftp_nb_get(FTP\Connection $ftp, string $local_filename, string $remote_filename, int $mode = FTP_BINARY, int $offset = 0): int|false {}
+    function ftp_nb_continue(FTP\Connection $ftp): int {}
 
     /** @param resource $stream */
-    function ftp_fput(FTP\Connection|resource $ftp, string $remote_filename, $stream, int $mode = FTP_BINARY, int $offset = 0): bool {}
+    function ftp_fput(FTP\Connection $ftp, string $remote_filename, $stream, int $mode = FTP_BINARY, int $offset = 0): bool {}
 
     /** @param resource $stream */
-    function ftp_nb_fput(FTP\Connection|resource $ftp, string $remote_filename, $stream, int $mode = FTP_BINARY, int $offset = 0): int {}
-    function ftp_put(FTP\Connection|resource $ftp, string $remote_filename, string $local_filename, int $mode = FTP_BINARY, int $offset = 0): bool {}
-    function ftp_append(FTP\Connection|resource $ftp, string $remote_filename, string $local_filename, int $mode = FTP_BINARY): bool {}
-    function ftp_nb_put(FTP\Connection|resource $ftp, string $remote_filename, string $local_filename, int $mode = FTP_BINARY, int $offset = 0): int|false {}
-    function ftp_size(FTP\Connection|resource $ftp, string $filename): int {}
-    function ftp_mdtm(FTP\Connection|resource $ftp, string $filename): int {}
-    function ftp_rename(FTP\Connection|resource $ftp, string $from, string $to): bool {}
-    function ftp_delete(FTP\Connection|resource $ftp, string $filename): bool {}
-    function ftp_site(FTP\Connection|resource $ftp, string $command): bool {}
-    function ftp_close(FTP\Connection|resource $ftp): bool {}
+    function ftp_nb_fput(FTP\Connection $ftp, string $remote_filename, $stream, int $mode = FTP_BINARY, int $offset = 0): int {}
+    function ftp_put(FTP\Connection $ftp, string $remote_filename, string $local_filename, int $mode = FTP_BINARY, int $offset = 0): bool {}
+    function ftp_append(FTP\Connection $ftp, string $remote_filename, string $local_filename, int $mode = FTP_BINARY): bool {}
+    function ftp_nb_put(FTP\Connection $ftp, string $remote_filename, string $local_filename, int $mode = FTP_BINARY, int $offset = 0): int|false {}
+    function ftp_size(FTP\Connection $ftp, string $filename): int {}
+    function ftp_mdtm(FTP\Connection $ftp, string $filename): int {}
+    function ftp_rename(FTP\Connection $ftp, string $from, string $to): bool {}
+    function ftp_delete(FTP\Connection $ftp, string $filename): bool {}
+    function ftp_site(FTP\Connection $ftp, string $command): bool {}
+    function ftp_close(FTP\Connection $ftp): bool {}
 
     /** @alias ftp_close */
-    function ftp_quit(FTP\Connection|resource $ftp): bool {}
+    function ftp_quit(FTP\Connection $ftp): bool {}
 
     /** @param int|bool $value */
-    function ftp_set_option(FTP\Connection|resource $ftp, int $option, $value): bool {}
-    function ftp_get_option(FTP\Connection|resource $ftp, int $option): int|bool {}
+    function ftp_set_option(FTP\Connection $ftp, int $option, $value): bool {}
+    function ftp_get_option(FTP\Connection $ftp, int $option): int|bool {}
 
 }

--- a/build/stubs/gd.php
+++ b/build/stubs/gd.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @generate-class-entries */
+
 /**
  * @strict-properties
  * @not-serializable
@@ -7,3015 +9,326 @@
 final class GdImage {}
 
 /**
- * Retrieve information about the currently installed GD library
- * @link https://php.net/manual/en/function.gd-info.php
- * @return array an associative array.
- * </p>
- * <p>
- * <table>
- * Elements of array returned by <b>gd_info</b>
- * <tr valign="top">
- * <td>Attribute</td>
- * <td>Meaning</td>
- * </tr>
- * <tr valign="top">
- * <td>GD Version</td>
- * <td>string value describing the installed
- * libgd version.</td>
- * </tr>
- * <tr valign="top">
- * <td>FreeType Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if FreeType Support is installed.</td>
- * </tr>
- * <tr valign="top">
- * <td>FreeType Linkage</td>
- * <td>string value describing the way in which
- * FreeType was linked. Expected values are: 'with freetype',
- * 'with TTF library', and 'with unknown library'. This element will
- * only be defined if FreeType Support evaluated to
- * <b>TRUE</b>.</td>
- * </tr>
- * <tr valign="top">
- * <td>T1Lib Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if T1Lib support is included.</td>
- * </tr>
- * <tr valign="top">
- * <td>GIF Read Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if support for reading GIF
- * images is included.</td>
- * </tr>
- * <tr valign="top">
- * <td>GIF Create Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if support for creating GIF
- * images is included.</td>
- * </tr>
- * <tr valign="top">
- * <td>JPEG Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if JPEG support is included.</td>
- * </tr>
- * <tr valign="top">
- * <td>PNG Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if PNG support is included.</td>
- * </tr>
- * <tr valign="top">
- * <td>WBMP Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if WBMP support is included.</td>
- * </tr>
- * <tr valign="top">
- * <td>XBM Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if XBM support is included.</td>
- * </tr>
- * <tr valign="top">
- * <td>WebP Support</td>
- * <td>boolean value. <b>TRUE</b>
- * if WebP support is included.</td>
- * </tr>
- * </table>
- * </p>
- * <p>
- * Previous to PHP 5.3.0, the JPEG Support attribute was named
- * JPG Support.
+ * @strict-properties
+ * @not-serializable
  */
-function gd_info () {}
+final class GdFont {}
 
 /**
- * Draws an arc
- * @link https://php.net/manual/en/function.imagearc.php
- * @param resource $image
- * @param int $cx <p>
- * x-coordinate of the center.
- * </p>
- * @param int $cy <p>
- * y-coordinate of the center.
- * </p>
- * @param int $width <p>
- * The arc width.
- * </p>
- * @param int $height <p>
- * The arc height.
- * </p>
- * @param int $start <p>
- * The arc start angle, in degrees.
- * </p>
- * @param int $end <p>
- * The arc end angle, in degrees.
- * 0° is located at the three-o'clock position, and the arc is drawn
- * clockwise.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * <b>imagecolorallocate</b>.
- * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
+ * @return array<string, string|bool>
+ * @refcount 1
  */
-function imagearc ($image, $cx, $cy, $width, $height, $start, $end, $color) {}
+function gd_info(): array {}
 
-/**
- * Draw an ellipse
- * @link https://php.net/manual/en/function.imageellipse.php
- * @param resource $image
- * @param int $cx <p>
- * x-coordinate of the center.
- * </p>
- * @param int $cy <p>
- * y-coordinate of the center.
- * </p>
- * @param int $width <p>
- * The ellipse width.
- * </p>
- * @param int $height <p>
- * The ellipse height.
- * </p>
- * @param int $color <p>
- * The color of the ellipse. A color identifier created with
- * <b>imagecolorallocate</b>.
- * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- */
-function imageellipse ($image, $cx, $cy, $width, $height, $color) {}
-
-/**
- * Draw a character horizontally
- * @link https://php.net/manual/en/function.imagechar.php
- * @param resource $image
- * @param int $font
- * @param int $x <p>
- * x-coordinate of the start.
- * </p>
- * @param int $y <p>
- * y-coordinate of the start.
- * </p>
- * @param string $c <p>
- * The character to draw.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * <b>imagecolorallocate</b>.
- * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- */
-function imagechar ($image, $font, $x, $y, $c, $color) {}
-
-/**
- * Draw a character vertically
- * @link https://php.net/manual/en/function.imagecharup.php
- * @param resource $image
- * @param int $font
- * @param int $x <p>
- * x-coordinate of the start.
- * </p>
- * @param int $y <p>
- * y-coordinate of the start.
- * </p>
- * @param string $c <p>
- * The character to draw.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * <b>imagecolorallocate</b>.
- * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- */
-function imagecharup ($image, $font, $x, $y, $c, $color) {}
-
-/**
- * Get the index of the color of a pixel
- * @link https://php.net/manual/en/function.imagecolorat.php
- * @param resource $image
- * @param int $x <p>
- * x-coordinate of the point.
- * </p>
- * @param int $y <p>
- * y-coordinate of the point.
- * </p>
- * @return int|false the index of the color or <b>FALSE</b> on failure
- */
-function imagecolorat ($image, $x, $y) {}
-
-/**
- * Allocate a color for an image
- * @link https://php.net/manual/en/function.imagecolorallocate.php
- * @param resource $image
- * @param int $red <p>Value of red component.</p>
- * @param int $green <p>Value of green component.</p>
- * @param int $blue <p>Value of blue component.</p>
- * @return int|false A color identifier or <b>FALSE</b> if the allocation failed.
- */
-function imagecolorallocate ($image, $red, $green, $blue) {}
-
-/**
- * Copy the palette from one image to another
- * @link https://php.net/manual/en/function.imagepalettecopy.php
- * @param resource $destination <p>
- * The destination image resource.
- * </p>
- * @param resource $source <p>
- * The source image resource.
- * </p>
- * @return void No value is returned.
- */
-function imagepalettecopy ($destination, $source) {}
-
-/**
- * Create a new image from the image stream in the string
- * @link https://php.net/manual/en/function.imagecreatefromstring.php
- * @param string $image <p>
- * A string containing the image data.
- * </p>
- * @return resource|false An image resource will be returned on success. <b>FALSE</b> is returned if
- * the image type is unsupported, the data is not in a recognised format,
- * or the image is corrupt and cannot be loaded.
- */
-function imagecreatefromstring ($image) {}
-
-/**
- * Get the index of the closest color to the specified color
- * @link https://php.net/manual/en/function.imagecolorclosest.php
- * @param resource $image
- * @param int $red <p>Value of red component.</p>
- * @param int $green <p>Value of green component.</p>
- * @param int $blue <p>Value of blue component.</p>
- * @return int|false the index of the closest color, in the palette of the image, to
- * the specified one or <b>FALSE</b> on failure
- */
-function imagecolorclosest ($image, $red, $green, $blue) {}
-
-/**
- * Get the index of the color which has the hue, white and blackness
- * @link https://php.net/manual/en/function.imagecolorclosesthwb.php
- * @param resource $image
- * @param int $red <p>Value of red component.</p>
- * @param int $green <p>Value of green component.</p>
- * @param int $blue <p>Value of blue component.</p>
- * @return int|false an integer with the index of the color which has
- * the hue, white and blackness nearest the given color or <b>FALSE</b> on failure
- */
-function imagecolorclosesthwb ($image, $red, $green, $blue) {}
-
-/**
- * De-allocate a color for an image
- * @link https://php.net/manual/en/function.imagecolordeallocate.php
- * @param resource $image
- * @param int $color <p>
- * The color identifier.
- * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- */
-function imagecolordeallocate ($image, $color) {}
-
-/**
- * Get the index of the specified color or its closest possible alternative
- * @link https://php.net/manual/en/function.imagecolorresolve.php
- * @param resource $image
- * @param int $red <p>Value of red component.</p>
- * @param int $green <p>Value of green component.</p>
- * @param int $blue <p>Value of blue component.</p>
- * @return int|false a color index or <b>FALSE</b> on failure
- */
-function imagecolorresolve ($image, $red, $green, $blue) {}
-
-/**
- * Get the index of the specified color
- * @link https://php.net/manual/en/function.imagecolorexact.php
- * @param resource $image
- * @param int $red <p>Value of red component.</p>
- * @param int $green <p>Value of green component.</p>
- * @param int $blue <p>Value of blue component.</p>
- * @return int|false the index of the specified color in the palette, -1 if the
- * color does not exist, or <b>FALSE</b> on failure
- */
-function imagecolorexact ($image, $red, $green, $blue) {}
-
-/**
- * Set the color for the specified palette index
- * @link https://php.net/manual/en/function.imagecolorset.php
- * @param resource $image
- * @param int $index <p>
- * An index in the palette.
- * </p>
- * @param int $red <p>Value of red component.</p>
- * @param int $green <p>Value of green component.</p>
- * @param int $blue <p>Value of blue component.</p>
- * @param int $alpha [optional] <p>
- * Value of alpha component.
- * </p>
- * @return void No value is returned.
- */
-function imagecolorset ($image, $index, $red, $green, $blue, $alpha = 0) {}
-
-/**
- * Define a color as transparent
- * @link https://php.net/manual/en/function.imagecolortransparent.php
- * @param resource $image
- * @param int $color [optional] <p>
- * A color identifier created with
- * <b>imagecolorallocate</b>.
- * </p>
- * @return int|false The identifier of the new (or current, if none is specified)
- * transparent color is returned. If <i>color</i>
- * is not specified, and the image has no transparent color, the
- * returned identifier will be -1. If an error occurs, <b>FALSE</b> is returned.
- */
-function imagecolortransparent ($image, $color = null) {}
-
-/**
- * Find out the number of colors in an image's palette
- * @link https://php.net/manual/en/function.imagecolorstotal.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such
- * as <b>imagecreatefromgif</b>.
- * </p>
- * @return int|false the number of colors in the specified image's palette, 0 for
- * truecolor images, or <b>FALSE</b> on failure
- */
-function imagecolorstotal ($image) {}
-
-/**
- * Get the colors for an index
- * @link https://php.net/manual/en/function.imagecolorsforindex.php
- * @param resource $image
- * @param int $index <p>
- * The color index.
- * </p>
- * @return array|false an associative array with red, green, blue and alpha keys that
- * contain the appropriate values for the specified color index or <b>FALSE</b> on failure
- */
-function imagecolorsforindex ($image, $index) {}
-
-/**
- * Copy part of an image
- * @link https://php.net/manual/en/function.imagecopy.php
- * @param resource $dst_im <p>
- * Destination image link resource.
- * </p>
- * @param resource $src_im <p>
- * Source image link resource.
- * </p>
- * @param int $dst_x <p>
- * x-coordinate of destination point.
- * </p>
- * @param int $dst_y <p>
- * y-coordinate of destination point.
- * </p>
- * @param int $src_x <p>
- * x-coordinate of source point.
- * </p>
- * @param int $src_y <p>
- * y-coordinate of source point.
- * </p>
- * @param int $src_w <p>
- * Source width.
- * </p>
- * @param int $src_h <p>
- * Source height.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagecopy ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h) {}
-
-/**
- * Copy and merge part of an image
- * @link https://php.net/manual/en/function.imagecopymerge.php
- * @param resource $dst_im <p>
- * Destination image link resource.
- * </p>
- * @param resource $src_im <p>
- * Source image link resource.
- * </p>
- * @param int $dst_x <p>
- * x-coordinate of destination point.
- * </p>
- * @param int $dst_y <p>
- * y-coordinate of destination point.
- * </p>
- * @param int $src_x <p>
- * x-coordinate of source point.
- * </p>
- * @param int $src_y <p>
- * y-coordinate of source point.
- * </p>
- * @param int $src_w <p>
- * Source width.
- * </p>
- * @param int $src_h <p>
- * Source height.
- * </p>
- * @param int $pct <p>
- * The two images will be merged according to pct
- * which can range from 0 to 100. When pct = 0,
- * no action is taken, when 100 this function behaves identically
- * to imagecopy for pallete images, while it
- * implements alpha transparency for true colour images.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagecopymerge ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $pct) {}
-
-/**
- * Copy and merge part of an image with gray scale
- * @link https://php.net/manual/en/function.imagecopymergegray.php
- * @param resource $dst_im <p>
- * Destination image link resource.
- * </p>
- * @param resource $src_im <p>
- * Source image link resource.
- * </p>
- * @param int $dst_x <p>
- * x-coordinate of destination point.
- * </p>
- * @param int $dst_y <p>
- * y-coordinate of destination point.
- * </p>
- * @param int $src_x <p>
- * x-coordinate of source point.
- * </p>
- * @param int $src_y <p>
- * y-coordinate of source point.
- * </p>
- * @param int $src_w <p>
- * Source width.
- * </p>
- * @param int $src_h <p>
- * Source height.
- * </p>
- * @param int $pct <p>
- * The src_im will be changed to grayscale according
- * to pct where 0 is fully grayscale and 100 is
- * unchanged. When pct = 100 this function behaves
- * identically to imagecopy for pallete images, while
- * it implements alpha transparency for true colour images.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagecopymergegray ($dst_im, $src_im, $dst_x, $dst_y, $src_x, $src_y, $src_w, $src_h, $pct) {}
-
-/**
- * Copy and resize part of an image
- * @link https://php.net/manual/en/function.imagecopyresized.php
- * @param resource $dst_image
- * @param resource $src_image
- * @param int $dst_x <p>
- * x-coordinate of destination point.
- * </p>
- * @param int $dst_y <p>
- * y-coordinate of destination point.
- * </p>
- * @param int $src_x <p>
- * x-coordinate of source point.
- * </p>
- * @param int $src_y <p>
- * y-coordinate of source point.
- * </p>
- * @param int $dst_w <p>
- * Destination width.
- * </p>
- * @param int $dst_h <p>
- * Destination height.
- * </p>
- * @param int $src_w <p>
- * Source width.
- * </p>
- * @param int $src_h <p>
- * Source height.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagecopyresized ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {}
-
-/**
- * Create a new palette based image
- * @link https://php.net/manual/en/function.imagecreate.php
- * @param int $width <p>
- * The image width.
- * </p>
- * @param int $height <p>
- * The image height.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreate ($width, $height) {}
-
-/**
- * Create a new true color image
- * @link https://php.net/manual/en/function.imagecreatetruecolor.php
- * @param int $width <p>
- * Image width.
- * </p>
- * @param int $height <p>
- * Image height.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatetruecolor ($width, $height) {}
-
-/**
- * Finds whether an image is a truecolor image
- * @link https://php.net/manual/en/function.imageistruecolor.php
- * @param resource $image
- * @return bool true if the image is truecolor, false
- * otherwise.
- */
-function imageistruecolor ($image) {}
-
-/**
- * Convert a true color image to a palette image
- * @link https://php.net/manual/en/function.imagetruecolortopalette.php
- * @param resource $image
- * @param bool $dither <p>
- * Indicates if the image should be dithered - if it is true then
- * dithering will be used which will result in a more speckled image but
- * with better color approximation.
- * </p>
- * @param int $ncolors <p>
- * Sets the maximum number of colors that should be retained in the palette.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagetruecolortopalette ($image, $dither, $ncolors) {}
-
-/**
- * Set the thickness for line drawing
- * @link https://php.net/manual/en/function.imagesetthickness.php
- * @param resource $image
- * @param int $thickness <p>
- * Thickness, in pixels.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagesetthickness ($image, $thickness) {}
-
-/**
- * Draw a partial arc and fill it
- * @link https://php.net/manual/en/function.imagefilledarc.php
- * @param resource $image
- * @param int $cx <p>
- * x-coordinate of the center.
- * </p>
- * @param int $cy <p>
- * y-coordinate of the center.
- * </p>
- * @param int $width <p>
- * The arc width.
- * </p>
- * @param int $height <p>
- * The arc height.
- * </p>
- * @param int $start <p>
- * The arc start angle, in degrees.
- * </p>
- * @param int $end <p>
- * The arc end angle, in degrees.
- * 0&deg; is located at the three-o'clock position, and the arc is drawn
- * clockwise.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * imagecolorallocate.
- * </p>
- * @param int $style <p>
- * A bitwise OR of the following possibilities:
- * IMG_ARC_PIE
- * @return bool true on success or false on failure.
- */
-function imagefilledarc ($image, $cx, $cy, $width, $height, $start, $end, $color, $style) {}
-
-/**
- * Draw a filled ellipse
- * @link https://php.net/manual/en/function.imagefilledellipse.php
- * @param resource $image
- * @param int $cx <p>
- * x-coordinate of the center.
- * </p>
- * @param int $cy <p>
- * y-coordinate of the center.
- * </p>
- * @param int $width <p>
- * The ellipse width.
- * </p>
- * @param int $height <p>
- * The ellipse height.
- * </p>
- * @param int $color <p>
- * The fill color. A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagefilledellipse ($image, $cx, $cy, $width, $height, $color) {}
-
-/**
- * Set the blending mode for an image
- * @link https://php.net/manual/en/function.imagealphablending.php
- * @param resource $image
- * @param bool $blendmode <p>
- * Whether to enable the blending mode or not. On true color images
- * the default value is true otherwise the default value is false
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagealphablending ($image, $blendmode) {}
-
-/**
- * Set the flag to save full alpha channel information (as opposed to single-color transparency) when saving PNG images
- * @link https://php.net/manual/en/function.imagesavealpha.php
- * @param resource $image
- * @param bool $saveflag <p>
- * Whether to save the alpha channel or not. Default to false.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagesavealpha ($image, $saveflag) {}
-
-/**
- * Allocate a color for an image
- * @link https://php.net/manual/en/function.imagecolorallocatealpha.php
- * @param resource $image
- * @param int $red <p>
- * Value of red component.
- * </p>
- * @param int $green <p>
- * Value of green component.
- * </p>
- * @param int $blue <p>
- * Value of blue component.
- * </p>
- * @param int $alpha <p>
- * A value between 0 and 127.
- * 0 indicates completely opaque while
- * 127 indicates completely transparent.
- * </p>
- * @return int|false A color identifier or false if the allocation failed.
- */
-function imagecolorallocatealpha ($image, $red, $green, $blue, $alpha) {}
-
-/**
- * Get the index of the specified color + alpha or its closest possible alternative
- * @link https://php.net/manual/en/function.imagecolorresolvealpha.php
- * @param resource $image
- * @param int $red <p>
- * Value of red component.
- * </p>
- * @param int $green <p>
- * Value of green component.
- * </p>
- * @param int $blue <p>
- * Value of blue component.
- * </p>
- * @param int $alpha <p>
- * A value between 0 and 127.
- * 0 indicates completely opaque while
- * 127 indicates completely transparent.
- * </p>
- * @return int|false a color index or <b>FALSE</b> on failure
- */
-function imagecolorresolvealpha ($image, $red, $green, $blue, $alpha) {}
-
-/**
- * Get the index of the closest color to the specified color + alpha
- * @link https://php.net/manual/en/function.imagecolorclosestalpha.php
- * @param resource $image
- * @param int $red <p>
- * Value of red component.
- * </p>
- * @param int $green <p>
- * Value of green component.
- * </p>
- * @param int $blue <p>
- * Value of blue component.
- * </p>
- * @param int $alpha <p>
- * A value between 0 and 127.
- * 0 indicates completely opaque while
- * 127 indicates completely transparent.
- * </p>
- * @return int|false the index of the closest color in the palette or
- * <b>FALSE</b> on failure
- */
-function imagecolorclosestalpha ($image, $red, $green, $blue, $alpha) {}
-
-/**
- * Get the index of the specified color + alpha
- * @link https://php.net/manual/en/function.imagecolorexactalpha.php
- * @param resource $image
- * @param int $red <p>
- * Value of red component.
- * </p>
- * @param int $green <p>
- * Value of green component.
- * </p>
- * @param int $blue <p>
- * Value of blue component.
- * </p>
- * @param int $alpha <p>
- * A value between 0 and 127.
- * 0 indicates completely opaque while
- * 127 indicates completely transparent.
- * </p>
- * @return int|false the index of the specified color+alpha in the palette of the
- * image, -1 if the color does not exist in the image's palette, or <b>FALSE</b>
- * on failure
- */
-function imagecolorexactalpha ($image, $red, $green, $blue, $alpha) {}
-
-/**
- * Copy and resize part of an image with resampling
- * @link https://php.net/manual/en/function.imagecopyresampled.php
- * @param resource $dst_image
- * @param resource $src_image
- * @param int $dst_x <p>
- * x-coordinate of destination point.
- * </p>
- * @param int $dst_y <p>
- * y-coordinate of destination point.
- * </p>
- * @param int $src_x <p>
- * x-coordinate of source point.
- * </p>
- * @param int $src_y <p>
- * y-coordinate of source point.
- * </p>
- * @param int $dst_w <p>
- * Destination width.
- * </p>
- * @param int $dst_h <p>
- * Destination height.
- * </p>
- * @param int $src_w <p>
- * Source width.
- * </p>
- * @param int $src_h <p>
- * Source height.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagecopyresampled ($dst_image, $src_image, $dst_x, $dst_y, $src_x, $src_y, $dst_w, $dst_h, $src_w, $src_h) {}
-
-/**
- * Rotate an image with a given angle
- * @link https://php.net/manual/en/function.imagerotate.php
- * @param resource $image
- * @param float $angle <p>
- * Rotation angle, in degrees.
- * </p>
- * @param int $bgd_color <p>
- * Specifies the color of the uncovered zone after the rotation
- * </p>
- * @param int $ignore_transparent [optional] <p>
- * If set and non-zero, transparent colors are ignored (otherwise kept).
- * </p>
- * @return resource|false the rotated image or <b>FALSE</b> on failure
- */
-function imagerotate ($image, $angle, $bgd_color, $ignore_transparent = null) {}
-
-/**
- * Should antialias functions be used or not. <br/>
- * Before 7.2.0 it's only available if PHP iscompiled with the bundled version of the GD library.
- * @link https://php.net/manual/en/function.imageantialias.php
- * @param resource $image
- * @param bool $enabled <p>
- * Whether to enable antialiasing or not.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imageantialias ($image, $enabled) {}
-
-/**
- * Set the tile image for filling
- * @link https://php.net/manual/en/function.imagesettile.php
- * @param resource $image
- * @param resource $tile <p>
- * The image resource to be used as a tile.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagesettile ($image, $tile) {}
-
-/**
- * Set the brush image for line drawing
- * @link https://php.net/manual/en/function.imagesetbrush.php
- * @param resource $image
- * @param resource $brush <p>
- * An image resource.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagesetbrush ($image, $brush) {}
-
-/**
- * Set the style for line drawing
- * @link https://php.net/manual/en/function.imagesetstyle.php
- * @param resource $image
- * @param array $style <p>
- * An array of pixel colors. You can use the
- * IMG_COLOR_TRANSPARENT constant to add a
- * transparent pixel.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagesetstyle ($image, array $style) {}
-
-/**
- * Create a new image from file or URL
- * @link https://php.net/manual/en/function.imagecreatefrompng.php
- * @param string $filename <p>
- * Path to the PNG image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefrompng ($filename) {}
-
-/**
- * Create a new image from file or URL
- * @link https://php.net/manual/en/function.imagecreatefromgif.php
- * @param string $filename <p>
- * Path to the GIF image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromgif ($filename) {}
-
-/**
- * Create a new image from file or URL
- * @link https://php.net/manual/en/function.imagecreatefromjpeg.php
- * @param string $filename <p>
- * Path to the JPEG image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromjpeg ($filename) {}
-
-/**
- * Create a new image from file or URL
- * @link https://php.net/manual/en/function.imagecreatefromwbmp.php
- * @param string $filename <p>
- * Path to the WBMP image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromwbmp ($filename) {}
-
-/**
- * Create a new image from file or URL
- * @link https://php.net/manual/en/function.imagecreatefromwebp.php
- * @param string $filename <p>
- * Path to the WebP image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- * @since 5.4
- */
-function imagecreatefromwebp ($filename) {}
-
-/**
- * Create a new image from file or URL
- * @link https://php.net/manual/en/function.imagecreatefromxbm.php
- * @param string $filename <p>
- * Path to the XBM image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromxbm ($filename) {}
-
-/**
- * Create a new image from file or URL
- * @link https://php.net/manual/en/function.imagecreatefromxpm.php
- * @param string $filename <p>
- * Path to the XPM image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromxpm ($filename) {}
-
-/**
- * Create a new image from GD file or URL
- * @link https://php.net/manual/en/function.imagecreatefromgd.php
- * @param string $filename <p>
- * Path to the GD file.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromgd ($filename) {}
-
-/**
- * Create a new image from GD2 file or URL
- * @link https://php.net/manual/en/function.imagecreatefromgd2.php
- * @param string $filename <p>
- * Path to the GD2 image.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromgd2 ($filename) {}
-
-/**
- * Create a new image from a given part of GD2 file or URL
- * @link https://php.net/manual/en/function.imagecreatefromgd2part.php
- * @param string $filename <p>
- * Path to the GD2 image.
- * </p>
- * @param int $srcX <p>
- * x-coordinate of source point.
- * </p>
- * @param int $srcY <p>
- * y-coordinate of source point.
- * </p>
- * @param int $width <p>
- * Source width.
- * </p>
- * @param int $height <p>
- * Source height.
- * </p>
- * @return resource|false an image resource identifier on success, false on errors.
- */
-function imagecreatefromgd2part ($filename, $srcX, $srcY, $width, $height) {}
-
-/**
- * Output a PNG image to either the browser or a file
- * @link https://php.net/manual/en/function.imagepng.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * <p>
- * &null; is invalid if the quality and
- * filters arguments are not used.
- * </p>
- * @param int $quality [optional] <p>
- * Compression level: from 0 (no compression) to 9.
- * </p>
- * @param int $filters [optional] <p>
- * Allows reducing the PNG file size. It is a bitmask field which may be
- * set to any combination of the PNG_FILTER_XXX
- * constants. PNG_NO_FILTER or
- * PNG_ALL_FILTERS may also be used to respectively
- * disable or activate all filters.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagepng ($image, $filename = null, $quality = null, $filters = null) {}
-
-/**
- * Output a WebP image to browser or file
- * @link https://php.net/manual/en/function.imagewebp.php
- * @param resource $image
- * @param string $to [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * @param int $quality [optional] <p>
- * quality ranges from 0 (worst quality, smaller file) to 100 (best quality, biggest file).
- * </p>
- * @return bool true on success or false on failure.
- * @since 5.4
- */
-function imagewebp ($image, $to = null, $quality = 80) {}
-
-/**
- * Output image to browser or file
- * @link https://php.net/manual/en/function.imagegif.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagegif ($image, $filename = null) {}
-
-/**
- * Output image to browser or file
- * @link https://php.net/manual/en/function.imagejpeg.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * <p>
- * To skip this argument in order to provide the
- * quality parameter, use &null;.
- * </p>
- * @param int $quality [optional] <p>
- * quality is optional, and ranges from 0 (worst
- * quality, smaller file) to 100 (best quality, biggest file). The
- * default is the default IJG quality value (about 75).
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagejpeg ($image, $filename = null, $quality = null) {}
-
-/**
- * Output image to browser or file
- * @link https://php.net/manual/en/function.imagewbmp.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * @param int $foreground [optional] <p>
- * You can set the foreground color with this parameter by setting an
- * identifier obtained from imagecolorallocate.
- * The default foreground color is black.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagewbmp ($image, $filename = null, $foreground = null) {}
-
-/**
- * Output GD image to browser or file. <br/>
- * Since 7.2.0 allows to output truecolor images.
- * @link https://php.net/manual/en/function.imagegd.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagegd ($image, $filename = null) {}
-
-/**
- * Output GD2 image to browser or file
- * @link https://php.net/manual/en/function.imagegd2.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * @param int $chunk_size [optional] <p>
- * Chunk size.
- * </p>
- * @param int $type [optional] <p>
- * Either IMG_GD2_RAW or
- * IMG_GD2_COMPRESSED. Default is
- * IMG_GD2_RAW.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagegd2 ($image, $filename = null, $chunk_size = null, $type = null) {}
-
-/**
- * Destroy an image
- * @link https://php.net/manual/en/function.imagedestroy.php
- * @param resource $image
- * @return bool true on success or false on failure.
- */
-function imagedestroy ($image) {}
-
-/**
- * Apply a gamma correction to a GD image
- * @link https://php.net/manual/en/function.imagegammacorrect.php
- * @param resource $image
- * @param float $inputgamma <p>
- * The input gamma.
- * </p>
- * @param float $outputgamma <p>
- * The output gamma.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagegammacorrect ($image, $inputgamma, $outputgamma) {}
-
-/**
- * Flood fill
- * @link https://php.net/manual/en/function.imagefill.php
- * @param resource $image
- * @param int $x <p>
- * x-coordinate of start point.
- * </p>
- * @param int $y <p>
- * y-coordinate of start point.
- * </p>
- * @param int $color <p>
- * The fill color. A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagefill ($image, $x, $y, $color) {}
-
-/**
- * Draw a filled polygon
- * @link https://php.net/manual/en/function.imagefilledpolygon.php
- * @param resource $image
- * @param array $points <p>
- * An array containing the x and y
- * coordinates of the polygons vertices consecutively.
- * </p>
- * @param int $num_points [optional] <p>
- * Total number of vertices, which must be at least 3.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagefilledpolygon ($image, array $points, $num_points, $color) {}
-
-/**
- * Draw a filled rectangle
- * @link https://php.net/manual/en/function.imagefilledrectangle.php
- * @param resource $image
- * @param int $x1 <p>
- * x-coordinate for point 1.
- * </p>
- * @param int $y1 <p>
- * y-coordinate for point 1.
- * </p>
- * @param int $x2 <p>
- * x-coordinate for point 2.
- * </p>
- * @param int $y2 <p>
- * y-coordinate for point 2.
- * </p>
- * @param int $color <p>
- * The fill color. A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagefilledrectangle ($image, $x1, $y1, $x2, $y2, $color) {}
-
-/**
- * Flood fill to specific color
- * @link https://php.net/manual/en/function.imagefilltoborder.php
- * @param resource $image
- * @param int $x <p>
- * x-coordinate of start.
- * </p>
- * @param int $y <p>
- * y-coordinate of start.
- * </p>
- * @param int $border <p>
- * The border color. A color identifier created with
- * imagecolorallocate.
- * </p>
- * @param int $color <p>
- * The fill color. A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagefilltoborder ($image, $x, $y, $border, $color) {}
-
-/**
- * Get font width
- * @link https://php.net/manual/en/function.imagefontwidth.php
- * @param int $font
- * @return int the width of the pixel
- */
-function imagefontwidth ($font) {}
-
-/**
- * Get font height
- * @link https://php.net/manual/en/function.imagefontheight.php
- * @param int $font
- * @return int the height of the pixel.
- */
-function imagefontheight ($font) {}
-
-/**
- * Enable or disable interlace
- * @link https://php.net/manual/en/function.imageinterlace.php
- * @param resource $image
- * @param int $interlace [optional] <p>
- * If non-zero, the image will be interlaced, else the interlace bit is
- * turned off.
- * </p>
- * @return int|false 1 if the interlace bit is set for the image,
- * 0 if it is not, or <b>FALSE</b> on failure
- */
-function imageinterlace ($image, $interlace = null) {}
-
-/**
- * Draw a line
- * @link https://php.net/manual/en/function.imageline.php
- * @param resource $image
- * @param int $x1 <p>
- * x-coordinate for first point.
- * </p>
- * @param int $y1 <p>
- * y-coordinate for first point.
- * </p>
- * @param int $x2 <p>
- * x-coordinate for second point.
- * </p>
- * @param int $y2 <p>
- * y-coordinate for second point.
- * </p>
- * @param int $color <p>
- * The line color. A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imageline ($image, $x1, $y1, $x2, $y2, $color) {}
-
-/**
- * Load a new font
- * @link https://php.net/manual/en/function.imageloadfont.php
- * @param string $file <p>
- * The font file format is currently binary and architecture
- * dependent. This means you should generate the font files on the
- * same type of CPU as the machine you are running PHP on.
- * </p>
- * <p>
- * <table>
- * Font file format
- * <tr valign="top">
- * <td>byte position</td>
- * <td>C data type</td>
- * <td>description</td>
- * </tr>
- * <tr valign="top">
- * <td>byte 0-3</td>
- * <td>int</td>
- * <td>number of characters in the font</td>
- * </tr>
- * <tr valign="top">
- * <td>byte 4-7</td>
- * <td>int</td>
- * <td>
- * value of first character in the font (often 32 for space)
- * </td>
- * </tr>
- * <tr valign="top">
- * <td>byte 8-11</td>
- * <td>int</td>
- * <td>pixel width of each character</td>
- * </tr>
- * <tr valign="top">
- * <td>byte 12-15</td>
- * <td>int</td>
- * <td>pixel height of each character</td>
- * </tr>
- * <tr valign="top">
- * <td>byte 16-</td>
- * <td>char</td>
- * <td>
- * array with character data, one byte per pixel in each
- * character, for a total of (nchars*width*height) bytes.
- * </td>
- * </tr>
- * </table>
- * </p>
- * @return int|false The font identifier which is always bigger than 5 to avoid conflicts with
- * built-in fonts or false on errors.
- */
-function imageloadfont ($file) {}
-
-/**
- * Draws a polygon
- * @link https://php.net/manual/en/function.imagepolygon.php
- * @param resource $image
- * @param array $points <p>
- * An array containing the polygon's vertices, e.g.:
- * <tr valign="top">
- * <td>points[0]</td>
- * <td>= x0</td>
- * </tr>
- * <tr valign="top">
- * <td>points[1]</td>
- * <td>= y0</td>
- * </tr>
- * <tr valign="top">
- * <td>points[2]</td>
- * <td>= x1</td>
- * </tr>
- * <tr valign="top">
- * <td>points[3]</td>
- * <td>= y1</td>
- * </tr>
- * </p>
- * @param int $num_points [optional] <p>
- * Total number of points (vertices).
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagepolygon ($image, array $points, $num_points, $color) {}
-
-/**
- * Draw a rectangle
- * @link https://php.net/manual/en/function.imagerectangle.php
- * @param resource $image
- * @param int $x1 <p>
- * Upper left x coordinate.
- * </p>
- * @param int $y1 <p>
- * Upper left y coordinate
- * 0, 0 is the top left corner of the image.
- * </p>
- * @param int $x2 <p>
- * Bottom right x coordinate.
- * </p>
- * @param int $y2 <p>
- * Bottom right y coordinate.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagerectangle ($image, $x1, $y1, $x2, $y2, $color) {}
-
-/**
- * Set a single pixel
- * @link https://php.net/manual/en/function.imagesetpixel.php
- * @param resource $image
- * @param int $x <p>
- * x-coordinate.
- * </p>
- * @param int $y <p>
- * y-coordinate.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagesetpixel ($image, $x, $y, $color) {}
-
-/**
- * Draw a string horizontally
- * @link https://php.net/manual/en/function.imagestring.php
- * @param resource $image
- * @param int $font
- * @param int $x <p>
- * x-coordinate of the upper left corner.
- * </p>
- * @param int $y <p>
- * y-coordinate of the upper left corner.
- * </p>
- * @param string $string <p>
- * The string to be written.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagestring ($image, $font, $x, $y, $string, $color) {}
-
-/**
- * Draw a string vertically
- * @link https://php.net/manual/en/function.imagestringup.php
- * @param resource $image
- * @param int $font
- * @param int $x <p>
- * x-coordinate of the upper left corner.
- * </p>
- * @param int $y <p>
- * y-coordinate of the upper left corner.
- * </p>
- * @param string $string <p>
- * The string to be written.
- * </p>
- * @param int $color <p>
- * A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagestringup ($image, $font, $x, $y, $string, $color) {}
-
-/**
- * Get image width
- * @link https://php.net/manual/en/function.imagesx.php
- * @param resource $image
- * @return int|false Return the width of the image or false on
- * errors.
- */
-function imagesx ($image) {}
-
-/**
- * Get image height
- * @link https://php.net/manual/en/function.imagesy.php
- * @param resource $image
- * @return int|false Return the height of the image or false on
- * errors.
- */
-function imagesy ($image) {}
-
-/**
- * Draw a dashed line
- * @link https://php.net/manual/en/function.imagedashedline.php
- * @param resource $image
- * @param int $x1 <p>
- * Upper left x coordinate.
- * </p>
- * @param int $y1 <p>
- * Upper left y coordinate 0, 0 is the top left corner of the image.
- * </p>
- * @param int $x2 <p>
- * Bottom right x coordinate.
- * </p>
- * @param int $y2 <p>
- * Bottom right y coordinate.
- * </p>
- * @param int $color <p>
- * The fill color. A color identifier created with
- * imagecolorallocate.
- * </p>
- * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * @deprecated Use combination of imagesetstyle() and imageline() instead
- */
-function imagedashedline ($image, $x1, $y1, $x2, $y2, $color) {}
-
-/**
- * Give the bounding box of a text using TrueType fonts
- * @link https://php.net/manual/en/function.imagettfbbox.php
- * @param float $size <p>
- * The font size. Depending on your version of GD, this should be
- * specified as the pixel size (GD1) or point size (GD2).
- * </p>
- * @param float $angle <p>
- * Angle in degrees in which text will be measured.
- * </p>
- * @param string $fontfile <p>
- * The name of the TrueType font file (can be a URL). Depending on
- * which version of the GD library that PHP is using, it may attempt to
- * search for files that do not begin with a leading '/' by appending
- * '.ttf' to the filename and searching along a library-defined font path.
- * </p>
- * @param string $text <p>
- * The string to be measured.
- * </p>
- * @return array|false imagettfbbox returns an array with 8
- * elements representing four points making the bounding box of the
- * text on success and false on error.
- * <tr valign="top">
- * <td>key</td>
- * <td>contents</td>
- * </tr>
- * <tr valign="top">
- * <td>0</td>
- * <td>lower left corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>1</td>
- * <td>lower left corner, Y position</td>
- * </tr>
- * <tr valign="top">
- * <td>2</td>
- * <td>lower right corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>3</td>
- * <td>lower right corner, Y position</td>
- * </tr>
- * <tr valign="top">
- * <td>4</td>
- * <td>upper right corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>5</td>
- * <td>upper right corner, Y position</td>
- * </tr>
- * <tr valign="top">
- * <td>6</td>
- * <td>upper left corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>7</td>
- * <td>upper left corner, Y position</td>
- * </tr>
- * </p>
- * <p>
- * The points are relative to the text regardless of the
- * angle, so "upper left" means in the top left-hand
- * corner seeing the text horizontally.
- */
-function imagettfbbox ($size, $angle, $fontfile, $text) {}
-
-/**
- * Write text to the image using TrueType fonts
- * @link https://php.net/manual/en/function.imagettftext.php
- * @param resource $image
- * @param float $size <p>
- * The font size. Depending on your version of GD, this should be
- * specified as the pixel size (GD1) or point size (GD2).
- * </p>
- * @param float $angle <p>
- * The angle in degrees, with 0 degrees being left-to-right reading text.
- * Higher values represent a counter-clockwise rotation. For example, a
- * value of 90 would result in bottom-to-top reading text.
- * </p>
- * @param int $x <p>
- * The coordinates given by x and
- * y will define the basepoint of the first
- * character (roughly the lower-left corner of the character). This
- * is different from the imagestring, where
- * x and y define the
- * upper-left corner of the first character. For example, "top left"
- * is 0, 0.
- * </p>
- * @param int $y <p>
- * The y-ordinate. This sets the position of the fonts baseline, not the
- * very bottom of the character.
- * </p>
- * @param int $color <p>
- * The color index. Using the negative of a color index has the effect of
- * turning off antialiasing. See imagecolorallocate.
- * </p>
- * @param string $fontfile <p>
- * The path to the TrueType font you wish to use.
- * </p>
- * <p>
- * Depending on which version of the GD library PHP is using, when
- * fontfile does not begin with a leading
- * / then .ttf will be appended
- * to the filename and the library will attempt to search for that
- * filename along a library-defined font path.
- * </p>
- * <p>
- * When using versions of the GD library lower than 2.0.18, a space character,
- * rather than a semicolon, was used as the 'path separator' for different font files.
- * Unintentional use of this feature will result in the warning message:
- * Warning: Could not find/open font. For these affected versions, the
- * only solution is moving the font to a path which does not contain spaces.
- * </p>
- * <p>
- * In many cases where a font resides in the same directory as the script using it
- * the following trick will alleviate any include problems.
- * </p>
- * <pre>
- * <?php
- * // Set the enviroment variable for GD
- * putenv('GDFONTPATH=' . realpath('.'));
- *
- * // Name the font to be used (note the lack of the .ttf extension)
- * $font = 'SomeFont';
- * ?>
- * </pre>
- * <p>
- * <strong>Note:</strong>
- * <code>open_basedir</code> does <em>not</em> apply to fontfile.
- * </p>
- * @param string $text <p>
- * The text string in UTF-8 encoding.
- * </p>
- * <p>
- * May include decimal numeric character references (of the form:
- * &amp;#8364;) to access characters in a font beyond position 127.
- * The hexadecimal format (like &amp;#xA9;) is supported.
- * Strings in UTF-8 encoding can be passed directly.
- * </p>
- * <p>
- * Named entities, such as &amp;copy;, are not supported. Consider using
- * html_entity_decode
- * to decode these named entities into UTF-8 strings (html_entity_decode()
- * supports this as of PHP 5.0.0).
- * </p>
- * <p>
- * If a character is used in the string which is not supported by the
- * font, a hollow rectangle will replace the character.
- * </p>
- * @return array|false an array with 8 elements representing four points making the
- * bounding box of the text. The order of the points is lower left, lower
- * right, upper right, upper left. The points are relative to the text
- * regardless of the angle, so "upper left" means in the top left-hand
- * corner when you see the text horizontally.
- * Returns false on error.
- */
-function imagettftext ($image, $size, $angle, $x, $y, $color, $fontfile, $text) {}
-
-/**
- * Give the bounding box of a text using fonts via freetype2
- * @link https://php.net/manual/en/function.imageftbbox.php
- * @param float $size <p>
- * The font size. Depending on your version of GD, this should be
- * specified as the pixel size (GD1) or point size (GD2).
- * </p>
- * @param float $angle <p>
- * Angle in degrees in which text will be
- * measured.
- * </p>
- * @param string $fontfile <p>
- * The name of the TrueType font file (can be a URL). Depending on
- * which version of the GD library that PHP is using, it may attempt to
- * search for files that do not begin with a leading '/' by appending
- * '.ttf' to the filename and searching along a library-defined font path.
- * </p>
- * @param string $text <p>
- * The string to be measured.
- * </p>
- * @param array $extrainfo [optional] <p>
- * <table>
- * Possible array indexes for extrainfo
- * <tr valign="top">
- * <td>Key</td>
- * <td>Type</td>
- * <td>Meaning</td>
- * </tr>
- * <tr valign="top">
- * <td>linespacing</td>
- * <td>float</td>
- * <td>Defines drawing linespacing</td>
- * </tr>
- * </table>
- * </p>
- * @return array|false imageftbbox returns an array with 8
- * elements representing four points making the bounding box of the
- * text:
- * <tr valign="top">
- * <td>0</td>
- * <td>lower left corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>1</td>
- * <td>lower left corner, Y position</td>
- * </tr>
- * <tr valign="top">
- * <td>2</td>
- * <td>lower right corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>3</td>
- * <td>lower right corner, Y position</td>
- * </tr>
- * <tr valign="top">
- * <td>4</td>
- * <td>upper right corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>5</td>
- * <td>upper right corner, Y position</td>
- * </tr>
- * <tr valign="top">
- * <td>6</td>
- * <td>upper left corner, X position</td>
- * </tr>
- * <tr valign="top">
- * <td>7</td>
- * <td>upper left corner, Y position</td>
- * </tr>
- * </p>
- * <p>
- * The points are relative to the text regardless of the
- * angle, so "upper left" means in the top left-hand
- * corner seeing the text horizontally.
- * Returns false on error.
- */
-function imageftbbox ($size, $angle, $fontfile, $text, $extrainfo = null ) {}
-
-/**
- * Write text to the image using fonts using FreeType 2
- * @link https://php.net/manual/en/function.imagefttext.php
- * @param resource $image
- * @param float $size <p>
- * The font size to use in points.
- * </p>
- * @param float $angle <p>
- * The angle in degrees, with 0 degrees being left-to-right reading text.
- * Higher values represent a counter-clockwise rotation. For example, a
- * value of 90 would result in bottom-to-top reading text.
- * </p>
- * @param int $x <p>
- * The coordinates given by x and
- * y will define the basepoint of the first
- * character (roughly the lower-left corner of the character). This
- * is different from the imagestring, where
- * x and y define the
- * upper-left corner of the first character. For example, "top left"
- * is 0, 0.
- * </p>
- * @param int $y <p>
- * The y-ordinate. This sets the position of the fonts baseline, not the
- * very bottom of the character.
- * </p>
- * @param int $color <p>
- * The index of the desired color for the text, see
- * imagecolorexact.
- * </p>
- * @param string $fontfile <p>
- * The path to the TrueType font you wish to use.
- * </p>
- * <p>
- * Depending on which version of the GD library PHP is using, when
- * fontfile does not begin with a leading
- * / then .ttf will be appended
- * to the filename and the library will attempt to search for that
- * filename along a library-defined font path.
- * </p>
- * <p>
- * When using versions of the GD library lower than 2.0.18, a space character,
- * rather than a semicolon, was used as the 'path separator' for different font files.
- * Unintentional use of this feature will result in the warning message:
- * Warning: Could not find/open font. For these affected versions, the
- * only solution is moving the font to a path which does not contain spaces.
- * </p>
- * <p>
- * In many cases where a font resides in the same directory as the script using it
- * the following trick will alleviate any include problems.
- * </p>
- * <pre>
- * <?php
- * // Set the enviroment variable for GD
- * putenv('GDFONTPATH=' . realpath('.'));
- *
- * // Name the font to be used (note the lack of the .ttf extension)
- * $font = 'SomeFont';
- * ?>
- * </pre>
- * <p>
- * <strong>Note:</strong>
- * <code>open_basedir</code> does <em>not</em> apply to fontfile.
- * </p>
- * @param string $text <p>
- * Text to be inserted into image.
- * </p>
- * @param array $extrainfo [optional] <p>
- * <table>
- * Possible array indexes for extrainfo
- * <tr valign="top">
- * <td>Key</td>
- * <td>Type</td>
- * <td>Meaning</td>
- * </tr>
- * <tr valign="top">
- * <td>linespacing</td>
- * <td>float</td>
- * <td>Defines drawing linespacing</td>
- * </tr>
- * </table>
- * </p>
- * @return array|false This function returns an array defining the four points of the box, starting in the lower left and moving counter-clockwise:
- * <tr valign="top">
- * <td>0</td>
- * <td>lower left x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>1</td>
- * <td>lower left y-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>2</td>
- * <td>lower right x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>3</td>
- * <td>lower right y-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>4</td>
- * <td>upper right x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>5</td>
- * <td>upper right y-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>6</td>
- * <td>upper left x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>7</td>
- * <td>upper left y-coordinate</td>
- * </tr>
- * Returns false on error.
- */
-function imagefttext ($image, $size, $angle, $x, $y, $color, $fontfile, $text, $extrainfo = null ) {}
-
-/**
- * Load a PostScript Type 1 font from file
- * @link https://php.net/manual/en/function.imagepsloadfont.php
- * @param string $filename <p>
- * Path to the Postscript font file.
- * </p>
- * @return resource|false In the case everything went right, a valid font index will be returned and
- * can be used for further purposes. Otherwise the function returns false.
- * @removed 7.0 This function was REMOVED in PHP 7.0.0.
- */
-function imagepsloadfont ($filename) {}
-
-/**
- * Free memory used by a PostScript Type 1 font
- * @link https://php.net/manual/en/function.imagepsfreefont.php
- * @param resource $font_index <p>
- * A font resource, returned by imagepsloadfont.
- * </p>
- * @return bool true on success or false on failure.
- * @removed 7.0
- */
-function imagepsfreefont ($font_index) {}
-
-/**
- * Change the character encoding vector of a font
- * @link https://php.net/manual/en/function.imagepsencodefont.php
- * @param resource $font_index <p>
- * A font resource, returned by imagepsloadfont.
- * </p>
- * @param string $encodingfile <p>
- * The exact format of this file is described in T1libs documentation.
- * T1lib comes with two ready-to-use files,
- * IsoLatin1.enc and
- * IsoLatin2.enc.
- * </p>
- * @return bool true on success or false on failure.
- * @removed 7.0
- */
-function imagepsencodefont ($font_index, $encodingfile) {}
-
-/**
- * Extend or condense a font
- * @link https://php.net/manual/en/function.imagepsextendfont.php
- * @param resource $font_index <p>
- * A font resource, returned by imagepsloadfont.
- * </p>
- * @param float $extend <p>
- * Extension value, must be greater than 0.
- * </p>
- * @return bool true on success or false on failure.
- * @removed 7.0
- */
-function imagepsextendfont ($font_index, $extend) {}
-
-/**
- * Slant a font
- * @link https://php.net/manual/en/function.imagepsslantfont.php
- * @param resource $font_index <p>
- * A font resource, returned by imagepsloadfont.
- * </p>
- * @param float $slant <p>
- * Slant level.
- * </p>
- * @return bool true on success or false on failure.
- * @removed 7.0 This function was REMOVED in PHP 7.0.0.
- */
-function imagepsslantfont ($font_index, $slant) {}
-
-/**
- * Draws a text over an image using PostScript Type1 fonts
- * @link https://php.net/manual/en/function.imagepstext.php
- * @param resource $image
- * @param string $text <p>
- * The text to be written.
- * </p>
- * @param resource $font_index <p>
- * A font resource, returned by imagepsloadfont.
- * </p>
- * @param int $size <p>
- * size is expressed in pixels.
- * </p>
- * @param int $foreground <p>
- * The color in which the text will be painted.
- * </p>
- * @param int $background <p>
- * The color to which the text will try to fade in with antialiasing.
- * No pixels with the color background are
- * actually painted, so the background image does not need to be of solid
- * color.
- * </p>
- * @param int $x <p>
- * x-coordinate for the lower-left corner of the first character.
- * </p>
- * @param int $y <p>
- * y-coordinate for the lower-left corner of the first character.
- * </p>
- * @param int $space [optional] <p>
- * Allows you to change the default value of a space in a font. This
- * amount is added to the normal value and can also be negative.
- * Expressed in character space units, where 1 unit is 1/1000th of an
- * em-square.
- * </p>
- * @param int $tightness [optional] <p>
- * tightness allows you to control the amount
- * of white space between characters. This amount is added to the
- * normal character width and can also be negative.
- * Expressed in character space units, where 1 unit is 1/1000th of an
- * em-square.
- * </p>
- * @param float $angle [optional] <p>
- * angle is in degrees.
- * </p>
- * @param int $antialias_steps [optional] <p>
- * Allows you to control the number of colours used for antialiasing
- * text. Allowed values are 4 and 16. The higher value is recommended
- * for text sizes lower than 20, where the effect in text quality is
- * quite visible. With bigger sizes, use 4. It's less computationally
- * intensive.
- * </p>
- * @return array|false This function returns an array containing the following elements:
- * <tr valign="top">
- * <td>0</td>
- * <td>lower left x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>1</td>
- * <td>lower left y-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>2</td>
- * <td>upper right x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>3</td>
- * <td>upper right y-coordinate</td>
- * </tr>
- * Returns false on error.
- * @removed 7.0 This function was REMOVED in PHP 7.0.0.
- */
-function imagepstext ($image, $text, $font_index, $size, $foreground, $background, $x, $y, $space = null, $tightness = null, $angle = null, $antialias_steps = null) {}
-
-/**
- * Give the bounding box of a text rectangle using PostScript Type1 fonts
- * @link https://php.net/manual/en/function.imagepsbbox.php
- * @param string $text <p>
- * The text to be written.
- * </p>
- * @param resource $font
- * @param int $size <p>
- * size is expressed in pixels.
- * </p>
- * @return array|false an array containing the following elements:
- * <tr valign="top">
- * <td>0</td>
- * <td>left x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>1</td>
- * <td>upper y-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>2</td>
- * <td>right x-coordinate</td>
- * </tr>
- * <tr valign="top">
- * <td>3</td>
- * <td>lower y-coordinate</td>
- * </tr>
- * Returns false on error.
- * @removed 7.0
- */
-function imagepsbbox ($text, $font, $size) {}
-
-/**
- * Return the image types supported by this PHP build
- * @link https://php.net/manual/en/function.imagetypes.php
- * @return int a bit-field corresponding to the image formats supported by the
- * version of GD linked into PHP. The following bits are returned,
- * IMG_BMP | IMG_GIF | IMG_JPG | IMG_PNG | IMG_WBMP | IMG_XPM | IMG_WEBP
- */
-function imagetypes () {}
-
-/**
- * Convert JPEG image file to WBMP image file
- * @link https://php.net/manual/en/function.jpeg2wbmp.php
- * @param string $jpegname <p>
- * Path to JPEG file.
- * </p>
- * @param string $wbmpname <p>
- * Path to destination WBMP file.
- * </p>
- * @param int $dest_height <p>
- * Destination image height.
- * </p>
- * @param int $dest_width <p>
- * Destination image width.
- * </p>
- * @param int $threshold <p>
- * Threshold value, between 0 and 8 (inclusive).
- * </p>
- * @return bool true on success or false on failure.
- * @deprecated 7.2 Use imagecreatefromjpeg() and imagewbmp() instead
- * @removed 8.0
- */
-function jpeg2wbmp ($jpegname, $wbmpname, $dest_height, $dest_width, $threshold) {}
-
-/**
- * Convert PNG image file to WBMP image file
- * @link https://php.net/manual/en/function.png2wbmp.php
- * @param string $pngname <p>
- * Path to PNG file.
- * </p>
- * @param string $wbmpname <p>
- * Path to destination WBMP file.
- * </p>
- * @param int $dest_height <p>
- * Destination image height.
- * </p>
- * @param int $dest_width <p>
- * Destination image width.
- * </p>
- * @param int $threshold <p>
- * Threshold value, between 0 and 8 (inclusive).
- * </p>
- * @return bool true on success or false on failure.
- * @deprecated 7.2 Use imagecreatefrompng() and imagewbmp() instead
- * @removed 8.0
- */
-function png2wbmp ($pngname, $wbmpname, $dest_height, $dest_width, $threshold) {}
+function imageloadfont(string $filename): GdFont|false {}
 
-/**
- * Output image to browser or file
- * @link https://php.net/manual/en/function.image2wbmp.php
- * @param resource $image
- * @param string $filename [optional] <p>
- * Path to the saved file. If not given, the raw image stream will be
- * outputted directly.
- * </p>
- * @param int $threshold [optional] <p>
- * Threshold value, between 0 and 255 (inclusive).
- * </p>
- * @return bool true on success or false on failure.
- * @deprecated 7.3 Use imagewbmp() instead
- * @removed 8.0
- */
-function image2wbmp ($image, $filename = null, $threshold = null) {}
-
-/**
- * Set the alpha blending flag to use the bundled libgd layering effects
- * @link https://php.net/manual/en/function.imagelayereffect.php
- * @param resource $image
- * @param int $effect <p>
- * One of the following constants:
- * IMG_EFFECT_REPLACE
- * Use pixel replacement (equivalent of passing true to
- * imagealphablending)
- * @return bool true on success or false on failure.
- */
-function imagelayereffect ($image, $effect) {}
-
-/**
- * Makes the colors of the palette version of an image more closely match the true color version
- * @link https://php.net/manual/en/function.imagecolormatch.php
- * @param $image1 resource <p>
- * A truecolor image link resource.
- * </p>
- * @param $image2 resource <p>
- * A palette image link resource pointing to an image that has the same
- * size as image1.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagecolormatch ($image1, $image2) {}
-
-/**
- * Output XBM image to browser or file
- * @link https://php.net/manual/en/function.imagexbm.php
- * @param resource $image
- * @param string $filename <p>
- * The path to save the file to. If not set or &null;, the raw image stream
- * will be outputted directly.
- * </p>
- * @param int $foreground [optional] <p>
- * You can set the foreground color with this parameter by setting an
- * identifier obtained from imagecolorallocate.
- * The default foreground color is black.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imagexbm ($image, $filename, $foreground = null) {}
-
-/**
- * Applies a filter to an image
- * @link https://php.net/manual/en/function.imagefilter.php
- * @param resource $image
- * @param int $filtertype <p>
- * filtertype can be one of the following:
- * IMG_FILTER_NEGATE: Reverses all colors of
- * the image.
- * @param int $arg1 [optional] <p>
- * IMG_FILTER_BRIGHTNESS: Brightness level.
- * @param int $arg2 [optional] <p>
- * IMG_FILTER_COLORIZE: Value of green component.
- * @param int $arg3 [optional] <p>
- * IMG_FILTER_COLORIZE: Value of blue component.
- * @param int $arg4 [optional] <p>
- * IMG_FILTER_COLORIZE: Alpha channel, A value
- * between 0 and 127. 0 indicates completely opaque while 127 indicates
- * completely transparent.
- * @return bool true on success or false on failure.
- */
-function imagefilter ($image, $filtertype, $arg1 = null, $arg2 = null, $arg3 = null, $arg4 = null) {}
-
-/**
- * Apply a 3x3 convolution matrix, using coefficient and offset
- * @link https://php.net/manual/en/function.imageconvolution.php
- * @param resource $image
- * @param array $matrix <p>
- * A 3x3 matrix: an array of three arrays of three floats.
- * </p>
- * @param float $div <p>
- * The divisor of the result of the convolution, used for normalization.
- * </p>
- * @param float $offset <p>
- * Color offset.
- * </p>
- * @return bool true on success or false on failure.
- */
-function imageconvolution ($image, array $matrix, $div, $offset) {}
-
-/**
- * @param resource $im An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
- * @param int $res_x [optional] The horizontal resolution in DPI.
- * @param int $res_y [optional] The vertical resolution in DPI.
- * @return array|bool When used as getter (that is without the optional parameters), it returns <b>TRUE</b> on success, or <b>FALSE</b> on failure. When used as setter (that is with one or both optional parameters given), it returns an indexed array of the horizontal and vertical resolution on success, or <b>FALSE</b> on failure.
- * @link https://php.net/manual/en/function.imageresolution.php
- * @since 7.2
- */
-function imageresolution ($im, $res_x = 96, $res_y = 96) {}
+function imagesetstyle(GdImage $image, array $style): bool {}
 
-
-/**
- * <b>imagesetclip()</b> sets the current clipping rectangle, i.e. the area beyond which no pixels will be drawn.
- * @param resource $im An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
- * @param int $x1 The x-coordinate of the upper left corner.
- * @param int $y1 The y-coordinate of the upper left corner.
- * @param int $x2 The x-coordinate of the lower right corner.
- * @param int $y2 The y-coordinate of the lower right corner.
- * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * @link https://php.net/manual/en/function.imagesetclip.php
- * @see imagegetclip()
- * @since 7.2
- */
-function imagesetclip ($im, $x1, $y1, $x2, $y2) {}
+/** @refcount 1 */
+function imagecreatetruecolor(int $width, int $height): GdImage|false {}
 
-/**
- * <b>imagegetclip()</b> retrieves the current clipping rectangle, i.e. the area beyond which no pixels will be drawn.
- * @param resource $im An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}
- * @return array|false an indexed array with the coordinates of the clipping rectangle which has the following entries:
- * <ul>
- * <li>x-coordinate of the upper left corner</li>
- * <li>y-coordinate of the upper left corner</li>
- * <li>x-coordinate of the lower right corner</li>
- * <li>y-coordinate of the lower right corner</li>
- * </ul>
- * Returns <b>FALSE</b> on error.
- * @link https://php.net/manual/en/function.imagegetclip.php
- * @see imagesetclip()
- * @since 7.2
- */
-function imagegetclip ($im) {}
+function imageistruecolor(GdImage $image): bool {}
 
-/**
- * <b>imageopenpolygon()</b> draws an open polygon on the given <b>image.</b> Contrary to {@see imagepolygon()}, no line is drawn between the last and the first point.
- * @param resource $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
- * @param array $points An array containing the polygon's vertices, e.g.:
- * <pre>
- * points[0]	= x0
- * points[1]	= y0
- * points[2]	= x1
- * points[3]	= y1
- * </pre>
- * @param int $num_points [optional] Total number of points (vertices).
- * @param int $color A color identifier created with {@see imagecolorallocate()}.
- * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * @link https://php.net/manual/en/function.imageopenpolygon.php
- * @since 7.2
- * @see imageplygon()
- */
-function imageopenpolygon ($image , $points, $num_points, $color) {}
+function imagetruecolortopalette(GdImage $image, bool $dither, int $num_colors): bool {}
 
-/**
- * <b>imagecreatefrombmp()</b> returns an image identifier representing the image obtained from the given filename.
- * <b>TIP</b> A URL can be used as a filename with this function if the fopen wrappers have been enabled. See {@see fopen()} for more details on how to specify the filename. See the Supported Protocols and Wrappers for links to information about what abilities the various wrappers have, notes on their usage, and information on any predefined variables they may provide.
- * @param string $filename Path to the BMP image.
- * @return resource|false Returns an image resource identifier on success, <b>FALSE</b> on errors.
- * @link https://php.net/manual/en/function.imagecreatefrombmp.php
- * @since 7.2
- */
-function imagecreatefrombmp($filename){}
+function imagepalettetotruecolor(GdImage $image): bool {}
 
-/**
- * Outputs or saves a BMP version of the given <b>image</b>.
- * @param resource $image An image resource, returned by one of the image creation functions, such as {@see imagecreatetruecolor()}.
- * @param mixed $to The path or an open stream resource (which is automatically being closed after this function returns) to save the file to. If not set or <b>NULL</b>, the raw image stream will be outputted directly.
- * <br />
- * <b>Note:</b> <b>NULL</b> is invalid if the <b>compressed</b> arguments is not used.
- * @param bool $compressed Whether the BMP should be compressed with run-length encoding (RLE), or not.
- * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * <br />
- * <b>Caution</b> However, if libgd fails to output the image, this function returns <b>TRUE</b>.
- * @link https://php.net/manual/en/function.imagebmp.php
- * @since 7.2
- */
-function imagebmp ($image, $to = null, $compressed = true) {}
+function imagecolormatch(GdImage $image1, GdImage $image2): bool {}
 
-/**
- * @param string $filename
- * @return resource|false
- */
-function imagecreatefromtga($filename) {}
+function imagesetthickness(GdImage $image, int $thickness): bool {}
 
-/**
- * Captures the whole screen
- *
- * https://www.php.net/manual/en/function.imagegrabscreen.php
- *
- * @return resource|false
- */
-function imagegrabscreen() {}
+function imagefilledellipse(GdImage $image, int $center_x, int $center_y, int $width, int $height, int $color): bool {}
 
-/**
- * Captures a window
- *
- * @link https://www.php.net/manual/en/function.imagegrabwindow.php
- *
- * @param int $handle
- * @param int|null $client_area
- * @return resource|false
- */
-function imagegrabwindow($handle, $client_area = null) {}
+function imagefilledarc(GdImage $image, int $center_x, int $center_y, int $width, int $height, int $start_angle, int $end_angle, int $color, int $style): bool {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-gif
- */
-define ('IMG_GIF', 1);
+function imagealphablending(GdImage $image, bool $enable): bool {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-jpg
- */
-define ('IMG_JPG', 2);
+function imagesavealpha(GdImage $image, bool $enable): bool {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * <p>
- * This constant has the same value as {@see IMG_JPG}
- * </p>
- * @link https://php.net/manual/en/image.constants.php#constant.img-jpeg
- */
-define ('IMG_JPEG', 2);
+function imagelayereffect(GdImage $image, int $effect): bool {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-png
- */
-define ('IMG_PNG', 4);
+function imagecolorallocatealpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int|false {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-wbmp
- */
-define ('IMG_WBMP', 8);
+function imagecolorresolvealpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-xpm
- */
-define ('IMG_XPM', 16);
+function imagecolorclosestalpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * @since 5.6.25
- * @since 7.0.10
- * @link https://php.net/manual/en/image.constants.php#constant.img-webp
- */
-define('IMG_WEBP', 32);
+function imagecolorexactalpha(GdImage $image, int $red, int $green, int $blue, int $alpha): int {}
 
-/**
- * Used as a return value by {@see imagetypes()}
- * @since 7.2
- * @link https://php.net/manual/en/image.constants.php#constant.img-bmp
- */
-define('IMG_BMP', 64);
+function imagecopyresampled(GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $dst_width, int $dst_height, int $src_width, int $src_height): bool {}
 
-/**
- * Special color option which can be used instead of color allocated with
- * {@see imagecolorallocate()} or {@see imagecolorallocatealpha()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-color-tiled
- */
-define ('IMG_COLOR_TILED', -5);
+#ifdef PHP_WIN32
 
-/**
- * Special color option which can be used instead of color allocated with
- * {@see imagecolorallocate()} or {@see imagecolorallocatealpha()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-color-styled
- */
-define ('IMG_COLOR_STYLED', -2);
+/** @refcount 1 */
+function imagegrabwindow(int $handle, bool $client_area = false): GdImage|false {}
 
-/**
- * Special color option which can be used instead of color allocated with
- * {@see imagecolorallocate()} or {@see imagecolorallocatealpha()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-color-brushed
- */
-define ('IMG_COLOR_BRUSHED', -3);
+/** @refcount 1 */
+function imagegrabscreen(): GdImage|false {}
 
-/**
- * Special color option which can be used instead of color allocated with
- * {@see imagecolorallocate()} or {@see imagecolorallocatealpha()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-color-styledbrushed
- */
-define ('IMG_COLOR_STYLEDBRUSHED', -4);
+#endif
 
-/**
- * Special color option which can be used instead of color allocated with
- * {@see imagecolorallocate()} or {@see imagecolorallocatealpha()}
- * @link https://php.net/manual/en/image.constants.php#constant.img-color-transparent
- */
-define ('IMG_COLOR_TRANSPARENT', -6);
+// TODO: $ignore_transparent is ignored???
+/** @refcount 1 */
+function imagerotate(GdImage $image, float $angle, int $background_color, bool $ignore_transparent = false): GdImage|false {}
 
-/**
- * A style constant used by the {@see imagefilledarc()} function.
- * <p>
- * This constant has the same value as {@see IMG_ARC_PIE}
- * </p>
- * @link https://php.net/manual/en/image.constants.php#constant.img-arc-rounded
- */
-define ('IMG_ARC_ROUNDED', 0);
+function imagesettile(GdImage $image, GdImage $tile): bool {}
 
-/**
- * A style constant used by the {@see imagefilledarc()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-arc-pie
- */
-define ('IMG_ARC_PIE', 0);
+function imagesetbrush(GdImage $image, GdImage $brush): bool {}
 
-/**
- * A style constant used by the {@see imagefilledarc()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-arc-chord
- */
-define ('IMG_ARC_CHORD', 1);
+/** @refcount 1 */
+function imagecreate(int $width, int $height): GdImage|false {}
 
-/**
- * A style constant used by the {@see imagefilledarc()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-arc-nofill
- */
-define ('IMG_ARC_NOFILL', 2);
+function imagetypes(): int {}
 
-/**
- * A style constant used by the {@see imagefilledarc()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-arc-edged
- */
-define ('IMG_ARC_EDGED', 4);
+/** @refcount 1 */
+function imagecreatefromstring(string $data): GdImage|false {}
 
-/**
- * A type constant used by the {@see imagegd2()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-gd2-raw
- */
-define ('IMG_GD2_RAW', 1);
+#ifdef HAVE_GD_AVIF
+/** @refcount 1 */
+function imagecreatefromavif(string $filename): GdImage|false {}
+#endif
 
-/**
- * A type constant used by the {@see imagegd2()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-gd2-compressed
- */
-define ('IMG_GD2_COMPRESSED', 2);
+/** @refcount 1 */
+function imagecreatefromgif(string $filename): GdImage|false {}
 
-/**
- * Alpha blending effect used by the {@see imagelayereffect()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-effect-replace
- */
-define ('IMG_EFFECT_REPLACE', 0);
+#ifdef HAVE_GD_JPG
+/** @refcount 1 */
+function imagecreatefromjpeg(string $filename): GdImage|false {}
+#endif
 
-/**
- * Alpha blending effect used by the {@see imagelayereffect()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-effect-alphablend
- */
-define ('IMG_EFFECT_ALPHABLEND', 1);
+#ifdef HAVE_GD_PNG
+/** @refcount 1 */
+function imagecreatefrompng(string $filename): GdImage|false {}
+#endif
 
-/**
- * Alpha blending effect used by the {@see imagelayereffect()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-effect-normal
- */
-define ('IMG_EFFECT_NORMAL', 2);
+#ifdef HAVE_GD_WEBP
+/** @refcount 1 */
+function imagecreatefromwebp(string $filename): GdImage|false {}
+#endif
 
-/**
- * Alpha blending effect used by the {@see imagelayereffect()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-effect-overlay
- */
-define ('IMG_EFFECT_OVERLAY', 3);
+/** @refcount 1 */
+function imagecreatefromxbm(string $filename): GdImage|false {}
 
-/**
- * Alpha blending effect used by the {@see imagelayereffect()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-effect-multiply
- * @since 7.2
- */
-define ('IMG_EFFECT_MULTIPLY', 4);
+#ifdef HAVE_GD_XPM
+/** @refcount 1 */
+function imagecreatefromxpm(string $filename): GdImage|false {}
+#endif
 
-/**
- * When the bundled version of GD is used this is 1 otherwise
- * it's set to 0.
- * @link https://php.net/manual/en/image.constants.php
- */
-define ('GD_BUNDLED', 1);
+/** @refcount 1 */
+function imagecreatefromwbmp(string $filename): GdImage|false {}
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-negate
- */
-define ('IMG_FILTER_NEGATE', 0);
+/** @refcount 1 */
+function imagecreatefromgd(string $filename): GdImage|false {}
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-grayscale
- */
-define ('IMG_FILTER_GRAYSCALE', 1);
+/** @refcount 1 */
+function imagecreatefromgd2(string $filename): GdImage|false {}
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-brightness
- */
-define ('IMG_FILTER_BRIGHTNESS', 2);
+/** @refcount 1 */
+function imagecreatefromgd2part(string $filename, int $x, int $y, int $width, int $height): GdImage|false {}
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-contrast
- */
-define ('IMG_FILTER_CONTRAST', 3);
+#ifdef HAVE_GD_BMP
+/** @refcount 1 */
+function imagecreatefrombmp(string $filename): GdImage|false {}
+#endif
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-colorize
- */
-define ('IMG_FILTER_COLORIZE', 4);
+#ifdef HAVE_GD_TGA
+function imagecreatefromtga(string $filename): GdImage|false {}
+#endif
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-edgedetect
- */
-define ('IMG_FILTER_EDGEDETECT', 5);
+function imagexbm(GdImage $image, ?string $filename, ?int $foreground_color = null): bool {}
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-gaussian-blur
- */
-define ('IMG_FILTER_GAUSSIAN_BLUR', 7);
+#ifdef HAVE_GD_AVIF
+/** @param resource|string|null $file */
+function imageavif(GdImage $image, $file = null, int $quality = -1, int $speed = -1): bool {}
+#endif
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-selective-blur
- */
-define ('IMG_FILTER_SELECTIVE_BLUR', 8);
+/** @param resource|string|null $file */
+function imagegif(GdImage $image, $file = null): bool {}
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-emboss
- */
-define ('IMG_FILTER_EMBOSS', 6);
+#ifdef HAVE_GD_PNG
+/** @param resource|string|null $file */
+function imagepng(GdImage $image, $file = null, int $quality = -1, int $filters = -1): bool {}
+#endif
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-mean-removal
- */
-define ('IMG_FILTER_MEAN_REMOVAL', 9);
+#ifdef HAVE_GD_WEBP
+/** @param resource|string|null $file */
+function imagewebp(GdImage $image, $file = null, int $quality = -1): bool {}
+#endif
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-smooth
- */
-define ('IMG_FILTER_SMOOTH', 10);
+#ifdef HAVE_GD_JPG
+/** @param resource|string|null $file */
+function imagejpeg(GdImage $image, $file = null, int $quality = -1): bool {}
+#endif
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-pixelate
- */
-define ('IMG_FILTER_PIXELATE', 11);
+/** @param resource|string|null $file */
+function imagewbmp(GdImage $image, $file = null, ?int $foreground_color = null): bool {}
 
-/**
- * Special GD filter used by the {@see imagefilter()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.img-filter-scatter
- * @since 7.4
- */
-define ('IMG_FILTER_SCATTER', 12);
+function imagegd(GdImage $image, ?string $file = null): bool {}
 
-/**
- * The GD version PHP was compiled against.
- * @since 5.2.4
- * @link https://php.net/manual/en/image.constants.php#constant.gd-version
- */
-define ('GD_VERSION', "2.0.35");
+function imagegd2(GdImage $image, ?string $file = null, int $chunk_size = UNKNOWN, int $mode = UNKNOWN): bool {}
 
-/**
- * The GD major version PHP was compiled against.
- * @since 5.2.4
- * @link https://php.net/manual/en/image.constants.php#constant.gd-major-version
- */
-define ('GD_MAJOR_VERSION', 2);
+#ifdef HAVE_GD_BMP
+/** @param resource|string|null $file */
+function imagebmp(GdImage $image, $file = null, bool $compressed = true): bool {}
+#endif
 
-/**
- * The GD minor version PHP was compiled against.
- * @since 5.2.4
- * @link https://php.net/manual/en/image.constants.php#constant.gd-minor-version
- */
-define ('GD_MINOR_VERSION', 0);
+function imagedestroy(GdImage $image): bool {}
 
-/**
- * The GD release version PHP was compiled against.
- * @since 5.2.4
- * @link https://php.net/manual/en/image.constants.php#constant.gd-release-version
- */
-define ('GD_RELEASE_VERSION', 35);
+function imagecolorallocate(GdImage $image, int $red, int $green, int $blue): int|false {}
 
-/**
- * The GD "extra" version (beta/rc..) PHP was compiled against.
- * @since 5.2.4
- * @link https://php.net/manual/en/image.constants.php#constant.gd-extra-version
- */
-define ('GD_EXTRA_VERSION', "");
+function imagepalettecopy(GdImage $dst, GdImage $src): void {}
 
+function imagecolorat(GdImage $image, int $x, int $y): int|false {}
 
-/**
- * A special PNG filter, used by the {@see imagepng()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.png-no-filter
- */
-define ('PNG_NO_FILTER', 0);
+function imagecolorclosest(GdImage $image, int $red, int $green, int $blue): int {}
 
-/**
- * A special PNG filter, used by the {@see imagepng()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.png-filter-none
- */
-define ('PNG_FILTER_NONE', 8);
+function imagecolorclosesthwb(GdImage $image, int $red, int $green, int $blue): int {}
 
-/**
- * A special PNG filter, used by the {@see imagepng()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.png-filter-sub
- */
-define ('PNG_FILTER_SUB', 16);
+function imagecolordeallocate(GdImage $image, int $color): bool {}
 
-/**
- * A special PNG filter, used by the {@see imagepng()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.png-filter-up
- */
-define ('PNG_FILTER_UP', 32);
+function imagecolorresolve(GdImage $image, int $red, int $green, int $blue): int {}
 
-/**
- * A special PNG filter, used by the {@see imagepng()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.png-filter-avg
- */
-define ('PNG_FILTER_AVG', 64);
+function imagecolorexact(GdImage $image, int $red, int $green, int $blue): int {}
 
-/**
- * A special PNG filter, used by the {@see imagepng()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.png-filter-paeth
- */
-define ('PNG_FILTER_PAETH', 128);
+/** @return false|null */
+function imagecolorset(GdImage $image, int $color, int $red, int $green, int $blue, int $alpha = 0): ?bool {}
 
 /**
- * A special PNG filter, used by the {@see imagepng()} function.
- * @link https://php.net/manual/en/image.constants.php#constant.png-all-filters
+ * @return array<string, int>
+ * @refcount 1
  */
-define ('PNG_ALL_FILTERS', 248);
+function imagecolorsforindex(GdImage $image, int $color): array {}
 
-/**
- * An affine transformation type constant used by the {@see imageaffinematrixget()} function.
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-affine-translate
- */
-define('IMG_AFFINE_TRANSLATE', 0);
+function imagegammacorrect(GdImage $image, float $input_gamma, float $output_gamma): bool {}
 
-/**
- * An affine transformation type constant used by the {@see imageaffinematrixget()} function.
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-affine-scale
- */
-define('IMG_AFFINE_SCALE', 1);
+function imagesetpixel(GdImage $image, int $x, int $y, int $color): bool {}
 
-/**
- * An affine transformation type constant used by the {@see imageaffinematrixget()} function.
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-affine-rotate
- */
-define('IMG_AFFINE_ROTATE', 2);
+function imageline(GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
-/**
- * An affine transformation type constant used by the {@see imageaffinematrixget()} function.
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-affine-shear-horizontal
- */
-define('IMG_AFFINE_SHEAR_HORIZONTAL', 3);
+function imagedashedline(GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
-/**
- * An affine transformation type constant used by the {@see imageaffinematrixget()} function.
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-affine-shear-vertical
- */
-define('IMG_AFFINE_SHEAR_VERTICAL', 4);
+function imagerectangle(GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
-/**
- * Same as {@see IMG_CROP_TRANSPARENT}. Before PHP 7.4.0, the bundled libgd fell back to
- * {@see IMG_CROP_SIDES}, if the image had no transparent color.
- * Used together with {@see imagecropauto()}.
- * @since 5.5
- */
-define('IMG_CROP_DEFAULT', 0);
+function imagefilledrectangle(GdImage $image, int $x1, int $y1, int $x2, int $y2, int $color): bool {}
 
-/**
- * Crops out a transparent background.
- * Used together with {@see imagecropauto()}.
- * @since 5.5
- */
-define('IMG_CROP_TRANSPARENT', 1);
+function imagearc(GdImage $image, int $center_x, int $center_y, int $width, int $height, int $start_angle, int $end_angle, int $color): bool {}
 
-/**
- * Crops out a black background.
- * Used together with {@see imagecropauto()}.
- * @since 5.5
- */
-define('IMG_CROP_BLACK', 2);
+function imageellipse(GdImage $image, int $center_x, int $center_y, int $width, int $height, int $color): bool {}
 
-/**
- * Crops out a white background.
- * Used together with {@see imagecropauto()}.
- * @since 5.5
- */
-define('IMG_CROP_WHITE', 3);
+function imagefilltoborder(GdImage $image, int $x, int $y, int $border_color, int $color): bool {}
 
-/**
- * Uses the 4 corners of the image to attempt to detect the background to crop.
- * Used together with {@see imagecropauto()}.
- * @since 5.5
- */
-define('IMG_CROP_SIDES', 4);
+function imagefill(GdImage $image, int $x, int $y, int $color): bool {}
 
-/**
- * Crops an image using the given <b>threshold</b> and <b>color</b>.
- * Used together with {@see imagecropauto()}.
- * @since 5.5
- */
-define('IMG_CROP_THRESHOLD', 5);
+function imagecolorstotal(GdImage $image): int {}
 
-/**
- * Used together with {@see imageflip()}
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-flip-both
- */
-define('IMG_FLIP_BOTH', 3);
+function imagecolortransparent(GdImage $image, ?int $color = null): int {}
 
-/**
- * Used together with {@see imageflip()}
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-flip-horizontal
- */
-define('IMG_FLIP_HORIZONTAL', 1);
+function imageinterlace(GdImage $image, ?bool $enable = null): bool {}
 
-/**
- * Used together with {@see imageflip()}
- * @since 5.5
- * @link https://php.net/manual/en/image.constants.php#constant.img-flip-vertical
- */
-define('IMG_FLIP_VERTICAL', 2);
+function imagepolygon(GdImage $image, array $points, int $num_points_or_color, ?int $color = null): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-bell
- * @since 5.5
- */
-define('IMG_BELL', 1);
+function imageopenpolygon(GdImage $image, array $points, int $num_points_or_color, ?int $color = null): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-bessel
- * @since 5.5
- */
-define('IMG_BESSEL', 2);
+function imagefilledpolygon(GdImage $image, array $points, int $num_points_or_color, ?int $color = null): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-bicubic
- * @since 5.5
- */
-define('IMG_BICUBIC', 4);
+function imagefontwidth(GdFont|int $font): int {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-bicubic-fixed
- * @since 5.5
- */
-define('IMG_BICUBIC_FIXED', 5);
+function imagefontheight(GdFont|int $font): int {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-bilinear-fixed
- * @since 5.5
- */
-define('IMG_BILINEAR_FIXED', 3);
+function imagechar(GdImage $image, GdFont|int $font, int $x, int $y, string $char, int $color): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-blackman
- * @since 5.5
- */
-define('IMG_BLACKMAN', 6);
+function imagecharup(GdImage $image, GdFont|int $font, int $x, int $y, string $char, int $color): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-box
- * @since 5.5
- */
-define('IMG_BOX', 7);
+function imagestring(GdImage $image, GdFont|int $font, int $x, int $y, string $string, int $color): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-bspline
- * @since 5.5
- */
-define('IMG_BSPLINE', 8);
+function imagestringup(GdImage $image, GdFont|int $font, int $x, int $y, string $string, int $color): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-catmullrom
- * @since 5.5
- */
-define('IMG_CATMULLROM', 9);
+function imagecopy(GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $src_width, int $src_height): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-gaussian
- * @since 5.5
- */
-define('IMG_GAUSSIAN', 10);
+function imagecopymerge(GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $src_width, int $src_height, int $pct): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-generalized-cubic
- * @since 5.5
- */
-define('IMG_GENERALIZED_CUBIC', 11);
+function imagecopymergegray(GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $src_width, int $src_height, int $pct): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-hermite
- * @since 5.5
- */
-define('IMG_HERMITE', 12);
+function imagecopyresized(GdImage $dst_image, GdImage $src_image, int $dst_x, int $dst_y, int $src_x, int $src_y, int $dst_width, int $dst_height, int $src_width, int $src_height): bool {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-hamming
- * @since 5.5
- */
-define('IMG_HAMMING', 13);
+function imagesx(GdImage $image): int {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-hanning
- * @since 5.5
- */
-define('IMG_HANNING', 14);
+function imagesy(GdImage $image): int {}
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-mitchell
- * @since 5.5
- */
-define('IMG_MITCHELL', 15);
+function imagesetclip(GdImage $image, int $x1, int $y1, int $x2, int $y2): bool {}
 
 /**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-power
- * @since 5.5
+ * @return array<int, int>
+ * @refcount 1
  */
-define('IMG_POWER', 17);
+function imagegetclip(GdImage $image): array {}
 
+#ifdef HAVE_GD_FREETYPE
 /**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-quadratic
- * @since 5.5
+ * @return array<int, int>|false
+ * @refcount 1
  */
-define('IMG_QUADRATIC', 18);
+function imageftbbox(float $size, float $angle, string $font_filename, string $string, array $options = []): array|false {}
 
 /**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-sinc
- * @since 5.5
+ * @return array<int, int>|false
+ * @refcount 1
  */
-define('IMG_SINC', 19);
+function imagefttext(GdImage $image, float $size, float $angle, int $x, int $y, int $color, string $font_filename, string $text, array $options = []): array|false {}
 
 /**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-nearest-neighbour
- * @since 5.5
+ * @return array<int, int>|false
+ * @alias imageftbbox
  */
-define('IMG_NEAREST_NEIGHBOUR', 16);
+function imagettfbbox(float $size, float $angle, string $font_filename, string $string, array $options = []): array|false {}
 
 /**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-weighted4
- * @since 5.5
+ * @return array<int, int>|false
+ * @alias imagefttext
  */
-define('IMG_WEIGHTED4', 21);
+function imagettftext(GdImage $image, float $size, float $angle, int $x, int $y, int $color, string $font_filename, string $text, array $options = []): array|false {}
+#endif
 
-/**
- * Used together with {@see imagesetinterpolation()}.
- * @link https://php.net/manual/en/image.constants.php#constant.img-triangle
- * @since 5.5
- */
-define('IMG_TRIANGLE', 20);
+/** @param array|int|float|bool $args */
+function imagefilter(GdImage $image, int $filter, ...$args): bool {}
 
-define('IMG_TGA', 128);
+function imageconvolution(GdImage $image, array $matrix, float $divisor, float $offset): bool {}
 
-/**
- * Return an image containing the affine tramsformed src image, using an optional clipping area
- * @link https://www.php.net/manual/en/function.imageaffine.php
- * @param resource $image <p>An image resource, returned by one of the image creation functions,
- * such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.</p>
- * @param array $affine <p>Array with keys 0 to 5.</p>
- * @param array $clip [optional] <p>Array with keys "x", "y", "width" and "height".</p>
- * @return resource|bool Return affined image resource on success or FALSE on failure.
- */
-function imageaffine($image, $affine, $clip = null) {}
+function imageflip(GdImage $image, int $mode): bool {}
 
-/**
- * Concat two matrices (as in doing many ops in one go)
- * @link https://www.php.net/manual/en/function.imageaffinematrixconcat.php
- * @param array $m1 <p>Array with keys 0 to 5.</p>
- * @param array $m2 <p>Array with keys 0 to 5.</p>
- * @return array|bool Array with keys 0 to 5 and float values or <b>FALSE</b> on failure.
- * @since 5.5
- */
-function imageaffinematrixconcat(array $m1, array $m2) {}
+function imageantialias(GdImage $image, bool $enable): bool {}
 
-/**
- * Return an image containing the affine tramsformed src image, using an optional clipping area
- * @link https://www.php.net/manual/en/function.imageaffinematrixget.php
- * @param int $type <p> One of <b>IMG_AFFINE_*</b> constants.
- * @param mixed $options [optional]
- * @return array|bool Array with keys 0 to 5 and float values or <b>FALSE</b> on failure.
- * @since 5.5
- */
+/** @refcount 1 */
+function imagecrop(GdImage $image, array $rectangle): GdImage|false {}
 
-function imageaffinematrixget ($type, $options = null) {}
+/** @refcount 1 */
+function imagecropauto(GdImage $image, int $mode = IMG_CROP_DEFAULT, float $threshold = 0.5, int $color = -1): GdImage|false {}
 
-/**
- * Crop an image using the given coordinates and size, x, y, width and height
- * @link https://www.php.net/manual/en/function.imagecrop.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
- * </p>
- * @param array $rect <p>Array with keys "x", "y", "width" and "height".</p>
- * @return resource|bool Return cropped image resource on success or FALSE on failure.
- * @since 5.5
- */
-function imagecrop ($image, $rect) {}
+/** @refcount 1 */
+function imagescale(GdImage $image, int $width, int $height = -1, int $mode = IMG_BILINEAR_FIXED): GdImage|false {}
 
-/**
- * Crop an image automatically using one of the available modes
- * @link https://www.php.net/manual/en/function.imagecropauto.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
- * </p>
- * @param int $mode [optional] <p>
- * One of <b>IMG_CROP_*</b> constants.
- * </p>
- * @param float $threshold [optional] <p>
- * Used <b>IMG_CROP_THRESHOLD</b> mode.
- * </p>
- * @param int $color [optional]
- * <p>
- * Used in <b>IMG_CROP_THRESHOLD</b> mode.
- * </p>
- * @return resource|bool Return cropped image resource on success or <b>FALSE</b> on failure.
- * @since 5.5
- */
-function imagecropauto ($image, $mode = IMG_CROP_DEFAULT, $threshold = .5, $color = -1) {}
+/** @refcount 1 */
+function imageaffine(GdImage $image, array $affine, ?array $clip = null): GdImage|false {}
 
 /**
- * Flips an image using a given mode
- * @link https://www.php.net/manual/en/function.imageflip.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
- * </p>
- * @param int $mode <p>
- * Flip mode, this can be one of the <b>IMG_FLIP_*</b> constants:
- * </p>
- * <table>
- * <thead>
- * <tr>
- * <th>Constant</th>
- * <th>Meaning</th>
- * </tr>
- * </thead>
- * <tr>
- * <td><b>IMG_FLIP_HORIZONTAL</b></td>
- * <td>
- * Flips the image horizontally.
- * </td>
- * </tr>
- * <tr>
- * <td><b>IMG_FLIP_VERTICAL</b></td>
- * <td>
- * Flips the image vertically.
- * </td>
- * </tr>
- * <tr>
- * <td><b>IMG_FLIP_BOTH</b></td>
- * <td>
- * Flips the image both horizontally and vertically.
- * </td>
- * </tr>
- * </tbody>
- * </table>
- * @return bool Returns <b>TRUE</b> on success or <b>FALSE</b> on failure.
- * @since 5.5
+ * @param array|float $options
+ * @refcount 1
+ * @return array<int, float>|false
  */
-function imageflip ($image, $mode) {}
+function imageaffinematrixget(int $type, $options): array|false {}
 
 /**
- * Converts a palette based image to true color
- * @link https://www.php.net/manual/en/function.imagepalettetotruecolor.php
- * @param resource $image <p>
- * An image resource, returnd by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
- * </p>
- * @return bool Returns <b>TRUE</b> if the convertion was complete, or if the source image already is a true color image, otherwise <b>FALSE</b> is returned.
- * @since 5.5
+ * @return array<int, float>|false
+ * @refcount 1
  */
-function imagepalettetotruecolor ($image) {}
+function imageaffinematrixconcat(array $matrix1, array $matrix2): array|false {}
 
-/**
- * @since 5.5
- * Scale an image using the given new width and height
- * @link https://www.php.net/manual/en/function.imagescale.php
- * @param resource $image <p>
- * An image resource, returnd by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
- * </p>
- * @param int $new_width
- * @param int $new_height [optional]
- * @param int $mode [optional] One of <b>IMG_NEAREST_NEIGHBOUR</b>, <b>IMG_BILINEAR_FIXED</b>, <b>IMG_BICUBIC</b>, <b>IMG_BICUBIC_FIXED</b> or anything else (will use two pass).
- * @return resource|bool Return scaled image resource on success or <b>FALSE</b> on failure.
- */
+function imagegetinterpolation(GdImage $image): int {}
 
-function imagescale ($image, $new_width, $new_height = -1, $mode = IMG_BILINEAR_FIXED) {}
+function imagesetinterpolation(GdImage $image, int $method = IMG_BILINEAR_FIXED): bool {}
 
 /**
- * Set the interpolation method
- * @link https://www.php.net/manual/en/function.imagesetinterpolation.php
- * @param resource $image <p>
- * An image resource, returned by one of the image creation functions, such as {@link https://www.php.net/manual/en/function.imagecreatetruecolor.php imagecreatetruecolor()}.
- * </p>
- * @param int $method <p>
- * The interpolation method, which can be one of the following:
- * <ul>
- * <li>
- * IMG_BELL: Bell filter.
- * </li>
- * <li>
- * IMG_BESSEL: Bessel filter.
- * </li>
- * <li>
- * IMG_BICUBIC: Bicubic interpolation.
- * </li>
- * <li>
- * IMG_BICUBIC_FIXED: Fixed point implementation of the bicubic interpolation.
- * </li>
- * <li>
- * IMG_BILINEAR_FIXED: Fixed point implementation of the  bilinear interpolation (<em>default (also on image creation)</em>).
- * </li>
- * <li>
- * IMG_BLACKMAN: Blackman window function.
- * </li>
- * <li>
- * IMG_BOX: Box blur filter.
- * </li>
- * <li>
- * IMG_BSPLINE: Spline interpolation.
- * </li>
- * <li>
- * IMG_CATMULLROM: Cubbic Hermite spline interpolation.
- * </li>
- * <li>
- * IMG_GAUSSIAN: Gaussian function.
- * </li>
- * <li>
- * IMG_GENERALIZED_CUBIC: Generalized cubic spline fractal interpolation.
- * </li>
- * <li>
- * IMG_HERMITE: Hermite interpolation.
- * </li>
- * <li>
- * IMG_HAMMING: Hamming filter.
- * </li>
- * <li>
- * IMG_HANNING: Hanning filter.
- * </li>
- * <li>
- * IMG_MITCHELL: Mitchell filter.
- * </li>
- * <li>
- * IMG_POWER: Power interpolation.
- * </li>
- * <li>
- * IMG_QUADRATIC: Inverse quadratic interpolation.
- * </li>
- * <li>
- * IMG_SINC: Sinc function.
- * </li>
- * <li>
- * IMG_NEAREST_NEIGHBOUR: Nearest neighbour interpolation.
- * </li>
- * <li>
- * IMG_WEIGHTED4: Weighting filter.
- * </li>
- * <li>
- * IMG_TRIANGLE: Triangle interpolation.
- * </li>
- * </ul>
- * </p>
- * @return bool Returns TRUE on success or FALSE on failure.
- * @since 5.5
+ * @return array<int, int>|true
+ * @refcount 1
  */
-function imagesetinterpolation ($image, $method = IMG_BILINEAR_FIXED) {}
+function imageresolution(GdImage $image, ?int $resolution_x = null, ?int $resolution_y = null): array|bool {}

--- a/build/stubs/imagick.php
+++ b/build/stubs/imagick.php
@@ -1,6744 +1,1386 @@
 <?php
 
-// Start of imagick v.3.4.3
-
-class ImagickException extends Exception  {
-}
-
-class ImagickDrawException extends Exception  {
-}
-
-class ImagickPixelIteratorException extends Exception  {
-}
-
-class ImagickPixelException extends Exception  {
-}
-
-/**
- * @method Imagick clone() (PECL imagick 2.0.0)<br/>Makes an exact copy of the Imagick object
- * @link https://php.net/manual/en/class.imagick.php
- */
-class Imagick implements Iterator, Countable {
-	const COLOR_BLACK = 11;
-	const COLOR_BLUE = 12;
-	const COLOR_CYAN = 13;
-	const COLOR_GREEN = 14;
-	const COLOR_RED = 15;
-	const COLOR_YELLOW = 16;
-	const COLOR_MAGENTA = 17;
-	const COLOR_OPACITY = 18;
-	const COLOR_ALPHA = 19;
-	const COLOR_FUZZ = 20;
-	const IMAGICK_EXTNUM = 30403;
-	const IMAGICK_EXTVER = "3.4.3";
-	const QUANTUM_RANGE = 65535;
-	const USE_ZEND_MM = 0;
-	const COMPOSITE_DEFAULT = 40;
-	const COMPOSITE_UNDEFINED = 0;
-	const COMPOSITE_NO = 1;
-	const COMPOSITE_ADD = 2;
-	const COMPOSITE_ATOP = 3;
-	const COMPOSITE_BLEND = 4;
-	const COMPOSITE_BUMPMAP = 5;
-	const COMPOSITE_CLEAR = 7;
-	const COMPOSITE_COLORBURN = 8;
-	const COMPOSITE_COLORDODGE = 9;
-	const COMPOSITE_COLORIZE = 10;
-	const COMPOSITE_COPYBLACK = 11;
-	const COMPOSITE_COPYBLUE = 12;
-	const COMPOSITE_COPY = 13;
-	const COMPOSITE_COPYCYAN = 14;
-	const COMPOSITE_COPYGREEN = 15;
-	const COMPOSITE_COPYMAGENTA = 16;
-	const COMPOSITE_COPYOPACITY = 17;
-	const COMPOSITE_COPYRED = 18;
-	const COMPOSITE_COPYYELLOW = 19;
-	const COMPOSITE_DARKEN = 20;
-	const COMPOSITE_DSTATOP = 21;
-	const COMPOSITE_DST = 22;
-	const COMPOSITE_DSTIN = 23;
-	const COMPOSITE_DSTOUT = 24;
-	const COMPOSITE_DSTOVER = 25;
-	const COMPOSITE_DIFFERENCE = 26;
-	const COMPOSITE_DISPLACE = 27;
-	const COMPOSITE_DISSOLVE = 28;
-	const COMPOSITE_EXCLUSION = 29;
-	const COMPOSITE_HARDLIGHT = 30;
-	const COMPOSITE_HUE = 31;
-	const COMPOSITE_IN = 32;
-	const COMPOSITE_LIGHTEN = 33;
-	const COMPOSITE_LUMINIZE = 35;
-	const COMPOSITE_MINUS = 36;
-	const COMPOSITE_MODULATE = 37;
-	const COMPOSITE_MULTIPLY = 38;
-	const COMPOSITE_OUT = 39;
-	const COMPOSITE_OVER = 40;
-	const COMPOSITE_OVERLAY = 41;
-	const COMPOSITE_PLUS = 42;
-	const COMPOSITE_REPLACE = 43;
-	const COMPOSITE_SATURATE = 44;
-	const COMPOSITE_SCREEN = 45;
-	const COMPOSITE_SOFTLIGHT = 46;
-	const COMPOSITE_SRCATOP = 47;
-	const COMPOSITE_SRC = 48;
-	const COMPOSITE_SRCIN = 49;
-	const COMPOSITE_SRCOUT = 50;
-	const COMPOSITE_SRCOVER = 51;
-	const COMPOSITE_SUBTRACT = 52;
-	const COMPOSITE_THRESHOLD = 53;
-	const COMPOSITE_XOR = 54;
-	const COMPOSITE_CHANGEMASK = 6;
-	const COMPOSITE_LINEARLIGHT = 34;
-	const COMPOSITE_DIVIDE = 55;
-	const COMPOSITE_DISTORT = 56;
-	const COMPOSITE_BLUR = 57;
-	const COMPOSITE_PEGTOPLIGHT = 58;
-	const COMPOSITE_VIVIDLIGHT = 59;
-	const COMPOSITE_PINLIGHT = 60;
-	const COMPOSITE_LINEARDODGE = 61;
-	const COMPOSITE_LINEARBURN = 62;
-	const COMPOSITE_MATHEMATICS = 63;
-	const COMPOSITE_MODULUSADD = 2;
-	const COMPOSITE_MODULUSSUBTRACT = 52;
-	const COMPOSITE_MINUSDST = 36;
-	const COMPOSITE_DIVIDEDST = 55;
-	const COMPOSITE_DIVIDESRC = 64;
-	const COMPOSITE_MINUSSRC = 65;
-	const COMPOSITE_DARKENINTENSITY = 66;
-	const COMPOSITE_LIGHTENINTENSITY = 67;
-	const MONTAGEMODE_FRAME = 1;
-	const MONTAGEMODE_UNFRAME = 2;
-	const MONTAGEMODE_CONCATENATE = 3;
-	const STYLE_NORMAL = 1;
-	const STYLE_ITALIC = 2;
-	const STYLE_OBLIQUE = 3;
-	const STYLE_ANY = 4;
-	const FILTER_UNDEFINED = 0;
-	const FILTER_POINT = 1;
-	const FILTER_BOX = 2;
-	const FILTER_TRIANGLE = 3;
-	const FILTER_HERMITE = 4;
-	const FILTER_HANNING = 5;
-	const FILTER_HAMMING = 6;
-	const FILTER_BLACKMAN = 7;
-	const FILTER_GAUSSIAN = 8;
-	const FILTER_QUADRATIC = 9;
-	const FILTER_CUBIC = 10;
-	const FILTER_CATROM = 11;
-	const FILTER_MITCHELL = 12;
-	const FILTER_LANCZOS = 22;
-	const FILTER_BESSEL = 13;
-	const FILTER_SINC = 14;
-	const FILTER_KAISER = 16;
-	const FILTER_WELSH = 17;
-	const FILTER_PARZEN = 18;
-	const FILTER_LAGRANGE = 21;
-	const FILTER_SENTINEL = 31;
-	const FILTER_BOHMAN = 19;
-	const FILTER_BARTLETT = 20;
-	const FILTER_JINC = 13;
-	const FILTER_SINCFAST = 15;
-	const FILTER_ROBIDOUX = 26;
-	const FILTER_LANCZOSSHARP = 23;
-	const FILTER_LANCZOS2 = 24;
-	const FILTER_LANCZOS2SHARP = 25;
-	const FILTER_ROBIDOUXSHARP = 27;
-	const FILTER_COSINE = 28;
-	const FILTER_SPLINE = 29;
-	const FILTER_LANCZOSRADIUS = 30;
-	const IMGTYPE_UNDEFINED = 0;
-	const IMGTYPE_BILEVEL = 1;
-	const IMGTYPE_GRAYSCALE = 2;
-	const IMGTYPE_GRAYSCALEMATTE = 3;
-	const IMGTYPE_PALETTE = 4;
-	const IMGTYPE_PALETTEMATTE = 5;
-	const IMGTYPE_TRUECOLOR = 6;
-	const IMGTYPE_TRUECOLORMATTE = 7;
-	const IMGTYPE_COLORSEPARATION = 8;
-	const IMGTYPE_COLORSEPARATIONMATTE = 9;
-	const IMGTYPE_OPTIMIZE = 10;
-	const IMGTYPE_PALETTEBILEVELMATTE = 11;
-	const RESOLUTION_UNDEFINED = 0;
-	const RESOLUTION_PIXELSPERINCH = 1;
-	const RESOLUTION_PIXELSPERCENTIMETER = 2;
-	const COMPRESSION_UNDEFINED = 0;
-	const COMPRESSION_NO = 1;
-	const COMPRESSION_BZIP = 2;
-	const COMPRESSION_FAX = 6;
-	const COMPRESSION_GROUP4 = 7;
-	const COMPRESSION_JPEG = 8;
-	const COMPRESSION_JPEG2000 = 9;
-	const COMPRESSION_LOSSLESSJPEG = 10;
-	const COMPRESSION_LZW = 11;
-	const COMPRESSION_RLE = 12;
-	const COMPRESSION_ZIP = 13;
-	const COMPRESSION_DXT1 = 3;
-	const COMPRESSION_DXT3 = 4;
-	const COMPRESSION_DXT5 = 5;
-	const COMPRESSION_ZIPS = 14;
-	const COMPRESSION_PIZ = 15;
-	const COMPRESSION_PXR24 = 16;
-	const COMPRESSION_B44 = 17;
-	const COMPRESSION_B44A = 18;
-	const COMPRESSION_LZMA = 19;
-	const COMPRESSION_JBIG1 = 20;
-	const COMPRESSION_JBIG2 = 21;
-	const PAINT_POINT = 1;
-	const PAINT_REPLACE = 2;
-	const PAINT_FLOODFILL = 3;
-	const PAINT_FILLTOBORDER = 4;
-	const PAINT_RESET = 5;
-	const GRAVITY_NORTHWEST = 1;
-	const GRAVITY_NORTH = 2;
-	const GRAVITY_NORTHEAST = 3;
-	const GRAVITY_WEST = 4;
-	const GRAVITY_CENTER = 5;
-	const GRAVITY_EAST = 6;
-	const GRAVITY_SOUTHWEST = 7;
-	const GRAVITY_SOUTH = 8;
-	const GRAVITY_SOUTHEAST = 9;
-	const GRAVITY_FORGET = 0;
-	const GRAVITY_STATIC = 10;
-	const STRETCH_NORMAL = 1;
-	const STRETCH_ULTRACONDENSED = 2;
-	const STRETCH_EXTRACONDENSED = 3;
-	const STRETCH_CONDENSED = 4;
-	const STRETCH_SEMICONDENSED = 5;
-	const STRETCH_SEMIEXPANDED = 6;
-	const STRETCH_EXPANDED = 7;
-	const STRETCH_EXTRAEXPANDED = 8;
-	const STRETCH_ULTRAEXPANDED = 9;
-	const STRETCH_ANY = 10;
-	const ALIGN_UNDEFINED = 0;
-	const ALIGN_LEFT = 1;
-	const ALIGN_CENTER = 2;
-	const ALIGN_RIGHT = 3;
-	const DECORATION_NO = 1;
-	const DECORATION_UNDERLINE = 2;
-	const DECORATION_OVERLINE = 3;
-	const DECORATION_LINETROUGH = 4;
-	const DECORATION_LINETHROUGH = 4;
-	const NOISE_UNIFORM = 1;
-	const NOISE_GAUSSIAN = 2;
-	const NOISE_MULTIPLICATIVEGAUSSIAN = 3;
-	const NOISE_IMPULSE = 4;
-	const NOISE_LAPLACIAN = 5;
-	const NOISE_POISSON = 6;
-	const NOISE_RANDOM = 7;
-	const CHANNEL_UNDEFINED = 0;
-	const CHANNEL_RED = 1;
-	const CHANNEL_GRAY = 1;
-	const CHANNEL_CYAN = 1;
-	const CHANNEL_GREEN = 2;
-	const CHANNEL_MAGENTA = 2;
-	const CHANNEL_BLUE = 4;
-	const CHANNEL_YELLOW = 4;
-	const CHANNEL_ALPHA = 8;
-	const CHANNEL_OPACITY = 8;
-	const CHANNEL_MATTE = 8;
-	const CHANNEL_BLACK = 32;
-	const CHANNEL_INDEX = 32;
-	const CHANNEL_ALL = 134217727;
-	const CHANNEL_DEFAULT = 134217719;
-	const CHANNEL_RGBA = 15;
-	const CHANNEL_TRUEALPHA = 64;
-	const CHANNEL_RGBS = 128;
-	const CHANNEL_GRAY_CHANNELS = 128;
-	const CHANNEL_SYNC = 256;
-	const CHANNEL_COMPOSITES = 47;
-	const METRIC_UNDEFINED = 0;
-	const METRIC_ABSOLUTEERRORMETRIC = 1;
-	const METRIC_MEANABSOLUTEERROR = 2;
-	const METRIC_MEANERRORPERPIXELMETRIC = 3;
-	const METRIC_MEANSQUAREERROR = 4;
-	const METRIC_PEAKABSOLUTEERROR = 5;
-	const METRIC_PEAKSIGNALTONOISERATIO = 6;
-	const METRIC_ROOTMEANSQUAREDERROR = 7;
-	const METRIC_NORMALIZEDCROSSCORRELATIONERRORMETRIC = 8;
-	const METRIC_FUZZERROR = 9;
-	const PIXEL_CHAR = 1;
-	const PIXEL_DOUBLE = 2;
-	const PIXEL_FLOAT = 3;
-	const PIXEL_INTEGER = 4;
-	const PIXEL_LONG = 5;
-	const PIXEL_QUANTUM = 6;
-	const PIXEL_SHORT = 7;
-	const EVALUATE_UNDEFINED = 0;
-	const EVALUATE_ADD = 1;
-	const EVALUATE_AND = 2;
-	const EVALUATE_DIVIDE = 3;
-	const EVALUATE_LEFTSHIFT = 4;
-	const EVALUATE_MAX = 5;
-	const EVALUATE_MIN = 6;
-	const EVALUATE_MULTIPLY = 7;
-	const EVALUATE_OR = 8;
-	const EVALUATE_RIGHTSHIFT = 9;
-	const EVALUATE_SET = 10;
-	const EVALUATE_SUBTRACT = 11;
-	const EVALUATE_XOR = 12;
-	const EVALUATE_POW = 13;
-	const EVALUATE_LOG = 14;
-	const EVALUATE_THRESHOLD = 15;
-	const EVALUATE_THRESHOLDBLACK = 16;
-	const EVALUATE_THRESHOLDWHITE = 17;
-	const EVALUATE_GAUSSIANNOISE = 18;
-	const EVALUATE_IMPULSENOISE = 19;
-	const EVALUATE_LAPLACIANNOISE = 20;
-	const EVALUATE_MULTIPLICATIVENOISE = 21;
-	const EVALUATE_POISSONNOISE = 22;
-	const EVALUATE_UNIFORMNOISE = 23;
-	const EVALUATE_COSINE = 24;
-	const EVALUATE_SINE = 25;
-	const EVALUATE_ADDMODULUS = 26;
-	const EVALUATE_MEAN = 27;
-	const EVALUATE_ABS = 28;
-	const EVALUATE_EXPONENTIAL = 29;
-	const EVALUATE_MEDIAN = 30;
-	const EVALUATE_SUM = 31;
-	const COLORSPACE_UNDEFINED = 0;
-	const COLORSPACE_RGB = 1;
-	const COLORSPACE_GRAY = 2;
-	const COLORSPACE_TRANSPARENT = 3;
-	const COLORSPACE_OHTA = 4;
-	const COLORSPACE_LAB = 5;
-	const COLORSPACE_XYZ = 6;
-	const COLORSPACE_YCBCR = 7;
-	const COLORSPACE_YCC = 8;
-	const COLORSPACE_YIQ = 9;
-	const COLORSPACE_YPBPR = 10;
-	const COLORSPACE_YUV = 11;
-	const COLORSPACE_CMYK = 12;
-	const COLORSPACE_SRGB = 13;
-	const COLORSPACE_HSB = 14;
-	const COLORSPACE_HSL = 15;
-	const COLORSPACE_HWB = 16;
-	const COLORSPACE_REC601LUMA = 17;
-	const COLORSPACE_REC709LUMA = 19;
-	const COLORSPACE_LOG = 21;
-	const COLORSPACE_CMY = 22;
-	const COLORSPACE_LUV = 23;
-	const COLORSPACE_HCL = 24;
-	const COLORSPACE_LCH = 25;
-	const COLORSPACE_LMS = 26;
-	const COLORSPACE_LCHAB = 27;
-	const COLORSPACE_LCHUV = 28;
-	const COLORSPACE_SCRGB = 29;
-	const COLORSPACE_HSI = 30;
-	const COLORSPACE_HSV = 31;
-	const COLORSPACE_HCLP = 32;
-	const COLORSPACE_YDBDR = 33;
-	const COLORSPACE_REC601YCBCR = 18;
-	const COLORSPACE_REC709YCBCR = 20;
-	const VIRTUALPIXELMETHOD_UNDEFINED = 0;
-	const VIRTUALPIXELMETHOD_BACKGROUND = 1;
-	const VIRTUALPIXELMETHOD_CONSTANT = 2;
-	const VIRTUALPIXELMETHOD_EDGE = 4;
-	const VIRTUALPIXELMETHOD_MIRROR = 5;
-	const VIRTUALPIXELMETHOD_TILE = 7;
-	const VIRTUALPIXELMETHOD_TRANSPARENT = 8;
-	const VIRTUALPIXELMETHOD_MASK = 9;
-	const VIRTUALPIXELMETHOD_BLACK = 10;
-	const VIRTUALPIXELMETHOD_GRAY = 11;
-	const VIRTUALPIXELMETHOD_WHITE = 12;
-	const VIRTUALPIXELMETHOD_HORIZONTALTILE = 13;
-	const VIRTUALPIXELMETHOD_VERTICALTILE = 14;
-	const VIRTUALPIXELMETHOD_HORIZONTALTILEEDGE = 15;
-	const VIRTUALPIXELMETHOD_VERTICALTILEEDGE = 16;
-	const VIRTUALPIXELMETHOD_CHECKERTILE = 17;
-	const PREVIEW_UNDEFINED = 0;
-	const PREVIEW_ROTATE = 1;
-	const PREVIEW_SHEAR = 2;
-	const PREVIEW_ROLL = 3;
-	const PREVIEW_HUE = 4;
-	const PREVIEW_SATURATION = 5;
-	const PREVIEW_BRIGHTNESS = 6;
-	const PREVIEW_GAMMA = 7;
-	const PREVIEW_SPIFF = 8;
-	const PREVIEW_DULL = 9;
-	const PREVIEW_GRAYSCALE = 10;
-	const PREVIEW_QUANTIZE = 11;
-	const PREVIEW_DESPECKLE = 12;
-	const PREVIEW_REDUCENOISE = 13;
-	const PREVIEW_ADDNOISE = 14;
-	const PREVIEW_SHARPEN = 15;
-	const PREVIEW_BLUR = 16;
-	const PREVIEW_THRESHOLD = 17;
-	const PREVIEW_EDGEDETECT = 18;
-	const PREVIEW_SPREAD = 19;
-	const PREVIEW_SOLARIZE = 20;
-	const PREVIEW_SHADE = 21;
-	const PREVIEW_RAISE = 22;
-	const PREVIEW_SEGMENT = 23;
-	const PREVIEW_SWIRL = 24;
-	const PREVIEW_IMPLODE = 25;
-	const PREVIEW_WAVE = 26;
-	const PREVIEW_OILPAINT = 27;
-	const PREVIEW_CHARCOALDRAWING = 28;
-	const PREVIEW_JPEG = 29;
-	const RENDERINGINTENT_UNDEFINED = 0;
-	const RENDERINGINTENT_SATURATION = 1;
-	const RENDERINGINTENT_PERCEPTUAL = 2;
-	const RENDERINGINTENT_ABSOLUTE = 3;
-	const RENDERINGINTENT_RELATIVE = 4;
-	const INTERLACE_UNDEFINED = 0;
-	const INTERLACE_NO = 1;
-	const INTERLACE_LINE = 2;
-	const INTERLACE_PLANE = 3;
-	const INTERLACE_PARTITION = 4;
-	const INTERLACE_GIF = 5;
-	const INTERLACE_JPEG = 6;
-	const INTERLACE_PNG = 7;
-	const FILLRULE_UNDEFINED = 0;
-	const FILLRULE_EVENODD = 1;
-	const FILLRULE_NONZERO = 2;
-	const PATHUNITS_UNDEFINED = 0;
-	const PATHUNITS_USERSPACE = 1;
-	const PATHUNITS_USERSPACEONUSE = 2;
-	const PATHUNITS_OBJECTBOUNDINGBOX = 3;
-	const LINECAP_UNDEFINED = 0;
-	const LINECAP_BUTT = 1;
-	const LINECAP_ROUND = 2;
-	const LINECAP_SQUARE = 3;
-	const LINEJOIN_UNDEFINED = 0;
-	const LINEJOIN_MITER = 1;
-	const LINEJOIN_ROUND = 2;
-	const LINEJOIN_BEVEL = 3;
-	const RESOURCETYPE_UNDEFINED = 0;
-	const RESOURCETYPE_AREA = 1;
-	const RESOURCETYPE_DISK = 2;
-	const RESOURCETYPE_FILE = 3;
-	const RESOURCETYPE_MAP = 4;
-	const RESOURCETYPE_MEMORY = 5;
-	const RESOURCETYPE_TIME = 7;
-	const RESOURCETYPE_THROTTLE = 8;
-	const RESOURCETYPE_THREAD = 6;
-	const DISPOSE_UNRECOGNIZED = 0;
-	const DISPOSE_UNDEFINED = 0;
-	const DISPOSE_NONE = 1;
-	const DISPOSE_BACKGROUND = 2;
-	const DISPOSE_PREVIOUS = 3;
-	const INTERPOLATE_UNDEFINED = 0;
-	const INTERPOLATE_AVERAGE = 1;
-	const INTERPOLATE_BICUBIC = 2;
-	const INTERPOLATE_BILINEAR = 3;
-	const INTERPOLATE_FILTER = 4;
-	const INTERPOLATE_INTEGER = 5;
-	const INTERPOLATE_MESH = 6;
-	const INTERPOLATE_NEARESTNEIGHBOR = 7;
-	const INTERPOLATE_SPLINE = 8;
-	const LAYERMETHOD_UNDEFINED = 0;
-	const LAYERMETHOD_COALESCE = 1;
-	const LAYERMETHOD_COMPAREANY = 2;
-	const LAYERMETHOD_COMPARECLEAR = 3;
-	const LAYERMETHOD_COMPAREOVERLAY = 4;
-	const LAYERMETHOD_DISPOSE = 5;
-	const LAYERMETHOD_OPTIMIZE = 6;
-	const LAYERMETHOD_OPTIMIZEPLUS = 8;
-	const LAYERMETHOD_OPTIMIZETRANS = 9;
-	const LAYERMETHOD_COMPOSITE = 12;
-	const LAYERMETHOD_OPTIMIZEIMAGE = 7;
-	const LAYERMETHOD_REMOVEDUPS = 10;
-	const LAYERMETHOD_REMOVEZERO = 11;
-	const LAYERMETHOD_TRIMBOUNDS = 16;
-	const ORIENTATION_UNDEFINED = 0;
-	const ORIENTATION_TOPLEFT = 1;
-	const ORIENTATION_TOPRIGHT = 2;
-	const ORIENTATION_BOTTOMRIGHT = 3;
-	const ORIENTATION_BOTTOMLEFT = 4;
-	const ORIENTATION_LEFTTOP = 5;
-	const ORIENTATION_RIGHTTOP = 6;
-	const ORIENTATION_RIGHTBOTTOM = 7;
-	const ORIENTATION_LEFTBOTTOM = 8;
-	const DISTORTION_UNDEFINED = 0;
-	const DISTORTION_AFFINE = 1;
-	const DISTORTION_AFFINEPROJECTION = 2;
-	const DISTORTION_ARC = 9;
-	const DISTORTION_BILINEAR = 6;
-	const DISTORTION_PERSPECTIVE = 4;
-	const DISTORTION_PERSPECTIVEPROJECTION = 5;
-	const DISTORTION_SCALEROTATETRANSLATE = 3;
-	const DISTORTION_POLYNOMIAL = 8;
-	const DISTORTION_POLAR = 10;
-	const DISTORTION_DEPOLAR = 11;
-	const DISTORTION_BARREL = 14;
-	const DISTORTION_SHEPARDS = 16;
-	const DISTORTION_SENTINEL = 18;
-	const DISTORTION_BARRELINVERSE = 15;
-	const DISTORTION_BILINEARFORWARD = 6;
-	const DISTORTION_BILINEARREVERSE = 7;
-	const DISTORTION_RESIZE = 17;
-	const DISTORTION_CYLINDER2PLANE = 12;
-	const DISTORTION_PLANE2CYLINDER = 13;
-	const LAYERMETHOD_MERGE = 13;
-	const LAYERMETHOD_FLATTEN = 14;
-	const LAYERMETHOD_MOSAIC = 15;
-	const ALPHACHANNEL_ACTIVATE = 1;
-	const ALPHACHANNEL_RESET = 7;
-	const ALPHACHANNEL_SET = 8;
-	const ALPHACHANNEL_UNDEFINED = 0;
-	const ALPHACHANNEL_COPY = 3;
-	const ALPHACHANNEL_DEACTIVATE = 4;
-	const ALPHACHANNEL_EXTRACT = 5;
-	const ALPHACHANNEL_OPAQUE = 6;
-	const ALPHACHANNEL_SHAPE = 9;
-	const ALPHACHANNEL_TRANSPARENT = 10;
-	const SPARSECOLORMETHOD_UNDEFINED = 0;
-	const SPARSECOLORMETHOD_BARYCENTRIC = 1;
-	const SPARSECOLORMETHOD_BILINEAR = 7;
-	const SPARSECOLORMETHOD_POLYNOMIAL = 8;
-	const SPARSECOLORMETHOD_SPEPARDS = 16;
-	const SPARSECOLORMETHOD_VORONOI = 18;
-	const SPARSECOLORMETHOD_INVERSE = 19;
-	const DITHERMETHOD_UNDEFINED = 0;
-	const DITHERMETHOD_NO = 1;
-	const DITHERMETHOD_RIEMERSMA = 2;
-	const DITHERMETHOD_FLOYDSTEINBERG = 3;
-	const FUNCTION_UNDEFINED = 0;
-	const FUNCTION_POLYNOMIAL = 1;
-	const FUNCTION_SINUSOID = 2;
-	const ALPHACHANNEL_BACKGROUND = 2;
-	const FUNCTION_ARCSIN = 3;
-	const FUNCTION_ARCTAN = 4;
-	const ALPHACHANNEL_FLATTEN = 11;
-	const ALPHACHANNEL_REMOVE = 12;
-	const STATISTIC_GRADIENT = 1;
-	const STATISTIC_MAXIMUM = 2;
-	const STATISTIC_MEAN = 3;
-	const STATISTIC_MEDIAN = 4;
-	const STATISTIC_MINIMUM = 5;
-	const STATISTIC_MODE = 6;
-	const STATISTIC_NONPEAK = 7;
-	const STATISTIC_STANDARD_DEVIATION = 8;
-	const MORPHOLOGY_CONVOLVE = 1;
-	const MORPHOLOGY_CORRELATE = 2;
-	const MORPHOLOGY_ERODE = 3;
-	const MORPHOLOGY_DILATE = 4;
-	const MORPHOLOGY_ERODE_INTENSITY = 5;
-	const MORPHOLOGY_DILATE_INTENSITY = 6;
-	const MORPHOLOGY_DISTANCE = 7;
-	const MORPHOLOGY_OPEN = 8;
-	const MORPHOLOGY_CLOSE = 9;
-	const MORPHOLOGY_OPEN_INTENSITY = 10;
-	const MORPHOLOGY_CLOSE_INTENSITY = 11;
-	const MORPHOLOGY_SMOOTH = 12;
-	const MORPHOLOGY_EDGE_IN = 13;
-	const MORPHOLOGY_EDGE_OUT = 14;
-	const MORPHOLOGY_EDGE = 15;
-	const MORPHOLOGY_TOP_HAT = 16;
-	const MORPHOLOGY_BOTTOM_HAT = 17;
-	const MORPHOLOGY_HIT_AND_MISS = 18;
-	const MORPHOLOGY_THINNING = 19;
-	const MORPHOLOGY_THICKEN = 20;
-	const MORPHOLOGY_VORONOI = 21;
-	const MORPHOLOGY_ITERATIVE = 22;
-	const KERNEL_UNITY = 1;
-	const KERNEL_GAUSSIAN = 2;
-	const KERNEL_DIFFERENCE_OF_GAUSSIANS = 3;
-	const KERNEL_LAPLACIAN_OF_GAUSSIANS = 4;
-	const KERNEL_BLUR = 5;
-	const KERNEL_COMET = 6;
-	const KERNEL_LAPLACIAN = 7;
-	const KERNEL_SOBEL = 8;
-	const KERNEL_FREI_CHEN = 9;
-	const KERNEL_ROBERTS = 10;
-	const KERNEL_PREWITT = 11;
-	const KERNEL_COMPASS = 12;
-	const KERNEL_KIRSCH = 13;
-	const KERNEL_DIAMOND = 14;
-	const KERNEL_SQUARE = 15;
-	const KERNEL_RECTANGLE = 16;
-	const KERNEL_OCTAGON = 17;
-	const KERNEL_DISK = 18;
-	const KERNEL_PLUS = 19;
-	const KERNEL_CROSS = 20;
-	const KERNEL_RING = 21;
-	const KERNEL_PEAKS = 22;
-	const KERNEL_EDGES = 23;
-	const KERNEL_CORNERS = 24;
-	const KERNEL_DIAGONALS = 25;
-	const KERNEL_LINE_ENDS = 26;
-	const KERNEL_LINE_JUNCTIONS = 27;
-	const KERNEL_RIDGES = 28;
-	const KERNEL_CONVEX_HULL = 29;
-	const KERNEL_THIN_SE = 30;
-	const KERNEL_SKELETON = 31;
-	const KERNEL_CHEBYSHEV = 32;
-	const KERNEL_MANHATTAN = 33;
-	const KERNEL_OCTAGONAL = 34;
-	const KERNEL_EUCLIDEAN = 35;
-	const KERNEL_USER_DEFINED = 36;
-	const KERNEL_BINOMIAL = 37;
-	const DIRECTION_LEFT_TO_RIGHT = 2;
-	const DIRECTION_RIGHT_TO_LEFT = 1;
-	const NORMALIZE_KERNEL_NONE = 0;
-	const NORMALIZE_KERNEL_VALUE = 8192;
-	const NORMALIZE_KERNEL_CORRELATE = 65536;
-	const NORMALIZE_KERNEL_PERCENT = 4096;
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Removes repeated portions of images to optimize
-	 * @link https://php.net/manual/en/imagick.optimizeimagelayers.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function optimizeImageLayers () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the maximum bounding region between images
-	 * @link https://php.net/manual/en/imagick.compareimagelayers.php
-	 * @param int $method <p>
-	 * One of the layer method constants.
-	 * </p>
-	 * @return Imagick <b>TRUE</b> on success.
-	 */
-	public function compareImageLayers ($method) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Quickly fetch attributes
-	 * @link https://php.net/manual/en/imagick.pingimageblob.php
-	 * @param string $image <p>
-	 * A string containing the image.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function pingImageBlob ($image) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Get basic image attributes in a lightweight manner
-	 * @link https://php.net/manual/en/imagick.pingimagefile.php
-	 * @param resource $filehandle <p>
-	 * An open filehandle to the image.
-	 * </p>
-	 * @param string $fileName [optional] <p>
-	 * Optional filename for this image.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function pingImageFile ($filehandle, $fileName = null) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a vertical mirror image
-	 * @link https://php.net/manual/en/imagick.transposeimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function transposeImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a horizontal mirror image
-	 * @link https://php.net/manual/en/imagick.transverseimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function transverseImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Remove edges from the image
-	 * @link https://php.net/manual/en/imagick.trimimage.php
-	 * @param float $fuzz <p>
-	 * By default target must match a particular pixel color exactly.
-	 * However, in many cases two colors may differ by a small amount.
-	 * The fuzz member of image defines how much tolerance is acceptable
-	 * to consider two colors as the same. This parameter represents the variation
-	 * on the quantum range.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function trimImage ($fuzz) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Applies wave filter to the image
-	 * @link https://php.net/manual/en/imagick.waveimage.php
-	 * @param float $amplitude <p>
-	 * The amplitude of the wave.
-	 * </p>
-	 * @param float $length <p>
-	 * The length of the wave.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function waveImage ($amplitude, $length) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds vignette filter to the image
-	 * @link https://php.net/manual/en/imagick.vignetteimage.php
-	 * @param float $blackPoint <p>
-	 * The black point.
-	 * </p>
-	 * @param float $whitePoint <p>
-	 * The white point
-	 * </p>
-	 * @param int $x <p>
-	 * X offset of the ellipse
-	 * </p>
-	 * @param int $y <p>
-	 * Y offset of the ellipse
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function vignetteImage ($blackPoint, $whitePoint, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Discards all but one of any pixel color
-	 * @link https://php.net/manual/en/imagick.uniqueimagecolors.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function uniqueImageColors () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Return if the image has a matte channel
-	 * @link https://php.net/manual/en/imagick.getimagematte.php
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function getImageMatte () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image matte channel
-	 * @link https://php.net/manual/en/imagick.setimagematte.php
-	 * @param bool $matte <p>
-	 * True activates the matte channel and false disables it.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageMatte ($matte) {}
-
-	/**
-	 * Adaptively resize image with data dependent triangulation
-	 *
-	 * If legacy is true, the calculations are done with the small rounding bug that existed in Imagick before 3.4.0.<br>
-	 * If false, the calculations should produce the same results as ImageMagick CLI does.<br>
-	 * <br>
-	 * <b>Note:</b> The behavior of the parameter bestfit changed in Imagick 3.0.0. Before this version given dimensions 400x400 an image of dimensions 200x150 would be left untouched.
-	 * In Imagick 3.0.0 and later the image would be scaled up to size 400x300 as this is the "best fit" for the given dimensions. If bestfit parameter is used both width and height must be given.
-	 * @link https://php.net/manual/en/imagick.adaptiveresizeimage.php
-	 * @param int $columns The number of columns in the scaled image.
-	 * @param int $rows The number of rows in the scaled image.
-	 * @param bool $bestfit [optional] Whether to fit the image inside a bounding box.<br>
-	 *                                 The behavior of the parameter bestfit changed in Imagick 3.0.0. Before this version given dimensions 400x400 an image of dimensions 200x150 would be left untouched. In Imagick 3.0.0 and later the image would be scaled up to size 400x300 as this is the "best fit" for the given dimensions. If bestfit parameter is used both width and height must be given.
-	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
-	 * @return bool TRUE on success
-	 * @throws ImagickException Throws ImagickException on error
-	 * @since 2.0.0
-	 */
-	public function adaptiveResizeImage ($columns, $rows, $bestfit = false, $legacy = false) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Simulates a pencil sketch
-	 * @link https://php.net/manual/en/imagick.sketchimage.php
-	 * @param float $radius <p>
-	 * The radius of the Gaussian, in pixels, not counting the center pixel
-	 * </p>
-	 * @param float $sigma <p>
-	 * The standard deviation of the Gaussian, in pixels.
-	 * </p>
-	 * @param float $angle <p>
-	 * Apply the effect along this angle.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function sketchImage ($radius, $sigma, $angle) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a 3D effect
-	 * @link https://php.net/manual/en/imagick.shadeimage.php
-	 * @param bool $gray <p>
-	 * A value other than zero shades the intensity of each pixel.
-	 * </p>
-	 * @param float $azimuth <p>
-	 * Defines the light source direction.
-	 * </p>
-	 * @param float $elevation <p>
-	 * Defines the light source direction.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function shadeImage ($gray, $azimuth, $elevation) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the size offset
-	 * @link https://php.net/manual/en/imagick.getsizeoffset.php
-	 * @return int the size offset associated with the Imagick object.
-	 */
-	public function getSizeOffset () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the size and offset of the Imagick object
-	 * @link https://php.net/manual/en/imagick.setsizeoffset.php
-	 * @param int $columns <p>
-	 * The width in pixels.
-	 * </p>
-	 * @param int $rows <p>
-	 * The height in pixels.
-	 * </p>
-	 * @param int $offset <p>
-	 * The image offset.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setSizeOffset ($columns, $rows, $offset) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds adaptive blur filter to image
-	 * @link https://php.net/manual/en/imagick.adaptiveblurimage.php
-	 * @param float $radius <p>
-	 * The radius of the Gaussian, in pixels, not counting the center pixel.
-	 * Provide a value of 0 and the radius will be chosen automagically.
-	 * </p>
-	 * @param float $sigma <p>
-	 * The standard deviation of the Gaussian, in pixels.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function adaptiveBlurImage ($radius, $sigma, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Enhances the contrast of a color image
-	 * @link https://php.net/manual/en/imagick.contraststretchimage.php
-	 * @param float $black_point <p>
-	 * The black point.
-	 * </p>
-	 * @param float $white_point <p>
-	 * The white point.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. <b>Imagick::CHANNEL_ALL</b>. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function contrastStretchImage ($black_point, $white_point, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adaptively sharpen the image
-	 * @link https://php.net/manual/en/imagick.adaptivesharpenimage.php
-	 * @param float $radius <p>
-	 * The radius of the Gaussian, in pixels, not counting the center pixel. Use 0 for auto-select.
-	 * </p>
-	 * @param float $sigma <p>
-	 * The standard deviation of the Gaussian, in pixels.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function adaptiveSharpenImage ($radius, $sigma, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a high-contrast, two-color image
-	 * @link https://php.net/manual/en/imagick.randomthresholdimage.php
-	 * @param float $low <p>
-	 * The low point
-	 * </p>
-	 * @param float $high <p>
-	 * The high point
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function randomThresholdImage ($low, $high, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * @param $xRounding
-	 * @param $yRounding
-	 * @param $strokeWidth [optional]
-	 * @param $displace [optional]
-	 * @param $sizeCorrection [optional]
-	 */
-	public function roundCornersImage ($xRounding, $yRounding, $strokeWidth, $displace, $sizeCorrection) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Rounds image corners
-	 * @link https://php.net/manual/en/imagick.roundcorners.php
-	 * @param float $x_rounding <p>
-	 * x rounding
-	 * </p>
-	 * @param float $y_rounding <p>
-	 * y rounding
-	 * </p>
-	 * @param float $stroke_width [optional] <p>
-	 * stroke width
-	 * </p>
-	 * @param float $displace [optional] <p>
-	 * image displace
-	 * </p>
-	 * @param float $size_correction [optional] <p>
-	 * size correction
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function roundCorners ($x_rounding, $y_rounding, $stroke_width = 10.0, $displace = 5.0, $size_correction = -6.0) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Set the iterator position
-	 * @link https://php.net/manual/en/imagick.setiteratorindex.php
-	 * @param int $index <p>
-	 * The position to set the iterator to
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setIteratorIndex ($index) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the index of the current active image
-	 * @link https://php.net/manual/en/imagick.getiteratorindex.php
-	 * @return int an integer containing the index of the image in the stack.
-	 */
-	public function getIteratorIndex () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Convenience method for setting crop size and the image geometry
-	 * @link https://php.net/manual/en/imagick.transformimage.php
-	 * @param string $crop <p>
-	 * A crop geometry string. This geometry defines a subregion of the image to crop.
-	 * </p>
-	 * @param string $geometry <p>
-	 * An image geometry string. This geometry defines the final size of the image.
-	 * </p>
-	 * @return Imagick <b>TRUE</b> on success.
-	 */
-	public function transformImage ($crop, $geometry) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image opacity level
-	 * @link https://php.net/manual/en/imagick.setimageopacity.php
-	 * @param float $opacity <p>
-	 * The level of transparency: 1.0 is fully opaque and 0.0 is fully
-	 * transparent.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageOpacity ($opacity) {}
-
-	/**
-	 * (PECL imagick 2.2.2)<br/>
-	 * Performs an ordered dither
-	 * @link https://php.net/manual/en/imagick.orderedposterizeimage.php
-	 * @param string $threshold_map <p>
-	 * A string containing the name of the threshold dither map to use
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function orderedPosterizeImage ($threshold_map, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Simulates a Polaroid picture
-	 * @link https://php.net/manual/en/imagick.polaroidimage.php
-	 * @param ImagickDraw $properties <p>
-	 * The polaroid properties
-	 * </p>
-	 * @param float $angle <p>
-	 * The polaroid angle
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function polaroidImage (ImagickDraw $properties, $angle) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the named image property
-	 * @link https://php.net/manual/en/imagick.getimageproperty.php
-	 * @param string $name <p>
-	 * name of the property (for example Exif:DateTime)
-	 * </p>
-	 * @return string|false a string containing the image property, false if a
-	 * property with the given name does not exist.
-	 */
-	public function getImageProperty ($name) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets an image property
-	 * @link https://php.net/manual/en/imagick.setimageproperty.php
-	 * @param string $name
-	 * @param string $value
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageProperty ($name, $value) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image interpolate pixel method
-	 * @link https://php.net/manual/en/imagick.setimageinterpolatemethod.php
-	 * @param int $method <p>
-	 * The method is one of the <b>Imagick::INTERPOLATE_*</b> constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageInterpolateMethod ($method) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the interpolation method
-	 * @link https://php.net/manual/en/imagick.getimageinterpolatemethod.php
-	 * @return int the interpolate method on success.
-	 */
-	public function getImageInterpolateMethod () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Stretches with saturation the image intensity
-	 * @link https://php.net/manual/en/imagick.linearstretchimage.php
-	 * @param float $blackPoint <p>
-	 * The image black point
-	 * </p>
-	 * @param float $whitePoint <p>
-	 * The image white point
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function linearStretchImage ($blackPoint, $whitePoint) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image length in bytes
-	 * @link https://php.net/manual/en/imagick.getimagelength.php
-	 * @return int an int containing the current image size.
-	 */
-	public function getImageLength () {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Set image size
-	 * @link https://php.net/manual/en/imagick.extentimage.php
-	 * @param int $width <p>
-	 * The new width
-	 * </p>
-	 * @param int $height <p>
-	 * The new height
-	 * </p>
-	 * @param int $x <p>
-	 * X position for the new size
-	 * </p>
-	 * @param int $y <p>
-	 * Y position for the new size
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function extentImage ($width, $height, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image orientation
-	 * @link https://php.net/manual/en/imagick.getimageorientation.php
-	 * @return int an int on success.
-	 */
-	public function getImageOrientation () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image orientation
-	 * @link https://php.net/manual/en/imagick.setimageorientation.php
-	 * @param int $orientation <p>
-	 * One of the orientation constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageOrientation ($orientation) {}
-
-	/**
-	 * (PECL imagick 2.1.0)<br/>
-	 * Changes the color value of any pixel that matches target
-	 * @link https://php.net/manual/en/imagick.paintfloodfillimage.php
-	 * @param mixed $fill <p>
-	 * ImagickPixel object or a string containing the fill color
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The amount of fuzz. For example, set fuzz to 10 and the color red at
-	 * intensities of 100 and 102 respectively are now interpreted as the
-	 * same color for the purposes of the floodfill.
-	 * </p>
-	 * @param mixed $bordercolor <p>
-	 * ImagickPixel object or a string containing the border color
-	 * </p>
-	 * @param int $x <p>
-	 * X start position of the floodfill
-	 * </p>
-	 * @param int $y <p>
-	 * Y start position of the floodfill
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function paintFloodfillImage ($fill, $fuzz, $bordercolor, $x, $y, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Replaces colors in the image from a color lookup table. Optional second parameter to replace colors in a specific channel. This method is available if Imagick has been compiled against ImageMagick version 6.3.6 or newer.
-	 * @link https://php.net/manual/en/imagick.clutimage.php
-	 * @param Imagick $lookup_table <p>
-	 * Imagick object containing the color lookup table
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * The Channeltype
-	 * constant. When not supplied, default channels are replaced.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 * @since 2.0.0
-	 */
-	public function clutImage (Imagick $lookup_table, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image properties
-	 * @link https://php.net/manual/en/imagick.getimageproperties.php
-	 * @param string $pattern [optional] <p>
-	 * The pattern for property names.
-	 * </p>
-	 * @param bool $only_names [optional] <p>
-	 * Whether to return only property names. If <b>FALSE</b> then also the values are returned
-	 * </p>
-	 * @return array an array containing the image properties or property names.
-	 */
-	public function getImageProperties ($pattern = "*", $only_names = true) {}
-
-	/**
-	 * (PECL imagick 2.2.0)<br/>
-	 * Returns the image profiles
-	 * @link https://php.net/manual/en/imagick.getimageprofiles.php
-	 * @param string $pattern [optional] <p>
-	 * The pattern for profile names.
-	 * </p>
-	 * @param bool $include_values [optional] <p>
-	 * Whether to return only profile names. If <b>FALSE</b> then only profile names will be returned.
-	 * </p>
-	 * @return array an array containing the image profiles or profile names.
-	 */
-	public function getImageProfiles ($pattern = "*", $include_values = true) {}
-
-	/**
-	 * (PECL imagick 2.0.1)<br/>
-	 * Distorts an image using various distortion methods
-	 * @link https://php.net/manual/en/imagick.distortimage.php
-	 * @param int $method <p>
-	 * The method of image distortion. See distortion constants
-	 * </p>
-	 * @param array $arguments <p>
-	 * The arguments for this distortion method
-	 * </p>
-	 * @param bool $bestfit <p>
-	 * Attempt to resize destination to fit distorted source
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function distortImage ($method, array $arguments, $bestfit) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Writes an image to a filehandle
-	 * @link https://php.net/manual/en/imagick.writeimagefile.php
-	 * @param resource $filehandle <p>
-	 * Filehandle where to write the image
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function writeImageFile ($filehandle) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Writes frames to a filehandle
-	 * @link https://php.net/manual/en/imagick.writeimagesfile.php
-	 * @param resource $filehandle <p>
-	 * Filehandle where to write the images
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function writeImagesFile ($filehandle) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Reset image page
-	 * @link https://php.net/manual/en/imagick.resetimagepage.php
-	 * @param string $page <p>
-	 * The page definition. For example 7168x5147+0+0
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function resetImagePage ($page) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Sets image clip mask
-	 * @link https://php.net/manual/en/imagick.setimageclipmask.php
-	 * @param Imagick $clip_mask <p>
-	 * The Imagick object containing the clip mask
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageClipMask (Imagick $clip_mask) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Gets image clip mask
-	 * @link https://php.net/manual/en/imagick.getimageclipmask.php
-	 * @return Imagick an Imagick object containing the clip mask.
-	 */
-	public function getImageClipMask () {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Animates an image or images
-	 * @link https://php.net/manual/en/imagick.animateimages.php
-	 * @param string $x_server <p>
-	 * X server address
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function animateImages ($x_server) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Recolors image
-	 * @link https://php.net/manual/en/imagick.recolorimage.php
-	 * @param array $matrix <p>
-	 * The matrix containing the color values
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function recolorImage (array $matrix) {}
-
-	/**
-	 * (PECL imagick 2.1.0)<br/>
-	 * Sets font
-	 * @link https://php.net/manual/en/imagick.setfont.php
-	 * @param string $font <p>
-	 * Font name or a filename
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setFont ($font) {}
-
-	/**
-	 * (PECL imagick 2.1.0)<br/>
-	 * Gets font
-	 * @link https://php.net/manual/en/imagick.getfont.php
-	 * @return string|false the string containing the font name or <b>FALSE</b> if not font is set.
-	 */
-	public function getFont () {}
-
-	/**
-	 * (PECL imagick 2.1.0)<br/>
-	 * Sets point size
-	 * @link https://php.net/manual/en/imagick.setpointsize.php
-	 * @param float $point_size <p>
-	 * Point size
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setPointSize ($point_size) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Gets point size
-	 * @link https://php.net/manual/en/imagick.getpointsize.php
-	 * @return float a float containing the point size.
-	 */
-	public function getPointSize () {}
-
-	/**
-	 * (PECL imagick 2.1.0)<br/>
-	 * Merges image layers
-	 * @link https://php.net/manual/en/imagick.mergeimagelayers.php
-	 * @param int $layer_method <p>
-	 * One of the <b>Imagick::LAYERMETHOD_*</b> constants
-	 * </p>
-	 * @return Imagick Returns an Imagick object containing the merged image.
-	 * @throws ImagickException
-	 */
-	public function mergeImageLayers ($layer_method) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Sets image alpha channel
-	 * @link https://php.net/manual/en/imagick.setimagealphachannel.php
-	 * @param int $mode <p>
-	 * One of the <b>Imagick::ALPHACHANNEL_*</b> constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageAlphaChannel ($mode) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Changes the color value of any pixel that matches target
-	 * @link https://php.net/manual/en/imagick.floodfillpaintimage.php
-	 * @param mixed $fill <p>
-	 * ImagickPixel object or a string containing the fill color
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The amount of fuzz. For example, set fuzz to 10 and the color red at intensities of 100 and 102 respectively are now interpreted as the same color.
-	 * </p>
-	 * @param mixed $target <p>
-	 * ImagickPixel object or a string containing the target color to paint
-	 * </p>
-	 * @param int $x <p>
-	 * X start position of the floodfill
-	 * </p>
-	 * @param int $y <p>
-	 * Y start position of the floodfill
-	 * </p>
-	 * @param bool $invert <p>
-	 * If <b>TRUE</b> paints any pixel that does not match the target color.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function floodFillPaintImage ($fill, $fuzz, $target, $x, $y, $invert, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Changes the color value of any pixel that matches target
-	 * @link https://php.net/manual/en/imagick.opaquepaintimage.php
-	 * @param mixed $target <p>
-	 * ImagickPixel object or a string containing the color to change
-	 * </p>
-	 * @param mixed $fill <p>
-	 * The replacement color
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The amount of fuzz. For example, set fuzz to 10 and the color red at intensities of 100 and 102 respectively are now interpreted as the same color.
-	 * </p>
-	 * @param bool $invert <p>
-	 * If <b>TRUE</b> paints any pixel that does not match the target color.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function opaquePaintImage ($target, $fill, $fuzz, $invert, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Paints pixels transparent
-	 * @link https://php.net/manual/en/imagick.transparentpaintimage.php
-	 * @param mixed $target <p>
-	 * The target color to paint
-	 * </p>
-	 * @param float $alpha <p>
-	 * The level of transparency: 1.0 is fully opaque and 0.0 is fully transparent.
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The amount of fuzz. For example, set fuzz to 10 and the color red at intensities of 100 and 102 respectively are now interpreted as the same color.
-	 * </p>
-	 * @param bool $invert <p>
-	 * If <b>TRUE</b> paints any pixel that does not match the target color.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function transparentPaintImage ($target, $alpha, $fuzz, $invert) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Animates an image or images
-	 * @link https://php.net/manual/en/imagick.liquidrescaleimage.php
-	 * @param int $width <p>
-	 * The width of the target size
-	 * </p>
-	 * @param int $height <p>
-	 * The height of the target size
-	 * </p>
-	 * @param float $delta_x <p>
-	 * How much the seam can traverse on x-axis.
-	 * Passing 0 causes the seams to be straight.
-	 * </p>
-	 * @param float $rigidity <p>
-	 * Introduces a bias for non-straight seams. This parameter is
-	 * typically 0.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function liquidRescaleImage ($width, $height, $delta_x, $rigidity) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Enciphers an image
-	 * @link https://php.net/manual/en/imagick.encipherimage.php
-	 * @param string $passphrase <p>
-	 * The passphrase
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function encipherImage ($passphrase) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Deciphers an image
-	 * @link https://php.net/manual/en/imagick.decipherimage.php
-	 * @param string $passphrase <p>
-	 * The passphrase
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function decipherImage ($passphrase) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Sets the gravity
-	 * @link https://php.net/manual/en/imagick.setgravity.php
-	 * @param int $gravity <p>
-	 * The gravity property. Refer to the list of
-	 * gravity constants.
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setGravity ($gravity) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Gets the gravity
-	 * @link https://php.net/manual/en/imagick.getgravity.php
-	 * @return int the gravity property. Refer to the list of
-	 * gravity constants.
-	 */
-	public function getGravity () {}
-
-	/**
-	 * (PECL imagick 2.2.1)<br/>
-	 * Gets channel range
-	 * @link https://php.net/manual/en/imagick.getimagechannelrange.php
-	 * @param int $channel <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return array an array containing minima and maxima values of the channel(s).
-	 */
-	public function getImageChannelRange ($channel) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Gets the image alpha channel
-	 * @link https://php.net/manual/en/imagick.getimagealphachannel.php
-	 * @return int a constant defining the current alpha channel value. Refer to this
-	 * list of alpha channel constants.
-	 */
-	public function getImageAlphaChannel () {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Gets channel distortions
-	 * @link https://php.net/manual/en/imagick.getimagechanneldistortions.php
-	 * @param Imagick $reference <p>
-	 * Imagick object containing the reference image
-	 * </p>
-	 * @param int $metric <p>
-	 * Refer to this list of metric type constants.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return float a double describing the channel distortion.
-	 */
-	public function getImageChannelDistortions (Imagick $reference, $metric, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Sets the image gravity
-	 * @link https://php.net/manual/en/imagick.setimagegravity.php
-	 * @param int $gravity <p>
-	 * The gravity property. Refer to the list of
-	 * gravity constants.
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setImageGravity ($gravity) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Gets the image gravity
-	 * @link https://php.net/manual/en/imagick.getimagegravity.php
-	 * @return int the images gravity property. Refer to the list of
-	 * gravity constants.
-	 */
-	public function getImageGravity () {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Imports image pixels
-	 * @link https://php.net/manual/en/imagick.importimagepixels.php
-	 * @param int $x <p>
-	 * The image x position
-	 * </p>
-	 * @param int $y <p>
-	 * The image y position
-	 * </p>
-	 * @param int $width <p>
-	 * The image width
-	 * </p>
-	 * @param int $height <p>
-	 * The image height
-	 * </p>
-	 * @param string $map <p>
-	 * Map of pixel ordering as a string. This can be for example RGB.
-	 * The value can be any combination or order of R = red, G = green, B = blue, A = alpha (0 is transparent),
-	 * O = opacity (0 is opaque), C = cyan, Y = yellow, M = magenta, K = black, I = intensity (for grayscale), P = pad.
-	 * </p>
-	 * @param int $storage <p>
-	 * The pixel storage method.
-	 * Refer to this list of pixel constants.
-	 * </p>
-	 * @param array $pixels <p>
-	 * The array of pixels
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function importImagePixels ($x, $y, $width, $height, $map, $storage, array $pixels) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Removes skew from the image
-	 * @link https://php.net/manual/en/imagick.deskewimage.php
-	 * @param float $threshold <p>
-	 * Deskew threshold
-	 * </p>
-	 * @return bool
-	 */
-	public function deskewImage ($threshold) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Segments an image
-	 * @link https://php.net/manual/en/imagick.segmentimage.php
-	 * @param int $COLORSPACE <p>
-	 * One of the COLORSPACE constants.
-	 * </p>
-	 * @param float $cluster_threshold <p>
-	 * A percentage describing minimum number of pixels
-	 * contained in hexedra before it is considered valid.
-	 * </p>
-	 * @param float $smooth_threshold <p>
-	 * Eliminates noise from the histogram.
-	 * </p>
-	 * @param bool $verbose [optional] <p>
-	 * Whether to output detailed information about recognised classes.
-	 * </p>
-	 * @return bool
-	 */
-	public function segmentImage ($COLORSPACE, $cluster_threshold, $smooth_threshold, $verbose = false) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Interpolates colors
-	 * @link https://php.net/manual/en/imagick.sparsecolorimage.php
-	 * @param int $SPARSE_METHOD <p>
-	 * Refer to this list of sparse method constants
-	 * </p>
-	 * @param array $arguments <p>
-	 * An array containing the coordinates.
-	 * The array is in format array(1,1, 2,45)
-	 * </p>
-	 * @param int $channel [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function sparseColorImage ($SPARSE_METHOD, array $arguments, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Remaps image colors
-	 * @link https://php.net/manual/en/imagick.remapimage.php
-	 * @param Imagick $replacement <p>
-	 * An Imagick object containing the replacement colors
-	 * </p>
-	 * @param int $DITHER <p>
-	 * Refer to this list of dither method constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function remapImage (Imagick $replacement, $DITHER) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Exports raw image pixels
-	 * @link https://php.net/manual/en/imagick.exportimagepixels.php
-	 * @param int $x <p>
-	 * X-coordinate of the exported area
-	 * </p>
-	 * @param int $y <p>
-	 * Y-coordinate of the exported area
-	 * </p>
-	 * @param int $width <p>
-	 * Width of the exported aread
-	 * </p>
-	 * @param int $height <p>
-	 * Height of the exported area
-	 * </p>
-	 * @param string $map <p>
-	 * Ordering of the exported pixels. For example "RGB".
-	 * Valid characters for the map are R, G, B, A, O, C, Y, M, K, I and P.
-	 * </p>
-	 * @param int $STORAGE <p>
-	 * Refer to this list of pixel type constants
-	 * </p>
-	 * @return array an array containing the pixels values.
-	 */
-	public function exportImagePixels ($x, $y, $width, $height, $map, $STORAGE) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * The getImageChannelKurtosis purpose
-	 * @link https://php.net/manual/en/imagick.getimagechannelkurtosis.php
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return array an array with kurtosis and skewness
-	 * members.
-	 */
-	public function getImageChannelKurtosis ($channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Applies a function on the image
-	 * @link https://php.net/manual/en/imagick.functionimage.php
-	 * @param int $function <p>
-	 * Refer to this list of function constants
-	 * </p>
-	 * @param array $arguments <p>
-	 * Array of arguments to pass to this function.
-	 * </p>
-	 * @param int $channel [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function functionImage ($function, array $arguments, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * @param $COLORSPACE
-	 */
-	public function transformImageColorspace ($COLORSPACE) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Replaces colors in the image
-	 * @link https://php.net/manual/en/imagick.haldclutimage.php
-	 * @param Imagick $clut <p>
-	 * Imagick object containing the Hald lookup image.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function haldClutImage (Imagick $clut, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * @param $CHANNEL [optional]
-	 */
-	public function autoLevelImage ($CHANNEL) {}
-
-	/**
-	 * @param $factor [optional]
-	 */
-	public function blueShiftImage ($factor) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Get image artifact
-	 * @link https://php.net/manual/en/imagick.getimageartifact.php
-	 * @param string $artifact <p>
-	 * The name of the artifact
-	 * </p>
-	 * @return string the artifact value on success.
-	 */
-	public function getImageArtifact ($artifact) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Set image artifact
-	 * @link https://php.net/manual/en/imagick.setimageartifact.php
-	 * @param string $artifact <p>
-	 * The name of the artifact
-	 * </p>
-	 * @param string $value <p>
-	 * The value of the artifact
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageArtifact ($artifact, $value) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Delete image artifact
-	 * @link https://php.net/manual/en/imagick.deleteimageartifact.php
-	 * @param string $artifact <p>
-	 * The name of the artifact to delete
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function deleteImageArtifact ($artifact) {}
-
-	/**
-	 * (PECL imagick 0.9.10-0.9.9)<br/>
-	 * Gets the colorspace
-	 * @link https://php.net/manual/en/imagick.getcolorspace.php
-	 * @return int an integer which can be compared against COLORSPACE constants.
-	 */
-	public function getColorspace () {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Set colorspace
-	 * @link https://php.net/manual/en/imagick.setcolorspace.php
-	 * @param int $COLORSPACE <p>
-	 * One of the COLORSPACE constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setColorspace ($COLORSPACE) {}
-
-	/**
-	 * @param $CHANNEL [optional]
-	 */
-	public function clampImage ($CHANNEL) {}
-
-	/**
-	 * @param $stack
-	 * @param $offset
-	 */
-	public function smushImages ($stack, $offset) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * The Imagick constructor
-	 * @link https://php.net/manual/en/imagick.construct.php
-	 * @param mixed $files <p>
-	 * The path to an image to load or an array of paths. Paths can include
-	 * wildcards for file names, or can be URLs.
-	 * </p>
-	 * @throws ImagickException Throws ImagickException on error.
-	 */
-	public function __construct ($files = null) {}
-
-	/**
-	 * @return string
-	 */
-	public function __toString () {}
-
-	public function count () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a MagickPixelIterator
-	 * @link https://php.net/manual/en/imagick.getpixeliterator.php
-	 * @return ImagickPixelIterator an ImagickPixelIterator on success.
-	 */
-	public function getPixelIterator () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Get an ImagickPixelIterator for an image section
-	 * @link https://php.net/manual/en/imagick.getpixelregioniterator.php
-	 * @param int $x <p>
-	 * The x-coordinate of the region.
-	 * </p>
-	 * @param int $y <p>
-	 * The y-coordinate of the region.
-	 * </p>
-	 * @param int $columns <p>
-	 * The width of the region.
-	 * </p>
-	 * @param int $rows <p>
-	 * The height of the region.
-	 * </p>
-	 * @return ImagickPixelIterator an ImagickPixelIterator for an image section.
-	 */
-	public function getPixelRegionIterator ($x, $y, $columns, $rows) {}
-
-	/**
-	 * (PECL imagick 0.9.0-0.9.9)<br/>
-	 * Reads image from filename
-	 * @link https://php.net/manual/en/imagick.readimage.php
-	 * @param string $filename
-	 * @return bool <b>TRUE</b> on success.
-	 * @throws ImagickException Throws ImagickException on error.
-	 */
-	public function readImage ($filename) {}
-
-	/**
-	 * @param $filenames
-	 * @throws ImagickException Throws ImagickException on error.
-	 */
-	public function readImages ($filenames) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Reads image from a binary string
-	 * @link https://php.net/manual/en/imagick.readimageblob.php
-	 * @param string $image
-	 * @param string $filename [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 * @throws ImagickException Throws ImagickException on error.
-	 */
-	public function readImageBlob ($image, $filename = null) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the format of a particular image
-	 * @link https://php.net/manual/en/imagick.setimageformat.php
-	 * @param string $format <p>
-	 * String presentation of the image format. Format support
-	 * depends on the ImageMagick installation.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageFormat ($format) {}
-
-	/**
-	 * Scales the size of an image to the given dimensions. Passing zero as either of the arguments will preserve dimension while scaling.<br>
-	 * If legacy is true, the calculations are done with the small rounding bug that existed in Imagick before 3.4.0.<br>
-	 * If false, the calculations should produce the same results as ImageMagick CLI does.
-	 * @link https://php.net/manual/en/imagick.scaleimage.php
-	 * @param int $cols
-	 * @param int $rows
-	 * @param bool $bestfit [optional] The behavior of the parameter bestfit changed in Imagick 3.0.0. Before this version given dimensions 400x400 an image of dimensions 200x150 would be left untouched. In Imagick 3.0.0 and later the image would be scaled up to size 400x300 as this is the "best fit" for the given dimensions. If bestfit parameter is used both width and height must be given.
-	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
-	 * @return bool <b>TRUE</b> on success.
-	 * @throws ImagickException Throws ImagickException on error
-	 * @since 2.0.0
-	 */
-	public function scaleImage ($cols, $rows, $bestfit = false, $legacy = false) {}
-
-	/**
-	 * (PECL imagick 0.9.0-0.9.9)<br/>
-	 * Writes an image to the specified filename
-	 * @link https://php.net/manual/en/imagick.writeimage.php
-	 * @param string $filename [optional] <p>
-	 * Filename where to write the image. The extension of the filename
-	 * defines the type of the file.
-	 * Format can be forced regardless of file extension using format: prefix,
-	 * for example "jpg:test.png".
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function writeImage ($filename = null) {}
-
-	/**
-	 * (PECL imagick 0.9.0-0.9.9)<br/>
-	 * Writes an image or image sequence
-	 * @link https://php.net/manual/en/imagick.writeimages.php
-	 * @param string $filename
-	 * @param bool $adjoin
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function writeImages ($filename, $adjoin) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds blur filter to image
-	 * @link https://php.net/manual/en/imagick.blurimage.php
-	 * @param float $radius <p>
-	 * Blur radius
-	 * </p>
-	 * @param float $sigma <p>
-	 * Standard deviation
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * The Channeltype
-	 * constant. When not supplied, all channels are blurred.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function blurImage ($radius, $sigma, $channel = null) {}
-
-	/**
-	 * Changes the size of an image to the given dimensions and removes any associated profiles.<br>
-	 * If legacy is true, the calculations are done with the small rounding bug that existed in Imagick before 3.4.0.<br>
-	 * If false, the calculations should produce the same results as ImageMagick CLI does.<br>
-	 * <br>
-	 * <b>Note:</b> The behavior of the parameter bestfit changed in Imagick 3.0.0. Before this version given dimensions 400x400 an image of dimensions 200x150 would be left untouched. In Imagick 3.0.0 and later the image would be scaled up to size 400x300 as this is the "best fit" for the given dimensions. If bestfit parameter is used both width and height must be given.
-	 * @link https://php.net/manual/en/imagick.thumbnailimage.php
-	 * @param int $columns <p>
-	 * Image width
-	 * </p>
-	 * @param int $rows <p>
-	 * Image height
-	 * </p>
-	 * @param bool $bestfit [optional] <p>
-	 * Whether to force maximum values
-	 * </p>
-	 * The behavior of the parameter bestfit changed in Imagick 3.0.0. Before this version given dimensions 400x400 an image of dimensions 200x150 would be left untouched. In Imagick 3.0.0 and later the image would be scaled up to size 400x300 as this is the "best fit" for the given dimensions. If bestfit parameter is used both width and height must be given.
-	 * @param bool $fill [optional]
-	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
-	 * @return bool <b>TRUE</b> on success.
-	 * @since 2.0.0
-	 */
-	public function thumbnailImage ($columns, $rows, $bestfit = false, $fill = false, $legacy = false) {}
-
-	/**
-	 * Creates a cropped thumbnail at the requested size.
-	 * If legacy is true, uses the incorrect behaviour that was present until Imagick 3.4.0.
-	 * If false it uses the correct behaviour.
-	 * @link https://php.net/manual/en/imagick.cropthumbnailimage.php
-	 * @param int $width The width of the thumbnail
-	 * @param int $height The Height of the thumbnail
-	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
-	 * @return bool TRUE on succes
-	 * @throws ImagickException Throws ImagickException on error
-	 * @since 2.0.0
-	 */
-	public function cropThumbnailImage ($width, $height, $legacy = false) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the filename of a particular image in a sequence
-	 * @link https://php.net/manual/en/imagick.getimagefilename.php
-	 * @return string a string with the filename of the image.
-	 */
-	public function getImageFilename () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the filename of a particular image
-	 * @link https://php.net/manual/en/imagick.setimagefilename.php
-	 * @param string $filename
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageFilename ($filename) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the format of a particular image in a sequence
-	 * @link https://php.net/manual/en/imagick.getimageformat.php
-	 * @return string a string containing the image format on success.
-	 */
-	public function getImageFormat () {}
-
-	/**
-	 * @link https://www.php.net/manual/en/imagick.getimagemimetype.php
-	 * @return string Returns the image mime-type.
-	 */
-	public function getImageMimeType () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Removes an image from the image list
-	 * @link https://php.net/manual/en/imagick.removeimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function removeImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Destroys the Imagick object
-	 * @link https://php.net/manual/en/imagick.destroy.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function destroy () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Clears all resources associated to Imagick object
-	 * @link https://php.net/manual/en/imagick.clear.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function clear () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image length in bytes
-	 * @link https://php.net/manual/en/imagick.getimagesize.php
-	 * @return int an int containing the current image size.
-	 * @deprecated use {@see Imagick::getImageLength()} instead
-	 */
-	public function getImageSize () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image sequence as a blob
-	 * @link https://php.net/manual/en/imagick.getimageblob.php
-	 * @return string a string containing the image.
-	 */
-	public function getImageBlob () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns all image sequences as a blob
-	 * @link https://php.net/manual/en/imagick.getimagesblob.php
-	 * @return string a string containing the images. On failure, throws ImagickException on failure
-	 * @throws ImagickException on failure
-	 */
-	public function getImagesBlob () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the Imagick iterator to the first image
-	 * @link https://php.net/manual/en/imagick.setfirstiterator.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setFirstIterator () {}
-
-	/**
-	 * (PECL imagick 2.0.1)<br/>
-	 * Sets the Imagick iterator to the last image
-	 * @link https://php.net/manual/en/imagick.setlastiterator.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setLastIterator () {}
-
-	public function resetIterator () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Move to the previous image in the object
-	 * @link https://php.net/manual/en/imagick.previousimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function previousImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Moves to the next image
-	 * @link https://php.net/manual/en/imagick.nextimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function nextImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Checks if the object has a previous image
-	 * @link https://php.net/manual/en/imagick.haspreviousimage.php
-	 * @return bool <b>TRUE</b> if the object has more images when traversing the list in the
-	 * reverse direction, returns <b>FALSE</b> if there are none.
-	 */
-	public function hasPreviousImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Checks if the object has more images
-	 * @link https://php.net/manual/en/imagick.hasnextimage.php
-	 * @return bool <b>TRUE</b> if the object has more images when traversing the list in the
-	 * forward direction, returns <b>FALSE</b> if there are none.
-	 */
-	public function hasNextImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Set the iterator position
-	 * @link https://php.net/manual/en/imagick.setimageindex.php
-	 * @param int $index <p>
-	 * The position to set the iterator to
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageIndex ($index) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the index of the current active image
-	 * @link https://php.net/manual/en/imagick.getimageindex.php
-	 * @return int an integer containing the index of the image in the stack.
-	 */
-	public function getImageIndex () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds a comment to your image
-	 * @link https://php.net/manual/en/imagick.commentimage.php
-	 * @param string $comment <p>
-	 * The comment to add
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function commentImage ($comment) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Extracts a region of the image
-	 * @link https://php.net/manual/en/imagick.cropimage.php
-	 * @param int $width <p>
-	 * The width of the crop
-	 * </p>
-	 * @param int $height <p>
-	 * The height of the crop
-	 * </p>
-	 * @param int $x <p>
-	 * The X coordinate of the cropped region's top left corner
-	 * </p>
-	 * @param int $y <p>
-	 * The Y coordinate of the cropped region's top left corner
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function cropImage ($width, $height, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds a label to an image
-	 * @link https://php.net/manual/en/imagick.labelimage.php
-	 * @param string $label <p>
-	 * The label to add
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function labelImage ($label) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the width and height as an associative array
-	 * @link https://php.net/manual/en/imagick.getimagegeometry.php
-	 * @return array an array with the width/height of the image.
-	 */
-	public function getImageGeometry () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Renders the ImagickDraw object on the current image
-	 * @link https://php.net/manual/en/imagick.drawimage.php
-	 * @param ImagickDraw $draw <p>
-	 * The drawing operations to render on the image.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function drawImage (ImagickDraw $draw) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Sets the image compression quality
-	 * @link https://php.net/manual/en/imagick.setimagecompressionquality.php
-	 * @param int $quality <p>
-	 * The image compression quality as an integer
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageCompressionQuality ($quality) {}
-
-	/**
-	 * (PECL imagick 2.2.2)<br/>
-	 * Gets the current image's compression quality
-	 * @link https://php.net/manual/en/imagick.getimagecompressionquality.php
-	 * @return int integer describing the images compression quality
-	 */
-	public function getImageCompressionQuality () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Annotates an image with text
-	 * @link https://php.net/manual/en/imagick.annotateimage.php
-	 * @param ImagickDraw $draw_settings <p>
-	 * The ImagickDraw object that contains settings for drawing the text
-	 * </p>
-	 * @param float $x <p>
-	 * Horizontal offset in pixels to the left of text
-	 * </p>
-	 * @param float $y <p>
-	 * Vertical offset in pixels to the baseline of text
-	 * </p>
-	 * @param float $angle <p>
-	 * The angle at which to write the text
-	 * </p>
-	 * @param string $text <p>
-	 * The string to draw
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function annotateImage (ImagickDraw $draw_settings, $x, $y, $angle, $text) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Composite one image onto another
-	 * @link https://php.net/manual/en/imagick.compositeimage.php
-	 * @param Imagick $composite_object <p>
-	 * Imagick object which holds the composite image
-	 * </p>
-	 * @param int $composite Composite operator
-	 * @param int $x <p>
-	 * The column offset of the composited image
-	 * </p>
-	 * @param int $y <p>
-	 * The row offset of the composited image
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function compositeImage (Imagick $composite_object, $composite, $x, $y, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Control the brightness, saturation, and hue
-	 * @link https://php.net/manual/en/imagick.modulateimage.php
-	 * @param float $brightness
-	 * @param float $saturation
-	 * @param float $hue
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function modulateImage ($brightness, $saturation, $hue) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the number of unique colors in the image
-	 * @link https://php.net/manual/en/imagick.getimagecolors.php
-	 * @return int <b>TRUE</b> on success.
-	 */
-	public function getImageColors () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a composite image
-	 * @link https://php.net/manual/en/imagick.montageimage.php
-	 * @param ImagickDraw $draw <p>
-	 * The font name, size, and color are obtained from this object.
-	 * </p>
-	 * @param string $tile_geometry <p>
-	 * The number of tiles per row and page (e.g. 6x4+0+0).
-	 * </p>
-	 * @param string $thumbnail_geometry <p>
-	 * Preferred image size and border size of each thumbnail
-	 * (e.g. 120x120+4+3>).
-	 * </p>
-	 * @param int $mode <p>
-	 * Thumbnail framing mode, see Montage Mode constants.
-	 * </p>
-	 * @param string $frame <p>
-	 * Surround the image with an ornamental border (e.g. 15x15+3+3). The
-	 * frame color is that of the thumbnail's matte color.
-	 * </p>
-	 * @return Imagick <b>TRUE</b> on success.
-	 */
-	public function montageImage (ImagickDraw $draw, $tile_geometry, $thumbnail_geometry, $mode, $frame) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Identifies an image and fetches attributes
-	 * @link https://php.net/manual/en/imagick.identifyimage.php
-	 * @param bool $appendRawOutput [optional]
-	 * @return array Identifies an image and returns the attributes. Attributes include
-	 * the image width, height, size, and others.
-	 */
-	public function identifyImage ($appendRawOutput = false) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Changes the value of individual pixels based on a threshold
-	 * @link https://php.net/manual/en/imagick.thresholdimage.php
-	 * @param float $threshold
-	 * @param int $channel [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function thresholdImage ($threshold, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Selects a threshold for each pixel based on a range of intensity
-	 * @link https://php.net/manual/en/imagick.adaptivethresholdimage.php
-	 * @param int $width <p>
-	 * Width of the local neighborhood.
-	 * </p>
-	 * @param int $height <p>
-	 * Height of the local neighborhood.
-	 * </p>
-	 * @param int $offset <p>
-	 * The mean offset
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function adaptiveThresholdImage ($width, $height, $offset) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Forces all pixels below the threshold into black
-	 * @link https://php.net/manual/en/imagick.blackthresholdimage.php
-	 * @param mixed $threshold <p>
-	 * The threshold below which everything turns black
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function blackThresholdImage ($threshold) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Force all pixels above the threshold into white
-	 * @link https://php.net/manual/en/imagick.whitethresholdimage.php
-	 * @param mixed $threshold
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function whiteThresholdImage ($threshold) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Append a set of images
-	 * @link https://php.net/manual/en/imagick.appendimages.php
-	 * @param bool $stack [optional] <p>
-	 * Whether to stack the images vertically.
-	 * By default (or if <b>FALSE</b> is specified) images are stacked left-to-right.
-	 * If <i>stack</i> is <b>TRUE</b>, images are stacked top-to-bottom.
-	 * </p>
-	 * @return Imagick Imagick instance on success.
-	 */
-	public function appendImages ($stack = false) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Simulates a charcoal drawing
-	 * @link https://php.net/manual/en/imagick.charcoalimage.php
-	 * @param float $radius <p>
-	 * The radius of the Gaussian, in pixels, not counting the center pixel
-	 * </p>
-	 * @param float $sigma <p>
-	 * The standard deviation of the Gaussian, in pixels
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function charcoalImage ($radius, $sigma) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Enhances the contrast of a color image
-	 * @link https://php.net/manual/en/imagick.normalizeimage.php
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function normalizeImage ($channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Simulates an oil painting
-	 * @link https://php.net/manual/en/imagick.oilpaintimage.php
-	 * @param float $radius <p>
-	 * The radius of the circular neighborhood.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function oilPaintImage ($radius) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Reduces the image to a limited number of color level
-	 * @link https://php.net/manual/en/imagick.posterizeimage.php
-	 * @param int $levels
-	 * @param bool $dither
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function posterizeImage ($levels, $dither) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Radial blurs an image
-	 * @link https://php.net/manual/en/imagick.radialblurimage.php
-	 * @param float $angle
-	 * @param int $channel [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function radialBlurImage ($angle, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a simulated 3d button-like effect
-	 * @link https://php.net/manual/en/imagick.raiseimage.php
-	 * @param int $width
-	 * @param int $height
-	 * @param int $x
-	 * @param int $y
-	 * @param bool $raise
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function raiseImage ($width, $height, $x, $y, $raise) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Resample image to desired resolution
-	 * @link https://php.net/manual/en/imagick.resampleimage.php
-	 * @param float $x_resolution
-	 * @param float $y_resolution
-	 * @param int $filter
-	 * @param float $blur
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function resampleImage ($x_resolution, $y_resolution, $filter, $blur) {}
-
-	/**
-	 * Scales an image to the desired dimensions with one of these filters:<br>
-	 * If legacy is true, the calculations are done with the small rounding bug that existed in Imagick before 3.4.0.<br>
-	 * If false, the calculations should produce the same results as ImageMagick CLI does.<br>
-	 * <br>
-	 * <b>Note:</b> The behavior of the parameter bestfit changed in Imagick 3.0.0. Before this version given dimensions 400x400 an image of dimensions 200x150 would be left untouched.<br>
-	 * In Imagick 3.0.0 and later the image would be scaled up to size 400x300 as this is the "best fit" for the given dimensions. If bestfit parameter is used both width and height must be given.
-	 * @link https://php.net/manual/en/imagick.resizeimage.php
-	 * @param int $columns Width of the image
-	 * @param int $rows Height of the image
-	 * @param int $filter Refer to the list of filter constants.
-	 * @param float $blur The blur factor where > 1 is blurry, < 1 is sharp.
-	 * @param bool $bestfit [optional] Added since 2.1.0. Added optional fit parameter. This method now supports proportional scaling. Pass zero as either parameter for proportional scaling
-	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
-	 * @return bool TRUE on success
-	 * @since 2.0.0
-	 */
-	public function resizeImage ($columns, $rows, $filter, $blur, $bestfit = false, $legacy = false) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Offsets an image
-	 * @link https://php.net/manual/en/imagick.rollimage.php
-	 * @param int $x <p>
-	 * The X offset.
-	 * </p>
-	 * @param int $y <p>
-	 * The Y offset.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function rollImage ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Rotates an image
-	 * @link https://php.net/manual/en/imagick.rotateimage.php
-	 * @param mixed $background <p>
-	 * The background color
-	 * </p>
-	 * @param float $degrees <p>
-	 * The number of degrees to rotate the image
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function rotateImage ($background, $degrees) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Scales an image with pixel sampling
-	 * @link https://php.net/manual/en/imagick.sampleimage.php
-	 * @param int $columns
-	 * @param int $rows
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function sampleImage ($columns, $rows) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Applies a solarizing effect to the image
-	 * @link https://php.net/manual/en/imagick.solarizeimage.php
-	 * @param int $threshold
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function solarizeImage ($threshold) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Simulates an image shadow
-	 * @link https://php.net/manual/en/imagick.shadowimage.php
-	 * @param float $opacity
-	 * @param float $sigma
-	 * @param int $x
-	 * @param int $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function shadowImage ($opacity, $sigma, $x, $y) {}
-
-	/**
-	 * @param $key
-	 * @param $value
-	 */
-	public function setImageAttribute ($key, $value) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image background color
-	 * @link https://php.net/manual/en/imagick.setimagebackgroundcolor.php
-	 * @param mixed $background
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageBackgroundColor ($background) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image composite operator
-	 * @link https://php.net/manual/en/imagick.setimagecompose.php
-	 * @param int $compose
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageCompose ($compose) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image compression
-	 * @link https://php.net/manual/en/imagick.setimagecompression.php
-	 * @param int $compression <p>
-	 * One of the <b>COMPRESSION</b> constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageCompression ($compression) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image delay
-	 * @link https://php.net/manual/en/imagick.setimagedelay.php
-	 * @param int $delay <p>
-	 * The amount of time expressed in 'ticks' that the image should be
-	 * displayed for. For animated GIFs there are 100 ticks per second, so a
-	 * value of 20 would be 20/100 of a second aka 1/5th of a second.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageDelay ($delay) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image depth
-	 * @link https://php.net/manual/en/imagick.setimagedepth.php
-	 * @param int $depth
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageDepth ($depth) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image gamma
-	 * @link https://php.net/manual/en/imagick.setimagegamma.php
-	 * @param float $gamma
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageGamma ($gamma) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image iterations
-	 * @link https://php.net/manual/en/imagick.setimageiterations.php
-	 * @param int $iterations <p>
-	 * The number of iterations the image should loop over. Set to '0' to loop
-	 * continuously.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageIterations ($iterations) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image matte color
-	 * @link https://php.net/manual/en/imagick.setimagemattecolor.php
-	 * @param mixed $matte
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageMatteColor ($matte) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the page geometry of the image
-	 * @link https://php.net/manual/en/imagick.setimagepage.php
-	 * @param int $width
-	 * @param int $height
-	 * @param int $x
-	 * @param int $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImagePage ($width, $height, $x, $y) {}
-
-	/**
-	 * @param $filename
-	 */
-	public function setImageProgressMonitor ($filename) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image resolution
-	 * @link https://php.net/manual/en/imagick.setimageresolution.php
-	 * @param float $x_resolution
-	 * @param float $y_resolution
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageResolution ($x_resolution, $y_resolution) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image scene
-	 * @link https://php.net/manual/en/imagick.setimagescene.php
-	 * @param int $scene
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageScene ($scene) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image ticks-per-second
-	 * @link https://php.net/manual/en/imagick.setimagetickspersecond.php
-	 * @param int $ticks_per_second <p>
-	 * The duration for which an image should be displayed expressed in ticks
-	 * per second.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageTicksPerSecond ($ticks_per_second) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image type
-	 * @link https://php.net/manual/en/imagick.setimagetype.php
-	 * @param int $image_type
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageType ($image_type) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image units of resolution
-	 * @link https://php.net/manual/en/imagick.setimageunits.php
-	 * @param int $units
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageUnits ($units) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sharpens an image
-	 * @link https://php.net/manual/en/imagick.sharpenimage.php
-	 * @param float $radius
-	 * @param float $sigma
-	 * @param int $channel [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function sharpenImage ($radius, $sigma, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Shaves pixels from the image edges
-	 * @link https://php.net/manual/en/imagick.shaveimage.php
-	 * @param int $columns
-	 * @param int $rows
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function shaveImage ($columns, $rows) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creating a parallelogram
-	 * @link https://php.net/manual/en/imagick.shearimage.php
-	 * @param mixed $background <p>
-	 * The background color
-	 * </p>
-	 * @param float $x_shear <p>
-	 * The number of degrees to shear on the x axis
-	 * </p>
-	 * @param float $y_shear <p>
-	 * The number of degrees to shear on the y axis
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function shearImage ($background, $x_shear, $y_shear) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Splices a solid color into the image
-	 * @link https://php.net/manual/en/imagick.spliceimage.php
-	 * @param int $width
-	 * @param int $height
-	 * @param int $x
-	 * @param int $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function spliceImage ($width, $height, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Fetch basic attributes about the image
-	 * @link https://php.net/manual/en/imagick.pingimage.php
-	 * @param string $filename <p>
-	 * The filename to read the information from.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function pingImage ($filename) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Reads image from open filehandle
-	 * @link https://php.net/manual/en/imagick.readimagefile.php
-	 * @param resource $filehandle
-	 * @param string $fileName [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function readImageFile ($filehandle, $fileName = null) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Displays an image
-	 * @link https://php.net/manual/en/imagick.displayimage.php
-	 * @param string $servername <p>
-	 * The X server name
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function displayImage ($servername) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Displays an image or image sequence
-	 * @link https://php.net/manual/en/imagick.displayimages.php
-	 * @param string $servername <p>
-	 * The X server name
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function displayImages ($servername) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Randomly displaces each pixel in a block
-	 * @link https://php.net/manual/en/imagick.spreadimage.php
-	 * @param float $radius
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function spreadImage ($radius) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Swirls the pixels about the center of the image
-	 * @link https://php.net/manual/en/imagick.swirlimage.php
-	 * @param float $degrees
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function swirlImage ($degrees) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Strips an image of all profiles and comments
-	 * @link https://php.net/manual/en/imagick.stripimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function stripImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns formats supported by Imagick
-	 * @link https://php.net/manual/en/imagick.queryformats.php
-	 * @param string $pattern [optional]
-	 * @return array an array containing the formats supported by Imagick.
-	 */
-	public static function queryFormats ($pattern = "*") {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the configured fonts
-	 * @link https://php.net/manual/en/imagick.queryfonts.php
-	 * @param string $pattern [optional] <p>
-	 * The query pattern
-	 * </p>
-	 * @return array an array containing the configured fonts.
-	 */
-	public static function queryFonts ($pattern = "*") {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns an array representing the font metrics
-	 * @link https://php.net/manual/en/imagick.queryfontmetrics.php
-	 * @param ImagickDraw $properties <p>
-	 * ImagickDraw object containing font properties
-	 * </p>
-	 * @param string $text <p>
-	 * The text
-	 * </p>
-	 * @param bool $multiline [optional] <p>
-	 * Multiline parameter. If left empty it is autodetected
-	 * </p>
-	 * @return array a multi-dimensional array representing the font metrics.
-	 */
-	public function queryFontMetrics (ImagickDraw $properties, $text, $multiline = null) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Hides a digital watermark within the image
-	 * @link https://php.net/manual/en/imagick.steganoimage.php
-	 * @param Imagick $watermark_wand
-	 * @param int $offset
-	 * @return Imagick <b>TRUE</b> on success.
-	 */
-	public function steganoImage (Imagick $watermark_wand, $offset) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds random noise to the image
-	 * @link https://php.net/manual/en/imagick.addnoiseimage.php
-	 * @param int $noise_type <p>
-	 * The type of the noise. Refer to this list of
-	 * noise constants.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function addNoiseImage ($noise_type, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Simulates motion blur
-	 * @link https://php.net/manual/en/imagick.motionblurimage.php
-	 * @param float $radius <p>
-	 * The radius of the Gaussian, in pixels, not counting the center pixel.
-	 * </p>
-	 * @param float $sigma <p>
-	 * The standard deviation of the Gaussian, in pixels.
-	 * </p>
-	 * @param float $angle <p>
-	 * Apply the effect along this angle.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * The channel argument affects only if Imagick is compiled against ImageMagick version
-	 * 6.4.4 or greater.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function motionBlurImage ($radius, $sigma, $angle, $channel = Imagick::CHANNEL_DEFAULT) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Forms a mosaic from images
-	 * @link https://php.net/manual/en/imagick.mosaicimages.php
-	 * @return Imagick <b>TRUE</b> on success.
-	 */
-	public function mosaicImages () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Method morphs a set of images
-	 * @link https://php.net/manual/en/imagick.morphimages.php
-	 * @param int $number_frames <p>
-	 * The number of in-between images to generate.
-	 * </p>
-	 * @return Imagick This method returns a new Imagick object on success.
-	 * Throw an <b>ImagickException</b> on error.
-	 * @throws ImagickException on error
-	 */
-	public function morphImages ($number_frames) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Scales an image proportionally to half its size
-	 * @link https://php.net/manual/en/imagick.minifyimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function minifyImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Transforms an image
-	 * @link https://php.net/manual/en/imagick.affinetransformimage.php
-	 * @param ImagickDraw $matrix <p>
-	 * The affine matrix
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function affineTransformImage (ImagickDraw $matrix) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Average a set of images
-	 * @link https://php.net/manual/en/imagick.averageimages.php
-	 * @return Imagick a new Imagick object on success.
-	 */
-	public function averageImages () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Surrounds the image with a border
-	 * @link https://php.net/manual/en/imagick.borderimage.php
-	 * @param mixed $bordercolor <p>
-	 * ImagickPixel object or a string containing the border color
-	 * </p>
-	 * @param int $width <p>
-	 * Border width
-	 * </p>
-	 * @param int $height <p>
-	 * Border height
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function borderImage ($bordercolor, $width, $height) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Removes a region of an image and trims
-	 * @link https://php.net/manual/en/imagick.chopimage.php
-	 * @param int $width <p>
-	 * Width of the chopped area
-	 * </p>
-	 * @param int $height <p>
-	 * Height of the chopped area
-	 * </p>
-	 * @param int $x <p>
-	 * X origo of the chopped area
-	 * </p>
-	 * @param int $y <p>
-	 * Y origo of the chopped area
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function chopImage ($width, $height, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Clips along the first path from the 8BIM profile
-	 * @link https://php.net/manual/en/imagick.clipimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function clipImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Clips along the named paths from the 8BIM profile
-	 * @link https://php.net/manual/en/imagick.clippathimage.php
-	 * @param string $pathname <p>
-	 * The name of the path
-	 * </p>
-	 * @param bool $inside <p>
-	 * If <b>TRUE</b> later operations take effect inside clipping path.
-	 * Otherwise later operations take effect outside clipping path.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function clipPathImage ($pathname, $inside) {}
-
-	/**
-	 * @param $pathname
-	 * @param $inside
-	 */
-	public function clipImagePath ($pathname, $inside) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Composites a set of images
-	 * @link https://php.net/manual/en/imagick.coalesceimages.php
-	 * @return Imagick a new Imagick object on success.
-	 */
-	public function coalesceImages () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Changes the color value of any pixel that matches target
-	 * @link https://php.net/manual/en/imagick.colorfloodfillimage.php
-	 * @param mixed $fill <p>
-	 * ImagickPixel object containing the fill color
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The amount of fuzz. For example, set fuzz to 10 and the color red at
-	 * intensities of 100 and 102 respectively are now interpreted as the
-	 * same color for the purposes of the floodfill.
-	 * </p>
-	 * @param mixed $bordercolor <p>
-	 * ImagickPixel object containing the border color
-	 * </p>
-	 * @param int $x <p>
-	 * X start position of the floodfill
-	 * </p>
-	 * @param int $y <p>
-	 * Y start position of the floodfill
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function colorFloodfillImage ($fill, $fuzz, $bordercolor, $x, $y) {}
-
-	/**
-	 * Blends the fill color with each pixel in the image. The 'opacity' color is a per channel strength factor for how strongly the color should be applied.<br>
-	 * If legacy is true, the behaviour of this function is incorrect, but consistent with how it behaved before Imagick version 3.4.0
-	 * @link https://php.net/manual/en/imagick.colorizeimage.php
-	 * @param mixed $colorize <p>
-	 * ImagickPixel object or a string containing the colorize color
-	 * </p>
-	 * @param mixed $opacity <p>
-	 * ImagickPixel object or an float containing the opacity value.
-	 * 1.0 is fully opaque and 0.0 is fully transparent.
-	 * </p>
-	 * @param bool $legacy [optional] Added since 3.4.0. Default value FALSE
-	 * @return bool <b>TRUE</b> on success.
-	 * @throws ImagickException Throws ImagickException on error
-	 * @since 2.0.0
-	 */
-	public function colorizeImage ($colorize, $opacity, $legacy = false) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the difference in one or more images
-	 * @link https://php.net/manual/en/imagick.compareimagechannels.php
-	 * @param Imagick $image <p>
-	 * Imagick object containing the image to compare.
-	 * </p>
-	 * @param int $channelType <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @param int $metricType <p>
-	 * One of the metric type constants.
-	 * </p>
-	 * @return array Array consisting of new_wand and
-	 * distortion.
-	 */
-	public function compareImageChannels (Imagick $image, $channelType, $metricType) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Compares an image to a reconstructed image
-	 * @link https://php.net/manual/en/imagick.compareimages.php
-	 * @param Imagick $compare <p>
-	 * An image to compare to.
-	 * </p>
-	 * @param int $metric <p>
-	 * Provide a valid metric type constant. Refer to this
-	 * list of metric constants.
-	 * </p>
-	 * @return array Array consisting of an Imagick object of the
-	 * reconstructed image and a double representing the difference.
-	 * @throws ImagickException Throws ImagickException on error.
-	 */
-	public function compareImages (Imagick $compare, $metric) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Change the contrast of the image
-	 * @link https://php.net/manual/en/imagick.contrastimage.php
-	 * @param bool $sharpen <p>
-	 * The sharpen value
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function contrastImage ($sharpen) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Combines one or more images into a single image
-	 * @link https://php.net/manual/en/imagick.combineimages.php
-	 * @param int $channelType <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return Imagick <b>TRUE</b> on success.
-	 */
-	public function combineImages ($channelType) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Applies a custom convolution kernel to the image
-	 * @link https://php.net/manual/en/imagick.convolveimage.php
-	 * @param array $kernel <p>
-	 * The convolution kernel
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function convolveImage (array $kernel, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Displaces an image's colormap
-	 * @link https://php.net/manual/en/imagick.cyclecolormapimage.php
-	 * @param int $displace <p>
-	 * The amount to displace the colormap.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function cycleColormapImage ($displace) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns certain pixel differences between images
-	 * @link https://php.net/manual/en/imagick.deconstructimages.php
-	 * @return Imagick a new Imagick object on success.
-	 */
-	public function deconstructImages () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Reduces the speckle noise in an image
-	 * @link https://php.net/manual/en/imagick.despeckleimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function despeckleImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Enhance edges within the image
-	 * @link https://php.net/manual/en/imagick.edgeimage.php
-	 * @param float $radius <p>
-	 * The radius of the operation.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function edgeImage ($radius) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a grayscale image with a three-dimensional effect
-	 * @link https://php.net/manual/en/imagick.embossimage.php
-	 * @param float $radius <p>
-	 * The radius of the effect
-	 * </p>
-	 * @param float $sigma <p>
-	 * The sigma of the effect
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function embossImage ($radius, $sigma) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Improves the quality of a noisy image
-	 * @link https://php.net/manual/en/imagick.enhanceimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function enhanceImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Equalizes the image histogram
-	 * @link https://php.net/manual/en/imagick.equalizeimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function equalizeImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Applies an expression to an image
-	 * @link https://php.net/manual/en/imagick.evaluateimage.php
-	 * @param int $op <p>
-	 * The evaluation operator
-	 * </p>
-	 * @param float $constant <p>
-	 * The value of the operator
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function evaluateImage ($op, $constant, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * Merges a sequence of images. This is useful for combining Photoshop layers into a single image.
-	 * This is replaced by:
-	 * <pre>
-	 * $im = $im->mergeImageLayers(\Imagick::LAYERMETHOD_FLATTEN)
-	 * </pre>
-	 * @link https://php.net/manual/en/imagick.flattenimages.php
-	 * @return Imagick Returns an Imagick object containing the merged image.
-	 * @throws ImagickException Throws ImagickException on error.
-	 * @since 2.0.0
-	 */
-	public function flattenImages () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a vertical mirror image
-	 * @link https://php.net/manual/en/imagick.flipimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function flipImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a horizontal mirror image
-	 * @link https://php.net/manual/en/imagick.flopimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function flopImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds a simulated three-dimensional border
-	 * @link https://php.net/manual/en/imagick.frameimage.php
-	 * @param mixed $matte_color <p>
-	 * ImagickPixel object or a string representing the matte color
-	 * </p>
-	 * @param int $width <p>
-	 * The width of the border
-	 * </p>
-	 * @param int $height <p>
-	 * The height of the border
-	 * </p>
-	 * @param int $inner_bevel <p>
-	 * The inner bevel width
-	 * </p>
-	 * @param int $outer_bevel <p>
-	 * The outer bevel width
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function frameImage ($matte_color, $width, $height, $inner_bevel, $outer_bevel) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Evaluate expression for each pixel in the image
-	 * @link https://php.net/manual/en/imagick.fximage.php
-	 * @param string $expression <p>
-	 * The expression.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return Imagick <b>TRUE</b> on success.
-	 */
-	public function fxImage ($expression, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gamma-corrects an image
-	 * @link https://php.net/manual/en/imagick.gammaimage.php
-	 * @param float $gamma <p>
-	 * The amount of gamma-correction.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function gammaImage ($gamma, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Blurs an image
-	 * @link https://php.net/manual/en/imagick.gaussianblurimage.php
-	 * @param float $radius <p>
-	 * The radius of the Gaussian, in pixels, not counting the center pixel.
-	 * </p>
-	 * @param float $sigma <p>
-	 * The standard deviation of the Gaussian, in pixels.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function gaussianBlurImage ($radius, $sigma, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * @param $key
-	 */
-	public function getImageAttribute ($key) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image background color
-	 * @link https://php.net/manual/en/imagick.getimagebackgroundcolor.php
-	 * @return ImagickPixel an ImagickPixel set to the background color of the image.
-	 */
-	public function getImageBackgroundColor () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the chromaticy blue primary point
-	 * @link https://php.net/manual/en/imagick.getimageblueprimary.php
-	 * @return array Array consisting of "x" and "y" coordinates of point.
-	 */
-	public function getImageBluePrimary () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image border color
-	 * @link https://php.net/manual/en/imagick.getimagebordercolor.php
-	 * @return ImagickPixel <b>TRUE</b> on success.
-	 */
-	public function getImageBorderColor () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the depth for a particular image channel
-	 * @link https://php.net/manual/en/imagick.getimagechanneldepth.php
-	 * @param int $channel <p>
-	 * Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to <b>Imagick::CHANNEL_DEFAULT</b>. Refer to this list of channel constants
-	 * </p>
-	 * @return int <b>TRUE</b> on success.
-	 */
-	public function getImageChannelDepth ($channel) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Compares image channels of an image to a reconstructed image
-	 * @link https://php.net/manual/en/imagick.getimagechanneldistortion.php
-	 * @param Imagick $reference <p>
-	 * Imagick object to compare to.
-	 * </p>
-	 * @param int $channel <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @param int $metric <p>
-	 * One of the metric type constants.
-	 * </p>
-	 * @return float <b>TRUE</b> on success.
-	 */
-	public function getImageChannelDistortion (Imagick $reference, $channel, $metric) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the extrema for one or more image channels
-	 * @link https://php.net/manual/en/imagick.getimagechannelextrema.php
-	 * @param int $channel <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return array <b>TRUE</b> on success.
-	 */
-	public function getImageChannelExtrema ($channel) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the mean and standard deviation
-	 * @link https://php.net/manual/en/imagick.getimagechannelmean.php
-	 * @param int $channel <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return array <b>TRUE</b> on success.
-	 */
-	public function getImageChannelMean ($channel) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns statistics for each channel in the image
-	 * @link https://php.net/manual/en/imagick.getimagechannelstatistics.php
-	 * @return array <b>TRUE</b> on success.
-	 */
-	public function getImageChannelStatistics () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the color of the specified colormap index
-	 * @link https://php.net/manual/en/imagick.getimagecolormapcolor.php
-	 * @param int $index <p>
-	 * The offset into the image colormap.
-	 * </p>
-	 * @return ImagickPixel <b>TRUE</b> on success.
-	 */
-	public function getImageColormapColor ($index) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image colorspace
-	 * @link https://php.net/manual/en/imagick.getimagecolorspace.php
-	 * @return int <b>TRUE</b> on success.
-	 */
-	public function getImageColorspace () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the composite operator associated with the image
-	 * @link https://php.net/manual/en/imagick.getimagecompose.php
-	 * @return int <b>TRUE</b> on success.
-	 */
-	public function getImageCompose () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image delay
-	 * @link https://php.net/manual/en/imagick.getimagedelay.php
-	 * @return int the image delay.
-	 */
-	public function getImageDelay () {}
-
-	/**
-	 * (PECL imagick 0.9.1-0.9.9)<br/>
-	 * Gets the image depth
-	 * @link https://php.net/manual/en/imagick.getimagedepth.php
-	 * @return int The image depth.
-	 */
-	public function getImageDepth () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Compares an image to a reconstructed image
-	 * @link https://php.net/manual/en/imagick.getimagedistortion.php
-	 * @param Imagick $reference <p>
-	 * Imagick object to compare to.
-	 * </p>
-	 * @param int $metric <p>
-	 * One of the metric type constants.
-	 * </p>
-	 * @return float the distortion metric used on the image (or the best guess
-	 * thereof).
-	 */
-	public function getImageDistortion (Imagick $reference, $metric) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the extrema for the image
-	 * @link https://php.net/manual/en/imagick.getimageextrema.php
-	 * @return array an associative array with the keys "min" and "max".
-	 */
-	public function getImageExtrema () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image disposal method
-	 * @link https://php.net/manual/en/imagick.getimagedispose.php
-	 * @return int the dispose method on success.
-	 */
-	public function getImageDispose () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image gamma
-	 * @link https://php.net/manual/en/imagick.getimagegamma.php
-	 * @return float the image gamma on success.
-	 */
-	public function getImageGamma () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the chromaticy green primary point
-	 * @link https://php.net/manual/en/imagick.getimagegreenprimary.php
-	 * @return array an array with the keys "x" and "y" on success, throws an ImagickException on failure.
-	 * @throws ImagickException on failure
-	 */
-	public function getImageGreenPrimary () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image height
-	 * @link https://php.net/manual/en/imagick.getimageheight.php
-	 * @return int the image height in pixels.
-	 */
-	public function getImageHeight () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image histogram
-	 * @link https://php.net/manual/en/imagick.getimagehistogram.php
-	 * @return array the image histogram as an array of ImagickPixel objects.
-	 */
-	public function getImageHistogram () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image interlace scheme
-	 * @link https://php.net/manual/en/imagick.getimageinterlacescheme.php
-	 * @return int the interlace scheme as an integer on success.
-	 * Trhow an <b>ImagickException</b> on error.
-	 * @throws ImagickException on error
-	 */
-	public function getImageInterlaceScheme () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image iterations
-	 * @link https://php.net/manual/en/imagick.getimageiterations.php
-	 * @return int the image iterations as an integer.
-	 */
-	public function getImageIterations () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image matte color
-	 * @link https://php.net/manual/en/imagick.getimagemattecolor.php
-	 * @return ImagickPixel ImagickPixel object on success.
-	 */
-	public function getImageMatteColor () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the page geometry
-	 * @link https://php.net/manual/en/imagick.getimagepage.php
-	 * @return array the page geometry associated with the image in an array with the
-	 * keys "width", "height", "x", and "y".
-	 */
-	public function getImagePage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the color of the specified pixel
-	 * @link https://php.net/manual/en/imagick.getimagepixelcolor.php
-	 * @param int $x <p>
-	 * The x-coordinate of the pixel
-	 * </p>
-	 * @param int $y <p>
-	 * The y-coordinate of the pixel
-	 * </p>
-	 * @return ImagickPixel an ImagickPixel instance for the color at the coordinates given.
-	 */
-	public function getImagePixelColor ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the named image profile
-	 * @link https://php.net/manual/en/imagick.getimageprofile.php
-	 * @param string $name <p>
-	 * The name of the profile to return.
-	 * </p>
-	 * @return string a string containing the image profile.
-	 */
-	public function getImageProfile ($name) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the chromaticity red primary point
-	 * @link https://php.net/manual/en/imagick.getimageredprimary.php
-	 * @return array the chromaticity red primary point as an array with the keys "x"
-	 * and "y".
-	 * Throw an <b>ImagickException</b> on error.
-	 * @throws ImagickException on error
-	 */
-	public function getImageRedPrimary () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image rendering intent
-	 * @link https://php.net/manual/en/imagick.getimagerenderingintent.php
-	 * @return int the image rendering intent.
-	 */
-	public function getImageRenderingIntent () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image X and Y resolution
-	 * @link https://php.net/manual/en/imagick.getimageresolution.php
-	 * @return array the resolution as an array.
-	 */
-	public function getImageResolution () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image scene
-	 * @link https://php.net/manual/en/imagick.getimagescene.php
-	 * @return int the image scene.
-	 */
-	public function getImageScene () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Generates an SHA-256 message digest
-	 * @link https://php.net/manual/en/imagick.getimagesignature.php
-	 * @return string a string containing the SHA-256 hash of the file.
-	 */
-	public function getImageSignature () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image ticks-per-second
-	 * @link https://php.net/manual/en/imagick.getimagetickspersecond.php
-	 * @return int the image ticks-per-second.
-	 */
-	public function getImageTicksPerSecond () {}
-
-	/**
-	 * (PECL imagick 0.9.10-0.9.9)<br/>
-	 * Gets the potential image type
-	 * @link https://php.net/manual/en/imagick.getimagetype.php
-	 * @return int the potential image type.
-	 * <b>imagick::IMGTYPE_UNDEFINED</b>
-	 * <b>imagick::IMGTYPE_BILEVEL</b>
-	 * <b>imagick::IMGTYPE_GRAYSCALE</b>
-	 * <b>imagick::IMGTYPE_GRAYSCALEMATTE</b>
-	 * <b>imagick::IMGTYPE_PALETTE</b>
-	 * <b>imagick::IMGTYPE_PALETTEMATTE</b>
-	 * <b>imagick::IMGTYPE_TRUECOLOR</b>
-	 * <b>imagick::IMGTYPE_TRUECOLORMATTE</b>
-	 * <b>imagick::IMGTYPE_COLORSEPARATION</b>
-	 * <b>imagick::IMGTYPE_COLORSEPARATIONMATTE</b>
-	 * <b>imagick::IMGTYPE_OPTIMIZE</b>
-	 */
-	public function getImageType () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image units of resolution
-	 * @link https://php.net/manual/en/imagick.getimageunits.php
-	 * @return int the image units of resolution.
-	 */
-	public function getImageUnits () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the virtual pixel method
-	 * @link https://php.net/manual/en/imagick.getimagevirtualpixelmethod.php
-	 * @return int the virtual pixel method on success.
-	 */
-	public function getImageVirtualPixelMethod () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the chromaticity white point
-	 * @link https://php.net/manual/en/imagick.getimagewhitepoint.php
-	 * @return array the chromaticity white point as an associative array with the keys
-	 * "x" and "y".
-	 */
-	public function getImageWhitePoint () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the image width
-	 * @link https://php.net/manual/en/imagick.getimagewidth.php
-	 * @return int the image width.
-	 */
-	public function getImageWidth () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the number of images in the object
-	 * @link https://php.net/manual/en/imagick.getnumberimages.php
-	 * @return int the number of images associated with Imagick object.
-	 */
-	public function getNumberImages () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the image total ink density
-	 * @link https://php.net/manual/en/imagick.getimagetotalinkdensity.php
-	 * @return float the image total ink density of the image.
-	 * Throw an <b>ImagickException</b> on error.
-	 * @throws ImagickException on error
-	 */
-	public function getImageTotalInkDensity () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Extracts a region of the image
-	 * @link https://php.net/manual/en/imagick.getimageregion.php
-	 * @param int $width <p>
-	 * The width of the extracted region.
-	 * </p>
-	 * @param int $height <p>
-	 * The height of the extracted region.
-	 * </p>
-	 * @param int $x <p>
-	 * X-coordinate of the top-left corner of the extracted region.
-	 * </p>
-	 * @param int $y <p>
-	 * Y-coordinate of the top-left corner of the extracted region.
-	 * </p>
-	 * @return Imagick Extracts a region of the image and returns it as a new wand.
-	 */
-	public function getImageRegion ($width, $height, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a new image as a copy
-	 * @link https://php.net/manual/en/imagick.implodeimage.php
-	 * @param float $radius <p>
-	 * The radius of the implode
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function implodeImage ($radius) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adjusts the levels of an image
-	 * @link https://php.net/manual/en/imagick.levelimage.php
-	 * @param float $blackPoint <p>
-	 * The image black point
-	 * </p>
-	 * @param float $gamma <p>
-	 * The gamma value
-	 * </p>
-	 * @param float $whitePoint <p>
-	 * The image white point
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function levelImage ($blackPoint, $gamma, $whitePoint, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Scales an image proportionally 2x
-	 * @link https://php.net/manual/en/imagick.magnifyimage.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function magnifyImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Replaces the colors of an image with the closest color from a reference image.
-	 * @link https://php.net/manual/en/imagick.mapimage.php
-	 * @param Imagick $map
-	 * @param bool $dither
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function mapImage (Imagick $map, $dither) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Changes the transparency value of a color
-	 * @link https://php.net/manual/en/imagick.mattefloodfillimage.php
-	 * @param float $alpha <p>
-	 * The level of transparency: 1.0 is fully opaque and 0.0 is fully
-	 * transparent.
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The fuzz member of image defines how much tolerance is acceptable to
-	 * consider two colors as the same.
-	 * </p>
-	 * @param mixed $bordercolor <p>
-	 * An <b>ImagickPixel</b> object or string representing the border color.
-	 * </p>
-	 * @param int $x <p>
-	 * The starting x coordinate of the operation.
-	 * </p>
-	 * @param int $y <p>
-	 * The starting y coordinate of the operation.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function matteFloodfillImage ($alpha, $fuzz, $bordercolor, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Applies a digital filter
-	 * @link https://php.net/manual/en/imagick.medianfilterimage.php
-	 * @param float $radius <p>
-	 * The radius of the pixel neighborhood.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function medianFilterImage ($radius) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Negates the colors in the reference image
-	 * @link https://php.net/manual/en/imagick.negateimage.php
-	 * @param bool $gray <p>
-	 * Whether to only negate grayscale pixels within the image.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function negateImage ($gray, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Change any pixel that matches color
-	 * @link https://php.net/manual/en/imagick.paintopaqueimage.php
-	 * @param mixed $target <p>
-	 * Change this target color to the fill color within the image. An
-	 * ImagickPixel object or a string representing the target color.
-	 * </p>
-	 * @param mixed $fill <p>
-	 * An ImagickPixel object or a string representing the fill color.
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The fuzz member of image defines how much tolerance is acceptable to
-	 * consider two colors as the same.
-	 * </p>
-	 * @param int $channel [optional] <p>
-	 * Provide any channel constant that is valid for your channel mode. To
-	 * apply to more than one channel, combine channeltype constants using
-	 * bitwise operators. Refer to this
-	 * list of channel constants.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function paintOpaqueImage ($target, $fill, $fuzz, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Changes any pixel that matches color with the color defined by fill
-	 * @link https://php.net/manual/en/imagick.painttransparentimage.php
-	 * @param mixed $target <p>
-	 * Change this target color to specified opacity value within the image.
-	 * </p>
-	 * @param float $alpha <p>
-	 * The level of transparency: 1.0 is fully opaque and 0.0 is fully
-	 * transparent.
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The fuzz member of image defines how much tolerance is acceptable to
-	 * consider two colors as the same.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function paintTransparentImage ($target, $alpha, $fuzz) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Quickly pin-point appropriate parameters for image processing
-	 * @link https://php.net/manual/en/imagick.previewimages.php
-	 * @param int $preview <p>
-	 * Preview type. See Preview type constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function previewImages ($preview) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds or removes a profile from an image
-	 * @link https://php.net/manual/en/imagick.profileimage.php
-	 * @param string $name
-	 * @param string $profile
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function profileImage ($name, $profile) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Analyzes the colors within a reference image
-	 * @link https://php.net/manual/en/imagick.quantizeimage.php
-	 * @param int $numberColors
-	 * @param int $colorspace
-	 * @param int $treedepth
-	 * @param bool $dither
-	 * @param bool $measureError
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function quantizeImage ($numberColors, $colorspace, $treedepth, $dither, $measureError) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Analyzes the colors within a sequence of images
-	 * @link https://php.net/manual/en/imagick.quantizeimages.php
-	 * @param int $numberColors
-	 * @param int $colorspace
-	 * @param int $treedepth
-	 * @param bool $dither
-	 * @param bool $measureError
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function quantizeImages ($numberColors, $colorspace, $treedepth, $dither, $measureError) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Smooths the contours of an image
-	 * @link https://php.net/manual/en/imagick.reducenoiseimage.php
-	 * @param float $radius
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function reduceNoiseImage ($radius) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Removes the named image profile and returns it
-	 * @link https://php.net/manual/en/imagick.removeimageprofile.php
-	 * @param string $name
-	 * @return string a string containing the profile of the image.
-	 */
-	public function removeImageProfile ($name) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Separates a channel from the image
-	 * @link https://php.net/manual/en/imagick.separateimagechannel.php
-	 * @param int $channel
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function separateImageChannel ($channel) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sepia tones an image
-	 * @link https://php.net/manual/en/imagick.sepiatoneimage.php
-	 * @param float $threshold
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function sepiaToneImage ($threshold) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image bias for any method that convolves an image
-	 * @link https://php.net/manual/en/imagick.setimagebias.php
-	 * @param float $bias
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageBias ($bias) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image chromaticity blue primary point
-	 * @link https://php.net/manual/en/imagick.setimageblueprimary.php
-	 * @param float $x
-	 * @param float $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageBluePrimary ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image border color
-	 * @link https://php.net/manual/en/imagick.setimagebordercolor.php
-	 * @param mixed $border <p>
-	 * The border color
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageBorderColor ($border) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the depth of a particular image channel
-	 * @link https://php.net/manual/en/imagick.setimagechanneldepth.php
-	 * @param int $channel
-	 * @param int $depth
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageChannelDepth ($channel, $depth) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the color of the specified colormap index
-	 * @link https://php.net/manual/en/imagick.setimagecolormapcolor.php
-	 * @param int $index
-	 * @param ImagickPixel $color
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageColormapColor ($index, ImagickPixel $color) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image colorspace
-	 * @link https://php.net/manual/en/imagick.setimagecolorspace.php
-	 * @param int $colorspace <p>
-	 * One of the COLORSPACE constants
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageColorspace ($colorspace) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image disposal method
-	 * @link https://php.net/manual/en/imagick.setimagedispose.php
-	 * @param int $dispose
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageDispose ($dispose) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image size
-	 * @link https://php.net/manual/en/imagick.setimageextent.php
-	 * @param int $columns
-	 * @param int $rows
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageExtent ($columns, $rows) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image chromaticity green primary point
-	 * @link https://php.net/manual/en/imagick.setimagegreenprimary.php
-	 * @param float $x
-	 * @param float $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageGreenPrimary ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image compression
-	 * @link https://php.net/manual/en/imagick.setimageinterlacescheme.php
-	 * @param int $interlace_scheme
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageInterlaceScheme ($interlace_scheme) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds a named profile to the Imagick object
-	 * @link https://php.net/manual/en/imagick.setimageprofile.php
-	 * @param string $name
-	 * @param string $profile
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageProfile ($name, $profile) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image chromaticity red primary point
-	 * @link https://php.net/manual/en/imagick.setimageredprimary.php
-	 * @param float $x
-	 * @param float $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageRedPrimary ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image rendering intent
-	 * @link https://php.net/manual/en/imagick.setimagerenderingintent.php
-	 * @param int $rendering_intent
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageRenderingIntent ($rendering_intent) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image virtual pixel method
-	 * @link https://php.net/manual/en/imagick.setimagevirtualpixelmethod.php
-	 * @param int $method
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageVirtualPixelMethod ($method) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image chromaticity white point
-	 * @link https://php.net/manual/en/imagick.setimagewhitepoint.php
-	 * @param float $x
-	 * @param float $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImageWhitePoint ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adjusts the contrast of an image
-	 * @link https://php.net/manual/en/imagick.sigmoidalcontrastimage.php
-	 * @param bool $sharpen
-	 * @param float $alpha
-	 * @param float $beta
-	 * @param int $channel [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function sigmoidalContrastImage ($sharpen, $alpha, $beta, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Composites two images
-	 * @link https://php.net/manual/en/imagick.stereoimage.php
-	 * @param Imagick $offset_wand
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function stereoImage (Imagick $offset_wand) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Repeatedly tiles the texture image
-	 * @link https://php.net/manual/en/imagick.textureimage.php
-	 * @param Imagick $texture_wand
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function textureImage (Imagick $texture_wand) {}
-
-	/**
-	 * pplies a color vector to each pixel in the image. The 'opacity' color is a per channel strength factor for how strongly the color should be applied.
-	 * If legacy is true, the behaviour of this function is incorrect, but consistent with how it behaved before Imagick version 3.4.0
-	 * @link https://php.net/manual/en/imagick.tintimage.php
-	 * @param mixed $tint
-	 * @param mixed $opacity
-	 * @param bool $legacy [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 * @throws ImagickException Throws ImagickException on error
-	 * @since 2.0.0
-	 */
-	public function tintImage ($tint, $opacity, $legacy = false) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sharpens an image
-	 * @link https://php.net/manual/en/imagick.unsharpmaskimage.php
-	 * @param float $radius
-	 * @param float $sigma
-	 * @param float $amount
-	 * @param float $threshold
-	 * @param int $channel [optional]
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function unsharpMaskImage ($radius, $sigma, $amount, $threshold, $channel = Imagick::CHANNEL_ALL) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a new Imagick object
-	 * @link https://php.net/manual/en/imagick.getimage.php
-	 * @return Imagick a new Imagick object with the current image sequence.
-	 */
-	public function getImage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds new image to Imagick object image list
-	 * @link https://php.net/manual/en/imagick.addimage.php
-	 * @param Imagick $source <p>
-	 * The source Imagick object
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function addImage (Imagick $source) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Replaces image in the object
-	 * @link https://php.net/manual/en/imagick.setimage.php
-	 * @param Imagick $replace <p>
-	 * The replace Imagick object
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setImage (Imagick $replace) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a new image
-	 * @link https://php.net/manual/en/imagick.newimage.php
-	 * @param int $cols <p>
-	 * Columns in the new image
-	 * </p>
-	 * @param int $rows <p>
-	 * Rows in the new image
-	 * </p>
-	 * @param mixed $background <p>
-	 * The background color used for this image
-	 * </p>
-	 * @param string $format [optional] <p>
-	 * Image format. This parameter was added in Imagick version 2.0.1.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function newImage ($cols, $rows, $background, $format = null) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Creates a new image
-	 * @link https://php.net/manual/en/imagick.newpseudoimage.php
-	 * @param int $columns <p>
-	 * columns in the new image
-	 * </p>
-	 * @param int $rows <p>
-	 * rows in the new image
-	 * </p>
-	 * @param string $pseudoString <p>
-	 * string containing pseudo image definition.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function newPseudoImage ($columns, $rows, $pseudoString) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the object compression type
-	 * @link https://php.net/manual/en/imagick.getcompression.php
-	 * @return int the compression constant
-	 */
-	public function getCompression () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the object compression quality
-	 * @link https://php.net/manual/en/imagick.getcompressionquality.php
-	 * @return int integer describing the compression quality
-	 */
-	public function getCompressionQuality () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the ImageMagick API copyright as a string
-	 * @link https://php.net/manual/en/imagick.getcopyright.php
-	 * @return string a string containing the copyright notice of Imagemagick and
-	 * Magickwand C API.
-	 */
-	public static function getCopyright () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * The filename associated with an image sequence
-	 * @link https://php.net/manual/en/imagick.getfilename.php
-	 * @return string a string on success.
-	 */
-	public function getFilename () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the format of the Imagick object
-	 * @link https://php.net/manual/en/imagick.getformat.php
-	 * @return string the format of the image.
-	 */
-	public function getFormat () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the ImageMagick home URL
-	 * @link https://php.net/manual/en/imagick.gethomeurl.php
-	 * @return string a link to the imagemagick homepage.
-	 */
-	public static function getHomeURL () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the object interlace scheme
-	 * @link https://php.net/manual/en/imagick.getinterlacescheme.php
-	 * @return int Gets the wand interlace
-	 * scheme.
-	 */
-	public function getInterlaceScheme () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a value associated with the specified key
-	 * @link https://php.net/manual/en/imagick.getoption.php
-	 * @param string $key <p>
-	 * The name of the option
-	 * </p>
-	 * @return string a value associated with a wand and the specified key.
-	 */
-	public function getOption ($key) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the ImageMagick package name
-	 * @link https://php.net/manual/en/imagick.getpackagename.php
-	 * @return string the ImageMagick package name as a string.
-	 */
-	public static function getPackageName () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the page geometry
-	 * @link https://php.net/manual/en/imagick.getpage.php
-	 * @return array the page geometry associated with the Imagick object in
-	 * an associative array with the keys "width", "height", "x", and "y",
-	 * throwing ImagickException on error.
-	 * @throws ImagickException on error
-	 */
-	public function getPage () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the quantum depth
-	 * @link https://php.net/manual/en/imagick.getquantumdepth.php
-	 * @return array the Imagick quantum depth as a string.
-	 */
-	public static function getQuantumDepth () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the Imagick quantum range
-	 * @link https://php.net/manual/en/imagick.getquantumrange.php
-	 * @return array the Imagick quantum range as a string.
-	 */
-	public static function getQuantumRange () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the ImageMagick release date
-	 * @link https://php.net/manual/en/imagick.getreleasedate.php
-	 * @return string the ImageMagick release date as a string.
-	 */
-	public static function getReleaseDate () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the specified resource's memory usage
-	 * @link https://php.net/manual/en/imagick.getresource.php
-	 * @param int $type <p>
-	 * Refer to the list of resourcetype constants.
-	 * </p>
-	 * @return int the specified resource's memory usage in megabytes.
-	 */
-	public static function getResource ($type) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the specified resource limit
-	 * @link https://php.net/manual/en/imagick.getresourcelimit.php
-	 * @param int $type <p>
-	 * Refer to the list of resourcetype constants.
-	 * </p>
-	 * @return int the specified resource limit in megabytes.
-	 */
-	public static function getResourceLimit ($type) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the horizontal and vertical sampling factor
-	 * @link https://php.net/manual/en/imagick.getsamplingfactors.php
-	 * @return array an associative array with the horizontal and vertical sampling
-	 * factors of the image.
-	 */
-	public function getSamplingFactors () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the size associated with the Imagick object
-	 * @link https://php.net/manual/en/imagick.getsize.php
-	 * @return array the size associated with the Imagick object as an array with the
-	 * keys "columns" and "rows".
-	 */
-	public function getSize () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the ImageMagick API version
-	 * @link https://php.net/manual/en/imagick.getversion.php
-	 * @return array the ImageMagick API version as a string and as a number.
-	 */
-	public static function getVersion () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the object's default background color
-	 * @link https://php.net/manual/en/imagick.setbackgroundcolor.php
-	 * @param mixed $background
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setBackgroundColor ($background) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the object's default compression type
-	 * @link https://php.net/manual/en/imagick.setcompression.php
-	 * @param int $compression
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setCompression ($compression) {}
-
-	/**
-	 * (PECL imagick 0.9.10-0.9.9)<br/>
-	 * Sets the object's default compression quality
-	 * @link https://php.net/manual/en/imagick.setcompressionquality.php
-	 * @param int $quality
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setCompressionQuality ($quality) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the filename before you read or write the image
-	 * @link https://php.net/manual/en/imagick.setfilename.php
-	 * @param string $filename
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setFilename ($filename) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the format of the Imagick object
-	 * @link https://php.net/manual/en/imagick.setformat.php
-	 * @param string $format
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setFormat ($format) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image compression
-	 * @link https://php.net/manual/en/imagick.setinterlacescheme.php
-	 * @param int $interlace_scheme
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setInterlaceScheme ($interlace_scheme) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Set an option
-	 * @link https://php.net/manual/en/imagick.setoption.php
-	 * @param string $key
-	 * @param string $value
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setOption ($key, $value) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the page geometry of the Imagick object
-	 * @link https://php.net/manual/en/imagick.setpage.php
-	 * @param int $width
-	 * @param int $height
-	 * @param int $x
-	 * @param int $y
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setPage ($width, $height, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the limit for a particular resource in megabytes
-	 * @link https://php.net/manual/en/imagick.setresourcelimit.php
-	 * @param int $type <p>
-	 * Refer to the list of resourcetype constants.
-	 * </p>
-	 * @param int $limit <p>
-	 * The resource limit. The unit depends on the type of the resource being limited.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public static function setResourceLimit ($type, $limit) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image resolution
-	 * @link https://php.net/manual/en/imagick.setresolution.php
-	 * @param float $x_resolution <p>
-	 * The horizontal resolution.
-	 * </p>
-	 * @param float $y_resolution <p>
-	 * The vertical resolution.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setResolution ($x_resolution, $y_resolution) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image sampling factors
-	 * @link https://php.net/manual/en/imagick.setsamplingfactors.php
-	 * @param array $factors
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setSamplingFactors (array $factors) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the size of the Imagick object
-	 * @link https://php.net/manual/en/imagick.setsize.php
-	 * @param int $columns
-	 * @param int $rows
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setSize ($columns, $rows) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the image type attribute
-	 * @link https://php.net/manual/en/imagick.settype.php
-	 * @param int $image_type
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setType ($image_type) {}
-
-	public function key () {}
-
-	public function next () {}
-
-	public function rewind () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Checks if the current item is valid
-	 * @link https://php.net/manual/en/imagick.valid.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function valid () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a reference to the current Imagick object
-	 * @link https://php.net/manual/en/imagick.current.php
-	 * @return Imagick self on success.
-	 */
-	public function current () {}
-
-	/**
-	 * Change the brightness and/or contrast of an image. It converts the brightness and contrast parameters into slope and intercept and calls a polynomical function to apply to the image.
-	 * @link https://php.net/manual/en/imagick.brightnesscontrastimage.php
-	 * @param string $brightness
-	 * @param string $contrast
-	 * @param int $CHANNEL [optional]
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function brightnessContrastImage ($brightness, $contrast, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
-
-	/**
-	 * Applies a user supplied kernel to the image according to the given morphology method.
-	 * @link https://php.net/manual/en/imagick.morphology.php
-	 * @param int $morphologyMethod Which morphology method to use one of the \Imagick::MORPHOLOGY_* constants.
-	 * @param int $iterations The number of iteration to apply the morphology function. A value of -1 means loop until no change found. How this is applied may depend on the morphology method. Typically this is a value of 1.
-	 * @param ImagickKernel $ImagickKernel
-	 * @param int $CHANNEL [optional]
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function morphology ($morphologyMethod, $iterations, ImagickKernel $ImagickKernel, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
-
-	/**
-	 * Applies a custom convolution kernel to the image.
-	 * @link https://php.net/manual/en/imagick.filter.php
-	 * @param ImagickKernel $ImagickKernel An instance of ImagickKernel that represents either a single kernel or a linked series of kernels.
-	 * @param int $CHANNEL [optional] Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to Imagick::CHANNEL_DEFAULT. Refer to this list of channel constants
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function filter (ImagickKernel $ImagickKernel , $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
-
-	/**
-	 * Apply color transformation to an image. The method permits saturation changes, hue rotation, luminance to alpha, and various other effects. Although variable-sized transformation matrices can be used, typically one uses a 5x5 matrix for an RGBA image and a 6x6 for CMYKA (or RGBA with offsets).
-	 * The matrix is similar to those used by Adobe Flash except offsets are in column 6 rather than 5 (in support of CMYKA images) and offsets are normalized (divide Flash offset by 255)
-	 * @link https://php.net/manual/en/imagick.colormatriximage.php
-	 * @param string $color_matrix
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function colorMatrixImage ($color_matrix = Imagick::CHANNEL_DEFAULT) { }
-
-	/**
-	 * Deletes an image property.
-	 * @link https://php.net/manual/en/imagick.deleteimageproperty.php
-	 * @param string $name The name of the property to delete.
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function deleteImageProperty ($name) { }
-
-	/**
-	 * Implements the discrete Fourier transform (DFT) of the image either as a magnitude / phase or real / imaginary image pair.
-	 * @link https://php.net/manual/en/imagick.forwardfouriertransformimage.php
-	 * @param bool $magnitude If true, return as magnitude / phase pair otherwise a real / imaginary image pair.
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function forwardFourierTransformimage ($magnitude) { }
-
-	/**
-	 * Gets the current image's compression type.
-	 * @link https://php.net/manual/en/imagick.getimagecompression.php
-	 * @return int
-	 * @since 3.3.0
-	 */
-	public function getImageCompression () { }
-
-	/**
-	 * Get the StringRegistry entry for the named key or false if not set.
-	 * @link https://php.net/manual/en/imagick.getregistry.php
-	 * @param string $key
-	 * @return string|false
-	 * @throws Exception Since version >=3.4.3. Throws an exception if the key does not exist, rather than terminating the program.
-	 * @since 3.3.0
-	 */
-	public static function getRegistry ($key) { }
-
-	/**
-	 * Returns the ImageMagick quantum range as an integer.
-	 * @link https://php.net/manual/en/imagick.getquantum.php
-	 * @return int
-	 * @since 3.3.0
-	 */
-	public static function getQuantum () { }
-
-	/**
-	 * Replaces any embedded formatting characters with the appropriate image property and returns the interpreted text. See https://www.imagemagick.org/script/escape.php for escape sequences.
-	 * @link https://php.net/manual/en/imagick.identifyformat.php
-	 * @see https://www.imagemagick.org/script/escape.php
-	 * @param string $embedText A string containing formatting sequences e.g. "Trim box: %@ number of unique colors: %k".
-	 * @return bool
-	 * @since 3.3.0
-	 */
-	public function identifyFormat ($embedText) { }
-
-	/**
-	 * Implements the inverse discrete Fourier transform (DFT) of the image either as a magnitude / phase or real / imaginary image pair.
-	 * @link https://php.net/manual/en/imagick.inversefouriertransformimage.php
-	 * @param Imagick $complement The second image to combine with this one to form either the magnitude / phase or real / imaginary image pair.
-	 * @param bool $magnitude If true, combine as magnitude / phase pair otherwise a real / imaginary image pair.
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function inverseFourierTransformImage ($complement, $magnitude) { }
-
-	/**
-	 * List all the registry settings. Returns an array of all the key/value pairs in the registry
-	 * @link https://php.net/manual/en/imagick.listregistry.php
-	 * @return array An array containing the key/values from the registry.
-	 * @since 3.3.0
-	 */
-	public static function listRegistry () { }
-
-	/**
-	 * Rotational blurs an image.
-	 * @link https://php.net/manual/en/imagick.rotationalblurimage.php
-	 * @param string $angle
-	 * @param string $CHANNEL
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function rotationalBlurImage ($angle, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
-
-	/**
-	 * Selectively blur an image within a contrast threshold. It is similar to the unsharpen mask that sharpens everything with contrast above a certain threshold.
-	 * @link https://php.net/manual/en/imagick.selectiveblurimage.php
-	 * @param float $radius
-	 * @param float $sigma
-	 * @param float $threshold
-	 * @param int $CHANNEL Provide any channel constant that is valid for your channel mode. To apply to more than one channel, combine channel constants using bitwise operators. Defaults to Imagick::CHANNEL_DEFAULT. Refer to this list of channel constants
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function selectiveBlurImage ($radius, $sigma, $threshold, $CHANNEL = Imagick::CHANNEL_DEFAULT) { }
-
-	/**
-	 * Set whether antialiasing should be used for operations. On by default.
-	 * @param bool $antialias
-	 * @return int
-	 * @since 3.3.0
-	 */
-	public function setAntiAlias ($antialias) { }
-
-	/**
-	 * @link https://php.net/manual/en/imagick.setimagebiasquantum.php
-	 * @param string $bias
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function setImageBiasQuantum ($bias) { }
-
-	/**
-	 * Set a callback that will be called during the processing of the Imagick image.
-	 * @link https://php.net/manual/en/imagick.setprogressmonitor.php
-	 * @param callable $callback The progress function to call. It should return true if image processing should continue, or false if it should be cancelled.
-	 * The offset parameter indicates the progress and the span parameter indicates the total amount of work needed to be done.
-	 * <pre> bool callback ( mixed $offset , mixed $span ) </pre>
-	 * <b>Caution</b>
-	 * The values passed to the callback function are not consistent. In particular the span parameter can increase during image processing. Because of this calculating the percentage complete of an image operation is not trivial.
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function setProgressMonitor ($callback) { }
-
-	/**
-	 * Sets the ImageMagick registry entry named key to value. This is most useful for setting "temporary-path" which controls where ImageMagick creates temporary images e.g. while processing PDFs.
-	 * @link https://php.net/manual/en/imagick.setregistry.php
-	 * @param string $key
-	 * @param string $value
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public static function setRegistry ($key, $value) { }
-
-	/**
-	 * Replace each pixel with corresponding statistic from the neighborhood of the specified width and height.
-	 * @link https://php.net/manual/en/imagick.statisticimage.php
-	 * @param int $type
-	 * @param int $width
-	 * @param int $height
-	 * @param int $channel [optional]
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function statisticImage ($type, $width, $height, $channel = Imagick::CHANNEL_DEFAULT ) { }
-
-	/**
-	 * Searches for a subimage in the current image and returns a similarity image such that an exact match location is
-	 * completely white and if none of the pixels match, black, otherwise some gray level in-between.
-	 * You can also pass in the optional parameters bestMatch and similarity. After calling the function similarity will
-	 * be set to the 'score' of the similarity between the subimage and the matching position in the larger image,
-	 * bestMatch will contain an associative array with elements x, y, width, height that describe the matching region.
-	 *
-	 * @link https://php.net/manual/en/imagick.subimagematch.php
-	 * @param Imagick $imagick
-	 * @param array $bestMatch [optional]
-	 * @param float $similarity [optional] A new image that displays the amount of similarity at each pixel.
-	 * @param float $similarity_threshold [optional] Only used if compiled with ImageMagick (library) > 7
-	 * @param int $metric [optional] Only used if compiled with ImageMagick (library) > 7
-	 * @return Imagick
-	 * @since 3.3.0
-	 */
-	public function subImageMatch (Imagick $imagick, array &$bestMatch, &$similarity, $similarity_threshold, $metric) { }
-
-	/**
-	 * Is an alias of Imagick::subImageMatch
-	 *
-	 * @param Imagick $imagick
-	 * @param array $bestMatch [optional]
-	 * @param float $similarity [optional] A new image that displays the amount of similarity at each pixel.
-	 * @param float $similarity_threshold [optional]
-	 * @param int $metric [optional]
-	 * @return Imagick
-	 * @see Imagick::subImageMatch() This function is an alias of subImageMatch()
-	 * @since 3.4.0
-	 */
-	public function similarityImage (Imagick $imagick, array &$bestMatch, &$similarity, $similarity_threshold, $metric) { }
-
-	/**
-	 * Returns any ImageMagick  configure options that match the specified pattern (e.g. "*" for all). Options include NAME, VERSION, LIB_VERSION, etc.
-	 * @return string
-	 * @since 3.4.0
-	 */
-	public function getConfigureOptions () { }
-
-	/**
-	 * GetFeatures() returns the ImageMagick features that have been compiled into the runtime.
-	 * @return string
-	 * @since 3.4.0
-	 */
-	public function getFeatures () { }
-
-	/**
-	 * @return int
-	 * @since 3.4.0
-	 */
-	public function getHDRIEnabled () { }
-
-	/**
-	 * Sets the image channel mask. Returns the previous set channel mask.
-	 * Only works with Imagick >=7
-	 * @param int $channel
-	 * @since 3.4.0
-	 */
-	public function setImageChannelMask ($channel) {}
-
-	/**
-	 * Merge multiple images of the same size together with the selected operator. https://www.imagemagick.org/Usage/layers/#evaluate-sequence
-	 * @param int $EVALUATE_CONSTANT
-	 * @return bool
-	 * @see https://www.imagemagick.org/Usage/layers/#evaluate-sequence
-	 * @since 3.4.0
-	 */
-	public function evaluateImages ($EVALUATE_CONSTANT) { }
-
-	/**
-	 * Extracts the 'mean' from the image and adjust the image to try make set its gamma appropriately.
-	 * @param int $channel [optional] Default value Imagick::CHANNEL_ALL
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function autoGammaImage ($channel = Imagick::CHANNEL_ALL) { }
-
-	/**
-	 * Adjusts an image so that its orientation is suitable $ for viewing (i.e. top-left orientation).
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function autoOrient () { }
-
-	/**
-	 * Composite one image onto another using the specified gravity.
-	 *
-	 * @param Imagick $imagick
-	 * @param int $COMPOSITE_CONSTANT
-	 * @param int $GRAVITY_CONSTANT
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function compositeImageGravity(Imagick $imagick, $COMPOSITE_CONSTANT, $GRAVITY_CONSTANT) { }
-
-	/**
-	 * Attempts to increase the appearance of large-scale light-dark transitions.
-	 *
-	 * @param float $radius
-	 * @param float $strength
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function localContrastImage($radius, $strength) { }
-
-	/**
-	 * Identifies the potential image type, returns one of the Imagick::IMGTYPE_* constants
-	 * @return int
-	 * @since 3.4.3
-	 */
-	public function identifyImageType() { }
-
-	/**
-	 * Sets the image to the specified alpha level. Will replace ImagickDraw::setOpacity()
-	 *
-	 * @param float $alpha
-	 * @return bool
-	 * @since 3.4.3
-	 */
-	public function setImageAlpha($alpha) { }
-}
-
-/**
- * @method ImagickDraw clone() (PECL imagick 2.0.0)<br/>Makes an exact copy of the specified ImagickDraw object
- * @link https://php.net/manual/en/class.imagickdraw.php
- */
-class ImagickDraw  {
-
-	public function resetVectorGraphics () {}
-
-	public function getTextKerning () {}
-
-	/**
-	 * @param $kerning
-	 */
-	public function setTextKerning ($kerning) {}
-
-	public function getTextInterWordSpacing () {}
-
-	/**
-	 * @param $spacing
-	 */
-	public function setTextInterWordSpacing ($spacing) {}
-
-	public function getTextInterLineSpacing () {}
-
-	/**
-	 * @param $spacing
-	 */
-	public function setTextInterLineSpacing ($spacing) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * The ImagickDraw constructor
-	 * @link https://php.net/manual/en/imagickdraw.construct.php
-	 */
-	public function __construct () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the fill color to be used for drawing filled objects
-	 * @link https://php.net/manual/en/imagickdraw.setfillcolor.php
-	 * @param ImagickPixel $fill_pixel <p>
-	 * ImagickPixel to use to set the color
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setFillColor (ImagickPixel $fill_pixel) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the opacity to use when drawing using the fill color or fill texture
-	 * @link https://php.net/manual/en/imagickdraw.setfillalpha.php
-	 * @param float $opacity <p>
-	 * fill alpha
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setFillAlpha ($opacity) {}
-
-	/**
-	 * @param $x_resolution
-	 * @param $y_resolution
-	 */
-	public function setResolution ($x_resolution, $y_resolution) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the color used for stroking object outlines
-	 * @link https://php.net/manual/en/imagickdraw.setstrokecolor.php
-	 * @param ImagickPixel $stroke_pixel <p>
-	 * the stroke color
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeColor (ImagickPixel $stroke_pixel) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the opacity of stroked object outlines
-	 * @link https://php.net/manual/en/imagickdraw.setstrokealpha.php
-	 * @param float $opacity <p>
-	 * opacity
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeAlpha ($opacity) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the width of the stroke used to draw object outlines
-	 * @link https://php.net/manual/en/imagickdraw.setstrokewidth.php
-	 * @param float $stroke_width <p>
-	 * stroke width
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeWidth ($stroke_width) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Clears the ImagickDraw
-	 * @link https://php.net/manual/en/imagickdraw.clear.php
-	 * @return bool an ImagickDraw object.
-	 */
-	public function clear () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a circle
-	 * @link https://php.net/manual/en/imagickdraw.circle.php
-	 * @param float $ox <p>
-	 * origin x coordinate
-	 * </p>
-	 * @param float $oy <p>
-	 * origin y coordinate
-	 * </p>
-	 * @param float $px <p>
-	 * perimeter x coordinate
-	 * </p>
-	 * @param float $py <p>
-	 * perimeter y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function circle ($ox, $oy, $px, $py) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws text on the image
-	 * @link https://php.net/manual/en/imagickdraw.annotation.php
-	 * @param float $x <p>
-	 * The x coordinate where text is drawn
-	 * </p>
-	 * @param float $y <p>
-	 * The y coordinate where text is drawn
-	 * </p>
-	 * @param string $text <p>
-	 * The text to draw on the image
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function annotation ($x, $y, $text) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Controls whether text is antialiased
-	 * @link https://php.net/manual/en/imagickdraw.settextantialias.php
-	 * @param bool $antiAlias
-	 * @return bool No value is returned.
-	 */
-	public function setTextAntialias ($antiAlias) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies specifies the text code set
-	 * @link https://php.net/manual/en/imagickdraw.settextencoding.php
-	 * @param string $encoding <p>
-	 * the encoding name
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setTextEncoding ($encoding) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the fully-specified font to use when annotating with text
-	 * @link https://php.net/manual/en/imagickdraw.setfont.php
-	 * @param string $font_name
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setFont ($font_name) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the font family to use when annotating with text
-	 * @link https://php.net/manual/en/imagickdraw.setfontfamily.php
-	 * @param string $font_family <p>
-	 * the font family
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setFontFamily ($font_family) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the font pointsize to use when annotating with text
-	 * @link https://php.net/manual/en/imagickdraw.setfontsize.php
-	 * @param float $pointsize <p>
-	 * the point size
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setFontSize ($pointsize) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the font style to use when annotating with text
-	 * @link https://php.net/manual/en/imagickdraw.setfontstyle.php
-	 * @param int $style <p>
-	 * STYLETYPE_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setFontStyle ($style) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the font weight
-	 * @link https://php.net/manual/en/imagickdraw.setfontweight.php
-	 * @param int $font_weight
-	 * @return bool
-	 */
-	public function setFontWeight ($font_weight) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the font
-	 * @link https://php.net/manual/en/imagickdraw.getfont.php
-	 * @return string|false a string on success and false if no font is set.
-	 */
-	public function getFont () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the font family
-	 * @link https://php.net/manual/en/imagickdraw.getfontfamily.php
-	 * @return string|false the font family currently selected or false if font family is not set.
-	 */
-	public function getFontFamily () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the font pointsize
-	 * @link https://php.net/manual/en/imagickdraw.getfontsize.php
-	 * @return float the font size associated with the current ImagickDraw object.
-	 */
-	public function getFontSize () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the font style
-	 * @link https://php.net/manual/en/imagickdraw.getfontstyle.php
-	 * @return int the font style constant (STYLE_) associated with the ImagickDraw object
-	 * or 0 if no style is set.
-	 */
-	public function getFontStyle () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the font weight
-	 * @link https://php.net/manual/en/imagickdraw.getfontweight.php
-	 * @return int an int on success and 0 if no weight is set.
-	 */
-	public function getFontWeight () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Frees all associated resources
-	 * @link https://php.net/manual/en/imagickdraw.destroy.php
-	 * @return bool No value is returned.
-	 */
-	public function destroy () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a rectangle
-	 * @link https://php.net/manual/en/imagickdraw.rectangle.php
-	 * @param float $x1 <p>
-	 * x coordinate of the top left corner
-	 * </p>
-	 * @param float $y1 <p>
-	 * y coordinate of the top left corner
-	 * </p>
-	 * @param float $x2 <p>
-	 * x coordinate of the bottom right corner
-	 * </p>
-	 * @param float $y2 <p>
-	 * y coordinate of the bottom right corner
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function rectangle ($x1, $y1, $x2, $y2) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a rounded rectangle
-	 * @link https://php.net/manual/en/imagickdraw.roundrectangle.php
-	 * @param float $x1 <p>
-	 * x coordinate of the top left corner
-	 * </p>
-	 * @param float $y1 <p>
-	 * y coordinate of the top left corner
-	 * </p>
-	 * @param float $x2 <p>
-	 * x coordinate of the bottom right
-	 * </p>
-	 * @param float $y2 <p>
-	 * y coordinate of the bottom right
-	 * </p>
-	 * @param float $rx <p>
-	 * x rounding
-	 * </p>
-	 * @param float $ry <p>
-	 * y rounding
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function roundRectangle ($x1, $y1, $x2, $y2, $rx, $ry) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws an ellipse on the image
-	 * @link https://php.net/manual/en/imagickdraw.ellipse.php
-	 * @param float $ox
-	 * @param float $oy
-	 * @param float $rx
-	 * @param float $ry
-	 * @param float $start
-	 * @param float $end
-	 * @return bool No value is returned.
-	 */
-	public function ellipse ($ox, $oy, $rx, $ry, $start, $end) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Skews the current coordinate system in the horizontal direction
-	 * @link https://php.net/manual/en/imagickdraw.skewx.php
-	 * @param float $degrees <p>
-	 * degrees to skew
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function skewX ($degrees) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Skews the current coordinate system in the vertical direction
-	 * @link https://php.net/manual/en/imagickdraw.skewy.php
-	 * @param float $degrees <p>
-	 * degrees to skew
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function skewY ($degrees) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Applies a translation to the current coordinate system
-	 * @link https://php.net/manual/en/imagickdraw.translate.php
-	 * @param float $x <p>
-	 * horizontal translation
-	 * </p>
-	 * @param float $y <p>
-	 * vertical translation
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function translate ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a line
-	 * @link https://php.net/manual/en/imagickdraw.line.php
-	 * @param float $sx <p>
-	 * starting x coordinate
-	 * </p>
-	 * @param float $sy <p>
-	 * starting y coordinate
-	 * </p>
-	 * @param float $ex <p>
-	 * ending x coordinate
-	 * </p>
-	 * @param float $ey <p>
-	 * ending y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function line ($sx, $sy, $ex, $ey) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws an arc
-	 * @link https://php.net/manual/en/imagickdraw.arc.php
-	 * @param float $sx <p>
-	 * Starting x ordinate of bounding rectangle
-	 * </p>
-	 * @param float $sy <p>
-	 * starting y ordinate of bounding rectangle
-	 * </p>
-	 * @param float $ex <p>
-	 * ending x ordinate of bounding rectangle
-	 * </p>
-	 * @param float $ey <p>
-	 * ending y ordinate of bounding rectangle
-	 * </p>
-	 * @param float $sd <p>
-	 * starting degrees of rotation
-	 * </p>
-	 * @param float $ed <p>
-	 * ending degrees of rotation
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function arc ($sx, $sy, $ex, $ey, $sd, $ed) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Paints on the image's opacity channel
-	 * @link https://php.net/manual/en/imagickdraw.matte.php
-	 * @param float $x <p>
-	 * x coordinate of the matte
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the matte
-	 * </p>
-	 * @param int $paintMethod <p>
-	 * PAINT_ constant
-	 * </p>
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function matte ($x, $y, $paintMethod) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a polygon
-	 * @link https://php.net/manual/en/imagickdraw.polygon.php
-	 * @param array $coordinates <p>
-	 * multidimensional array like array( array( 'x' => 3, 'y' => 4 ), array( 'x' => 2, 'y' => 6 ) );
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function polygon (array $coordinates) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a point
-	 * @link https://php.net/manual/en/imagickdraw.point.php
-	 * @param float $x <p>
-	 * point's x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * point's y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function point ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the text decoration
-	 * @link https://php.net/manual/en/imagickdraw.gettextdecoration.php
-	 * @return int one of the DECORATION_ constants
-	 * and 0 if no decoration is set.
-	 */
-	public function getTextDecoration () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the code set used for text annotations
-	 * @link https://php.net/manual/en/imagickdraw.gettextencoding.php
-	 * @return string a string specifying the code set
-	 * or false if text encoding is not set.
-	 */
-	public function getTextEncoding () {}
-
-	public function getFontStretch () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the font stretch to use when annotating with text
-	 * @link https://php.net/manual/en/imagickdraw.setfontstretch.php
-	 * @param int $fontStretch <p>
-	 * STRETCH_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setFontStretch ($fontStretch) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Controls whether stroked outlines are antialiased
-	 * @link https://php.net/manual/en/imagickdraw.setstrokeantialias.php
-	 * @param bool $stroke_antialias <p>
-	 * the antialias setting
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeAntialias ($stroke_antialias) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies a text alignment
-	 * @link https://php.net/manual/en/imagickdraw.settextalignment.php
-	 * @param int $alignment <p>
-	 * ALIGN_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setTextAlignment ($alignment) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies a decoration
-	 * @link https://php.net/manual/en/imagickdraw.settextdecoration.php
-	 * @param int $decoration <p>
-	 * DECORATION_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setTextDecoration ($decoration) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the color of a background rectangle
-	 * @link https://php.net/manual/en/imagickdraw.settextundercolor.php
-	 * @param ImagickPixel $under_color <p>
-	 * the under color
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setTextUnderColor (ImagickPixel $under_color) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the overall canvas size
-	 * @link https://php.net/manual/en/imagickdraw.setviewbox.php
-	 * @param int $x1 <p>
-	 * left x coordinate
-	 * </p>
-	 * @param int $y1 <p>
-	 * left y coordinate
-	 * </p>
-	 * @param int $x2 <p>
-	 * right x coordinate
-	 * </p>
-	 * @param int $y2 <p>
-	 * right y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setViewbox ($x1, $y1, $x2, $y2) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adjusts the current affine transformation matrix
-	 * @link https://php.net/manual/en/imagickdraw.affine.php
-	 * @param array $affine <p>
-	 * Affine matrix parameters
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function affine (array $affine) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.bezier.php
-	 * @param array $coordinates <p>
-	 * Multidimensional array like array( array( 'x' => 1, 'y' => 2 ),
-	 * array( 'x' => 3, 'y' => 4 ) )
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function bezier (array $coordinates) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Composites an image onto the current image
-	 * @link https://php.net/manual/en/imagickdraw.composite.php
-	 * @param int $compose <p>
-	 * composition operator. One of COMPOSITE_ constants
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate of the top left corner
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the top left corner
-	 * </p>
-	 * @param float $width <p>
-	 * width of the composition image
-	 * </p>
-	 * @param float $height <p>
-	 * height of the composition image
-	 * </p>
-	 * @param Imagick $compositeWand <p>
-	 * the Imagick object where composition image is taken from
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function composite ($compose, $x, $y, $width, $height, Imagick $compositeWand) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws color on image
-	 * @link https://php.net/manual/en/imagickdraw.color.php
-	 * @param float $x <p>
-	 * x coordinate of the paint
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the paint
-	 * </p>
-	 * @param int $paintMethod <p>
-	 * one of the PAINT_ constants
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function color ($x, $y, $paintMethod) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds a comment
-	 * @link https://php.net/manual/en/imagickdraw.comment.php
-	 * @param string $comment <p>
-	 * The comment string to add to vector output stream
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function comment ($comment) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Obtains the current clipping path ID
-	 * @link https://php.net/manual/en/imagickdraw.getclippath.php
-	 * @return string|false a string containing the clip path ID or false if no clip path exists.
-	 */
-	public function getClipPath () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the current polygon fill rule
-	 * @link https://php.net/manual/en/imagickdraw.getcliprule.php
-	 * @return int one of the FILLRULE_ constants.
-	 */
-	public function getClipRule () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the interpretation of clip path units
-	 * @link https://php.net/manual/en/imagickdraw.getclipunits.php
-	 * @return int an int on success.
-	 */
-	public function getClipUnits () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the fill color
-	 * @link https://php.net/manual/en/imagickdraw.getfillcolor.php
-	 * @return ImagickPixel an ImagickPixel object.
-	 */
-	public function getFillColor () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the opacity used when drawing
-	 * @link https://php.net/manual/en/imagickdraw.getfillopacity.php
-	 * @return float The opacity.
-	 */
-	public function getFillOpacity () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the fill rule
-	 * @link https://php.net/manual/en/imagickdraw.getfillrule.php
-	 * @return int a FILLRULE_ constant
-	 */
-	public function getFillRule () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the text placement gravity
-	 * @link https://php.net/manual/en/imagickdraw.getgravity.php
-	 * @return int a GRAVITY_ constant on success and 0 if no gravity is set.
-	 */
-	public function getGravity () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the current stroke antialias setting
-	 * @link https://php.net/manual/en/imagickdraw.getstrokeantialias.php
-	 * @return bool <b>TRUE</b> if antialiasing is on and false if it is off.
-	 */
-	public function getStrokeAntialias () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the color used for stroking object outlines
-	 * @link https://php.net/manual/en/imagickdraw.getstrokecolor.php
-	 * @return ImagickPixel an ImagickPixel object which describes the color.
-	 */
-	public function getStrokeColor () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns an array representing the pattern of dashes and gaps used to stroke paths
-	 * @link https://php.net/manual/en/imagickdraw.getstrokedasharray.php
-	 * @return array an array on success and empty array if not set.
-	 */
-	public function getStrokeDashArray () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the offset into the dash pattern to start the dash
-	 * @link https://php.net/manual/en/imagickdraw.getstrokedashoffset.php
-	 * @return float a float representing the offset and 0 if it's not set.
-	 */
-	public function getStrokeDashOffset () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the shape to be used at the end of open subpaths when they are stroked
-	 * @link https://php.net/manual/en/imagickdraw.getstrokelinecap.php
-	 * @return int one of the LINECAP_ constants or 0 if stroke linecap is not set.
-	 */
-	public function getStrokeLineCap () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the shape to be used at the corners of paths when they are stroked
-	 * @link https://php.net/manual/en/imagickdraw.getstrokelinejoin.php
-	 * @return int one of the LINEJOIN_ constants or 0 if stroke line join is not set.
-	 */
-	public function getStrokeLineJoin () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the stroke miter limit
-	 * @link https://php.net/manual/en/imagickdraw.getstrokemiterlimit.php
-	 * @return int an int describing the miter limit
-	 * and 0 if no miter limit is set.
-	 */
-	public function getStrokeMiterLimit () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the opacity of stroked object outlines
-	 * @link https://php.net/manual/en/imagickdraw.getstrokeopacity.php
-	 * @return float a double describing the opacity.
-	 */
-	public function getStrokeOpacity () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the width of the stroke used to draw object outlines
-	 * @link https://php.net/manual/en/imagickdraw.getstrokewidth.php
-	 * @return float a double describing the stroke width.
-	 */
-	public function getStrokeWidth () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the text alignment
-	 * @link https://php.net/manual/en/imagickdraw.gettextalignment.php
-	 * @return int one of the ALIGN_ constants and 0 if no align is set.
-	 */
-	public function getTextAlignment () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the current text antialias setting
-	 * @link https://php.net/manual/en/imagickdraw.gettextantialias.php
-	 * @return bool <b>TRUE</b> if text is antialiased and false if not.
-	 */
-	public function getTextAntialias () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a string containing vector graphics
-	 * @link https://php.net/manual/en/imagickdraw.getvectorgraphics.php
-	 * @return string a string containing the vector graphics.
-	 */
-	public function getVectorGraphics () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the text under color
-	 * @link https://php.net/manual/en/imagickdraw.gettextundercolor.php
-	 * @return ImagickPixel an ImagickPixel object describing the color.
-	 */
-	public function getTextUnderColor () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adds a path element to the current path
-	 * @link https://php.net/manual/en/imagickdraw.pathclose.php
-	 * @return bool No value is returned.
-	 */
-	public function pathClose () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a cubic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetoabsolute.php
-	 * @param float $x1 <p>
-	 * x coordinate of the first control point
-	 * </p>
-	 * @param float $y1 <p>
-	 * y coordinate of the first control point
-	 * </p>
-	 * @param float $x2 <p>
-	 * x coordinate of the second control point
-	 * </p>
-	 * @param float $y2 <p>
-	 * y coordinate of the first control point
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate of the curve end
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the curve end
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToAbsolute ($x1, $y1, $x2, $y2, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a cubic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetorelative.php
-	 * @param float $x1 <p>
-	 * x coordinate of starting control point
-	 * </p>
-	 * @param float $y1 <p>
-	 * y coordinate of starting control point
-	 * </p>
-	 * @param float $x2 <p>
-	 * x coordinate of ending control point
-	 * </p>
-	 * @param float $y2 <p>
-	 * y coordinate of ending control point
-	 * </p>
-	 * @param float $x <p>
-	 * ending x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * ending y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToRelative ($x1, $y1, $x2, $y2, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a quadratic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetoquadraticbezierabsolute.php
-	 * @param float $x1 <p>
-	 * x coordinate of the control point
-	 * </p>
-	 * @param float $y1 <p>
-	 * y coordinate of the control point
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate of the end point
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the end point
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToQuadraticBezierAbsolute ($x1, $y1, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a quadratic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetoquadraticbezierrelative.php
-	 * @param float $x1 <p>
-	 * starting x coordinate
-	 * </p>
-	 * @param float $y1 <p>
-	 * starting y coordinate
-	 * </p>
-	 * @param float $x <p>
-	 * ending x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * ending y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToQuadraticBezierRelative ($x1, $y1, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a quadratic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetoquadraticbeziersmoothabsolute.php
-	 * @param float $x <p>
-	 * ending x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * ending y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToQuadraticBezierSmoothAbsolute ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a quadratic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetoquadraticbeziersmoothrelative.php
-	 * @param float $x <p>
-	 * ending x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * ending y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToQuadraticBezierSmoothRelative ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a cubic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetosmoothabsolute.php
-	 * @param float $x2 <p>
-	 * x coordinate of the second control point
-	 * </p>
-	 * @param float $y2 <p>
-	 * y coordinate of the second control point
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate of the ending point
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the ending point
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToSmoothAbsolute ($x2, $y2, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a cubic Bezier curve
-	 * @link https://php.net/manual/en/imagickdraw.pathcurvetosmoothrelative.php
-	 * @param float $x2 <p>
-	 * x coordinate of the second control point
-	 * </p>
-	 * @param float $y2 <p>
-	 * y coordinate of the second control point
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate of the ending point
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the ending point
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathCurveToSmoothRelative ($x2, $y2, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws an elliptical arc
-	 * @link https://php.net/manual/en/imagickdraw.pathellipticarcabsolute.php
-	 * @param float $rx <p>
-	 * x radius
-	 * </p>
-	 * @param float $ry <p>
-	 * y radius
-	 * </p>
-	 * @param float $x_axis_rotation <p>
-	 * x axis rotation
-	 * </p>
-	 * @param bool $large_arc_flag <p>
-	 * large arc flag
-	 * </p>
-	 * @param bool $sweep_flag <p>
-	 * sweep flag
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathEllipticArcAbsolute ($rx, $ry, $x_axis_rotation, $large_arc_flag, $sweep_flag, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws an elliptical arc
-	 * @link https://php.net/manual/en/imagickdraw.pathellipticarcrelative.php
-	 * @param float $rx <p>
-	 * x radius
-	 * </p>
-	 * @param float $ry <p>
-	 * y radius
-	 * </p>
-	 * @param float $x_axis_rotation <p>
-	 * x axis rotation
-	 * </p>
-	 * @param bool $large_arc_flag <p>
-	 * large arc flag
-	 * </p>
-	 * @param bool $sweep_flag <p>
-	 * sweep flag
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathEllipticArcRelative ($rx, $ry, $x_axis_rotation, $large_arc_flag, $sweep_flag, $x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Terminates the current path
-	 * @link https://php.net/manual/en/imagickdraw.pathfinish.php
-	 * @return bool No value is returned.
-	 */
-	public function pathFinish () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a line path
-	 * @link https://php.net/manual/en/imagickdraw.pathlinetoabsolute.php
-	 * @param float $x <p>
-	 * starting x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * ending x coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathLineToAbsolute ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a line path
-	 * @link https://php.net/manual/en/imagickdraw.pathlinetorelative.php
-	 * @param float $x <p>
-	 * starting x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * starting y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathLineToRelative ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a horizontal line path
-	 * @link https://php.net/manual/en/imagickdraw.pathlinetohorizontalabsolute.php
-	 * @param float $x <p>
-	 * x coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathLineToHorizontalAbsolute ($x) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a horizontal line
-	 * @link https://php.net/manual/en/imagickdraw.pathlinetohorizontalrelative.php
-	 * @param float $x <p>
-	 * x coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathLineToHorizontalRelative ($x) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a vertical line
-	 * @link https://php.net/manual/en/imagickdraw.pathlinetoverticalabsolute.php
-	 * @param float $y <p>
-	 * y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathLineToVerticalAbsolute ($y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a vertical line path
-	 * @link https://php.net/manual/en/imagickdraw.pathlinetoverticalrelative.php
-	 * @param float $y <p>
-	 * y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathLineToVerticalRelative ($y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Starts a new sub-path
-	 * @link https://php.net/manual/en/imagickdraw.pathmovetoabsolute.php
-	 * @param float $x <p>
-	 * x coordinate of the starting point
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the starting point
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathMoveToAbsolute ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Starts a new sub-path
-	 * @link https://php.net/manual/en/imagickdraw.pathmovetorelative.php
-	 * @param float $x <p>
-	 * target x coordinate
-	 * </p>
-	 * @param float $y <p>
-	 * target y coordinate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pathMoveToRelative ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Declares the start of a path drawing list
-	 * @link https://php.net/manual/en/imagickdraw.pathstart.php
-	 * @return bool No value is returned.
-	 */
-	public function pathStart () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Draws a polyline
-	 * @link https://php.net/manual/en/imagickdraw.polyline.php
-	 * @param array $coordinates <p>
-	 * array of x and y coordinates: array( array( 'x' => 4, 'y' => 6 ), array( 'x' => 8, 'y' => 10 ) )
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function polyline (array $coordinates) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Terminates a clip path definition
-	 * @link https://php.net/manual/en/imagickdraw.popclippath.php
-	 * @return bool No value is returned.
-	 */
-	public function popClipPath () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Terminates a definition list
-	 * @link https://php.net/manual/en/imagickdraw.popdefs.php
-	 * @return bool No value is returned.
-	 */
-	public function popDefs () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Terminates a pattern definition
-	 * @link https://php.net/manual/en/imagickdraw.poppattern.php
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function popPattern () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Starts a clip path definition
-	 * @link https://php.net/manual/en/imagickdraw.pushclippath.php
-	 * @param string $clip_mask_id <p>
-	 * Clip mask Id
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function pushClipPath ($clip_mask_id) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Indicates that following commands create named elements for early processing
-	 * @link https://php.net/manual/en/imagickdraw.pushdefs.php
-	 * @return bool No value is returned.
-	 */
-	public function pushDefs () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Indicates that subsequent commands up to a ImagickDraw::opPattern() command comprise the definition of a named pattern
-	 * @link https://php.net/manual/en/imagickdraw.pushpattern.php
-	 * @param string $pattern_id <p>
-	 * the pattern Id
-	 * </p>
-	 * @param float $x <p>
-	 * x coordinate of the top-left corner
-	 * </p>
-	 * @param float $y <p>
-	 * y coordinate of the top-left corner
-	 * </p>
-	 * @param float $width <p>
-	 * width of the pattern
-	 * </p>
-	 * @param float $height <p>
-	 * height of the pattern
-	 * </p>
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function pushPattern ($pattern_id, $x, $y, $width, $height) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Renders all preceding drawing commands onto the image
-	 * @link https://php.net/manual/en/imagickdraw.render.php
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function render () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Applies the specified rotation to the current coordinate space
-	 * @link https://php.net/manual/en/imagickdraw.rotate.php
-	 * @param float $degrees <p>
-	 * degrees to rotate
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function rotate ($degrees) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Adjusts the scaling factor
-	 * @link https://php.net/manual/en/imagickdraw.scale.php
-	 * @param float $x <p>
-	 * horizontal factor
-	 * </p>
-	 * @param float $y <p>
-	 * vertical factor
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function scale ($x, $y) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Associates a named clipping path with the image
-	 * @link https://php.net/manual/en/imagickdraw.setclippath.php
-	 * @param string $clip_mask <p>
-	 * the clipping path name
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setClipPath ($clip_mask) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Set the polygon fill rule to be used by the clipping path
-	 * @link https://php.net/manual/en/imagickdraw.setcliprule.php
-	 * @param int $fill_rule <p>
-	 * FILLRULE_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setClipRule ($fill_rule) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the interpretation of clip path units
-	 * @link https://php.net/manual/en/imagickdraw.setclipunits.php
-	 * @param int $clip_units <p>
-	 * the number of clip units
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setClipUnits ($clip_units) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the opacity to use when drawing using the fill color or fill texture
-	 * @link https://php.net/manual/en/imagickdraw.setfillopacity.php
-	 * @param float $fillOpacity <p>
-	 * the fill opacity
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setFillOpacity ($fillOpacity) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the URL to use as a fill pattern for filling objects
-	 * @link https://php.net/manual/en/imagickdraw.setfillpatternurl.php
-	 * @param string $fill_url <p>
-	 * URL to use to obtain fill pattern.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function setFillPatternURL ($fill_url) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the fill rule to use while drawing polygons
-	 * @link https://php.net/manual/en/imagickdraw.setfillrule.php
-	 * @param int $fill_rule <p>
-	 * FILLRULE_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setFillRule ($fill_rule) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the text placement gravity
-	 * @link https://php.net/manual/en/imagickdraw.setgravity.php
-	 * @param int $gravity <p>
-	 * GRAVITY_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setGravity ($gravity) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the pattern used for stroking object outlines
-	 * @link https://php.net/manual/en/imagickdraw.setstrokepatternurl.php
-	 * @param string $stroke_url <p>
-	 * stroke URL
-	 * </p>
-	 * @return bool imagick.imagickdraw.return.success;
-	 */
-	public function setStrokePatternURL ($stroke_url) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the offset into the dash pattern to start the dash
-	 * @link https://php.net/manual/en/imagickdraw.setstrokedashoffset.php
-	 * @param float $dash_offset <p>
-	 * dash offset
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeDashOffset ($dash_offset) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the shape to be used at the end of open subpaths when they are stroked
-	 * @link https://php.net/manual/en/imagickdraw.setstrokelinecap.php
-	 * @param int $linecap <p>
-	 * LINECAP_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeLineCap ($linecap) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the shape to be used at the corners of paths when they are stroked
-	 * @link https://php.net/manual/en/imagickdraw.setstrokelinejoin.php
-	 * @param int $linejoin <p>
-	 * LINEJOIN_ constant
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeLineJoin ($linejoin) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the miter limit
-	 * @link https://php.net/manual/en/imagickdraw.setstrokemiterlimit.php
-	 * @param int $miterlimit <p>
-	 * the miter limit
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeMiterLimit ($miterlimit) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the opacity of stroked object outlines
-	 * @link https://php.net/manual/en/imagickdraw.setstrokeopacity.php
-	 * @param float $stroke_opacity <p>
-	 * stroke opacity. 1.0 is fully opaque
-	 * </p>
-	 * @return bool No value is returned.
-	 */
-	public function setStrokeOpacity ($stroke_opacity) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the vector graphics
-	 * @link https://php.net/manual/en/imagickdraw.setvectorgraphics.php
-	 * @param string $xml <p>
-	 * xml containing the vector graphics
-	 * </p>
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function setVectorGraphics ($xml) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Destroys the current ImagickDraw in the stack, and returns to the previously pushed ImagickDraw
-	 * @link https://php.net/manual/en/imagickdraw.pop.php
-	 * @return bool <b>TRUE</b> on success and false on failure.
-	 */
-	public function pop () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Clones the current ImagickDraw and pushes it to the stack
-	 * @link https://php.net/manual/en/imagickdraw.push.php
-	 * @return bool <b>TRUE</b> on success or <b>FALSE</b> on failure.
-	 */
-	public function push () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Specifies the pattern of dashes and gaps used to stroke paths
-	 * @link https://php.net/manual/en/imagickdraw.setstrokedasharray.php
-	 * @param array $dashArray <p>
-	 * array of floats
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setStrokeDashArray (array $dashArray) {}
+/** @generate-function-entries */
+
+class Imagick
+{
+#if MagickLibVersion > 0x628
+    public function optimizeImageLayers(): bool  {}
+
+    // METRIC_*
+    public function compareImageLayers(int $metric): Imagick  {}
+
+    public function pingImageBlob(string $image): bool  {}
+
+    public function pingImageFile(resource $filehandle, ?string $filename = null): bool  {}
+
+    public function transposeImage(): bool  {}
+
+    public function transverseImage(): bool  {}
+
+    public function trimImage(float $fuzz): bool  {}
+
+    public function waveImage(float $amplitude, float $length): bool  {}
+
+    public function vignetteImage(float $black_point, float $white_point, int $x, int $y): bool  {}
+
+    public function uniqueImageColors(): bool  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+//    PHP_ME(imagick, getimagematte, imagick_zero_args, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
+    /** @deprecated */
+    public function getImageMatte(): bool  {}
+#endif
+#endif
+
+    // TODO - enabled?
+    public function setImageMatte(bool $matte): bool  {}
+
+    public function adaptiveResizeImage(
+        int $columns,
+        int $rows,
+        bool $bestfit = false,
+        bool $legacy = false): bool  {}
+
+    public function sketchImage(float $radius, float $sigma, float $angle): bool  {}
+
+    public function shadeImage(bool $gray, float $azimuth, float $elevation): bool  {}
+
+    public function getSizeOffset(): int  {}
+
+    public function setSizeOffset(int $columns, int $rows, int $offset): bool  {}
+
+
+    public function adaptiveBlurImage(
+        float $radius,
+        float $sigma,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool  {}
+
+    public function contrastStretchImage(
+        float $black_point,
+        float $white_point,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool  {}
+
+    public function adaptiveSharpenImage(
+        float $radius,
+        float $sigma,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool  {}
+
+
+    public function randomThresholdImage(
+        float $low,
+        float $high,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool  {}
+
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function roundCornersImage(
+        float $x_rounding,
+        float $y_rounding,
+        float $stroke_width = 10,
+        float $displace = 5,
+        float $size_correction = -6): bool {}
+
+    /* This alias is due to BWC */
+    /**
+     * @deprecated
+     * @alias Imagick::roundCornersImage
+     */
+    public function roundCorners(
+        float $x_rounding,
+        float $y_rounding,
+        float $stroke_width = 10,
+        float $displace = 5,
+        float $size_correction = -6): bool {}
+
+#endif
+
+    public function setIteratorIndex(int $index): bool  {}
+
+    public function getIteratorIndex(): int  {}
+
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function transformImage(string $crop, string $geometry): Imagick  {}
+#endif
+#endif
+
+#if MagickLibVersion > 0x630
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function setImageOpacity(float $opacity): bool  {}
+#endif
+
+#if MagickLibVersion >= 0x700
+    public function setImageAlpha(float $alpha): bool {}
+#endif
+
+#if MagickLibVersion < 0x700
+
+    /** @deprecated */
+    public function orderedPosterizeImage(
+        string $threshold_map,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool  {}
+#endif
+#endif
+
+#if MagickLibVersion > 0x631
+    // TODO - ImagickDraw ....
+    public function polaroidImage(ImagickDraw $settings, float $angle): bool  {}
+
+    public function getImageProperty(string $name): string  {}
+
+    public function setImageProperty(string $name, string $value): bool  {}
+
+    public function deleteImageProperty(string $name): bool  {}
+
+    // Replaces any embedded formatting characters with the appropriate
+    // image property and returns the interpreted text.
+    // See http://www.imagemagick.org/script/escape.php for escape sequences.
+    // -format "%m:%f %wx%h"
+    public function identifyFormat(string $format): string  {}
+
+
+#if IM_HAVE_IMAGICK_SETIMAGEINTERPOLATEMETHOD
+    // INTERPOLATE_*
+    public function setImageInterpolateMethod(int $method): bool  {}
+#endif
+
+    // why does this not need to be inside the 'if' for IM_HAVE_IMAGICK_SETIMAGEINTERPOLATEMETHOD ..?
+    public function getImageInterpolateMethod(): int  {}
+
+    public function linearStretchImage(float $black_point, float $white_point): bool  {}
+
+    public function getImageLength(): int  {}
+
+    public function extentImage(int $width, int $height, int $x, int $y): bool  {}
+#endif
+#if MagickLibVersion > 0x633
+    public function getImageOrientation(): int  {}
+
+    public function setImageOrientation(int $orientation): bool  {}
+#endif
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion > 0x634
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function paintFloodfillImage(
+        ImagickPixel|string $fill_color,
+        float $fuzz,
+        ImagickPixel|string $border_color,
+        int $x,
+        int $y,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool {}
+#endif
+#endif
+#endif
+
+#if MagickLibVersion > 0x635
+
+    // TODO - Imagick
+    public function clutImage(Imagick $lookup_table, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function getImageProperties(string $pattern = "*", bool $include_values = true): array  {}
+
+    public function getImageProfiles(string $pattern = "*", bool $include_values = true): array  {}
+
+    // DISTORTION_*
+    public function distortImage(int $distortion, array $arguments, bool $bestfit): bool  {}
+
+    public function writeImageFile(resource $filehandle, ?string $format = null): bool  {}
+
+    public function writeImagesFile(resource $filehandle, ?string $format = null): bool  {}
+
+    public function resetImagePage(string $page): bool  {}
+
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function setImageClipMask(imagick $clip_mask): bool  {}
+
+    /** @deprecated */
+    public function getImageClipMask(): Imagick  {}
+#endif
+
+    // TODO - x server?
+    public function animateImages(string $x_server): bool  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function recolorImage(array $matrix): bool  {}
+#endif
+#endif
+#endif
+
+#if MagickLibVersion > 0x636
+    public function setFont(string $font): bool  {}
+
+    public function getFont(): string  {}
+
+    public function setPointSize(float $point_size): bool  {}
+
+    public function getPointSize(): float  {}
+
+    // LAYERMETHOD_*
+    public function mergeImageLayers(int $layermethod): Imagick  {}
+#endif
+
+#if MagickLibVersion > 0x637
+    // ALPHACHANNEL_*
+    public function setImageAlphaChannel(int $alphachannel): bool  {}
+
+    // TODO - ImagickPixel ugh
+//  TODO - ugh MagickBooleanType MagickFloodfillPaintImage(MagickWand *wand,
+//    const PixelWand *fill,const double fuzz,const PixelWand *bordercolor,
+//    const ssize_t x,const ssize_t y,const MagickBooleanType invert)
+
+    public function floodfillPaintImage(
+        ImagickPixel|string $fill_color,
+        float $fuzz,
+        ImagickPixel|string $border_color,
+        int $x,
+        int $y,
+        bool $invert,
+        ?int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool{}
+
+
+
+    public function opaquePaintImage(
+        ImagickPixel|string $target_color,
+        ImagickPixel|string $fill_color,
+        float $fuzz,
+        bool $invert,
+        int $channel = Imagick::CHANNEL_DEFAULT): bool {}
+
+    public function transparentPaintImage(
+        ImagickPixel|string $target_color,
+        float $alpha,
+        float $fuzz,
+        bool $invert
+    ): bool  {}
+#endif
+#if MagickLibVersion > 0x638
+    public function liquidRescaleImage(int $width, int $height, float $delta_x, float $rigidity): bool  {}
+
+    public function encipherImage(string $passphrase): bool  {}
+
+//    PHP_ME(imagick, decipherimage, imagick_decipherimage_args, ZEND_ACC_PUBLIC)
+    public function decipherImage(string $passphrase): bool  {}
+#endif
+
+#if MagickLibVersion > 0x639
+
+    // GRAVITY_*
+    public function setGravity(int $gravity): bool  {}
+
+    public function getGravity(): int  {}
+
+    // CHANNEL_
+    public function getImageChannelRange(int $channel): array  {}
+
+    public function getImageAlphaChannel(): int  {}
+#endif
+
+#if MagickLibVersion > 0x642
+    public function getImageChannelDistortions(
+        Imagick $reference_image,
+        int $metric,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): float {}
+#endif
+
+#if MagickLibVersion > 0x643
+    // GRAVITY_
+    public function setImageGravity(int $gravity): bool  {}
+
+    public function getImageGravity(): int  {}
+#endif
+
+#if MagickLibVersion > 0x645
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $width
+     * @param int $height
+     * @param string $map
+     * @param int $pixelstorage // PIXELSTORAGE
+     * @param array $pixels
+     * @return bool
+     */
+    public function importImagePixels(
+        int $x,
+        int $y,
+        int $width,
+        int $height,
+        string $map,
+        int $pixelstorage,
+        array $pixels): bool {}
+
+    public function deskewImage(float $threshold): bool  {}
 
     /**
-     * Sets the opacity to use when drawing using the fill or stroke color or texture. Fully opaque is 1.0.
-     *
-     * @param float $opacity
-     * @return void
-     * @since 3.4.1
+     * @param int $colorspace // COLORSPACE
+     * @param float $cluster_threshold
+     * @param float $smooth_threshold
+     * @param bool $verbose
+     * @return bool
      */
-	public function setOpacity($opacity) { }
+    public function segmentImage(
+        int $colorspace,
+        float $cluster_threshold,
+        float $smooth_threshold,
+        bool $verbose = false
+    ): bool  {}
 
-	/**
-	 * Returns the opacity used when drawing with the fill or stroke color or texture. Fully opaque is 1.0.
-	 *
-	 * @return float
-	 * @since 3.4.1
-	 */
-	public function getOpacity() { }
+    // SPARSECOLORMETHOD_*
+    public function sparseColorImage(
+        int $sparsecolormethod,
+        array $arguments,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool {}
 
-	/**
-	 * Sets the image font resolution.
-	 *
-	 * @param float $x
-	 * @param float $y
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function setFontResolution($x, $y) { }
-
-	/**
-	 * Gets the image X and Y resolution.
-	 *
-	 * @return array
-	 * @since 3.4.1
-	 */
-	public function getFontResolution() { }
-
-	/**
-	 * Returns the direction that will be used when annotating with text.
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function getTextDirection() { }
-
-	/**
-	 * Sets the font style to use when annotating with text. The AnyStyle enumeration acts as a wild-card "don't care" option.
-	 *
-	 * @param int $direction
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function setTextDirection($direction) { }
-
-	/**
-	 * Returns the border color used for drawing bordered objects.
-	 *
-	 * @return ImagickPixel
-	 * @since 3.4.1
-	 */
-	public function getBorderColor() { }
-
-	/**
-	 * Sets the border color to be used for drawing bordered objects.
-	 * @param ImagickPixel $color
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function setBorderColor(ImagickPixel $color) { }
-
-	/**
-	 * Obtains the vertical and horizontal resolution.
-	 *
-	 * @return string|null
-	 * @since 3.4.1
-	 */
-	public function getDensity() { }
-
-	/**
-	 * Sets the vertical and horizontal resolution.
-	 * @param string $density_string
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function setDensity($density_string) { }
-}
-
-/**
- * @link https://php.net/manual/en/class.imagickpixeliterator.php
- */
-class ImagickPixelIterator implements Iterator {
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * The ImagickPixelIterator constructor
-	 * @link https://php.net/manual/en/imagickpixeliterator.construct.php
-	 * @param Imagick $wand
-	 */
-	public function __construct (Imagick $wand) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a new pixel iterator
-	 * @link https://php.net/manual/en/imagickpixeliterator.newpixeliterator.php
-	 * @param Imagick $wand
-	 * @return bool <b>TRUE</b> on success. Throwing ImagickPixelIteratorException.
-	 * @throws ImagickPixelIteratorException
-	 */
-	public function newPixelIterator (Imagick $wand) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns a new pixel iterator
-	 * @link https://php.net/manual/en/imagickpixeliterator.newpixelregioniterator.php
-	 * @param Imagick $wand
-	 * @param int $x
-	 * @param int $y
-	 * @param int $columns
-	 * @param int $rows
-	 * @return bool a new ImagickPixelIterator on success; on failure, throws ImagickPixelIteratorException
-	 * @throws ImagickPixelIteratorException
-	 */
-	public function newPixelRegionIterator (Imagick $wand, $x, $y, $columns, $rows) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the current pixel iterator row
-	 * @link https://php.net/manual/en/imagickpixeliterator.getiteratorrow.php
-	 * @return int the integer offset of the row, throwing ImagickPixelIteratorException on error.
-	 * @throws ImagickPixelIteratorException on error
-	 */
-	public function getIteratorRow () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Set the pixel iterator row
-	 * @link https://php.net/manual/en/imagickpixeliterator.setiteratorrow.php
-	 * @param int $row
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setIteratorRow ($row) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the pixel iterator to the first pixel row
-	 * @link https://php.net/manual/en/imagickpixeliterator.setiteratorfirstrow.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setIteratorFirstRow () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the pixel iterator to the last pixel row
-	 * @link https://php.net/manual/en/imagickpixeliterator.setiteratorlastrow.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setIteratorLastRow () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the previous row
-	 * @link https://php.net/manual/en/imagickpixeliterator.getpreviousiteratorrow.php
-	 * @return array the previous row as an array of ImagickPixelWand objects from the
-	 * ImagickPixelIterator, throwing ImagickPixelIteratorException on error.
-	 * @throws ImagickPixelIteratorException on error
-	 */
-	public function getPreviousIteratorRow () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the current row of ImagickPixel objects
-	 * @link https://php.net/manual/en/imagickpixeliterator.getcurrentiteratorrow.php
-	 * @return array a row as an array of ImagickPixel objects that can themselves be iterated.
-	 */
-	public function getCurrentIteratorRow () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the next row of the pixel iterator
-	 * @link https://php.net/manual/en/imagickpixeliterator.getnextiteratorrow.php
-	 * @return array the next row as an array of ImagickPixel objects, throwing
-	 * ImagickPixelIteratorException on error.
-	 * @throws ImagickPixelIteratorException on error
-	 */
-	public function getNextIteratorRow () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Resets the pixel iterator
-	 * @link https://php.net/manual/en/imagickpixeliterator.resetiterator.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function resetIterator () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Syncs the pixel iterator
-	 * @link https://php.net/manual/en/imagickpixeliterator.synciterator.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function syncIterator () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Deallocates resources associated with a PixelIterator
-	 * @link https://php.net/manual/en/imagickpixeliterator.destroy.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function destroy () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Clear resources associated with a PixelIterator
-	 * @link https://php.net/manual/en/imagickpixeliterator.clear.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function clear () {}
-
-	/**
-	 * @param Imagick $Imagick
-	 */
-	public static function getpixeliterator (Imagick $Imagick) {}
-
-	/**
-	 * @param Imagick $Imagick
-	 * @param $x
-	 * @param $y
-	 * @param $columns
-	 * @param $rows
-	 */
-	public static function getpixelregioniterator (Imagick $Imagick, $x, $y, $columns, $rows) {}
-
-	public function key () {}
-
-	public function next () {}
-
-	public function rewind () {}
-
-	public function current () {}
-
-	public function valid () {}
-
-}
-
-/**
- * @method clone()
- * @link https://php.net/manual/en/class.imagickpixel.php
- */
-class ImagickPixel  {
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the normalized HSL color of the ImagickPixel object
-	 * @link https://php.net/manual/en/imagickpixel.gethsl.php
-	 * @return array the HSL value in an array with the keys "hue",
-	 * "saturation", and "luminosity". Throws ImagickPixelException on failure.
-	 * @throws ImagickPixelException on failure
-	 */
-	public function getHSL () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the normalized HSL color
-	 * @link https://php.net/manual/en/imagickpixel.sethsl.php
-	 * @param float $hue <p>
-	 * The normalized value for hue, described as a fractional arc
-	 * (between 0 and 1) of the hue circle, where the zero value is
-	 * red.
-	 * </p>
-	 * @param float $saturation <p>
-	 * The normalized value for saturation, with 1 as full saturation.
-	 * </p>
-	 * @param float $luminosity <p>
-	 * The normalized value for luminosity, on a scale from black at
-	 * 0 to white at 1, with the full HS value at 0.5 luminosity.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setHSL ($hue, $saturation, $luminosity) {}
-
-	public function getColorValueQuantum () {}
-
-	/**
-	 * @param $color_value
-	 */
-	public function setColorValueQuantum ($color_value) {}
-
-	public function getIndex () {}
-
-	/**
-	 * @param $index
-	 */
-	public function setIndex ($index) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * The ImagickPixel constructor
-	 * @link https://php.net/manual/en/imagickpixel.construct.php
-	 * @param string $color [optional] <p>
-	 * The optional color string to use as the initial value of this object.
-	 * </p>
-	 */
-	public function __construct ($color = null) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the color
-	 * @link https://php.net/manual/en/imagickpixel.setcolor.php
-	 * @param string $color <p>
-	 * The color definition to use in order to initialise the
-	 * ImagickPixel object.
-	 * </p>
-	 * @return bool <b>TRUE</b> if the specified color was set, <b>FALSE</b> otherwise.
-	 */
-	public function setColor ($color) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Sets the normalized value of one of the channels
-	 * @link https://php.net/manual/en/imagickpixel.setcolorvalue.php
-	 * @param int $color <p>
-	 * One of the Imagick color constants e.g. \Imagick::COLOR_GREEN or \Imagick::COLOR_ALPHA.
-	 * </p>
-	 * @param float $value <p>
-	 * The value to set this channel to, ranging from 0 to 1.
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function setColorValue ($color, $value) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Gets the normalized value of the provided color channel
-	 * @link https://php.net/manual/en/imagickpixel.getcolorvalue.php
-	 * @param int $color <p>
-	 * The color to get the value of, specified as one of the Imagick color
-	 * constants. This can be one of the RGB colors, CMYK colors, alpha and
-	 * opacity e.g (Imagick::COLOR_BLUE, Imagick::COLOR_MAGENTA).
-	 * </p>
-	 * @return float The value of the channel, as a normalized floating-point number, throwing
-	 * ImagickPixelException on error.
-	 * @throws ImagickPixelException on error
-	 */
-	public function getColorValue ($color) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Clears resources associated with this object
-	 * @link https://php.net/manual/en/imagickpixel.clear.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function clear () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Deallocates resources associated with this object
-	 * @link https://php.net/manual/en/imagickpixel.destroy.php
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function destroy () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Check the distance between this color and another
-	 * @link https://php.net/manual/en/imagickpixel.issimilar.php
-	 * @param ImagickPixel $color <p>
-	 * The ImagickPixel object to compare this object against.
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The maximum distance within which to consider these colors as similar.
-	 * The theoretical maximum for this value is the square root of three
-	 * (1.732).
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function isSimilar (ImagickPixel $color, $fuzz) {}
-
-	/**
-	 * (No version information available, might only be in SVN)<br/>
-	 * Check the distance between this color and another
-	 * @link https://php.net/manual/en/imagickpixel.ispixelsimilar.php
-	 * @param ImagickPixel $color <p>
-	 * The ImagickPixel object to compare this object against.
-	 * </p>
-	 * @param float $fuzz <p>
-	 * The maximum distance within which to consider these colors as similar.
-	 * The theoretical maximum for this value is the square root of three
-	 * (1.732).
-	 * </p>
-	 * @return bool <b>TRUE</b> on success.
-	 */
-	public function isPixelSimilar (ImagickPixel $color, $fuzz) {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the color
-	 * @link https://php.net/manual/en/imagickpixel.getcolor.php
-	 * @param bool $normalized [optional] <p>
-	 * Normalize the color values
-	 * </p>
-	 * @return array An array of channel values, each normalized if <b>TRUE</b> is given as param. Throws
-	 * ImagickPixelException on error.
-	 * @throws ImagickPixelException on error.
-	 */
-	public function getColor ($normalized = false) {}
-
-	/**
-	 * (PECL imagick 2.1.0)<br/>
-	 * Returns the color as a string
-	 * @link https://php.net/manual/en/imagickpixel.getcolorasstring.php
-	 * @return string the color of the ImagickPixel object as a string.
-	 */
-	public function getColorAsString () {}
-
-	/**
-	 * (PECL imagick 2.0.0)<br/>
-	 * Returns the color count associated with this color
-	 * @link https://php.net/manual/en/imagickpixel.getcolorcount.php
-	 * @return int the color count as an integer on success, throws
-	 * ImagickPixelException on failure.
-	 * @throws ImagickPixelException on failure.
-	 */
-	public function getColorCount () {}
-
-	/**
-	 * @param $colorCount
-	 */
-	public function setColorCount ($colorCount) {}
+    public function remapImage(Imagick $replacement, int $dither_method): bool  {}
+#endif
 
 
-	/**
-	 * Returns true if the distance between two colors is less than the specified distance. The fuzz value should be in the range 0-QuantumRange.<br>
-	 * The maximum value represents the longest possible distance in the colorspace. e.g. from RGB(0, 0, 0) to RGB(255, 255, 255) for the RGB colorspace
-	 * @link https://php.net/manual/en/imagickpixel.ispixelsimilarquantum.php
-	 * @param string $pixel
-	 * @param string $fuzz
-	 * @return bool
-	 * @since 3.3.0
-	 */
-	public function isPixelSimilarQuantum($color, $fuzz) { }
+#if PHP_IMAGICK_HAVE_HOUGHLINE
+    public function houghLineImage(int $width, int $height, float $threshold): bool {}
+#endif
 
-	/**
-	 * Returns the color of the pixel in an array as Quantum values. If ImageMagick was compiled as HDRI these will be floats, otherwise they will be integers.
-	 * @link https://php.net/manual/en/imagickpixel.getcolorquantum.php
-	 * @return mixed The quantum value of the color element. Float if ImageMagick was compiled with HDRI, otherwise an int.
-	 * @since 3.3.0
-	 */
-	public function getColorQuantum() { }
+#if MagickLibVersion > 0x646
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $width
+     * @param int $height
+     * @param string $map e.g. "RGB"
+     * @param int $pixelstorage // PIXELSTORAGE
+     * @return array
+     */
+    public function exportImagePixels(
+        int $x,
+        int $y,
+        int $width,
+        int $height,
+        string $map,
+        int $pixelstorage
+    ): array {}
+#endif
 
-	/**
-	 * Sets the color count associated with this color from another ImagickPixel object.
-	 *
-	 * @param ImagickPixel $srcPixel
-	 * @return bool
-	 * @since 3.4.1
-	 */
-	public function setColorFromPixel(ImagickPixel $srcPixel) { }
-}
-// End of imagick v.3.2.0RC1
+#if MagickLibVersion > 0x648
+    public function getImageChannelKurtosis(int $channel = Imagick::CHANNEL_DEFAULT): array  {}
 
-// Start of Imagick v3.3.0RC1
+    public function functionImage(
+        int $function,
+        array $parameters,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool {}
+#endif
 
-/**
- * @link https://php.net/manual/en/class.imagickkernel.php
- */
-class ImagickKernel {
-	/**
-	 * Attach another kernel to this kernel to allow them to both be applied in a single morphology or filter function. Returns the new combined kernel.
-	 * @link https://php.net/manual/en/imagickkernel.addkernel.php
-	 * @param ImagickKernel $imagickKernel
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function addKernel(ImagickKernel $imagickKernel) { }
+#if MagickLibVersion > 0x651
+    // COLORSPACE_*
+    public function transformImageColorspace(int $colorspace): bool  {}
+#endif
 
-	/**
-	 * Adds a given amount of the 'Unity' Convolution Kernel to the given pre-scaled and normalized Kernel. This in effect adds that amount of the original image into the resulting convolution kernel. The resulting effect is to convert the defined kernels into blended soft-blurs, unsharp kernels or into sharpening kernels.
-	 * @link https://php.net/manual/en/imagickkernel.addunitykernel.php
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function addUnityKernel() { }
+#if MagickLibVersion > 0x652
+    public function haldClutImage(Imagick $clut, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+#endif
 
-	/**
-	 * Create a kernel from a builtin in kernel. See https://www.imagemagick.org/Usage/morphology/#kernel for examples.<br>
-	 * Currently the 'rotation' symbols are not supported. Example: $diamondKernel = ImagickKernel::fromBuiltIn(\Imagick::KERNEL_DIAMOND, "2");
-	 * @link https://php.net/manual/en/imagickkernel.frombuiltin.php
-	 * @param string $kernelType The type of kernel to build e.g. \Imagick::KERNEL_DIAMOND
-	 * @param string $kernelString A string that describes the parameters e.g. "4,2.5"
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public static function fromBuiltin($kernelType, $kernelString) { }
+#if MagickLibVersion > 0x655
+    public function autoLevelImage(int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
 
-	/**
-	 * Create a kernel from a builtin in kernel. See https://www.imagemagick.org/Usage/morphology/#kernel for examples.<br>
-	 * Currently the 'rotation' symbols are not supported. Example: $diamondKernel = ImagickKernel::fromBuiltIn(\Imagick::KERNEL_DIAMOND, "2");
-	 * @link https://php.net/manual/en/imagickkernel.frombuiltin.php
-	 * @see https://www.imagemagick.org/Usage/morphology/#kernel
-	 * @param array $matrix A matrix (i.e. 2d array) of values that define the kernel. Each element should be either a float value, or FALSE if that element shouldn't be used by the kernel.
-	 * @param array $origin [optional] Which element of the kernel should be used as the origin pixel. e.g. For a 3x3 matrix specifying the origin as [2, 2] would specify that the bottom right element should be the origin pixel.
-	 * @return ImagickKernel
-	 * @since 3.3.0
-	 */
-	public static function fromMatrix($matrix, $origin) { }
+    public function blueShiftImage(float $factor = 1.5): bool  {}
+#endif
 
-	/**
-	 * Get the 2d matrix of values used in this kernel. The elements are either float for elements that are used or 'false' if the element should be skipped.
-	 * @link https://php.net/manual/en/imagickkernel.getmatrix.php
-	 * @return array A matrix (2d array) of the values that represent the kernel.
-	 * @since 3.3.0
-	 */
-	public function getMatrix() { }
+#if MagickLibVersion > 0x656
+    /**
+     * @param string $artifact example 'compose:args'
+     * @return string
+     */
+    public function getImageArtifact(string $artifact): string  {}
 
-	/**
-	 * ScaleKernelInfo() scales the given kernel list by the given amount, with or without normalization of the sum of the kernel values (as per given flags).<br>
-	 * The exact behaviour of this function depends on the normalization type being used please see https://www.imagemagick.org/api/morphology.php#ScaleKernelInfo for details.<br>
-	 * Flag should be one of Imagick::NORMALIZE_KERNEL_VALUE, Imagick::NORMALIZE_KERNEL_CORRELATE, Imagick::NORMALIZE_KERNEL_PERCENT or not set.
-	 * @link https://php.net/manual/en/imagickkernel.scale.php
-	 * @see https://www.imagemagick.org/api/morphology.php#ScaleKernelInfo
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function scale() { }
+    /**
+     * @param string $artifact example 'compose:args'
+     * @param string $value example  "1,0,-0.5,0.5"
+     * @return bool
+     */
+    public function setImageArtifact(string $artifact, string $value): bool  {}
 
-	/**
-	 * Separates a linked set of kernels and returns an array of ImagickKernels.
-	 * @link https://php.net/manual/en/imagickkernel.separate.php
-	 * @return void
-	 * @since 3.3.0
-	 */
-	public function seperate() { }
+    public function deleteImageArtifact(string $artifact): bool  {}
+
+    // Will return CHANNEL_*
+    public function getColorspace(): int  {}
+
+//    PHP_ME(imagick, setcolorspace, imagick_setcolorspace_args, ZEND_ACC_PUBLIC)
+    public function setColorspace(int $colorspace): bool  {}
+
+    // CHANNEL_*
+    public function clampImage(int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+#endif
+
+#if MagickLibVersion > 0x667
+    // stack By default, images are stacked left-to-right. Set stack to MagickTrue to stack them top-to-bottom.
+    //offset minimum distance in pixels between images.
+    public function smushImages(bool $stack, int $offset): Imagick  {}
+#endif
+
+//    PHP_ME(imagick, __construct, imagick_construct_args, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
+    // TODO int|float? :spocks_eyebrow.gif:
+    public function __construct(string|array|int|float|null $files = null) {}
+
+    public function __toString(): string  {}
+
+#if PHP_VERSION_ID >= 50600
+    // This calls MagickGetNumberImages underneath
+    // mode is unused. Remove at next major release
+    // https://github.com/Imagick/imagick/commit/13302500c0ab0ce58e6502e68871187180f7987c
+    public function count(int $mode = 0): int  {}
+#else
+    public function count(): int  {}
+#endif
+
+    public function getPixelIterator(): ImagickPixelIterator  {}
+
+    public function getPixelRegionIterator(int $x, int $y, int $columns, int $rows): ImagickPixelIterator  {}
+
+    public function readImage(string $filename): bool  {}
+
+    public function readImages(array $filenames): bool  {}
+
+    public function readImageBlob(string $image, ?string $filename = null): bool  {}
+
+    public function setImageFormat(string $format): bool  {}
+
+    public function scaleImage(int $columns, int $rows, bool $bestfit = false, bool $legacy = false): bool  {}
+
+    public function writeImage(?string $filename = null): bool  {}
+
+    public function writeImages(string $filename, bool $adjoin): bool  {}
+
+    // CHANNEL_
+    public function blurImage(float $radius, float $sigma, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function thumbnailImage(
+        ?int $columns,
+        ?int $rows,
+        bool $bestfit = false,
+        bool $fill = false,
+        bool $legacy = false): bool {}
+
+    public function cropThumbnailImage(int $width, int $height, bool $legacy = false): bool  {}
+
+    public function getImageFilename(): string  {}
+
+    public function setImageFilename(string $filename): bool  {}
+
+    public function getImageFormat(): string  {}
+
+    public function getImageMimeType(): string  {}
+
+    public function removeImage(): bool  {}
+
+    /** @alias Imagick::clear */
+    public function destroy(): bool  {}
+
+    public function clear(): bool  {}
+
+    public function clone(): Imagick  {}
+        
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function getImageSize(): int  {}
+#endif
+#endif
+
+    public function getImageBlob(): string  {}
+
+    public function getImagesBlob(): string  {}
+
+    public function setFirstIterator(): bool  {}
+
+    public function setLastIterator(): bool  {}
+
+    public function resetIterator(): void {}
+
+    public function previousImage(): bool  {}
+
+    public function nextImage(): bool  {}
+
+    public function hasPreviousImage(): bool  {}
+
+    public function hasNextImage(): bool  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function setImageIndex(int $index): bool  {}
+
+    /** @deprecated */
+    public function getImageIndex(): int  {}
+#endif
+#endif
+
+    public function commentImage(string $comment): bool  {}
+
+    public function cropImage(int $width, int $height, int $x, int $y): bool  {}
+
+    public function labelImage(string $label): bool  {}
+
+    public function getImageGeometry(): array  {}
+
+    public function drawImage(ImagickDraw $drawing): bool  {}
+
+    public function setImageCompressionQuality(int $quality): bool  {}
+
+    public function getImageCompressionQuality(): int  {}
+
+    public function setImageCompression(int $compression): bool  {}
+
+    public function getImageCompression(): int  {}
+
+    public function annotateImage(
+        ImagickDraw $settings,
+        float $x,
+        float $y,
+        float $angle,
+        string $text
+    ): bool  {}
+
+    public function compositeImage(
+        Imagick $composite_image,
+        int $composite,
+        int $x,
+        int $y,
+        int $channel = Imagick::CHANNEL_DEFAULT): bool{}
+
+    public function modulateImage(float $brightness, float $saturation, float $hue): bool  {}
+
+    public function getImageColors(): int  {}
+
+
+
+    /**
+     * @param ImagickDraw $settings
+     * @param string $tile_geometry  e.g. "3x2+0+0"
+     * @param string $thumbnail_geometry e.g. "200x160+3+3>"
+     * @param int $monatgemode // MONTAGEMODE_
+     * @param string $frame // "10x10+2+2"
+     * @return Imagick
+     */
+    public function montageImage(
+        ImagickDraw $settings,
+        string $tile_geometry,
+        string $thumbnail_geometry,
+        int $monatgemode,
+        string $frame
+    ): Imagick {}
+
+    public function identifyImage(bool $append_raw_output = false): array  {}
+
+    public function thresholdImage(float $threshold, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function adaptiveThresholdImage(int $width, int $height, int $offset): bool  {}
+
+    public function blackThresholdImage(ImagickPixel|string $threshold_color): bool  {}
+
+    public function whiteThresholdImage(ImagickPixel|string $threshold_color): bool  {}
+
+    public function appendImages(bool $stack): Imagick  {}
+
+    public function charcoalImage(float $radius, float $sigma): bool  {}
+
+    public function normalizeImage(int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function oilPaintImage(float $radius): bool  {}
+
+    public function posterizeImage(int $levels, bool $dither): bool  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function radialBlurImage(float $angle, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+#endif
+#endif
+
+    public function raiseImage(int $width, int $height, int $x, int $y, bool $raise): bool  {}
+
+    public function resampleImage(float $x_resolution, float $y_resolution, int $filter, float $blur): bool  {}
+
+    public function resizeImage(
+        int $columns,
+        int $rows,
+        int $filter,
+        float $blur,
+        bool $bestfit = false,
+        bool $legacy = false): bool {}
+
+    public function rollImage(int $x, int $y): bool  {}
+
+    public function rotateImage(ImagickPixel|string $background_color, float $degrees): bool  {}
+
+    public function sampleImage(int $columns, int $rows): bool  {}
+
+    public function solarizeImage(int $threshold): bool  {}
+
+    public function shadowImage(float $opacity, float $sigma, int $x, int $y): bool  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function setImageAttribute(string $key, string $value): bool  {}
+#endif
+#endif
+
+    public function setImageBackgroundColor(ImagickPixel|string $background_color): bool  {}
+
+#if MagickLibVersion >= 0x700
+    public function setImageChannelMask(int $channel): int {}
+#endif
+
+    public function setImageCompose(int $compose): bool  {}
+
+    public function setImageDelay(int $delay): bool  {}
+
+    public function setImageDepth(int $depth): bool  {}
+
+    public function setImageGamma(float $gamma): bool  {}
+
+    public function setImageIterations(int $iterations): bool  {}
+
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function setImageMatteColor(ImagickPixel|string $matte_color): bool  {}
+#endif
+
+    public function setImagePage(int $width, int $height, int $x, int $y): bool  {}
+
+    // TODO test this.
+    public function setImageProgressMonitor(string $filename): bool {}
+
+#if MagickLibVersion > 0x653
+    public function setProgressMonitor(callable $callback): bool  {}
+#endif
+
+    public function setImageResolution(float $x_resolution, float $y_resolution): bool  {}
+
+    // I have no idea what scene does.
+    public function setImageScene(int $scene): bool  {}
+
+    public function setImageTicksPerSecond(int $ticks_per_second): bool  {}
+
+    // IMGTYPE_*
+    public function setImageType(int $image_type): bool  {}
+
+    public function setImageUnits(int $units): bool  {}
+
+    public function sharpenImage(float $radius, float $sigma, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function shaveImage(int $columns, int $rows): bool  {}
+
+    public function shearImage(ImagickPixel|string $background_color, float $x_shear, float $y_shear): bool  {}
+
+    public function spliceImage(int $width, int $height, int $x, int $y): bool  {}
+
+    public function pingImage(string $filename): bool  {}
+
+    public function readImageFile(resource $filehandle, ?string $filename = null): bool  {}
+
+    public function displayImage(string $servername): bool  {}
+
+    public function displayImages(string $servername): bool  {}
+
+    public function spreadImage(float $radius): bool  {}
+
+    public function swirlImage(float $degrees): bool  {}
+
+    public function stripImage(): bool  {}
+
+    public static function queryFormats(string $pattern = "*"): array  {}
+
+    public static function queryFonts(string $pattern = "*"): array  {}
+
+    /* TODO  $multiline == null,  means we should autodetect */
+    public function queryFontMetrics(ImagickDraw $settings, string $text, ?bool $multiline = null): array  {}
+
+    public function steganoImage(Imagick $watermark, int $offset): Imagick  {}
+
+    // NOISE_*
+    public function addNoiseImage(int $noise, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function motionBlurImage(
+        float $radius,
+        float $sigma,
+        float $angle,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ):bool {}
+
+#if MagickLibVersion < 0x700
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+    /** @deprecated */
+    public function mosaicImages(): Imagick  {}
+#endif
+#endif
+
+    public function morphImages(int $number_frames): Imagick  {}
+
+    public function minifyImage(): bool  {}
+
+    public function affineTransformImage(ImagickDraw $settings): bool  {}
+
+#if MagickLibVersion < 0x700
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+    /** @deprecated */
+    public function averageImages(): Imagick  {}
+#endif
+#endif
+
+    public function borderImage(ImagickPixel|string $border_color, int $width, int $height): bool  {}
+
+    public static function calculateCrop(
+        int $original_width,
+        int $original_height,
+        int $desired_width,
+        int $desired_height,
+        bool $legacy = false): array {}
+
+    public function chopImage(int $width, int $height, int $x, int $y): bool  {}
+
+    public function clipImage(): bool  {}
+
+    public function clipPathImage(string $pathname, bool $inside): bool  {}
+
+    /* clippathimage has been deprecated. Create alias here and use the newer API function if present */
+    /** @alias Imagick::clipPathImage */
+    public function clipImagePath(string $pathname, bool $inside): void  {}
+
+    public function coalesceImages(): Imagick  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function colorFloodfillImage(
+        ImagickPixel|string $fill_color,
+        float $fuzz,
+        ImagickPixel|string $border_color,
+        int $x,
+        int $y
+    ): bool  {}
+#endif
+#endif
+
+    // TODO - opacity is actually float if legacy is true...
+    public function colorizeImage(
+        ImagickPixel|string $colorize_color,
+        ImagickPixel|string|false $opacity_color,
+        ?bool $legacy = false ): bool  {}
+
+    public function compareImageChannels(Imagick $reference, int $channel, int $metric): array  {}
+
+    public function compareImages(Imagick $reference, int $metric): array  {}
+
+    public function contrastImage(bool $sharpen): bool  {}
+
+    public function combineImages(int $colorspace): Imagick  {}
+
+    // kernel is a 2d array of float values
+    public function convolveImage(array $kernel, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function cycleColormapImage(int $displace): bool  {}
+
+    public function deconstructImages(): Imagick  {}
+
+    public function despeckleImage(): bool  {}
+
+    public function edgeImage(float $radius): bool  {}
+
+    public function embossImage(float $radius, float $sigma): bool  {}
+
+    public function enhanceImage(): bool  {}
+
+    public function equalizeImage(): bool  {}
+
+    // EVALUATE_*
+    public function evaluateImage(int $evaluate, float $constant, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+#if MagickLibVersion >= 0x687
+//	Merge multiple images of the same size together with the selected operator.
+//http://www.imagemagick.org/Usage/layers/#evaluate-sequence
+
+    // EVALUATE_*
+    public function evaluateImages(int $evaluate): bool {}
+
+#endif
+
+#if MagickLibVersion < 0x700
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+    /** @deprecated */
+    public function flattenImages(): Imagick  {}
+#endif
+#endif
+    public function flipImage(): bool  {}
+
+    public function flopImage(): bool  {}
+
+#if MagickLibVersion >= 0x655
+    public function forwardFourierTransformImage(bool $magnitude): bool  {}
+#endif
+
+    public function frameImage(
+        ImagickPixel|string $matte_color,
+        int $width,
+        int $height,
+        int $inner_bevel,
+        int $outer_bevel
+    ): bool  {}
+
+
+    public function fxImage(string $expression, int $channel = Imagick::CHANNEL_DEFAULT): Imagick  {}
+
+    public function gammaImage(float $gamma, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+    public function gaussianBlurImage(float $radius, float $sigma, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+#if MagickLibVersion < 0x700
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+    /** @deprecated */
+    public function getImageAttribute(string $key): string  {}
+#endif
+#endif
+
+    public function getImageBackgroundColor(): ImagickPixel  {}
+
+    public function getImageBluePrimary(): array  {}
+
+    public function getImageBorderColor(): ImagickPixel  {}
+
+    public function getImageChannelDepth(int $channel): int  {}
+
+    public function getImageChannelDistortion(Imagick $reference, int $channel, int $metric): float  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function getImageChannelExtrema(int $channel): array  {}
+#endif
+#endif
+
+    public function getImageChannelMean(int $channel): array  {}
+
+    public function getImageChannelStatistics(): array  {}
+
+    // index - the offset into the image colormap. I have no idea.
+    public function getImageColormapColor(int $index): ImagickPixel  {}
+
+    public function getImageColorspace(): int  {}
+
+    public function getImageCompose(): int  {}
+
+    public function getImageDelay(): int  {}
+
+    public function getImageDepth(): int  {}
+
+    // METRIC_
+    public function getImageDistortion(Imagick $reference, int $metric): float  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function getImageExtrema(): array  {}
+#endif
+#endif
+
+    public function getImageDispose(): int  {}
+
+    public function getImageGamma(): float  {}
+
+    public function getImageGreenPrimary(): array  {}
+
+    public function getImageHeight(): int  {}
+
+    public function getImageHistogram(): array  {}
+
+    public function getImageInterlaceScheme(): int  {}
+
+    public function getImageIterations(): int  {}
+
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function getImageMatteColor(): ImagickPixel  {}
+#endif
+
+    public function getImagePage(): array  {}
+
+    public function getImagePixelColor(int $x, int $y): ImagickPixel  {}
+
+
+#if IM_HAVE_IMAGICK_SETIMAGEPIXELCOLOR
+    // TODO - needs a test.
+    public function setImagePixelColor(int $x, int $y, ImagickPixel|string $color): ImagickPixel  {}
+#endif
+
+    public function getImageProfile(string $name): string  {}
+
+    public function getImageRedPrimary(): array  {}
+
+    public function getImageRenderingIntent(): int  {}
+
+    public function getImageResolution(): array  {}
+
+    public function getImageScene(): int  {}
+
+    public function getImageSignature(): string  {}
+
+    public function getImageTicksPerSecond(): int  {}
+
+    public function getImageType(): int  {}
+
+    public function getImageUnits(): int  {}
+
+    public function getImageVirtualPixelMethod(): int  {}
+
+    public function getImageWhitePoint(): array  {}
+
+    public function getImageWidth(): int  {}
+
+    public function getNumberImages(): int  {}
+
+    public function getImageTotalInkDensity(): float  {}
+
+    public function getImageRegion(int $width, int $height, int $x, int $y): Imagick  {}
+
+    public function implodeImage(float $radius): bool  {}
+
+#if MagickLibVersion >= 0x658
+    // TODO MagickWand *magnitude_wand,MagickWand *phase_wand,
+    public function inverseFourierTransformImage(Imagick $complement, bool $magnitude): bool  {}
+#endif
+
+    public function levelImage(
+        float $black_point,
+        float $gamma,
+        float $white_point,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool    {}
+
+    public function magnifyImage(): bool  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function mapImage(imagick $map, bool $dither): bool  {}
+
+    /** @deprecated */
+    public function matteFloodfillImage(
+        float $alpha,
+        float $fuzz,
+        ImagickPixel|string $border_color,
+        int $x,
+        int $y
+    ): bool  {}
+#endif
+#endif
+
+#if MagickLibVersion < 0x700
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+    /** @deprecated */
+    public function medianFilterImage(float $radius): bool  {}
+#endif
+#endif
+
+    public function negateImage(bool $gray, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function paintOpaqueImage(
+        ImagickPixel|string $target_color,
+        ImagickPixel|string $fill_color,
+        float $fuzz,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool  {}
+
+    /** @deprecated */
+    public function paintTransparentImage(ImagickPixel|string $target_color, float $alpha, float $fuzz): bool  {}
+#endif
+#endif
+
+    // PREVIEW_*
+    public function previewImages(int $preview): bool  {}
+
+    public function profileImage(string $name, string $profile): bool  {}
+
+    public function  quantizeImage(
+        int $number_colors,
+        int $colorspace,
+        int $tree_depth,
+        bool $dither,
+        bool $measure_error
+    ):  bool {}
+
+
+    public function quantizeImages(
+        int $number_colors,
+        int $colorspace,
+        int $tree_depth,
+        bool $dither,
+        bool $measure_error): bool {}
+
+#if !defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function reduceNoiseImage(float $radius): bool  {}
+#endif
+#endif
+
+    public function removeImageProfile(string $name): string  {}
+
+    public function separateImageChannel(int $channel): bool  {}
+
+    public function sepiaToneImage(float $threshold): bool  {}
+
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function setImageBias(float $bias): bool  {}
+
+    /** @deprecated */
+    public function setImageBiasQuantum(string $bias): void  {}
+#endif
+
+    public function setImageBluePrimary(float $x, float $y): bool  {}
+    /* {{{ proto bool Imagick::setImageBluePrimary(float x,float y)
+For IM7 the prototype is
+proto bool Imagick::setImageBluePrimary(float x, float y, float z) */
+
+    public function setImageBorderColor(ImagickPixel|string $border_color): bool  {}
+
+    public function setImageChannelDepth(int $channel, int $depth): bool  {}
+
+    public function setImageColormapColor(int $index, ImagickPixel|string $color): bool  {}
+
+    public function setImageColorspace(int $colorspace): bool  {}
+
+    public function setImageDispose(int $dispose): bool  {}
+
+    public function setImageExtent(int $columns, int $rows): bool  {}
+
+    public function setImageGreenPrimary(float $x, float $y): bool  {}
+
+    // INTERLACE_*
+    public function setImageInterlaceScheme(int $interlace): bool  {}
+
+    public function setImageProfile(string $name, string $profile): bool  {}
+
+    public function setImageRedPrimary(float $x, float $y): bool  {}
+
+    // RENDERINGINTENT
+    public function setImageRenderingIntent(int $rendering_intent): bool  {}
+
+    public function setImageVirtualPixelMethod(int $method): bool  {}
+
+    public function setImageWhitePoint(float $x, float $y): bool  {}
+
+    public function  sigmoidalContrastImage(
+        bool $sharpen,
+        float $alpha,
+        float $beta,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool{}
+
+    // TODO - MagickStereoImage() composites two images and produces a single
+    // image that is the composite of a left and right image of a stereo pair
+    public function stereoImage(Imagick $offset_image): bool  {}
+
+    public function textureImage(Imagick $texture): Imagick  {}
+
+    public function tintImage(
+        ImagickPixel|string $tint_color,
+        ImagickPixel|string $opacity_color,
+        bool $legacy = false
+    ): bool  {}
+
+    public function unsharpMaskImage(
+        float $radius,
+        float $sigma,
+        float $amount,
+        float $threshold,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool {}
+
+    public function getImage(): Imagick  {}
+
+    public function addImage(Imagick $image): bool  {}
+
+    public function setImage(Imagick $image): bool  {}
+
+
+    public function newImage(
+        int $columns,
+        int $rows,
+        ImagickPixel|string $background_color,
+        string $format = null
+    ): bool  {}
+
+    // TODO - canvas? description
+    public function newPseudoImage(int $columns, int $rows, string $pseudo_format): bool  {}
+
+    public function getCompression(): int  {}
+
+    public function getCompressionQuality(): int  {}
+
+    public static function getCopyright(): string  {}
+
+    public static function getConfigureOptions(string $pattern = "*"): string {}
+
+
+#if MagickLibVersion > 0x660
+    public static function getFeatures(): string {}
+#endif
+
+    public function getFilename(): string  {}
+
+    public function getFormat(): string  {}
+
+    public static function getHomeURL(): string  {}
+
+    public function getInterlaceScheme(): int {}
+
+    public function getOption(string $key): string  {}
+
+    public static function getPackageName(): string  {}
+
+    public function getPage(): array  {}
+
+    public static function getQuantum(): int  {}
+
+    public static function getHdriEnabled(): bool {}
+
+    public static function getQuantumDepth(): array  {}
+
+    public static function getQuantumRange(): array  {}
+
+    public static function getReleaseDate(): string  {}
+
+    public static function getResource(int $type): int  {}
+
+    public static function getResourceLimit(int $type): int  {}
+
+    public function getSamplingFactors(): array  {}
+
+    public function getSize(): array  {}
+
+    public static function getVersion(): array  {}
+
+    public function setBackgroundColor(ImagickPixel|string $background_color): bool  {}
+
+    public function setCompression(int $compression): bool  {}
+
+    public function setCompressionQuality(int $quality): bool  {}
+
+    public function setFilename(string $filename): bool  {}
+
+    public function setFormat(string $format): bool  {}
+
+    // INTERLACE_*
+    public function setInterlaceScheme(int $interlace): bool  {}
+
+    public function setOption(string $key, string $value): bool  {}
+
+    public function setPage(int $width, int $height, int $x, int $y): bool  {}
+
+    public static function setResourceLimit(int $type, int $limit): bool  {}
+
+    public function setResolution(float $x_resolution, float $y_resolution): bool  {}
+
+    public function setSamplingFactors(array $factors): bool  {}
+
+    public function setSize(int $columns, int $rows): bool  {}
+
+    // IMGTYPE_*
+    public function setType(int $imgtype): bool  {}
+
+#if MagickLibVersion > 0x628
+    /** @alias Imagick::getIteratorIndex */
+    public function key(): int  {}
+
+//#else
+//# if defined(MAGICKCORE_EXCLUDE_DEPRECATED)
+//#  error "MAGICKCORE_EXCLUDE_DEPRECATED should not be defined with ImageMagick version below 6.2.8"
+//# else
+////    PHP_MALIAS(imagick, key, getimageindex, imagick_zero_args, ZEND_ACC_PUBLIC)
+//        /** @alias Imagick::getImageIndex */
+//    public function key(): int  {}
+//
+//# endif
+//#endif
+
+    /** @alias Imagick::nextImage
+     *  @tentative-return-type
+     */
+    public function next(): void  {}
+
+    /** @alias Imagick::setFirstIterator
+     *  @tentative-return-type
+     */
+    public function rewind(): void  {}
+
+    public function valid(): bool  {}
+
+    public function current(): Imagick  {}
+
+#if MagickLibVersion >= 0x659
+    public function brightnessContrastImage(
+        float $brightness,
+        float $contrast,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool {}
+#endif
+
+#if MagickLibVersion > 0x661
+    public function colorMatrixImage(array $color_matrix): bool  {}
+#endif
+
+    public function selectiveBlurImage(
+        float $radius,
+        float $sigma,
+        float $threshold,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool {}
+
+#if MagickLibVersion >= 0x689
+    public function rotationalBlurImage(float $angle, int $channel = Imagick::CHANNEL_DEFAULT): bool  {}
+#endif
+
+#if MagickLibVersion >= 0x683
+    public function statisticImage(
+        int $type,
+        int $width,
+        int $height,
+        int $channel = Imagick::CHANNEL_DEFAULT
+        ): bool {}
+#endif
+
+#if MagickLibVersion >= 0x652
+    public function subimageMatch(Imagick $image, ?array &$offset = null, ?float &$similarity = null, float $threshold = 0.0, int $metric = 0): Imagick  {}
+
+    /** @alias Imagick::subimageMatch */
+    public function similarityimage(Imagick $image, ?array &$offset = null, ?float &$similarity = null, float $threshold = 0.0, int $metric = 0): Imagick  {}
+#endif
+
+    public static function setRegistry(string $key, string $value): bool  {}
+
+    public static function getRegistry(string $key): string  {}
+
+    public static function listRegistry(): array {}
+
+#if MagickLibVersion >= 0x680
+
+    /**
+     * @param int $morphology MORPHOLOGY_*
+     * @param int $iterations
+     * @param ImagickKernel $kernel
+     * @param int $channel
+     * @return bool
+     */
+    public function morphology(
+        int $morphology,
+        int $iterations,
+        ImagickKernel $kernel,
+        int $channel = Imagick::CHANNEL_DEFAULT
+    ): bool {}
+#endif
+
+#ifdef IMAGICK_WITH_KERNEL
+#if MagickLibVersion < 0x700
+    /** @deprecated */
+    public function filter(ImagickKernel $kernel, int $channel = Imagick::CHANNEL_UNDEFINED): bool  {}
+#endif
+#endif
+
+    public function setAntialias(bool $antialias): void {}
+
+    public function getAntialias(): bool {}
+
+#if MagickLibVersion > 0x676
+    /**
+     * @param string $color_correction_collection
+     * <ColorCorrectionCollection xmlns="urn:ASC:CDL:v1.2">
+     * <ColorCorrection id="cc03345">
+     * <SOPNode>
+     * <Slope> 0.9 1.2 0.5 </Slope>
+     * <Offset> 0.4 -0.5 0.6 </Offset>
+     * <Power> 1.0 0.8 1.5 </Power>
+     * </SOPNode>
+     * <SATNode>
+     * <Saturation> 0.85 </Saturation>
+     * </SATNode>
+     * </ColorCorrection>
+     * </ColorCorrectionCollection>
+     *
+     * @return bool
+     */
+    public function colorDecisionListImage(string $color_correction_collection): bool {}
+#endif
+
+#if MagickLibVersion >= 0x687
+    public function optimizeImageTransparency(): void {}
+#endif
+
+#if MagickLibVersion >= 0x660
+    public function autoGammaImage(?int $channel = Imagick::CHANNEL_ALL): void {}
+#endif
+
+#if MagickLibVersion >= 0x692
+    public function autoOrient(): void {}
+
+    /** @alias Imagick::autoOrient */
+    public function autoOrientate(): void {}
+
+    // COMPOSITE_*
+    public function compositeImageGravity(Imagick $image, int $composite_constant, int $gravity): bool {}
+
+#endif
+
+#if MagickLibVersion >= 0x693
+    public function localContrastImage(float $radius, float $strength): void {}
+#endif
+
+#if MagickLibVersion >= 0x700
+    // Identifies the potential image type, returns one of the Imagick::IMGTYPE_* constants
+    public function identifyImageType(): int {}
+#endif
+
+
+#if IM_HAVE_IMAGICK_GETSETIMAGEMASK
+    // PIXELMASK_*
+    public function getImageMask(int $pixelmask): ?Imagick {}
+
+    // PIXELMASK_*
+    public function setImageMask(Imagick $clip_mask, int $pixelmask): void {}
+#endif
+
+
+    // TODO - needs deleting from docs.
+//    public function getImageMagickLicense(): string  {}
+
+    // TODO - needs deleting from docs.
+//    public function render(): bool  {}
+
+//    public function floodfillPaintImage(
+//        ImagickPixel|string $fill,
+//        float $fuzz,
+//        ImagickPixel|string $bordercolor,
+//        int $x,
+//        int $y,
+//        bool $invert,
+//        int $channel = Imagick::CHANNEL_DEFAULT): null {}
 }

--- a/build/stubs/ldap.php
+++ b/build/stubs/ldap.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @generate-class-entries */
+
 namespace LDAP {
 
     /**
@@ -25,4 +27,200 @@ namespace LDAP {
     final class ResultEntry
     {
     }
+
+}
+
+namespace {
+
+    #ifdef HAVE_ORALDAP
+    function ldap_connect(?string $uri = null, int $port = 389, string $wallet = UNKNOWN, string $password = UNKNOWN, int $auth_mode = GSLC_SSL_NO_AUTH): LDAP\Connection|false {}
+    #else
+    function ldap_connect(?string $uri = null, int $port = 389): LDAP\Connection|false {}
+    #endif
+
+    function ldap_unbind(LDAP\Connection $ldap): bool {}
+
+    /** @alias ldap_unbind */
+    function ldap_close(LDAP\Connection $ldap): bool {}
+
+    function ldap_bind(LDAP\Connection $ldap, ?string $dn = null, ?string $password = null): bool {}
+
+    function ldap_bind_ext(LDAP\Connection $ldap, ?string $dn = null, ?string $password = null, ?array $controls = null): LDAP\Result|false {}
+
+    #ifdef HAVE_LDAP_SASL
+    function ldap_sasl_bind(LDAP\Connection $ldap, ?string $dn = null, ?string $password = null, ?string $mech = null, ?string $realm = null, ?string $authc_id = null, ?string $authz_id = null, ?string $props = null): bool {}
+    #endif
+
+    /** @param LDAP\Connection|array $ldap */
+    function ldap_read($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
+
+    /** @param LDAP\Connection|array $ldap */
+    function ldap_list($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
+
+    /** @param LDAP\Connection|array $ldap */
+    function ldap_search($ldap, array|string $base, array|string $filter, array $attributes = [], int $attributes_only = 0, int $sizelimit = -1, int $timelimit = -1, int $deref = LDAP_DEREF_NEVER, ?array $controls = null): LDAP\Result|array|false {}
+
+    function ldap_free_result(LDAP\Result $result): bool {}
+
+    function ldap_count_entries(LDAP\Connection $ldap, LDAP\Result $result): int {}
+
+    function ldap_first_entry(LDAP\Connection $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
+
+    function ldap_next_entry(LDAP\Connection $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
+
+    /**
+     * @return array<int|string, int|array>|false
+     * @refcount 1
+     */
+    function ldap_get_entries(LDAP\Connection $ldap, LDAP\Result $result): array|false {}
+
+    function ldap_first_attribute(LDAP\Connection $ldap, LDAP\ResultEntry $entry): string|false {}
+
+    function ldap_next_attribute(LDAP\Connection $ldap, LDAP\ResultEntry $entry): string|false {}
+
+    /**
+     * @return array<int|string, int|string|array>
+     * @refcount 1
+     */
+    function ldap_get_attributes(LDAP\Connection $ldap, LDAP\ResultEntry $entry): array {}
+
+    /**
+     * @return array<int|string, int|string>|false
+     * @refcount 1
+     */
+    function ldap_get_values_len(LDAP\Connection $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
+
+    /**
+     * @return array<int|string, int|string>|false
+     * @refcount 1
+     * @alias ldap_get_values_len
+     */
+    function ldap_get_values(LDAP\Connection $ldap, LDAP\ResultEntry $entry, string $attribute): array|false {}
+
+    function ldap_get_dn(LDAP\Connection $ldap, LDAP\ResultEntry $entry): string|false {}
+
+    /**
+     * @return array<int|string, int|string>|false
+     * @refcount 1
+     */
+    function ldap_explode_dn(string $dn, int $with_attrib): array|false {}
+
+    function ldap_dn2ufn(string $dn): string|false {}
+
+    function ldap_add(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+
+    function ldap_add_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+
+    function ldap_delete(LDAP\Connection $ldap, string $dn, ?array $controls = null): bool {}
+
+    function ldap_delete_ext(LDAP\Connection $ldap, string $dn, ?array $controls = null): LDAP\Result|false {}
+
+    function ldap_modify_batch(LDAP\Connection $ldap, string $dn, array $modifications_info, ?array $controls = null): bool {}
+
+    function ldap_mod_add(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+
+    function ldap_mod_add_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+
+    function ldap_mod_replace(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+
+    /** @alias ldap_mod_replace */
+    function ldap_modify(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+
+    function ldap_mod_replace_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+
+    function ldap_mod_del(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): bool {}
+
+    function ldap_mod_del_ext(LDAP\Connection $ldap, string $dn, array $entry, ?array $controls = null): LDAP\Result|false {}
+
+    function ldap_errno(LDAP\Connection $ldap): int {}
+
+    function ldap_error(LDAP\Connection $ldap): string {}
+
+    function ldap_err2str(int $errno): string {}
+
+    function ldap_compare(LDAP\Connection $ldap, string $dn, string $attribute, string $value, ?array $controls = null): bool|int {}
+
+    #if (LDAP_API_VERSION > 2000) || defined(HAVE_ORALDAP)
+    function ldap_rename(LDAP\Connection $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): bool {}
+
+    function ldap_rename_ext(LDAP\Connection $ldap, string $dn, string $new_rdn, string $new_parent, bool $delete_old_rdn, ?array $controls = null): LDAP\Result|false {}
+
+    /** @param array|string|int $value */
+    function ldap_get_option(LDAP\Connection $ldap, int $option, &$value = null): bool {}
+
+    /** @param array|string|int|bool $value */
+    function ldap_set_option(?LDAP\Connection $ldap, int $option, $value): bool {}
+
+    function ldap_count_references(LDAP\Connection $ldap, LDAP\Result $result): int {}
+
+    function ldap_first_reference(LDAP\Connection $ldap, LDAP\Result $result): LDAP\ResultEntry|false {}
+
+    function ldap_next_reference(LDAP\Connection $ldap, LDAP\ResultEntry $entry): LDAP\ResultEntry|false {}
+
+    #ifdef HAVE_LDAP_PARSE_REFERENCE
+    /** @param array $referrals */
+    function ldap_parse_reference(LDAP\Connection $ldap, LDAP\ResultEntry $entry, &$referrals): bool {}
+    #endif
+
+    #ifdef HAVE_LDAP_PARSE_RESULT
+    /**
+     * @param int $error_code
+     * @param string $matched_dn
+     * @param string $error_message
+     * @param array $referrals
+     * @param array $controls
+     */
+    function ldap_parse_result(LDAP\Connection $ldap, LDAP\Result $result, &$error_code, &$matched_dn = null, &$error_message = null, &$referrals = null, &$controls = null): bool {}
+    #endif
+    #endif
+
+    #if defined(LDAP_API_FEATURE_X_OPENLDAP) && defined(HAVE_3ARG_SETREBINDPROC)
+    function ldap_set_rebind_proc(LDAP\Connection $ldap, ?callable $callback): bool {}
+    #endif
+
+    #ifdef HAVE_LDAP_START_TLS_S
+    function ldap_start_tls(LDAP\Connection $ldap): bool {}
+    #endif
+
+    function ldap_escape(string $value, string $ignore = "", int $flags = 0): string {}
+
+    #ifdef STR_TRANSLATION
+    function ldap_t61_to_8859(string $value): string|false {}
+
+    function ldap_8859_to_t61(string $value): string|false {}
+    #endif
+
+
+    #ifdef HAVE_LDAP_EXTENDED_OPERATION_S
+    /**
+     * @param string $response_data
+     * @param string $response_oid
+     */
+    function ldap_exop(LDAP\Connection $ldap, string $request_oid, ?string $request_data = null, ?array $controls = NULL, &$response_data = UNKNOWN, &$response_oid = null): LDAP\Result|bool {}
+    #endif
+
+    #ifdef HAVE_LDAP_PASSWD
+    /**
+     * @param array $controls
+     */
+    function ldap_exop_passwd(LDAP\Connection $ldap, string $user = "", string $old_password = "", string $new_password = "", &$controls = null): string|bool {}
+    #endif
+
+
+    #ifdef HAVE_LDAP_WHOAMI_S
+    function ldap_exop_whoami(LDAP\Connection $ldap): string|false {}
+    #endif
+
+    #ifdef HAVE_LDAP_REFRESH_S
+    function ldap_exop_refresh(LDAP\Connection $ldap, string $dn, int $ttl): int|false {}
+    #endif
+
+    #ifdef HAVE_LDAP_PARSE_EXTENDED_RESULT
+    /**
+     * @param string $response_data
+     * @param string $response_oid
+     */
+    function ldap_parse_exop(LDAP\Connection $ldap, LDAP\Result $result, &$response_data = null, &$response_oid = null): bool {}
+    #endif
+
 }

--- a/lib/private/Avatar/Avatar.php
+++ b/lib/private/Avatar/Avatar.php
@@ -151,6 +151,7 @@ abstract class Avatar implements IAvatar {
 
 	/**
 	 * Generate png avatar with GD
+	 * @throws \Exception when an error occurs in gd calls
 	 */
 	protected function generateAvatar(string $userDisplayName, int $size, bool $darkTheme): string {
 		$text = $this->getAvatarText();
@@ -158,6 +159,9 @@ abstract class Avatar implements IAvatar {
 		$backgroundColor = $textColor->alphaBlending(0.1, $darkTheme ? new Color(0, 0, 0) : new Color(255, 255, 255));
 
 		$im = imagecreatetruecolor($size, $size);
+		if ($im === false) {
+			throw new \Exception('Failed to create avatar image');
+		}
 		$background = imagecolorallocate(
 			$im,
 			$backgroundColor->red(),
@@ -169,6 +173,9 @@ abstract class Avatar implements IAvatar {
 			$textColor->green(),
 			$textColor->blue()
 		);
+		if ($background === false || $textColor === false) {
+			throw new \Exception('Failed to create avatar image color');
+		}
 		imagefilledrectangle($im, 0, 0, $size, $size, $background);
 
 		$font = __DIR__ . '/../../../core/fonts/NotoSans-Regular.ttf';
@@ -191,7 +198,7 @@ abstract class Avatar implements IAvatar {
 	/**
 	 * Calculate real image ttf center
 	 *
-	 * @param resource $image
+	 * @param \GdImage $image
 	 * @param string $text text string
 	 * @param string $font font path
 	 * @param int $size font size

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -59,7 +59,7 @@ class OC_Image implements \OCP\IImage {
 	// Default quality for webp images
 	protected const DEFAULT_WEBP_QUALITY = 80;
 
-	/** @var false|resource|\GdImage */
+	/** @var false|\GdImage */
 	protected $resource = false; // tmp resource.
 	/** @var int */
 	protected $imageType = IMAGETYPE_PNG; // Default to png if file type isn't evident.
@@ -67,20 +67,20 @@ class OC_Image implements \OCP\IImage {
 	protected $mimeType = 'image/png'; // Default to png
 	/** @var null|string */
 	protected $filePath = null;
-	/** @var finfo */
-	private $fileInfo;
+	/** @var ?finfo */
+	private $fileInfo = null;
 	/** @var \OCP\ILogger */
 	private $logger;
 	/** @var \OCP\IConfig */
 	private $config;
-	/** @var array */
-	private $exif;
+	/** @var ?array */
+	private $exif = null;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param resource|string|\GdImage $imageRef The path to a local file, a base64 encoded string or a resource created by
-	 * an imagecreate* function.
+	 * @param mixed $imageRef Deprecated, should be null
+	 * @psalm-assert null $imageRef
 	 * @param \OCP\ILogger $logger
 	 * @param \OCP\IConfig $config
 	 * @throws \InvalidArgumentException in case the $imageRef parameter is not null
@@ -107,11 +107,11 @@ class OC_Image implements \OCP\IImage {
 	/**
 	 * Determine whether the object contains an image resource.
 	 *
+	 * @psalm-assert-if-true \GdImage $this->resource
 	 * @return bool
 	 */
 	public function valid(): bool {
-		if ((is_resource($this->resource) && get_resource_type($this->resource) === 'gd') ||
-			(is_object($this->resource) && get_class($this->resource) === \GdImage::class)) {
+		if (is_object($this->resource) && get_class($this->resource) === \GdImage::class) {
 			return true;
 		}
 
@@ -134,10 +134,7 @@ class OC_Image implements \OCP\IImage {
 	 */
 	public function width(): int {
 		if ($this->valid()) {
-			$width = imagesx($this->resource);
-			if ($width !== false) {
-				return $width;
-			}
+			return imagesx($this->resource);
 		}
 		return -1;
 	}
@@ -149,10 +146,7 @@ class OC_Image implements \OCP\IImage {
 	 */
 	public function height(): int {
 		if ($this->valid()) {
-			$height = imagesy($this->resource);
-			if ($height !== false) {
-				return $height;
-			}
+			return imagesy($this->resource);
 		}
 		return -1;
 	}
@@ -338,25 +332,14 @@ class OC_Image implements \OCP\IImage {
 	}
 
 	/**
-	 * @param resource|\GdImage $resource
-	 * @throws \InvalidArgumentException in case the supplied resource does not have the type "gd"
+	 * @param \GdImage $resource
 	 */
-	public function setResource($resource) {
-		// For PHP<8
-		if (is_resource($resource) && get_resource_type($resource) === 'gd') {
-			$this->resource = $resource;
-			return;
-		}
-		// PHP 8 has real objects for GD stuff
-		if (is_object($resource) && get_class($resource) === \GdImage::class) {
-			$this->resource = $resource;
-			return;
-		}
-		throw new \InvalidArgumentException('Supplied resource is not of type "gd".');
+	public function setResource(\GdImage $resource): void {
+		$this->resource = $resource;
 	}
 
 	/**
-	 * @return false|resource|\GdImage Returns the image resource if any
+	 * @return false|\GdImage Returns the image resource if any
 	 */
 	public function resource() {
 		return $this->resource;
@@ -394,8 +377,7 @@ class OC_Image implements \OCP\IImage {
 				$res = imagepng($this->resource);
 				break;
 			case "image/jpeg":
-				/** @psalm-suppress InvalidScalarArgument */
-				imageinterlace($this->resource, (PHP_VERSION_ID >= 80000 ? true : 1));
+				imageinterlace($this->resource, true);
 				$quality = $this->getJpegQuality();
 				$res = imagejpeg($this->resource, null, $quality);
 				break;
@@ -584,7 +566,7 @@ class OC_Image implements \OCP\IImage {
 	 * It is the responsibility of the caller to position the pointer at the correct place and to close the handle again.
 	 *
 	 * @param resource $handle
-	 * @return resource|\GdImage|false An image resource or false on error
+	 * @return \GdImage|false An image resource or false on error
 	 */
 	public function loadFromFileHandle($handle) {
 		$contents = stream_get_contents($handle);
@@ -663,7 +645,7 @@ class OC_Image implements \OCP\IImage {
 	 * Loads an image from a local file.
 	 *
 	 * @param bool|string $imagePath The path to a local file.
-	 * @return bool|resource|\GdImage An image resource or false on error
+	 * @return bool|\GdImage An image resource or false on error
 	 */
 	public function loadFromFile($imagePath = false) {
 		// exif_imagetype throws "read error!" if file is less than 12 byte
@@ -801,7 +783,7 @@ class OC_Image implements \OCP\IImage {
 	 * Loads an image from a string of data.
 	 *
 	 * @param string $str A string of image data as read from a file.
-	 * @return bool|resource|\GdImage An image resource or false on error
+	 * @return bool|\GdImage An image resource or false on error
 	 */
 	public function loadFromData(string $str) {
 		if (!$this->checkImageDataSize($str)) {
@@ -827,7 +809,7 @@ class OC_Image implements \OCP\IImage {
 	 * Loads an image from a base64 encoded string.
 	 *
 	 * @param string $str A string base64 encoded string of image data.
-	 * @return bool|resource|\GdImage An image resource or false on error
+	 * @return bool|\GdImage An image resource or false on error
 	 */
 	public function loadFromBase64(string $str) {
 		$data = base64_decode($str);
@@ -868,7 +850,7 @@ class OC_Image implements \OCP\IImage {
 
 	/**
 	 * @param $maxSize
-	 * @return resource|bool|\GdImage
+	 * @return bool|\GdImage
 	 */
 	private function resizeNew(int $maxSize) {
 		if (!$this->valid()) {
@@ -909,7 +891,7 @@ class OC_Image implements \OCP\IImage {
 	/**
 	 * @param int $width
 	 * @param int $height
-	 * @return resource|bool|\GdImage
+	 * @return bool|\GdImage
 	 */
 	public function preciseResizeNew(int $width, int $height) {
 		if (!($width > 0) || !($height > 0)) {
@@ -985,13 +967,13 @@ class OC_Image implements \OCP\IImage {
 
 		// preserve transparency
 		if ($this->imageType == IMAGETYPE_GIF or $this->imageType == IMAGETYPE_PNG) {
-			imagecolortransparent($process, imagecolorallocatealpha($process, 0, 0, 0, 127));
+			imagecolortransparent($process, imagecolorallocatealpha($process, 0, 0, 0, 127) ?: null);
 			imagealphablending($process, false);
 			imagesavealpha($process, true);
 		}
 
-		imagecopyresampled($process, $this->resource, 0, 0, $x, $y, $targetWidth, $targetHeight, $width, $height);
-		if ($process === false) {
+		$result = imagecopyresampled($process, $this->resource, 0, 0, $x, $y, $targetWidth, $targetHeight, $width, $height);
+		if ($result === false) {
 			$this->logger->debug('OC_Image->centerCrop, Error re-sampling process image ' . $width . 'x' . $height, ['app' => 'core']);
 			return false;
 		}
@@ -1027,7 +1009,7 @@ class OC_Image implements \OCP\IImage {
 	 * @param int $y Vertical position
 	 * @param int $w Width
 	 * @param int $h Height
-	 * @return resource|\GdImage|false
+	 * @return \GdImage|false
 	 */
 	public function cropNew(int $x, int $y, int $w, int $h) {
 		if (!$this->valid()) {
@@ -1042,13 +1024,13 @@ class OC_Image implements \OCP\IImage {
 
 		// preserve transparency
 		if ($this->imageType == IMAGETYPE_GIF or $this->imageType == IMAGETYPE_PNG) {
-			imagecolortransparent($process, imagecolorallocatealpha($process, 0, 0, 0, 127));
+			imagecolortransparent($process, imagecolorallocatealpha($process, 0, 0, 0, 127) ?: null);
 			imagealphablending($process, false);
 			imagesavealpha($process, true);
 		}
 
-		imagecopyresampled($process, $this->resource, 0, 0, $x, $y, $w, $h, $w, $h);
-		if ($process === false) {
+		$result = imagecopyresampled($process, $this->resource, 0, 0, $x, $y, $w, $h, $w, $h);
+		if ($result === false) {
 			$this->logger->debug(__METHOD__ . '(): Error re-sampling process image ' . $w . 'x' . $h, ['app' => 'core']);
 			return false;
 		}

--- a/lib/public/IStreamImage.php
+++ b/lib/public/IStreamImage.php
@@ -28,6 +28,7 @@ namespace OCP;
  */
 interface IStreamImage extends IImage {
 	/**
+	 * @since 24.0.0
 	 * @return false|resource Returns the image resource if any
 	 */
 	public function resource();

--- a/lib/public/IStreamImage.php
+++ b/lib/public/IStreamImage.php
@@ -27,4 +27,8 @@ namespace OCP;
  * @since 24.0.0
  */
 interface IStreamImage extends IImage {
+	/**
+	 * @return false|resource Returns the image resource if any
+	 */
+	public function resource();
 }


### PR DESCRIPTION
## Summary

In PHP>=8.1, LDAP and FTP resources are always typed objects

## TODO

- [x] Wait for https://github.com/nextcloud/server/pull/44607 and rebase
- [x] Update stubs for gd and ftp
- [x] Remove references to gd resource as well

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
