### PR TITLE
fix(DateTimeFormatter): Adjust invalid doc blocks

### DIFF
--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -136,14 +136,13 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * Gives the relative date of the timestamp
 	 * Only works for past dates
 	 *
-	 * @param int|\DateTime	$timestamp	Either a Unix timestamp or DateTime object
+	 * @param int|\DateTime	$timestamp		Either a Unix timestamp or DateTime object
 	 * @param int|\DateTime	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
-	 * @return string	Dates returned are:
+	 * @param \OCP\IL10N $l				The locale to use
+	 * @return string Formatted date span. Dates returned are:
 	 * 				<  1 month	=> Today, Yesterday, n days ago
 	 * 				< 13 month	=> last month, n months ago
 	 * 				>= 13 month	=> last year, n years ago
-	 * @param \OCP\IL10N	$l			The locale to use
-	 * @return string Formatted date span
 	 */
 	public function formatDateSpan($timestamp, $baseTimestamp = null, ?\OCP\IL10N $l = null) {
 		$l = $this->getLocale($l);
@@ -220,15 +219,14 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 *
 	 * @param int|\DateTime	$timestamp	Either a Unix timestamp or DateTime object
 	 * @param int|\DateTime	$baseTimestamp	Timestamp to compare $timestamp against, defaults to current time
-	 * @return string	Dates returned are:
+	 * @param \OCP\IL10N	$l			The locale to use
+	 * @return string Formatted time span. Dates returned are:
 	 * 				< 60 sec	=> seconds ago
 	 * 				<  1 hour	=> n minutes ago
 	 * 				<  1 day	=> n hours ago
 	 * 				<  1 month	=> Yesterday, n days ago
 	 * 				< 13 month	=> last month, n months ago
 	 * 				>= 13 month	=> last year, n years ago
-	 * @param \OCP\IL10N	$l			The locale to use
-	 * @return string Formatted time span
 	 */
 	public function formatTimeSpan($timestamp, $baseTimestamp = null, ?\OCP\IL10N $l = null) {
 		$l = $this->getLocale($l);


### PR DESCRIPTION
## Summary

Noticed this in the psalm baseline, we can fix this easily so :broom: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
