### PR TITLE
occ: Improve `user:lastseen` timestamp

### DIFF
--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -49,9 +49,6 @@ class Info extends Base {
 
 		$groups = $this->groupManager->getUserGroupIds($user);
 
-		if (ini_get('date.timezone')) {
-			date_default_timezone_set(ini_get('date.timezone'));
-		}
 		if ($user->getLastLogin() == 0) {
 			$lastseen = "never";
 		} else {

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -56,7 +56,7 @@ class Info extends Base {
 			'groups' => $groups,
 			'quota' => $user->getQuota(),
 			'storage' => $this->getStorageInfo($user),
-			'last_seen' => date(\DateTimeInterface::ATOM, $user->getLastLogin()), // ISO-8601
+			'last_seen' => date('Y-m-d H:i:s T', $user->getLastLogin()),
 			'user_directory' => $user->getHome(),
 			'backend' => $user->getBackendClassName()
 		];

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -46,12 +46,18 @@ class Info extends Base {
 			$output->writeln('<error>user not found</error>');
 			return 1;
 		}
+
 		$groups = $this->groupManager->getUserGroupIds($user);
+
+		if (ini_get('date.timezone')) {
+			date_default_timezone_set(ini_get('date.timezone'));
+		}
 		if ($user->getLastLogin() == 0) {
 			$lastseen = "never";
 		} else {
 			$lastseen = date('Y-m-d H:i:s T', $user->getLastLogin());
 		}
+
 		$data = [
 			'user_id' => $user->getUID(),
 			'display_name' => $user->getDisplayName(),
@@ -65,6 +71,7 @@ class Info extends Base {
 			'user_directory' => $user->getHome(),
 			'backend' => $user->getBackendClassName()
 		];
+
 		$this->writeArrayInOutputFormat($input, $output, $data);
 		return 0;
 	}

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -46,15 +46,7 @@ class Info extends Base {
 			$output->writeln('<error>user not found</error>');
 			return 1;
 		}
-
 		$groups = $this->groupManager->getUserGroupIds($user);
-
-		if ($user->getLastLogin() == 0) {
-			$lastseen = "never";
-		} else {
-			$lastseen = date('Y-m-d H:i:s T', $user->getLastLogin());
-		}
-
 		$data = [
 			'user_id' => $user->getUID(),
 			'display_name' => $user->getDisplayName(),
@@ -64,11 +56,10 @@ class Info extends Base {
 			'groups' => $groups,
 			'quota' => $user->getQuota(),
 			'storage' => $this->getStorageInfo($user),
-			'last_seen' => $lastseen,
+			'last_seen' => date(\DateTimeInterface::ATOM, $user->getLastLogin()), // ISO-8601
 			'user_directory' => $user->getHome(),
 			'backend' => $user->getBackendClassName()
 		];
-
 		$this->writeArrayInOutputFormat($input, $output, $data);
 		return 0;
 	}

--- a/core/Command/User/Info.php
+++ b/core/Command/User/Info.php
@@ -47,6 +47,11 @@ class Info extends Base {
 			return 1;
 		}
 		$groups = $this->groupManager->getUserGroupIds($user);
+		if ($user->getLastLogin() == 0) {
+			$lastseen = "never";
+		} else {
+			$lastseen = date('Y-m-d H:i:s T', $user->getLastLogin());
+		}
 		$data = [
 			'user_id' => $user->getUID(),
 			'display_name' => $user->getDisplayName(),
@@ -56,7 +61,7 @@ class Info extends Base {
 			'groups' => $groups,
 			'quota' => $user->getQuota(),
 			'storage' => $this->getStorageInfo($user),
-			'last_seen' => date('Y-m-d H:i:s T', $user->getLastLogin()),
+			'last_seen' => $lastseen,
 			'user_directory' => $user->getHome(),
 			'backend' => $user->getBackendClassName()
 		];

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -43,6 +43,11 @@ class LastSeen extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$singleUserId = $input->getArgument('uid');
+
+		if (ini_get('date.timezone')) {
+			date_default_timezone_set(ini_get('date.timezone'));
+		}
+
 		if ($singleUserId) {
 			$user = $this->userManager->get($singleUserId);
 			if (is_null($user)) {

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -56,7 +56,7 @@ class LastSeen extends Base {
 			} else {
 				$date = new \DateTime();
 				$date->setTimestamp($lastLogin);
-				$output->writeln($user->getUID() . "'s last login: " . $date->format('Y-m-d H:i'));
+				$output->writeln($user->getUID() . "'s last login: " . $date->format('Y-m-d H:i:s T'));
 			}
 
 			return 0;
@@ -74,7 +74,7 @@ class LastSeen extends Base {
 			} else {
 				$date = new \DateTime();
 				$date->setTimestamp($lastLogin);
-				$output->writeln($user->getUID() . "'s last login: " . $date->format('Y-m-d H:i'));
+				$output->writeln($user->getUID() . "'s last login: " . $date->format('Y-m-d H:i:s T'));
 			}
 		});
 		return 0;

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -44,10 +44,6 @@ class LastSeen extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$singleUserId = $input->getArgument('uid');
 
-		if (ini_get('date.timezone')) {
-			date_default_timezone_set(ini_get('date.timezone'));
-		}
-
 		if ($singleUserId) {
 			$user = $this->userManager->get($singleUserId);
 			if (is_null($user)) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/44641

## Summary


## TODO

- [x] Decide whether to display times always in UTC or pull Timezone from `php.ini` setting
- [x] Fix bug in `user:info` where last login is zero (don't show Unix epoch time)

## Checklist

- [X] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [X] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
