### PR TITLE
fix(session): Do not update authtoken last_check for passwordless

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -767,8 +767,6 @@ class Session implements IUserSession, Emitter {
 				return false;
 			}
 
-			$dbToken->setLastCheck($now);
-			$this->tokenProvider->updateToken($dbToken);
 			return true;
 		}
 

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -11,9 +11,11 @@ namespace Test\User;
 use OC\AppFramework\Http\Request;
 use OC\Authentication\Events\LoginFailed;
 use OC\Authentication\Exceptions\InvalidTokenException;
+use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
+use OC\Authentication\Token\PublicKeyToken;
 use OC\Security\CSRF\CsrfTokenManager;
 use OC\Session\Memory;
 use OC\User\LoginException;
@@ -35,6 +37,8 @@ use OCP\Security\ISecureRandom;
 use OCP\User\Events\PostLoginEvent;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
+use function array_diff;
+use function get_class_methods;
 
 /**
  * @group DB
@@ -307,6 +311,80 @@ class SessionTest extends \Test\TestCase {
 			->method('dispatch');
 
 		$userSession->login('foo', 'bar');
+	}
+
+	public function testPasswordlessLoginNoLastCheckUpdate(): void {
+		$session = $this->getMockBuilder(Memory::class)->setConstructorArgs([''])->getMock();
+		$managerMethods = get_class_methods(Manager::class);
+		// Keep following methods intact in order to ensure hooks are working
+		$mockedManagerMethods = array_diff($managerMethods, ['__construct', 'emit', 'listen']);
+		$manager = $this->getMockBuilder(Manager::class)
+			->setMethods($mockedManagerMethods)
+			->setConstructorArgs([
+				$this->config,
+				$this->createMock(ICacheFactory::class),
+				$this->createMock(IEventDispatcher::class),
+			])
+			->getMock();
+		$userSession = new Session($manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->random, $this->lockdownManager, $this->logger, $this->dispatcher);
+
+		$session->expects($this->never())
+			->method('set');
+		$session->expects($this->once())
+			->method('regenerateId');
+		$token = new PublicKeyToken();
+		$token->setLoginName('foo');
+		$token->setLastCheck(0); // Never
+		$token->setUid('foo');
+		$this->tokenProvider
+			->method('getPassword')
+			->with($token)
+			->willThrowException(new PasswordlessTokenException());
+		$this->tokenProvider
+			->method('getToken')
+			->with('app-password')
+			->willReturn($token);
+		$this->tokenProvider->expects(self::never())
+			->method('updateToken');
+
+		$userSession->login('foo', 'app-password');
+	}
+
+	public function testLoginLastCheckUpdate(): void {
+		$session = $this->getMockBuilder(Memory::class)->setConstructorArgs([''])->getMock();
+		$managerMethods = get_class_methods(Manager::class);
+		// Keep following methods intact in order to ensure hooks are working
+		$mockedManagerMethods = array_diff($managerMethods, ['__construct', 'emit', 'listen']);
+		$manager = $this->getMockBuilder(Manager::class)
+			->setMethods($mockedManagerMethods)
+			->setConstructorArgs([
+				$this->config,
+				$this->createMock(ICacheFactory::class),
+				$this->createMock(IEventDispatcher::class),
+			])
+			->getMock();
+		$userSession = new Session($manager, $session, $this->timeFactory, $this->tokenProvider, $this->config, $this->random, $this->lockdownManager, $this->logger, $this->dispatcher);
+
+		$session->expects($this->never())
+			->method('set');
+		$session->expects($this->once())
+			->method('regenerateId');
+		$token = new PublicKeyToken();
+		$token->setLoginName('foo');
+		$token->setLastCheck(0); // Never
+		$token->setUid('foo');
+		$this->tokenProvider
+			->method('getPassword')
+			->with($token)
+			->willReturn('secret');
+		$this->tokenProvider
+			->method('getToken')
+			->with('app-password')
+			->willReturn($token);
+		$this->tokenProvider->expects(self::once())
+			->method('updateToken');
+
+		$userSession->login('foo', 'app-password');
 	}
 
 	public function testLoginNonExisting() {


### PR DESCRIPTION
## Summary

The column oc_authtoken.last_check is used to debounce the password checks of the login password encoded in app passwords. If instances have set `auth.storeCryptedPassword` to `false`, the password column stays NULL and there is no password check. In that case we keep the last_check column updated without any actual check performed. This is superfluous.

## How to test

1. Set `auth.storeCryptedPassword => false,` in config/config.php
2. Open the user security settings and generate an app password
3. Open the oc_authtoken table, find the last row and set last_check to 0
4. Run `curl -u "USER:APPPASSWORD" https://localhost/apps/files`
5. Look at the updated row in oc_authtoken

Master: last_check is set to the current timestamp. This indicates that there was an UPDATE query.
Here: last_check remains 0.

Note: in reality last_check will stay at the time of token creation. You can skip setting last_check to 0 but then you have to wait more than five minutes between creating and using the token.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
