### PR TITLE
fix overlay of oc-dialog 

### DIFF
--- a/core/src/jquery/css/jquery.ocdialog.scss
+++ b/core/src/jquery/css/jquery.ocdialog.scss
@@ -4,7 +4,7 @@
 	border-radius: var(--border-radius-large);
 	box-shadow: 0 0 30px var(--color-box-shadow);
 	padding: 24px;
-	z-index: 10000;
+	z-index: 100001;
 	font-size: 100%;
 	box-sizing: border-box;
 	min-width: 200px;
@@ -69,7 +69,7 @@
 .oc-dialog-dim {
 	background-color: #000;
 	opacity: .2;
-	z-index: 9999;
+	z-index: 100001;
 	position: fixed;
 	top: 0;
 	left: 0;

--- a/core/src/jquery/ocdialog.js
+++ b/core/src/jquery/ocdialog.js
@@ -234,7 +234,7 @@ $.widget('oc.ocdialog', {
 		}
 		this.overlay = $('<div>')
 			.addClass('oc-dialog-dim')
-			.appendTo(contentDiv)
+			.insertBefore(this.$dialog)
 		this.overlay.on('click keydown keyup', function(event) {
 			if (event.target !== self.$dialog.get(0) && self.$dialog.find($(event.target)).length === 0) {
 				event.preventDefault()


### PR DESCRIPTION
* Resolves: #44487
* Resolves: #44488 

## Summary

- Icrement Z-index of oc-dialog-dim\
- Increment z-index of oc-dialog- Insert oc-dialog-dim before oc-dialog\

- Co-authored-by: Co-author RayanBekri <rmt.bekri@gmail.com>" @RayanBekri
Signed-off-by: JEEEEEEEEEEEEEEEEEEEEEED <118366366+jadjoud@users.noreply.github.com>


## Before:
![bug-report](https://github.com/nextcloud/server/assets/118366366/18addf4b-c52c-4cdb-89c3-edfdaa21ae66)

![2024-03-26 14-35-52](https://github.com/nextcloud/server/assets/118366366/f615487a-5b54-4b51-b15f-9b7032100b3c)

## After:
![Nextcloud-Fix](https://github.com/nextcloud/server/assets/118366366/2f97d0c9-aa2d-46a6-b1d7-541a7f939b39)


## TODO

- [ ] ...

## Checklist


- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
