### PR TITLE
fix(3rdparty): Add a CI job to check 3rdparty integrity 

### DIFF
--- a/.github/workflows/block-outdated-3rdparty.yml
+++ b/.github/workflows/block-outdated-3rdparty.yml
@@ -1,0 +1,53 @@
+name: Block merging with outdated 3rdparty/
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: block-outdated-3rdparty-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  block-outdated-3rdparty:
+    name: Block merging with outdated 3rdparty/
+
+    runs-on: ubuntu-latest-low
+
+    steps:
+      - name: Check requirement
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: changes
+        continue-on-error: true
+        with:
+          filters: |
+            src:
+              - '3rdparty'
+              - 'version.php'
+
+      - name: Checkout
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: 3rdparty commit hash on current branch
+        id: actual
+        run: |
+          echo "commit=$(git submodule status | grep ' 3rdparty' | egrep -o '[a-f0-9]{40}')" >> "$GITHUB_OUTPUT"
+
+      - name: Last 3rdparty commit on target branch
+        id: target
+        run: |
+          echo "commit=$(git ls-remote https://github.com/nextcloud/3rdparty ${{ github.base_ref }} | awk '{ print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Compare if 3rdparty commits are different
+        run: |
+          echo '3rdparty/ seems to not point to the last commit of the dedicated branch:'
+          echo "Branch has: ${{ steps.actual.outputs.commit }}"
+          echo "${{ github.base_ref }} has: ${{ steps.target.outputs.commit }}"
+
+      - name: Fail if 3rdparty commits are different
+        if: ${{ steps.changes.outputs.src != 'false' && steps.actual.outputs.commit != steps.target.outputs.commit }}
+        run: |
+          exit 1


### PR DESCRIPTION
* Should prevent bugs like https://github.com/nextcloud/server/pull/44377#issuecomment-2039651912

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
