### PR TITLE
fix(Blurhash): Suppress imagecreatefromstring() E_WARNING

### DIFF
--- a/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
+++ b/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
@@ -88,7 +88,7 @@ class GenerateBlurhashMetadata implements IEventListener {
 		try {
 			// using preview image to generate the blurhash
 			$preview = $this->preview->getPreview($file, 256, 256);
-			$image = imagecreatefromstring($preview->getContent());
+			$image = @imagecreatefromstring($preview->getContent());
 		} catch (NotFoundException $e) {
 			// https://github.com/nextcloud/server/blob/9d70fd3e64b60a316a03fb2b237891380c310c58/lib/private/legacy/OC_Image.php#L668
 			// The preview system can fail on huge picture, in that case we use our own image resizer.
@@ -114,7 +114,7 @@ class GenerateBlurhashMetadata implements IEventListener {
 	 * @throws LockedException
 	 */
 	private function resizedImageFromFile(File $file): GdImage|false {
-		$image = imagecreatefromstring($file->getContent());
+		$image = @imagecreatefromstring($file->getContent());
 		if ($image === false) {
 			return false;
 		}


### PR DESCRIPTION
* Resolves: #44702 <!-- related github issue -->

## Summary

We're already checking return value to determine if the format is unrecognized. There's no reason to let `imagecreatefromstring()` generate it's own E_WARNING when the format is unrecognized. 

Ref: https://www.php.net/manual/en/function.imagecreatefromstring.php#refsect1-function.imagecreatefromstring-returnvalues

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
