### PR TITLE
add a seperate storage method to distinguish between 'path exists' and 'path is available'

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -919,4 +919,8 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			}
 		}
 	}
+
+	public function pathAvailable(string $path): bool {
+		return !$this->file_exists($path);
+	}
 }

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -95,7 +95,7 @@ class Local extends \OC\Files\Storage\Common {
 		$this->config = \OC::$server->get(IConfig::class);
 		$this->mimeTypeDetector = \OC::$server->get(IMimeTypeDetector::class);
 		$this->defUMask = $this->config->getSystemValue('localstorage.umask', 0022);
-		$this->caseInsensitive = $this->config->getSystemValueBool('localstorage.case_insensitive', false);
+		$this->caseInsensitive = $arguments['case_insensitive'] ?? $this->config->getSystemValueBool('localstorage.case_insensitive', false);
 
 		// support Write-Once-Read-Many file systems
 		$this->unlinkOnTruncate = $this->config->getSystemValueBool('localstorage.unlink_on_truncate', false);
@@ -281,6 +281,8 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function file_exists($path) {
 		if ($this->caseInsensitive) {
+			// if the underlying filesystem is case-insensitive, we do our own case-sensitive
+			// comparison to ensure our `file_exists` implementation is always case-sensitive
 			$fullPath = $this->getSourcePath($path);
 			$parentPath = dirname($fullPath);
 			if (!is_dir($parentPath)) {
@@ -291,6 +293,11 @@ class Local extends \OC\Files\Storage\Common {
 		} else {
 			return file_exists($this->getSourcePath($path));
 		}
+	}
+
+	public function pathAvailable(string $path): bool {
+		// use the native file-exists even for case-insensitive filesystems
+		return !file_exists($this->getSourcePath($path));
 	}
 
 	public function filemtime($path) {

--- a/lib/private/Files/Storage/Storage.php
+++ b/lib/private/Files/Storage/Storage.php
@@ -136,4 +136,16 @@ interface Storage extends \OCP\Files\Storage {
 	 * - permissions
 	 */
 	public function getDirectoryContent($directory): \Traversable;
+
+	/**
+	 * Check if a filepath is available/unused
+	 *
+	 * This is usually the inverse of `file_exists` but some filesystems might have additional restrictions for
+	 * which file names are available.
+	 * For example with case-insensitive filesystems where names that only differ by case would conflict.
+	 *
+	 * @param string $path
+	 * @return bool
+	 */
+	public function pathAvailable(string $path): bool;
 }


### PR DESCRIPTION
For case-insensitive filesystems, these require different logic.

- [x] extend the api to handle both cases
- [ ] adjust the move/copy/etc implementation to use the correct version
- [ ] adjust external uses to the correct version