### PR TITLE
chore: migrate OC Dialog in user row to NcDialog

### DIFF
--- a/apps/settings/src/components/Users/UserRowActions.vue
+++ b/apps/settings/src/components/Users/UserRowActions.vue
@@ -38,6 +38,7 @@
 			:disabled="disabled"
 			:aria-label="text"
 			:icon="icon"
+			:close-after-click="true"
 			@click="(event) => action(event, { ...user })">
 			{{ text }}
 		</NcActionButton>


### PR DESCRIPTION
* Resolves: #44704

## Summary
Currently, we have fixed the problem that the OC dialog popup now has the correct overlay to prevent clicking out of the dialog. However, for the sake of not blending the technologies of jquery and vue together and keeping it consistent, this PR replaces the OC dialog with our own custom NcDialog! :)

## Showcase of the changes
https://github.com/nextcloud/server/assets/110193237/ac00b222-bf88-4517-90ef-a5d5639d036d

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
