### PR TITLE
Update Imaginary to optionally process files locally

### DIFF
--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -76,7 +76,7 @@ class Imaginary extends ProviderV2 {
 		}
 		$imaginaryUrl = rtrim($imaginaryUrl, '/');
 
-		// Set to true if Imaginary was configured with "-mount" with the NextCloud data directory, else set to false
+		// Set to true if Imaginary was configured with "-mount" with the Nextcloud data directory, else set to false
 		$locallymounted = $this->config->getSystemValueString('preview_imaginary_locally_mounted',false);
 		if (!$locallymounted) {
 			// Object store, needed if data directory is not locally mounted 

--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -77,7 +77,7 @@ class Imaginary extends ProviderV2 {
 		$imaginaryUrl = rtrim($imaginaryUrl, '/');
 
 		// Set to true if Imaginary was configured with "-mount" with the Nextcloud data directory, else set to false
-		$locallymounted = $this->config->getSystemValueString('preview_imaginary_locally_mounted',false);
+		$locallymounted = $this->config->getSystemValueBool('preview_imaginary_locally_mounted',false);
 		if (!$locallymounted) {
 			// Object store, needed if data directory is not locally mounted 
 			$stream = $file->fopen('r');


### PR DESCRIPTION
Enhancement proposal from my request:
https://github.com/nextcloud/server/issues/44708

Updates Imaginary to look for a new configuration parameter 'preview_imaginary_locally_mounted" in config.php.  If set to 'true', it will pass the file path to Imaginary to process locally.  If set to 'false', it will process it the existing way by uploading the file via POST.

The Imaginary server must have been initiated with "-mount /foo/bar/NEXTCLOUD-DATA-DIRECTORY" in order to function properly.


* Resolves: #44708  <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
