### PR TITLE
fix(auth): Keep redirect URL during 2FA setup and challenge

### DIFF
--- a/core/Controller/TwoFactorChallengeController.php
+++ b/core/Controller/TwoFactorChallengeController.php
@@ -213,13 +213,14 @@ class TwoFactorChallengeController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	#[FrontpageRoute(verb: 'GET', url: 'login/setupchallenge')]
-	public function setupProviders(): StandaloneTemplateResponse {
+	public function setupProviders(?string $redirect_url = null): StandaloneTemplateResponse {
 		$user = $this->userSession->getUser();
 		$setupProviders = $this->twoFactorManager->getLoginSetupProviders($user);
 
 		$data = [
 			'providers' => $setupProviders,
 			'logout_url' => $this->getLogoutUrl(),
+			'redirect_url' => $redirect_url,
 		];
 
 		return new StandaloneTemplateResponse($this->appName, 'twofactorsetupselection', $data, 'guest');
@@ -230,7 +231,7 @@ class TwoFactorChallengeController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	#[FrontpageRoute(verb: 'GET', url: 'login/setupchallenge/{providerId}')]
-	public function setupProvider(string $providerId) {
+	public function setupProvider(string $providerId, ?string $redirect_url = null) {
 		$user = $this->userSession->getUser();
 		$providers = $this->twoFactorManager->getLoginSetupProviders($user);
 
@@ -251,6 +252,7 @@ class TwoFactorChallengeController extends Controller {
 		$data = [
 			'provider' => $provider,
 			'logout_url' => $this->getLogoutUrl(),
+			'redirect_url' => $redirect_url,
 			'template' => $tmpl->fetchPage(),
 		];
 		$response = new StandaloneTemplateResponse($this->appName, 'twofactorsetupchallenge', $data, 'guest');
@@ -264,11 +266,12 @@ class TwoFactorChallengeController extends Controller {
 	 * @todo handle the extreme edge case of an invalid provider ID and redirect to the provider selection page
 	 */
 	#[FrontpageRoute(verb: 'POST', url: 'login/setupchallenge/{providerId}')]
-	public function confirmProviderSetup(string $providerId) {
+	public function confirmProviderSetup(string $providerId, ?string $redirect_url = null) {
 		return new RedirectResponse($this->urlGenerator->linkToRoute(
 			'core.TwoFactorChallenge.showChallenge',
 			[
 				'challengeProviderId' => $providerId,
+				'redirect_url' => $redirect_url,
 			]
 		));
 	}

--- a/core/Middleware/TwoFactorMiddleware.php
+++ b/core/Middleware/TwoFactorMiddleware.php
@@ -134,8 +134,10 @@ class TwoFactorMiddleware extends Middleware {
 
 	public function afterException($controller, $methodName, Exception $exception) {
 		if ($exception instanceof TwoFactorAuthRequiredException) {
-			$params = [];
-			if (isset($this->request->server['REQUEST_URI'])) {
+			$params = [
+				'redirect_url' => $this->request->getParam('redirect_url'),
+			];
+			if (!isset($params['redirect_url']) && isset($this->request->server['REQUEST_URI'])) {
 				$params['redirect_url'] = $this->request->server['REQUEST_URI'];
 			}
 			return new RedirectResponse($this->urlGenerator->linkToRoute('core.TwoFactorChallenge.selectChallenge', $params));

--- a/core/templates/twofactorsetupselection.php
+++ b/core/templates/twofactorsetupselection.php
@@ -33,6 +33,7 @@ declare(strict_types=1);
 			   href="<?php p(\OC::$server->getURLGenerator()->linkToRoute('core.TwoFactorChallenge.setupProvider',
 			   	[
 			   		'providerId' => $provider->getId(),
+			   		'redirect_url' => $_['redirect_url'],
 			   	]
 			   )) ?>">
 				<?php

--- a/tests/Core/Controller/TwoFactorChallengeControllerTest.php
+++ b/tests/Core/Controller/TwoFactorChallengeControllerTest.php
@@ -337,7 +337,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->controller->solveChallenge('myprovider', 'token', '/url'));
 	}
 
-	public function testSetUpProviders() {
+	public function testSetUpProviders(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -357,6 +357,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 					$provider,
 				],
 				'logout_url' => 'logoutAttribute',
+				'redirect_url' => null,
 			],
 			'guest'
 		);
@@ -392,7 +393,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 		$this->assertEquals($expected, $response);
 	}
 
-	public function testSetUpProvider() {
+	public function testSetUpProvider(): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
@@ -426,6 +427,7 @@ class TwoFactorChallengeControllerTest extends TestCase {
 				'provider' => $provider,
 				'logout_url' => 'logoutAttribute',
 				'template' => 'tmpl',
+				'redirect_url' => null,
 			],
 			'guest'
 		);
@@ -435,13 +437,14 @@ class TwoFactorChallengeControllerTest extends TestCase {
 		$this->assertEquals($expected, $response);
 	}
 
-	public function testConfirmProviderSetup() {
+	public function testConfirmProviderSetup(): void {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')
 			->with(
 				'core.TwoFactorChallenge.showChallenge',
 				[
 					'challengeProviderId' => 'totp',
+					'redirect_url' => null,
 				])
 			->willReturn('2fa/select/page');
 		$expected = new RedirectResponse('2fa/select/page');


### PR DESCRIPTION
## Summary

The redirect URL is crucial when a user is sent to Nextcloud to grant access for clients during the *login flow*. Without this, users will log in and land on the default page instead of the grant page for the setup.

## How to test

1. Log in as admin
2. Enforce 2FA
3. Install a 2FA provider like TOTP
4. Log out
5. Open /settings/user -> you get redirected to the login (note the redirect URL in the address bar)
6. Follow the steps to set up TOTP and confirm your OTP for the first time (always note the redirect URL in the address bar)

Master: land at /apps/dashboard, /apps/files or whatever the default is
Here: land at /settings/user

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
