### PR TITLE
feat(occ): Add --disabled option to occ user:list

### DIFF
--- a/core/Command/User/ListCommand.php
+++ b/core/Command/User/ListCommand.php
@@ -45,6 +45,11 @@ class ListCommand extends Base {
 			->setName('user:list')
 			->setDescription('list configured users')
 			->addOption(
+				'disabled',
+				'd',
+				InputOption::VALUE_NONE,
+				'List disabled users only'
+			)->addOption(
 				'limit',
 				'l',
 				InputOption::VALUE_OPTIONAL,
@@ -71,7 +76,11 @@ class ListCommand extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$users = $this->userManager->searchDisplayName('', (int) $input->getOption('limit'), (int) $input->getOption('offset'));
+		if ($input->getOption('disabled')) {
+			$users = $this->userManager->getDisabledUsers((int) $input->getOption('limit'), (int) $input->getOption('offset'));
+		} else {
+			$users = $this->userManager->searchDisplayName('', (int) $input->getOption('limit'), (int) $input->getOption('offset'));
+		}
 
 		$this->writeArrayInOutputFormat($input, $output, $this->formatUsers($users, (bool)$input->getOption('info')));
 		return 0;


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Allows to easily list disabled users from cli in a efficient way

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
