### PR TITLE
fix(LDAP): do not count mapped users x-times active configs

### DIFF
--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -415,12 +415,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 	 */
 	public function countMappedUsers(): int {
 		$this->setup();
-
-		$users = 0;
-		foreach ($this->backends as $backend) {
-			$users += $backend->countMappedUsers();
-		}
-		return $users;
+		return $this->refBackend?->countMappedUsers() ?? 0;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

the method counts all rows in the mapping tables, which are not specific to single configurations, but contains users from all

So if you are operating on a one-click host with a user limit of 500, but have two LDAPs connected with altogether 300 users, without this fix they are interpreted as 600 users, and the 301st could not log in.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
