### PR TITLE
fix(federation): give some time to prepare both servers

### DIFF
--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -160,7 +160,7 @@ class RequestSharedSecret extends Job {
 		// if we received a unexpected response we try again later
 		if (
 			$status !== Http::STATUS_OK
-			&& $status !== Http::STATUS_FORBIDDEN
+			&& ($status !== Http::STATUS_FORBIDDEN || $this->getAttempt($argument) < 5)
 		) {
 			$this->retainJob = true;
 		}
@@ -173,14 +173,20 @@ class RequestSharedSecret extends Job {
 		$url = $argument['url'];
 		$created = isset($argument['created']) ? (int)$argument['created'] : $this->time->getTime();
 		$token = $argument['token'];
+		$attempt = $this->getAttempt($argument) + 1;
 
 		$this->jobList->add(
 			RequestSharedSecret::class,
 			[
 				'url' => $url,
 				'token' => $token,
-				'created' => $created
+				'created' => $created,
+				'attempt' => $attempt
 			]
 		);
+	}
+
+	protected function getAttempt(array $argument): int {
+		return $argument['attempt'] ?? 0;
 	}
 }

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -142,6 +142,7 @@ class RequestSharedSecretTest extends TestCase {
 						'url' => 'url',
 						'token' => 'token',
 						'created' => 42,
+						'attempt' => 1,
 					]
 				);
 		} else {
@@ -164,12 +165,12 @@ class RequestSharedSecretTest extends TestCase {
 	 *
 	 * @param int $statusCode
 	 */
-	public function testRun($statusCode) {
+	public function testRun(int $statusCode, int $attempt = 0): void {
 		$target = 'targetURL';
 		$source = 'sourceURL';
 		$token = 'token';
 
-		$argument = ['url' => $target, 'token' => $token];
+		$argument = ['url' => $target, 'token' => $token, 'attempt' => $attempt];
 
 		$this->timeFactory->method('getTime')->willReturn(42);
 
@@ -196,7 +197,7 @@ class RequestSharedSecretTest extends TestCase {
 		$this->invokePrivate($this->requestSharedSecret, 'run', [$argument]);
 		if (
 			$statusCode !== Http::STATUS_OK
-			&& $statusCode !== Http::STATUS_FORBIDDEN
+			&& ($statusCode !== Http::STATUS_FORBIDDEN || $attempt < 5)
 		) {
 			$this->assertTrue($this->invokePrivate($this->requestSharedSecret, 'retainJob'));
 		} else {
@@ -207,6 +208,7 @@ class RequestSharedSecretTest extends TestCase {
 	public function dataTestRun() {
 		return [
 			[Http::STATUS_OK],
+			[Http::STATUS_FORBIDDEN, 5],
 			[Http::STATUS_FORBIDDEN],
 			[Http::STATUS_CONFLICT],
 		];


### PR DESCRIPTION
* Resolves: #39941

## Summary


- when this background job runs, while the current server was not being added as trusted_server in the other instance, yet, the secret sharing would not be attempted again, without visual feedback.
- the change allows 5 attempts, which gives more than 20minutes to complete. More do not really help as the endpoint is brute force protected.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
