### PR TITLE
fix(memcache): remove double $$ to fix error

### DIFF
--- a/lib/private/Memcache/LoggerWrapperCache.php
+++ b/lib/private/Memcache/LoggerWrapperCache.php
@@ -75,7 +75,7 @@ class LoggerWrapperCache extends Cache implements IMemcacheTTL {
 			FILE_APPEND
 		);
 
-		return $this->wrappedCache->set($key, $value, $$ttl);
+		return $this->wrappedCache->set($key, $value, $ttl);
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
Extra Dollar Sign caused errors in Nextcloud. Removing the Dollar Sign Solved the Problem.


* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
