### PR TITLE
fix(Router): Stop loading routes of disabled apps

### DIFF
--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -154,7 +154,7 @@ class Router implements IRouter {
 		}
 		$this->eventLogger->start('route:load:' . $requestedApp, 'Loading Routes for ' . $requestedApp);
 
-		if ($requestedApp !== null) {
+		if ($requestedApp !== null && in_array($requestedApp, \OC_App::getEnabledApps())) {
 			$routes = $this->getAttributeRoutes($requestedApp);
 			if (count($routes) > 0) {
 				$this->useCollection($requestedApp);


### PR DESCRIPTION
## Summary

Routes of disabled apps should not be loaded. The classes are not loaded by the autoloader and the request will fail trying to use reflection on them.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
