### PR TITLE
Enable more psalm rules

### DIFF
--- a/apps/dav/lib/CardDAV/SystemAddressbook.php
+++ b/apps/dav/lib/CardDAV/SystemAddressbook.php
@@ -303,7 +303,6 @@ class SystemAddressbook extends AddressBook {
 			return false;
 		}
 
-		/** @psalm-suppress NoInterfaceProperties */
 		$sharedSecret = $server['PHP_AUTH_PW'] ?? null;
 		if ($sharedSecret === null) {
 			return false;

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -149,7 +149,6 @@ class SFTP extends Common {
 
 		$login = false;
 		foreach ($this->auth as $auth) {
-			/** @psalm-suppress TooManyArguments */
 			$login = $this->client->login($this->user, $auth);
 			if ($login === true) {
 				break;

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -450,7 +450,6 @@ class ThemingController extends Controller {
 	 * Get the manifest for an app
 	 *
 	 * @param string $app ID of the app
-	 * @psalm-suppress LessSpecificReturnStatement The content of the Manifest doesn't need to be described in the return type
 	 * @return JSONResponse<Http::STATUS_OK, array{name: string, short_name: string, start_url: string, theme_color: string, background_color: string, description: string, icons: array{src: non-empty-string, type: string, sizes: string}[], display: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{}, array{}>
 	 *
 	 * 200: Manifest returned

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -249,8 +249,6 @@ abstract class AbstractMapping {
 			$slice++;
 			$fdnsSlice = array_slice($fdns, $sliceSize * ($slice - 1), $sliceSize);
 
-			/** @see https://github.com/vimeo/psalm/issues/4995 */
-			/** @psalm-suppress TypeDoesNotContainType */
 			if (!isset($qb)) {
 				$qb = $this->prepareListOfIdsQuery($fdnsSlice);
 				continue;

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -80,6 +80,11 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/comments/lib/Activity/Provider.php">
+    <InvalidOperand>
+      <code>$mentionCount</code>
+      <code>$mentionCount</code>
+      <code>$mentionCount</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getCurrentUserId</code>
       <code>getCurrentUserId</code>
@@ -126,11 +131,21 @@
       <code><![CDATA[list<string>]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/comments/lib/Notification/Notifier.php">
+    <InvalidOperand>
+      <code><![CDATA[$mentionTypeCount[$mention['type']]]]></code>
+    </InvalidOperand>
+  </file>
   <file src="apps/comments/lib/Search/LegacyProvider.php">
     <MissingThrowsDocblock>
       <code>get</code>
       <code>get</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="apps/contactsinteraction/lib/AddressBook.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getLastModified() ?? 0]]></code>
+    </InvalidOperand>
   </file>
   <file src="apps/contactsinteraction/lib/Card.php">
     <MissingThrowsDocblock>
@@ -278,6 +293,11 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php">
+    <InvalidOperand>
+      <code>$offset</code>
+      <code>$offset</code>
+      <code>$stopAt</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>executeQuery</code>
       <code>executeQuery</code>
@@ -335,6 +355,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/BackgroundJob/UserStatusAutomation.php">
+    <InvalidOperand>
+      <code>$timestamp</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>executeQuery</code>
       <code>executeQuery</code>
@@ -451,6 +474,17 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CalDAV/BirthdayService.php">
+    <ImplicitToStringCast>
+      <code><![CDATA[$doc->UID]]></code>
+    </ImplicitToStringCast>
+    <InvalidOperand>
+      <code>$year</code>
+      <code>$year</code>
+      <code>$year</code>
+      <code>$year</code>
+      <code>$year</code>
+      <code>$year</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>createCalendar</code>
     </MissingThrowsDocblock>
@@ -483,6 +517,11 @@
     <InvalidNullableReturnType>
       <code>array</code>
     </InvalidNullableReturnType>
+    <InvalidOperand>
+      <code>$calendarId</code>
+      <code>$calendarType</code>
+      <code>$calendarType</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code>Reader::read($objectData)</code>
     </LessSpecificReturnStatement>
@@ -782,6 +821,9 @@
     </NullableReturnStatement>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipPlugin.php">
+    <ImplicitToStringCast>
+      <code>$uid</code>
+    </ImplicitToStringCast>
     <RedundantCast>
       <code><![CDATA[(string)$iTipMessage->recipientName]]></code>
     </RedundantCast>
@@ -915,6 +957,9 @@
     <InvalidArgument>
       <code>$webcalData</code>
     </InvalidArgument>
+    <InvalidOperand>
+      <code><![CDATA[$parsed['port']]]></code>
+    </InvalidOperand>
   </file>
   <file src="apps/dav/lib/CardDAV/Activity/Backend.php">
     <MissingThrowsDocblock>
@@ -987,6 +1032,10 @@
     <FalsableReturnStatement>
       <code>false</code>
     </FalsableReturnStatement>
+    <InvalidOperand>
+      <code>$id</code>
+      <code>$property</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code>Reader::read($cardData)</code>
     </LessSpecificReturnStatement>
@@ -1073,6 +1122,13 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CardDAV/PhotoCache.php">
+    <InvalidOperand>
+      <code>$addressBookId</code>
+      <code>$size</code>
+      <code>$size * $ratio</code>
+      <code>1 / $ratio</code>
+      <code>2 ** ceil(log($size) / log(2))</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code><![CDATA[[
 				'Content-Type' => $type,
@@ -1207,6 +1263,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Command/MoveCalendar.php">
+    <InvalidOperand>
+      <code>$increment</code>
+      <code>$increment</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addArgument</code>
@@ -1268,11 +1328,17 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Comments/CommentNode.php">
+    <InvalidOperand>
+      <code>IComment::MAX_MESSAGE_LENGTH</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new Forbidden('Only authors are allowed to edit their comment.');]]></code>
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Comments/CommentsPlugin.php">
+    <InvalidOperand>
+      <code>\OCP\Comments\IComment::MAX_MESSAGE_LENGTH</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>createComment</code>
       <code>createComment</code>
@@ -1416,6 +1482,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/File.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getId()]]></code>
+      <code>rand()</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->node]]></code>
     </LessSpecificReturnStatement>
@@ -1658,6 +1728,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="apps/dav/lib/Controller/DirectController.php">
+    <InvalidOperand>
+      <code>60 * 60 * 24</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getRelativePath</code>
       <code>getUserFolder</code>
@@ -1834,6 +1907,11 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Files/FileSearchBackend.php">
+    <InvalidOperand>
+      <code>$operatorCount</code>
+      <code>0 + $value</code>
+      <code>self::OPERATOR_LIMIT</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code>$value</code>
     </InvalidReturnStatement>
@@ -1899,7 +1977,20 @@
       <code>delete</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="apps/dav/lib/Listener/SubscriptionListener.php">
+    <InvalidOperand>
+      <code>$subscriptionId</code>
+      <code>$subscriptionId</code>
+      <code>$subscriptionId</code>
+      <code>$subscriptionId</code>
+    </InvalidOperand>
+  </file>
   <file src="apps/dav/lib/Migration/BuildCalendarSearchIndexBackgroundJob.php">
+    <InvalidOperand>
+      <code>$offset</code>
+      <code>$offset</code>
+      <code>$stopAt</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>executeQuery</code>
       <code>executeQuery</code>
@@ -1909,6 +2000,9 @@
     </ParamNameMismatch>
   </file>
   <file src="apps/dav/lib/Migration/BuildSocialSearchIndexBackgroundJob.php">
+    <InvalidOperand>
+      <code>$offset</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>executeQuery</code>
       <code>executeQuery</code>
@@ -2211,6 +2305,11 @@
       <code>getTable</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="apps/dav/lib/Migration/Version1025Date20240308063933.php">
+    <InvalidOperand>
+      <code>$updated</code>
+    </InvalidOperand>
+  </file>
   <file src="apps/dav/lib/Migration/Version1029Date20231004091403.php">
     <MissingThrowsDocblock>
       <code>addColumn</code>
@@ -2366,6 +2465,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/SystemTag/SystemTagNode.php">
+    <InvalidOperand>
+      <code>$userAssignable</code>
+      <code>$userVisible</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new Forbidden('No permission to delete tag ' . $this->tag->getId());]]></code>
       <code><![CDATA[throw new NotFound('Tag with id ' . $this->tag->getId() . ' not found');]]></code>
@@ -2435,6 +2538,10 @@
     <FalsableReturnStatement>
       <code>false</code>
     </FalsableReturnStatement>
+    <InvalidOperand>
+      <code>$currentNodeSize</code>
+      <code><![CDATA[$this->currentNodeRead]]></code>
+    </InvalidOperand>
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->currentStream]]></code>
     </InvalidPropertyAssignmentValue>
@@ -2459,6 +2566,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Upload/ChunkingV2Plugin.php">
+    <InvalidOperand>
+      <code><![CDATA[$tempTargetFile->getSize() + $additionalSize]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_create, [
 				Filesystem::signal_param_path => $hookPath,
@@ -2604,12 +2714,23 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/UserMigration/CalendarMigrator.php">
+    <InvalidOperand>
+      <code>$size += ($componentCount * 450) / 1024</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>createCalendar</code>
       <code>getCalendarExports</code>
     </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/UserMigration/ContactsMigrator.php">
+    <ImplicitToStringCast>
+      <code><![CDATA[$vCard->FN ?? 'null']]></code>
+      <code><![CDATA[$vCard->FN ?? 'null']]></code>
+      <code><![CDATA[$vCard->FN ?? 'null']]></code>
+    </ImplicitToStringCast>
+    <InvalidOperand>
+      <code>$size += ($contactsCount * 350) / 1024</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code><![CDATA[[
 			'name' => $addressBookNode->getName(),
@@ -2663,6 +2784,12 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/encryption/lib/Command/DropLegacyFileKey.php">
+    <ImplicitToStringCast>
+      <code>$e</code>
+    </ImplicitToStringCast>
+    <InvalidOperand>
+      <code>time()</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>fopen</code>
       <code>fopen</code>
@@ -2679,6 +2806,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/encryption/lib/Command/FixEncryptedVersion.php">
+    <InvalidOperand>
+      <code>$encryptedVersion</code>
+      <code>$newEncryptedVersion</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -2750,6 +2881,11 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/encryption/lib/Crypto/Crypt.php">
+    <InvalidOperand>
+      <code>$version</code>
+      <code>$version</code>
+      <code>$version</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>checkSignature</code>
       <code>generateIv</code>
@@ -2775,6 +2911,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/encryption/lib/Crypto/EncryptAll.php">
+    <InvalidOperand>
+      <code>time()</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>ask</code>
       <code>fopen</code>
@@ -2901,6 +3040,10 @@
       <code>$shareId</code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <InvalidOperand>
+      <code>$id</code>
+      <code>time()</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>execute</code>
       <code>execute</code>
@@ -3041,6 +3184,16 @@
       <code>imagePath</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="apps/federation/lib/BackgroundJob/GetSharedSecret.php">
+    <InvalidOperand>
+      <code>$status</code>
+    </InvalidOperand>
+  </file>
+  <file src="apps/federation/lib/BackgroundJob/RequestSharedSecret.php">
+    <InvalidOperand>
+      <code>$status</code>
+    </InvalidOperand>
+  </file>
   <file src="apps/federation/lib/Command/SyncFederationAddressBooks.php">
     <MissingThrowsDocblock>
       <code>parent::__construct()</code>
@@ -3055,6 +3208,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/federation/lib/DbHandler.php">
+    <InvalidOperand>
+      <code>$id</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code>$result</code>
     </LessSpecificReturnStatement>
@@ -3132,6 +3288,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files/lib/Activity/Filter/Favorites.php">
+    <ImplicitToStringCast>
+      <code><![CDATA[$query->createNamedParameter('files')]]></code>
+      <code><![CDATA[$query->createNamedParameter('files')]]></code>
+    </ImplicitToStringCast>
     <MissingThrowsDocblock>
       <code>imagePath</code>
     </MissingThrowsDocblock>
@@ -3418,6 +3578,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files/lib/Command/RepairTree.php">
+    <InvalidOperand>
+      <code>count($rows)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addOption</code>
       <code>beginTransaction</code>
@@ -3454,6 +3617,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files/lib/Command/ScanAppData.php">
+    <InvalidOperand>
+      <code>$secs / 3600</code>
+      <code>$secs / 60</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>get</code>
@@ -3511,6 +3678,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="apps/files/lib/Controller/OpenLocalEditorController.php">
+    <InvalidOperand>
+      <code>self::TOKEN_RETRIES</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>delete</code>
       <code>verifyToken</code>
@@ -3842,6 +4012,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Command/Create.php">
+    <InvalidOperand>
+      <code><![CDATA[$mount->getId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addArgument</code>
@@ -3909,6 +4082,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Command/ListCommand.php">
+    <InvalidOperand>
+      <code>$key</code>
+      <code>$key</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -3951,6 +4128,11 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Command/Scan.php">
+    <InvalidOperand>
+      <code>$secs % 60</code>
+      <code>$secs / 3600</code>
+      <code>$secs / 60</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -3985,6 +4167,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Config/ConfigAdapter.php">
+    <InvalidOperand>
+      <code><![CDATA[$storageConfig->getId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>manipulateStorageConfig</code>
       <code>manipulateStorageConfig</code>
@@ -4394,6 +4579,13 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Service/StoragesService.php">
+    <InvalidOperand>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+      <code>$id</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>get</code>
       <code>get</code>
@@ -4491,6 +4683,10 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/Command/CleanupRemoteStorages.php">
+    <InvalidOperand>
+      <code>count($remoteShareIds)</code>
+      <code>count($remoteStorages)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addOption</code>
       <code>executeQuery</code>
@@ -4561,6 +4757,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/Controller/RemoteController.php">
+    <InvalidOperand>
+      <code>$id</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[new \OC\Files\View('/' . \OC_User::getUser() . '/files/')]]></code>
     </MissingThrowsDocblock>
@@ -4730,6 +4929,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/External/Manager.php">
+    <InvalidOperand>
+      <code>$i</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code>$mount</code>
     </LessSpecificReturnStatement>
@@ -4795,6 +4997,9 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="apps/files_sharing/lib/External/Storage.php">
+    <InvalidOperand>
+      <code>$port</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>Server::get(IConfig::class)</code>
       <code>Server::get(IConfig::class)</code>
@@ -4824,6 +5029,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/Helper.php">
+    <InvalidOperand>
+      <code>$i</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>setSystemValue</code>
     </MissingThrowsDocblock>
@@ -4990,6 +5198,9 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="apps/files_sharing/lib/SharedMount.php">
+    <InvalidOperand>
+      <code>$i</code>
+    </InvalidOperand>
     <InvalidReturnType>
       <code>bool</code>
     </InvalidReturnType>
@@ -5249,6 +5460,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_trashbin/lib/Trash/LegacyTrashBackend.php">
+    <InvalidOperand>
+      <code><![CDATA[$item->getDeletedTime()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getUserFolder</code>
       <code>getUserFolder</code>
@@ -5264,6 +5478,21 @@
     <InvalidArgument>
       <code>$timestamp</code>
     </InvalidArgument>
+    <InvalidOperand>
+      <code>$availableSpace += $delSize</code>
+      <code>$availableSpace += $tmp</code>
+      <code>$configuredTrashbinSize - $trashbinSize</code>
+      <code>$i</code>
+      <code><![CDATA[$quota - $userFolder->getSize(false)]]></code>
+      <code>$size += $tmp</code>
+      <code><![CDATA[$size += self::calculateSize(new View('/' . $user . '/files_trashbin/files/' . $file))]]></code>
+      <code><![CDATA[$size += self::calculateSize(new View('/' . $user . '/files_trashbin/versions/' . $file))]]></code>
+      <code>$size += self::delete($filename, $user, $timestamp)</code>
+      <code>$size += self::deleteVersions($view, $file, $filename, $timestamp, $user)</code>
+      <code>$timestamp</code>
+      <code>$timestamp</code>
+      <code>$tmp</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>$timestamp</code>
     </InvalidScalarArgument>
@@ -5373,6 +5602,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php">
+    <InvalidOperand>
+      <code><![CDATA[$trashbinFolder->getSize() / 1024]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>newFolder</code>
     </MissingThrowsDocblock>
@@ -5595,6 +5827,21 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/files_versions/lib/Storage.php">
+    <InvalidOperand>
+      <code>$diff</code>
+      <code><![CDATA[$quota - $userFolder->getSize(false)]]></code>
+      <code>$revision</code>
+      <code>$revision</code>
+      <code>$revision</code>
+      <code>$revision</code>
+      <code>$version</code>
+      <code>round($diff / 2419200)</code>
+      <code>round($diff / 29030400)</code>
+      <code>round($diff / 3600)</code>
+      <code>round($diff / 60)</code>
+      <code>round($diff / 604800)</code>
+      <code>round($diff / 86400)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path . $revision, 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED])]]></code>
       <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path . $revision, 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED])]]></code>
@@ -5671,6 +5918,12 @@
     </RedundantCondition>
   </file>
   <file src="apps/files_versions/lib/Versions/LegacyVersionsBackend.php">
+    <InvalidOperand>
+      <code><![CDATA[$file->getMtime()]]></code>
+      <code><![CDATA[$file->getMtime()]]></code>
+      <code><![CDATA[$version->getTimestamp()]]></code>
+      <code><![CDATA[(int)$version['version']]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>delete</code>
       <code>fopen</code>
@@ -5809,6 +6062,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/oauth2/lib/Db/ClientMapper.php">
+    <InvalidOperand>
+      <code>$id</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>findEntities</code>
       <code>findEntity</code>
@@ -6105,6 +6361,9 @@
     </MissingThrowsDocblock>
   </file>
   <file src="apps/settings/lib/Mailer/NewUserMailHelper.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->timeFactory->getTime()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>setUserValue</code>
       <code>setUserValue</code>
@@ -6647,6 +6906,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/settings/lib/SetupChecks/TempSpaceAvailable.php">
+    <InvalidOperand>
+      <code>$freeSpaceInNextcloudTemp / 1024</code>
+      <code>$freeSpaceInTemp / 1024</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$nextcloudTempPath]))]]></code>
       <code><![CDATA[SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$phpTempPath]))]]></code>
@@ -6703,6 +6966,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/settings/lib/UserMigration/AccountMigrator.php">
+    <InvalidOperand>
+      <code><![CDATA[$avatarFile->getSize() / 1024]]></code>
+      <code><![CDATA[$size += $avatarFile->getSize() / 1024]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>new \OCP\Image()</code>
     </MissingThrowsDocblock>
@@ -6909,6 +7176,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>executeUpdate</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="apps/testing/lib/Settings/DeclarativeSettingsForm.php">
+    <InvalidOperand>
+      <code>60 * 24</code>
+    </InvalidOperand>
+  </file>
   <file src="apps/theming/lib/Command/UpdateConfig.php">
     <MissingThrowsDocblock>
       <code>addArgument</code>
@@ -6935,6 +7207,12 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/theming/lib/IconBuilder.php">
+    <InvalidOperand>
+      <code><![CDATA[$appIconFile->getImageHeight() * 0.05]]></code>
+      <code><![CDATA[$appIconFile->getImageWidth() * 0.05]]></code>
+      <code>512 / 2 - $innerHeight / 2</code>
+      <code>512 / 2 - $innerWidth / 2</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>adaptiveResizeImage</code>
       <code>getContent</code>
@@ -6952,6 +7230,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/theming/lib/ImageManager.php">
+    <InvalidOperand>
+      <code>imagesy($newImage) / (imagesx($newImage) / $newWidth)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>cleanup</code>
       <code>getFolder</code>
@@ -7012,6 +7293,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>imagePath</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="apps/theming/lib/Themes/CommonThemeTrait.php">
+    <InvalidOperand>
+      <code>$currentVersion</code>
+    </InvalidOperand>
+  </file>
   <file src="apps/theming/lib/ThemingDefaults.php">
     <MissingThrowsDocblock>
       <code>getImage</code>
@@ -7020,6 +7306,13 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/theming/lib/Util.php">
+    <InvalidOperand>
+      <code>$color / 255.0</code>
+      <code>$userCacheBusterValue</code>
+      <code>0.0722 * $blue</code>
+      <code>0.2126 * $red</code>
+      <code>0.7152 * $green</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code><![CDATA[array_values($color->getRgb())]]></code>
     </InvalidReturnStatement>
@@ -7126,6 +7419,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/updatenotification/lib/Command/Check.php">
+    <InvalidOperand>
+      <code>$updatesAvailableCount</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>parent::__construct()</code>
       <code>setName</code>
@@ -7159,6 +7455,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </InvalidScope>
   </file>
   <file src="apps/user_ldap/lib/Access.php">
+    <InvalidOperand>
+      <code>$lastNo + $attempts</code>
+      <code>rand(1000, 9999)</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code>$uuid</code>
       <code>$values</code>
@@ -7196,6 +7496,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/user_ldap/lib/Command/CheckGroup.php">
+    <InvalidOperand>
+      <code><![CDATA[$event->getGroup()->count()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -7346,6 +7649,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/user_ldap/lib/Connection.php">
+    <InvalidOperand>
+      <code>$errno</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>establishConnection</code>
       <code>establishConnection</code>
@@ -7376,7 +7682,18 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>findEntities</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="apps/user_ldap/lib/GroupPluginManager.php">
+    <InvalidOperand>
+      <code>$action</code>
+    </InvalidOperand>
+  </file>
   <file src="apps/user_ldap/lib/Group_LDAP.php">
+    <InvalidOperand>
+      <code>$limit</code>
+      <code>$limit</code>
+      <code>$offset</code>
+      <code>$offset</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>$groupID</code>
     </InvalidScalarArgument>
@@ -7420,6 +7737,7 @@ On Nginx those are typically the lines starting with "location ~" that need an u
   <file src="apps/user_ldap/lib/Jobs/Sync.php">
     <InvalidOperand>
       <code>$i</code>
+      <code>24 * 60 * 60 / $runsPerDay</code>
     </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(AccessFactory::class)</code>
@@ -7494,6 +7812,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>executeQuery</code>
       <code>executeQuery</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/UUIDFixInsert.php">
+    <InvalidOperand>
+      <code>count($records) * 0.8</code>
+    </InvalidOperand>
   </file>
   <file src="apps/user_ldap/lib/Migration/Version1010Date20200630192842.php">
     <MissingThrowsDocblock>
@@ -7598,6 +7921,12 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <FalsableReturnStatement>
       <code><![CDATA[$this->avatarImage]]></code>
     </FalsableReturnStatement>
+    <InvalidOperand>
+      <code>$property</code>
+      <code>$property</code>
+      <code>$pwdMaxAgeInt</code>
+      <code>$secondsToExpiry / 60 / 60</code>
+    </InvalidOperand>
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->refreshedFeatures]]></code>
     </InvalidPropertyAssignmentValue>
@@ -7650,6 +7979,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </RedundantCondition>
   </file>
   <file src="apps/user_ldap/lib/UserPluginManager.php">
+    <InvalidOperand>
+      <code>$action</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
@@ -7659,6 +7991,15 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <ImplementedReturnTypeMismatch>
       <code>string|false</code>
     </ImplementedReturnTypeMismatch>
+    <InvalidOperand>
+      <code>$limit</code>
+      <code>$limit</code>
+      <code>$limit</code>
+      <code>$offset</code>
+      <code>$offset</code>
+      <code>$offset</code>
+      <code>count($ldap_users)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>cacheUserDisplayName</code>
       <code>countUsers</code>
@@ -7709,6 +8050,13 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidArrayOffset>
       <code>$possibleAttrs[$i]</code>
     </InvalidArrayOffset>
+    <InvalidOperand>
+      <code><![CDATA[!$result['count'] > 0]]></code>
+      <code>$errorNo</code>
+      <code>$port</code>
+      <code>$port</code>
+      <code>(int)$tls</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>countUsers</code>
       <code>detectGroupMemberAssoc</code>
@@ -7743,6 +8091,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/user_status/lib/Controller/UserStatusController.php">
+    <InvalidOperand>
+      <code>$clearAt</code>
+      <code>$clearAt</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>findByUserId</code>
     </MissingThrowsDocblock>
@@ -7822,6 +8174,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/user_status/lib/Service/StatusService.php">
+    <InvalidOperand>
+      <code>$userId</code>
+      <code>self::MAXIMUM_MESSAGE_LENGTH</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>delete</code>
       <code>delete</code>
@@ -7853,6 +8209,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/weather_status/lib/Service/WeatherStatusService.php">
+    <InvalidOperand>
+      <code>$lat</code>
+      <code>$lon</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>setUserValue</code>
       <code>setUserValue</code>
@@ -7906,6 +8266,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </InvalidReturnType>
   </file>
   <file src="apps/workflowengine/lib/Check/FileSystemTags.php">
+    <InvalidOperand>
+      <code><![CDATA[$cache->getNumericStorageId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new \LogicException('Should not happen: Storage is instance of GroupFolderStorage but no group folder storage found while unwrapping.');]]></code>
     </MissingThrowsDocblock>
@@ -7953,6 +8316,12 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>setName</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="apps/workflowengine/lib/Controller/AWorkflowController.php">
+    <InvalidOperand>
+      <code>$id</code>
+      <code>$id</code>
+    </InvalidOperand>
+  </file>
   <file src="apps/workflowengine/lib/Controller/UserWorkflowsController.php">
     <MissingThrowsDocblock>
       <code>parent::create($class, $name, $checks, $operation, $entity, $events)</code>
@@ -7978,6 +8347,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="apps/workflowengine/lib/Helper/ScopeContext.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getScope()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new \InvalidArgumentException('Invalid scope');]]></code>
       <code><![CDATA[throw new \InvalidArgumentException('user scope requires a user id');]]></code>
@@ -8133,6 +8505,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </ParamNameMismatch>
   </file>
   <file src="core/BackgroundJobs/GenerateMetadataJob.php">
+    <InvalidOperand>
+      <code><![CDATA[$node->getId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getDirectoryListing</code>
       <code>getUserFolder</code>
@@ -8232,6 +8607,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Background/Delete.php">
+    <InvalidOperand>
+      <code>$jobId</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>getArgument</code>
@@ -8241,6 +8619,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Background/Job.php">
+    <InvalidOperand>
+      <code>$jobId</code>
+      <code>$jobId</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -8252,6 +8634,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Background/ListCommand.php">
+    <InvalidOperand>
+      <code>$limit</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addOption</code>
       <code>addOption</code>
@@ -8265,6 +8650,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Base.php">
+    <InvalidOperand>
+      <code>$key</code>
+      <code>$key</code>
+      <code>$key</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addOption</code>
       <code>getOption</code>
@@ -8359,6 +8749,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Config/Import.php">
+    <InvalidOperand>
+      <code>$app</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>0</code>
       <code>1</code>
@@ -8417,6 +8810,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Config/System/SetConfig.php">
+    <InvalidOperand>
+      <code>(double) $value</code>
+      <code>(int) $value</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -8475,6 +8872,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Db/ConvertType.php">
+    <InvalidOperand>
+      <code>$numChunks</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>0</code>
       <code>1</code>
@@ -8757,6 +9157,14 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Info/File.php">
+    <InvalidOperand>
+      <code><![CDATA[$node->getId()]]></code>
+      <code><![CDATA[$node->getSize()]]></code>
+      <code><![CDATA[$stat['size']]]></code>
+      <code><![CDATA[$storageConfig->getId()]]></code>
+      <code>count($children)</code>
+      <code>count($children)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -8785,6 +9193,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Info/FileUtils.php">
+    <InvalidOperand>
+      <code><![CDATA[$mountPoint->getStorageConfig()->getId()]]></code>
+      <code><![CDATA[$share->getShareType()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getDirectoryListing</code>
       <code>getUserFolder</code>
@@ -8806,6 +9218,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Integrity/CheckApp.php">
+    <InvalidOperand>
+      <code>count($result)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -8816,6 +9231,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Integrity/CheckCore.php">
+    <InvalidOperand>
+      <code>count($result)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>parent::__construct()</code>
       <code>setName</code>
@@ -8947,6 +9365,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Maintenance/Mimetype/UpdateDB.php">
+    <InvalidOperand>
+      <code>$totalNewMimetypes</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addOption</code>
       <code>parent::__construct()</code>
@@ -8986,6 +9407,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Maintenance/RepairShareOwnership.php">
+    <InvalidOperand>
+      <code>count($shares)</code>
+      <code>count($shares)</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code>$found</code>
       <code>$found</code>
@@ -9022,6 +9447,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Preview/Generate.php">
+    <InvalidOperand>
+      <code>count($specifications)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -9040,6 +9468,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Preview/Repair.php">
+    <InvalidOperand>
+      <code><![CDATA[$oldPreviewFolder->getId()]]></code>
+      <code><![CDATA[$this->memoryLimit / 1024 / 1024]]></code>
+      <code><![CDATA[$this->memoryTreshold / 1024 / 1024]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addOption</code>
       <code>addOption</code>
@@ -9059,6 +9492,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedInterfaceMethod>
   </file>
   <file src="core/Command/Preview/ResetRenderedTexts.php">
+    <InvalidOperand>
+      <code>$avatarsToDeleteCount</code>
+      <code>$previewsToDeleteCount</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code>[]</code>
     </InvalidReturnStatement>
@@ -9115,6 +9552,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/SetupChecks.php">
+    <InvalidOperand>
+      <code>$placeholder</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getOption</code>
       <code>parent::__construct()</code>
@@ -9148,6 +9588,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/SystemTag/Edit.php">
+    <InvalidOperand>
+      <code>$userAssignable</code>
+      <code>$userVisible</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>addOption</code>
@@ -9329,6 +9773,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/User/Keys/Verify.php">
+    <InvalidOperand>
+      <code>strlen($privateKey)</code>
+      <code>strlen($publicKey)</code>
+      <code>strlen($publicKeyDerived)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addArgument</code>
       <code>getArgument</code>
@@ -9365,6 +9814,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Command/User/Report.php">
+    <InvalidOperand>
+      <code>self::DEFAULT_COUNT_DIRS_MAX_USERS</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>addOption</code>
       <code><![CDATA[new View('/')]]></code>
@@ -9452,6 +9904,12 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Controller/AvatarController.php">
+    <InvalidOperand>
+      <code>$size</code>
+      <code>$size</code>
+      <code>$size</code>
+      <code>$size</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>get</code>
       <code>getContent</code>
@@ -9495,9 +9953,19 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedInterfaceMethod>
   </file>
   <file src="core/Controller/CssController.php">
+    <InvalidOperand>
+      <code>$ttl</code>
+      <code>$ttl</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getFolder</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/GuestAvatarController.php">
+    <InvalidOperand>
+      <code>$size</code>
+      <code>$size</code>
+    </InvalidOperand>
   </file>
   <file src="core/Controller/HoverCardController.php">
     <MissingThrowsDocblock>
@@ -9505,6 +9973,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="core/Controller/JsController.php">
+    <InvalidOperand>
+      <code>$ttl</code>
+      <code>$ttl</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getFolder</code>
     </MissingThrowsDocblock>
@@ -10421,7 +10893,21 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>getIcon</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="cron.php">
+    <ImplicitToStringCast>
+      <code>$ex</code>
+      <code>$ex</code>
+    </ImplicitToStringCast>
+    <InvalidOperand>
+      <code>$dataDirectoryUser</code>
+      <code><![CDATA[$job->getId()]]></code>
+      <code>$user</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/autoloader.php">
+    <InvalidOperand>
+      <code>$root</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
@@ -10524,6 +11010,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Accounts/Account.php">
+    <InvalidOperand>
+      <code>$incrementals[$index]</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new RuntimeException('Requested collection is not an IAccountPropertyCollection');]]></code>
       <code><![CDATA[throw new \InvalidArgumentException('getProperty cannot retrieve an IAccountsPropertyCollection');]]></code>
@@ -10566,11 +11055,19 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Activity/Event.php">
+    <InvalidOperand>
+      <code>$placeholder</code>
+    </InvalidOperand>
     <ParamNameMismatch>
       <code>$affectedUser</code>
     </ParamNameMismatch>
   </file>
   <file src="lib/private/Activity/EventMerger.php">
+    <InvalidOperand>
+      <code>$combined</code>
+      <code>$combined</code>
+      <code>$placeholder</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>setParsedSubject</code>
       <code>setRichSubject</code>
@@ -10637,6 +11134,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </TypeDoesNotContainType>
   </file>
   <file src="lib/private/App/AppManager.php">
+    <InvalidOperand>
+      <code>$jsonError</code>
+      <code>$jsonError</code>
+    </InvalidOperand>
     <LessSpecificImplementedReturnType>
       <code>array</code>
       <code>array</code>
@@ -10697,6 +11198,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>$array[$element][]</code>
       <code>$array[$element][]</code>
     </InvalidArrayOffset>
+    <InvalidOperand>
+      <code>filemtime($file)</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code>(string)$xml</code>
     </InvalidReturnStatement>
@@ -10710,7 +11214,17 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>\OCP\Server::get(IBinaryFinder::class)</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/App/PlatformRepository.php">
+    <InvalidOperand>
+      <code>ord($match[2]) - 96</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/AppConfig.php">
+    <InvalidOperand>
+      <code>$type</code>
+      <code>self::APP_MAX_LENGTH</code>
+      <code>self::KEY_MAX_LENGTH</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>assertParams</code>
       <code>assertParams</code>
@@ -10756,6 +11270,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </NullableReturnStatement>
   </file>
   <file src="lib/private/AppFramework/App.php">
+    <InvalidOperand>
+      <code>strlen($output)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(IAppManager::class)</code>
       <code>\OCP\Server::get(IAppManager::class)</code>
@@ -10832,6 +11349,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/AppFramework/Http/Dispatcher.php">
+    <InvalidOperand>
+      <code><![CDATA[$throwable->getLine()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>buildResponse</code>
       <code>buildResponse</code>
@@ -10916,6 +11436,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/AppFramework/Middleware/Security/BruteForceMiddleware.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->delaySlept]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>sleepDelayOrThrowOnMax</code>
       <code><![CDATA[throw new OCSException($e->getMessage(), Http::STATUS_TOO_MANY_REQUESTS);]]></code>
@@ -11149,6 +11672,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Authentication/Token/PublicKeyTokenProvider.php">
+    <InvalidOperand>
+      <code>self::TOKEN_MIN_LENGTH</code>
+      <code>strlen($token)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>atomic</code>
       <code>atomic</code>
@@ -11187,6 +11714,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Authentication/TwoFactorAuth/Manager.php">
+    <InvalidOperand>
+      <code>count($missing)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getId</code>
       <code>getId</code>
@@ -11268,6 +11798,13 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Avatar/Avatar.php">
+    <InvalidOperand>
+      <code>$size * 0.4</code>
+      <code>$xi - $xr</code>
+      <code>$yi + $yr</code>
+      <code>($xi - $xr) / 2</code>
+      <code>($yi + $yr) / 2</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getContent</code>
       <code>getContent</code>
@@ -11279,7 +11816,16 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>getFolder</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/Avatar/PlaceholderAvatar.php">
+    <InvalidOperand>
+      <code>$size</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Avatar/UserAvatar.php">
+    <InvalidOperand>
+      <code>$size</code>
+      <code>$size</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>new \OCP\Image()</code>
       <code>new \OCP\Image()</code>
@@ -11291,6 +11837,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/BackgroundJob/JobList.php">
+    <InvalidOperand>
+      <code><![CDATA[$job->getId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[\OCP\Server::get($row['class'])]]></code>
       <code><![CDATA[\OCP\Server::get($row['class'])]]></code>
@@ -11436,6 +11985,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Collaboration/Reference/File/FileReferenceProvider.php">
+    <InvalidOperand>
+      <code>$fileId</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>imagePath</code>
     </MissingThrowsDocblock>
@@ -11517,6 +12069,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Comments/Comment.php">
+    <InvalidOperand>
+      <code>$maxLength</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new \InvalidArgumentException('Integer expected.');]]></code>
       <code><![CDATA[throw new \InvalidArgumentException('Non empty string expected.');]]></code>
@@ -11683,6 +12238,13 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code><![CDATA[$params['adapter']]]></code>
       <code><![CDATA[$params['tablePrefix']]]></code>
     </InvalidArrayOffset>
+    <InvalidOperand>
+      <code><![CDATA[$this->getTransactionNestingLevel()]]></code>
+      <code>$timeTook</code>
+      <code>$timeTook</code>
+      <code>$timeTook</code>
+      <code><![CDATA[$traces[1]['line']]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(ClockInterface::class)</code>
       <code>\OCP\Server::get(ClockInterface::class)</code>
@@ -11808,10 +12370,21 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code><![CDATA[$params['collation']]]></code>
     </InvalidArrayOffset>
   </file>
+  <file src="lib/private/DB/QueryBuilder/FunctionBuilder/PgSqlFunctionBuilder.php">
+    <ImplicitToStringCast>
+      <code>$castedExpression</code>
+      <code>$castedExpression</code>
+    </ImplicitToStringCast>
+  </file>
   <file src="lib/private/DB/QueryBuilder/QueryBuilder.php">
     <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
+    <InvalidOperand>
+      <code>$placeholder</code>
+      <code>$placeholder</code>
+      <code>$placeholder</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>execute</code>
       <code>executeStatement</code>
@@ -11889,6 +12462,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </InvalidReturnType>
   </file>
   <file src="lib/private/DateTimeZone.php">
+    <InvalidOperand>
+      <code>abs($offset)</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>$timestamp</code>
     </InvalidScalarArgument>
@@ -11898,6 +12474,17 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>get</code>
       <code>get</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Diagnostics/Event.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getDuration()]]></code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/private/Diagnostics/EventLogger.php">
+    <InvalidOperand>
+      <code>$duration * 1000</code>
+      <code>$timeInMs</code>
+    </InvalidOperand>
   </file>
   <file src="lib/private/Diagnostics/Query.php">
     <ImplementedReturnTypeMismatch>
@@ -11913,6 +12500,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </InvalidReturnType>
   </file>
   <file src="lib/private/DirectEditing/Manager.php">
+    <InvalidOperand>
+      <code>$fileId</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code><![CDATA[$query->execute()]]></code>
     </InvalidReturnStatement>
@@ -11960,6 +12550,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedMethod>
   </file>
   <file src="lib/private/Encryption/DecryptAll.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getTimestamp()]]></code>
+      <code>$uid</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>rename</code>
     </MissingThrowsDocblock>
@@ -12004,6 +12598,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidNullableReturnType>
       <code>deleteUserKey</code>
     </InvalidNullableReturnType>
+    <InvalidOperand>
+      <code><![CDATA[$this->getTimestamp()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>file_get_contents</code>
       <code>file_put_contents</code>
@@ -12030,6 +12627,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Encryption/Update.php">
+    <InvalidOperand>
+      <code><![CDATA[$info->getId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[Filesystem::getPath($params['fileSource'])]]></code>
       <code><![CDATA[Filesystem::getPath($params['fileSource'])]]></code>
@@ -12043,6 +12643,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Encryption/Util.php">
+    <InvalidOperand>
+      <code>$key</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getUidAndFilename</code>
     </MissingThrowsDocblock>
@@ -12086,6 +12689,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidNullableReturnType>
       <code>array</code>
     </InvalidNullableReturnType>
+    <InvalidOperand>
+      <code>0 + $min</code>
+      <code>0 + $sum</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>$path</code>
       <code>\OC_Util::normalizeUnicode($path)</code>
@@ -12155,6 +12762,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidArgument>
       <code>self::SCAN_RECURSIVE_INCOMPLETE</code>
     </InvalidArgument>
+    <InvalidOperand>
+      <code>$childName</code>
+      <code>$size += $childSize</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code>$existingChildren</code>
     </InvalidReturnStatement>
@@ -12253,10 +12864,18 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </ParamNameMismatch>
   </file>
   <file src="lib/private/Files/Config/CachedMountInfo.php">
+    <InvalidOperand>
+      <code>$rootId</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[Filesystem::initMountPoints($this->getUser()->getUID())]]></code>
       <code><![CDATA[throw new \Exception("Mount provider $mountProvider name exceeds the limit of 128 characters");]]></code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Config/LazyStorageMountInfo.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getRootId()]]></code>
+    </InvalidOperand>
   </file>
   <file src="lib/private/Files/Config/MountProviderCollection.php">
     <InvalidOperand>
@@ -12364,6 +12983,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </TooManyArguments>
   </file>
   <file src="lib/private/Files/Lock/LockManager.php">
+    <ImplicitToStringCast>
+      <code><![CDATA[$this->lockInScope]]></code>
+    </ImplicitToStringCast>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new PreConditionNotMetException('Could not obtain lock scope as already in use by ' . $this->lockInScope);]]></code>
     </MissingThrowsDocblock>
@@ -12380,6 +13002,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Mount/Manager.php">
+    <InvalidOperand>
+      <code><![CDATA[count($this->mounts)]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new NotFoundException("No mount for path " . $path . " existing mounts (" . count($this->mounts) ."): " . implode(",", array_keys($this->mounts)));]]></code>
       <code><![CDATA[throw new \Exception("No mounts even after explicitly setting up the root mounts");]]></code>
@@ -12597,6 +13222,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Node/Root.php">
+    <InvalidOperand>
+      <code>$id</code>
+      <code>$id</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code>$folders</code>
       <code><![CDATA[$this->createNode($fullPath, $fileInfo, false)]]></code>
@@ -12642,6 +13271,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/ObjectStore/ObjectStoreStorage.php">
+    <InvalidOperand>
+      <code>$fileId</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>$source</code>
     </InvalidScalarArgument>
@@ -12738,6 +13370,16 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>objectExists</code>
       <code>request</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/ObjectStore/SwiftFactory.php">
+    <InvalidOperand>
+      <code><![CDATA[$request->getUri()->getPort()]]></code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/private/Files/Search/SearchBinaryOperator.php">
+    <ImplicitToStringCast>
+      <code><![CDATA[$this->arguments[0]]]></code>
+    </ImplicitToStringCast>
   </file>
   <file src="lib/private/Files/SetupManager.php">
     <MissingThrowsDocblock>
@@ -12843,6 +13485,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>ArrayCache</code>
       <code>ArrayCache</code>
     </InvalidClass>
+    <InvalidOperand>
+      <code><![CDATA[$response->getStatusCode()]]></code>
+      <code>round($elapsed * 1000, 1)</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code><![CDATA[$response->getBody()]]></code>
     </InvalidReturnStatement>
@@ -13144,9 +13790,17 @@ On Nginx those are typically the lines starting with "location ~" that need an u
   </file>
   <file src="lib/private/Files/Storage/Wrapper/Encryption.php">
     <InvalidOperand>
+      <code>$lastChunkNr</code>
+      <code>$lastChunkNr</code>
+      <code>$lastChunkNr * $blockSize</code>
+      <code>$lastChunkNr * $unencryptedBlockSize</code>
+      <code>$newUnencryptedSize += $lastChunkNr * $unencryptedBlockSize</code>
+      <code>$newUnencryptedSize += $unencryptedBlockSize</code>
+      <code>$newUnencryptedSize += strlen($decryptedLastChunk)</code>
       <code>$result</code>
       <code>$result</code>
       <code><![CDATA[$this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, false, $isRename)]]></code>
+      <code>ceil($size / $blockSize) - 1</code>
     </InvalidOperand>
     <InvalidReturnStatement>
       <code>$newUnencryptedSize</code>
@@ -13200,6 +13854,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </InvalidReturnType>
   </file>
   <file src="lib/private/Files/Storage/Wrapper/Quota.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getQuota() - $used]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new \Exception("No quota or quota callback provider");]]></code>
     </MissingThrowsDocblock>
@@ -13217,6 +13874,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Stream/SeekableHttpStream.php">
+    <InvalidOperand>
+      <code>$start</code>
+    </InvalidOperand>
     <InvalidReturnType>
       <code>stream_close</code>
       <code>stream_flush</code>
@@ -13407,6 +14067,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/FilesMetadata/FilesMetadataManager.php">
+    <InvalidOperand>
+      <code><![CDATA[$filesMetadata->getFileId()]]></code>
+      <code>self::JSON_MAXSIZE</code>
+      <code>strlen($json)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(IDBConnection::class)</code>
       <code>\OCP\Server::get(IDBConnection::class)</code>
@@ -13414,6 +14079,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/FilesMetadata/MetadataQuery.php">
+    <InvalidOperand>
+      <code><![CDATA[count($this->knownJoinedIndex)]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getMetadataKeyField</code>
     </MissingThrowsDocblock>
@@ -13449,6 +14117,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/FullTextSearch/Model/IndexDocument.php">
+    <InvalidOperand>
+      <code>$source</code>
+    </InvalidOperand>
     <TypeDoesNotContainNull>
       <code><![CDATA[is_null($this->getContent())]]></code>
     </TypeDoesNotContainNull>
@@ -13541,6 +14212,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </NullableReturnStatement>
   </file>
   <file src="lib/private/Http/WellKnown/RequestManager.php">
+    <InvalidOperand>
+      <code>count($registrations)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new RuntimeException("Well known handlers requested before the apps had been fully registered");]]></code>
     </MissingThrowsDocblock>
@@ -13649,6 +14323,7 @@ On Nginx those are typically the lines starting with "location ~" that need an u
   <file src="lib/private/LargeFileHelper.php">
     <InvalidOperand>
       <code>$matches[1]</code>
+      <code>0 + $result</code>
     </InvalidOperand>
     <MissingThrowsDocblock>
       <code>get</code>
@@ -13758,6 +14433,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="lib/private/Log.php">
+    <InvalidOperand>
+      <code>$key</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(IUserSession::class)</code>
       <code>\OCP\Server::get(IUserSession::class)</code>
@@ -13768,10 +14446,26 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </RedundantCondition>
   </file>
   <file src="lib/private/Log/ErrorHandler.php">
+    <InvalidOperand>
+      <code><![CDATA[$error['line']]]></code>
+      <code><![CDATA[$exception->getLine()]]></code>
+      <code>$line</code>
+      <code>$line</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>log</code>
       <code>log</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Log/Errorlog.php">
+    <InvalidOperand>
+      <code>$level</code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/private/Log/ExceptionSerializer.php">
+    <InvalidOperand>
+      <code>$elemCount - 5</code>
+    </InvalidOperand>
   </file>
   <file src="lib/private/Log/File.php">
     <TypeDoesNotContainNull>
@@ -13784,6 +14478,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </RedundantCondition>
   </file>
   <file src="lib/private/Log/Rotate.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->maxSize]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(IConfig::class)</code>
       <code>\OCP\Server::get(IConfig::class)</code>
@@ -13841,6 +14538,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
 			]), $missingCacheHint);]]></code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/Memcache/LoggerWrapperCache.php">
+    <InvalidOperand>
+      <code>$ttl</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Memcache/Memcached.php">
     <MissingThrowsDocblock>
       <code><![CDATA[throw new HintException("Expected 'memcached_options' config to be an array, got $options");]]></code>
@@ -13867,6 +14569,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/MemoryInfo.php">
+    <InvalidOperand>
+      <code>$memoryLimit *= 1024</code>
+      <code>$memoryLimit *= 1024</code>
+      <code>$memoryLimit *= 1024</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[throw new \InvalidArgumentException($number.' is not a valid numeric string (in memory_limit ini directive)');]]></code>
     </MissingThrowsDocblock>
@@ -13893,6 +14600,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>imagePath</code>
       <code>imagePath</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Notification/Notification.php">
+    <InvalidOperand>
+      <code>$placeholder</code>
+    </InvalidOperand>
   </file>
   <file src="lib/private/Preview/BackgroundCleanupJob.php">
     <InvalidReturnStatement>
@@ -13925,6 +14637,28 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidArgument>
       <code>$maxPreviewImage</code>
     </InvalidArgument>
+    <InvalidOperand>
+      <code>$height / $maxHeight</code>
+      <code>$height / $maxHeight</code>
+      <code>$height / $pow4height</code>
+      <code>$height / $ratio</code>
+      <code>$height / $ratio</code>
+      <code>$height / $ratio</code>
+      <code>$height /= $ratio</code>
+      <code>$height /= $ratioW</code>
+      <code>$width * $ratio</code>
+      <code>$width * $ratio</code>
+      <code>$width * $ratio</code>
+      <code>$width / $maxWidth</code>
+      <code>$width / $maxWidth</code>
+      <code>$width / $pow4width</code>
+      <code>$width /= $ratio</code>
+      <code>$width /= $ratioH</code>
+      <code>4 ** ceil(log($height) / log(4))</code>
+      <code>4 ** ceil(log($width) / log(4))</code>
+      <code><![CDATA[abs($height - $preview->height()) * 0.5]]></code>
+      <code><![CDATA[abs($width - $preview->width()) * 0.5]]></code>
+    </InvalidOperand>
     <LessSpecificReturnType>
       <code>null|string</code>
     </LessSpecificReturnType>
@@ -14004,6 +14738,23 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Preview/MarkDown.php">
+    <InvalidOperand>
+      <code>$actualFontSize * 2</code>
+      <code>$actualFontSize * 2</code>
+      <code>$actualFontSize *= 1.1</code>
+      <code>$actualFontSize *= 1.2</code>
+      <code>$actualFontSize *= 1.4</code>
+      <code>$actualFontSize *= 1.6</code>
+      <code>$actualFontSize *= 1.8</code>
+      <code>$linesWrapped * ceil($actualFontSize * 2)</code>
+      <code>$maxX * 0.05</code>
+      <code>$maxY * 0.05</code>
+      <code>$nextLineStart + $actualFontSize</code>
+      <code>$nextLineStart -= $actualFontSize</code>
+      <code>(1 / $actualFontSize * 1.3) * $maxX</code>
+      <code>1 / $actualFontSize</code>
+      <code><![CDATA[1 / ($maxX >= 512 ? 60 : 40) * $maxX]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>fopen</code>
       <code>fopen</code>
@@ -14019,6 +14770,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Preview/Office.php">
+    <InvalidOperand>
+      <code><![CDATA[$file->getId()]]></code>
+      <code><![CDATA[$file->getId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>Server::get(ITempManager::class)</code>
       <code>Server::get(ITempManager::class)</code>
@@ -14060,6 +14815,12 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Preview/TXT.php">
+    <InvalidOperand>
+      <code>$fontSize * 1.5</code>
+      <code>$index * $lineSize</code>
+      <code>$index * $lineSize</code>
+      <code>(1 / 32) * $maxX</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>fopen</code>
       <code>fopen</code>
@@ -14226,6 +14987,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>get</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/Repair/AddAppConfigLazyMigration.php">
+    <InvalidOperand>
+      <code>$c</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Repair/CleanTags.php">
     <MissingThrowsDocblock>
       <code>execute</code>
@@ -14238,6 +15004,21 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>executeQuery</code>
       <code>executeQuery</code>
     </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Repair/NC11/FixMountStorages.php">
+    <InvalidOperand>
+      <code>$entriesUpdated</code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/private/Repair/NC16/CleanupCardDAVPhotoCache.php">
+    <InvalidOperand>
+      <code>count($folders)</code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/private/Repair/OldGroupMembershipShares.php">
+    <InvalidOperand>
+      <code>$deletedEntries</code>
+    </InvalidOperand>
   </file>
   <file src="lib/private/Repair/Owncloud/CleanPreviews.php">
     <InvalidArgument>
@@ -14270,6 +15051,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>getTable</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/Repair/Owncloud/UpdateLanguageCodes.php">
+    <InvalidOperand>
+      <code>$affectedRows</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Repair/RemoveLinkShares.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->userToNotify]]></code>
@@ -14290,6 +15076,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Repair/RepairInvalidShares.php">
+    <InvalidOperand>
+      <code>$deletedEntries</code>
+      <code>$updatedEntries</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>execute</code>
     </MissingThrowsDocblock>
@@ -14305,6 +15095,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>$out</code>
     </ParamNameMismatch>
   </file>
+  <file src="lib/private/Route/CachingRouter.php">
+    <InvalidOperand>
+      <code>(int)$absolute</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Route/Router.php">
     <InvalidClass>
       <code>\OC_APP</code>
@@ -14312,6 +15107,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
+    <InvalidOperand>
+      <code>$app</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>generate</code>
       <code>generate</code>
@@ -14403,15 +15201,31 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>executeStatement</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/Security/Bruteforce/Backend/MemoryCacheBackend.php">
+    <InvalidOperand>
+      <code>$timestamp</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Security/Bruteforce/CleanupJob.php">
     <MissingThrowsDocblock>
       <code>execute</code>
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Security/Bruteforce/Throttler.php">
+    <InvalidOperand>
+      <code>$delay * 1000</code>
+      <code>$firstDelay * 2 ** $attempts</code>
+      <code><![CDATA[$this->timeFactory->getTime() - 3600 * $maxAgeHours]]></code>
+      <code>3600 * $maxAgeHours</code>
+    </InvalidOperand>
     <NullArgument>
       <code>null</code>
     </NullArgument>
+  </file>
+  <file src="lib/private/Security/CSP/ContentSecurityPolicyManager.php">
+    <InvalidOperand>
+      <code><![CDATA[$value > $currentValue]]></code>
+    </InvalidOperand>
   </file>
   <file src="lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php">
     <NoInterfaceProperties>
@@ -14473,6 +15287,13 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code><![CDATA[throw new \RuntimeException('String contains non hex chars: ' . $hex);]]></code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/Security/Hasher.php">
+    <InvalidOperand>
+      <code>1</code>
+      <code>2</code>
+      <code>3</code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Security/IdentityProof/Manager.php">
     <MissingThrowsDocblock>
       <code>getFolder</code>
@@ -14499,7 +15320,20 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>getExistingAttemptCount</code>
     </MissingThrowsDocblock>
   </file>
+  <file src="lib/private/Security/SecureRandom.php">
+    <InvalidOperand>
+      <code>$length</code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/private/Security/TrustedDomainHelper.php">
+    <InvalidOperand>
+      <code><![CDATA[$parsedUrl['port']]]></code>
+    </InvalidOperand>
+  </file>
   <file src="lib/private/Security/VerificationToken/VerificationToken.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->timeFactory->getTime()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>setUserValue</code>
       <code>setUserValue</code>
@@ -14859,6 +15693,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedThisPropertyFetch>
   </file>
   <file src="lib/private/Setup/MySQL.php">
+    <InvalidOperand>
+      <code>$i</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>executeQuery</code>
       <code>throw $ex;</code>
@@ -14883,6 +15720,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Setup/PostgreSQL.php">
+    <InvalidOperand>
+      <code>$i</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>execute</code>
       <code>execute</code>
@@ -14910,6 +15750,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <InvalidOperand>
+      <code>$shareType</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
@@ -15020,6 +15863,12 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidArgument>
       <code>$id</code>
     </InvalidArgument>
+    <InvalidOperand>
+      <code>$days</code>
+      <code>$days</code>
+      <code>$defaultExpireDays</code>
+      <code><![CDATA[$this->shareApiLinkDefaultExpireDays()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code><![CDATA[\OC_Hook::emit(Share::class, 'post_set_expiration_date', [
 				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
@@ -15145,6 +15994,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>FederatedShareProvider</code>
       <code>ShareByMailProvider</code>
     </InvalidNullableReturnType>
+    <InvalidOperand>
+      <code>$shareType</code>
+    </InvalidOperand>
     <InvalidReturnStatement>
       <code>$provider</code>
       <code>$provider</code>
@@ -15222,6 +16074,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Share20/Share.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->fileId]]></code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->node]]></code>
     </LessSpecificReturnStatement>
@@ -15241,6 +16096,16 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <MoreSpecificReturnType>
       <code>getNode</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/private/SpeechToText/SpeechToTextManager.php">
+    <InvalidOperand>
+      <code><![CDATA[$file->getId()]]></code>
+    </InvalidOperand>
+  </file>
+  <file src="lib/private/SpeechToText/TranscriptionJob.php">
+    <InvalidOperand>
+      <code>$fileId</code>
+    </InvalidOperand>
   </file>
   <file src="lib/private/StreamImage.php">
     <MissingThrowsDocblock>
@@ -15318,6 +16183,14 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/SystemTag/SystemTagManager.php">
+    <InvalidOperand>
+      <code>$userAssignable</code>
+      <code>$userAssignable</code>
+      <code>$userAssignable</code>
+      <code>$userVisible</code>
+      <code>$userVisible</code>
+      <code>$userVisible</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>beginTransaction</code>
       <code>execute</code>
@@ -15369,6 +16242,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Tags.php">
+    <InvalidOperand>
+      <code><![CDATA[$tag->getId()]]></code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>$from</code>
       <code>$names</code>
@@ -15510,6 +16386,11 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/TextProcessing/Manager.php">
+    <InvalidOperand>
+      <code>$maxExecutionTime * 0.8</code>
+      <code><![CDATA[$provider->getExpectedRuntime()]]></code>
+      <code><![CDATA[$provider->getExpectedRuntime()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>delete</code>
       <code><![CDATA[throw new RuntimeException('Failure while trying to find tasks by appId and identifier: ' . $e->getMessage(), 0, $e);]]></code>
@@ -15530,11 +16411,19 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/TextToImage/Db/TaskMapper.php">
+    <InvalidOperand>
+      <code>$timeout</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>executeStatement</code>
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/TextToImage/Manager.php">
+    <InvalidOperand>
+      <code>$maxExecutionTime * 0.8</code>
+      <code><![CDATA[$provider->getExpectedRuntime()]]></code>
+      <code><![CDATA[$this->getPreferredProviders()[0]->getExpectedRuntime()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>delete</code>
       <code>update</code>
@@ -15569,6 +16458,13 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Updater.php">
+    <InvalidOperand>
+      <code>$appId</code>
+      <code><![CDATA[$event->getCurrentStep()]]></code>
+      <code><![CDATA[$event->getIncrement()]]></code>
+      <code><![CDATA[$event->getMaxStep()]]></code>
+      <code><![CDATA[$event->getMaxStep()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(Repair::class)</code>
       <code>\OCP\Server::get(Repair::class)</code>
@@ -15731,6 +16627,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     <InvalidNullableReturnType>
       <code>int</code>
     </InvalidNullableReturnType>
+    <InvalidOperand>
+      <code>$name</code>
+    </InvalidOperand>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
@@ -15815,6 +16714,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/legacy/OC_EventSource.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->fallBackId]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>send</code>
       <code>send</code>
@@ -15829,6 +16731,18 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedDocblockClass>
   </file>
   <file src="lib/private/legacy/OC_Files.php">
+    <InvalidOperand>
+      <code><![CDATA[$fileSize += $fileInfo->getSize()]]></code>
+      <code>$fileSize - $ranges[1]</code>
+      <code>$fileSize - $ranges[1]</code>
+      <code>$fileSize - 1</code>
+      <code>$fileSize - 1</code>
+      <code>$fileSize - 1</code>
+      <code><![CDATA[$rangeArray[$ind - 1]['to'] + 1]]></code>
+      <code><![CDATA[$rangeArray[$ind - 1]['to'] + 1]]></code>
+      <code>$ranges[1] + 1</code>
+      <code>$ranges[1] + 1</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(IEventDispatcher::class)</code>
       <code>\OCP\Server::get(IEventDispatcher::class)</code>
@@ -15861,6 +16775,21 @@ On Nginx those are typically the lines starting with "location ~" that need an u
       <code>$matches[0][$last_match]</code>
       <code>$matches[1][$last_match]</code>
     </InvalidArrayOffset>
+    <InvalidOperand>
+      <code>$bytes *= $bytes_array[$matches[1]]</code>
+      <code>$bytes / 1024</code>
+      <code>$bytes / 1024</code>
+      <code>$bytes / 1024</code>
+      <code>$bytes / 1024</code>
+      <code>$bytes / 1024</code>
+      <code>$free + $used</code>
+      <code>$quota - $used</code>
+      <code>$used / $total</code>
+      <code>$used / $total</code>
+      <code>($used / $total) * 10000</code>
+      <code>round(($used / $total) * 10000) / 100</code>
+      <code>round(($used / $total) * 10000) / 100</code>
+    </InvalidOperand>
     <InvalidScalarArgument>
       <code>$path</code>
     </InvalidScalarArgument>
@@ -15888,6 +16817,24 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/legacy/OC_Image.php">
+    <InvalidOperand>
+      <code>$h</code>
+      <code>$height</code>
+      <code>$height</code>
+      <code>$maxSize * $ratioOrig</code>
+      <code>$maxSize / $ratioOrig</code>
+      <code>$maxWidth / $ratio</code>
+      <code>$memory_limit</code>
+      <code>$o</code>
+      <code>$o</code>
+      <code>$o</code>
+      <code>$ratio * $maxHeight</code>
+      <code>$w</code>
+      <code>$width</code>
+      <code>$width</code>
+      <code>($heightOrig / 2) - ($height / 2)</code>
+      <code>($widthOrig / 2) - ($width / 2)</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>_output</code>
       <code>_output</code>
@@ -15910,6 +16857,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/private/legacy/OC_Template.php">
+    <InvalidOperand>
+      <code><![CDATA[$exception->getLine()]]></code>
+    </InvalidOperand>
     <InvalidReturnType>
       <code>bool|string</code>
     </InvalidReturnType>
@@ -16054,6 +17004,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/public/AppFramework/Http/FileDisplayResponse.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->file->getSize()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getContent</code>
       <code>getContent</code>
@@ -16074,6 +17027,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/public/AppFramework/Http/Response.php">
+    <InvalidOperand>
+      <code>$cacheSeconds</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code><![CDATA[array_merge($mergeWith, $this->headers)]]></code>
     </LessSpecificReturnStatement>
@@ -16106,6 +17062,10 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </AmbiguousConstantInheritance>
   </file>
   <file src="lib/public/BackgroundJob/Job.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getId()]]></code>
+      <code>$timeTaken</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
       <code>\OCP\Server::get(LoggerInterface::class)</code>
@@ -16133,6 +17093,17 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/public/Color.php">
+    <InvalidOperand>
+      <code><![CDATA[$opacity * $this->blue()]]></code>
+      <code><![CDATA[$opacity * $this->green()]]></code>
+      <code><![CDATA[$opacity * $this->red()]]></code>
+      <code><![CDATA[(1 - $opacity) * $source->blue()]]></code>
+      <code><![CDATA[(1 - $opacity) * $source->green()]]></code>
+      <code><![CDATA[(1 - $opacity) * $source->red()]]></code>
+      <code>1 - $opacity</code>
+      <code>1 - $opacity</code>
+      <code>1 - $opacity</code>
+    </InvalidOperand>
     <LessSpecificReturnStatement>
       <code>$step</code>
     </LessSpecificReturnStatement>
@@ -16173,6 +17144,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/public/Files/Lock/LockContext.php">
+    <InvalidOperand>
+      <code><![CDATA[$this->getNode()->getId()]]></code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>getId</code>
       <code>getId</code>
@@ -16243,6 +17217,9 @@ On Nginx those are typically the lines starting with "location ~" that need an u
     </MissingThrowsDocblock>
   </file>
   <file src="lib/public/Util.php">
+    <InvalidOperand>
+      <code>0 + (string)$number</code>
+    </InvalidOperand>
     <MissingThrowsDocblock>
       <code>Server::get(\OCP\L10N\IFactory::class)</code>
       <code>Server::get(\OCP\L10N\IFactory::class)</code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -33,6 +33,11 @@
       <code>$cardData</code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="3rdparty/sabre/dav/lib/DAVACL/ACLTrait.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Sabre\DAV\Exception\Forbidden('Setting ACL is not supported on this node');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="3rdparty/sabre/dav/lib/DAVACL/AbstractPrincipalCollection.php">
     <LessSpecificImplementedReturnType>
       <code>array</code>
@@ -43,13 +48,154 @@
       <code>unserialize</code>
     </MethodSignatureMustProvideReturnType>
   </file>
+  <file src="apps/admin_audit/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/cloud_federation_api/lib/Controller/RequestHandlerController.php">
+    <MissingThrowsDocblock>
+      <code>resolveCloudId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/comments/lib/Activity/Filter.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/comments/lib/Activity/Listener.php">
+    <MissingThrowsDocblock>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setMessage</code>
+      <code>setObject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/comments/lib/Activity/Provider.php">
+    <MissingThrowsDocblock>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>setParsedMessage</code>
+      <code>setRichMessage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/comments/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/comments/lib/Controller/NotificationsController.php">
+    <MissingThrowsDocblock>
+      <code>setApp</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setUser</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/comments/lib/Listener/CommentsEntityEventListener.php">
+    <MissingThrowsDocblock>
+      <code>addEntityCollection</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/comments/lib/Notification/Listener.php">
     <LessSpecificReturnStatement>
       <code>$uids</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code><![CDATA[list<string>]]></code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="apps/comments/lib/Search/LegacyProvider.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/contactsinteraction/lib/Card.php">
+    <MissingThrowsDocblock>
+      <code>throw new NotImplemented();</code>
+      <code>throw new NotImplemented();</code>
+      <code>throw new NotImplemented();</code>
+      <code>throw new NotImplemented();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/contactsinteraction/lib/Db/CardSearchDao.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/contactsinteraction/lib/Db/RecentContactMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>findEntities</code>
+      <code>findEntities</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php">
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/contactsinteraction/lib/Migration/Version010000Date20200304152605.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dashboard/lib/Controller/DashboardController.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dashboard/lib/Controller/LayoutApiController.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/appinfo/v1/caldav.php">
     <UndefinedGlobalVariable>
@@ -89,8 +235,225 @@
     <InvalidArgument>
       <code>registerEventListener</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/AppInfo/PluginManager.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new \Exception('Could not load ' . $className, 0, $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Avatars/AvatarHome.php">
+    <MissingThrowsDocblock>
+      <code>getAvatar</code>
+      <code>getAvatar</code>
+      <code><![CDATA[throw new Forbidden('Permission denied to create a file');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to create a folder');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to delete this folder');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this folder');]]></code>
+      <code><![CDATA[throw new MethodNotAllowed('File format not allowed');]]></code>
+      <code><![CDATA[throw new MethodNotAllowed('Invalid image size');]]></code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/BuildReminderIndexBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/CleanupInvitationTokenJob.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/GenerateBirthdayCalendarBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>syncUser</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/PruneOutdatedSyncTokensJob.php">
+    <MissingThrowsDocblock>
+      <code>pruneOutdatedSyncTokens</code>
+      <code>pruneOutdatedSyncTokens</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/UpdateCalendarResourcesRoomsBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getLastInsertId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/UploadCleanup.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getDirectoryListing</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/UserStatusAutomation.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BulkUpload/BulkUploadPlugin.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new MultipartRequestParser($request, $this->logger)]]></code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/BulkUpload/MultipartRequestParser.php">
+    <MissingThrowsDocblock>
+      <code>isAt</code>
+      <code>isAt</code>
+      <code>readBoundary</code>
+      <code>readPartContent</code>
+      <code>readPartContent</code>
+      <code>readPartHeaders</code>
+      <code>readPartHeaders</code>
+      <code>readPartHeaders</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Backend.php">
+    <MissingThrowsDocblock>
+      <code>publish</code>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setAuthor</code>
+      <code>setAuthor</code>
+      <code>setAuthor</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+      <code>setType</code>
+      <code>setType</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Filter/Calendar.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Filter/Todo.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Provider/Base.php">
+    <MissingThrowsDocblock>
+      <code>setRichSubject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Provider/Calendar.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Provider/Event.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>throw new \InvalidArgumentException();</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Activity/Provider/Todo.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/AppCalendar/AppCalendar.php">
+    <MissingThrowsDocblock>
+      <code>createFromString</code>
+      <code><![CDATA[throw new Forbidden('Creating a new entry is not allowed');]]></code>
+      <code><![CDATA[throw new Forbidden('Deleting an entry is not implemented');]]></code>
+      <code><![CDATA[throw new Forbidden('Setting ACL is not supported on this node');]]></code>
+      <code><![CDATA[throw new NotFound('Node not found');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/AppCalendar/CalendarObject.php">
+    <MissingThrowsDocblock>
+      <code>createFromString</code>
+      <code>createFromString</code>
+      <code><![CDATA[throw new Forbidden('Setting ACL is not supported on this node');]]></code>
+      <code><![CDATA[throw new Forbidden('This calendar-object is read-only');]]></code>
+      <code><![CDATA[throw new Forbidden('This calendar-object is read-only');]]></code>
+      <code><![CDATA[throw new Forbidden('This calendar-object is read-only');]]></code>
+      <code><![CDATA[throw new NotFound('Invalid node');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/BirthdayCalendar/EnablePlugin.php">
+    <MissingThrowsDocblock>
+      <code>parse</code>
+      <code>setStatus</code>
+      <code>setStatus</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>syncUser</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CalDAV/BirthdayService.php">
+    <MissingThrowsDocblock>
+      <code>createCalendar</code>
+    </MissingThrowsDocblock>
     <UndefinedMethod>
       <code>setDateTime</code>
       <code>setDateTime</code>
@@ -101,6 +464,11 @@
       <code><![CDATA[$newCalendarData->VEVENT->DTSTART]]></code>
       <code><![CDATA[$newCalendarData->VEVENT->SUMMARY]]></code>
     </UndefinedPropertyFetch>
+  </file>
+  <file src="apps/dav/lib/CalDAV/CachedSubscription.php">
+    <MissingThrowsDocblock>
+      <code>throw new UnsupportedLimitOnInitialSyncException();</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CalDAV/CachedSubscriptionObject.php">
     <NullableReturnStatement>
@@ -118,6 +486,111 @@
     <LessSpecificReturnStatement>
       <code>Reader::read($objectData)</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code><![CDATA[throw new BadRequest('Calendar objects must have a VJOURNAL, VEVENT or VTODO component');]]></code>
+      <code><![CDATA[throw new DAV\Exception('The ' . $sccs . ' property must be of type: \Sabre\CalDAV\Property\SupportedCalendarComponentSet');]]></code>
+      <code><![CDATA[throw new Forbidden('The {http://calendarserver.org/ns/}source property is required when creating subscriptions');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Calendarobject does not exists: ' . $uri);]]></code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$objectData</code>
       <code>$uris</code>
@@ -130,6 +603,15 @@
       <code>null</code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/dav/lib/CalDAV/Calendar.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new NotFound('Calendar object not found');]]></code>
+      <code><![CDATA[throw new NotFound('Calendar object not found');]]></code>
+      <code>throw new UnsupportedLimitOnInitialSyncException();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/CalDAV/CalendarHome.php">
     <InvalidNullableReturnType>
       <code>INode</code>
@@ -137,6 +619,10 @@
     <LessSpecificImplementedReturnType>
       <code>INode</code>
     </LessSpecificImplementedReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new MethodNotAllowed('The resource you tried to create has a reserved name');]]></code>
+      <code><![CDATA[throw new NotFound('Node with name \'' . $name . '\' could not be found');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[$calendarPlugin->getCalendarInCalendarHome($this->principalInfo['uri'], $calendarUri)]]></code>
     </NullableReturnStatement>
@@ -149,6 +635,22 @@
       <code>$principal</code>
     </ParamNameMismatch>
   </file>
+  <file src="apps/dav/lib/CalDAV/Integration/ExternalCalendar.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new DAV\Exception\MethodNotAllowed('Creating collections in calendar objects is not allowed');]]></code>
+      <code><![CDATA[throw new DAV\Exception\MethodNotAllowed('Renaming calendars is not yet supported');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Provided calendar uri was not app-generated');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/CalDAV/Plugin.php">
     <ImplementedReturnTypeMismatch>
       <code>string|null</code>
@@ -159,10 +661,32 @@
       <code>$principalInfo</code>
     </ParamNameMismatch>
   </file>
+  <file src="apps/dav/lib/CalDAV/Proxy/ProxyMapper.php">
+    <MissingThrowsDocblock>
+      <code>findEntities</code>
+      <code>findEntities</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/CalDAV/PublicCalendar.php">
     <MoreSpecificImplementedParamType>
       <code>$paths</code>
     </MoreSpecificImplementedParamType>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Publishing/PublishPlugin.php">
+    <MissingThrowsDocblock>
+      <code>parse</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Reminder/Backend.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getLastInsertId</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php">
     <LessSpecificReturnStatement>
@@ -178,6 +702,10 @@
     <LessSpecificReturnStatement>
       <code>$emailAddresses</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>generateDateString</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code><![CDATA[array<string, array{LANG?: string}>]]></code>
     </MoreSpecificReturnType>
@@ -188,11 +716,21 @@
     </UndefinedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid notification provider registered');]]></code>
+    </MissingThrowsDocblock>
     <UndefinedConstant>
       <code>$provider::NOTIFICATION_TYPE</code>
     </UndefinedConstant>
   </file>
   <file src="apps/dav/lib/CalDAV/Reminder/Notifier.php">
+    <MissingThrowsDocblock>
+      <code>generateDateString</code>
+      <code>imagePath</code>
+      <code>setIcon</code>
+      <code>setParsedMessage</code>
+      <code>setParsedSubject</code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainType>
       <code>$diff === false</code>
     </TypeDoesNotContainType>
@@ -203,6 +741,10 @@
       <code>VObject\Reader::read($calendarData,
 				VObject\Reader::OPTION_FORGIVING)</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>getRemindersToProcess</code>
+      <code><![CDATA[throw new \TypeError('Multiple master objects');]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>VObject\Component\VCalendar|null</code>
       <code>VObject\Component\VEvent[]</code>
@@ -225,6 +767,15 @@
     <InvalidReturnType>
       <code>string[]</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
       <code>null</code>
@@ -240,6 +791,10 @@
     </RedundantCondition>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipService.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
     <UndefinedMethod>
       <code>getNormalizedValue</code>
       <code>getNormalizedValue</code>
@@ -253,6 +808,11 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$vevent->DTEND]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>handleSameOrganizerException</code>
+      <code>handleSameOrganizerException</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>get</code>
       <code>getChildren</code>
@@ -269,6 +829,9 @@
     <InvalidNullableReturnType>
       <code>bool</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CalDAV/Search/Xml/Filter/ParamFilter.php">
     <InvalidReturnStatement>
@@ -282,6 +845,12 @@
     </InvalidReturnType>
   </file>
   <file src="apps/dav/lib/CalDAV/Search/Xml/Request/CalendarSearchReport.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new BadRequest('At least one{' . SearchPlugin::NS_Nextcloud . '}prop-filter or {' . SearchPlugin::NS_Nextcloud . '}param-filter is required for this request');]]></code>
+      <code><![CDATA[throw new BadRequest('The {' . SearchPlugin::NS_Nextcloud . '}filter element is required for this request');]]></code>
+      <code><![CDATA[throw new BadRequest('{' . SearchPlugin::NS_Nextcloud . '}prop-filter or {' . SearchPlugin::NS_Nextcloud . '}param-filter given without any {' . SearchPlugin::NS_Nextcloud . '}comp-filter');]]></code>
+      <code><![CDATA[throw new BadRequest('{' . SearchPlugin::NS_Nextcloud . '}search-term is required for this request');]]></code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainType>
       <code><![CDATA[!is_array($newProps['filters']['comps'])]]></code>
       <code><![CDATA[!is_array($newProps['filters']['params'])]]></code>
@@ -291,10 +860,111 @@
       <code><![CDATA[!isset($newProps['filters']['props']) || !is_array($newProps['filters']['props'])]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="apps/dav/lib/CalDAV/Security/RateLimitingPlugin.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('Calendar limit reached', 0);]]></code>
+      <code><![CDATA[throw new TooManyRequests('Too many calendars created', 0, $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Status/StatusService.php">
+    <MissingThrowsDocblock>
+      <code>setUserStatus</code>
+      <code>setUserStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObject.php">
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Trashbin/DeletedCalendarObjectsCollection.php">
+    <MissingThrowsDocblock>
+      <code>getDeletedCalendarObjectsByPrincipal</code>
+      <code><![CDATA[throw new BadRequest('The calendar object you\'re trying to restore is not marked as deleted');]]></code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+      <code>throw new NotFound();</code>
+      <code>throw new NotImplemented();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Trashbin/RestoreTarget.php">
+    <MissingThrowsDocblock>
+      <code>restore</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Trashbin/TrashbinHome.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('Permission denied to create a directory in the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to create files in the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to delete the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('not implemented');]]></code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php">
     <InvalidArgument>
       <code>$webcalData</code>
     </InvalidArgument>
+  </file>
+  <file src="apps/dav/lib/CardDAV/Activity/Backend.php">
+    <MissingThrowsDocblock>
+      <code>publish</code>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setAuthor</code>
+      <code>setAuthor</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+      <code>setType</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CardDAV/Activity/Filter.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CardDAV/Activity/Provider/Addressbook.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CardDAV/Activity/Provider/Base.php">
+    <MissingThrowsDocblock>
+      <code>setRichSubject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CardDAV/Activity/Provider/Card.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CardDAV/AddressBook.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>throw new UnsupportedLimitOnInitialSyncException();</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CardDAV/AddressBookImpl.php">
     <InvalidArgument>
@@ -320,6 +990,56 @@
     <LessSpecificReturnStatement>
       <code>Reader::read($cardData)</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getUID</code>
+      <code>getUID</code>
+      <code><![CDATA[throw new \InvalidArgumentException('Card does not exists: ' . $id);]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Card does not exists: ' . $uri);]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>VCard</code>
     </MoreSpecificReturnType>
@@ -327,10 +1047,30 @@
       <code><![CDATA[$addressBooks[$row['id']][$readOnlyPropertyName] === 0]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="apps/dav/lib/CardDAV/ImageExportPlugin.php">
+    <MissingThrowsDocblock>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>getContent</code>
+      <code>setStatus</code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CardDAV/Integration/ExternalAddressBook.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new DAV\Exception\MethodNotAllowed('Creating collections in address book objects is not allowed');]]></code>
+      <code><![CDATA[throw new DAV\Exception\MethodNotAllowed('Renaming address books is not yet supported');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Provided address book uri was not app-generated');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/CardDAV/MultiGetExportPlugin.php">
     <InvalidNullableReturnType>
       <code>bool</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>parse</code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CardDAV/PhotoCache.php">
     <LessSpecificReturnStatement>
@@ -339,6 +1079,20 @@
 				'body' => $val
 			]]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>getExtension</code>
+      <code>getFile</code>
+      <code>getFolder</code>
+      <code>getFolder</code>
+      <code>init</code>
+      <code>new \OCP\Image()</code>
+      <code>newFolder</code>
+      <code>putContent</code>
+      <code>putContent</code>
+      <code>throw new NotFoundException;</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>false|array{body: string, Content-Type: string}</code>
     </MoreSpecificReturnType>
@@ -348,21 +1102,204 @@
       <code>string|null</code>
     </ImplementedReturnTypeMismatch>
   </file>
+  <file src="apps/dav/lib/CardDAV/SyncService.php">
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>ensureSystemAddressBookExists</code>
+      <code>parseMultiStatus</code>
+      <code>request</code>
+      <code>request</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/CardDAV/SystemAddressbook.php">
+    <MissingThrowsDocblock>
+      <code>getServers</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/CardDAV/UserAddressBooks.php">
     <InvalidArgument>
       <code><![CDATA[$this->principalUri]]></code>
       <code><![CDATA[$this->principalUri]]></code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new MethodNotAllowed('The resource you tried to create has a reserved name');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/CardDAV/Xml/Groups.php">
     <InvalidPropertyAssignmentValue>
       <code>$groups</code>
     </InvalidPropertyAssignmentValue>
   </file>
+  <file src="apps/dav/lib/Command/CreateAddressBook.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>createAddressBook</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$user> in unknown.");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/CreateCalendar.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>createCalendar</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>query</code>
+      <code>setName</code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$user> in unknown.");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/DeleteCalendar.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new \InvalidArgumentException(
+					'Please specify a calendar name or --birthday');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException(
+				'User <' . $user . '> has no calendar named <' . $name . '>. You can run occ dav:list-calendars to list calendars URIs for this user.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException(
+				'User <' . $user . '> is unknown.');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/FixCalendarSyncCommand.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code><![CDATA[parent::__construct('dav:fix-missing-caldav-changes')]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/ListCalendars.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$user> is unknown.");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/MoveCalendar.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>checkShares</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new \InvalidArgumentException("Unable to find a suitable calendar name for <$userDestination> with initial name <$name>.");]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$userDestination> already has a calendar named <$name>.");]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$userDestination> is unknown.");]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$userOrigin> has no calendar named <$name>. You can run occ dav:list-calendars to list calendars URIs for this user.");]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$userOrigin> is unknown.");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/RemoveInvalidShares.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/RetentionCleanupCommand.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[parent::__construct('dav:retention:clean-up')]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/SendEventReminders.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>processReminders</code>
+      <code>processReminders</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/SyncBirthdayCalendar.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>syncUser</code>
+      <code><![CDATA[throw new \InvalidArgumentException("User <$user> in unknown.");]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Birthday calendars are disabled');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Command/SyncSystemAddressBook.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Comments/CommentNode.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('Only authors are allowed to edit their comment.');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/Comments/CommentsPlugin.php">
+    <MissingThrowsDocblock>
+      <code>createComment</code>
+      <code>createComment</code>
+      <code>save</code>
+      <code>setStatus</code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
     <UndefinedFunction>
       <code>\Sabre\HTTP\toDate($value)</code>
     </UndefinedFunction>
+  </file>
+  <file src="apps/dav/lib/Comments/EntityTypeCollection.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('"name" parameter must be non-empty string');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Comments/RootCollection.php">
+    <MissingThrowsDocblock>
+      <code>initCollections</code>
+      <code>initCollections</code>
+      <code>initCollections</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Connector/LegacyPublicAuth.php">
+    <MissingThrowsDocblock>
+      <code>sleepDelayOrThrowOnMax</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php">
     <InvalidNullableReturnType>
@@ -373,14 +1310,59 @@
     <LessSpecificReturnStatement>
       <code>$data</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>logClientIn</code>
+      <code>setStatus</code>
+      <code>setStatus</code>
+      <code>throw new TooManyRequests();</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>array{bool, string}</code>
     </MoreSpecificReturnType>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/BearerAuth.php">
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>tryTokenLogin</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/ChecksumUpdatePlugin.php">
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/CommentPropertiesPlugin.php">
+    <MissingThrowsDocblock>
+      <code>getChildren</code>
+      <code>getChildren</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/DavAclPlugin.php">
+    <MissingThrowsDocblock>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code>checkPrivileges</code>
+      <code><![CDATA[throw new NotFound(
+				sprintf(
+					"%s with name '%s' could not be found",
+					$type,
+					$node->getName()
+				)
+			);]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/Directory.php">
     <InvalidPropertyAssignmentValue>
@@ -395,6 +1377,21 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->node]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getDirectoryListing</code>
+      <code><![CDATA[throw new InvalidPath($ex->getMessage());]]></code>
+      <code><![CDATA[throw new InvalidPath($ex->getMessage());]]></code>
+      <code>throw new \Sabre\DAV\Exception\Forbidden();</code>
+      <code>throw new \Sabre\DAV\Exception\Forbidden();</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>Folder</code>
     </MoreSpecificReturnType>
@@ -407,16 +1404,102 @@
       <code>$fullSourcePath</code>
     </ParamNameMismatch>
   </file>
+  <file src="apps/dav/lib/Connector/Sabre/DummyGetResponsePlugin.php">
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/FakeLockerPlugin.php">
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/Connector/Sabre/File.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->node]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_create, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath,
+				\OC\Files\Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_create, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath,
+				\OC\Files\Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_create, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_create, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_update, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_update, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_write, [
+			\OC\Files\Filesystem::signal_param_path => $hookPath
+		])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_write, [
+			\OC\Files\Filesystem::signal_param_path => $hookPath
+		])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_update, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath,
+				\OC\Files\Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_update, [
+				\OC\Files\Filesystem::signal_param_path => $hookPath,
+				\OC\Files\Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_write, [
+			\OC\Files\Filesystem::signal_param_path => $hookPath,
+			\OC\Files\Filesystem::signal_param_run => &$run,
+		])]]></code>
+      <code><![CDATA[\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_write, [
+			\OC\Files\Filesystem::signal_param_path => $hookPath,
+			\OC\Files\Filesystem::signal_param_run => &$run,
+		])]]></code>
+      <code>convertToSabreException</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new FileLocked($e->getMessage(), $e->getCode(), $e);]]></code>
+      <code><![CDATA[throw new FileLocked($e->getMessage(), $e->getCode(), $e);]]></code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$data</code>
     </MoreSpecificImplementedParamType>
     <MoreSpecificReturnType>
       <code>\OCP\Files\File</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/FilesPlugin.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IFilesMetadataManager::class)</code>
+      <code>\OCP\Server::get(IFilesMetadataManager::class)</code>
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code>handleUpdatePropertiesMetadata</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/FilesReportPlugin.php">
     <InvalidArgument>
@@ -425,6 +1508,12 @@
     <InvalidNullableReturnType>
       <code>bool</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
     <TooManyArguments>
       <code><![CDATA[new PreconditionFailed('Cannot filter by non-existing tag', 0, $e)]]></code>
     </TooManyArguments>
@@ -435,15 +1524,49 @@
       <code>getPath</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/Connector/Sabre/LockPlugin.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new FileLocked($e->getMessage(), $e->getCode(), $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/MtimeSanitizer.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('X-OC-MTime header must be a valid positive integer');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('X-OC-MTime header must be an integer (unix timestamp).');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/Connector/Sabre/Node.php">
     <InvalidNullableReturnType>
       <code>int</code>
       <code>integer</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>changeLock</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getStorage</code>
+      <code>lockFile</code>
+      <code>rename</code>
+      <code><![CDATA[throw new InvalidPath($ex->getMessage());]]></code>
+      <code><![CDATA[throw new \Sabre\DAV\Exception('Failed to get fileinfo for '. $this->path);]]></code>
+      <code><![CDATA[throw new \Sabre\DAV\Exception('Failed to rename '. $this->path . ' to ' . $newPath);]]></code>
+      <code>unlockFile</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[$this->info->getId()]]></code>
       <code><![CDATA[$this->info->getId()]]></code>
     </NullableReturnStatement>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/ObjectTree.php">
+    <MissingThrowsDocblock>
+      <code>throw new \Sabre\DAV\Exception\Forbidden();</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/Principal.php">
     <InvalidNullableReturnType>
@@ -458,6 +1581,9 @@
     <InvalidScalarArgument>
       <code>$results</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>userToPrincipal</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[$this->circleToPrincipal($decodedName)
 					?: $this->circleToPrincipal($name)]]></code>
@@ -474,7 +1600,37 @@
       <code>\OCA\Circles\Api\v1\Circles</code>
     </UndefinedClass>
   </file>
+  <file src="apps/dav/lib/Connector/Sabre/PublicAuth.php">
+    <MissingThrowsDocblock>
+      <code>getPathInfo</code>
+      <code>getToken</code>
+      <code>sleepDelayOrThrowOnMax</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/QuotaPlugin.php">
+    <MissingThrowsDocblock>
+      <code>calculateUri</code>
+      <code>checkQuota</code>
+      <code>checkQuota</code>
+      <code>checkQuota</code>
+      <code>checkQuota</code>
+      <code>checkQuota</code>
+      <code>free_space</code>
+      <code>getFreeSpace</code>
+      <code><![CDATA[throw new \Exception('Invalid destination node');]]></code>
+      <code><![CDATA[throw new \Exception('Invalid destination node');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Connector/Sabre/Server.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct($treeOrNode)</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/Connector/Sabre/ServerFactory.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
     <TooManyArguments>
       <code>new \OCA\DAV\Connector\Sabre\QuotaPlugin($view, true)</code>
     </TooManyArguments>
@@ -490,6 +1646,10 @@
     </InvalidArgument>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/TagsPlugin.php">
+    <MissingThrowsDocblock>
+      <code>getChildren</code>
+      <code>getChildren</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
@@ -497,15 +1657,45 @@
       <code>getId</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/Controller/DirectController.php">
+    <MissingThrowsDocblock>
+      <code>getRelativePath</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>insert</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/Controller/InvitationResponseController.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
     <UndefinedPropertyAssignment>
       <code><![CDATA[$vEvent->DTSTAMP]]></code>
     </UndefinedPropertyAssignment>
+  </file>
+  <file src="apps/dav/lib/Controller/OutOfOfficeController.php">
+    <MissingThrowsDocblock>
+      <code>clearAbsence</code>
+      <code>createOrUpdateAbsence</code>
+      <code>createOrUpdateAbsence</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/DAV/CustomPropertiesBackend.php">
     <InvalidArgument>
       <code>$whereValues</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>prepare</code>
+      <code>prepare</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/DAV/GroupPrincipalBackend.php">
     <InvalidNullableReturnType>
@@ -531,18 +1721,117 @@
       <code>null</code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/dav/lib/DAV/Sharing/Plugin.php">
+    <MissingThrowsDocblock>
+      <code>parse</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/DAV/Sharing/SharingMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/DAV/SystemPrincipalBackend.php">
     <InvalidNullableReturnType>
       <code>array</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Sabre\DAV\Exception('Principal not found');]]></code>
+      <code><![CDATA[throw new \Sabre\DAV\Exception('Principal not found');]]></code>
+      <code><![CDATA[throw new \Sabre\DAV\Exception('Setting members of the group is not supported yet');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/dav/lib/Db/Absence.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Exception('Creating out-of-office data without ID');]]></code>
+      <code><![CDATA[throw new InvalidArgumentException("The user doesn't match the user id of this absence! Expected " . $this->getUserId() . ", got " . $user->getUID());]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Db/AbsenceMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code><![CDATA[throw new \RuntimeException(
+				'The impossible has happened! The query returned multiple absence settings for one user.',
+				0,
+				$e,
+			);]]></code>
+      <code><![CDATA[throw new \RuntimeException(
+				'The impossible has happened! The query returned multiple absence settings for one user.',
+				0,
+				$e,
+			);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Db/DirectMapper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>parent::findEntity($qb)</code>
+      <code>parent::findEntity($qb)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Db/PropertyMapper.php">
+    <MissingThrowsDocblock>
+      <code>findEntities</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Direct/DirectFile.php">
+    <MissingThrowsDocblock>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code><![CDATA[throw new Forbidden("direct download not allowed on directories");]]></code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Direct/DirectHome.php">
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code><![CDATA[throw new MethodNotAllowed('Listing members of this collection is disabled');]]></code>
+      <code>throw new NotFound();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/Direct/Server.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct($treeOrNode)</code>
+    </MissingThrowsDocblock>
     <UndefinedThisPropertyAssignment>
       <code><![CDATA[$this->enablePropfindDepthInfinityf]]></code>
     </UndefinedThisPropertyAssignment>
+  </file>
+  <file src="apps/dav/lib/Files/BrowserErrorPagePlugin.php">
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Files/FileSearchBackend.php">
     <InvalidReturnStatement>
@@ -551,6 +1840,14 @@
     <InvalidReturnType>
       <code>?string</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code><![CDATA[throw new \InvalidArgumentException("Invalid search value for '{http://owncloud.org/ns}owner-id', only the current user id is allowed");]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid search query, maximum operator limit of ' . self::OPERATOR_LIMIT . ' exceeded, got ' . $operatorCount . ' operators');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Search is only supported on directories');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Searching more than one folder is not supported');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Using uri\'s as scope is not supported, please use a path relative to the search arbiter instead');]]></code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$search</code>
     </ParamNameMismatch>
@@ -570,21 +1867,405 @@
       <code>bool</code>
     </InvalidReturnType>
   </file>
+  <file src="apps/dav/lib/Files/RootCollection.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception('Home does not exist');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Files/Sharing/FilesDropPlugin.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new MethodNotAllowed('Only PUT is allowed on files drop');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Files/Sharing/PublicLinkCheckPlugin.php">
+    <MissingThrowsDocblock>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/HookManager.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->usersToDelete]]></code>
       <code><![CDATA[$this->usersToDelete]]></code>
     </InvalidPropertyAssignmentValue>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Listener/ClearPhotoCacheListener.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Migration/BuildCalendarSearchIndexBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$arguments</code>
     </ParamNameMismatch>
   </file>
   <file src="apps/dav/lib/Migration/BuildSocialSearchIndexBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$arguments</code>
     </ParamNameMismatch>
+  </file>
+  <file src="apps/dav/lib/Migration/CalDAVRemoveEmptyValue.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/RemoveClassifiedEventActivity.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/RemoveDeletedUsersCalendarSubscriptions.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/RemoveOrphanEventsAndContacts.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1004Date20170825134824.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>changeColumn</code>
+      <code>changeColumn</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1004Date20170919104507.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1004Date20170924124212.php">
+    <MissingThrowsDocblock>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1005Date20180413093149.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1006Date20180619154313.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1006Date20180628111625.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181030113700.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181105104826.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>execute</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181105104833.php">
+    <MissingThrowsDocblock>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181105110300.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>execute</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181105112049.php">
+    <MissingThrowsDocblock>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181114084440.php">
+    <MissingThrowsDocblock>
+      <code>addIndex</code>
+      <code>dropIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1011Date20190806104428.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1012Date20190808122342.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1016Date20201109085907.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1017Date20210216083742.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1018Date20210312100735.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1029Date20231004091403.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>getTable</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1030Date20240205103243.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Provisioning/Apple/AppleProvisioningNode.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('Renaming ' . self::FILENAME . ' is forbidden');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Provisioning/Apple/AppleProvisioningPlugin.php">
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/RootCollection.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IRootFolder::class)</code>
+      <code>\OCP\Server::get(IRootFolder::class)</code>
+      <code>\OCP\Server::get(SystemTag\SystemTagsInUseCollection::class)</code>
+      <code>\OCP\Server::get(SystemTag\SystemTagsInUseCollection::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/Search/ContactsSearchProvider.php">
     <InvalidOperand>
@@ -628,13 +2309,119 @@
       <code>hasTime</code>
     </UndefinedMethod>
   </file>
+  <file src="apps/dav/lib/Server.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(ICacheFactory::class)</code>
+      <code>\OCP\Server::get(ICacheFactory::class)</code>
+      <code>\OCP\Server::get(RateLimitingPlugin::class)</code>
+      <code>\OCP\Server::get(RateLimitingPlugin::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Service/AbsenceService.php">
+    <MissingThrowsDocblock>
+      <code>findByUserId</code>
+      <code>findByUserId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/SetupChecks/NeedsSystemAddressBookSync.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('No outstanding DAV system address book sync.'))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('The DAV system address book sync has not run yet as your instance has more than 1000 users or because an error occurred. Please run it manually by calling "occ dav:sync-system-addressbook".'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/SetupChecks/WebdavEndpoint.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success(
+			$this->l10n->t('Your web server is properly set up to allow file synchronization over WebDAV.')
+		)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagMappingNode.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('No permission to unassign tag ' . $this->tag->getId());]]></code>
+      <code><![CDATA[throw new Forbidden('No permission to unassign tag to ' . $this->objectId);]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $this->tag->getId() . ' not found');]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $this->tag->getId() . ' not found', 0, $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagNode.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('No permission to delete tag ' . $this->tag->getId());]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $this->tag->getId() . ' not found');]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $this->tag->getId() . ' not found', 0, $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagPlugin.php">
+    <MissingThrowsDocblock>
+      <code>createTag</code>
+      <code>createTag</code>
+      <code>createTag</code>
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code>setStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagsByIdCollection.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new BadRequest('Invalid tag id', 0, $e);]]></code>
+      <code><![CDATA[throw new BadRequest('Invalid tag id', 0, $e);]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to create collections');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to delete this collection');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this collection');]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $name . ' not found');]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $name . ' not found', 0, $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php">
+    <MissingThrowsDocblock>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code><![CDATA[throw new BadRequest('Invalid tag id', 0, $e);]]></code>
+      <code><![CDATA[throw new BadRequest('Invalid tag id', 0, $e);]]></code>
+      <code><![CDATA[throw new Forbidden('No permission to assign tag ' . $tagId);]]></code>
+      <code><![CDATA[throw new Forbidden('No permission to assign tag to ' . $this->objectId);]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to create collections');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to delete this collection');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this collection');]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $tagName . ' not found', 0, $e);]]></code>
+      <code><![CDATA[throw new NotFound('Tag with id ' . $tagName . ' not present for object ' . $this->objectId);]]></code>
+      <code><![CDATA[throw new PreconditionFailed('Tag with id ' . $tagId . ' does not exist, cannot assign');]]></code>
+      <code><![CDATA[throw new PreconditionFailed('Tag with id ' . $tagId . ' does not exist, cannot assign');]]></code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$tagId</code>
       <code>$tagName</code>
     </ParamNameMismatch>
   </file>
   <file src="apps/dav/lib/SystemTag/SystemTagsObjectTypeCollection.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('Permission denied to delete this collection');]]></code>
+      <code>throw new MethodNotAllowed();</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$objectName</code>
     </ParamNameMismatch>
@@ -657,11 +2444,80 @@
     <InvalidReturnType>
       <code>array</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>loadContext</code>
+      <code><![CDATA[throw new \Exception('Stream from assembly node shorter than expected, got ' . $this->currentNodeRead . ' bytes, expected ' . $currentNodeSize);]]></code>
+    </MissingThrowsDocblock>
     <RedundantFunctionCall>
       <code>array_values</code>
     </RedundantFunctionCall>
   </file>
+  <file src="apps/dav/lib/Upload/ChunkingPlugin.php">
+    <MissingThrowsDocblock>
+      <code>setStatus</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/dav/lib/Upload/ChunkingV2Plugin.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_create, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_create, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_create, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_create, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_update, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_update, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_write, [
+			Filesystem::signal_param_path => $hookPath,
+		])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_write, [
+			Filesystem::signal_param_path => $hookPath,
+		])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_update, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_update, [
+				Filesystem::signal_param_path => $hookPath,
+			])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_write, [
+			Filesystem::signal_param_path => $hookPath,
+		])]]></code>
+      <code><![CDATA[OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_write, [
+			Filesystem::signal_param_path => $hookPath,
+		])]]></code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IMimeTypeDetector::class)</code>
+      <code>\OCP\Server::get(IMimeTypeDetector::class)</code>
+      <code>\OCP\Server::get(IRootFolder::class)</code>
+      <code>\OCP\Server::get(IRootFolder::class)</code>
+      <code>calculateUri</code>
+      <code>checkPrerequisites</code>
+      <code>checkPrerequisites</code>
+      <code>checkPrerequisites</code>
+      <code>new View()</code>
+      <code>setStatus</code>
+      <code>setStatus</code>
+      <code>setStatus</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new BadRequest('Invalid chunk name, must be numeric between 1 and 10000');]]></code>
+      <code><![CDATA[throw new InsufficientStorage("Insufficient space in $this->uploadPath");]]></code>
+      <code><![CDATA[throw new InsufficientStorage("Insufficient space in $this->uploadPath");]]></code>
+      <code><![CDATA[throw new InvalidArgumentException('X-OC-MTime header must be an integer (unix timestamp).');]]></code>
+      <code>unlock</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getId</code>
       <code>getId</code>
@@ -670,6 +2526,88 @@
       <code>getNode</code>
       <code>getSize</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/dav/lib/Upload/FutureFile.php">
+    <MissingThrowsDocblock>
+      <code>AssemblyStream::wrap($nodes)</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code><![CDATA[throw new Forbidden('Permission denied to put into this file');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this file');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Upload/PartFile.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code><![CDATA[throw new Forbidden('Permission denied to get this file');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to put into this file');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this file');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Upload/UploadFile.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>get</code>
+      <code>get</code>
+      <code>put</code>
+      <code>put</code>
+      <code>put</code>
+      <code>put</code>
+      <code>put</code>
+      <code>put</code>
+      <code>put</code>
+      <code>setName</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Upload/UploadFolder.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getChild</code>
+      <code>getChild</code>
+      <code>getChild</code>
+      <code>getChild</code>
+      <code>getChild</code>
+      <code>getChild</code>
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new Forbidden('Permission denied to create file (filename ' . $name . ')');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this folder');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/Upload/UploadHome.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[Filesystem::initMountPoints($user->getUID())]]></code>
+      <code>createDirectory</code>
+      <code>createDirectory</code>
+      <code>createDirectory</code>
+      <code>createDirectory</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getChild</code>
+      <code>getChild</code>
+      <code>getChild</code>
+      <code>getChildren</code>
+      <code>getChildren</code>
+      <code><![CDATA[new View('/' . $user->getUID() . '/uploads')]]></code>
+      <code>new View()</code>
+      <code><![CDATA[throw new Forbidden('Permission denied to create file (filename ' . $name . ')');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this folder');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/dav/lib/UserMigration/CalendarMigrator.php">
+    <MissingThrowsDocblock>
+      <code>createCalendar</code>
+      <code>getCalendarExports</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/dav/lib/UserMigration/ContactsMigrator.php">
     <LessSpecificReturnStatement>
@@ -680,42 +2618,261 @@
 			'vCards' => $vCards,
 		]]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>createAddressBook</code>
+      <code><![CDATA[throw new ContactsMigratorException('Each ' . ContactsMigrator::FILENAME_EXT . ' file must have a corresponding ' . ContactsMigrator::METADATA_EXT . ' file');]]></code>
+      <code><![CDATA[throw new ContactsMigratorException('Failed to sort address book files in ' . ContactsMigrator::PATH_ROOT);]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>array{name: string, displayName: string, description: ?string, vCards: VCard[]}</code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/encryption/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>registerEncryptionModule</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Command/DisableMasterKey.php">
+    <MissingThrowsDocblock>
+      <code>ask</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Command/DropLegacyFileKey.php">
+    <MissingThrowsDocblock>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>new View()</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Command/EnableMasterKey.php">
+    <MissingThrowsDocblock>
+      <code>ask</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Command/FixEncryptedVersion.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>fopen</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>put</code>
+      <code>put</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/encryption/lib/Command/FixKeyLocation.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getDirectoryListing</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getOption</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>new View()</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new \Exception("Failed to open " . $node->getPath());]]></code>
+      <code><![CDATA[throw new \Exception("Invalid base path " . $basePath);]]></code>
+      <code><![CDATA[throw new \Exception("Wrong encryption manager");]]></code>
+      <code><![CDATA[throw new \Exception($node->getPath() . " still encrypted after attempting to decrypt with " . $key);]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code><![CDATA[\Generator<File>]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/encryption/lib/Command/RecoverUser.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>ask</code>
+      <code>ask</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Command/ScanLegacyFormat.php">
+    <MissingThrowsDocblock>
+      <code>new View()</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Controller/SettingsController.php">
+    <MissingThrowsDocblock>
+      <code>generateHeader</code>
+      <code>getPrivateKey</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/encryption/lib/Crypto/Crypt.php">
+    <MissingThrowsDocblock>
+      <code>checkSignature</code>
+      <code>generateIv</code>
+      <code>getKeySize</code>
+      <code>hasSignature</code>
+      <code>opensslOpen</code>
+      <code>opensslSeal</code>
+      <code>symmetricDecryptFileContent</code>
+      <code>symmetricEncryptFileContent</code>
+      <code><![CDATA[throw new ServerNotAvailableException('Legacy cipher is no longer supported!');]]></code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainType>
       <code><![CDATA[get_class($res) === 'OpenSSLAsymmetricKey']]></code>
     </TypeDoesNotContainType>
+  </file>
+  <file src="apps/encryption/lib/Crypto/DecryptAll.php">
+    <MissingThrowsDocblock>
+      <code>ask</code>
+      <code>ask</code>
+      <code>getMasterKeyPassword</code>
+      <code>getPrivateKey</code>
+      <code>setHidden</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Crypto/EncryptAll.php">
+    <MissingThrowsDocblock>
+      <code>ask</code>
+      <code>fopen</code>
+      <code>rename</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/encryption/lib/Crypto/Encryption.php">
     <ImplementedParamTypeMismatch>
       <code>$position</code>
     </ImplementedParamTypeMismatch>
+    <MissingThrowsDocblock>
+      <code>addSystemKeys</code>
+      <code>generateFileKey</code>
+      <code>getDecryptAllKey</code>
+      <code>getDecryptAllKey</code>
+      <code>getDecryptAllUid</code>
+      <code>getOwner</code>
+      <code>getOwner</code>
+      <code>multiKeyDecrypt</code>
+      <code>multiKeyDecryptLegacy</code>
+      <code>multiKeyEncrypt</code>
+      <code>new View()</code>
+      <code>new View()</code>
+      <code>userHasKeys</code>
+      <code>userHasKeys</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Hooks/UserHooks.php">
+    <MissingThrowsDocblock>
+      <code>generateHeader</code>
+      <code>generateHeader</code>
+      <code>getPrivateKey</code>
+      <code>initMountPoints</code>
+      <code>throw new GenericEncryptionException($message, $message);</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/encryption/lib/KeyManager.php">
     <InvalidThrow>
       <code>throw $exception;</code>
     </InvalidThrow>
+    <MissingThrowsDocblock>
+      <code>acquireLock</code>
+      <code>acquireLock</code>
+      <code>generateHeader</code>
+      <code>generateHeader</code>
+      <code>getMasterKeyPassword</code>
+      <code>getMasterKeyPassword</code>
+      <code>getPrivateKey</code>
+      <code>getPrivateKey</code>
+      <code>multiKeyDecrypt</code>
+      <code>multiKeyDecryptLegacy</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Recovery.php">
+    <MissingThrowsDocblock>
+      <code>addSystemKeys</code>
+      <code>generateHeader</code>
+      <code>multiKeyDecrypt</code>
+      <code>multiKeyDecryptLegacy</code>
+      <code>multiKeyEncrypt</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/encryption/lib/Session.php">
     <TooManyArguments>
       <code><![CDATA[new Exceptions\PrivateKeyMissingException('please try to log-out and log-in again', 0)]]></code>
     </TooManyArguments>
   </file>
+  <file src="apps/encryption/lib/Settings/Admin.php">
+    <MissingThrowsDocblock>
+      <code>new View()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/encryption/lib/Users/Setup.php">
+    <MissingThrowsDocblock>
+      <code>userHasKeys</code>
+      <code>userHasKeys</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/encryption/lib/Util.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->files->getMount($path)->getStorage()]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>\OC\Files\Storage\Storage|null</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="apps/federatedfilesharing/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>addCloudFederationProvider</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/federatedfilesharing/lib/Controller/RequestHandlerController.php">
     <InvalidArgument>
@@ -727,6 +2884,14 @@
       <code>$id</code>
       <code>$remoteId</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>resolveCloudId</code>
+      <code><![CDATA[throw new OCSException('Server does not support federated cloud sharing', 503);]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/federatedfilesharing/lib/FederatedShareProvider.php">
     <InvalidArgument>
@@ -736,6 +2901,60 @@
       <code>$shareId</code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getLastInsertId</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>sendPermissionUpdate</code>
+      <code>sendPermissionUpdate</code>
+      <code>setId</code>
+      <code>setId</code>
+      <code>setProviderId</code>
+      <code>setProviderId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federatedfilesharing/lib/Migration/Version1010Date20200630191755.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federatedfilesharing/lib/Migration/Version1011Date20201120125158.php">
+    <MissingThrowsDocblock>
+      <code>Type::getType(Types::STRING)</code>
+      <code>execute</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+      <code>setOptions</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/federatedfilesharing/lib/Notifications.php">
     <InvalidReturnType>
@@ -743,6 +2962,16 @@
       <code>bool</code>
       <code>bool</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>tryHttpPostToShareEndpoint</code>
+      <code>tryHttpPostToShareEndpoint</code>
+      <code>tryLegacyEndPoint</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federatedfilesharing/lib/Notifier.php">
+    <MissingThrowsDocblock>
+      <code>resolveCloudId</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php">
     <InvalidArgument>
@@ -760,19 +2989,165 @@
     <InvalidScalarArgument>
       <code><![CDATA[(int)$share['id']]]></code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>addAction</code>
+      <code>addAction</code>
+      <code>create</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getShareById</code>
+      <code>notify</code>
+      <code>publish</code>
+      <code>publish</code>
+      <code>publish</code>
+      <code>setAffectedUser</code>
+      <code>setAffectedUser</code>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setLabel</code>
+      <code>setLabel</code>
+      <code>setLink</code>
+      <code>setLink</code>
+      <code>setLink</code>
+      <code>setLink</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+      <code>setType</code>
+      <code>setType</code>
+      <code>setUser</code>
+      <code>setUser</code>
+      <code><![CDATA[throw new HintException('Updating reshares not allowed');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federatedfilesharing/lib/Settings/PersonalSection.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federation/lib/Command/SyncFederationAddressBooks.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federation/lib/Controller/OCSAuthAPIController.php">
+    <MissingThrowsDocblock>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>getToken</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/federation/lib/DbHandler.php">
     <LessSpecificReturnStatement>
       <code>$result</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getLastInsertId</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code><![CDATA[list<array{id: int, url: string, url_hash: string, shared_secret: ?string, status: int, sync_token: ?string}>]]></code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="apps/federation/lib/Migration/Version1010Date20200630191302.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federation/lib/Settings/Admin.php">
+    <MissingThrowsDocblock>
+      <code>getServers</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federation/lib/SyncFederationAddressBooks.php">
+    <MissingThrowsDocblock>
+      <code>getAllServer</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/federation/lib/TrustedServers.php">
+    <MissingThrowsDocblock>
+      <code>addServer</code>
+      <code>getServerById</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files/ajax/download.php">
     <InvalidArgument>
       <code>$files_list</code>
     </InvalidArgument>
+  </file>
+  <file src="apps/files/lib/Activity/FavoriteProvider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>setRichSubject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Activity/Filter/Favorites.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Activity/Filter/FileChanges.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Activity/Helper.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files/lib/Activity/Provider.php">
     <FalsableReturnStatement>
@@ -782,6 +3157,17 @@
       <code>$folder</code>
       <code><![CDATA[$this->fileEncrypted[$fileId]]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>getCurrentUserId</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>resolveCloudId</code>
+      <code>setIcon</code>
+      <code>setIcon</code>
+      <code>setRichSubject</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>Folder</code>
     </MoreSpecificReturnType>
@@ -802,11 +3188,318 @@
       <code><![CDATA[$this->fileIsEncrypted]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="apps/files/lib/App.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(IAppManager::class)</code>
+      <code>Server::get(IAppManager::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IFactory::class)</code>
+      <code>Server::get(IFactory::class)</code>
+      <code>Server::get(IGroupManager::class)</code>
+      <code>Server::get(IGroupManager::class)</code>
+      <code>Server::get(IUrlGenerator::class)</code>
+      <code>Server::get(IUrlGenerator::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/BackgroundJob/ScanFiles.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/BackgroundJob/TransferOwnership.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>getRelativePath</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>notify</code>
+      <code>notify</code>
+      <code>notify</code>
+      <code>notify</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setDateTime</code>
+      <code>setDateTime</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setUser</code>
+      <code>setUser</code>
+      <code>setUser</code>
+      <code>setUser</code>
+      <code>transfer</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Collaboration/Resources/Listener.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(IManager::class)</code>
+      <code>Server::get(IManager::class)</code>
+      <code>Server::get(ResourceProvider::class)</code>
+      <code>Server::get(ResourceProvider::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Collaboration/Resources/ResourceProvider.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code><![CDATA[throw new ResourceException('File not found');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Copy.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getFullPath</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>isUpdateable</code>
+      <code>isUpdateable</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>ask</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getArgument</code>
+      <code>getFilesByUser</code>
+      <code>getFilesByUser</code>
+      <code>getHelper</code>
+      <code>getNode</code>
+      <code>getOption</code>
+      <code>getStorage</code>
+      <code>isDeletable</code>
+      <code>isDeletable</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/DeleteOrphanedFiles.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Get.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Move.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>isUpdateable</code>
+      <code>isUpdateable</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>move</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Object/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>deleteObject</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Object/Get.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Object/ObjectUtil.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code><![CDATA[throw new \Exception("configured object store class is not an object store implementation");]]></code>
+      <code><![CDATA[throw new \Exception("no arguments configured for object store configuration");]]></code>
+      <code><![CDATA[throw new \Exception("no class configured for object store configuration");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Object/Put.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>writeObject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Put.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>newFile</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/RepairTree.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Command/Scan.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files/lib/Command/ScanAppData.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>query</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
       <code>null</code>
     </NullArgument>
+  </file>
+  <file src="apps/files/lib/Command/TransferOwnership.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>transfer</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Controller/ApiController.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Helper::getStorageInfo($dir ?: '/')]]></code>
+      <code>setConfig</code>
+      <code>setConfig</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files/lib/Controller/DirectEditingController.php">
     <InvalidArgument>
@@ -817,7 +3510,80 @@
       <code>open</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/files/lib/Controller/OpenLocalEditorController.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>verifyToken</code>
+      <code>verifyToken</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Controller/TransferOwnershipController.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>insert</code>
+      <code>insert</code>
+      <code>notify</code>
+      <code>notify</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setUser</code>
+      <code>setUser</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Controller/ViewController.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getPermissions</code>
+      <code>getPermissions</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getStorageInfo</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>redirectToFile</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Db/OpenLocalEditorMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Db/TransferOwnershipMapper.php">
+    <MissingThrowsDocblock>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files/lib/Helper.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \UnexpectedValueException('$tags must be an array');]]></code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>$file</code>
       <code>$i</code>
@@ -834,7 +3600,111 @@
       <code>$i</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/files/lib/Listener/SyncLivePhotosListener.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMetadata</code>
+      <code>getMetadata</code>
+      <code>saveMetadata</code>
+      <code>saveMetadata</code>
+      <code><![CDATA[throw new AbortedEventException("Cannot delete the video part of a live photo");]]></code>
+      <code><![CDATA[throw new AbortedEventException($ex->getMessage());]]></code>
+      <code><![CDATA[throw new AbortedEventException($ex->getMessage());]]></code>
+      <code><![CDATA[throw new AbortedEventException('A file already exist at destination path of the Live Photo');]]></code>
+      <code><![CDATA[throw new AbortedEventException('A file already exist at destination path of the Live Photo');]]></code>
+      <code><![CDATA[throw new AbortedEventException('Cannot change the extension of a Live Photo');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Migration/Version11301Date20191205150729.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Migration/Version12101Date20221011153334.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Notification/Notifier.php">
+    <MissingThrowsDocblock>
+      <code>addParsedAction</code>
+      <code>addParsedAction</code>
+      <code>delete</code>
+      <code>setLink</code>
+      <code>setLink</code>
+      <code>setParsedLabel</code>
+      <code>setParsedLabel</code>
+      <code>setPrimary</code>
+      <code>setPrimary</code>
+      <code>setRichMessage</code>
+      <code>setRichMessage</code>
+      <code>setRichMessage</code>
+      <code>setRichMessage</code>
+      <code>setRichMessage</code>
+      <code>setRichSubject</code>
+      <code>setRichSubject</code>
+      <code>setRichSubject</code>
+      <code>setRichSubject</code>
+      <code>setRichSubject</code>
+      <code><![CDATA[throw new \InvalidArgumentException('User not found');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Search/FilesSearchProvider.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code><![CDATA[throw new InvalidArgumentException('Unsupported filter type');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Service/LivePhotosService.php">
+    <MissingThrowsDocblock>
+      <code>getString</code>
+      <code>getString</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files/lib/Service/OwnershipTransferService.php">
+    <MissingThrowsDocblock>
+      <code>analyse</code>
+      <code>new View()</code>
+      <code>rename</code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainType>
       <code>empty($encryptedFiles)</code>
     </TypeDoesNotContainType>
@@ -842,16 +3712,353 @@
       <code>isReadyForUser</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/files/lib/Service/TagService.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code><![CDATA[throw new \RuntimeException('No homeFolder set');]]></code>
+      <code><![CDATA[throw new \RuntimeException('No tagger set');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Service/UserConfig.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception('No user logged in');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files/lib/Service/ViewConfig.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception('No user logged in');]]></code>
+      <code><![CDATA[throw new \Exception('No user logged in');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_external/appinfo/routes.php">
     <InvalidScope>
       <code>$this</code>
     </InvalidScope>
   </file>
+  <file src="apps/files_external/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Applicable.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>updateStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Backends.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Config.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>updateStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Create.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setOption</code>
+      <code>setOption</code>
+      <code><![CDATA[throw new NoUserException("user $userId not found");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>removeStorage</code>
+      <code>setName</code>
+      <code>setOption</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Export.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>setArgument</code>
+      <code>setName</code>
+      <code>setOption</code>
+      <code>setOption</code>
+      <code>setOption</code>
+      <code>setOption</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Import.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setOption</code>
+      <code>setOption</code>
+      <code><![CDATA[throw new NoUserException("user $userId not found");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/ListCommand.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new NoUserException("user $userId not found");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Notify.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>execute</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Option.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>setName</code>
+      <code>updateStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Scan.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/StorageAuthBase.php">
+    <MissingThrowsDocblock>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Command/Verify.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Config/ConfigAdapter.php">
+    <MissingThrowsDocblock>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid object store');]]></code>
+      <code>wrapStorage</code>
+      <code>wrapStorage</code>
+      <code>wrapStorage</code>
+      <code>wrapStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Config/ExternalMountPoint.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId, ConfigAdapter::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Config/SimpleSubstitutionTrait.php">
+    <MissingThrowsDocblock>
+      <code>checkPlaceholder</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_external/lib/Controller/StoragesController.php">
+    <MissingThrowsDocblock>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+    </MissingThrowsDocblock>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
       <code>(int)$status</code>
     </RedundantCast>
+  </file>
+  <file src="apps/files_external/lib/Controller/UserGlobalStoragesController.php">
+    <MissingThrowsDocblock>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Controller/UserStoragesController.php">
+    <MissingThrowsDocblock>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+      <code>manipulateStorageConfig</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Auth/Password/LoginCredentials.php">
+    <MissingThrowsDocblock>
+      <code>getPassword</code>
+      <code>getUserAttribute</code>
+      <code><![CDATA[throw new InsufficientDataForMeaningfulAnswerException('No login credentials saved');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Auth/Password/SessionCredentials.php">
+    <MissingThrowsDocblock>
+      <code>getPassword</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Auth/PublicKey/RSA.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \RuntimeException('unable to load private key');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \RuntimeException('unable to load private key');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Lib/Backend/Backend.php">
     <LessSpecificReturnStatement>
@@ -861,12 +4068,152 @@
       <code><![CDATA[class-string<IStorage>]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/files_external/lib/Lib/Backend/SMB.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('invalid authentication backend');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('user or password is not set');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/PersonalMount.php">
+    <MissingThrowsDocblock>
+      <code>getStorage</code>
+      <code>removeStorage</code>
+      <code>updateStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/AmazonS3.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[IteratorDirectory::wrap(array_map(function (array $item) {
+				return $item['name'];
+			}, $content))]]></code>
+      <code>Server::get(ICacheFactory::class)</code>
+      <code>Server::get(ICacheFactory::class)</code>
+      <code>Server::get(IMimeTypeDetector::class)</code>
+      <code>Server::get(IMimeTypeDetector::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>deleteObject</code>
+      <code>deleteObject</code>
+      <code>doesDirectoryExist</code>
+      <code>doesDirectoryExist</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>throw $e;</code>
+      <code>throw $s3Exception;</code>
+      <code>writeObject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/FTP.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[CountWrapper::wrap($stream, function ($writtenSize) use (&$size) {
+				$size = $writtenSize;
+			})]]></code>
+      <code>IteratorDirectory::wrap($files)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new StorageNotAvailableException("Could not set UTF-8 mode");]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException("Failed to create ftp connection", 0, $e);]]></code>
+      <code><![CDATA[throw new \Exception("Invalid date format for directory: $currentDir");]]></code>
+      <code><![CDATA[throw new \Exception('Creating ' . self::class . ' storage failed, required parameters not set');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/FtpConnection.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("Failed to connect to ftp");]]></code>
+      <code><![CDATA[throw new \Exception("Failed to connect to login to ftp");]]></code>
+      <code><![CDATA[throw new \RuntimeException("Metadata can't be parsed from item '$item' , not enough parts.");]]></code>
+      <code><![CDATA[throw new \RuntimeException("Metadata can't be parsed from item '$item' , not enough parts.");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/OwnCloud.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct($params)</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_external/lib/Lib/Storage/SFTP.php">
     <InternalMethod>
       <code>put</code>
     </InternalMethod>
+    <MissingThrowsDocblock>
+      <code><![CDATA[CountWrapper::wrap($stream, function (int $writtenSize) use (&$size) {
+				$size = $writtenSize;
+			})]]></code>
+      <code>get</code>
+      <code>get</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code><![CDATA[throw new \Exception("Failed to wrap stream");]]></code>
+      <code><![CDATA[throw new \Exception("Failed to write steam to sftp storage");]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('no authentication parameters specified');]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('no authentication parameters specified');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/SFTPReadStream.php">
+    <MissingThrowsDocblock>
+      <code>loadContext</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Lib/Storage/SFTPWriteStream.php">
+    <MissingThrowsDocblock>
+      <code>loadContext</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Lib/Storage/SMB.php">
+    <MissingThrowsDocblock>
+      <code>IteratorDirectory::wrap($names)</code>
+      <code>createServer</code>
+      <code>del</code>
+      <code>dir</code>
+      <code>dir</code>
+      <code>dir</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFolderContents</code>
+      <code>getFolderContents</code>
+      <code>rename</code>
+      <code>rename</code>
+      <code>rmdir</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new EntityTooLargeException("not enough available space to create file", 0, $e);]]></code>
+      <code><![CDATA[throw new EntityTooLargeException("not enough available space to create file", 0, $e);]]></code>
+      <code>throw new NotPermittedException();</code>
+      <code><![CDATA[throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);]]></code>
+      <code><![CDATA[throw new \Exception(
+					'Invalid logger. Got '
+					. get_class($params['logger'])
+					. ' Expected ' . LoggerInterface::class
+				);]]></code>
+      <code><![CDATA[throw new \Exception('Invalid configuration, no credentials provided');]]></code>
+      <code><![CDATA[throw new \Exception('Invalid configuration, no host provided');]]></code>
+      <code><![CDATA[throw new \OCP\Files\ForbiddenException($e->getMessage(), false, $e);]]></code>
+      <code><![CDATA[throw new \OCP\Files\NotFoundException($e->getMessage(), 0, $e);]]></code>
+      <code><![CDATA[throw new \OCP\Files\NotFoundException($e->getMessage(), 0, $e);]]></code>
+      <code>write</code>
+      <code>write</code>
+    </MissingThrowsDocblock>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
       <code><![CDATA[(int)$e->getCode()]]></code>
@@ -885,11 +4232,110 @@
       <code>filetype</code>
       <code>fopen</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>deleteObject</code>
+      <code>deleteObject</code>
+      <code>doesObjectExist</code>
+      <code>doesObjectExist</code>
+      <code>doesObjectExist</code>
+      <code>doesObjectExist</code>
+      <code>fetchObject</code>
+      <code>fetchObject</code>
+      <code>fetchObject</code>
+      <code>fetchObject</code>
+      <code>fetchObject</code>
+      <code>fetchObject</code>
+      <code>fetchObject</code>
+      <code>fetchObject</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new StorageBadConfigException("API Key or password, Login, Bucket and Region have to be configured.");]]></code>
+      <code><![CDATA[throw new \Exception('failed to remove original');]]></code>
+      <code>withPath</code>
+      <code>writeObject</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/Migration/DummyUserSession.php">
     <InvalidReturnType>
       <code>login</code>
     </InvalidReturnType>
+  </file>
+  <file src="apps/files_external/lib/Migration/Version1011Date20200630192246.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>changeColumn</code>
+      <code>getTable</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Migration/Version1015Date20211104103506.php">
+    <MissingThrowsDocblock>
+      <code>getS3Mounts</code>
+      <code><![CDATA[throw new \Exception('Could not fetch existing mounts for migration');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Migration/Version1016Date20220324154536.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Migration/Version22000Date20210216084416.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_external/lib/MountConfig.php">
     <InternalMethod>
@@ -899,11 +4345,296 @@
       <code>setIV</code>
       <code>setKey</code>
     </InternalMethod>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
     <TooManyArguments>
       <code>test</code>
     </TooManyArguments>
   </file>
+  <file src="apps/files_external/lib/Service/BackendService.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new \RuntimeException('Invalid empty placeholder');]]></code>
+      <code><![CDATA[throw new \RuntimeException(sprintf(
+				'Invalid placeholder %s, only [a-z0-9] are allowed', $placeholder
+			));]]></code>
+      <code><![CDATA[throw new \RuntimeException(sprintf('A handler is already registered for %s', $placeholder));]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Service/DBConfigService.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getLastInsertId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Service/LegacyStoragesService.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \UnexpectedValueException('Invalid authentication mechanism ' . $storageOptions['authMechanism']);]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('Invalid backend ' . $storageOptions['backend']);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Service/StoragesService.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Service/UserGlobalStoragesService.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \DomainException('UserGlobalStoragesService writing disallowed');]]></code>
+      <code><![CDATA[throw new \DomainException('UserGlobalStoragesService writing disallowed');]]></code>
+      <code><![CDATA[throw new \DomainException('UserGlobalStoragesService writing disallowed');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_external/lib/Settings/Section.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Activity/Filter.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Activity/Providers/Base.php">
+    <MissingThrowsDocblock>
+      <code>resolveCloudId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Activity/Providers/Downloads.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Activity/Providers/Groups.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Activity/Providers/PublicLinks.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Activity/Providers/RemoteShares.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Activity/Providers/Users.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Cache.php">
+    <MissingThrowsDocblock>
+      <code>getNodeId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Collaboration/ShareRecipientSorter.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Command/CleanupRemoteStorages.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Command/DeleteOrphanShares.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Command/ExiprationNotification.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/AcceptController.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getNode</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/DeletedShareAPIController.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getFullId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getNodeId</code>
+      <code>getRelativePath</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>throw new NotFoundException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/RemoteController.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new \OC\Files\View('/' . \OC_User::getUser() . '/files/')]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/SettingsController.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_sharing/lib/Controller/ShareAPIController.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>canAccessShare</code>
+      <code>canAccessShare</code>
+      <code>canAccessShare</code>
+      <code>deleteShare</code>
+      <code>deleteShare</code>
+      <code>formatShare</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getFormattedShares</code>
+      <code>getFormattedShares</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNodeId</code>
+      <code>getPermissions</code>
+      <code>getPermissions</code>
+      <code>getPermissions</code>
+      <code>getSize</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>lock</code>
+      <code>retrieveFederatedDisplayName</code>
+      <code>retrieveFederatedDisplayName</code>
+      <code><![CDATA[throw new OCSBadRequestException('Invalid share attributes provided: \"' . $attributesString . '\"');]]></code>
+      <code><![CDATA[throw new OCSException($e->getHint(), (int)$code);]]></code>
+      <code><![CDATA[throw new \RuntimeException('Should not happen, instanceOfStorage but getInstanceOfStorage return null');]]></code>
+      <code><![CDATA[throw new \RuntimeException('Should not happen, instanceOfStorage but not a wrapper');]]></code>
+    </MissingThrowsDocblock>
     <RedundantCast>
       <code>(int)$code</code>
       <code>(int)$code</code>
@@ -923,40 +4654,337 @@
     <InvalidArgument>
       <code>$files_list</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>emitAccessShareHook</code>
+      <code>emitAccessShareHook</code>
+      <code>emitAccessShareHook</code>
+      <code>emitAccessShareHook</code>
+      <code>emitAccessShareHook</code>
+      <code>emitAccessShareHook</code>
+      <code>getId</code>
+      <code>getShareByToken</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>publish</code>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+      <code>throw $exception;</code>
+      <code>throw new NotFoundException();</code>
+      <code>updateShare</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/ShareInfoController.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>getDirectoryListing</code>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getNode</code>
+      <code>getPermissions</code>
+      <code>getPermissions</code>
+      <code>getSize</code>
+      <code>getSize</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getProperty</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getStorage</code>
+      <code>imagePath</code>
+      <code>setHeaderActions</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/DeleteOrphanedSharesJob.php">
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/ExpireSharesJob.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/External/Manager.php">
     <LessSpecificReturnStatement>
       <code>$mount</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>insertIfNotExist</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>setApp</code>
+      <code>setObject</code>
+      <code>setUser</code>
+      <code>writeShareToDb</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>Mount</code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/files_sharing/lib/External/Mount.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct($storage, $mountpoint, $options, $loader, null, null, MountProvider::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/External/MountProvider.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_sharing/lib/External/Scanner.php">
+    <MissingThrowsDocblock>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$cacheData</code>
     </MoreSpecificImplementedParamType>
+  </file>
+  <file src="apps/files_sharing/lib/External/Storage.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IOCMDiscoveryService::class)</code>
+      <code>Server::get(IOCMDiscoveryService::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>checkStorageAvailability</code>
+      <code>get</code>
+      <code>getShareInfo</code>
+      <code><![CDATA[parent::__construct(
+			[
+				'secure' => ((parse_url($remote, PHP_URL_SCHEME) ?? 'https') === 'https'),
+				'host' => $host,
+				'root' => $webDavEndpoint,
+				'user' => $options['token'],
+				'authType' => \Sabre\DAV\Client::AUTH_BASIC,
+				'password' => (string)$options['password']
+			]
+		)]]></code>
+      <code>propfind</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Helper.php">
+    <MissingThrowsDocblock>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Hooks.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[new \OC\Files\View('/')]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Listener/LoadAdditionalListener.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Listener/UserShareAcceptanceListener.php">
+    <MissingThrowsDocblock>
+      <code>acceptShare</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Middleware/OCSShareAPIMiddleware.php">
+    <MissingThrowsDocblock>
+      <code>cleanup</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/Middleware/SharingCheckMiddleware.php">
     <InvalidArgument>
       <code><![CDATA[$exception->getMessage()]]></code>
     </InvalidArgument>
   </file>
+  <file src="apps/files_sharing/lib/Migration/Version11300Date20201120141438.php">
+    <MissingThrowsDocblock>
+      <code>Type::getType(Types::STRING)</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>execute</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+      <code>setOptions</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Migration/Version21000Date20201223143245.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Migration/Version22000Date20210216084241.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Migration/Version24000Date20220404142216.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_sharing/lib/MountProvider.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new View('/' . $user->getUID() . '/files')]]></code>
+    </MissingThrowsDocblock>
     <RedundantFunctionCall>
       <code>array_values</code>
     </RedundantFunctionCall>
+  </file>
+  <file src="apps/files_sharing/lib/Notification/Listener.php">
+    <MissingThrowsDocblock>
+      <code>getArgument</code>
+      <code>getFullId</code>
+      <code>notify</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setUser</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/Notification/Notifier.php">
+    <MissingThrowsDocblock>
+      <code>addParsedAction</code>
+      <code>addParsedAction</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getNode</code>
+      <code>getRelativePath</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>imagePath</code>
+      <code>setIcon</code>
+      <code>setLink</code>
+      <code>setLink</code>
+      <code>setParsedLabel</code>
+      <code>setParsedLabel</code>
+      <code>setParsedSubject</code>
+      <code>setPrimary</code>
+      <code>setPrimary</code>
+      <code>setRichMessage</code>
+      <code>setRichSubject</code>
+      <code>throw new AlreadyProcessedException();</code>
+      <code>throw new AlreadyProcessedException();</code>
+      <code>throw new AlreadyProcessedException();</code>
+      <code>throw new AlreadyProcessedException();</code>
+      <code>throw new AlreadyProcessedException();</code>
+      <code>throw new AlreadyProcessedException();</code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid share type');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Temporary failure');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Temporary failure');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_sharing/lib/OrphanHelper.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/ShareBackend/File.php">
     <InvalidArgument>
       <code>$itemSource</code>
       <code>$itemSource</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OC\Files\Filesystem::initMountPoints($shareWith)</code>
+      <code><![CDATA[new \OC\Files\View('/' . $shareWith . '/files')]]></code>
+      <code>query</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$shareWith</code>
     </MoreSpecificImplementedParamType>
   </file>
   <file src="apps/files_sharing/lib/ShareBackend/Folder.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>fetchRow</code>
     </UndefinedInterfaceMethod>
@@ -965,6 +4993,16 @@
     <InvalidReturnType>
       <code>bool</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>execute</code>
+      <code>getNodeId</code>
+      <code>parent::__construct($storage, $absMountPoint, $arguments, $loader, null, null, MountProvider::class)</code>
+      <code>stripUserFilesPath</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_sharing/lib/SharedStorage.php">
     <FalsableReturnStatement>
@@ -976,11 +5014,27 @@
     <InvalidReturnStatement>
       <code>new FailedCache()</code>
     </InvalidReturnStatement>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getNodeType</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[$this->sourceRootInfo]]></code>
     </NullableReturnStatement>
   </file>
   <file src="apps/files_sharing/lib/Updater.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+    </MissingThrowsDocblock>
     <UndefinedMethod>
       <code>moveMount</code>
     </UndefinedMethod>
@@ -991,6 +5045,122 @@
       <code><![CDATA[isset($_['hideFileList']) && $_['hideFileList'] !== true]]></code>
     </RedundantCondition>
   </file>
+  <file src="apps/files_trashbin/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new \OC\Files\View('/' . $user)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/CleanUp.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>execute</code>
+      <code>get</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new InvalidOptionException('Either specify a user_id or --all-users');]]></code>
+      <code><![CDATA[throw new InvalidOptionException('Either specify a user_id or --all-users');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/ExpireTrash.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code><![CDATA[new \OC\Files\View('/' . $user)]]></code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/RestoreAllFiles.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new InvalidOptionException("Invalid scope '$scope'");]]></code>
+      <code><![CDATA[throw new InvalidOptionException("Invalid timestamp '$timestamp'");]]></code>
+      <code><![CDATA[throw new InvalidOptionException('Either specify a user_id or --all-users');]]></code>
+      <code><![CDATA[throw new InvalidOptionException('Either specify a user_id or --all-users');]]></code>
+      <code><![CDATA[throw new InvalidOptionException('since must be before until');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/Size.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Events/BeforeNodeRestoredEvent.php">
+    <MissingThrowsDocblock>
+      <code>throw $ex;</code>
+      <code><![CDATA[throw new Exception('Operation aborted');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Helper.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new \OC\Files\View('/' . $user . '/files_trashbin/files')]]></code>
+      <code><![CDATA[throw new \Exception('Directory does not exists');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Listeners/SyncLivePhotosListener.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Migration/Version1010Date20200630192639.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_trashbin/lib/Sabre/AbstractTrash.php">
     <InvalidNullableReturnType>
       <code>int</code>
@@ -999,6 +5169,12 @@
       <code><![CDATA[$this->data->getId()]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/files_trashbin/lib/Sabre/AbstractTrashFile.php">
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_trashbin/lib/Sabre/AbstractTrashFolder.php">
     <InvalidReturnStatement>
       <code>$entry</code>
@@ -1006,11 +5182,23 @@
     <InvalidReturnType>
       <code>ITrash</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_trashbin/lib/Sabre/RestoreFolder.php">
     <InvalidNullableReturnType>
       <code>getChild</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
@@ -1020,6 +5208,15 @@
       <code>INode</code>
     </MismatchingDocblockReturnType>
   </file>
+  <file src="apps/files_trashbin/lib/Sabre/TrashHome.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('Not allowed to create files in the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('Not allowed to create folders in the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this trashbin');]]></code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_trashbin/lib/Sabre/TrashRoot.php">
     <InvalidReturnStatement>
       <code>$entry</code>
@@ -1027,8 +5224,35 @@
     <InvalidReturnType>
       <code>ITrash</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Forbidden('Not allowed to create files in the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('Not allowed to create folders in the trashbin');]]></code>
+      <code><![CDATA[throw new Forbidden('Permission denied to rename this trashbin');]]></code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/Storage.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_trashbin/lib/Trash/LegacyTrashBackend.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>$file</code>
     </UndefinedInterfaceMethod>
@@ -1043,6 +5267,115 @@
     <InvalidScalarArgument>
       <code>$timestamp</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'delete', ['path' => $path])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'delete', ['path' => $path])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'deleteAll', ['paths' => $filePaths])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'deleteAll', ['paths' => $filePaths])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'preDelete', ['path' => $path])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'preDelete', ['path' => $path])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'preDeleteAll', ['paths' => $filePaths])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Trashbin', 'preDeleteAll', ['paths' => $filePaths])]]></code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>free_space</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code><![CDATA[new View('/' . $owner)]]></code>
+      <code><![CDATA[new View('/' . $uid . '/files')]]></code>
+      <code><![CDATA[new View('/' . $user . '/files_trashbin')]]></code>
+      <code><![CDATA[new View('/' . $user . '/files_trashbin/files/' . $file)]]></code>
+      <code><![CDATA[new View('/' . $user . '/files_trashbin/versions')]]></code>
+      <code><![CDATA[new View('/' . $user . '/files_trashbin/versions/' . $file)]]></code>
+      <code><![CDATA[new View('/' . $user)]]></code>
+      <code><![CDATA[new View('/' . $user)]]></code>
+      <code><![CDATA[new View('/' . $user)]]></code>
+      <code><![CDATA[new View('/' . $user)]]></code>
+      <code><![CDATA[new View('/' . $user)]]></code>
+      <code><![CDATA[new View('/' . $user)]]></code>
+      <code><![CDATA[new View('/')]]></code>
+      <code><![CDATA[new View('/')]]></code>
+      <code><![CDATA[new View('/')]]></code>
+      <code>newFolder</code>
+      <code>newFolder</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>rename</code>
+      <code>rename</code>
+      <code><![CDATA[self::copy_recursive($owner . '/files_versions/' . $ownerPath, $owner . '/files_trashbin/versions/' . static::getTrashFilename(basename($ownerPath), $timestamp), $rootView)]]></code>
+      <code>self::copy_recursive($source, $target, $view)</code>
+      <code>self::getUidAndFilename($file_path)</code>
+      <code><![CDATA[self::getUidAndFilename($params['path'])]]></code>
+      <code>self::getUidAndFilename($target)</code>
+      <code><![CDATA[throw new Exception('View should not be null');]]></code>
+      <code><![CDATA[throw new NotPermittedException("Can't restore trash item because the target folder is not writable");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php">
+    <MissingThrowsDocblock>
+      <code>newFolder</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_versions/appinfo/routes.php">
     <InvalidScope>
@@ -1050,81 +5383,1641 @@
       <code>$this</code>
     </InvalidScope>
   </file>
+  <file src="apps/files_versions/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/BackgroundJob/ExpireVersions.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new \OC\Files\View('/' . $user)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Command/CleanUp.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>delete</code>
+      <code>get</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getStorage</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Command/Expire.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Command/ExpireVersions.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code><![CDATA[new \OC\Files\View('/' . $user)]]></code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Controller/PreviewController.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Db/VersionsMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>findEntities</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Listener/FileEventsListener.php">
+    <MissingThrowsDocblock>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code><![CDATA[new View(\OC_User::getUser() . '/files')]]></code>
+      <code>throw $e;</code>
+      <code>throw $ex;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Listener/VersionAuthorListener.php">
+    <MissingThrowsDocblock>
+      <code>getMTime</code>
+      <code>getMTime</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Listener/VersionStorageMoveListener.php">
+    <MissingThrowsDocblock>
+      <code>getDirectoryListing</code>
+      <code>getDirectoryListing</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Migration/Version1020Date20221114144058.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/files_versions/lib/Sabre/RestoreFolder.php">
     <InvalidNullableReturnType>
       <code>getChild</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
+  </file>
+  <file src="apps/files_versions/lib/Sabre/RootCollection.php">
+    <MissingThrowsDocblock>
+      <code>throw new \Sabre\DAV\Exception\Forbidden();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Sabre/VersionCollection.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Sabre/VersionFile.php">
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_versions/lib/Sabre/VersionHome.php">
     <InvalidNullableReturnType>
       <code>getChild</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NoUserException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Sabre/VersionRoot.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new Forbidden();</code>
+      <code>throw new NotFound();</code>
+      <code>throw new NotFound();</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/files_versions/lib/Storage.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path . $revision, 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $path . $revision, 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path . $revision, 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'preDelete', ['path' => $path . $revision, 'trigger' => self::DELETE_TRIGGER_MASTER_REMOVED])]]></code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getOwner</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>lockFile</code>
+      <code>lockFile</code>
+      <code><![CDATA[new View('')]]></code>
+      <code><![CDATA[new View('/' . $uid . '/')]]></code>
+      <code><![CDATA[new View('/' . $uid . '/')]]></code>
+      <code><![CDATA[new View('/' . $uid . '/files_versions')]]></code>
+      <code><![CDATA[new View('/' . $uid . '/files_versions')]]></code>
+      <code><![CDATA[new View('/' . $user)]]></code>
+      <code><![CDATA[new View('/'. $targetOwner)]]></code>
+      <code><![CDATA[new View('/'. $targetOwner)]]></code>
+      <code><![CDATA[new View('/'. $user->getUID().'/files')]]></code>
+      <code><![CDATA[new View('/'.$uid.'/files')]]></code>
+      <code><![CDATA[new View('/'.$uid.'/files_versions')]]></code>
+      <code><![CDATA[new View('/'.$user->getUID())]]></code>
+      <code>self::getUidAndFilename($path)</code>
+      <code>self::getUidAndFilename($path)</code>
+      <code>self::getUidAndFilename($source)</code>
+      <code>self::getUidAndFilename($targetPath)</code>
+      <code><![CDATA[throw new \OC\User\NoUserException('Backends provided no user object for ' . $uid);]]></code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code><![CDATA[$storage1->instanceOfStorage('\OC\Files\ObjectStore\ObjectStoreStorage')]]></code>
     </RedundantCondition>
+  </file>
+  <file src="apps/files_versions/lib/Versions/LegacyVersionsBackend.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getNode</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>insert</code>
+      <code><![CDATA[new View('/' . $user->getUID())]]></code>
+      <code><![CDATA[new View('/' . $user->getUID())]]></code>
+      <code>newFolder</code>
+      <code><![CDATA[throw new Exception("Relative path not found for node with path: " . $source->getPath());]]></code>
+      <code><![CDATA[throw new Forbidden('You cannot delete this version because you do not have delete permissions on the source file.');]]></code>
+      <code><![CDATA[throw new Forbidden('You cannot restore this version because you do not have update permissions on the source file.');]]></code>
+      <code><![CDATA[throw new Forbidden('You cannot update the version\'s metadata because you do not have update permissions on the source file.');]]></code>
+      <code><![CDATA[throw new NotFoundException("File not found ($fileId)");]]></code>
+      <code><![CDATA[throw new NotFoundException("File not found ($fileId)");]]></code>
+      <code><![CDATA[throw new NotFoundException("No user logged in");]]></code>
+      <code><![CDATA[throw new NotFoundException("Relative path not found for file $fileId (" . $file->getPath() . ')');]]></code>
+      <code><![CDATA[throw new NotFoundException("User $owner not found for $fileId");]]></code>
+      <code><![CDATA[throw new NotFoundException("Version file not accessible by current user");]]></code>
+      <code><![CDATA[throw new NotFoundException("version file not found for share owner");]]></code>
+      <code><![CDATA[throw new \Exception('Target does not have a relative path' . $target->getPath());]]></code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/files_versions/lib/Versions/VersionManager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'rollback', [
+				'path' => $version->getVersionPath(),
+				'revision' => $version->getRevisionId(),
+				'node' => $version->getSourceFile(),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Versions', 'rollback', [
+				'path' => $version->getVersionPath(),
+				'revision' => $version->getRevisionId(),
+				'node' => $version->getSourceFile(),
+			])]]></code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getBackendForStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code><![CDATA[self::handleAppLocks(fn (): ?bool => $backend->rollback($version))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/lookup_server_connector/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/lookup_server_connector/lib/BackgroundJobs/RetryJob.php">
     <InvalidArgument>
       <code><![CDATA[$this->retries + 1]]></code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/oauth2/lib/Controller/OauthApiController.php">
+    <MissingThrowsDocblock>
+      <code>decrypt</code>
+      <code>rotate</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
+  <file src="apps/oauth2/lib/Controller/SettingsController.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>getByUid</code>
+      <code>insert</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/oauth2/lib/Db/AccessTokenMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/oauth2/lib/Db/ClientMapper.php">
+    <MissingThrowsDocblock>
+      <code>findEntities</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/oauth2/lib/Migration/Version010401Date20181207190718.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/oauth2/lib/Migration/Version010402Date20190107124745.php">
+    <MissingThrowsDocblock>
+      <code>addUniqueIndex</code>
+      <code>dropIndex</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/oauth2/lib/Migration/Version011601Date20230522143227.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/oauth2/lib/Migration/Version011602Date20230613160650.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/oauth2/lib/Migration/Version011603Date20230620111039.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/provisioning_api/lib/Capabilities.php">
+    <MissingThrowsDocblock>
+      <code>query</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/AUserData.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/AppConfigController.php">
+    <MissingThrowsDocblock>
+      <code>setValueMixed</code>
+      <code><![CDATA[throw new NotAdminException($this->l10n->t('Logged in account must be an administrator or have authorization to edit this setting.'));]]></code>
+      <code><![CDATA[throw new \Exception("User is not logged in.");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/PreferencesController.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/provisioning_api/lib/Controller/UsersController.php">
+    <MissingThrowsDocblock>
+      <code>addPropertyWithDefaults</code>
+      <code>addPropertyWithDefaults</code>
+      <code>getProperty</code>
+      <code>getPropertyCollection</code>
+      <code>getPropertyCollection</code>
+      <code>getPropertyCollection</code>
+      <code>getUserData</code>
+      <code>getUserData</code>
+      <code>setLocallyVerified</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new InvalidArgumentException("Invalid limit value: $limit");]]></code>
+      <code><![CDATA[throw new InvalidArgumentException("Invalid offset value: $offset");]]></code>
+      <code>updateAccount</code>
+      <code>updateAccount</code>
+      <code>updateAccount</code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainNull>
       <code>$groupid === null</code>
       <code>$groupid === null</code>
     </TypeDoesNotContainNull>
+  </file>
+  <file src="apps/provisioning_api/lib/Controller/VerificationController.php">
+    <MissingThrowsDocblock>
+      <code>decrypt</code>
+      <code><![CDATA[throw new InvalidArgumentException('Logged in account is not mail address owner');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/provisioning_api/lib/FederatedShareProviderFactory.php">
+    <MissingThrowsDocblock>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/provisioning_api/lib/Middleware/ProvisioningApiMiddleware.php">
     <InvalidReturnType>
       <code>Response</code>
     </InvalidReturnType>
   </file>
+  <file src="apps/settings/lib/Activity/GroupProvider.php">
+    <MissingThrowsDocblock>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Activity/Provider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Activity/SecurityFilter.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Activity/SecurityProvider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/settings/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getSettingsManager</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/settings/lib/BackgroundJobs/VerifyUserData.php">
+    <MissingThrowsDocblock>
+      <code>getProperty</code>
+      <code>updateAccount</code>
+      <code>updateAccount</code>
+      <code>updateAccount</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Command/AdminDelegation/Add.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>create</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Command/AdminDelegation/Remove.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Command/AdminDelegation/Show.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Controller/AdminSettingsController.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new NotAdminException("Logged in user doesn't have permission to access these settings.");]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/settings/lib/Controller/AppSettingsController.php">
+    <MissingThrowsDocblock>
+      <code>getAppsForCategory</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>ignoreNextcloudRequirementForApp</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/settings/lib/Controller/AuthSettingsController.php">
+    <MissingThrowsDocblock>
+      <code>generateToken</code>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Controller/ChangePasswordController.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(\OCA\Encryption\KeyManager::class)</code>
+      <code>\OCP\Server::get(\OCA\Encryption\KeyManager::class)</code>
+      <code>\OCP\Server::get(\OCA\Encryption\Recovery::class)</code>
+      <code>\OCP\Server::get(\OCA\Encryption\Recovery::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Controller/LogSettingsController.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \UnexpectedValueException('Log file not available');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Controller/MailSettingsController.php">
+    <MissingThrowsDocblock>
+      <code>setSystemValues</code>
+      <code>setSystemValues</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Controller/UsersController.php">
+    <MissingThrowsDocblock>
+      <code>getKey</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>updateAccount</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/settings/lib/Hooks.php">
     <InvalidArrayOffset>
       <code><![CDATA[[$user->getEMailAddress() => $user->getDisplayName()]]]></code>
     </InvalidArrayOffset>
+    <MissingThrowsDocblock>
+      <code>send</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Listener/AppPasswordCreatedActivityListener.php">
+    <MissingThrowsDocblock>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Listener/UserAddedToGroupActivityListener.php">
+    <MissingThrowsDocblock>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Listener/UserRemovedFromGroupActivityListener.php">
+    <MissingThrowsDocblock>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Mailer/NewUserMailHelper.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/Additional.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/ArtificialIntelligence.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/Delegation.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/Groupware.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/Overview.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/Security.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/Server.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Admin/Sharing.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Personal/Availability.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Personal/Calendar.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Personal/PersonalInfo.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Personal/Security.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Sections/Personal/SyncClients.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Service/AuthorizedGroupService.php">
+    <MissingThrowsDocblock>
+      <code>find</code>
+      <code>find</code>
+      <code>find</code>
+      <code>findAll</code>
+      <code>handleException</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/settings/lib/Settings/Admin/Security.php">
     <UndefinedInterfaceMethod>
       <code>isReady</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/settings/lib/Settings/Admin/Server.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/settings/lib/Settings/Admin/Sharing.php">
     <NullArgument>
       <code>null</code>
     </NullArgument>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/PersonalInfo.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Helper::getStorageInfo('/')]]></code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getProperty</code>
+      <code>getPropertyCollection</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/Security/TwoFactor.php">
+    <MissingThrowsDocblock>
+      <code>getProviders</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/ServerDevNotice.php">
+    <MissingThrowsDocblock>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/AppDirsWithDifferentOwner.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('App directories have the correct owner "%s"', [$currentUserInfos['name'] ?? '']))]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t("Some app directories are owned by a different user than the web server one. This may be the case if apps have been installed manually. Check the permissions of the following app directories:\n%s", implode("\n", $appDirsWithDifferentOwner))
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/BruteForceThrottler.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+				$this->l10n->t('Your remote address was identified as "%s" and is brute-force throttled at the moment slowing down the performance of various requests. If the remote address is not your address this can be an indication that a proxy is not configured correctly.', [$address]),
+				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
+			)]]></code>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Your remote address could not be determined.'))]]></code>
+      <code><![CDATA[SetupResult::info($this->l10n->t('Your remote address could not be determined.'))]]></code>
+      <code><![CDATA[SetupResult::success(
+				$this->l10n->t('Your remote address "%s" is not brute-force throttled.', [$address])
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/CheckUserCertificates.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error($this->l10n->t('There are some administration imported SSL certificates present, that are not used anymore with Nextcloud 21. They can be imported on the command line via "occ security:certificates:import" command. Their paths inside the data directory are shown below.'))]]></code>
+      <code><![CDATA[SetupResult::info($this->l10n->t('A background job is pending that checks for administration imported SSL certificates. Please check back later.'))]]></code>
+      <code>SetupResult::success()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/CodeIntegrity.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+				$this->l10n->t('Some files have not passed the integrity check. {link1} {link2}'),
+				$this->urlGenerator->linkToDocs('admin-code-integrity'),
+				[
+					'link1' => [
+						'type' => 'highlight',
+						'id' => 'getFailedIntegrityCheckFiles',
+						'name' => 'List of invalid files…',
+						'link' => $this->urlGenerator->linkToRoute('settings.CheckSetup.getFailedIntegrityCheckFiles'),
+					],
+					'link2' => [
+						'type' => 'highlight',
+						'id' => 'rescanFailedIntegrityCheck',
+						'name' => 'Rescan…',
+						'link' => $this->urlGenerator->linkToRoute('settings.CheckSetup.rescanFailedIntegrityCheck'),
+					],
+				],
+			)]]></code>
+      <code><![CDATA[SetupResult::info($this->l10n->t('Integrity checker has been disabled. Integrity cannot be verified.'))]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('No altered files'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/CronErrors.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+				$this->l10n->t(
+					"It was not possible to execute the cron job via CLI. The following technical errors have appeared:\n%s",
+					implode("\n", array_map(fn (array $error) => '- '.$error['error'].' '.$error['hint'], $errors))
+				)
+			)]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('The last cron job ran without errors.'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/CronInfo.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+				$this->l10n->t(
+					'Last background job execution ran %s. Something seems wrong. {link}.',
+					[$relativeTime]
+				),
+				descriptionParameters:[
+					'link' => [
+						'type' => 'highlight',
+						'id' => 'backgroundjobs',
+						'name' => 'Check the background job settings',
+						'link' => $this->urlGenerator->linkToRoute('settings.AdminSettings.index', ['section' => 'server']) . '#backgroundjobs',
+					],
+				],
+			)]]></code>
+      <code><![CDATA[SetupResult::success(
+				$this->l10n->t(
+					'Last background job execution ran %s.',
+					[$relativeTime]
+				)
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DataDirectoryProtected.php">
+    <MissingThrowsDocblock>
+      <code>SetupResult::success()</code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('Could not check that the data directory is protected. Please check manually that your server does not allow access to the data directory.') . "\n" . $this->serverConfigHelp())]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DatabaseHasMissingColumns.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success('None')]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('The database is missing some optional columns. Due to the fact that adding columns on big tables could take some time they were not added automatically when they can be optional. By running "occ db:add-missing-columns" those missing columns could be added manually while the instance keeps running. Once the columns are added some features might improve responsiveness or usability.').$list
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DatabaseHasMissingIndices.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success('None')]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('The database is missing some indexes. Due to the fact that adding indexes on big tables could take some time they were not added automatically. By running "occ db:add-missing-indices" those missing indexes could be added manually while the instance keeps running. Once the indexes are added queries to those tables are usually much faster.').$list
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DatabaseHasMissingPrimaryKeys.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success('None')]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('The database is missing some primary keys. Due to the fact that adding primary keys on big tables could take some time they were not added automatically. By running "occ db:add-missing-primary-keys" those missing primary keys could be added manually while the instance keeps running.').$list
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DatabasePendingBigIntConversions.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t('Some columns in the database are missing a conversion to big int. Due to the fact that changing column types on big tables could take some time they were not changed automatically. By running "occ db:convert-filecache-bigint" those pending changes could be applied manually. This operation needs to be made while the instance is offline.').$list,
+				$this->urlGenerator->linkToDocs('admin-bigint-conversion')
+			)]]></code>
+      <code><![CDATA[SetupResult::success('None')]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DebugMode.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Debug mode is disabled.'))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('This instance is running in debug mode. Only enable this for local development and not in production environments.'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/DefaultPhoneRegionSet.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t('Your installation has no default phone region set. This is required to validate phone numbers in the profile settings without a country code. To allow numbers without a country code, please add "default_phone_region" with the respective ISO 3166-1 code of the region to your config file.'),
+				'https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements'
+			)]]></code>
+      <code><![CDATA[SetupResult::success($this->config->getSystemValueString('default_phone_region', ''))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/EmailTestSuccessful.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t('You have not set or verified your email server configuration, yet. Please head over to the "Basic settings" in order to set them. Afterwards, use the "Send email" button below the form to verify your settings.'),
+				$this->urlGenerator->linkToDocs('admin-email')
+			)]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Email test was successfully sent'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/FileLocking.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t('The database is used for transactional file locking. To enhance performance, please configure memcache, if available.'),
+				$this->urlGenerator->linkToDocs('admin-transactional-locking')
+			)]]></code>
+      <code>SetupResult::success()</code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('Transactional file locking is disabled, this might lead to issues with race conditions. Enable "filelocking.enabled" in config.php to avoid these problems.'),
+				$this->urlGenerator->linkToDocs('admin-transactional-locking')
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/ForwardedForHeaders.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+				$this->l10n->t('The reverse proxy header configuration is incorrect. This is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),
+				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
+			)]]></code>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Your "trusted_proxies" setting is not correctly set, it should be an array.'))]]></code>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Your remote address could not be determined.'))]]></code>
+      <code><![CDATA[SetupResult::info($this->l10n->t('Your remote address could not be determined.'))]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Your IP address was resolved as %s', [$detectedRemoteAddress]))]]></code>
+      <code>SetupResult::success()</code>
+      <code><![CDATA[SetupResult::warning(
+					$this->l10n->t('The reverse proxy header configuration is incorrect, or you are accessing Nextcloud from a trusted proxy. If not, this is a security issue and can allow an attacker to spoof their IP address as visible to the Nextcloud.'),
+					$this->urlGenerator->linkToDocs('admin-reverse-proxy')
+				)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/HttpsUrlGeneration.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+					$this->l10n->t('Accessing site insecurely via HTTP. You are strongly advised to set up your server to require HTTPS instead. Without it some important web functionality like "copy to clipboard" or "service workers" will not work!'),
+					$this->urlGenerator->linkToDocs('admin-security')
+				)]]></code>
+      <code><![CDATA[SetupResult::info(
+					$this->l10n->t('Accessing site insecurely via HTTP.'),
+					$this->urlGenerator->linkToDocs('admin-security')
+				)]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('You are accessing your instance over a secure connection, and your instance is generating secure URLs.'))]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('You are accessing your instance over a secure connection, however your instance is generating insecure URLs. This most likely means that you are behind a reverse proxy and the overwrite config variables are not set correctly.'),
+				$this->urlGenerator->linkToDocs('admin-reverse-proxy')
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/InternetConnectivity.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Internet connectivity is disabled in configuration file.'))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('This server has no working internet connection: Multiple endpoints could not be reached. This means that some of the features like mounting external storage, notifications about updates or installation of third-party apps will not work. Accessing files remotely and sending of notification emails might not work, either. Establish a connection from this server to the internet to enjoy all features.'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/JavaScriptModules.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Your webserver does not serve `.mjs` files using the JavaScript MIME type. This will break some apps by preventing browsers from executing the JavaScript files. You should configure your webserver to serve `.mjs` files with either the `text/javascript` or `application/javascript` MIME type.'))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('Could not check for JavaScript support via any of your `trusted_domains` nor `overwrite.cli.url`. This may be the result of a server-side DNS mismatch or outbound firewall rule. Please check manually if your webserver serves `.mjs` files using the JavaScript MIME type.') . "\n" . $this->serverConfigHelp())]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/JavaScriptSourceMaps.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('Your webserver is not set up to serve `.js.map` files. Without these files, JavaScript Source Maps won\'t function properly, making it more challenging to troubleshoot and debug any issues that may arise.'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/LegacySSEKeyFormat.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Disabled'))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('The old server-side-encryption format is enabled. We recommend disabling this.'), $this->urlGenerator->linkToDocs('admin-sse-legacy-format'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/MaintenanceWindowStart.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success(
+			str_replace(
+				['{start}', '{end}'],
+				[$startValue, $endValue],
+				$this->l10n->t('Maintenance window to execute heavy background jobs is between {start}:00 UTC and {end}:00 UTC')
+			)
+		)]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('Server has no maintenance window start time configured. This means resource intensive daily background jobs will also be executed during your main usage time. We recommend to set it to a time of low usage, so users are less impacted by the load caused from these heavy tasks.'),
+				$this->urlGenerator->linkToDocs('admin-background-jobs')
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/MemcacheConfigured.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t('No memory cache has been configured. To enhance performance, please configure a memcache, if available.'),
+				$this->urlGenerator->linkToDocs('admin-performance')
+			)]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Configured'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/MysqlUnicodeSupport.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('MySQL is used as database and does support 4-byte characters'))]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('You are not using MySQL'))]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('MySQL is used as database but does not support 4-byte characters. To be able to handle 4-byte characters (like emojis) without issues in filenames or comments for example it is recommended to enable the 4-byte support in MySQL.'),
+				$this->urlGenerator->linkToDocs('admin-mysql-utf8mb4'),
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/OcxProviders.php">
+    <MissingThrowsDocblock>
+      <code>SetupResult::success()</code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('Could not check if your web server properly resolves the OCM and OCS provider URLs.', ) . "\n" . $this->serverConfigHelp(),
+			)]]></code>
+      <code><![CDATA[SetupResult::warning(
+			$this->l10n->t('Your web server is not properly set up to resolve %1$s.
+This is most likely related to a web server configuration that was not updated to deliver this folder directly.
+Please compare your configuration against the shipped rewrite rules in ".htaccess" for Apache or the provided one in the documentation for Nginx.
+On Nginx those are typically the lines starting with "location ~" that need an update.', [join(', ', array_map(fn ($s) => '"'.$s.'"', $missingProviders))]),
+			$this->urlGenerator->linkToDocs('admin-nginx'),
+		)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/OverwriteCliUrl.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success(
+					$this->l10n->t(
+						'The "overwrite.cli.url" option in your config.php is correctly set to "%s".',
+						[$currentOverwriteCliUrl]
+					)
+				)]]></code>
+      <code><![CDATA[SetupResult::success(
+					$this->l10n->t(
+						'The "overwrite.cli.url" option in your config.php is set to "%s" which is a correct URL. Suggested URL is "%s".',
+						[$currentOverwriteCliUrl, $suggestedOverwriteCliUrl]
+					)
+				)]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t(
+					'Please make sure to set the "overwrite.cli.url" option in your config.php file to the URL that your users mainly use to access this Nextcloud. Suggestion: "%s". Otherwise there might be problems with the URL generation via cron. (It is possible though that the suggested URL is not the URL that your users mainly use to access this Nextcloud. Best is to double check this in any case.)',
+					[$suggestedOverwriteCliUrl]
+				)
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpDefaultCharset.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success('UTF-8')]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('PHP configuration option "default_charset" should be UTF-8'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpDisabledFunctions.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('The function is available.'))]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('The PHP function "set_time_limit" is not available. This could result in scripts being halted mid-execution, breaking your installation. Enabling this function is strongly recommended.'),
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpFreetypeSupport.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t('Your PHP does not have FreeType support, resulting in breakage of profile pictures and the settings interface.'),
+			)]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Supported'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpGetEnv.php">
+    <MissingThrowsDocblock>
+      <code>SetupResult::success()</code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('PHP does not seem to be setup properly to query system environment variables. The test with getenv("PATH") only returns an empty response.'), $this->urlGenerator->linkToDocs('admin-php-fpm'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpMemoryLimit.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error($this->l10n->t('The PHP memory limit is below the recommended value of %s.', Util::humanFileSize(MemoryInfo::RECOMMENDED_MEMORY_LIMIT)))]]></code>
+      <code><![CDATA[SetupResult::success(Util::humanFileSize($this->memoryInfo->getMemoryLimit()))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpModules.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+				$this->l10n->t('This instance is missing some required PHP modules. It is required to install them: %s.', implode(', ', $missingRequiredModules)),
+				$this->urlGenerator->linkToDocs('admin-php-modules')
+			)]]></code>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t("This instance is missing some recommended PHP modules. For improved performance and better compatibility it is highly recommended to install them:\n%s", $moduleList),
+				$this->urlGenerator->linkToDocs('admin-php-modules')
+			)]]></code>
+      <code>SetupResult::success()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpOpcacheSetup.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Correctly configured'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpOutdated.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('You are currently running PHP %s.', [PHP_VERSION]))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('You are currently running PHP %s. PHP 8.1 is now deprecated in Nextcloud 30. Nextcloud 31 may require at least PHP 8.2. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [PHP_VERSION]), 'https://secure.php.net/supported-versions.php')]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PhpOutputBuffering.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error($this->l10n->t('PHP configuration option "output_buffering" must be disabled'))]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Disabled'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PushService.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+			$this->l10n->t('This is the unsupported community build of Nextcloud. Given the size of this instance, performance, reliability and scalability cannot be guaranteed. Push notifications are limited to avoid overloading our free service. Learn more about the benefits of Nextcloud Enterprise at {link}.'),
+			descriptionParameters:[
+				'link' => [
+					'type' => 'highlight',
+					'id' => 'link',
+					'name' => 'https://nextcloud.com/enterprise',
+					'link' => 'https://nextcloud.com/enterprise',
+				],
+			],
+		)]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Free push service'))]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Valid enterprise license'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/RandomnessSecure.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+				$this->l10n->t('No suitable source for randomness found by PHP which is highly discouraged for security reasons.'),
+				$this->urlGenerator->linkToDocs('admin-security')
+			)]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Secure'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/ReadOnlyConfig.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info($this->l10n->t('The read-only config has been enabled. This prevents setting some configurations via the web-interface. Furthermore, the file needs to be made writable manually for every update.'))]]></code>
+      <code><![CDATA[SetupResult::success($this->l10n->t('Nextcloud configuration file is writable'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/SecurityHeaders.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success(
+			$this->l10n->t('Your server is correctly configured to send security headers.')
+		)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/SupportedDatabase.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Unknown database platform'))]]></code>
+      <code>SetupResult::success($version)</code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('SQLite is currently being used as the backend database. For larger installations we recommend that you switch to a different database backend. This is particularly recommended when using the desktop client for file synchronisation. To migrate to another database use the command line tool: "occ db:convert-type".'),
+				$this->urlGenerator->linkToDocs('admin-db-conversion')
+			)]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('MariaDB version "%s" is used. Nextcloud 21 and higher do not support this version and require MariaDB 10.2 or higher.', $version))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('MySQL version "%s" is used. Nextcloud 21 and higher do not support this version and require MySQL 8.0 or MariaDB 10.2 or higher.', $version))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('PostgreSQL version "%s" is used. Nextcloud 21 and higher do not support this version and require PostgreSQL 9.6 or higher.', $version))]]></code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>prepare</code>
+      <code>prepare</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/SystemIs64bit.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('64-bit'))]]></code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('It seems like you are running a 32-bit PHP version. Nextcloud needs 64-bit to run well. Please upgrade your OS and PHP to 64-bit!'),
+				$this->urlGenerator->linkToDocs('admin-system-requirements')
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/TempSpaceAvailable.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$nextcloudTempPath]))]]></code>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$phpTempPath]))]]></code>
+      <code><![CDATA[SetupResult::error($this->l10n->t('Error while checking the temporary PHP path - it was not properly set to a directory. Returned value: %s', [$phpTempPath]))]]></code>
+      <code><![CDATA[SetupResult::error('The temporary directory of this instance points to an either non-existing or non-writable directory.')]]></code>
+      <code><![CDATA[SetupResult::success(
+				$this->l10n->t(
+					"This instance uses an S3 based object store as primary storage, and has enough space in the temporary directory.\n%s",
+					[$spaceDetail]
+				)
+			)]]></code>
+      <code><![CDATA[SetupResult::success(
+				$this->l10n->t("Temporary directory is correctly configured:\n%s", [$spaceDetail])
+			)]]></code>
+      <code><![CDATA[SetupResult::warning(
+			$this->l10n->t(
+				"This instance uses an S3 based object store as primary storage. The uploaded files are stored temporarily on the server and thus it is recommended to have 50 GiB of free space available in the temp directory of PHP. To improve this please change the temporary directory in the php.ini or make more space available in that path. \nChecking the available space in the temporary path resulted in %.1f GiB instead of the recommended 50 GiB. Path: %s",
+				[round($freeSpaceInTempInGB, 1),$phpTempPath]
+			)
+		)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/TransactionIsolation.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::error(
+					$this->l10n->t('Your database does not run with "READ COMMITTED" transaction isolation level. This can cause problems when multiple actions are executed in parallel.'),
+					$this->urlGenerator->linkToDocs('admin-db-transaction')
+				)]]></code>
+      <code><![CDATA[SetupResult::success('Read committed')]]></code>
+      <code>SetupResult::success()</code>
+      <code><![CDATA[SetupResult::warning(
+				$this->l10n->t('Was not able to get transaction isolation level: %s', $e->getMessage())
+			)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/WellKnownUrls.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info($this->l10n->t('`check_for_working_wellknown_setup` is set to false in your configuration, so this check was skipped.'))]]></code>
+      <code><![CDATA[SetupResult::success(
+			$this->l10n->t('Your server is correctly configured to serve `.well-known` URLs.')
+		)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/Woff2Loading.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::info(
+				$this->l10n->t('Could not check for WOFF2 loading support. Please check manually if your webserver serves `.woff2` files.') . "\n" . $this->serverConfigHelp(),
+				$this->urlGenerator->linkToDocs('admin-nginx'),
+			)]]></code>
+      <code><![CDATA[SetupResult::warning(
+			$this->l10n->t('Your web server is not properly set up to deliver .woff2 files. This is typically an issue with the Nginx configuration. For Nextcloud 15 it needs an adjustement to also deliver .woff2 files. Compare your Nginx configuration to the recommended configuration in our documentation.'),
+			$this->urlGenerator->linkToDocs('admin-nginx'),
+		)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/settings/lib/UserMigration/AccountMigrator.php">
+    <MissingThrowsDocblock>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/sharebymail/lib/Activity.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/sharebymail/lib/ShareByMailProvider.php">
     <InvalidArgument>
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getLastInsertId</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getRelativePath</code>
+      <code>getShareById</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>publish</code>
+      <code>send</code>
+      <code>send</code>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setId</code>
+      <code>setId</code>
+      <code>setObject</code>
+      <code>setProviderId</code>
+      <code>setProviderId</code>
+      <code>setSubject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/systemtags/lib/Activity/Listener.php">
     <InvalidArgument>
       <code><![CDATA[$event->getObjectId()]]></code>
       <code><![CDATA[$event->getObjectId()]]></code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>getTagBefore</code>
+      <code>getTagsByIds</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setAuthor</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setSubject</code>
+      <code>setType</code>
+      <code>setType</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/systemtags/lib/Activity/Provider.php">
+    <MissingThrowsDocblock>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>getCurrentUserId</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/systemtags/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/systemtags/lib/Search/TagSearchProvider.php">
+    <MissingThrowsDocblock>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/testing/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/testing/lib/Controller/LockingController.php">
+    <MissingThrowsDocblock>
+      <code>getLockingProvider</code>
+      <code>getLockingProvider</code>
+      <code>getLockingProvider</code>
+      <code>getLockingProvider</code>
+      <code>getLockingProvider</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/testing/lib/Listener/SetDeclarativeSettingsValueListener.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/testing/lib/Locking/FakeDBLockingProvider.php">
+    <MissingThrowsDocblock>
+      <code>executeUpdate</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Command/UpdateConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Controller/ThemingController.php">
+    <MissingThrowsDocblock>
+      <code>compileString</code>
+      <code>setDefaultApps</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Controller/UserThemeController.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new OCSForbiddenException('Theme switching is disabled');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/IconBuilder.php">
+    <MissingThrowsDocblock>
+      <code>adaptiveResizeImage</code>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>new Imagick()</code>
+      <code>new Imagick()</code>
+      <code>new Imagick()</code>
+      <code>new Imagick()</code>
+      <code>readImageBlob</code>
+      <code>readImageBlob</code>
+      <code>readImageBlob</code>
+      <code>readImageBlob</code>
+      <code>scaleImage</code>
+      <code>scaleImage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/ImageManager.php">
+    <MissingThrowsDocblock>
+      <code>cleanup</code>
+      <code>getFolder</code>
+      <code>newFile</code>
+      <code>newFolder</code>
+      <code>newFolder</code>
+      <code>newFolder</code>
+      <code>putContent</code>
+      <code>putContent</code>
+      <code><![CDATA[throw new \Exception('Unsupported image type: ' . $detectedMimeType);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Jobs/MigrateBackgroundImages.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+      <code>getFolder</code>
+      <code>getFolder</code>
+      <code>getFolder</code>
+      <code>newFolder</code>
+      <code>newFolder</code>
+      <code>newFolder</code>
+      <code>runMigration</code>
+      <code>runMigration</code>
+      <code>throw $t;</code>
+      <code><![CDATA[throw new \Exception('Job '.self::class.' called with wrong argument');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Service/BackgroundService.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+      <code>new \OCP\Image()</code>
+      <code>newFolder</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new InvalidArgumentException('Invalid image file');]]></code>
+      <code><![CDATA[throw new InvalidArgumentException('The given color is invalid');]]></code>
+      <code><![CDATA[throw new InvalidArgumentException('The given file name is invalid');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Service/ThemesService.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Settings/AdminSection.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/Settings/PersonalSection.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/theming/lib/ThemingDefaults.php">
+    <MissingThrowsDocblock>
+      <code>getImage</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/theming/lib/Util.php">
     <InvalidReturnStatement>
@@ -1133,6 +7026,127 @@
     <InvalidReturnType>
       <code>array{0: int, 1: int, 2: int}</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[Color::rgbToHex(['R' => $red, 'G' => $green, 'B' => $blue])]]></code>
+      <code>darken</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getFolder</code>
+      <code>lighten</code>
+      <code>mix</code>
+      <code>new Color($color)</code>
+      <code>new Color($color)</code>
+      <code>new Color($color)</code>
+      <code>new Color($color1)</code>
+      <code><![CDATA[new Color(Color::rgbToHex(['R' => $red, 'G' => $green, 'B' => $blue]))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Activity/Provider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php">
+    <MissingThrowsDocblock>
+      <code>notify</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setUser</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Db/BackupCodeMapper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>findEntities</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Listener/ActivityPublisher.php">
+    <MissingThrowsDocblock>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setSubject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Listener/ClearNotifications.php">
+    <MissingThrowsDocblock>
+      <code>setApp</code>
+      <code>setObject</code>
+      <code>setUser</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Migration/Version1002Date20170607104347.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Migration/Version1002Date20170607113030.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Migration/Version1002Date20170919123342.php">
+    <MissingThrowsDocblock>
+      <code>Type::getType(Types::SMALLINT)</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+      <code>setOptions</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Migration/Version1002Date20180821043638.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/updatenotification/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/updatenotification/lib/BackgroundJob/AppUpdatedNotifications.php">
+    <MissingThrowsDocblock>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/updatenotification/lib/Command/Check.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/updatenotification/lib/Controller/AdminController.php">
+    <MissingThrowsDocblock>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/updatenotification/lib/Notification/AppUpdateNotifier.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/updatenotification/lib/Notification/Notifier.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/user_ldap/ajax/getNewServerConfigPrefix.php">
     <InvalidScalarArgument>
@@ -1152,11 +7166,193 @@
     <InvalidReturnType>
       <code>string[]</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>countUsers</code>
+      <code>fetchListOfUsers</code>
+      <code>getGroupMapper</code>
+      <code>getGroupMapper</code>
+      <code>getGroupMapper</code>
+      <code>getUserMapper</code>
+      <code>searchGroups</code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invoker does not support controlPagedResultResponse, call LDAP Wrapper directly instead.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('provided name template for username does not contain any allowed characters');]]></code>
+    </MissingThrowsDocblock>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
   </file>
+  <file src="apps/user_ldap/lib/AccessFactory.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(Manager::class)</code>
+      <code>Server::get(Manager::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/CheckGroup.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/CheckUser.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/CreateEmptyConfig.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/DeleteConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/PromoteGroup.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setOption</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/ResetGroup.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/ResetUser.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/Search.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>validateOffsetAndLimit</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/SetConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/ShowConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/ShowRemnants.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/TestConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>countObjects</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Command/UpdateUUID.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Configuration.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/user_ldap/lib/Connection.php">
+    <MissingThrowsDocblock>
+      <code>establishConnection</code>
+      <code>establishConnection</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new ServerNotAvailableException('Connection to LDAP server could not be established');]]></code>
+    </MissingThrowsDocblock>
     <NoValue>
       <code>$subj</code>
     </NoValue>
@@ -1166,25 +7362,120 @@
 						break;</code>
     </ParadoxicalCondition>
   </file>
+  <file src="apps/user_ldap/lib/Controller/RenewPasswordController.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Db/GroupMembershipMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>findEntities</code>
+      <code>findEntities</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/user_ldap/lib/Group_LDAP.php">
     <InvalidScalarArgument>
       <code>$groupID</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>dn2groupname</code>
+      <code>fetchListOfUsers</code>
+      <code>filterValidGroups</code>
+      <code>filterValidGroups</code>
+      <code>gidNumber2Name</code>
+      <code>inGroup</code>
+      <code>primaryGroupID2Name</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/user_ldap/lib/Group_Proxy.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("Should not have been called");]]></code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$gid</code>
     </ParamNameMismatch>
+  </file>
+  <file src="apps/user_ldap/lib/Helper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new \LogicException('String expected ' . \gettype($dn) . ' given');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Jobs/CleanUp.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(UserMapping::class)</code>
+      <code>\OCP\Server::get(UserMapping::class)</code>
+      <code>markUser</code>
+      <code>userExistsOnLDAP</code>
+      <code>userExistsOnLDAP</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/user_ldap/lib/Jobs/Sync.php">
     <InvalidOperand>
       <code>$i</code>
     </InvalidOperand>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(AccessFactory::class)</code>
+      <code>\OCP\Server::get(AccessFactory::class)</code>
+      <code>\OCP\Server::get(UserMapping::class)</code>
+      <code>\OCP\Server::get(UserMapping::class)</code>
+      <code>fetchListOfUsers</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
     </NullArgument>
   </file>
+  <file src="apps/user_ldap/lib/LDAP.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>processLDAPError</code>
+      <code>processLDAPError</code>
+      <code>processLDAPError</code>
+      <code>processLDAPError</code>
+      <code>processLDAPError</code>
+      <code>processLDAPError</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/LDAPProviderFactory.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/user_ldap/lib/Mapping/AbstractMapping.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>getXbyY</code>
+      <code>getXbyY</code>
+      <code>getXbyY</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code>isset($qb)</code>
     </RedundantCondition>
@@ -1192,10 +7483,116 @@
       <code>isset($qb)</code>
     </TypeDoesNotContainNull>
   </file>
+  <file src="apps/user_ldap/lib/Mapping/UserMapping.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IRequest::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/GroupMappingMigration.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1010Date20200630192842.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1120Date20210917155206.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1130Date20211102154716.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1130Date20220110154718.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1141Date20220323143801.php">
+    <MissingThrowsDocblock>
+      <code>rollBack</code>
+      <code>throw $t;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1190Date20230706134108.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Proxy.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(GroupMapping::class)</code>
+      <code>Server::get(GroupMapping::class)</code>
+      <code>Server::get(UserMapping::class)</code>
+      <code>Server::get(UserMapping::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/Settings/Section.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/SetupChecks/LdapInvalidUuids.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[SetupResult::success($this->l10n->t('None found'))]]></code>
+      <code><![CDATA[SetupResult::warning($this->l10n->t('Invalid UUIDs of LDAP accounts or groups have been found. Please review your "Override UUID detection" settings in the Expert part of the LDAP configuration and use "occ ldap:update-uuid" to update them.'))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_ldap/lib/User/DeletedUsersIndex.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/user_ldap/lib/User/Manager.php">
     <InvalidDocblock>
       <code>public function setLdapAccess(Access $access) {</code>
     </InvalidDocblock>
+    <MissingThrowsDocblock>
+      <code>checkAccess</code>
+      <code>getUserMapper</code>
+      <code>resolveRule</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/user_ldap/lib/User/User.php">
     <FalsableReturnStatement>
@@ -1207,14 +7604,90 @@
     <InvalidReturnType>
       <code>null</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>Server::get(IAccountManager::class)</code>
+      <code>Server::get(IAccountManager::class)</code>
+      <code>cacheUserDisplayName</code>
+      <code>getHomePath</code>
+      <code>notify</code>
+      <code>readAttribute</code>
+      <code>readAttribute</code>
+      <code>readAttribute</code>
+      <code>resolveRule</code>
+      <code>resolveRule</code>
+      <code>search</code>
+      <code>search</code>
+      <code>setApp</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setUser</code>
+      <code>setUser</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new \InvalidArgumentException('uid must not be an empty string!');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('uid must not be null!');]]></code>
+      <code>updateExtStorageHome</code>
+      <code>updateExtStorageHome</code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code><![CDATA[$aQuota && (count($aQuota) > 0)]]></code>
     </RedundantCondition>
+  </file>
+  <file src="apps/user_ldap/lib/UserPluginManager.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/user_ldap/lib/User_LDAP.php">
     <ImplementedReturnTypeMismatch>
       <code>string|false</code>
     </ImplementedReturnTypeMismatch>
+    <MissingThrowsDocblock>
+      <code>cacheUserDisplayName</code>
+      <code>countUsers</code>
+      <code>countUsers</code>
+      <code>createUser</code>
+      <code>deleteUser</code>
+      <code>dn2username</code>
+      <code>fetchListOfUsers</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getDisplayName</code>
+      <code>getUUID</code>
+      <code>getUserMapper</code>
+      <code>getUserMapper</code>
+      <code>getUserMapper</code>
+      <code>nextcloudUserNames</code>
+      <code>readAttribute</code>
+      <code>readAttribute</code>
+      <code>setApp</code>
+      <code>setDisplayName</code>
+      <code>setObject</code>
+      <code>setPassword</code>
+      <code>setUser</code>
+      <code><![CDATA[throw new \Exception('LDAP setPassword: Could not get user object for uid ' . $uid .
+				'. Maybe the LDAP entry has no set display name attribute?');]]></code>
+      <code><![CDATA[throw new \Exception('This is implemented directly in User_Proxy');]]></code>
+      <code>userExists</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$limit</code>
       <code>$offset</code>
@@ -1236,11 +7709,182 @@
     <InvalidArrayOffset>
       <code>$possibleAttrs[$i]</code>
     </InvalidArrayOffset>
+    <MissingThrowsDocblock>
+      <code>countUsers</code>
+      <code>detectGroupMemberAssoc</code>
+      <code>determineGroups</code>
+      <code>determineGroups</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>testBaseDN</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/user_status/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>registerProvider</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/user_status/lib/Connector/UserStatusProvider.php">
+    <MissingThrowsDocblock>
+      <code>setUserStatus</code>
+      <code>setUserStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Controller/UserStatusController.php">
+    <MissingThrowsDocblock>
+      <code>findByUserId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Dashboard/UserStatusWidget.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Db/UserStatusMapper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>findEntities</code>
+      <code>findEntities</code>
+      <code>findEntities</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Listener/UserLiveStatusListener.php">
+    <MissingThrowsDocblock>
+      <code>throw $e;</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Migration/Version0001Date20200602134824.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Migration/Version0002Date20200902144824.php">
+    <MissingThrowsDocblock>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Migration/Version1000Date20201111130204.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Migration/Version1003Date20210809144824.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Migration/Version1008Date20230921144701.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/user_status/lib/Service/StatusService.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>insert</code>
+      <code>insert</code>
+      <code>insert</code>
+      <code>insert</code>
+      <code>throw $ex;</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/weather_status/lib/Service/WeatherStatusService.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/AppInfo/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>injectFn</code>
+      <code>injectFn</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/workflowengine/lib/Check/AbstractStringCheck.php">
     <NullArgument>
@@ -1262,6 +7906,9 @@
     </InvalidReturnType>
   </file>
   <file src="apps/workflowengine/lib/Check/FileSystemTags.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \LogicException('Should not happen: Storage is instance of GroupFolderStorage but no group folder storage found while unwrapping.');]]></code>
+    </MissingThrowsDocblock>
     <UndefinedDocblockClass>
       <code><![CDATA[$this->storage]]></code>
     </UndefinedDocblockClass>
@@ -1280,15 +7927,61 @@
       <code>$minute1</code>
     </InvalidScalarArgument>
   </file>
+  <file src="apps/workflowengine/lib/Check/RequestURL.php">
+    <MissingThrowsDocblock>
+      <code>getPathInfo</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="apps/workflowengine/lib/Check/TFileCheck.php">
     <InvalidArgument>
       <code><![CDATA[['app' => Application::APP_ID, 'class' => get_class($subject)]]]></code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \UnexpectedValueException(
+					'Expected Node subject for File entity, got {class}',
+					['app' => Application::APP_ID, 'class' => get_class($subject)]
+				);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/Command/Index.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/Controller/UserWorkflowsController.php">
+    <MissingThrowsDocblock>
+      <code>parent::create($class, $name, $checks, $operation, $entity, $events)</code>
+      <code>parent::destroy($id)</code>
+      <code>parent::destroy($id)</code>
+      <code>parent::update($id, $name, $checks, $operation, $entity, $events)</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/workflowengine/lib/Entity/File.php">
     <InvalidReturnType>
       <code>string</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>imagePath</code>
+      <code>setEntitySubject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/Helper/ScopeContext.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid scope');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('user scope requires a user id');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/workflowengine/lib/Manager.php">
     <InvalidArgument>
@@ -1303,8 +7996,118 @@
     <InvalidReturnType>
       <code>bool</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>beginTransaction</code>
+      <code>beginTransaction</code>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>commit</code>
+      <code>commit</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getLastInsertId</code>
+      <code>getLastInsertId</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>rollBack</code>
+      <code>rollBack</code>
+      <code>rollBack</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new \UnexpectedValueException($this->l->t('Check #%s does not exist', $missingCheck));]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException($this->l->t('Entity %s does not exist', [$entity]));]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException($this->l->t('Entity %s has no event %s', [$entity, array_shift($diff)]));]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException($this->l->t('Entity %s is invalid', [$entity]));]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException($this->l->t('No events are chosen.'));]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/Migration/PopulateNewlyIntroducedDatabaseFields.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/Migration/Version2000Date20190808074233.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>getTable</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/Migration/Version2200Date20210805101925.php">
+    <MissingThrowsDocblock>
+      <code>changeColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="apps/workflowengine/lib/Service/Logger.php">
+    <MissingThrowsDocblock>
+      <code>log</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="apps/workflowengine/lib/Service/RuleMatcher.php">
+    <MissingThrowsDocblock>
+      <code>query</code>
+      <code>query</code>
+      <code><![CDATA[throw new RuntimeException('Must set file info before running the check');]]></code>
+      <code><![CDATA[throw new \LogicException('Entity was not set yet');]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException($this->l->t('Check %s is invalid or does not exist', $check['class']));]]></code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getAllConfiguredScopesForOperation</code>
       <code>getChecks</code>
@@ -1313,12 +8116,70 @@
       <code>isUserScopeEnabled</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/workflowengine/lib/Settings/Section.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="core/BackgroundJobs/CheckForUserCertificates.php">
     <ParamNameMismatch>
       <code>$arguments</code>
     </ParamNameMismatch>
   </file>
+  <file src="core/BackgroundJobs/GenerateMetadataJob.php">
+    <MissingThrowsDocblock>
+      <code>getDirectoryListing</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/App/Disable.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/App/Enable.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/App/GetPath.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="core/Command/App/Install.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>enable</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainType>
       <code>$result === false</code>
     </TypeDoesNotContainType>
@@ -1327,36 +8188,672 @@
     <LessSpecificImplementedReturnType>
       <code>array</code>
     </LessSpecificImplementedReturnType>
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/App/Remove.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/App/Update.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code>$result === true</code>
     </RedundantCondition>
+  </file>
+  <file src="core/Command/Background/Base.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Background/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Background/Job.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getProperty</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Background/ListCommand.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Base.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Broadcast/Test.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Check.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Config/App/DeleteConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Config/App/GetConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getDetails</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Config/App/SetConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>convertTypeToInt</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getDetails</code>
+      <code>getHelper</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setValueArray</code>
+      <code>setValueArray</code>
+      <code>setValueBool</code>
+      <code>setValueFloat</code>
+      <code>setValueInt</code>
+      <code>setValueMixed</code>
+      <code>setValueString</code>
+      <code><![CDATA[throw new AppConfigIncorrectTypeException('Value is not a boolean, please use \'true\' or \'false\'');]]></code>
+      <code><![CDATA[throw new AppConfigIncorrectTypeException('Value is not a float');]]></code>
+      <code><![CDATA[throw new AppConfigIncorrectTypeException('Value is not an integer');]]></code>
+      <code><![CDATA[throw new \Exception('Only compatible with OC\AppConfig as it uses internal methods');]]></code>
+      <code>updateType</code>
+      <code>updateType</code>
+      <code>updateType</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Config/Import.php">
     <InvalidScalarArgument>
       <code>0</code>
       <code>1</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setSystemValues</code>
+      <code><![CDATA[throw new \UnexpectedValueException('At least one key of the following is expected: ' . implode(', ', $this->validRootKeys));]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('Found invalid entries in root: ' . implode(', ', $additionalKeys));]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('Invalid system config value for "' . $configName . '". Only arrays, bools, integers, floats, strings and null (delete) are allowed.');]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('The apps config array is not an array');]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('The system config array is not an array');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Config/ListConfigs.php">
     <FalsableReturnStatement>
       <code><![CDATA[$this->appConfig->getValues($app, false)]]></code>
     </FalsableReturnStatement>
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <TooManyArguments>
       <code>getFilteredValues</code>
     </TooManyArguments>
+  </file>
+  <file src="core/Command/Config/System/Base.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Config/System/DeleteConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>setName</code>
+      <code><![CDATA[throw new \UnexpectedValueException('Config parameter does not exist');]]></code>
+      <code><![CDATA[throw new \UnexpectedValueException('Config parameter does not exist');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Config/System/GetConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Config/System/SetConfig.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>castValue</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>mergeArrayValue</code>
+      <code>setName</code>
+      <code><![CDATA[throw new \UnexpectedValueException('Config parameter does not exist');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/AddMissingColumns.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/AddMissingIndices.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>migrateToSchema</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/AddMissingPrimaryKeys.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/ConvertFilecacheBigInt.php">
+    <MissingThrowsDocblock>
+      <code>getDatabasePlatform</code>
+      <code>getHelper</code>
+      <code>migrateToSchema</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/ConvertMysqlToMB4.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>run</code>
+      <code>setName</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Db/ConvertType.php">
     <InvalidScalarArgument>
       <code>0</code>
       <code>1</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>ask</code>
+      <code>createSchema</code>
+      <code>execute</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getColumn</code>
+      <code>getHelper</code>
+      <code>getHelper</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getSchemaManager</code>
+      <code>listTableNames</code>
+      <code>migrate</code>
+      <code><![CDATA[new MigrationService('core', $fromDB)]]></code>
+      <code><![CDATA[new MigrationService('core', $toDB)]]></code>
+      <code>parent::__construct()</code>
+      <code>setHidden</code>
+      <code>setName</code>
+      <code>setOption</code>
+      <code>setOption</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>setSystemValues</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new \InvalidArgumentException(
+				'Converting to SQLite (sqlite3) is currently not supported.'
+			);]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException(
+				'The --clear-schema option is not supported when converting to Oracle (oci).'
+			);]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException(sprintf(
+				'Can not convert from %1$s to %1$s.',
+				$type
+			));]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/Migrations/ExecuteCommand.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>executeStep</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code><![CDATA[new MigrationService($appName, $this->connection)]]></code>
+      <code><![CDATA[new MigrationService($appName, $this->connection, new ConsoleOutput($output))]]></code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/Migrations/GenerateCommand.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code><![CDATA[new MigrationService($appName, $this->connection, new ConsoleOutput($output))]]></code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new RuntimeException('Failed to generate new migration step. Could not write to ' . $path);]]></code>
+      <code><![CDATA[throw new \RuntimeException("Could not create folder \"$directory\"");]]></code>
+      <code><![CDATA[throw new \RuntimeException("Could not create folder \"$directory\"");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/Migrations/MigrateCommand.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>migrate</code>
+      <code><![CDATA[new MigrationService($appName, $this->connection)]]></code>
+      <code><![CDATA[new MigrationService($appName, $this->connection, new ConsoleOutput($output))]]></code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Db/Migrations/StatusCommand.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code><![CDATA[new MigrationService($appName, $this->connection, new ConsoleOutput($output))]]></code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/ChangeKeyStorageRoot.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>ask</code>
+      <code>getArgument</code>
+      <code>moveAllKeys</code>
+      <code>parent::__construct()</code>
+      <code>rename</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/DecryptAll.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>enableApp</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/Disable.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Encryption/Enable.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
     </NullArgument>
+  </file>
+  <file src="core/Command/Encryption/EncryptAll.php">
+    <MissingThrowsDocblock>
+      <code>ask</code>
+      <code>enableApp</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>throw $ex;</code>
+      <code><![CDATA[throw new \Exception('Server side encryption is not enabled');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/ListModules.php">
+    <MissingThrowsDocblock>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/MigrateKeyStorage.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>updateKeys</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/SetDefaultModule.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/ShowKeyStorageRoot.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Encryption/Status.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/FilesMetadata/Get.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Group/Add.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Group/AddUser.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Group/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Group/Info.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Group/ListCommand.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Group/RemoveUser.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Info/File.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getDirectoryListing</code>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getFilesByUser</code>
+      <code>getFilesByUser</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getOption</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>new View()</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Info/FileUtils.php">
+    <MissingThrowsDocblock>
+      <code>getDirectoryListing</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Info/Space.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Integrity/CheckApp.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Integrity/CheckCore.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Integrity/SignApp.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct(null)</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Integrity/SignCore.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct(null)</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/L10n/CreateJs.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>setName</code>
+      <code><![CDATA[throw new UnexpectedValueException("PHP translation file <$phpFile> does not exist.");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Log/File.php">
     <InvalidReturnStatement>
@@ -1365,34 +8862,197 @@
     <InvalidReturnType>
       <code>string[]</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>validateRotateSize</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Log/Manage.php">
     <InvalidArgument>
       <code>$levelNum</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>convertLevelNumber</code>
+      <code>convertLevelNumber</code>
+      <code>convertLevelString</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>validateBackend</code>
+      <code>validateTimezone</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Maintenance/DataFingerprint.php">
     <InvalidScalarArgument>
       <code><![CDATA[$this->timeFactory->getTime()]]></code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Maintenance/Install.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(\OC\Setup::class)</code>
+      <code>\OCP\Server::get(\OC\Setup::class)</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>ask</code>
+      <code>getHelper</code>
+      <code>getHelper</code>
+      <code>getHelper</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setHidden</code>
+      <code>setHidden</code>
+      <code>setName</code>
+      <code><![CDATA[throw new InvalidArgumentException("Database <$db> is not supported. " . implode(", ", $supportedDatabases) . " are supported.");]]></code>
+      <code><![CDATA[throw new InvalidArgumentException("Database account not provided.");]]></code>
+      <code><![CDATA[throw new InvalidArgumentException("Database name not provided.");]]></code>
+      <code><![CDATA[throw new InvalidArgumentException('Invalid e-mail-address <' . $adminEmail . '> for <' . $adminLogin . '>.');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Maintenance/Mimetype/UpdateDB.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getAllMappings</code>
       <code>updateFilecache</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="core/Command/Maintenance/Mimetype/UpdateJS.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Maintenance/Mode.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Maintenance/Repair.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Command/Maintenance/RepairShareOwnership.php">
     <LessSpecificReturnStatement>
       <code>$found</code>
       <code>$found</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getWrongShareOwnership</code>
+      <code>getWrongShareOwnershipForUser</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>array{shareId: int, fileTarget: string, initiator: string, receiver: string, owner: string, mountOwner: string}[]</code>
       <code>array{shareId: int, fileTarget: string, initiator: string, receiver: string, owner: string, mountOwner: string}[]</code>
     </MoreSpecificReturnType>
   </file>
+  <file src="core/Command/Maintenance/UpdateHtaccess.php">
+    <MissingThrowsDocblock>
+      <code>\OC\Setup::updateHtaccess()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Maintenance/UpdateTheme.php">
+    <MissingThrowsDocblock>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Preview/Generate.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>generatePreviews</code>
+      <code>generatePreviews</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="core/Command/Preview/Repair.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>get</code>
+      <code>getDirectoryListing</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>section</code>
       <code>section</code>
@@ -1402,31 +9062,1353 @@
     <InvalidReturnStatement>
       <code>[]</code>
     </InvalidReturnStatement>
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Security/BruteforceAttempts.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Security/BruteforceResetAttempts.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Security/ImportCertificate.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addCertificate</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Security/ListCertificates.php">
+    <MissingThrowsDocblock>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Security/RemoveCertificate.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/SetupChecks.php">
+    <MissingThrowsDocblock>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Status.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code><![CDATA[parent::__construct('status')]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/SystemTag/Add.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/SystemTag/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/SystemTag/Edit.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/SystemTag/ListCommand.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/TwoFactorAuth/Base.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct($name)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/TwoFactorAuth/Cleanup.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/TwoFactorAuth/Disable.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/TwoFactorAuth/Enable.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/TwoFactorAuth/Enforce.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/TwoFactorAuth/State.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/Upgrade.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(Updater::class)</code>
+      <code>\OCP\Server::get(Updater::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Add.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>ask</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setDisplayName</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/AuthTokens/Add.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>generateToken</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setAliases</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/AuthTokens/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code><![CDATA[throw new RuntimeException('Invalid date format. Acceptable formats are: ISO8601 (w/o fractions), "YYYY-MM-DD" and Unix time in seconds.');]]></code>
+      <code><![CDATA[throw new RuntimeException('Not enough arguments. Specify the token <id> or use the --last-used-before option.');]]></code>
+      <code><![CDATA[throw new RuntimeException('Option --last-used-before cannot be used with [<id>]');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/AuthTokens/ListCommand.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Delete.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Disable.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Enable.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Info.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Keys/Verify.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>getArgument</code>
+      <code>getKey</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/LastSeen.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/ListCommand.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Report.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code><![CDATA[new View('/')]]></code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/ResetPassword.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>ask</code>
+      <code>ask</code>
+      <code>ask</code>
+      <code>getArgument</code>
+      <code>getHelper</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/Setting.php">
+    <MissingThrowsDocblock>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addArgument</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setArgument</code>
+      <code>setDisplayName</code>
+      <code>setName</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new \InvalidArgumentException('The "default-value" option can only be used when specifying a key.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The "delete" option can not be used together with "default-value".');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The "delete" option can not be used together with "value".');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The "delete" option can only be used when specifying a key.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The "error-if-not-exists" option can only be used together with "delete".');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The "update-only" option can only be used together with "value".');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The user "' . $uid . '" does not exist.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The value argument can not be used together with "default-value".');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('The value argument can only be used when specifying a key.');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Command/User/SyncAccountDataCommand.php">
+    <MissingThrowsDocblock>
+      <code>addOption</code>
+      <code>addOption</code>
+      <code>getOption</code>
+      <code>getOption</code>
+      <code>parent::__construct()</code>
+      <code>setName</code>
+      <code>updateAccount</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/AppPasswordController.php">
+    <MissingThrowsDocblock>
+      <code>generateToken</code>
+      <code>rotate</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/AvatarController.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>new \OCP\Image()</code>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/ClientFlowLoginController.php">
+    <MissingThrowsDocblock>
+      <code>generateToken</code>
+      <code>getByIdentifier</code>
+      <code>getByIdentifier</code>
+      <code>getByIdentifier</code>
+      <code>insert</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Controller/ClientFlowLoginV2Controller.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>getId</code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainType>
       <code>!is_string($stateToken)</code>
     </TypeDoesNotContainType>
   </file>
   <file src="core/Controller/CollaborationResourcesController.php">
+    <MissingThrowsDocblock>
+      <code>addResource</code>
+      <code>getResourceForUser</code>
+      <code><![CDATA[throw new CollectionException('Can not access collection');]]></code>
+      <code><![CDATA[throw new ResourceException('Can not access resource');]]></code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>searchCollections</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="core/Controller/CssController.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/HoverCardController.php">
+    <MissingThrowsDocblock>
+      <code>findOne</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/JsController.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/LoginController.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(Helper::class)</code>
+      <code>\OCP\Server::get(Helper::class)</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/Controller/LostController.php">
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
   </file>
+  <file src="core/Controller/OCSController.php">
+    <MissingThrowsDocblock>
+      <code>getCapabilities</code>
+      <code>getCapabilities</code>
+      <code>getKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/PreviewController.php">
+    <MissingThrowsDocblock>
+      <code>getStorage</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>isReadable</code>
+      <code>isReadable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/ProfileApiController.php">
+    <MissingThrowsDocblock>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/ReferenceController.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/TextToImageApiController.php">
+    <MissingThrowsDocblock>
+      <code>getContent</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Controller/TwoFactorChallengeController.php">
+    <MissingThrowsDocblock>
+      <code>getLoginSetupProviders</code>
+      <code>getLoginSetupProviders</code>
+      <code>getLoginSetupProviders</code>
+      <code>getProviderSet</code>
+      <code>getProviderSet</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="core/Controller/UnifiedSearchController.php">
+    <MissingThrowsDocblock>
+      <code>search</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>findMatchingRoute</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="core/Controller/WhatsNewController.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new \RuntimeException("Acting user cannot be resolved");]]></code>
+      <code><![CDATA[throw new \RuntimeException("Acting user cannot be resolved");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Db/LoginFlowV2Mapper.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>execute</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Db/ProfileConfigMapper.php">
+    <MissingThrowsDocblock>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="core/Middleware/TwoFactorMiddleware.php">
+    <MissingThrowsDocblock>
+      <code>getProviderSet</code>
+      <code>getProviderSet</code>
+      <code>throw new TwoFactorAuthRequiredException();</code>
+      <code>throw new TwoFactorAuthRequiredException();</code>
+      <code>throw new UserAlreadyLoggedInException();</code>
+      <code>throw new UserAlreadyLoggedInException();</code>
+    </MissingThrowsDocblock>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
+  </file>
+  <file src="core/Migrations/Version13000Date20170705121758.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version13000Date20170718121200.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getDatabasePlatform</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version13000Date20170814074715.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version13000Date20170919121250.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version14000Date20180404140050.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>execute</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version14000Date20180516101403.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version14000Date20180518120534.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version14000Date20180522074438.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version14000Date20180626223656.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version14000Date20180710092004.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version14000Date20180712153140.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version15000Date20180926101451.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version15000Date20181015062942.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version15000Date20181029084625.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version16000Date20190207141427.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version16000Date20190212081545.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version16000Date20190427105638.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version17000Date20190514105811.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version18000Date20190920085628.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>execute</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version18000Date20191014105105.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version19000Date20200211083441.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version20000Date20201109081915.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version20000Date20201109081918.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>execute</code>
+      <code>setPrimaryKey</code>
+      <code>tableExists</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version20000Date20201111081915.php">
+    <MissingThrowsDocblock>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version21000Date20201120141228.php">
+    <MissingThrowsDocblock>
+      <code>changeColumn</code>
+      <code>changeColumn</code>
+      <code>changeColumn</code>
+      <code>changeColumn</code>
+      <code>changeColumn</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version21000Date20201202095923.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version21000Date20210119195004.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version21000Date20210309185126.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version21000Date20210309185127.php">
+    <MissingThrowsDocblock>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version22000Date20210216080825.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>getTable</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version23000Date20210721100600.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version23000Date20210930122352.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version23000Date20211203110726.php">
+    <MissingThrowsDocblock>
+      <code>getTable</code>
+      <code>renameIndex</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version24000Date20211210141942.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version24000Date20211213081604.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version24000Date20211222112246.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>getTable</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version24000Date20211230140012.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version24000Date20220131153041.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version24000Date20220202150027.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version24000Date20220425072957.php">
+    <MissingThrowsDocblock>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version25000Date20220515204012.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version25000Date20220602190540.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version25000Date20220905140840.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version25000Date20221007010957.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version27000Date20220613163520.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version28000Date20230616104802.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version28000Date20230728104802.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version28000Date20230803221055.php">
+    <MissingThrowsDocblock>
+      <code>addIndex</code>
+      <code>getColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version28000Date20230906104802.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version28000Date20231004103301.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>addIndex</code>
+      <code>addUniqueIndex</code>
+      <code>setPrimaryKey</code>
+      <code>setPrimaryKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version28000Date20231103104802.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version29000Date20231126110901.php">
+    <MissingThrowsDocblock>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version29000Date20231213104850.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version29000Date20240124132201.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>dropIndex</code>
+      <code>getTable</code>
+      <code>modifyColumn</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version29000Date20240124132202.php">
+    <MissingThrowsDocblock>
+      <code>addColumn</code>
+      <code>addIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Migrations/Version29000Date20240131122720.php">
+    <MissingThrowsDocblock>
+      <code>dropIndex</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Notification/CoreNotifier.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="core/Service/LoginFlowV2Service.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>generateToken</code>
+      <code>insert</code>
+      <code><![CDATA[throw new \RuntimeException('Could not initialize keys');]]></code>
+      <code><![CDATA[throw new \RuntimeException('OpenSSL reported a problem');]]></code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="core/routes.php">
     <InvalidScope>
@@ -1440,6 +10422,10 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/autoloader.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code><![CDATA[$this->memoryCache]]></code>
     </RedundantCondition>
@@ -1448,11 +10434,148 @@
     <InvalidArgument>
       <code>$restrictions</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IEventDispatcher::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IThrottler::class)</code>
+      <code>Server::get(IThrottler::class)</code>
+      <code>Server::get(IURLGenerator::class)</code>
+      <code>Server::get(IURLGenerator::class)</code>
+      <code>Server::get(IURLGenerator::class)</code>
+      <code>Server::get(IURLGenerator::class)</code>
+      <code>Server::get(IURLGenerator::class)</code>
+      <code>Server::get(IURLGenerator::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(OCP\App\IAppManager::class)</code>
+      <code>Server::get(OCP\App\IAppManager::class)</code>
+      <code>Server::get(\OCP\App\IAppManager::class)</code>
+      <code>Server::get(\OCP\App\IAppManager::class)</code>
+      <code>Server::get(\OCP\App\IAppManager::class)</code>
+      <code>Server::get(\OCP\App\IAppManager::class)</code>
+      <code>Server::get(\OCP\Diagnostics\IEventLogger::class)</code>
+      <code>Server::get(\OCP\Diagnostics\IEventLogger::class)</code>
+      <code>Server::get(\OCP\Encryption\IManager::class)</code>
+      <code>Server::get(\OCP\Encryption\IManager::class)</code>
+      <code>Server::get(\OCP\ICacheFactory::class)</code>
+      <code>Server::get(\OCP\ICacheFactory::class)</code>
+      <code>Server::get(\OCP\IDBConnection::class)</code>
+      <code>Server::get(\OCP\IDBConnection::class)</code>
+      <code>Server::get(\OCP\IDBConnection::class)</code>
+      <code>Server::get(\OCP\IDBConnection::class)</code>
+      <code>Server::get(\OCP\IGroupManager::class)</code>
+      <code>Server::get(\OCP\IGroupManager::class)</code>
+      <code>Server::get(\OCP\IUserManager::class)</code>
+      <code>Server::get(\OCP\IUserManager::class)</code>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>Server::get(\OC\AllConfig::class)</code>
+      <code>Server::get(\OC\AllConfig::class)</code>
+      <code>Server::get(\OC\AllConfig::class)</code>
+      <code>Server::get(\OC\AllConfig::class)</code>
+      <code>Server::get(\OC\Core\Controller\SetupController::class)</code>
+      <code>Server::get(\OC\Core\Controller\SetupController::class)</code>
+      <code>Server::get(\OC\Route\Router::class)</code>
+      <code>Server::get(\OC\Route\Router::class)</code>
+      <code>Server::get(\OC\Route\Router::class)</code>
+      <code>Server::get(\OC\Route\Router::class)</code>
+      <code>Server::get(\OC\Session\CryptoWrapper::class)</code>
+      <code>Server::get(\OC\Session\CryptoWrapper::class)</code>
+      <code>Server::get(\OC\SystemConfig::class)</code>
+      <code>Server::get(\OC\SystemConfig::class)</code>
+      <code>Server::get(\OC\User\Session::class)</code>
+      <code>Server::get(\OC\User\Session::class)</code>
+      <code>Server::get(\OC\User\Session::class)</code>
+      <code>Server::get(\OC\User\Session::class)</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>getRawPathInfo</code>
+      <code>getRawPathInfo</code>
+      <code>getRawPathInfo</code>
+      <code>match</code>
+      <code><![CDATA[throw new Exception('Not installed');]]></code>
+      <code><![CDATA[throw new \OCP\HintException('Application ' . implode(', ', $incompatibleShippedApps) . ' is not present or has a non-compatible version with this server. Please check the apps directory.', $hint);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Accounts/Account.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new RuntimeException('Requested collection is not an IAccountPropertyCollection');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('getProperty cannot retrieve an IAccountsPropertyCollection');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('setProperty cannot set an IAccountsPropertyCollection');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Accounts/AccountManager.php">
+    <MissingThrowsDocblock>
+      <code>addProperty</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getProperty</code>
+      <code>getPropertyCollection</code>
+      <code>getPropertyCollection</code>
+      <code>setLocallyVerified</code>
+      <code>setScope</code>
+      <code>setScope</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new InvalidArgumentException('scope');]]></code>
+      <code><![CDATA[throw new InvalidArgumentException('scope');]]></code>
+      <code><![CDATA[throw new InvalidArgumentException(sprintf('sanitizePhoneNumberValue can only sanitize phone numbers, %s given', $property->getName()));]]></code>
+      <code><![CDATA[throw new InvalidArgumentException(sprintf('sanitizeWebsite can only sanitize web domains, %s given', $property->getName()));]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Accounts/AccountProperty.php">
+    <MissingThrowsDocblock>
+      <code>setScope</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Accounts/Hooks.php">
+    <MissingThrowsDocblock>
+      <code>updateAccount</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Activity/Event.php">
     <ParamNameMismatch>
       <code>$affectedUser</code>
     </ParamNameMismatch>
+  </file>
+  <file src="lib/private/Activity/EventMerger.php">
+    <MissingThrowsDocblock>
+      <code>setParsedSubject</code>
+      <code>setRichSubject</code>
+      <code>setTimestamp</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Activity/Manager.php">
     <InvalidPropertyAssignmentValue>
@@ -1463,6 +10586,10 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->settings]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>setAuthor</code>
+      <code>setTimestamp</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>ActivitySettings[]</code>
     </MoreSpecificReturnType>
@@ -1471,6 +10598,37 @@
     </TypeDoesNotContainType>
   </file>
   <file src="lib/private/AllConfig.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValues</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$key</code>
     </MoreSpecificImplementedParamType>
@@ -1483,8 +10641,45 @@
       <code>array</code>
       <code>array</code>
     </LessSpecificImplementedReturnType>
+    <MissingThrowsDocblock>
+      <code>disableApp</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>loadShippedJson</code>
+      <code>loadShippedJson</code>
+      <code>loadShippedJson</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>setValue</code>
+      <code>throw $ex;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/App/AppStore/Fetcher/AppDiscoverFetcher.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+      <code>getFolder</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/App/AppStore/Fetcher/Fetcher.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>getContent</code>
+      <code>getFolder</code>
+      <code>getFolder</code>
+      <code>newFile</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
     <TooManyArguments>
       <code>fetch</code>
     </TooManyArguments>
@@ -1509,10 +10704,86 @@
       <code>array</code>
     </InvalidReturnType>
   </file>
+  <file src="lib/private/App/Platform.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IBinaryFinder::class)</code>
+      <code>\OCP\Server::get(IBinaryFinder::class)</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/AppConfig.php">
+    <MissingThrowsDocblock>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>assertParams</code>
+      <code>decrypt</code>
+      <code>decrypt</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getTypedValue</code>
+      <code>getTypedValue</code>
+      <code>getTypedValue</code>
+      <code>getValueType</code>
+      <code>isLazy</code>
+      <code>isLazy</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new AppConfigUnknownKeyException('unknown config key');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[$this->fastCache[$app][$key] ?? $default]]></code>
     </NullableReturnStatement>
+  </file>
+  <file src="lib/private/AppFramework/App.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>dispatch</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/AppFramework/Bootstrap/BootContext.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/AppFramework/Bootstrap/Coordinator.php">
     <InvalidPropertyAssignmentValue>
@@ -1524,6 +10795,12 @@
       <code>getName</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/private/AppFramework/Bootstrap/RegistrationContext.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new RuntimeException("Only the Talk app is allowed to register a Talk backend");]]></code>
+      <code><![CDATA[throw new RuntimeException("There can only be one Talk backend");]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/AppFramework/DependencyInjection/DIContainer.php">
     <ImplementedReturnTypeMismatch>
       <code>boolean|null</code>
@@ -1534,11 +10811,31 @@
     <InvalidReturnType>
       <code>\OCP\IServerContainer</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>parent::query($name)</code>
+      <code>parent::query($name)</code>
+      <code>parent::query($name)</code>
+      <code>parent::query($name)</code>
+      <code>parent::query($name)</code>
+      <code>parent::query($name)</code>
+      <code>parent::query($name)</code>
+      <code>parent::query($name)</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getAppDataDir</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/AppFramework/Http/Dispatcher.php">
+    <MissingThrowsDocblock>
+      <code>buildResponse</code>
+      <code>buildResponse</code>
+    </MissingThrowsDocblock>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->method]]></code>
     </NoInterfaceProperties>
@@ -1557,6 +10854,30 @@
     </InvalidReturnType>
   </file>
   <file src="lib/private/AppFramework/Http/Request.php">
+    <MissingThrowsDocblock>
+      <code>cookies</code>
+      <code>env</code>
+      <code>files</code>
+      <code>method</code>
+      <code>method</code>
+      <code>method</code>
+      <code>parameters</code>
+      <code>parameters</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code>server</code>
+      <code><![CDATA[throw new \RuntimeException('You cannot change the contents of the request object');]]></code>
+      <code><![CDATA[throw new \RuntimeException('You cannot change the contents of the request object');]]></code>
+      <code><![CDATA[throw new \RuntimeException('You cannot change the contents of the request object');]]></code>
+      <code><![CDATA[throw new \RuntimeException('You cannot change the contents of the request object');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>$name</code>
       <code>$remoteAddress</code>
@@ -1584,13 +10905,42 @@
       <code>setOCSVersion</code>
     </InternalMethod>
   </file>
+  <file src="lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php">
+    <MissingThrowsDocblock>
+      <code>sleepDelayOrThrowOnMax</code>
+      <code>throw new NeedAuthenticationException();</code>
+      <code><![CDATA[throw new NotFoundException('Link sharing is disabled');]]></code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/AppFramework/Middleware/Security/BruteForceMiddleware.php">
+    <MissingThrowsDocblock>
+      <code>sleepDelayOrThrowOnMax</code>
+      <code><![CDATA[throw new OCSException($e->getMessage(), Http::STATUS_TOO_MANY_REQUESTS);]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/AppFramework/Middleware/Security/CORSMiddleware.php">
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
+  <file src="lib/private/AppFramework/Middleware/Security/ReloadExecutionMiddleware.php">
+    <MissingThrowsDocblock>
+      <code>throw new ReloadExecutionException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/AppFramework/Middleware/Security/SameSiteCookieMiddleware.php">
+    <MissingThrowsDocblock>
+      <code>throw new LaxSameSiteCookieFailedException();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php">
+    <MissingThrowsDocblock>
+      <code>findAllClassesForUser</code>
+    </MissingThrowsDocblock>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
@@ -1598,12 +10948,30 @@
       <code>\OCA\Talk\Controller\PageController</code>
     </UndefinedClass>
   </file>
+  <file src="lib/private/AppFramework/Routing/RouteActionHandler.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[App::main($this->controllerName, $this->actionName, $this->container, $params)]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/AppFramework/Routing/RouteConfig.php">
     <InvalidArrayOffset>
       <code><![CDATA[$action['url-postfix']]]></code>
     </InvalidArrayOffset>
+    <MissingThrowsDocblock>
+      <code>processIndexRoutes</code>
+      <code><![CDATA[throw new \UnexpectedValueException('Invalid route name: use the format foo#bar to reference FooController::bar');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/AppFramework/Routing/RouteParser.php">
+    <MissingThrowsDocblock>
+      <code>processIndexRoutes</code>
+      <code><![CDATA[throw new \UnexpectedValueException('Invalid route name: use the format foo#bar to reference FooController::bar');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/AppFramework/Services/AppConfig.php">
+    <MissingThrowsDocblock>
+      <code>setValueMixed</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$default</code>
     </MoreSpecificImplementedParamType>
@@ -1653,6 +11021,12 @@
     <MissingTemplateParam>
       <code>ArrayAccess</code>
     </MissingTemplateParam>
+    <MissingThrowsDocblock>
+      <code><![CDATA[$this->container]]></code>
+      <code>factory</code>
+      <code>offsetGet</code>
+      <code>offsetSet</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>\stdClass</code>
     </MoreSpecificReturnType>
@@ -1665,10 +11039,72 @@
       <code><![CDATA[$this->tar->extractInString($path)]]></code>
     </UndefinedDocblockClass>
   </file>
+  <file src="lib/private/Archive/ZIP.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Listeners/RemoteWipeActivityListener.php">
+    <MissingThrowsDocblock>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setSubject</code>
+      <code>setType</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Listeners/RemoteWipeNotificationsListener.php">
+    <MissingThrowsDocblock>
+      <code>notify</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+      <code>setUser</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Listeners/UserDeletedFilesCleanupListener.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("Account has no home storage");]]></code>
+      <code><![CDATA[throw new \Exception("Home storage has invalid cache");]]></code>
+      <code><![CDATA[throw new \Exception("UserDeletedEvent fired without matching BeforeUserDeletedEvent");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Listeners/UserDeletedWebAuthnCleanupListener.php">
+    <MissingThrowsDocblock>
+      <code>deleteByUid</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Login/CompleteLoginCommand.php">
+    <MissingThrowsDocblock>
+      <code>completeLogin</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Login/SetUserTimezoneCommand.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Login/TwoFactorCommand.php">
+    <MissingThrowsDocblock>
+      <code>getLoginSetupProviders</code>
+      <code>getProviderSet</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Authentication/LoginCredentials/Store.php">
     <RedundantCondition>
       <code>$trySession</code>
     </RedundantCondition>
+  </file>
+  <file src="lib/private/Authentication/Token/Manager.php">
+    <MissingThrowsDocblock>
+      <code>getProvider</code>
+      <code>getToken</code>
+      <code>renewSessionToken</code>
+      <code><![CDATA[throw new \Exception('Token conflict handled, but UIDs do not match. This should not happen', 0, $e);]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Authentication/Token/PublicKeyToken.php">
     <UndefinedMagicMethod>
@@ -1690,6 +11126,105 @@
       <code>setType</code>
     </UndefinedMagicMethod>
   </file>
+  <file src="lib/private/Authentication/Token/PublicKeyTokenMapper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/Token/PublicKeyTokenProvider.php">
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>decrypt</code>
+      <code>getTokenById</code>
+      <code>insert</code>
+      <code>rotate</code>
+      <code>throw $exception;</code>
+      <code>throw new ExpiredTokenException($token);</code>
+      <code><![CDATA[throw new InvalidTokenException("Invalid token type");]]></code>
+      <code><![CDATA[throw new InvalidTokenException("Invalid token type");]]></code>
+      <code><![CDATA[throw new InvalidTokenException("Invalid token type");]]></code>
+      <code><![CDATA[throw new InvalidTokenException("Invalid token type");]]></code>
+      <code>throw new TokenPasswordExpiredException($token);</code>
+      <code>throw new WipeTokenException($token);</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDao.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/TwoFactorAuth/Manager.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getProviderSet</code>
+      <code>getProviders</code>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>setAffectedUser</code>
+      <code>setApp</code>
+      <code>setAuthor</code>
+      <code>setSubject</code>
+      <code>setType</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/TwoFactorAuth/MandatoryTwoFactor.php">
+    <MissingThrowsDocblock>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/TwoFactorAuth/ProviderLoader.php">
+    <MissingThrowsDocblock>
+      <code>OC_App::loadApp($appId)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/TwoFactorAuth/ProviderManager.php">
+    <MissingThrowsDocblock>
+      <code>getProviders</code>
+      <code>throw new InvalidProviderException($providerId);</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Authentication/TwoFactorAuth/ProviderSet.php">
     <InvalidArgument>
       <code><![CDATA[$this->providers]]></code>
@@ -1708,6 +11243,89 @@
       <code><![CDATA[$this->providers]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/Authentication/WebAuthn/CredentialRepository.php">
+    <MissingThrowsDocblock>
+      <code>insertOrUpdate</code>
+      <code>insertOrUpdate</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/WebAuthn/Db/PublicKeyCredentialMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>findEntities</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Authentication/WebAuthn/Manager.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>throw $e;</code>
+      <code>throw $exception;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Avatar/Avatar.php">
+    <MissingThrowsDocblock>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Avatar/AvatarManager.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Avatar/UserAvatar.php">
+    <MissingThrowsDocblock>
+      <code>new \OCP\Image()</code>
+      <code>new \OCP\Image()</code>
+      <code>setResource</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/BackgroundJob/JobList.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OCP\Server::get($row['class'])]]></code>
+      <code><![CDATA[\OCP\Server::get($row['class'])]]></code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code><![CDATA[throw new \InvalidArgumentException('Background job arguments can\'t exceed 4000 characters (json encoded)');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php">
     <InvalidArgument>
       <code>$image</code>
@@ -1721,6 +11339,11 @@
     <InvalidReturnType>
       <code>GdImage|false</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getPreview</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Cache/CappedMemoryCache.php">
     <MissingTemplateParam>
@@ -1732,6 +11355,23 @@
       <code>bool|mixed</code>
       <code>bool|mixed</code>
     </LessSpecificImplementedReturnType>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>file_get_contents</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>getStorage</code>
+      <code>hasKey</code>
+      <code><![CDATA[new View('/' . $user->getUID() . '/cache')]]></code>
+      <code>new View()</code>
+      <code>rename</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Calendar/Manager.php">
     <LessSpecificReturnStatement>
@@ -1770,7 +11410,84 @@
 			}, $context->getCalendarProviders())]]></code>
     </NamedArgumentNotAllowed>
   </file>
+  <file src="lib/private/Collaboration/Collaborators/LookupPlugin.php">
+    <MissingThrowsDocblock>
+      <code>resolveCloudId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Collaborators/RemoteGroupPlugin.php">
+    <MissingThrowsDocblock>
+      <code>splitGroupRemote</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Collaborators/Search.php">
+    <MissingThrowsDocblock>
+      <code>resolve</code>
+      <code>resolve</code>
+      <code><![CDATA[throw new \InvalidArgumentException('Provided ShareType is invalid');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Reference/File/FileReferenceEventListener.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getNodeId</code>
+      <code>getNodeId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Reference/File/FileReferenceProvider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Reference/ReferenceManager.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Resources/Collection.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Resources/Manager.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getLastInsertId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Collaboration/Resources/Resource.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Command/CallableJob.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid serialized callable');]]></code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$serializedCallable</code>
     </ParamNameMismatch>
@@ -1779,31 +11496,161 @@
     <InvalidArgument>
       <code>[LaravelClosure::class]</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid serialized callable');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Command/CommandJob.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid serialized command');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Command/CronBus.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid command');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid command');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Command/QueueBus.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Trying to push a command which serialized form can not be stored in the database (>4000 character)');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Comments/Comment.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Integer expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Non empty string expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Non-empty String expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+      <code><![CDATA[throw new \LogicException('Cannot get creation date before setting one or writting to database');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Comments/Manager.php">
+    <MissingThrowsDocblock>
+      <code>checkRoleParameters</code>
+      <code>checkRoleParameters</code>
+      <code>checkRoleParameters</code>
+      <code>checkRoleParameters</code>
+      <code>determineTopmostParentId</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getDirectoryListing</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getLastInsertId</code>
+      <code>prepareCommentForDatabaseWrite</code>
+      <code>save</code>
+      <code>setId</code>
+      <code><![CDATA[throw new NotFoundException('Comment to update does ceased to exist');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('String expected.');]]></code>
+    </MissingThrowsDocblock>
     <RedundantCast>
       <code>(string)$id</code>
     </RedundantCast>
+  </file>
+  <file src="lib/private/Comments/ManagerFactory.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Config.php">
     <InvalidOperand>
       <code><![CDATA[$this->delete($key)]]></code>
       <code><![CDATA[$this->set($key, $value)]]></code>
     </InvalidOperand>
+    <MissingThrowsDocblock>
+      <code>readData</code>
+      <code>writeData</code>
+      <code>writeData</code>
+      <code>writeData</code>
+    </MissingThrowsDocblock>
     <UndefinedVariable>
       <code>$CONFIG</code>
       <code>$CONFIG</code>
     </UndefinedVariable>
   </file>
   <file src="lib/private/Console/Application.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>getArgument</code>
+    </MissingThrowsDocblock>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
+  </file>
+  <file src="lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/ContactsManager.php">
     <InvalidArgument>
       <code>$searchOptions</code>
     </InvalidArgument>
+  </file>
+  <file src="lib/private/DB/Adapter.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/DB/AdapterMySQL.php">
     <InternalMethod>
@@ -1812,6 +11659,18 @@
     <InvalidArrayOffset>
       <code><![CDATA[$params['collation']]]></code>
     </InvalidArrayOffset>
+  </file>
+  <file src="lib/private/DB/AdapterOCI8.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Oracle requires a table name to be passed into lastInsertId()');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/AdapterPgSql.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeUpdate</code>
+      <code>fetchOne</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/DB/Connection.php">
     <InternalMethod>
@@ -1824,6 +11683,46 @@
       <code><![CDATA[$params['adapter']]]></code>
       <code><![CDATA[$params['tablePrefix']]]></code>
     </InvalidArrayOffset>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(ClockInterface::class)</code>
+      <code>\OCP\Server::get(ClockInterface::class)</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getDatabasePlatform</code>
+      <code>getDatabasePlatform</code>
+      <code>insertIgnoreConflict</code>
+      <code>log</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/ConnectionAdapter.php">
+    <MissingThrowsDocblock>
+      <code>getDatabasePlatform</code>
+      <code>getDatabasePlatform</code>
+      <code>lockTable</code>
+      <code>throw DbalException::wrap($e);</code>
+      <code><![CDATA[throw new \Exception('Database ' . $platform::class . ' not supported');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/ConnectionFactory.php">
+    <MissingThrowsDocblock>
+      <code>DriverManager::getConnection(
+			$additionalConnectionParams,
+			new Configuration(),
+			$eventManager
+		)</code>
+      <code>getDefaultConnectionParams</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/DB/Exceptions/DbalException.php">
     <RedundantCondition>
@@ -1837,9 +11736,60 @@
     <LessSpecificReturnStatement>
       <code>$s</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get($class)</code>
+      <code>\OCP\Server::get($class)</code>
+      <code>addColumn</code>
+      <code>addColumn</code>
+      <code>createSchema</code>
+      <code>createSchema</code>
+      <code>dropTable</code>
+      <code>ensureOracleConstraints</code>
+      <code>ensureOracleConstraints</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>insertIfNotExist</code>
+      <code>migrateToSchema</code>
+      <code>migrateToSchema</code>
+      <code>migrateToSchema</code>
+      <code>setPrimaryKey</code>
+      <code>tableExists</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>IMigrationStep</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/private/DB/Migrator.php">
+    <MissingThrowsDocblock>
+      <code>createSchemaManager</code>
+      <code>createSchemaManager</code>
+      <code>getDatabasePlatform</code>
+      <code>introspectSchema</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/MySqlTools.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/OracleConnection.php">
+    <MissingThrowsDocblock>
+      <code>getDatabasePlatform</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/PgSqlTools.php">
+    <MissingThrowsDocblock>
+      <code>getDatabase</code>
+      <code>getSchemaManager</code>
+      <code>listSequences</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/PreparedStatement.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Exception("You have to execute the prepared statement before accessing the results");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php">
     <ImplicitToStringCast>
@@ -1862,6 +11812,12 @@
     <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>lastInsertId</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>$alias</code>
     </NullableReturnStatement>
@@ -1874,9 +11830,48 @@
     <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Only strings, Literals and Parameters are allowed');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>$string</code>
     </NullableReturnStatement>
+  </file>
+  <file src="lib/private/DB/ResultAdapter.php">
+    <MissingThrowsDocblock>
+      <code>fetch</code>
+      <code>fetchAll</code>
+      <code>fetchOne</code>
+      <code>fetchOne</code>
+      <code>rowCount</code>
+      <code><![CDATA[throw new \Exception('Fetch mode needs to be assoc, num or column.');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/SQLiteSessionInit.php">
+    <MissingThrowsDocblock>
+      <code>getWrappedConnection</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/SchemaWrapper.php">
+    <MissingThrowsDocblock>
+      <code>createSchema</code>
+      <code>createTable</code>
+      <code>dropTable</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/DB/SetTransactionIsolationLevel.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>getDatabasePlatform</code>
+      <code>setTransactionIsolation</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Dashboard/Manager.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new InvalidArgumentException('Dashboard widget with this id has already been registered');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/DateTimeFormatter.php">
     <FalsableReturnStatement>
@@ -1897,6 +11892,12 @@
     <InvalidScalarArgument>
       <code>$timestamp</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Diagnostics/Query.php">
     <ImplementedReturnTypeMismatch>
@@ -1919,6 +11920,30 @@
       <code>TemplateResponse</code>
       <code>int</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getRelativePath</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>throw new NotFoundException();</code>
+      <code><![CDATA[throw new \RuntimeException("Editor $editorId is unknown");]]></code>
+      <code><![CDATA[throw new \RuntimeException('Failed to validate the token');]]></code>
+      <code><![CDATA[throw new \RuntimeException('No default editor found for files mimetype');]]></code>
+      <code><![CDATA[throw new \RuntimeException('No editor found');]]></code>
+      <code><![CDATA[throw new \RuntimeException('No matching editor found');]]></code>
+    </MissingThrowsDocblock>
     <UndefinedMethod>
       <code>$template</code>
       <code>$template</code>
@@ -1934,18 +11959,62 @@
       <code>getShareForToken</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/private/Encryption/DecryptAll.php">
+    <MissingThrowsDocblock>
+      <code>rename</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Encryption/EncryptionWrapper.php">
+    <MissingThrowsDocblock>
+      <code>new View()</code>
+      <code>new View()</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Encryption/File.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[['users' => $uniqueUserIds, 'public' => $public]]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getUidAndFilename</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>array{users: string[], public: bool}</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/private/Encryption/HookManager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[Filesystem::getPath($params['fileSource'])]]></code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>new View()</code>
+      <code>new View()</code>
+      <code><![CDATA[throw new \Exception("Inconsistent data, File unshared, but owner not found. Should not happen");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Encryption/Keys/Storage.php">
     <InvalidNullableReturnType>
       <code>deleteUserKey</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>file_get_contents</code>
+      <code>file_put_contents</code>
+      <code>getKeyWithUid</code>
+      <code>getKeyWithUid</code>
+      <code>getUidAndFilename</code>
+      <code>rename</code>
+      <code><![CDATA[throw new ServerNotAvailableException('Could not decrypt key', 0, $e);]]></code>
+      <code><![CDATA[throw new ServerNotAvailableException('Invalid encryption key');]]></code>
+      <code><![CDATA[throw new ServerNotAvailableException('Invalid encryption key');]]></code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
       <code>null</code>
@@ -1956,8 +12025,40 @@
     <ImplementedReturnTypeMismatch>
       <code>bool</code>
     </ImplementedReturnTypeMismatch>
+    <MissingThrowsDocblock>
+      <code>isReady</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Encryption/Update.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[Filesystem::getPath($params['fileSource'])]]></code>
+      <code><![CDATA[Filesystem::getPath($params['fileSource'])]]></code>
+      <code>getPath</code>
+      <code><![CDATA[new View('/' . $owner . '/files')]]></code>
+      <code><![CDATA[throw new InvalidArgumentException('No file found for ' . $info->getId());]]></code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Encryption/Util.php">
+    <MissingThrowsDocblock>
+      <code>getUidAndFilename</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/EventDispatcher/ServiceEventListener.php">
+    <MissingThrowsDocblock>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Federation/CloudFederationProviderManager.php">
+    <MissingThrowsDocblock>
+      <code>resolveCloudId</code>
+      <code>resolveCloudId</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$providerId</code>
     </ParamNameMismatch>
@@ -1966,6 +12067,14 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->folder]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>getAppDataFolder</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>throw $cachedFolder;</code>
+      <code><![CDATA[throw new \RuntimeException('Could not get appdata folder');]]></code>
+      <code><![CDATA[throw new \RuntimeException('no instance id!');]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>Folder</code>
     </MoreSpecificReturnType>
@@ -1981,6 +12090,23 @@
       <code>$path</code>
       <code>\OC_Util::normalizeUnicode($path)</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getLastInsertId</code>
+      <code>moveFromCache</code>
+      <code>moveFromCache</code>
+      <code><![CDATA[new Storage($this->storage, true, $dependencies->getConnection())]]></code>
+      <code>put</code>
+      <code>removeChildren</code>
+      <code><![CDATA[throw new \RuntimeException("Failed to copy to " . $targetPath . " from cache with source data " . json_encode($data) . " ");]]></code>
+      <code><![CDATA[throw new \RuntimeException("Invalid source cache entry on copyFromCache");]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
       <code>null</code>
@@ -1998,6 +12124,9 @@
       <code>insert</code>
       <code>put</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("Invalid cache");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Cache/HomeCache.php">
     <FalsableReturnStatement>
@@ -2007,6 +12136,20 @@
       <code>$file</code>
       <code>$file</code>
     </MoreSpecificImplementedParamType>
+  </file>
+  <file src="lib/private/Files/Cache/Propagator.php">
+    <MissingThrowsDocblock>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code><![CDATA[throw new \BadMethodCallException('Not in batch');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Cache/QuerySearchHelper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code><![CDATA[throw new \InvalidArgumentException("This search operation requires the user to be set in the query");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Cache/Scanner.php">
     <InvalidArgument>
@@ -2018,33 +12161,111 @@
     <InvalidReturnType>
       <code>array[]</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'addToCache', ['file' => $path, 'data' => $data])]]></code>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'addToCache', ['file' => $path, 'data' => $data])]]></code>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'addToCache', ['file' => $path, 'data' => $data])]]></code>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'addToCache', ['file' => $path, 'data' => $data])]]></code>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'correctFolderSize', ['path' => $path])]]></code>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'correctFolderSize', ['path' => $path])]]></code>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'removeFromCache', ['file' => $path])]]></code>
+      <code><![CDATA[\OC_Hook::emit('Scanner', 'removeFromCache', ['file' => $path])]]></code>
+      <code>acquireLock</code>
+      <code>acquireLock</code>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>insert</code>
+      <code>put</code>
+      <code>scanFile</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Cache/SearchBuilder.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid operator type: ' . $comparison->getType());]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid operator type: ' . get_class($operator));]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid type for field ' . $operator->getField());]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid type for field ' . $operator->getField());]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Unsupported comparison field ' . $operator->getField());]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Unsupported comparison for field  ' . $operator->getField() . ': ' . $operator->getType());]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Unsupported query value for mimetype: ' . $value . ', only values in the format "mime/type" or "mime/%" are supported');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Cache/Storage.php">
     <InvalidNullableReturnType>
       <code>array</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>get</code>
+      <code>get</code>
+      <code>insertIfNotExist</code>
+      <code>lastInsertId</code>
+      <code>rollBack</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[self::getGlobalCache()->getStorageInfo($storageId)]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="lib/private/Files/Cache/StorageGlobal.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Files/Cache/Updater.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>moveFromCache</code>
+      <code>moveFromCache</code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code><![CDATA[$this->cache instanceof Cache]]></code>
     </RedundantCondition>
+  </file>
+  <file src="lib/private/Files/Cache/Watcher.php">
+    <MissingThrowsDocblock>
+      <code>scanFile</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Cache/Wrapper/CacheWrapper.php">
     <LessSpecificImplementedReturnType>
       <code>array</code>
       <code>array</code>
     </LessSpecificImplementedReturnType>
+    <MissingThrowsDocblock>
+      <code>Server::get(CacheDependencies::class)</code>
+      <code>Server::get(CacheDependencies::class)</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$searchQuery</code>
     </ParamNameMismatch>
+  </file>
+  <file src="lib/private/Files/Config/CachedMountInfo.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[Filesystem::initMountPoints($this->getUser()->getUID())]]></code>
+      <code><![CDATA[throw new \Exception("Mount provider $mountProvider name exceeds the limit of 128 characters");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Config/MountProviderCollection.php">
     <InvalidOperand>
       <code>$user</code>
     </InvalidOperand>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("No root mounts provided by any provider");]]></code>
+      <code><![CDATA[throw new \Exception('No home storage configured for user ' . $user);]]></code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code><![CDATA[get_class($provider) !== 'OCA\Files_Sharing\MountProvider']]></code>
     </RedundantCondition>
@@ -2063,9 +12284,41 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->cacheInfoCache[$fileId]]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>beginTransaction</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>insertIfNotExist</code>
+      <code><![CDATA[new LazyPathCachedMountInfo(
+				$user,
+				(int)$row['storage_id'],
+				(int)$row['root_id'],
+				$row['mount_point'],
+				$row['mount_provider_class'] ?? '',
+				$mount_id,
+				$pathCallback,
+			)]]></code>
+      <code>rollBack</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>array{int, string, int}</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/private/Files/FileInfo.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \TypeError('Null offset not supported');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Filesystem.php">
     <LessSpecificReturnStatement>
@@ -2073,6 +12326,34 @@
       <code><![CDATA[self::getMountManager()->findByNumericId($id)]]></code>
       <code><![CDATA[self::getMountManager()->findByStorageId($id)]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>file_get_contents</code>
+      <code>file_put_contents</code>
+      <code>fopen</code>
+      <code>free_space</code>
+      <code>fromTmpFile</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getMimeType</code>
+      <code>getOwner</code>
+      <code>new Mount\MountPoint($class, $mountpoint, $arguments, self::getLoader())</code>
+      <code>new View($root)</code>
+      <code>readfile</code>
+      <code>rename</code>
+      <code>self::initMountPoints($user)</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>Mount\MountPoint[]</code>
       <code>Mount\MountPoint[]</code>
@@ -2082,7 +12363,36 @@
       <code>addStorageWrapper</code>
     </TooManyArguments>
   </file>
+  <file src="lib/private/Files/Lock/LockManager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new PreConditionNotMetException('Could not obtain lock scope as already in use by ' . $this->lockInScope);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Mount/CacheMountProvider.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/cache', ['datadir' => $cacheDir], $loader, null, null, self::class)]]></code>
+      <code><![CDATA[new MountPoint('\OC\Files\Storage\Local', '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/uploads'], $loader, null, null, self::class)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Mount/HomeMountPoint.php">
+    <MissingThrowsDocblock>
+      <code>parent::__construct($storage, $mountpoint, $arguments, $loader, $mountOptions, $mountId, $mountProvider)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Mount/Manager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new NotFoundException("No mount for path " . $path . " existing mounts (" . count($this->mounts) ."): " . implode(",", array_keys($this->mounts)));]]></code>
+      <code><![CDATA[throw new \Exception("No mounts even after explicitly setting up the root mounts");]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Files/Mount/MountPoint.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new \Exception('The root storage could not be initialized. Please contact your local administrator.', $exception->getCode(), $exception);]]></code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>wrap</code>
     </UndefinedInterfaceMethod>
@@ -2091,9 +12401,25 @@
     <InvalidNullableReturnType>
       <code>\OCP\Files\Mount\IMountPoint</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
+  </file>
+  <file src="lib/private/Files/Mount/RootMountProvider.php">
+    <MissingThrowsDocblock>
+      <code>OC_App::loadApp(strtolower($segments[1]))</code>
+      <code><![CDATA[new MountPoint($config['class'], '/', $config['arguments'], $loader, null, null, self::class)]]></code>
+      <code><![CDATA[new MountPoint($config['class'], '/', $config['arguments'], $loader, null, null, self::class)]]></code>
+      <code><![CDATA[new MountPoint(LocalRootStorage::class, '/', ['datadir' => $configDataDirectory], $loader, null, null, self::class)]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Node/File.php">
     <InvalidReturnStatement>
@@ -2102,6 +12428,16 @@
     <InvalidReturnType>
       <code>string</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Node/Folder.php">
     <LessSpecificReturnStatement>
@@ -2110,6 +12446,22 @@
 			return $this->createNode($file->getPath(), $file);
 		}, $files)]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IUserManager::class)</code>
+      <code>\OCP\Server::get(IUserManager::class)</code>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>checkPermissions</code>
+      <code>file_put_contents</code>
+      <code>free_space</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getFileInfo</code>
+      <code>getFullPath</code>
+      <code>getRelativePath</code>
+      <code><![CDATA[throw new \InvalidArgumentException('searching by owner is only allowed in the users home folder');]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$node</code>
     </MoreSpecificImplementedParamType>
@@ -2119,6 +12471,10 @@
     </MoreSpecificReturnType>
   </file>
   <file src="lib/private/Files/Node/HookConnector.php">
+    <MissingThrowsDocblock>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>emit</code>
       <code>emit</code>
@@ -2139,11 +12495,22 @@
     <InvalidReturnStatement>
       <code><![CDATA[$this->__call(__FUNCTION__, func_get_args())]]></code>
     </InvalidReturnStatement>
+    <MissingThrowsDocblock>
+      <code>getFullPath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Node/LazyRoot.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception('Lazy root folder closure didn\'t return a root folder');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Node/LazyUserFolder.php">
     <LessSpecificReturnStatement>
       <code>$node</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("No mountpoint for user folder");]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>Folder</code>
     </MoreSpecificReturnType>
@@ -2158,6 +12525,40 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->parent]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>createNonExistingNode</code>
+      <code>createNonExistingNode</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code>getFileInfo</code>
+      <code><![CDATA[throw new PreConditionNotMetException('The view passed to the node should not have any fake root set');]]></code>
+      <code><![CDATA[throw new \Exception("No storage for node");]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>INode|IRootFolder</code>
     </MoreSpecificReturnType>
@@ -2172,6 +12573,29 @@
       <code><![CDATA[$this->fileInfo]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/Files/Node/NonExistingFile.php">
+    <MissingThrowsDocblock>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Node/NonExistingFolder.php">
+    <MissingThrowsDocblock>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+      <code>throw new NotFoundException();</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Files/Node/Root.php">
     <LessSpecificReturnStatement>
       <code>$folders</code>
@@ -2181,6 +12605,16 @@
       <code><![CDATA[$this->mountManager->findIn($mountPoint)]]></code>
       <code><![CDATA[$this->user]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>new MountPoint($storage, $mountPoint, $arguments)</code>
+      <code><![CDATA[new View('')]]></code>
+      <code><![CDATA[throw new \Exception("Account folder for \"$userId\" exists as a file");]]></code>
+      <code><![CDATA[throw new \Exception("getByIdInPath with non folder");]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>MountPoint[]</code>
       <code>Node</code>
@@ -2195,10 +12629,46 @@
       <code>remove</code>
     </UndefinedMethod>
   </file>
+  <file src="lib/private/Files/ObjectStore/Azure.php">
+    <MissingThrowsDocblock>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/ObjectStore/ObjectStoreScanner.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>getIncomplete</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Files/ObjectStore/ObjectStoreStorage.php">
     <InvalidScalarArgument>
       <code>$source</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>put</code>
+      <code>put</code>
+      <code>put</code>
+      <code>throw $e;</code>
+      <code>throw $ex;</code>
+      <code>throw $ex;</code>
+      <code><![CDATA[throw new NotFoundException('Source object not found');]]></code>
+      <code><![CDATA[throw new \Exception("Invalid source cache for object store copy");]]></code>
+      <code><![CDATA[throw new \Exception("Object not found after writing (urn: $urn, path: $path)", 404);]]></code>
+      <code>writeStream</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/ObjectStore/S3.php">
+    <MissingThrowsDocblock>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code><![CDATA[throw new Exception('No upload id returned');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/ObjectStore/S3ConnectionTrait.php">
     <InternalClass>
@@ -2208,6 +12678,15 @@
     <InternalMethod>
       <code>ClientResolver::_default_signature_provider()</code>
     </InternalMethod>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new \Exception("Bucket has to be configured.");]]></code>
+    </MissingThrowsDocblock>
     <UndefinedFunction>
       <code>Promise\promise_for(
 					new Credentials($key, $secret)
@@ -2219,11 +12698,25 @@
     <InternalMethod>
       <code>upload</code>
     </InternalMethod>
+    <MissingThrowsDocblock>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+      <code>getConnection</code>
+    </MissingThrowsDocblock>
     <UndefinedFunction>
       <code>\Aws\serialize($command)</code>
     </UndefinedFunction>
   </file>
   <file src="lib/private/Files/ObjectStore/S3Signature.php">
+    <MissingThrowsDocblock>
+      <code>parse</code>
+      <code>parse</code>
+      <code>withHeader</code>
+      <code>withHeader</code>
+      <code>withPath</code>
+      <code>withQuery</code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
     </NullArgument>
@@ -2233,6 +12726,85 @@
       <code>string</code>
     </InvalidReturnType>
   </file>
+  <file src="lib/private/Files/ObjectStore/Swift.php">
+    <MissingThrowsDocblock>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>getContainer</code>
+      <code>objectExists</code>
+      <code>objectExists</code>
+      <code>request</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/SetupManager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[OC_Hook::emit('OC_Filesystem', 'preSetup', ['user' => $user->getUID()])]]></code>
+      <code><![CDATA[OC_Hook::emit('OC_Filesystem', 'preSetup', ['user' => $user->getUID()])]]></code>
+      <code>getMountsInPath</code>
+      <code><![CDATA[new MountPoint(
+				new NullStorage([]),
+				'/' . $user->getUID()
+			)]]></code>
+      <code><![CDATA[new MountPoint(
+				new NullStorage([]),
+				'/' . $user->getUID() . '/files'
+			)]]></code>
+      <code>setupForUserWith</code>
+      <code>setupForUserWith</code>
+      <code>setupForUserWith</code>
+      <code>setupForUserWith</code>
+      <code>setupForUserWith</code>
+      <code>setupForUserWith</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/SimpleFS/NewSimpleFile.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>putContent</code>
+      <code>putContent</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/SimpleFS/SimpleFile.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>putContent</code>
+      <code>putContent</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/SimpleFS/SimpleFolder.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getDirectoryListing</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Files/Storage/Common.php">
     <ImplementedReturnTypeMismatch>
       <code>string|false</code>
@@ -2241,6 +12813,20 @@
       <code>!$permissions</code>
       <code><![CDATA[$this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file)]]></code>
     </InvalidOperand>
+    <MissingThrowsDocblock>
+      <code>Server::get(CacheDependencies::class)</code>
+      <code>Server::get(CacheDependencies::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new ForbiddenException('Invalid path: ' . $path, false);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException('Directory listing failed');]]></code>
+    </MissingThrowsDocblock>
     <NoInterfaceProperties>
       <code><![CDATA[$storage->cache]]></code>
       <code><![CDATA[$storage->cache]]></code>
@@ -2263,6 +12849,65 @@
     <InvalidReturnType>
       <code>fopen</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>convertException</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>propfind</code>
+      <code>put</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>simpleResponse</code>
+      <code>simpleResponse</code>
+      <code>simpleResponse</code>
+      <code>simpleResponse</code>
+      <code>simpleResponse</code>
+      <code>simpleResponse</code>
+      <code><![CDATA[throw new ForbiddenException('Invalid path: ' . $path, false);]]></code>
+      <code>throw new \OCP\Lock\LockedException($path);</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
@@ -2276,11 +12921,107 @@
       <code>getCache</code>
       <code>verifyPath</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('Missing "exception" argument in FailedStorage constructor');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Storage/Local.php">
     <ImplicitToStringCast>
       <code>$file</code>
     </ImplicitToStringCast>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>getSourcePath</code>
+      <code>new \OC\LargeFileHelper</code>
+      <code>new \OC\LargeFileHelper()</code>
+      <code><![CDATA[throw new StorageNotAvailableException('Local storage path does not exist "' . $this->getSourcePath('') . '"');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('No data directory set for local storage');]]></code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainNull>
       <code>$space === false || is_null($space)</code>
       <code>is_null($space)</code>
@@ -2294,6 +13035,86 @@
       <code><![CDATA[$storage->scanner]]></code>
       <code><![CDATA[$storage->scanner]]></code>
     </NoInterfaceProperties>
+  </file>
+  <file src="lib/private/Files/Storage/LocalTempFileTrait.php">
+    <MissingThrowsDocblock>
+      <code>fopen</code>
+      <code>fopen</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Files/Storage/Wrapper/Availability.php">
+    <MissingThrowsDocblock>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>checkAvailability</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+      <code>setUnavailable</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Storage/Wrapper/Encoding.php">
     <InvalidArgument>
@@ -2339,6 +13160,36 @@
       <code>$lastChunkPos</code>
       <code>$size</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC\Files\Stream\Encryption::wrap($source, $path, $fullPath, $header,
+					$this->uid, $encryptionModule, $this->storage, $this, $this->util, $this->fileHelper, $mode,
+					$size, $unencryptedSize, $headerSize, $signed)]]></code>
+      <code>copyBetweenStorage</code>
+      <code>copyBetweenStorage</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>getEncryptionModule</code>
+      <code>put</code>
+      <code>put</code>
+      <code>put</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Storage/Wrapper/Jail.php">
     <InvalidReturnStatement>
@@ -2348,6 +13199,11 @@
       <code>bool</code>
     </InvalidReturnType>
   </file>
+  <file src="lib/private/Files/Storage/Wrapper/Quota.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("No quota or quota callback provider");]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Files/Storage/Wrapper/Wrapper.php">
     <InvalidReturnStatement>
       <code><![CDATA[$this->getWrapperStorage()->test()]]></code>
@@ -2355,6 +13211,10 @@
     <InvalidReturnType>
       <code>true</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Stream/SeekableHttpStream.php">
     <InvalidReturnType>
@@ -2368,6 +13228,12 @@
     </RedundantCondition>
   </file>
   <file src="lib/private/Files/Type/Detection.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$mimetype</code>
     </ParamNameMismatch>
@@ -2379,11 +13245,29 @@
     <InvalidReturnType>
       <code>int</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new \Exception("Database threw an unique constraint on inserting a new mimetype, but couldn't return the ID for this very mimetype");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Files/Utils/Scanner.php">
     <LessSpecificReturnStatement>
       <code>$mounts</code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>beginTransaction</code>
+      <code>commit</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid path to scan');]]></code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>\OC\Files\Mount\MountPoint[]</code>
     </MoreSpecificReturnType>
@@ -2392,16 +13276,204 @@
     <InvalidScalarArgument>
       <code>$mtime</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>Server::get(IManager::class)</code>
+      <code>Server::get(IManager::class)</code>
+      <code><![CDATA[\OC_Hook::emit(
+					Filesystem::CLASSNAME,
+					Filesystem::signal_read,
+					[Filesystem::signal_param_path => $this->getHookPath($path)]
+				)]]></code>
+      <code><![CDATA[\OC_Hook::emit(
+					Filesystem::CLASSNAME,
+					Filesystem::signal_read,
+					[Filesystem::signal_param_path => $this->getHookPath($path)]
+				)]]></code>
+      <code><![CDATA[\OC_Hook::emit(
+					Filesystem::CLASSNAME, "post_umount",
+					[Filesystem::signal_param_path => $relPath]
+				)]]></code>
+      <code><![CDATA[\OC_Hook::emit(
+					Filesystem::CLASSNAME, "post_umount",
+					[Filesystem::signal_param_path => $relPath]
+				)]]></code>
+      <code><![CDATA[\OC_Hook::emit(
+				Filesystem::CLASSNAME, "umount",
+				[Filesystem::signal_param_path => $relPath]
+			)]]></code>
+      <code><![CDATA[\OC_Hook::emit(
+				Filesystem::CLASSNAME, "umount",
+				[Filesystem::signal_param_path => $relPath]
+			)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_create, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+				Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_create, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+				Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_create, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_create, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_update, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_update, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_write, [
+			Filesystem::signal_param_path => $this->getHookPath($path),
+		])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_write, [
+			Filesystem::signal_param_path => $this->getHookPath($path),
+		])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_update, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+				Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_update, [
+				Filesystem::signal_param_path => $this->getHookPath($path),
+				Filesystem::signal_param_run => &$run,
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_write, [
+			Filesystem::signal_param_path => $this->getHookPath($path),
+			Filesystem::signal_param_run => &$run,
+		])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_write, [
+			Filesystem::signal_param_path => $this->getHookPath($path),
+			Filesystem::signal_param_run => &$run,
+		])]]></code>
+      <code>assertPathLength</code>
+      <code>assertPathLength</code>
+      <code>assertPathLength</code>
+      <code>assertPathLength</code>
+      <code>assertPathLength</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>basicOperation</code>
+      <code>changeLock</code>
+      <code>changeLock</code>
+      <code>file_put_contents</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getPathRelativeToFiles</code>
+      <code>lockFile</code>
+      <code>lockFile</code>
+      <code>lockFile</code>
+      <code><![CDATA[new View('/' . $uid . '/files')]]></code>
+      <code>put</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+      <code>throw $e;</code>
+      <code><![CDATA[throw new ConnectionLostException("Connection lost. Status: $connectionStatus");]]></code>
+      <code><![CDATA[throw new InvalidPathException("Path $absolutePath is not in the expected root");]]></code>
+      <code>unlockFile</code>
+      <code>unlockFile</code>
+      <code>unlockFile</code>
+      <code>unlockFile</code>
+      <code>unlockFile</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>acquireLock</code>
       <code>changeLock</code>
       <code>releaseLock</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/FilesMetadata/FilesMetadataManager.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IDBConnection::class)</code>
+      <code>\OCP\Server::get(IDBConnection::class)</code>
+      <code>tableExists</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/FilesMetadata/MetadataQuery.php">
+    <MissingThrowsDocblock>
+      <code>getMetadataKeyField</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/FilesMetadata/Model/FilesMetadata.php">
+    <MissingThrowsDocblock>
+      <code>setValueArray</code>
+      <code>setValueBool</code>
+      <code>setValueFloat</code>
+      <code>setValueInt</code>
+      <code>setValueIntList</code>
+      <code>setValueString</code>
+      <code>setValueStringList</code>
+      <code>throw new FilesMetadataNotFoundException();</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/FilesMetadata/Service/IndexRequestService.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/FilesMetadata/Service/MetadataRequestService.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/FullTextSearch/Model/IndexDocument.php">
     <TypeDoesNotContainNull>
       <code><![CDATA[is_null($this->getContent())]]></code>
     </TypeDoesNotContainNull>
+  </file>
+  <file src="lib/private/Group/Database.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IUserManager::class)</code>
+      <code>\OCP\Server::get(IUserManager::class)</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Group/Group.php">
     <InvalidArgument>
@@ -2444,6 +13516,20 @@
       <code>isAdmin</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/Http/Client/Client.php">
+    <MissingThrowsDocblock>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code><![CDATA[throw new LocalServerException('Could not detect any host');]]></code>
+      <code><![CDATA[throw new LocalServerException('Host "'.$host.'" violates local access rules');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Http/Client/Response.php">
     <InvalidNullableReturnType>
       <code>string|resource</code>
@@ -2454,6 +13540,11 @@
 			$this->response->getBody()->getContents()]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="lib/private/Http/WellKnown/RequestManager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new RuntimeException("Well known handlers requested before the apps had been fully registered");]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Installer.php">
     <InvalidArgument>
       <code>false</code>
@@ -2463,6 +13554,35 @@
       <code><![CDATA[$app['path']]]></code>
       <code><![CDATA[$app['path']]]></code>
     </InvalidArrayOffset>
+    <MissingThrowsDocblock>
+      <code><![CDATA[OC_App::executeRepairSteps($app, $info['repair-steps']['install'])]]></code>
+      <code>\OCP\Server::get(Connection::class)</code>
+      <code>\OCP\Server::get(Connection::class)</code>
+      <code>\OCP\Server::get(Connection::class)</code>
+      <code>\OCP\Server::get(Connection::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>migrate</code>
+      <code>new MigrationService($app, \OCP\Server::get(Connection::class))</code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
     </NullArgument>
@@ -2487,6 +13607,20 @@
       <code>ExcludeFoldersByPathFilterIterator</code>
     </MissingTemplateParam>
   </file>
+  <file src="lib/private/KnownUser/KnownUserMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>findEntities</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/KnownUser/KnownUserService.php">
+    <MissingThrowsDocblock>
+      <code>insert</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/L10N/Factory.php">
     <ImplementedReturnTypeMismatch>
       <code>null|string</code>
@@ -2494,11 +13628,52 @@
     <LessSpecificImplementedReturnType>
       <code>array|mixed</code>
     </LessSpecificImplementedReturnType>
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new \RuntimeException('Failed to get an IUser instance');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/L10N/L10N.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[Calendar::getDateFormat('short', $this->locale)]]></code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/LDAP/NullLDAPProviderFactory.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("No LDAP provider is available");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/LargeFileHelper.php">
     <InvalidOperand>
       <code>$matches[1]</code>
     </InvalidOperand>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Lock/DBLockingProvider.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>tableExists</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Lockdown/Filesystem/NullCache.php">
     <InvalidNullableReturnType>
@@ -2510,6 +13685,15 @@
     <InvalidReturnType>
       <code>getIncomplete</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[$file !== '' ? null :
 			new CacheEntry([
@@ -2540,6 +13724,23 @@
       <code>getCache</code>
       <code>opendir</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+      <code><![CDATA[throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
       <code>null</code>
@@ -2557,9 +13758,20 @@
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="lib/private/Log.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IUserSession::class)</code>
+      <code>\OCP\Server::get(IUserSession::class)</code>
+      <code><![CDATA[throw new \RuntimeException('Log implementation has no path');]]></code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code>$request</code>
     </RedundantCondition>
+  </file>
+  <file src="lib/private/Log/ErrorHandler.php">
+    <MissingThrowsDocblock>
+      <code>log</code>
+      <code>log</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Log/File.php">
     <TypeDoesNotContainNull>
@@ -2571,12 +13783,31 @@
       <code><![CDATA[is_string($request->getMethod())]]></code>
     </RedundantCondition>
   </file>
+  <file src="lib/private/Log/Rotate.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Log/Systemdlog.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new HintException(
+				'PHP extension php-systemd is not available.',
+				'Please install and enable PHP extension systemd if you wish to log to the Systemd journal.');]]></code>
+    </MissingThrowsDocblock>
     <UndefinedFunction>
       <code><![CDATA[sd_journal_send('PRIORITY='.$journal_level,
 			'SYSLOG_IDENTIFIER='.$this->syslogId,
 			'MESSAGE=' . $this->logDetailsAsJSON($app, $message, $level))]]></code>
     </UndefinedFunction>
+  </file>
+  <file src="lib/private/Mail/Mailer.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IBinaryFinder::class)</code>
+      <code>\OCP\Server::get(IBinaryFinder::class)</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Memcache/APCu.php">
     <InvalidReturnStatement>
@@ -2585,6 +13816,12 @@
     <InvalidReturnType>
       <code>bool</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Memcache/Cache.php">
     <LessSpecificImplementedReturnType>
@@ -2594,10 +13831,95 @@
       <code>mixed</code>
     </LessSpecificImplementedReturnType>
   </file>
+  <file src="lib/private/Memcache/Factory.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \OCP\HintException(strtr($missingCacheMessage, [
+				'{class}' => $distributedCacheClass, '{use}' => 'distributed'
+			]), $missingCacheHint);]]></code>
+      <code><![CDATA[throw new \OCP\HintException(strtr($missingCacheMessage, [
+				'{class}' => $localCacheClass, '{use}' => 'local'
+			]), $missingCacheHint);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Memcache/Memcached.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new HintException("Expected 'memcached_options' config to be an array, got $options");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Memcache/Redis.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+      <code>getCache</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/MemoryInfo.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException($number.' is not a valid numeric string (in memory_limit ini directive)');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Migration/BackgroundRepair.php">
+    <MissingThrowsDocblock>
+      <code>OC_App::loadApp($app)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/NaturalSort.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/NavigationManager.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Preview/BackgroundCleanupJob.php">
     <InvalidReturnStatement>
       <code>[]</code>
     </InvalidReturnStatement>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Bitmap.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>new Imagick()</code>
+      <code>new \OCP\Image()</code>
+      <code>readImage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Bundled.php">
+    <MissingThrowsDocblock>
+      <code>getSize</code>
+      <code>getSize</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Preview/Generator.php">
     <InvalidArgument>
@@ -2609,6 +13931,16 @@
     <MismatchingDocblockParamType>
       <code>ISimpleFile</code>
     </MismatchingDocblockParamType>
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>getExtension</code>
+      <code>getFolder</code>
+      <code>getPreviewFolder</code>
+      <code>getPreviewFolder</code>
+      <code>isReadable</code>
+      <code>newFolder</code>
+      <code><![CDATA[throw new NotFoundException('No provider successfully handled the preview generation');]]></code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>height</code>
       <code>height</code>
@@ -2619,6 +13951,84 @@
       <code>width</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/Preview/GeneratorHelper.php">
+    <MissingThrowsDocblock>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>new OCPImage()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/HEIC.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>new \Imagick()</code>
+      <code>new \OCP\Image()</code>
+      <code>readImage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/IMagickSupport.php">
+    <MissingThrowsDocblock>
+      <code>new \Imagick()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Image.php">
+    <MissingThrowsDocblock>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Imaginary.php">
+    <MissingThrowsDocblock>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getSize</code>
+      <code>getSize</code>
+      <code>new Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/MP3.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/MarkDown.php">
+    <MissingThrowsDocblock>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>new \OCP\Image()</code>
+      <code>setResource</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Movie.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Office.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(ITempManager::class)</code>
+      <code>Server::get(ITempManager::class)</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Preview/ProviderV1Adapter.php">
     <InvalidReturnStatement>
       <code>$thumbnail === false ? null: $thumbnail</code>
@@ -2626,16 +14036,122 @@
     <InvalidReturnType>
       <code>?IImage</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[new View(dirname($file->getPath()))]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/ProviderV2.php">
+    <MissingThrowsDocblock>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>getStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/SVG.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>new \OCP\Image()</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Storage/Root.php">
+    <MissingThrowsDocblock>
+      <code>getStorage</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/TXT.php">
+    <MissingThrowsDocblock>
+      <code>fopen</code>
+      <code>fopen</code>
+      <code>new \OCP\Image()</code>
+      <code>setResource</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/Watcher.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>getFolder</code>
+      <code>getId</code>
+      <code>getId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Preview/WatcherConnector.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(Watcher::class)</code>
+      <code>\OCP\Server::get(Watcher::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Profile/Actions/EmailAction.php">
+    <MissingThrowsDocblock>
+      <code>getProperty</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Profile/Actions/FediverseAction.php">
+    <MissingThrowsDocblock>
+      <code>getProperty</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Profile/Actions/PhoneAction.php">
+    <MissingThrowsDocblock>
+      <code>getProperty</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Profile/Actions/TwitterAction.php">
+    <MissingThrowsDocblock>
+      <code>getProperty</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Profile/Actions/WebsiteAction.php">
+    <MissingThrowsDocblock>
+      <code>getProperty</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Profile/ProfileManager.php">
+    <MissingThrowsDocblock>
+      <code>getProperty</code>
+      <code>insert</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Profiler/Profiler.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[new FileProfilerStorage($config->getValue('datadirectory', \OC::$SERVERROOT . '/data') . '/__profiler')]]></code>
+      <code>write</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/RedisFactory.php">
     <InvalidArgument>
       <code>\RedisCluster::OPT_SLAVE_FAILOVER</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>getSslContext</code>
+      <code>getSslContext</code>
+      <code><![CDATA[new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, true, $auth)]]></code>
+      <code><![CDATA[new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, true, $auth, $connectionParameters)]]></code>
+      <code><![CDATA[throw new \Exception('Redis Cluster support is not available');]]></code>
+      <code><![CDATA[throw new \Exception('Redis cluster config is missing the "seeds" attribute');]]></code>
+      <code><![CDATA[throw new \Exception('Redis support is not available');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Remote/Api/OCS.php">
     <ImplementedReturnTypeMismatch>
       <code>array</code>
     </ImplementedReturnTypeMismatch>
+    <MissingThrowsDocblock>
+      <code>checkResponseArray</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+      <code>request</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Remote/Instance.php">
     <InvalidReturnStatement>
@@ -2647,6 +14163,81 @@
     <InvalidScalarArgument>
       <code>$response</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>getStatus</code>
+      <code>getStatus</code>
+      <code>getStatus</code>
+      <code>getStatus</code>
+      <code>getStatus</code>
+      <code>getStatus</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Repair.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(AddAppConfigLazyMigration::class)</code>
+      <code>\OCP\Server::get(AddAppConfigLazyMigration::class)</code>
+      <code>\OCP\Server::get(AddBruteForceCleanupJob::class)</code>
+      <code>\OCP\Server::get(AddBruteForceCleanupJob::class)</code>
+      <code>\OCP\Server::get(AddCheckForUserCertificatesJob::class)</code>
+      <code>\OCP\Server::get(AddCheckForUserCertificatesJob::class)</code>
+      <code>\OCP\Server::get(AddMetadataGenerationJob::class)</code>
+      <code>\OCP\Server::get(AddMetadataGenerationJob::class)</code>
+      <code>\OCP\Server::get(AddMissingSecretJob::class)</code>
+      <code>\OCP\Server::get(AddMissingSecretJob::class)</code>
+      <code>\OCP\Server::get(AddRemoveOldTasksBackgroundJob::class)</code>
+      <code>\OCP\Server::get(AddRemoveOldTasksBackgroundJob::class)</code>
+      <code>\OCP\Server::get(AddTokenCleanupJob::class)</code>
+      <code>\OCP\Server::get(AddTokenCleanupJob::class)</code>
+      <code>\OCP\Server::get(CleanUpAbandonedApps::class)</code>
+      <code>\OCP\Server::get(CleanUpAbandonedApps::class)</code>
+      <code>\OCP\Server::get(ClearGeneratedAvatarCache::class)</code>
+      <code>\OCP\Server::get(ClearGeneratedAvatarCache::class)</code>
+      <code>\OCP\Server::get(EncryptionLegacyCipher::class)</code>
+      <code>\OCP\Server::get(EncryptionLegacyCipher::class)</code>
+      <code>\OCP\Server::get(EncryptionMigration::class)</code>
+      <code>\OCP\Server::get(EncryptionMigration::class)</code>
+      <code>\OCP\Server::get(IManager::class)</code>
+      <code>\OCP\Server::get(IManager::class)</code>
+      <code>\OCP\Server::get(ITimeFactory::class)</code>
+      <code>\OCP\Server::get(ITimeFactory::class)</code>
+      <code>\OCP\Server::get(JSCombiner::class)</code>
+      <code>\OCP\Server::get(JSCombiner::class)</code>
+      <code>\OCP\Server::get(LookupServerSendCheck::class)</code>
+      <code>\OCP\Server::get(LookupServerSendCheck::class)</code>
+      <code>\OCP\Server::get(RepairDavShares::class)</code>
+      <code>\OCP\Server::get(RepairDavShares::class)</code>
+      <code>\OCP\Server::get(ResetGeneratedAvatarFlag::class)</code>
+      <code>\OCP\Server::get(ResetGeneratedAvatarFlag::class)</code>
+      <code>\OCP\Server::get(ShippedDashboardEnable::class)</code>
+      <code>\OCP\Server::get(ShippedDashboardEnable::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Repair/CleanTags.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Repair/Collation.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Repair/Owncloud/CleanPreviews.php">
     <InvalidArgument>
@@ -2654,6 +14245,13 @@
     </InvalidArgument>
   </file>
   <file src="lib/private/Repair/Owncloud/CleanPreviewsBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>delete</code>
+      <code>getDirectoryListing</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$arguments</code>
     </ParamNameMismatch>
@@ -2663,17 +14261,46 @@
       <code>$arguments</code>
     </ParamNameMismatch>
   </file>
+  <file src="lib/private/Repair/Owncloud/SaveAccountsTableData.php">
+    <MissingThrowsDocblock>
+      <code>createSchema</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getTable</code>
+      <code>getTable</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Repair/RemoveLinkShares.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->userToNotify]]></code>
     </InvalidPropertyAssignmentValue>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Repair/RepairDavShares.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Repair/RepairInvalidShares.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$out</code>
     </ParamNameMismatch>
   </file>
   <file src="lib/private/Repair/RepairMimeTypes.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$out</code>
     </ParamNameMismatch>
@@ -2685,6 +14312,16 @@
     <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>generate</code>
+      <code>generate</code>
+      <code>generate</code>
+      <code>generate</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getAttributeRoutes</code>
+      <code>getAttributeRoutes</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code><![CDATA[$this->collectionName]]></code>
     </NullableReturnStatement>
@@ -2694,6 +14331,46 @@
       <code>$provider instanceof Provider</code>
     </RedundantCondition>
   </file>
+  <file src="lib/private/Search/Filter/FloatFilter.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('Invalid float value '. $value);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Search/Filter/GroupFilter.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('Group '.$value.' not found');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Search/Filter/IntegerFilter.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('Invalid integer value '. $value);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Search/Filter/StringFilter.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('String filter can’t be empty');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Search/Filter/StringsFilter.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('Strings filter can’t be empty');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Search/Filter/UserFilter.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('User '.$value.' not found');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Search/Provider/File.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IRootFolder::class)</code>
+      <code>\OCP\Server::get(IRootFolder::class)</code>
+      <code>\OCP\Server::get(IUserSession::class)</code>
+      <code>\OCP\Server::get(IUserSession::class)</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Search/Result/File.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$data->getId()]]></code>
@@ -2701,6 +14378,35 @@
       <code><![CDATA[$data->getPermissions()]]></code>
       <code><![CDATA[$this->hasPreview($data)]]></code>
     </InvalidPropertyAssignmentValue>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getRelativePath</code>
+      <code><![CDATA[throw new \Exception("Search result not in user folder");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Search/SearchComposer.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('Filter name is already used');]]></code>
+      <code>throw new UnsupportedFilter($name, $providerId);</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Security/Bruteforce/Backend/DatabaseBackend.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Security/Bruteforce/CleanupJob.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Security/Bruteforce/Throttler.php">
     <NullArgument>
@@ -2717,6 +14423,20 @@
       <code><![CDATA[\strlen($this->value)]]></code>
     </InvalidArgument>
   </file>
+  <file src="lib/private/Security/CSRF/CsrfTokenManager.php">
+    <MissingThrowsDocblock>
+      <code>getToken</code>
+      <code>getToken</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Security/CertificateManager.php">
+    <MissingThrowsDocblock>
+      <code>file_get_contents</code>
+      <code>fopen</code>
+      <code>rename</code>
+      <code><![CDATA[throw new \RuntimeException('Unable to open file handler to create certificate bundle "' . $tmpPath . '".');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Security/CredentialsManager.php">
     <InvalidReturnStatement>
       <code><![CDATA[$qb->execute()]]></code>
@@ -2726,6 +14446,14 @@
       <code>int</code>
       <code>int</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>decrypt</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>setValues</code>
+      <code>setValues</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Security/Crypto.php">
     <InternalMethod>
@@ -2736,6 +14464,46 @@
       <code>setPassword</code>
       <code>setPassword</code>
     </InternalMethod>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Exception('Authenticated ciphertext could not be decoded.');]]></code>
+      <code><![CDATA[throw new Exception('Decryption failed');]]></code>
+      <code><![CDATA[throw new Exception('HMAC does not match.');]]></code>
+      <code><![CDATA[throw new \RuntimeException('Hex string is not of even length: ' . $hex);]]></code>
+      <code><![CDATA[throw new \RuntimeException('Hex to bin conversion failed: ' . $hex);]]></code>
+      <code><![CDATA[throw new \RuntimeException('String contains non hex chars: ' . $hex);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Security/IdentityProof/Manager.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+      <code>newFile</code>
+      <code>newFile</code>
+      <code>putContent</code>
+      <code>putContent</code>
+      <code>putContent</code>
+      <code>putContent</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Security/IdentityProof/Signer.php">
+    <MissingThrowsDocblock>
+      <code>getKey</code>
+      <code>getKey</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Security/RateLimiting/Backend/DatabaseBackend.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getExistingAttemptCount</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Security/VerificationToken/VerificationToken.php">
+    <MissingThrowsDocblock>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Server.php">
     <ImplementedReturnTypeMismatch>
@@ -2751,6 +14519,204 @@
       <code><![CDATA[$this->get(IUserSession::class)]]></code>
       <code><![CDATA[$this->get(\OCP\Encryption\IManager::class)]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>\OC\Encryption\File</code>
       <code>\OC\Encryption\Manager</code>
@@ -2767,11 +14733,32 @@
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->hasNoAppContainer]]></code>
     </InvalidPropertyAssignmentValue>
+    <MissingThrowsDocblock>
+      <code>parent::query($name, $autoload)</code>
+      <code>parent::query($name, $autoload)</code>
+      <code>parent::query($name, false)</code>
+      <code>parent::query($name, false)</code>
+    </MissingThrowsDocblock>
     <NoValue>
       <code><![CDATA[return $this->appContainers[$namespace];]]></code>
     </NoValue>
   </file>
   <file src="lib/private/Session/Internal.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IProvider::class)</code>
+      <code>\OCP\Server::get(IProvider::class)</code>
+      <code>getId</code>
+      <code>invoke</code>
+      <code>invoke</code>
+      <code>invoke</code>
+      <code>invoke</code>
+      <code>invoke</code>
+      <code>renewSessionToken</code>
+      <code>reopen</code>
+      <code>reopen</code>
+      <code>reopen</code>
+      <code>trapError</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
@@ -2781,7 +14768,72 @@
       <code>$value</code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="lib/private/Settings/AuthorizedGroupMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Settings/DeclarativeManager.php">
+    <MissingThrowsDocblock>
+      <code>getSectionType</code>
+      <code>getSectionType</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code><![CDATA[throw new Exception('Invalid schema. Please check the logs for more details.');]]></code>
+      <code><![CDATA[throw new Exception('Non unique field IDs detected: ' . join(', ', $intersectionFieldIDs));]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Settings/Manager.php">
+    <MissingThrowsDocblock>
+      <code>findAllClassesForUser</code>
+      <code>findAllClassesForUser</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Setup.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(IAppConfig::class)</code>
+      <code>Server::get(IAppConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IConfig::class)</code>
+      <code>Server::get(IGroupManager::class)</code>
+      <code>Server::get(IGroupManager::class)</code>
+      <code>Server::get(IJobList::class)</code>
+      <code>Server::get(IJobList::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(IRequest::class)</code>
+      <code>Server::get(ITimeFactory::class)</code>
+      <code>Server::get(ITimeFactory::class)</code>
+      <code>Server::get(IUserManager::class)</code>
+      <code>Server::get(IUserManager::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(IUserSession::class)</code>
+      <code>Server::get(PublicKeyTokenProvider::class)</code>
+      <code>Server::get(PublicKeyTokenProvider::class)</code>
+      <code>Server::get(SystemConfig::class)</code>
+      <code>Server::get(SystemConfig::class)</code>
+      <code>Server::get(\OC\Setup::class)</code>
+      <code>Server::get(\OC\Setup::class)</code>
+      <code>\OCP\Server::get(\OC\AppFramework\Bootstrap\Coordinator::class)</code>
+      <code>\OCP\Server::get(\OC\AppFramework\Bootstrap\Coordinator::class)</code>
+      <code>getSupportedDatabases</code>
+      <code>isHtaccessWorking</code>
+      <code>login</code>
+      <code>self::updateHtaccess()</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code><![CDATA[throw new \Exception(\OC::$SERVERROOT . " does not have enough space for writing the htaccess file! Not writing it back!");]]></code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code><![CDATA[$type === 'pdo']]></code>
     </RedundantCondition>
@@ -2790,6 +14842,12 @@
     </UndefinedVariable>
   </file>
   <file src="lib/private/Setup/AbstractDatabase.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>migrate</code>
+      <code><![CDATA[new MigrationService('core', \OC::$server->get(Connection::class), $output)]]></code>
+    </MissingThrowsDocblock>
     <TypeDoesNotContainType>
       <code><![CDATA[ctype_digit($this->dbPort)]]></code>
     </TypeDoesNotContainType>
@@ -2800,12 +14858,117 @@
       <code><![CDATA[$this->dbprettyname]]></code>
     </UndefinedThisPropertyFetch>
   </file>
+  <file src="lib/private/Setup/MySQL.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>throw $ex;</code>
+      <code><![CDATA[throw new \OC\DatabaseSetupException($this->trans->t('MySQL Login and/or password not valid'),
+				$this->trans->t('You need to enter details of an existing account.'), 0, $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Setup/OCI.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \OC\DatabaseSetupException($this->trans->t('Oracle Login and/or password not valid'),
+				'Check environment: ORACLE_HOME=' . getenv('ORACLE_HOME')
+				. ' ORACLE_SID=' . getenv('ORACLE_SID')
+				. ' LD_LIBRARY_PATH=' . getenv('LD_LIBRARY_PATH')
+				. ' NLS_LANG=' . getenv('NLS_LANG')
+				. ' tnsnames.ora is ' . (is_readable(getenv('ORACLE_HOME') . '/network/admin/tnsnames.ora') ? '' : 'not ') . 'readable', 0, $e);]]></code>
+      <code><![CDATA[throw new \OC\DatabaseSetupException($this->trans->t('Oracle connection could not be established'),
+					$errorMessage . ' Check environment: ORACLE_HOME=' . getenv('ORACLE_HOME')
+					. ' ORACLE_SID=' . getenv('ORACLE_SID')
+					. ' LD_LIBRARY_PATH=' . getenv('LD_LIBRARY_PATH')
+					. ' NLS_LANG=' . getenv('NLS_LANG')
+					. ' tnsnames.ora is ' . (is_readable(getenv('ORACLE_HOME') . '/network/admin/tnsnames.ora') ? '' : 'not ') . 'readable', 0, $e);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Setup/PostgreSQL.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+      <code>prepare</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Share/Share.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Share20/DefaultShareProvider.php">
     <InvalidArgument>
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[$share->getId()]]></code>
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getDirectoryListing</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getLastInsertId</code>
+      <code>getNodeId</code>
+      <code>getNodeId</code>
+      <code>getNodeId</code>
+      <code>getNodeId</code>
+      <code>getNodeType</code>
+      <code>getNodeType</code>
+      <code>setId</code>
+      <code>setId</code>
+      <code>setProviderId</code>
+      <code>setProviderId</code>
+      <code><![CDATA[throw new BackendError('Invalid backend');]]></code>
+      <code><![CDATA[throw new ProviderException('Group "' . $share->getSharedWith() . '" does not exist');]]></code>
+      <code><![CDATA[throw new ProviderException('Invalid shareType');]]></code>
+      <code><![CDATA[throw new ProviderException('Recipient does not match');]]></code>
+      <code><![CDATA[throw new ProviderException('Recipient not in receiving group');]]></code>
+    </MissingThrowsDocblock>
     <TooManyArguments>
       <code>set</code>
     </TooManyArguments>
@@ -2813,10 +14976,160 @@
       <code>getParent</code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="lib/private/Share20/Hooks.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Share20/LegacyHooks.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_shared', $postHookData)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_shared', $postHookData)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_unshare', $formatted)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_unshare', $formatted)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_unshareFromSelf', $formatted)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_unshareFromSelf', $formatted)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'pre_shared', $preHookData)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'pre_shared', $preHookData)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'pre_unshare', $formatted)]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'pre_unshare', $formatted)]]></code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNodeId</code>
+      <code>getNodeId</code>
+      <code>getNodeType</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Share20/Manager.php">
     <InvalidArgument>
       <code>$id</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_set_expiration_date', [
+				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+				'itemSource' => $share->getNode()->getId(),
+				'date' => $share->getExpirationDate(),
+				'uidOwner' => $share->getSharedBy(),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_set_expiration_date', [
+				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+				'itemSource' => $share->getNode()->getId(),
+				'date' => $share->getExpirationDate(),
+				'uidOwner' => $share->getSharedBy(),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_update_password', [
+				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+				'itemSource' => $share->getNode()->getId(),
+				'uidOwner' => $share->getSharedBy(),
+				'token' => $share->getToken(),
+				'disabled' => is_null($share->getPassword()),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_update_password', [
+				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+				'itemSource' => $share->getNode()->getId(),
+				'uidOwner' => $share->getSharedBy(),
+				'token' => $share->getToken(),
+				'disabled' => is_null($share->getPassword()),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_update_permissions', [
+				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+				'itemSource' => $share->getNode()->getId(),
+				'shareType' => $share->getShareType(),
+				'shareWith' => $share->getSharedWith(),
+				'uidOwner' => $share->getSharedBy(),
+				'permissions' => $share->getPermissions(),
+				'attributes' => $share->getAttributes() !== null ? $share->getAttributes()->toArray() : null,
+				'path' => $userFolder->getRelativePath($share->getNode()->getPath()),
+			])]]></code>
+      <code><![CDATA[\OC_Hook::emit(Share::class, 'post_update_permissions', [
+				'itemType' => $share->getNode() instanceof \OCP\Files\File ? 'file' : 'folder',
+				'itemSource' => $share->getNode()->getId(),
+				'shareType' => $share->getShareType(),
+				'shareWith' => $share->getSharedWith(),
+				'uidOwner' => $share->getSharedBy(),
+				'permissions' => $share->getPermissions(),
+				'attributes' => $share->getAttributes() !== null ? $share->getAttributes()->toArray() : null,
+				'path' => $userFolder->getRelativePath($share->getNode()->getPath()),
+			])]]></code>
+      <code>canShare</code>
+      <code>deleteShare</code>
+      <code>generalCreateChecks</code>
+      <code>getFullId</code>
+      <code>getFullId</code>
+      <code>getFullId</code>
+      <code>getFullId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getNode</code>
+      <code>getProvider</code>
+      <code>getProvider</code>
+      <code>getProvider</code>
+      <code>getProvider</code>
+      <code>getProviderForType</code>
+      <code>getProviderForType</code>
+      <code>getProviderForType</code>
+      <code>getProviderForType</code>
+      <code>getProviderForType</code>
+      <code>getProviderForType</code>
+      <code>getRelativePath</code>
+      <code>getShareById</code>
+      <code>getStorage</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>groupCreateChecks</code>
+      <code>linkCreateChecks</code>
+      <code><![CDATA[throw new \InvalidArgumentException('invalid path');]]></code>
+      <code>userCreateChecks</code>
+      <code>validateExpirationDateInternal</code>
+      <code>validateExpirationDateInternal</code>
+      <code>validateExpirationDateInternal</code>
+      <code>validateExpirationDateInternal</code>
+      <code>validateExpirationDateInternal</code>
+      <code>validateExpirationDateInternal</code>
+      <code>validateExpirationDateLink</code>
+      <code>validateExpirationDateLink</code>
+      <code>verifyPassword</code>
+    </MissingThrowsDocblock>
     <TooManyArguments>
       <code>update</code>
     </TooManyArguments>
@@ -2840,6 +15153,47 @@
     <InvalidReturnType>
       <code>getProviderForType</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
       <code>null</code>
@@ -2862,60 +15216,227 @@
       <code>private $shareByCircleProvider = null;</code>
     </UndefinedDocblockClass>
   </file>
+  <file src="lib/private/Share20/PublicShareTemplateFactory.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new Exception("Can't retrieve public share template providers as context is not defined");]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Share20/Share.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->node]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>getUserFolder</code>
+      <code>throw new \InvalidArgumentException();</code>
+      <code>throw new \InvalidArgumentException();</code>
+      <code>throw new \InvalidArgumentException();</code>
+      <code>throw new \InvalidArgumentException();</code>
+      <code>throw new \InvalidArgumentException();</code>
+      <code>throw new \InvalidArgumentException();</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>getNode</code>
     </MoreSpecificReturnType>
   </file>
+  <file src="lib/private/StreamImage.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+      <code><![CDATA[throw new \BadMethodCallException('Not implemented');]]></code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Streamer.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>query</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>get</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/SubAdmin.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>listen</code>
       <code>listen</code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/Support/Subscription/Registry.php">
+    <MissingThrowsDocblock>
+      <code>query</code>
+      <code>query</code>
+      <code>setApp</code>
+      <code>setDateTime</code>
+      <code>setObject</code>
+      <code>setSubject</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getSupportedApps</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/private/SystemConfig.php">
+    <MissingThrowsDocblock>
+      <code>deleteKey</code>
+      <code>setValue</code>
+      <code>setValues</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/SystemTag/ManagerFactory.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/SystemTag/SystemTagManager.php">
+    <MissingThrowsDocblock>
+      <code>beginTransaction</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getLastInsertId</code>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code>getTagsByIds</code>
+      <code>rollBack</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/SystemTag/SystemTagObjectMapper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>getTagsByIds</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/SystemTag/SystemTagsInFilesDetector.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \LogicException('Could not climb up to root folder');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/TagManager.php">
     <InvalidNullableReturnType>
       <code>\OCP\ITags</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code>execute</code>
+      <code>executeQuery</code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>null</code>
     </NullableReturnStatement>
+  </file>
+  <file src="lib/private/Tagging/TagMapper.php">
+    <MissingThrowsDocblock>
+      <code>findEntities</code>
+      <code>findEntity</code>
+      <code>findEntity</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Tags.php">
     <InvalidScalarArgument>
       <code>$from</code>
       <code>$names</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
     <MoreSpecificImplementedParamType>
       <code>$tag</code>
     </MoreSpecificImplementedParamType>
+  </file>
+  <file src="lib/private/Talk/Broker.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new RuntimeException("Not all apps have been registered yet");]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Teams/TeamManager.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \RuntimeException('No provider found for id ' .$providerId);]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/TempManager.php">
     <FalsableReturnStatement>
       <code>false</code>
       <code>false</code>
     </FalsableReturnStatement>
+    <MissingThrowsDocblock>
+      <code>getTempBaseDir</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Template/Base.php">
+    <MissingThrowsDocblock>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/Template/CSSResourceLocator.php">
+    <MissingThrowsDocblock>
+      <code>append</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$style</code>
       <code>$style</code>
     </ParamNameMismatch>
   </file>
+  <file src="lib/private/Template/JSCombiner.php">
+    <MissingThrowsDocblock>
+      <code>getContent</code>
+      <code>getDirectoryListing</code>
+      <code>getFolder</code>
+      <code>newFile</code>
+      <code>newFile</code>
+      <code>newFile</code>
+      <code>newFolder</code>
+      <code>newFolder</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/Template/JSConfigHelper.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Config', 'js', ['array' => &$array])]]></code>
+      <code><![CDATA[\OC_Hook::emit('\OCP\Config', 'js', ['array' => &$array])]]></code>
+      <code>get</code>
+      <code>get</code>
+      <code>getCapabilities</code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
       <code>null</code>
@@ -2925,10 +15446,18 @@
     <InvalidArgument>
       <code>false</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>append</code>
+    </MissingThrowsDocblock>
     <ParamNameMismatch>
       <code>$script</code>
       <code>$script</code>
     </ParamNameMismatch>
+  </file>
+  <file src="lib/private/Template/ResourceLocator.php">
+    <MissingThrowsDocblock>
+      <code>append</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/TemplateLayout.php">
     <InvalidParamDefault>
@@ -2939,19 +15468,167 @@
       <code>$appName</code>
       <code>$appName</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(CSSResourceLocator::class)</code>
+      <code>\OCP\Server::get(CSSResourceLocator::class)</code>
+      <code>\OCP\Server::get(Defaults::class)</code>
+      <code>\OCP\Server::get(Defaults::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IInitialStateService::class)</code>
+      <code>\OCP\Server::get(IInitialStateService::class)</code>
+      <code>\OCP\Server::get(IRegistry::class)</code>
+      <code>\OCP\Server::get(IRegistry::class)</code>
+      <code>\OCP\Server::get(IURLGenerator::class)</code>
+      <code>\OCP\Server::get(IURLGenerator::class)</code>
+      <code>\OCP\Server::get(JSResourceLocator::class)</code>
+      <code>\OCP\Server::get(JSResourceLocator::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getInitialStates</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/private/TextProcessing/Db/TaskMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/TextProcessing/Manager.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code><![CDATA[throw new RuntimeException('Failure while trying to find tasks by appId and identifier: ' . $e->getMessage(), 0, $e);]]></code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/TextProcessing/TaskBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>getTask</code>
+      <code>getTask</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/TextToImage/Db/Task.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(ITimeFactory::class)</code>
+      <code>\OCP\Server::get(ITimeFactory::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/TextToImage/Db/TaskMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeStatement</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/TextToImage/Manager.php">
+    <MissingThrowsDocblock>
+      <code>delete</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/TextToImage/RemoveOldTasksBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>getFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/TextToImage/TaskBackgroundJob.php">
+    <MissingThrowsDocblock>
+      <code>getTask</code>
+      <code>getTask</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/URLGenerator.php">
     <InvalidReturnStatement>
       <code>$path</code>
     </InvalidReturnStatement>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>\OCP\Server::get(IAppManager::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getAppPath</code>
+      <code>getAppWebPath</code>
+      <code>getAppWebPath</code>
+      <code>getAppWebPath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Updater.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(Repair::class)</code>
+      <code>\OCP\Server::get(Repair::class)</code>
+      <code>\OCP\Server::get(Repair::class)</code>
+      <code>\OCP\Server::get(Repair::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>migrate</code>
+      <code><![CDATA[new MigrationService('core', \OC::$server->get(Connection::class))]]></code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Updater/ChangesCheck.php">
+    <MissingThrowsDocblock>
+      <code>insert</code>
+      <code>update</code>
+      <code>update</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/Updater/ChangesMapper.php">
+    <MissingThrowsDocblock>
+      <code>execute</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/User/Database.php">
     <FalsableReturnStatement>
       <code>false</code>
     </FalsableReturnStatement>
+    <MissingThrowsDocblock>
+      <code>atomic</code>
+      <code>atomic</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code><![CDATA[throw new \Exception('key uid is expected to be set in $param');]]></code>
+      <code><![CDATA[throw new \RuntimeException($uid . ' does not exist');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/User/Listeners/UserChangedListener.php">
+    <MissingThrowsDocblock>
+      <code>getAvatar</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/User/Manager.php">
     <ImplementedReturnTypeMismatch>
@@ -2960,6 +15637,18 @@
     <InvalidArgument>
       <code>$backend</code>
     </InvalidArgument>
+    <MissingThrowsDocblock>
+      <code>Server::get(IFactory::class)</code>
+      <code>Server::get(IFactory::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>execute</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>createUser</code>
       <code>getUsersForUserValueCaseInsensitive</code>
@@ -2969,12 +15658,67 @@
     <ImplementedReturnTypeMismatch>
       <code>boolean|null</code>
     </ImplementedReturnTypeMismatch>
+    <MissingThrowsDocblock>
+      <code>\OC_Util::copySkeleton($user, $userFolder)</code>
+      <code>generateToken</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getPassword</code>
+      <code>getPassword</code>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>getToken</code>
+      <code>logClientIn</code>
+      <code>loginWithToken</code>
+      <code>renewSessionToken</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>sleepDelayOrThrowOnMax</code>
+      <code>sleepDelayOrThrowOnMax</code>
+      <code>throw new LoginException();</code>
+      <code>throw new \OC\User\NoUserException();</code>
+    </MissingThrowsDocblock>
     <NoInterfaceProperties>
       <code><![CDATA[$request->server]]></code>
       <code><![CDATA[$request->server]]></code>
     </NoInterfaceProperties>
   </file>
   <file src="lib/private/User/User.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(AccountManager::class)</code>
+      <code>\OCP\Server::get(AccountManager::class)</code>
+      <code>\OCP\Server::get(AvatarManager::class)</code>
+      <code>\OCP\Server::get(AvatarManager::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getAvatar</code>
+      <code>getAvatar</code>
+      <code>getPropertyCollection</code>
+      <code>setPrimaryEMailAddress</code>
+      <code>setUser</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>emit</code>
       <code>emit</code>
@@ -2999,6 +15743,63 @@
       <code><![CDATA[$dir['path']]]></code>
       <code><![CDATA[$dir['url']]]></code>
     </InvalidArrayOffset>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(Coordinator::class)</code>
+      <code>\OCP\Server::get(Coordinator::class)</code>
+      <code>\OCP\Server::get(IAppConfig::class)</code>
+      <code>\OCP\Server::get(IAppConfig::class)</code>
+      <code>\OCP\Server::get(Installer::class)</code>
+      <code>\OCP\Server::get(Installer::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(Repair::class)</code>
+      <code>\OCP\Server::get(Repair::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\App\IAppManager::class)</code>
+      <code>\OCP\Server::get(\OCP\Support\Subscription\IRegistry::class)</code>
+      <code>\OCP\Server::get(\OCP\Support\Subscription\IRegistry::class)</code>
+      <code><![CDATA[\OC_App::checkAppDependencies(
+			\OC::$server->getConfig(),
+			$l,
+			$appData,
+			$ignoreMax
+		)]]></code>
+      <code>addPsr4</code>
+      <code>addPsr4</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>migrate</code>
+      <code><![CDATA[new MigrationService($appId, \OC::$server->get(\OC\DB\Connection::class))]]></code>
+      <code><![CDATA[new \OC\Files\View('/' . OC_User::getUser() . '/' . $appId)]]></code>
+      <code><![CDATA[new \OC\Files\View('/' . OC_User::getUser())]]></code>
+      <code><![CDATA[self::executeRepairSteps($appId, $appData['repair-steps']['post-migration'])]]></code>
+      <code><![CDATA[self::executeRepairSteps($appId, $appData['repair-steps']['pre-migration'])]]></code>
+      <code>self::loadApp($appId)</code>
+    </MissingThrowsDocblock>
     <NullArgument>
       <code>null</code>
     </NullArgument>
@@ -3007,12 +15808,45 @@
       <code>$appId === null</code>
     </TypeDoesNotContainNull>
   </file>
+  <file src="lib/private/legacy/OC_Defaults.php">
+    <MissingThrowsDocblock>
+      <code>imagePath</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/legacy/OC_EventSource.php">
+    <MissingThrowsDocblock>
+      <code>send</code>
+      <code>send</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/private/legacy/OC_FileChunking.php">
+    <MissingThrowsDocblock>
+      <code>assemble</code>
+    </MissingThrowsDocblock>
     <UndefinedDocblockClass>
       <code>\OC\InsufficientStorageException</code>
     </UndefinedDocblockClass>
   </file>
   <file src="lib/private/legacy/OC_Files.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IEventDispatcher::class)</code>
+      <code>\OCP\Server::get(IEventDispatcher::class)</code>
+      <code>\OCP\Server::get(IEventDispatcher::class)</code>
+      <code>\OCP\Server::get(IEventDispatcher::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>lockFile</code>
+      <code>new View()</code>
+      <code>readfile</code>
+      <code>readfile</code>
+      <code>readfilePart</code>
+      <code>readfilePart</code>
+      <code>unlockFile</code>
+      <code>unlockFile</code>
+    </MissingThrowsDocblock>
     <RedundantCondition>
       <code>$getType === self::ZIP_DIR</code>
       <code>$getType === self::ZIP_DIR</code>
@@ -3030,16 +15864,99 @@
     <InvalidScalarArgument>
       <code>$path</code>
     </InvalidScalarArgument>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IBinaryFinder::class)</code>
+      <code>\OCP\Server::get(IBinaryFinder::class)</code>
+      <code>\OCP\Server::get(\OCP\IConfig::class)</code>
+      <code>\OCP\Server::get(\OCP\IConfig::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>setUserValue</code>
+      <code>setUserValue</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
     <UndefinedInterfaceMethod>
       <code>getQuota</code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="lib/private/legacy/OC_Image.php">
+    <MissingThrowsDocblock>
+      <code>_output</code>
+      <code>_output</code>
+      <code><![CDATA[new OC_Image(null, $this->logger, $this->config)]]></code>
+      <code><![CDATA[new OC_Image(null, $this->logger, $this->config)]]></code>
+      <code><![CDATA[new OC_Image(null, $this->logger, $this->config)]]></code>
+      <code><![CDATA[new OC_Image(null, $this->logger, $this->config)]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/legacy/OC_JSON.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/legacy/OC_Response.php">
+    <MissingThrowsDocblock>
+      <code>formatUnsignedInteger</code>
+      <code>new \OC\LargeFileHelper</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/legacy/OC_Template.php">
     <InvalidReturnType>
       <code>bool|string</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(\OCP\Defaults::class)</code>
+      <code>\OCP\Server::get(\OCP\Defaults::class)</code>
+      <code><![CDATA[\OC_App::loadApp('theming')]]></code>
+      <code>find</code>
+      <code>throw $e;</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/private/legacy/OC_User.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[OC_Hook::emit(
+					'OC_User',
+					'post_login',
+					[
+						'uid' => $uid,
+						'password' => $password,
+						'isTokenLogin' => false,
+					]
+				)]]></code>
+      <code><![CDATA[OC_Hook::emit(
+					'OC_User',
+					'post_login',
+					[
+						'uid' => $uid,
+						'password' => $password,
+						'isTokenLogin' => false,
+					]
+				)]]></code>
+      <code><![CDATA[OC_Hook::emit("OC_User", "pre_login", ["run" => &$run, "uid" => $uid, 'backend' => $backend])]]></code>
+      <code><![CDATA[OC_Hook::emit("OC_User", "pre_login", ["run" => &$run, "uid" => $uid, 'backend' => $backend])]]></code>
+      <code>Server::get(ISession::class)</code>
+      <code>Server::get(ISession::class)</code>
+      <code>Server::get(IUserManager::class)</code>
+      <code>Server::get(IUserManager::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>Server::get(LoggerInterface::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>throw new LoginException($message);</code>
+    </MissingThrowsDocblock>
     <UndefinedClass>
       <code>\Test\Util\User\Dummy</code>
     </UndefinedClass>
@@ -3048,6 +15965,49 @@
     <InvalidReturnType>
       <code>void</code>
     </InvalidReturnType>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(\OC\Setup::class)</code>
+      <code>\OCP\Server::get(\OC\Setup::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>getSupportedDatabases</code>
+      <code>self::needUpgrade($config)</code>
+      <code><![CDATA[throw new \OCP\HintException('Can\'t create test file to check for working .htaccess file.',
+				'Make sure it is possible for the web server to write to ' . $testFile);]]></code>
+      <code><![CDATA[throw new \RuntimeException('no instance id!');]]></code>
+      <code><![CDATA[throw new \RuntimeException('username is reserved name: ' . $appdata);]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/private/legacy/template/functions.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[\OCP\Server::get('DateTimeFormatter')]]></code>
+      <code><![CDATA[\OCP\Server::get('DateTimeFormatter')]]></code>
+      <code>get</code>
+      <code>get</code>
+      <code>imagePath</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/public/AppFramework/ApiController.php">
     <NoInterfaceProperties>
@@ -3058,22 +16018,83 @@
     <InternalMethod>
       <code><![CDATA[new RouteConfig($this->container, $router, $routes)]]></code>
     </InternalMethod>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code><![CDATA[\OC\AppFramework\App::main($controllerName, $methodName, $this->container)]]></code>
+      <code><![CDATA[throw new \RuntimeException('Can only setup routes with real router');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/public/AppFramework/Db/Entity.php">
     <InvalidNullableReturnType>
       <code>string</code>
     </InvalidNullableReturnType>
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \BadFunctionCallException($attributeName .
+				' is not a valid attribute');]]></code>
+      <code><![CDATA[throw new \BadFunctionCallException($methodName .
+				' does not exist');]]></code>
+      <code><![CDATA[throw new \BadFunctionCallException($name .
+				' is not a valid attribute');]]></code>
+      <code><![CDATA[throw new \BadFunctionCallException($name .
+				' is not a valid attribute');]]></code>
+    </MissingThrowsDocblock>
     <NullableReturnStatement>
       <code>$column</code>
     </NullableReturnStatement>
+  </file>
+  <file src="lib/public/AppFramework/Db/QBMapper.php">
+    <MissingThrowsDocblock>
+      <code>executeQuery</code>
+      <code>executeQuery</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>executeStatement</code>
+      <code>getLastInsertId</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/AppFramework/Http/FileDisplayResponse.php">
+    <MissingThrowsDocblock>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>getContent</code>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getSize</code>
+      <code>getSize</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/AppFramework/Http/RedirectToDefaultAppResponse.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/public/AppFramework/Http/Response.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[array_merge($mergeWith, $this->headers)]]></code>
     </LessSpecificReturnStatement>
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(ITimeFactory::class)</code>
+      <code>\OCP\Server::get(ITimeFactory::class)</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
     <MoreSpecificReturnType>
       <code>array{X-Request-Id: string, Cache-Control: string, Content-Security-Policy: string, Feature-Policy: string, X-Robots-Tag: string, Last-Modified?: string, ETag?: string, ...H}</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/public/AppFramework/Http/ZipResponse.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('No resource provided');]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/public/Authentication/Token/IToken.php">
     <AmbiguousConstantInheritance>
@@ -3084,6 +16105,33 @@
       <code>WIPE_TOKEN</code>
     </AmbiguousConstantInheritance>
   </file>
+  <file src="lib/public/BackgroundJob/Job.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/BackgroundJob/TimedJob.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('Invalid sensitivity');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/Collaboration/AutoComplete/AutoCompleteEvent.php">
+    <MissingThrowsDocblock>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+      <code>getArgument</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/Collaboration/Collaborators/SearchResultType.php">
+    <MissingThrowsDocblock>
+      <code>getValidatedType</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/public/Color.php">
     <LessSpecificReturnStatement>
       <code>$step</code>
@@ -3091,6 +16139,12 @@
     <MoreSpecificReturnType>
       <code>array{0: int, 1: int, 2: int}</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/public/Defaults.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/public/Diagnostics/IQueryLogger.php">
     <LessSpecificImplementedReturnType>
@@ -3108,10 +16162,43 @@
       <code>\OC_App::getStorage($app)</code>
     </FalsableReturnStatement>
   </file>
+  <file src="lib/public/Files/Events/Node/BeforeNodeDeletedEvent.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new AbortedEventException($ex?->getMessage() ?? 'Operation aborted');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/Files/Events/Node/BeforeNodeRenamedEvent.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new AbortedEventException($ex?->getMessage() ?? 'Operation aborted');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/Files/Lock/LockContext.php">
+    <MissingThrowsDocblock>
+      <code>getId</code>
+      <code>getId</code>
+    </MissingThrowsDocblock>
+  </file>
   <file src="lib/public/Files/Storage.php">
     <InvalidParamDefault>
       <code>array</code>
     </InvalidParamDefault>
+  </file>
+  <file src="lib/public/Files/Template/Template.php">
+    <MissingThrowsDocblock>
+      <code>getEtag</code>
+      <code>getEtag</code>
+      <code>getId</code>
+      <code>getId</code>
+      <code>getMTime</code>
+      <code>getMTime</code>
+      <code>getSize</code>
+      <code>getSize</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/Group/Backend/ABackend.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \Exception("Should not have been called");]]></code>
+    </MissingThrowsDocblock>
   </file>
   <file src="lib/public/L10N/ILanguageIterator.php">
     <MissingTemplateParam>
@@ -3125,5 +16212,68 @@
     <MoreSpecificReturnType>
       <code>null|IPreview::MODE_FILL|IPreview::MODE_COVER</code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="lib/public/Search/FilterDefinition.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new InvalidArgumentException('Invalid filter name. Allowed characters are [-0-9a-z]');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/SetupCheck/SetupResult.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IValidator::class)</code>
+      <code>\OCP\Server::get(IValidator::class)</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/TextProcessing/Task.php">
+    <MissingThrowsDocblock>
+      <code>process</code>
+      <code><![CDATA[throw new \RuntimeException('Task of type ' . $this->getType() . ' cannot visit provider with task type ' . $provider->getTaskType());]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/TextToImage/Task.php">
+    <MissingThrowsDocblock>
+      <code>\OCP\Server::get(IAppDataFactory::class)</code>
+      <code>\OCP\Server::get(IAppDataFactory::class)</code>
+      <code>getFolder</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/UserMigration/TMigratorBasicVersionHandling.php">
+    <MissingThrowsDocblock>
+      <code>getMigratorVersion</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/Util.php">
+    <MissingThrowsDocblock>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>Server::get(\OCP\L10N\IFactory::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IConfig::class)</code>
+      <code>\OCP\Server::get(IniGetWrapper::class)</code>
+      <code>\OCP\Server::get(IniGetWrapper::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OCP\Server::get(LoggerInterface::class)</code>
+      <code>\OC_Hook::emit($signalclass, $signalname, $params)</code>
+      <code>\OC_Hook::emit($signalclass, $signalname, $params)</code>
+      <code><![CDATA[\OC_Util::needUpgrade(\OC::$server->getSystemConfig())]]></code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>setSystemValue</code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="lib/public/WorkflowEngine/GenericEntityEvent.php">
+    <MissingThrowsDocblock>
+      <code><![CDATA[throw new \InvalidArgumentException('DisplayName must not be empty');]]></code>
+      <code><![CDATA[throw new \InvalidArgumentException('EventName must not be empty');]]></code>
+    </MissingThrowsDocblock>
+  </file>
+  <file src="remote.php">
+    <MissingThrowsDocblock>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+      <code>get</code>
+    </MissingThrowsDocblock>
   </file>
 </files>

--- a/core/Controller/OCMController.php
+++ b/core/Controller/OCMController.php
@@ -58,6 +58,7 @@ class OCMController extends Controller {
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
+	 * @psalm-suppress UnusedPsalmSuppress
 	 * @psalm-suppress MoreSpecificReturnType
 	 * @psalm-suppress LessSpecificReturnStatement
 	 * @return DataResponse<Http::STATUS_OK, array{enabled: bool, apiVersion: string, endPoint: string, resourceTypes: array{name: string, shareTypes: string[], protocols: array{webdav: string}}[]}, array{X-NEXTCLOUD-OCM-PROVIDERS: true, Content-Type: 'application/json'}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR, array{message: string}, array{}>

--- a/lib/private/App/PlatformRepository.php
+++ b/lib/private/App/PlatformRepository.php
@@ -50,10 +50,6 @@ class PlatformRepository {
 			$ext = new \ReflectionExtension($name);
 			try {
 				$prettyVersion = $ext->getVersion();
-				/** @psalm-suppress TypeDoesNotContainNull
-				 * @psalm-suppress RedundantCondition
-				 * TODO Remove these annotations once psalm fixes the method signature ( https://github.com/vimeo/psalm/pull/8655 )
-				 */
 				$prettyVersion = $this->normalizeVersion($prettyVersion ?? '0');
 			} catch (\UnexpectedValueException $e) {
 				$prettyVersion = '0';

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -113,7 +113,6 @@ class AppConfig implements IAppConfig {
 	 * @deprecated 29.0.0 use {@see setAppValueString()}
 	 */
 	public function setAppValue(string $key, string $value): void {
-		/** @psalm-suppress InternalMethod */
 		$this->appConfig->setValueMixed($this->appName, $key, $value);
 	}
 
@@ -235,8 +234,6 @@ class AppConfig implements IAppConfig {
 	 * @return string
 	 */
 	public function getAppValue(string $key, string $default = ''): string {
-		/** @psalm-suppress InternalMethod */
-		/** @psalm-suppress UndefinedInterfaceMethod */
 		return $this->appConfig->getValueMixed($this->appName, $key, $default);
 	}
 

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -136,7 +136,6 @@ class Connection extends PrimaryReadReplicaConnection {
 		try {
 			if ($this->_conn) {
 				$this->reconnectIfNeeded();
-				/** @psalm-suppress InternalMethod */
 				return parent::connect();
 			}
 
@@ -145,7 +144,6 @@ class Connection extends PrimaryReadReplicaConnection {
 			// Only trigger the event logger for the initial connect call
 			$eventLogger = \OC::$server->get(IEventLogger::class);
 			$eventLogger->start('connect:db', 'db connection opened');
-			/** @psalm-suppress InternalMethod */
 			$status = parent::connect();
 			$eventLogger->end('connect:db');
 

--- a/lib/private/Dashboard/Manager.php
+++ b/lib/private/Dashboard/Manager.php
@@ -68,7 +68,6 @@ class Manager implements IManager {
 		}
 		$services = $this->lazyWidgets;
 		foreach ($services as $service) {
-			/** @psalm-suppress InvalidCatch */
 			try {
 				if (!$this->appManager->isEnabledForUser($service['appId'])) {
 					// all apps are registered, but some may not be enabled for the user

--- a/lib/private/Memcache/Memcached.php
+++ b/lib/private/Memcache/Memcached.php
@@ -69,7 +69,6 @@ class Memcached extends Cache implements IMemcache {
 			 * By default enable igbinary serializer if available
 			 *
 			 * Psalm checks depend on if igbinary is installed or not with memcached
-			 * @psalm-suppress RedundantCondition
 			 * @psalm-suppress TypeDoesNotContainType
 			 */
 			if (\Memcached::HAVE_IGBINARY) {

--- a/lib/private/UserStatus/Manager.php
+++ b/lib/private/UserStatus/Manager.php
@@ -89,9 +89,6 @@ class Manager implements IManager {
 			return;
 		}
 
-		/**
-		 * @psalm-suppress InvalidCatch
-		 */
 		try {
 			$provider = $this->container->get($this->providerClass);
 		} catch (ContainerExceptionInterface $e) {

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -609,7 +609,6 @@ class OC_Helper {
 	/**
 	 * Get storage info including all mount points and quota
 	 *
-	 * @psalm-suppress LessSpecificReturnStatement Legacy code outputs weird types - manually validated that they are correct
 	 * @return StorageInfo
 	 */
 	private static function getGlobalStorageInfo(int|float $quota, IUser $user, IMountPoint $mount): array {

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -300,7 +300,6 @@ class OC_Image implements \OCP\IImage {
 				$retVal = imagegif($this->resource, $filePath);
 				break;
 			case IMAGETYPE_JPEG:
-				/** @psalm-suppress InvalidScalarArgument */
 				imageinterlace($this->resource, (PHP_VERSION_ID >= 80000 ? true : 1));
 				$retVal = imagejpeg($this->resource, $filePath, $this->getJpegQuality());
 				break;
@@ -394,7 +393,6 @@ class OC_Image implements \OCP\IImage {
 				$res = imagepng($this->resource);
 				break;
 			case "image/jpeg":
-				/** @psalm-suppress InvalidScalarArgument */
 				imageinterlace($this->resource, (PHP_VERSION_ID >= 80000 ? true : 1));
 				$quality = $this->getJpegQuality();
 				$res = imagejpeg($this->resource, null, $quality);

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -250,9 +250,6 @@ class Response {
 	 */
 	public function getHeaders() {
 		/** @var IRequest $request */
-		/**
-		 * @psalm-suppress UndefinedClass
-		 */
 		$request = \OC::$server->get(IRequest::class);
 		$mergeWith = [
 			'X-Request-Id' => $request->getId(),

--- a/lib/public/Server.php
+++ b/lib/public/Server.php
@@ -51,7 +51,6 @@ final class Server {
 	 * @since 25.0.0
 	 */
 	public static function get(string $serviceName) {
-		/** @psalm-suppress UndefinedClass */
 		return \OC::$server->get($serviceName);
 	}
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     errorBaseline="build/psalm-baseline.xml"
 	findUnusedBaselineEntry="false"
 	findUnusedCode="false"
+	checkForThrowsDocblock="true"
 >
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
 	findUnusedCode="false"
 	checkForThrowsDocblock="true"
 	strictBinaryOperands="true"
+	findUnusedPsalmSuppress="true"
 >
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,7 @@
 	findUnusedBaselineEntry="false"
 	findUnusedCode="false"
 	checkForThrowsDocblock="true"
+	strictBinaryOperands="true"
 >
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />


### PR DESCRIPTION
## Summary

Enables a few more useful rules:
- MissingThrowsDocblock: Ensures every method has the appropriate `@throws` annotations
- InvalidOperand: Ensures values/variables of different types are not used in an operation without explicit casting (e.g. `'test' . 123`
- UnusedPsalmSuppress: Reports on unused supresses

I only fixed the problems of the last rule because there weren't a lot, but the first two ones I added to the baseline. Those errors will only show up for new or refactored code.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
