### PR TITLE
[stable27] Fix opening "Remote shares" dialog even if Notifications is available

### DIFF
--- a/apps/federatedfilesharing/js/external.js
+++ b/apps/federatedfilesharing/js/external.js
@@ -78,7 +78,7 @@
 			this.filesApp = filesApp;
 			this.processIncomingShareFromUrl();
 
-			if (!$('#header').find('div.notifications').length) {
+			if (!('notifications' in OC.appswebroots)) {
 				// No notification app, display the modal
 				this.processSharesToConfirm();
 			}


### PR DESCRIPTION
This fix is only for Nextcloud 27; in Nextcloud 28, even if the fix would also apply, [the federated files plugin is currently not loaded due to the changes in the Files app](https://github.com/nextcloud/server/issues/44824), so additional fixes are needed for this one to have any effect.

Since Nextcloud 25, when a user opens the Files app a _Remote share_ dialog is shown to accept each pending remote share. However, this is a regression rather than a feature.

The dialog has been there already for ages, but it was supposed to be shown only if the Notifications app is not available, and [to know whether the app is available or not it is checked if the header contains the Notifications button](https://github.com/nextcloud/server/blob/3b94da9c1d9869db35cf8b33da82119d93c1402f/apps/federatedfilesharing/js/external.js#L81-L84). However, in Nextcloud 25 [the DOM of the Notifications app changed](https://github.com/nextcloud/notifications/commit/8b7eb8dd4f8ef18e3496c99b314bb1e14b63eaf1#diff-7f56f40d9dae3769ff5d649044ffefe4dcfd61546275a80f5fb1b21db502d01d), so the button is no longer found and thus the dialog is always shown when there are pending shares.

Even if the correct element query was used the dialog may be still shown anyway if _external.js_ is loaded before the notifications button is added to the header. Therefore now it is checked if the Notifications app is available or not from the OC API.

Note that, with the fixed behaviour, it is possible to remove a notification about a pending share without accepting it, and once the notification is removed it will not appear again (unlike the _Remote share_ dialog, which appears again and again whenever you open the Files app if there is a pending share; this is specially noticeable with group shares, as declined group shares are marked as pending rather than removed). Nevertheless, in that case the user could open the _Pending shares_ entry in the Files app navigation and accept the share from there if needed (this would be possible in Nextcloud 27 and earlier; in [Nextcloud 28 and later remote shares are not listed in share views due to a bug](https://github.com/nextcloud/server/issues/44318)).

## How to test

- Setup Nextcloud server A
- Setup Nextcloud server B
- Enable notifications app in server B
- In server A, share a file with user X of server B
- In server B, log in as user X
- Open the Files app

### Result with this pull request

The "Remote share" dialog is not shown, but the share can be accepted from the notification

### Result without this pull request

The "Remote share" dialog is shown, even if there is also a notification to accept the share
