### PR TITLE
fix(user_ldap): Remove unicode character from log lines

### DIFF
--- a/apps/user_ldap/lib/LoginListener.php
+++ b/apps/user_ldap/lib/LoginListener.php
@@ -59,7 +59,7 @@ class LoginListener implements IEventListener {
 
 	public function onPostLogin(IUser $user): void {
 		$this->logger->info(
-			__CLASS__ . ' – {user} postLogin',
+			__CLASS__ . ' - {user} postLogin',
 			[
 				'app' => 'user_ldap',
 				'user' => $user->getUID(),
@@ -84,7 +84,7 @@ class LoginListener implements IEventListener {
 			$groupObject = $this->groupManager->get($groupId);
 			if ($groupObject === null) {
 				$this->logger->error(
-					__CLASS__ . ' – group {group} could not be found (user {user})',
+					__CLASS__ . ' - group {group} could not be found (user {user})',
 					[
 						'app' => 'user_ldap',
 						'user' => $userId,
@@ -98,7 +98,7 @@ class LoginListener implements IEventListener {
 			} catch (Exception $e) {
 				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 					$this->logger->error(
-						__CLASS__ . ' – group {group} membership failed to be added (user {user})',
+						__CLASS__ . ' - group {group} membership failed to be added (user {user})',
 						[
 							'app' => 'user_ldap',
 							'user' => $userId,
@@ -113,7 +113,7 @@ class LoginListener implements IEventListener {
 			$this->groupBackend->addRelationshipToCaches($userId, null, $groupId);
 			$this->dispatcher->dispatchTyped(new UserAddedEvent($groupObject, $userObject));
 			$this->logger->info(
-				__CLASS__ . ' – {user} added to {group}',
+				__CLASS__ . ' - {user} added to {group}',
 				[
 					'app' => 'user_ldap',
 					'user' => $userId,
@@ -127,7 +127,7 @@ class LoginListener implements IEventListener {
 			} catch (Exception $e) {
 				if ($e->getReason() !== Exception::REASON_DATABASE_OBJECT_NOT_FOUND) {
 					$this->logger->error(
-						__CLASS__ . ' – group {group} membership failed to be removed (user {user})',
+						__CLASS__ . ' - group {group} membership failed to be removed (user {user})',
 						[
 							'app' => 'user_ldap',
 							'user' => $userId,
@@ -142,7 +142,7 @@ class LoginListener implements IEventListener {
 			$groupObject = $this->groupManager->get($groupId);
 			if ($groupObject === null) {
 				$this->logger->error(
-					__CLASS__ . ' – group {group} could not be found (user {user})',
+					__CLASS__ . ' - group {group} could not be found (user {user})',
 					[
 						'app' => 'user_ldap',
 						'user' => $userId,
@@ -153,7 +153,7 @@ class LoginListener implements IEventListener {
 			}
 			$this->dispatcher->dispatchTyped(new UserRemovedEvent($groupObject, $userObject));
 			$this->logger->info(
-				'service "updateGroups" – {user} removed from {group}',
+				'service "updateGroups" - {user} removed from {group}',
 				[
 					'user' => $userId,
 					'group' => $groupId

--- a/apps/user_ldap/lib/Service/UpdateGroupsService.php
+++ b/apps/user_ldap/lib/Service/UpdateGroupsService.php
@@ -66,7 +66,7 @@ class UpdateGroupsService {
 
 		if (empty($actualGroups) && empty($knownGroups)) {
 			$this->logger->info(
-				'service "updateGroups" – groups do not seem to be configured properly, aborting.',
+				'service "updateGroups" - groups do not seem to be configured properly, aborting.',
 			);
 			return;
 		}
@@ -75,7 +75,7 @@ class UpdateGroupsService {
 		$this->handleCreatedGroups(array_diff($actualGroups, $knownGroups));
 		$this->handleRemovedGroups(array_diff($knownGroups, $actualGroups));
 
-		$this->logger->debug('service "updateGroups" – Finished.');
+		$this->logger->debug('service "updateGroups" - Finished.');
 	}
 
 	/**
@@ -83,10 +83,10 @@ class UpdateGroupsService {
 	 * @throws Exception
 	 */
 	public function handleKnownGroups(array $groups): void {
-		$this->logger->debug('service "updateGroups" – Dealing with known Groups.');
+		$this->logger->debug('service "updateGroups" - Dealing with known Groups.');
 
 		foreach ($groups as $group) {
-			$this->logger->debug('service "updateGroups" – Dealing with {group}.', ['group' => $group]);
+			$this->logger->debug('service "updateGroups" - Dealing with {group}.', ['group' => $group]);
 			$groupMemberships = $this->groupMembershipMapper->findGroupMemberships($group);
 			$knownUsers = array_map(
 				static fn (GroupMembership $groupMembership): string => $groupMembership->getUserid(),
@@ -99,7 +99,7 @@ class UpdateGroupsService {
 			if ($groupObject === null) {
 				/* We are not expecting the group to not be found since it was returned by $this->groupBackend->getGroups() */
 				$this->logger->error(
-					'service "updateGroups" – Failed to get group {group} for update',
+					'service "updateGroups" - Failed to get group {group} for update',
 					[
 						'group' => $group
 					]
@@ -113,7 +113,7 @@ class UpdateGroupsService {
 					if ($e->getReason() !== Exception::REASON_DATABASE_OBJECT_NOT_FOUND) {
 						/* If reason is not found something else removed the membership, that’s fine */
 						$this->logger->error(
-							__CLASS__ . ' – group {group} membership failed to be removed (user {user})',
+							__CLASS__ . ' - group {group} membership failed to be removed (user {user})',
 							[
 								'app' => 'user_ldap',
 								'user' => $removedUser,
@@ -130,7 +130,7 @@ class UpdateGroupsService {
 					$this->dispatcher->dispatchTyped(new UserRemovedEvent($groupObject, $userObject));
 				}
 				$this->logger->info(
-					'service "updateGroups" – {user} removed from {group}',
+					'service "updateGroups" - {user} removed from {group}',
 					[
 						'user' => $removedUser,
 						'group' => $group
@@ -144,7 +144,7 @@ class UpdateGroupsService {
 					if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 						/* If reason is unique constraint something else added the membership, that’s fine */
 						$this->logger->error(
-							__CLASS__ . ' – group {group} membership failed to be added (user {user})',
+							__CLASS__ . ' - group {group} membership failed to be added (user {user})',
 							[
 								'app' => 'user_ldap',
 								'user' => $addedUser,
@@ -161,7 +161,7 @@ class UpdateGroupsService {
 					$this->dispatcher->dispatchTyped(new UserAddedEvent($groupObject, $userObject));
 				}
 				$this->logger->info(
-					'service "updateGroups" – {user} added to {group}',
+					'service "updateGroups" - {user} added to {group}',
 					[
 						'user' => $addedUser,
 						'group' => $group
@@ -169,7 +169,7 @@ class UpdateGroupsService {
 				);
 			}
 		}
-		$this->logger->debug('service "updateGroups" – FINISHED dealing with known Groups.');
+		$this->logger->debug('service "updateGroups" - FINISHED dealing with known Groups.');
 	}
 
 	/**
@@ -177,10 +177,10 @@ class UpdateGroupsService {
 	 * @throws Exception
 	 */
 	public function handleCreatedGroups(array $createdGroups): void {
-		$this->logger->debug('service "updateGroups" – dealing with created Groups.');
+		$this->logger->debug('service "updateGroups" - dealing with created Groups.');
 
 		foreach ($createdGroups as $createdGroup) {
-			$this->logger->info('service "updateGroups" – new group "' . $createdGroup . '" found.');
+			$this->logger->info('service "updateGroups" - new group "' . $createdGroup . '" found.');
 
 			$users = $this->groupBackend->usersInGroup($createdGroup);
 			$groupObject = $this->groupManager->get($createdGroup);
@@ -190,7 +190,7 @@ class UpdateGroupsService {
 				} catch (Exception $e) {
 					if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
 						$this->logger->error(
-							__CLASS__ . ' – group {group} membership failed to be added (user {user})',
+							__CLASS__ . ' - group {group} membership failed to be added (user {user})',
 							[
 								'app' => 'user_ldap',
 								'user' => $user,
@@ -210,7 +210,7 @@ class UpdateGroupsService {
 				}
 			}
 		}
-		$this->logger->debug('service "updateGroups" – FINISHED dealing with created Groups.');
+		$this->logger->debug('service "updateGroups" - FINISHED dealing with created Groups.');
 	}
 
 	/**
@@ -218,7 +218,7 @@ class UpdateGroupsService {
 	 * @throws Exception
 	 */
 	public function handleRemovedGroups(array $removedGroups): void {
-		$this->logger->debug('service "updateGroups" – dealing with removed groups.');
+		$this->logger->debug('service "updateGroups" - dealing with removed groups.');
 
 		$this->groupMembershipMapper->deleteGroups($removedGroups);
 		foreach ($removedGroups as $group) {
@@ -235,7 +235,7 @@ class UpdateGroupsService {
 		}
 
 		$this->logger->info(
-			'service "updateGroups" – groups {removedGroups} were removed.',
+			'service "updateGroups" - groups {removedGroups} were removed.',
 			[
 				'removedGroups' => $removedGroups
 			]


### PR DESCRIPTION
## Summary

Spotted that in log files, a unicode character was used instead of an ascii dash, resulting in an ugly thing in json encoding instead of a simple dash.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
