### PR TITLE
chore: Fix update-psalm-baseline to use correct php version depending on branch

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -8,6 +8,7 @@
     errorBaseline="build/psalm-baseline.xml"
 	findUnusedBaselineEntry="false"
 	findUnusedCode="false"
+	phpVersion="8.1"
 >
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />


### PR DESCRIPTION
## Summary

~The workflow currently always use 8.1, it should use the same PHP version as the psalm run on the target branch.~
Adding the PHP version to psalm.xml so that the update-baseline workflow is aware of it. Backports will need to adapt the PHP version to the one used in their psalm workflow (the lowest PHP version supported usually).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
