### PR TITLE
feat: reduce available languages per config value "reduce_to_languages"

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -5,7 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
- 
+
 /**
  * This configuration file is only provided to document the different
  * configuration options and their usage.
@@ -227,6 +227,15 @@ $CONFIG = [
  * Defaults to ``en``
  */
 'default_locale' => 'en_US',
+
+/**
+ * With this setting is possible to reduce the languages available in the
+ * language chooser. The languages have to be set as array values using ISO_639-1
+ * language codes such as ``en`` for English, ``de`` for German etc.
+ *
+ * For example: Set to ['de', 'fr'] to only allow German and French languages.
+ */
+'reduce_to_languages' => [],
 
 /**
  * This sets the default region for phone numbers on your Nextcloud server,

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -576,6 +576,10 @@ class Factory implements IFactory {
 		}
 
 		$languageCodes = $this->findAvailableLanguages();
+		$reduceToLanguages = $this->config->getSystemValue('reduce_to_languages', []);
+		if (!empty($reduceToLanguages)) {
+			$languageCodes = array_intersect($languageCodes, $reduceToLanguages);
+		}
 
 		$commonLanguages = [];
 		$otherLanguages = [];


### PR DESCRIPTION
Example: restrict to en, de, es, fr, it languages


```
./occ config:system:set reduce_to_languages 0  --value  en 
./occ config:system:set reduce_to_languages 1  --value  de 
./occ config:system:set reduce_to_languages 2  --value  es 
./occ config:system:set reduce_to_languages 3  --value  fr 
./occ config:system:set reduce_to_languages 4  --value  it
```


* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
