### PR TITLE
fix(status): Update status time when reverting to it manually

### DIFF
--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -532,9 +532,12 @@ class StatusService {
 			return null;
 		}
 
-		if ($revertedManually && $backupUserStatus->getStatus() === IUserStatus::OFFLINE) {
-			// When the user reverts the status manually they are online
-			$backupUserStatus->setStatus(IUserStatus::ONLINE);
+		if ($revertedManually) {
+			if ($backupUserStatus->getStatus() === IUserStatus::OFFLINE) {
+				// When the user reverts the status manually they are online
+				$backupUserStatus->setStatus(IUserStatus::ONLINE);
+			}
+			$backupUserStatus->setStatusTimestamp($this->timeFactory->getTime());
 		}
 
 		$backupUserStatus->setIsBackup(false);


### PR DESCRIPTION
This prevents the DAV meeting status from overwriting it again

* Resolves: #44877 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
