### PR TITLE
feat(files): Use receiving users language for the ownership transfer target folder

### DIFF
--- a/build/integration/features/bootstrap/CommandLineContext.php
+++ b/build/integration/features/bootstrap/CommandLineContext.php
@@ -51,7 +51,7 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 		foreach ($results as $path => $data) {
 			$path = rawurldecode($path);
 			$parts = explode(' ', $path);
-			if (basename($parts[0]) !== 'transferred') {
+			if (basename($parts[0]) !== 'Transferred') {
 				continue;
 			}
 			if (isset($parts[2]) && $parts[2] === $sourceUser) {

--- a/build/integration/files_features/transfer-ownership.feature
+++ b/build/integration/files_features/transfer-ownership.feature
@@ -39,7 +39,7 @@ Feature: transfer-ownership
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
-		And transfer folder name contains "transferred from user0 -risky- ヂspḷay -na|-|e- on"
+		And transfer folder name contains "Transferred from user0 -risky- ヂspḷay -na|-|e- on"
 		And using old dav path
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
@@ -345,7 +345,7 @@ Feature: transfer-ownership
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
-		And transfer folder name contains "transferred from user0 -risky- ヂspḷay -na|-|e- on"
+		And transfer folder name contains "Transferred from user0 -risky- ヂspḷay -na|-|e- on"
 		And using old dav path
 		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/32978

## Summary

Use the receiving users language for the target folder name.
See last of this:

![Screenshot_20240418_000139](https://github.com/nextcloud/server/assets/1855448/ab8fc4ee-20de-46f4-a4c6-b544ad2a5f0d)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
