### PR TITLE
fix: Use strict_types in ClearGeneratedAvatarCacheCommand.php

### DIFF
--- a/core/Command/User/ClearGeneratedAvatarCacheCommand.php
+++ b/core/Command/User/ClearGeneratedAvatarCacheCommand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * @copyright Copyright (c) 2024, Nextcloud GmbH
  *


### PR DESCRIPTION
fix: add missing ClearGeneratedAvatarCacheCommand.php in autoload_static.php and declare strict_types for the new file as suggested 

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
