### PR TITLE
fix(sharing): Don't change the type of the controller argument

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -648,8 +648,8 @@ class ShareAPIController extends OCSController {
 		//Expire date
 		if ($expireDate !== '') {
 			try {
-				$expireDate = $this->parseDate($expireDate);
-				$share->setExpirationDate($expireDate);
+				$expireDateTime = $this->parseDate($expireDate);
+				$share->setExpirationDate($expireDateTime);
 			} catch (\Exception $e) {
 				throw new OCSNotFoundException($this->l->t('Invalid date, date format must be YYYY-MM-DD'));
 			}


### PR DESCRIPTION
> [EA] New value type (\DateTime) is not matching the resolved parameter type and might introduce types-related false-positives.

![grafik](https://github.com/nextcloud/server/assets/213943/95d0f05f-94a0-46f5-97b0-09ea4e70ff96)

* Resolves: #44838

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
