### PR TITLE
fix(CI): Update to pull_request trigger

### DIFF
--- a/.github/workflows/dependabot-approve-merge.yml
+++ b/.github/workflows/dependabot-approve-merge.yml
@@ -6,7 +6,7 @@
 name: Dependabot
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - main
       - master


### PR DESCRIPTION
## Summary

Using `pull_request_target` can expose secrets based on a quirk in how GitHub applies permissions to forks.
See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

_Even if i'm not sure this is a problem here as this Workflow applies to Dependabot, submitting the PR to review :)_

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)