### PR TITLE
perf(templates): Emit RegisterTemplateCreatorEvent to register template creators more lazy

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -431,6 +431,7 @@ return array(
     'OCP\\Files\\Template\\FileCreatedFromTemplateEvent' => $baseDir . '/lib/public/Files/Template/FileCreatedFromTemplateEvent.php',
     'OCP\\Files\\Template\\ICustomTemplateProvider' => $baseDir . '/lib/public/Files/Template/ICustomTemplateProvider.php',
     'OCP\\Files\\Template\\ITemplateManager' => $baseDir . '/lib/public/Files/Template/ITemplateManager.php',
+    'OCP\\Files\\Template\\RegisterTemplateCreatorEvent' => $baseDir . '/lib/public/Files/Template/RegisterTemplateCreatorEvent.php',
     'OCP\\Files\\Template\\Template' => $baseDir . '/lib/public/Files/Template/Template.php',
     'OCP\\Files\\Template\\TemplateFileCreator' => $baseDir . '/lib/public/Files/Template/TemplateFileCreator.php',
     'OCP\\Files\\UnseekableException' => $baseDir . '/lib/public/Files/UnseekableException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -464,6 +464,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\Template\\FileCreatedFromTemplateEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Template/FileCreatedFromTemplateEvent.php',
         'OCP\\Files\\Template\\ICustomTemplateProvider' => __DIR__ . '/../../..' . '/lib/public/Files/Template/ICustomTemplateProvider.php',
         'OCP\\Files\\Template\\ITemplateManager' => __DIR__ . '/../../..' . '/lib/public/Files/Template/ITemplateManager.php',
+        'OCP\\Files\\Template\\RegisterTemplateCreatorEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Template/RegisterTemplateCreatorEvent.php',
         'OCP\\Files\\Template\\Template' => __DIR__ . '/../../..' . '/lib/public/Files/Template/Template.php',
         'OCP\\Files\\Template\\TemplateFileCreator' => __DIR__ . '/../../..' . '/lib/public/Files/Template/TemplateFileCreator.php',
         'OCP\\Files\\UnseekableException' => __DIR__ . '/../../..' . '/lib/public/Files/UnseekableException.php',

--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -40,6 +40,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Template\FileCreatedFromTemplateEvent;
 use OCP\Files\Template\ICustomTemplateProvider;
 use OCP\Files\Template\ITemplateManager;
+use OCP\Files\Template\RegisterTemplateCreatorEvent;
 use OCP\Files\Template\Template;
 use OCP\Files\Template\TemplateFileCreator;
 use OCP\IConfig;
@@ -119,6 +120,7 @@ class TemplateManager implements ITemplateManager {
 		if (!empty($this->types)) {
 			return $this->types;
 		}
+		$this->eventDispatcher->dispatchTyped(new RegisterTemplateCreatorEvent($this));
 		foreach ($this->registeredTypes as $registeredType) {
 			$this->types[] = $registeredType();
 		}

--- a/lib/public/Files/Template/RegisterTemplateCreatorEvent.php
+++ b/lib/public/Files/Template/RegisterTemplateCreatorEvent.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright Copyright (c) 2024 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCP\Files\Template;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * @since 30.0.0
+ */
+class RegisterTemplateCreatorEvent extends Event {
+
+	/**
+	 * @since 30.0.0
+	 */
+	public function __construct(
+		private ITemplateManager $templateManager
+	) {
+	}
+
+	/**
+	 * @since 30.0.0
+	 */
+	public function getTemplateManager(): ITemplateManager {
+		return $this->templateManager;
+	}
+}


### PR DESCRIPTION
This allows for lazy registration of template creators (which are objects that define how a new file can be created for apps like text/collabora/onlyoffice)

While generally I'd prefer to move this to the register method instead of using an event this requires some API redesign so this event is a quick solution.

Contributes to #44951 