### PR TITLE
perf(ILockManager): Allow registering a lock provider lazy

### DIFF
--- a/lib/private/Files/Lock/LockManager.php
+++ b/lib/private/Files/Lock/LockManager.php
@@ -7,8 +7,11 @@ use OCP\Files\Lock\ILockManager;
 use OCP\Files\Lock\ILockProvider;
 use OCP\Files\Lock\LockContext;
 use OCP\PreConditionNotMetException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 class LockManager implements ILockManager {
+	private ?string $lockProviderClass = null;
 	private ?ILockProvider $lockProvider = null;
 	private ?LockContext $lockInScope = null;
 
@@ -20,12 +23,34 @@ class LockManager implements ILockManager {
 		$this->lockProvider = $lockProvider;
 	}
 
+	public function registerLazyLockProvider(string $lockProviderClass): void {
+		if ($this->lockProviderClass || $this->lockProvider) {
+			throw new PreConditionNotMetException('There is already a registered lock provider');
+		}
+
+		$this->lockProviderClass = $lockProviderClass;
+	}
+
+	private function getLockProvider(): ?ILockProvider {
+		if ($this->lockProvider) {
+			return $this->lockProvider;
+		}
+		if ($this->lockProviderClass) {
+			try {
+				$this->lockProvider = \OCP\Server::get($this->lockProviderClass);
+			} catch (NotFoundExceptionInterface|ContainerExceptionInterface $e) {
+			}
+		}
+
+		return $this->lockProvider;
+	}
+
 	public function isLockProviderAvailable(): bool {
-		return $this->lockProvider !== null;
+		return $this->getLockProvider() !== null;
 	}
 
 	public function runInScope(LockContext $lock, callable $callback): void {
-		if (!$this->lockProvider) {
+		if (!$this->getLockProvider()) {
 			$callback();
 			return;
 		}
@@ -47,26 +72,26 @@ class LockManager implements ILockManager {
 	}
 
 	public function getLocks(int $fileId): array {
-		if (!$this->lockProvider) {
+		if (!$this->getLockProvider()) {
 			throw new PreConditionNotMetException('No lock provider available');
 		}
 
-		return $this->lockProvider->getLocks($fileId);
+		return $this->getLockProvider()->getLocks($fileId);
 	}
 
 	public function lock(LockContext $lockInfo): ILock {
-		if (!$this->lockProvider) {
+		if (!$this->getLockProvider()) {
 			throw new PreConditionNotMetException('No lock provider available');
 		}
 
-		return $this->lockProvider->lock($lockInfo);
+		return $this->getLockProvider()->lock($lockInfo);
 	}
 
 	public function unlock(LockContext $lockInfo): void {
-		if (!$this->lockProvider) {
+		if (!$this->getLockProvider()) {
 			throw new PreConditionNotMetException('No lock provider available');
 		}
 
-		$this->lockProvider->unlock($lockInfo);
+		$this->getLockProvider()->unlock($lockInfo);
 	}
 }

--- a/lib/public/Files/Lock/ILockManager.php
+++ b/lib/public/Files/Lock/ILockManager.php
@@ -42,8 +42,16 @@ interface ILockManager extends ILockProvider {
 	/**
 	 * @throws PreConditionNotMetException if there is already a lock provider registered
 	 * @since 24.0.0
+	 * @deprecated 30.0.0 Use registerLazyLockProvider
 	 */
 	public function registerLockProvider(ILockProvider $lockProvider): void;
+
+	/**
+	 * @param string $lockProviderClass
+	 * @return void
+	 * @since 30.0.0
+	 */
+	public function registerLazyLockProvider(string $lockProviderClass): void;
 
 	/**
 	 * @return bool


### PR DESCRIPTION
In order to register the lock provider without directly initializing required dependencies through DI we need to register it lazy.

As the LockManager is only handling registration/delegation of method calls it doesn't come with its own dependencies and therefore is enough to handle this. We could also move this to a dedicated registerLockProvider method but as of now there is just one use case with the files_lock app and this seems too little to justify for a explicit registration method.

Contributes to https://github.com/nextcloud/server/issues/44951

Required for https://github.com/nextcloud/files_lock/pull/297