### PR TITLE
fix(contactsMenu): Attach user cloud to each contact entry

### DIFF
--- a/core/src/components/UnifiedSearch/SearchableList.vue
+++ b/core/src/components/UnifiedSearch/SearchableList.vue
@@ -46,7 +46,8 @@
 						:wide="true"
 						@click="itemSelected(element)">
 						<template #icon>
-							<NcAvatar :user="element.user" :show-user-status="false" :hide-favorite="false" />
+							<NcAvatar v-if="element.isUser" :user="element.user"  :show-user-status="false" :hide-favorite="false" />
+							<NcAvatar v-else :url="element.avatar"  :show-user-status="false" :hide-favorite="false" />
 						</template>
 						{{ element.displayName }}
 					</NcButton>
@@ -117,7 +118,6 @@ export default {
 			})
 		},
 	},
-
 	methods: {
 		clearSearch() {
 			this.searchTerm = ''
@@ -128,6 +128,7 @@ export default {
 			this.opened = false
 		},
 		searchTermChanged(term) {
+			console.debug('Users (search)', this.filteredList) // WIP, would remove
 			this.$emit('search-term-change', term)
 		},
 	},

--- a/core/src/services/UnifiedSearchService.js
+++ b/core/src/services/UnifiedSearchService.js
@@ -116,6 +116,7 @@ export async function getContacts({ searchTerm }) {
 			id: authenticatedUser.uid,
 			fullName: authenticatedUser.displayName,
 			emailAddresses: [],
+			isUser: true,
 		  }
 		contacts.unshift(authenticatedUser)
 		return contacts

--- a/core/src/views/UnifiedSearchModal.vue
+++ b/core/src/views/UnifiedSearchModal.vue
@@ -383,6 +383,7 @@ export default {
 		},
 		mapContacts(contacts) {
 			return contacts.map(contact => {
+				console.debug('CONTACT VIEW', contact) // WIP would remove
 				return {
 					// id: contact.id,
 					// name: '',
@@ -391,6 +392,8 @@ export default {
 					subname: contact.emailAddresses[0] ? contact.emailAddresses[0] : '',
 					icon: '',
 					user: contact.id,
+					isUser: contact.isUser,
+					avatar: contact.avatar,
 				}
 			})
 		},

--- a/lib/private/Contacts/ContactsMenu/Entry.php
+++ b/lib/private/Contacts/ContactsMenu/Entry.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 
 namespace OC\Contacts\ContactsMenu;
 
+use OC\Federation\CloudId;
 use OCP\Contacts\ContactsMenu\IAction;
 use OCP\Contacts\ContactsMenu\IEntry;
 use function array_merge;
@@ -34,32 +35,30 @@ use function array_merge;
 class Entry implements IEntry {
 	public const PROPERTY_STATUS_MESSAGE_TIMESTAMP = 'statusMessageTimestamp';
 
-	/** @var string|int|null */
-	private $id = null;
+	public function __construct(
+		private ?string $id = null,
+		private string $fullName = '',
+		private array $emailAddresses = [],
+		private ?string $avatar = null,
+		private ?string $profileTitle = null,
+		private ?string $profileUrl = null,
+		private array $actions = [],
+		private array $properties = [],
+		private ?string $status = null,
+		private ?string $statusMessage = null,
+		private ?int $statusMessageTimestamp = null,
+		private ?string $statusIcon = null,
+		private ?CloudId $cloud = null
+	) {
+	}
 
-	private string $fullName = '';
-
-	/** @var string[] */
-	private array $emailAddresses = [];
-
-	private ?string $avatar = null;
-
-	private ?string $profileTitle = null;
-
-	private ?string $profileUrl = null;
-
-	/** @var IAction[] */
-	private array $actions = [];
-
-	private array $properties = [];
-
-	private ?string $status = null;
-	private ?string $statusMessage = null;
-	private ?int $statusMessageTimestamp = null;
-	private ?string $statusIcon = null;
 
 	public function setId(string $id): void {
 		$this->id = $id;
+	}
+
+	public function getId(): string {
+		return $this->id;
 	}
 
 	public function setFullName(string $displayName): void {
@@ -163,8 +162,25 @@ class Entry implements IEntry {
 		return $this->properties[$key];
 	}
 
+
+	public function getStatusMessage(): ?string {
+		return $this->statusMessage;
+	}
+
+	public function getStatusMessageTimestamp(): ?int {
+		return $this->statusMessageTimestamp;
+	}
+
+	public function setCloudId(CloudId $cloudId) {
+		$this->cloud = $cloudId;
+	}
+
+	public function getCloud(): CloudId {
+		return $this->cloud;
+	}
+
 	/**
-	 * @return array{id: int|string|null, fullName: string, avatar: string|null, topAction: mixed, actions: array, lastMessage: '', emailAddresses: string[], profileTitle: string|null, profileUrl: string|null, status: string|null, statusMessage: null|string, statusMessageTimestamp: null|int, statusIcon: null|string, isUser: bool, uid: mixed}
+	 * @return array{id: int|string|null, fullName: string, avatar: string|null, topAction: mixed, actions: array, lastMessage: '', emailAddresses: string[], profileTitle: string|null, profileUrl: string|null, status: string|null, statusMessage: null|string, statusMessageTimestamp: null|int, statusIcon: null|string, isUser: bool, uid: mixed, cloud: mixed}
 	 */
 	public function jsonSerialize(): array {
 		$topAction = !empty($this->actions) ? $this->actions[0]->jsonSerialize() : null;
@@ -188,14 +204,7 @@ class Entry implements IEntry {
 			'statusIcon' => $this->statusIcon,
 			'isUser' => $this->getProperty('isUser') === true,
 			'uid' => $this->getProperty('UID'),
+			'cloud' => $this->cloud,
 		];
-	}
-
-	public function getStatusMessage(): ?string {
-		return $this->statusMessage;
-	}
-
-	public function getStatusMessageTimestamp(): ?int {
-		return $this->statusMessageTimestamp;
 	}
 }

--- a/lib/private/Federation/CloudId.php
+++ b/lib/private/Federation/CloudId.php
@@ -88,4 +88,16 @@ class CloudId implements ICloudId {
 	public function getRemote(): string {
 		return $this->remote;
 	}
+
+	/**
+	 * @return array{id: string, user: string, remote: string, displayName: string|null}
+	 */
+	public function jsonSerialize(): array {
+		return [
+			'id' => $this->id,
+			'user' => $this->user,
+			'remote' => $this->remote,
+			'displayName' => $this->displayName,
+		];
+	}
 }

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -115,6 +115,19 @@ class URLGenerator implements IURLGenerator {
 		return $this->getAbsoluteURL($this->linkToRoute($routeName, $arguments));
 	}
 
+
+	public function linkToRemoteRouteAbsolute(string $remote, $routeName, array $arguments = []): string {
+		return $this->formatAsUrl($remote, $this->linkToRoute($routeName, $arguments));
+	}
+
+	private function formatAsUrl(string $baseUrl, string $restUrl): ?string {
+		$baseUrl = trim($baseUrl);
+		if (empty($baseUrl) || !filter_var(preg_match("~^(?:f|ht)tps?://~i", $baseUrl) ? $baseUrl : "http://$baseUrl", FILTER_VALIDATE_URL)) {
+			return null;
+		}
+		return filter_var($baseUrl . $restUrl, FILTER_VALIDATE_URL) ? $baseUrl . $restUrl : null;
+	}
+
 	public function linkToOCSRouteAbsolute(string $routeName, array $arguments = []): string {
 		// Returns `/subfolder/index.php/ocsapp/…` with `'htaccess.IgnoreFrontController' => false` in config.php
 		// And `/subfolder/ocsapp/…` with `'htaccess.IgnoreFrontController' => true` in config.php


### PR DESCRIPTION
The contact entry should carry cloud information, this can help to fix various issues including:

- Displaying correct avatar links for federated users

This can also lead to UI improvements in the frontend where, it's federated contacts are shown with a marker or indicator on the UI.


* Resolves: https://github.com/nextcloud/server/issues/44319

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
