### PR TITLE
chore(deps): Bump sabre/dav from 4.5.0 to 4.6.0

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -470,9 +470,6 @@ class DAV extends Common {
 				$this->client->proppatch($this->encodePath($path), ['{DAV:}lastmodified' => $mtime]);
 				// non-owncloud clients might not have accepted the property, need to recheck it
 				$response = $this->client->propfind($this->encodePath($path), ['{DAV:}getlastmodified'], 0);
-				if ($response === false) {
-					return false;
-				}
 				if (isset($response['{DAV:}getlastmodified'])) {
 					$remoteMtime = strtotime($response['{DAV:}getlastmodified']);
 					if ($remoteMtime !== $mtime) {
@@ -911,9 +908,6 @@ class DAV extends Common {
 				self::PROPFIND_PROPS,
 				1
 			);
-			if ($responses === false) {
-				return;
-			}
 
 			array_shift($responses); //the first entry is the current directory
 			if (!$this->statCache->hasKey($directory)) {


### PR DESCRIPTION
* Ref https://github.com/nextcloud/3rdparty/pull/1708

## Summary
| Production Changes | From  | To    | Compare                                                      |
|--------------------|-------|-------|--------------------------------------------------------------|
| sabre/dav          | 4.5.0 | 4.6.0 | [...](https://github.com/sabre-io/dav/compare/4.5.0...4.6.0) |
| sabre/xml          | 2.2.6 | 2.2.7 | [...](https://github.com/sabre-io/xml/compare/2.2.6...2.2.7) |


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
