### PR TITLE
chore: Add missing parameter to docblock tag psalm-taint-sink

### DIFF
--- a/lib/public/DB/QueryBuilder/IQueryBuilder.php
+++ b/lib/public/DB/QueryBuilder/IQueryBuilder.php
@@ -990,7 +990,7 @@ interface IQueryBuilder {
 	 * @return IQueryFunction
 	 * @since 8.2.0
 	 *
-	 * @psalm-taint-sink sql
+	 * @psalm-taint-sink sql $call
 	 */
 	public function createFunction($call);
 


### PR DESCRIPTION
## Summary

Fix error caught by newer psalm versions: https://github.com/nextcloud/server/actions/runs/8783970520/job/24101242428?pr=44533 (pr https://github.com/nextcloud/server/pull/44533)

> Error: lib/public/DB/QueryBuilder/IQueryBuilder.php:995:2: InvalidDocblock: @psalm-taint-sink expects 2 arguments (see https://psalm.dev/008)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
