### PR TITLE
perf(files_sharing): Move events to listener classes and registration instead of boot

### DIFF
--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -56,6 +56,8 @@ return array(
     'OCA\\Files_Sharing\\Hooks' => $baseDir . '/../lib/Hooks.php',
     'OCA\\Files_Sharing\\ISharedMountPoint' => $baseDir . '/../lib/ISharedMountPoint.php',
     'OCA\\Files_Sharing\\ISharedStorage' => $baseDir . '/../lib/ISharedStorage.php',
+    'OCA\\Files_Sharing\\Listener\\BeforeDirectFileDownloadListener' => $baseDir . '/../lib/Listener/BeforeDirectFileDownloadListener.php',
+    'OCA\\Files_Sharing\\Listener\\BeforeZipCreatedListener' => $baseDir . '/../lib/Listener/BeforeZipCreatedListener.php',
     'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => $baseDir . '/../lib/Listener/LoadAdditionalListener.php',
     'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => $baseDir . '/../lib/Listener/LoadSidebarListener.php',
     'OCA\\Files_Sharing\\Listener\\ShareInteractionListener' => $baseDir . '/../lib/Listener/ShareInteractionListener.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -71,6 +71,8 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Hooks' => __DIR__ . '/..' . '/../lib/Hooks.php',
         'OCA\\Files_Sharing\\ISharedMountPoint' => __DIR__ . '/..' . '/../lib/ISharedMountPoint.php',
         'OCA\\Files_Sharing\\ISharedStorage' => __DIR__ . '/..' . '/../lib/ISharedStorage.php',
+        'OCA\\Files_Sharing\\Listener\\BeforeDirectFileDownloadListener' => __DIR__ . '/..' . '/../lib/Listener/BeforeDirectFileDownloadListener.php',
+        'OCA\\Files_Sharing\\Listener\\BeforeZipCreatedListener' => __DIR__ . '/..' . '/../lib/Listener/BeforeZipCreatedListener.php',
         'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => __DIR__ . '/..' . '/../lib/Listener/LoadAdditionalListener.php',
         'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => __DIR__ . '/..' . '/../lib/Listener/LoadSidebarListener.php',
         'OCA\\Files_Sharing\\Listener\\ShareInteractionListener' => __DIR__ . '/..' . '/../lib/Listener/ShareInteractionListener.php',

--- a/apps/files_sharing/lib/Listener/BeforeDirectFileDownloadListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeDirectFileDownloadListener.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Sharing\Listener;
+
+use OCA\Files_Sharing\ViewOnly;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\BeforeDirectFileDownloadEvent;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+
+/**
+ * @template-implements IEventListener<BeforeDirectFileDownloadEvent|Event>
+ */
+class BeforeDirectFileDownloadListener implements IEventListener {
+
+	public function __construct(
+		private IUserSession $userSession,
+		private IRootFolder $rootFolder,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof BeforeDirectFileDownloadEvent)) {
+			return;
+		}
+
+		$pathsToCheck = [$event->getPath()];
+		// Check only for user/group shares. Don't restrict e.g. share links
+		$user = $this->userSession->getUser();
+		if ($user) {
+			$viewOnlyHandler = new ViewOnly(
+				$this->rootFolder->getUserFolder($user->getUID())
+			);
+			if (!$viewOnlyHandler->check($pathsToCheck)) {
+				$event->setSuccessful(false);
+				$event->setErrorMessage('Access to this resource or one of its sub-items has been denied.');
+			}
+		}
+	}
+}

--- a/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2019, Roeland Jago Douma <roeland@famdouma.nl>
+ *
+ * @author John Molakvoæ <skjnldsv@protonmail.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Files_Sharing\Listener;
+
+use OCA\Files_Sharing\ViewOnly;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\BeforeZipCreatedEvent;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+
+/**
+ * @template-implements IEventListener<BeforeZipCreatedEvent|Event>
+ */
+class BeforeZipCreatedListener implements IEventListener {
+
+	public function __construct(
+		private IUserSession $userSession,
+		private IRootFolder $rootFolder,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof BeforeZipCreatedEvent)) {
+			return;
+		}
+
+		$dir = $event->getDirectory();
+		$files = $event->getFiles();
+
+		$pathsToCheck = [];
+		foreach ($files as $file) {
+			$pathsToCheck[] = $dir . '/' . $file;
+		}
+
+		// Check only for user/group shares. Don't restrict e.g. share links
+		$user = $this->userSession->getUser();
+		if ($user) {
+			$viewOnlyHandler = new ViewOnly(
+				$this->rootFolder->getUserFolder($user->getUID())
+			);
+			if (!$viewOnlyHandler->check($pathsToCheck)) {
+				$event->setErrorMessage('Access to this resource or one of its sub-items has been denied.');
+				$event->setSuccessful(false);
+			} else {
+				$event->setSuccessful(true);
+			}
+		} else {
+			$event->setSuccessful(true);
+		}
+	}
+}


### PR DESCRIPTION
* Contributes to https://github.com/nextcloud/server/issues/44951

## Summary

There is no need to register event listeners in boot, instead they can be moved to the register method to be more lazy. For the two listeners that were pulling in dependencies (IRootFolder, IUserSession) those can be moved to dedicated listeners, so DI will only initialize those dependencies when actually needed.

There is still some stuff left that could be migrated separately (will require additional API changes for the mount providers for example), but those are the obvious and easy ones.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
