### PR TITLE
fix: Drop workarounds for unsupported obsolete PHP versions

### DIFF
--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -30,7 +30,6 @@
 namespace OC\App;
 
 use OCP\ICache;
-use function libxml_disable_entity_loader;
 use function simplexml_load_string;
 
 class InfoParser {
@@ -59,13 +58,7 @@ class InfoParser {
 		}
 
 		libxml_use_internal_errors(true);
-		if ((PHP_VERSION_ID < 80000)) {
-			$loadEntities = libxml_disable_entity_loader(false);
-			$xml = simplexml_load_string(file_get_contents($file));
-			libxml_disable_entity_loader($loadEntities);
-		} else {
-			$xml = simplexml_load_string(file_get_contents($file));
-		}
+		$xml = simplexml_load_string(file_get_contents($file));
 
 		if ($xml === false) {
 			libxml_clear_errors();

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -281,10 +281,6 @@ class Installer {
 				// Check if the signature actually matches the downloaded content
 				$certificate = openssl_get_publickey($app['certificate']);
 				$verified = (bool)openssl_verify(file_get_contents($tempFile), base64_decode($app['releases'][0]['signature']), $certificate, OPENSSL_ALGO_SHA512);
-				// PHP 8+ deprecates openssl_free_key and automatically destroys the key instance when it goes out of scope
-				if ((PHP_VERSION_ID < 80000)) {
-					openssl_free_key($certificate);
-				}
 
 				if ($verified === true) {
 					// Seems to match, let's proceed
@@ -305,6 +301,15 @@ class Installer {
 					$folders = array_diff($allFiles, ['.', '..']);
 					$folders = array_values($folders);
 
+					if (count($folders) < 1) {
+						throw new \Exception(
+							sprintf(
+								'Extracted app %s has no folders',
+								$appId
+							)
+						);
+					}
+
 					if (count($folders) > 1) {
 						throw new \Exception(
 							sprintf(
@@ -315,13 +320,17 @@ class Installer {
 					}
 
 					// Check if appinfo/info.xml has the same app ID as well
-					if ((PHP_VERSION_ID < 80000)) {
-						$loadEntities = libxml_disable_entity_loader(false);
-						$xml = simplexml_load_string(file_get_contents($extractDir . '/' . $folders[0] . '/appinfo/info.xml'));
-						libxml_disable_entity_loader($loadEntities);
-					} else {
-						$xml = simplexml_load_string(file_get_contents($extractDir . '/' . $folders[0] . '/appinfo/info.xml'));
+					$xml = simplexml_load_string(file_get_contents($extractDir . '/' . $folders[0] . '/appinfo/info.xml'));
+
+					if ($xml === false) {
+						throw new \Exception(
+							sprintf(
+								'Failed to load info.xml for app id %s',
+								$appId,
+							)
+						);
 					}
+
 					if ((string)$xml->id !== $appId) {
 						throw new \Exception(
 							sprintf(

--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -294,8 +294,7 @@ class OC_Image implements \OCP\IImage {
 				$retVal = imagegif($this->resource, $filePath);
 				break;
 			case IMAGETYPE_JPEG:
-				/** @psalm-suppress InvalidScalarArgument */
-				imageinterlace($this->resource, (PHP_VERSION_ID >= 80000 ? true : 1));
+				imageinterlace($this->resource, true);
 				$retVal = imagejpeg($this->resource, $filePath, $this->getJpegQuality());
 				break;
 			case IMAGETYPE_PNG:

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -73,7 +73,7 @@ class App {
 	 */
 	public function __construct(string $appName, array $urlParams = []) {
 		$runIsSetupDirectly = \OC::$server->getConfig()->getSystemValueBool('debug')
-			&& (PHP_VERSION_ID < 70400 || (PHP_VERSION_ID >= 70400 && !ini_get('zend.exception_ignore_args')));
+			&& !ini_get('zend.exception_ignore_args');
 
 		if ($runIsSetupDirectly) {
 			$applicationClassName = get_class($this);

--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -149,8 +149,7 @@ class ImageTest extends \Test\TestCase {
 		$img = new \OC_Image(null, null, $config);
 		$img->loadFromFile(OC::$SERVERROOT.'/tests/data/testimage.jpg');
 		$raw = imagecreatefromstring(file_get_contents(OC::$SERVERROOT.'/tests/data/testimage.jpg'));
-		/** @psalm-suppress InvalidScalarArgument */
-		imageinterlace($raw, (PHP_VERSION_ID >= 80000 ? true : 1));
+		imageinterlace($raw, true);
 		ob_start();
 		imagejpeg($raw, null, 80);
 		$expected = ob_get_clean();


### PR DESCRIPTION
## Summary

Drop workarounds for unsupported obsolete PHP versions, minimum PHP is now 8.1.
Also improved error handling in Installer.php to be type safe.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
