### PR TITLE
chore(deps): Bump php-opencloud/openstack from 3.2.1 to 3.10.0

### DIFF
--- a/lib/private/Files/ObjectStore/SwiftV2CachingAuthService.php
+++ b/lib/private/Files/ObjectStore/SwiftV2CachingAuthService.php
@@ -25,11 +25,14 @@ declare(strict_types=1);
  */
 namespace OC\Files\ObjectStore;
 
+use OpenStack\Common\Auth\Token;
 use OpenStack\Identity\v2\Service;
 
 class SwiftV2CachingAuthService extends Service {
 	public function authenticate(array $options = []): array {
-		if (!empty($options['v2cachedToken'])) {
+		if (isset($options['v2cachedToken'], $options['v2serviceUrl'])
+			&& $options['v2cachedToken'] instanceof Token
+			&& is_string($options['v2serviceUrl'])) {
 			return [$options['v2cachedToken'], $options['v2serviceUrl']];
 		} else {
 			return parent::authenticate($options);


### PR DESCRIPTION
* Ref https://github.com/nextcloud/3rdparty/pull/1770

## Summary

| Production Changes      | From   | To      | Compare                                                                    |
|-------------------------|--------|---------|----------------------------------------------------------------------------|
| guzzlehttp/uri-template | v0.2.0 | v1.0.3  | [...](https://github.com/guzzle/uri-template/compare/v0.2.0...v1.0.3)      |
| php-opencloud/openstack | v3.2.1 | v3.10.0 | [...](https://github.com/php-opencloud/openstack/compare/v3.2.1...v3.10.0) |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
