### PR TITLE
fix(provisioning_api): Show warning but do not fail when listing accounts in case of users removed from backend but still in database

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -59,6 +59,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
+use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
@@ -196,7 +197,14 @@ class UsersController extends AUserData {
 		$usersDetails = [];
 		foreach ($users as $userId) {
 			$userId = (string) $userId;
-			$userData = $this->getUserData($userId);
+			try {
+				$userData = $this->getUserData($userId);
+			} catch (OCSNotFoundException $e) {
+				// We still want to return all other accounts, but this one was removed from the backends
+				// yet they are still in our database. Might be a LDAP remnant.
+				$userData = null;
+				$this->logger->warning('Found one enabled account that is removed from its backend, but still exists in Nextcloud database', ['accountId' => $userId]);
+			}
 			// Do not insert empty entry
 			if ($userData !== null) {
 				$usersDetails[$userId] = $userData;
@@ -269,12 +277,19 @@ class UsersController extends AUserData {
 
 		$usersDetails = [];
 		foreach ($users as $userId) {
-			$userData = $this->getUserData($userId);
+			try {
+				$userData = $this->getUserData($userId);
+			} catch (OCSNotFoundException $e) {
+				// We still want to return all other accounts, but this one was removed from the backends
+				// yet they are still in our database. Might be a LDAP remnant.
+				$userData = null;
+				$this->logger->warning('Found one disabled account that was removed from its backend, but still exists in Nextcloud database', ['accountId' => $userId]);
+			}
 			// Do not insert empty entry
 			if ($userData !== null) {
 				$usersDetails[$userId] = $userData;
 			} else {
-				// Logged user does not have permissions to see this user
+				// Currently logged in user does not have permissions to see this user
 				// only showing its id
 				$usersDetails[$userId] = ['id' => $userId];
 			}


### PR DESCRIPTION
* Resolves: #43658

## Summary
E.g. if a user is deleted on LDAP but still on our database we should not hard fail when listing users, but be more resilient.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
