### PR TITLE
docs: annotate that ICalendar.getPermissions return's a bitmask of \O…

### DIFF
--- a/apps/dav/lib/CalDAV/CalendarImpl.php
+++ b/apps/dav/lib/CalDAV/CalendarImpl.php
@@ -129,6 +129,7 @@ class CalendarImpl implements ICreateFromString, IHandleImipMessage {
 
 	/**
 	 * @return int build up using \OCP\Constants
+	 * @psalm-return int-mask-of<\OCP\Constants::PERMISSION_*>
 	 * @since 13.0.0
 	 */
 	public function getPermissions(): int {

--- a/lib/public/Calendar/ICalendar.php
+++ b/lib/public/Calendar/ICalendar.php
@@ -72,6 +72,7 @@ interface ICalendar {
 
 	/**
 	 * @return int build up using \OCP\Constants
+	 * @psalm-return int-mask-of<\OCP\Constants::PERMISSION_*>
 	 * @since 13.0.0
 	 */
 	public function getPermissions(): int;


### PR DESCRIPTION
## Summary

Annotate that ICalendar.getPermissions return's a bitmask of \OCP\Constants::PERMISSION_*

## TODO

- [ ] Check Psalm
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
