### PR TITLE
fix(lib):When performing a fresh installation, the version files under /core/Migrations/ cannot be loaded, resulting in the inability to install properly.

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -222,7 +222,7 @@ class MigrationService {
 				new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
 				\RecursiveIteratorIterator::LEAVES_ONLY
 			),
-			'#^.+\\/Version[^\\/]{1,255}\\.php$#i',
+			'#^.+\Version(\d+)Date(\d+)\.php$#i',
 			\RegexIterator::GET_MATCH);
 
 		$files = array_keys(iterator_to_array($iterator));


### PR DESCRIPTION
fix(lib):When performing a fresh installation, the version files under /core/Migrations/ cannot be loaded, resulting in the inability to install properly.