### PR TITLE
fix(DAV): Migrate known exceptions to Sabre exceptions when copying

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -469,20 +469,28 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 
 	public function copyInto($targetName, $sourcePath, INode $sourceNode) {
 		if ($sourceNode instanceof File || $sourceNode instanceof Directory) {
-			$destinationPath = $this->getPath() . '/' . $targetName;
-			$sourcePath = $sourceNode->getPath();
-
-			if (!$this->fileView->isCreatable($this->getPath())) {
-				throw new \Sabre\DAV\Exception\Forbidden();
-			}
-
 			try {
-				$this->fileView->verifyPath($this->getPath(), $targetName);
-			} catch (InvalidPathException $ex) {
-				throw new InvalidPath($ex->getMessage());
-			}
+				$destinationPath = $this->getPath() . '/' . $targetName;
+				$sourcePath = $sourceNode->getPath();
 
-			return $this->fileView->copy($sourcePath, $destinationPath);
+				if (!$this->fileView->isCreatable($this->getPath())) {
+					throw new \Sabre\DAV\Exception\Forbidden();
+				}
+
+				try {
+					$this->fileView->verifyPath($this->getPath(), $targetName);
+				} catch (InvalidPathException $ex) {
+					throw new InvalidPath($ex->getMessage());
+				}
+
+				return $this->fileView->copy($sourcePath, $destinationPath);
+			} catch (StorageNotAvailableException $e) {
+				throw new ServiceUnavailable($e->getMessage());
+			} catch (ForbiddenException $ex) {
+				throw new Forbidden($ex->getMessage(), $ex->getRetry());
+			} catch (LockedException $e) {
+				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
+			}
 		}
 
 		return false;


### PR DESCRIPTION
* Found while writing tests for https://github.com/nextcloud/files_accesscontrol/pull/522

## Steps

1. Create a file/folder
2. Set up access control so you can not access the item
3. Try to copy it

## Expected (After)

```
403 Forbidden

<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:o="http://owncloud.org/ns">
  <s:exception>OCA\DAV\Connector\Sabre\Exception\Forbidden</s:exception>
  <s:message>Access denied</s:message>
  <o:retry xmlns:o="o:">false</o:retry>
  <o:reason xmlns:o="o:">Access denied</o:reason>
</d:error>
```

## Actual (Before)

```
500 Internal Server Error

<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:exception>OCP\Files\ForbiddenException</s:exception>
  <s:message>Access denied</s:message>
</d:error>
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
