### PR TITLE
fix(db): Prevent two connections for single node databases

### DIFF
--- a/tests/lib/DB/ConnectionTest.php
+++ b/tests/lib/DB/ConnectionTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\DB;
+
+use Doctrine\DBAL\Configuration;
+use Doctrine\DBAL\Driver;
+use Doctrine\DBAL\Driver\Connection as DriverConnection;
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use OC\DB\Adapter;
+use OC\DB\Connection;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class ConnectionTest extends TestCase {
+
+	public function testSingleNodeConnectsToPrimaryOnly(): void {
+		$connectionParams = [
+			'user' => 'test',
+			'password' => 'topsecret',
+			'host' => 'test',
+		];
+		$adapter = $this->createMock(Adapter::class);
+		$driver = $this->createMock(Driver::class);
+		$configuration = $this->createMock(Configuration::class);
+		$connection = $this->getMockBuilder(Connection::class)
+			->onlyMethods(['connectTo'])
+			->setConstructorArgs([
+				[
+					'adapter' => $adapter,
+					'platform' => new MySQLPlatform(),
+					'tablePrefix' => 'nctest',
+					'primary' => $connectionParams,
+					'replica' => [
+						$connectionParams,
+					],
+				],
+				$driver,
+				$configuration,
+			])
+			->getMock();
+		$driverConnection = $this->createMock(DriverConnection::class);
+		$connection->expects(self::once())
+			->method('connectTo')
+			->with('primary')
+			->willReturn($driverConnection);
+
+		$connection->ensureConnectedToReplica();
+		$connection->ensureConnectedToPrimary();
+		$connection->ensureConnectedToReplica();
+	}
+
+	public function testClusterConnectsToPrimaryAndReplica(): void {
+		$connectionParamsPrimary = [
+			'user' => 'test',
+			'password' => 'topsecret',
+			'host' => 'testprimary',
+		];
+		$connectionParamsReplica = [
+			'user' => 'test',
+			'password' => 'topsecret',
+			'host' => 'testreplica',
+		];
+		$adapter = $this->createMock(Adapter::class);
+		$driver = $this->createMock(Driver::class);
+		$configuration = $this->createMock(Configuration::class);
+		$connection = $this->getMockBuilder(Connection::class)
+			->onlyMethods(['connectTo'])
+			->setConstructorArgs([
+				[
+					'adapter' => $adapter,
+					'platform' => new MySQLPlatform(),
+					'tablePrefix' => 'nctest',
+					'primary' => $connectionParamsPrimary,
+					'replica' => [
+						$connectionParamsReplica,
+					],
+				],
+				$driver,
+				$configuration,
+			])
+			->getMock();
+		$driverConnection = $this->createMock(DriverConnection::class);
+		$connection->expects(self::exactly(2))
+			->method('connectTo')
+			->willReturn($driverConnection);
+
+		$connection->ensureConnectedToReplica();
+		$connection->ensureConnectedToPrimary();
+		$connection->ensureConnectedToReplica();
+	}
+
+}


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/45003

## Summary

### Two connections to one database node

Since https://github.com/nextcloud/server/pull/41998 our connection always extends Doctrine's PrimaryReadReplicaConnection. This baseclass requires a primary and at least one replica and always does the read-write split.
For simpler Nextcloud installations we only have one database node and no replica. We do not want two database connections.
This overwrites the ``\Doctrine\DBAL\Connections\PrimaryReadReplicaConnection::performConnect`` method so we always connect to the primary if there is no replica. If there is one, we do the Doctrine read-write split.

### ~~Missing transaction isolation level for replica~~

~~Nextcloud uses READ COMMITTED as transaction isolation level. Setting it for the session was missing for the replica connections.~~ Reverted because it implicitly causes a connection to the primary just to set the session variable.

## How to test - Single node

1. Set up nextcloud with a single database node (mysql, postgres, oracle)
2. Enable query logging
    I. `'log_query' => true',`
    II. `'query_log_file' => '/var/www/nextcloud/data/query.log',`
3. Send some requests

master: you see replica and primary connections prefixes for the logged queries. That indicates that Nextcloud opens two connections per request.
here: you only see primary connections. That indicates that Nextcloud only opens one connection per request.

## How to test - Cluster

 1. Set up nextcloud with a single database node (mysql, postgres, oracle)
 2. Add a fake replica by using a different hostname
3. Enable query logging
    I. `'log_query' => true',`
    II. `'query_log_file' => '/var/www/nextcloud/data/query.log',`
4. Send some requests

master and here: Nextcloud opens two connections.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
