### PR TITLE
fix: update last_login timestamp for token based-logins

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -334,6 +334,7 @@ class Session implements IUserSession, Emitter {
 		if ($isToken) {
 			$this->setToken($loginDetails['token']->getId());
 			$this->lockdownManager->setToken($loginDetails['token']);
+			$user->updateLastLoginTimestamp();
 			$firstTimeLogin = false;
 		} else {
 			$this->setToken(null);


### PR DESCRIPTION
* Resolves: #31075
* maybe Resolves: #32953
* fix https://github.com/nextcloud/server/issues/45983 

## Summary

Currently, the last login timestamp of a user is only updated when he logs in with his password. Since token-based logins do not update the timestamp, it may appear as if the user is inactive although he is regularly logged in with token-based clients (desktop client, mobile app, ...).

For this reason, the last_login timestamp should be updated for each individual login.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
