### PR TITLE
Avoid updating the same oc_authtoken row twice

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -370,7 +370,7 @@ $CONFIG = [
  * Tokens are still checked every 5 minutes for validity
  * max value: 300
  *
- * Defaults to ``300``
+ * Defaults to ``60``
  */
 'token_auth_activity_update' => 60,
 

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -308,6 +308,8 @@ class PublicKeyTokenProvider implements IProvider {
 		if (!($token instanceof PublicKeyToken)) {
 			throw new InvalidTokenException("Invalid token type");
 		}
+		$now = $this->time->getTime();
+		$token->setLastActivity($now);
 		$this->mapper->update($token);
 		$this->cacheToken($token);
 	}


### PR DESCRIPTION
- **docs: Update token_auth_activity_update default value to match implementation**
- **fix: Always set last activity if we update the row of an authtoken anyways**

## Summary

Checking out query frequency on an instance I noticed that the following two queries roughly are happening quite frequently and checking the code I noticed that it might happen that we issue two update queries for the same row in a request.

    UPDATE `oc_authtoken` SET `last_check` = ? WHERE `id` = ?
    UPDATE `oc_authtoken` SET `last_activity` = ? WHERE ( `id` = ? ) AND ( `last_activity` < ? )


If we update the last_checked value of a row anyways I think we could directly also set the last activity value to avoid double updates of that row.

This is triggered from https://github.com/nextcloud/server/blob/ec5133b739eabc76271789504b4dbb91a534f552/lib/private/User/Session.php#L818-L829 where checkTokenCredentials might update the last_check value and updateTokenActivity could then perform a second update just for the activity.

I could verify this by manually `update oc_authtoken set last_check = 0, last_activity = 0;` to simulate older timestampts and stepping through the next request with a debugger