### PR TITLE
fix(argon2): respect max value for hashingThreads

### DIFF
--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -39,10 +39,14 @@ class Hasher implements IHasher {
 	public function __construct(
 		private IConfig $config,
 	) {
-		if (\defined('PASSWORD_ARGON2ID') || \defined('PASSWORD_ARGON2I')) {
-			// password_hash fails, when the minimum values are undershot.
-			// In this case, apply minimum.
-			$this->options['threads'] = max($this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_THREADS), 1);
+		if (\defined('PASSWORD_ARGON2_PROVIDER')) {
+			// password_hash fails, when the minimum values are undershot or maximum overshot
+			// In this case, apply minimum/maximum.
+			if (PASSWORD_ARGON2_PROVIDER === 'sodium') {
+				$this->options['threads'] = 1;
+			} else { // standard (libargon) or openssl
+				$this->options['threads'] = max($this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_THREADS), 1);
+			}
 			// The minimum memory cost is 8 KiB per thread.
 			$this->options['memory_cost'] = max($this->config->getSystemValueInt('hashingMemoryCost', PASSWORD_ARGON2_DEFAULT_MEMORY_COST), $this->options['threads'] * 8);
 			$this->options['time_cost'] = max($this->config->getSystemValueInt('hashingTimeCost', PASSWORD_ARGON2_DEFAULT_TIME_COST), 1);

--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -39,10 +39,15 @@ class Hasher implements IHasher {
 	public function __construct(
 		private IConfig $config,
 	) {
-		if (\defined('PASSWORD_ARGON2ID') || \defined('PASSWORD_ARGON2I')) {
-			// password_hash fails, when the minimum values are undershot.
-			// In this case, apply minimum.
-			$this->options['threads'] = max($this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_THREADS), 1);
+		if (\defined('PASSWORD_ARGON2_PROVIDER')) {
+			// password_hash fails, when the minimum values are undershot or maximum overshot. So apply minimum/maximum.
+			/** @psalm-suppress TypeDoesNotContainType - The constant defaults to "standard" but when sodium is installed it will be "sodium" */
+			if (PASSWORD_ARGON2_PROVIDER === 'sodium') {
+				$this->options['threads'] = 1;
+			} else {
+				// standard (libargon) or openssl
+				$this->options['threads'] = max($this->config->getSystemValueInt('hashingThreads', PASSWORD_ARGON2_DEFAULT_THREADS), 1);
+			}
 			// The minimum memory cost is 8 KiB per thread.
 			$this->options['memory_cost'] = max($this->config->getSystemValueInt('hashingMemoryCost', PASSWORD_ARGON2_DEFAULT_MEMORY_COST), $this->options['threads'] * 8);
 			$this->options['time_cost'] = max($this->config->getSystemValueInt('hashingTimeCost', PASSWORD_ARGON2_DEFAULT_TIME_COST), 1);


### PR DESCRIPTION
## Summary

When argon2 password hashing is provided bu sodium extension, threads is not supported, so value > 1 raise an exception

See https://github.com/php/php-src/blob/PHP-8.1.28/ext/sodium/sodium_pwhash.c#L65

Threads are only supported by standard extension (libargon2) and soon by openssl extension (with OpenSSL 3.2 and PHP 8.4)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
