### PR TITLE
fix(settings): hide up-to-date message during load

### DIFF
--- a/apps/settings/src/components/AppList.vue
+++ b/apps/settings/src/components/AppList.vue
@@ -14,7 +14,7 @@
 			<template v-if="useListView">
 				<div v-if="showUpdateAll" class="apps-list__toolbar">
 					{{ n('settings', '%n app has an update available', '%n apps have an update available', counter) }}
-					<NcButton v-if="showUpdateAll"
+					<NcButton
 						id="app-list-update-all"
 						type="primary"
 						@click="updateAll">
@@ -22,7 +22,7 @@
 					</NcButton>
 				</div>
 
-				<div v-if="!showUpdateAll" class="apps-list__toolbar">
+				<div v-else-if="!loading" class="apps-list__toolbar">
 					{{ t('settings', 'All apps are up-to-date.') }}
 				</div>
 


### PR DESCRIPTION
## Summary

During loading of the AppList the message 'All apps are up-to-date.' was always shown even if there were updates available afterwards.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
