### PR TITLE
[stable27] fix: Wait until file has been added to filelist before opening

### DIFF
--- a/apps/files/src/views/TemplatePicker.vue
+++ b/apps/files/src/views/TemplatePicker.vue
@@ -217,24 +217,25 @@ export default {
 				this.logger.debug('Created new file', fileInfo)
 
 				// Fetch FileInfo and model
-				const data = await fileList?.addAndFetchFileInfo(this.name).then((status, data) => data)
-				const model = new OCA.Files.FileInfoModel(data, {
-					filesClient: fileList?.filesClient,
-				})
-
-				// Run default action
-				const fileAction = OCA.Files.fileActions.getDefaultFileAction(fileInfo.mime, 'file', OC.PERMISSION_ALL)
-				if (fileAction) {
-					fileAction.action(fileInfo.basename, {
-						$file: fileList?.findFileEl(this.name),
-						dir: currentDirectory,
-						fileList,
-						fileActions: fileList?.fileActions,
-						fileInfoModel: model,
+				fileList?.addAndFetchFileInfo(this.name).then((status, data) => {
+					const model = new OCA.Files.FileInfoModel(data, {
+						filesClient: fileList?.filesClient,
 					})
-				}
 
-				this.close()
+					// Run default action
+					const fileAction = OCA.Files.fileActions.getDefaultFileAction(fileInfo.mime, 'file', OC.PERMISSION_ALL)
+					if (fileAction) {
+						fileAction.action(fileInfo.basename, {
+							$file: fileList?.findFileEl(this.name),
+							dir: currentDirectory,
+							fileList,
+							fileActions: fileList?.fileActions,
+							fileInfoModel: model,
+						})
+					}
+
+					this.close()
+				})
 			} catch (error) {
 				this.logger.error('Error while creating the new file from template')
 				console.error(error)


### PR DESCRIPTION
When creating a new file from a template there is a race condition between the file opening and adding the entry to the file list (which is required by some apps like ONLYOFFICE to obtain further info).

This can be reproduced by setting browser throttling of network connections to be very slow with ONLYOFFICE.

In order to fix that we should wait for the success callback of addAndFetchFileInfo before we continue any further and try to open the file. Await is not working here due to [the usage of `$.Deferred()`](https://github.com/nextcloud/server/blob/abcbea3eac9f2ec4bcb9b8b318d67728423092c9/apps/files/js/filelist.js#L3160)