### PR TITLE
feat(exception-template): allow to link to specific documentation for how to retreive server log

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2242,6 +2242,11 @@ $CONFIG = [
 'upgrade.cli-upgrade-link' => '',
 
 /**
+ * Allows to modify the exception server logs documentation link in order to link to a different documentation
+ */
+'documentation_url.server_logs' => '',
+
+/**
  * Set this Nextcloud instance to debugging mode
  *
  * Only enable this for local development and not in production environments

--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -26,7 +26,7 @@ function print_exception(Throwable $e, \OCP\IL10N $l): void {
 	<p><?php p($l->t('If this happens again, please send the technical details below to the server administrator.')) ?></p>
 	<p><?php p($l->t('More details can be found in the server log.')) ?></p>
 	<?php if (isset($_['serverLogsDocumentation']) && $_['serverLogsDocumentation'] !== ''): ?>
-		<p><a href="<?php print_unescaped($_['serverLogsDocumentation']) ?>" target="_blank" rel="noopener"><?php p($l->t('See this documentation how to retreive them.')) ?></a></p>
+		<p><a href="<?php print_unescaped($_['serverLogsDocumentation']) ?>" target="_blank" rel="noopener"><?php p($l->t('For more details see the documentation ↗.')) ?></a></p>
 	<?php endif; ?>
 
 	<h3><?php p($l->t('Technical details')) ?></h3>

--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -25,6 +25,9 @@ function print_exception(Throwable $e, \OCP\IL10N $l): void {
 	<p><?php p($l->t('The server was unable to complete your request.')) ?></p>
 	<p><?php p($l->t('If this happens again, please send the technical details below to the server administrator.')) ?></p>
 	<p><?php p($l->t('More details can be found in the server log.')) ?></p>
+	<?php if (isset($_['serverLogsDocumentation']) && $_['serverLogsDocumentation'] !== ''): ?>
+		<p><a href="<?php print_unescaped($_['serverLogsDocumentation']) ?>" target="_blank" rel="noopener"><?php p($l->t('See this documentation how to retreive them.')) ?></a></p>
+	<?php endif; ?>
 
 	<h3><?php p($l->t('Technical details')) ?></h3>
 	<ul>

--- a/lib/private/legacy/OC_Template.php
+++ b/lib/private/legacy/OC_Template.php
@@ -306,6 +306,7 @@ class OC_Template extends \OC\Template\Base {
 		http_response_code($statusCode);
 		try {
 			$debug = \OC::$server->getSystemConfig()->getValue('debug', false);
+			$serverLogsDocumentation = \OC::$server->getSystemConfig()->getValue('documentation_url.server_logs', '');
 			$request = \OC::$server->getRequest();
 			$content = new \OC_Template('', 'exception', 'error', false);
 			$content->assign('errorClass', get_class($exception));
@@ -315,6 +316,7 @@ class OC_Template extends \OC\Template\Base {
 			$content->assign('line', $exception->getLine());
 			$content->assign('exception', $exception);
 			$content->assign('debugMode', $debug);
+			$content->assign('serverLogsDocumentation', $serverLogsDocumentation);
 			$content->assign('remoteAddr', $request->getRemoteAddress());
 			$content->assign('requestID', $request->getId());
 			$content->printPage();


### PR DESCRIPTION
The idea is to allow to link to a certain documentation whenever the exception template comes up which is useful e.g. for AIO so that people can go to the correct directly without having to open a new thread for it.

![image](https://github.com/nextcloud/server/assets/42591237/41442293-81f2-46c3-8235-f1eb3d208f9f)
