### PR TITLE
perf(db): Sort data for IN before chunking

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -620,6 +620,9 @@ class Cache implements ICache {
 		$query->delete('filecache')
 			->whereParentInParameter('parentIds');
 
+		// Sorting before chunking allows the db to find the entries close to each
+		// other in the index
+		sort($parentIds, SORT_NUMERIC);
 		foreach (array_chunk($parentIds, 1000) as $parentIdChunk) {
 			$query->setParameter('parentIds', $parentIdChunk, IQueryBuilder::PARAM_INT_ARRAY);
 			$query->execute();


### PR DESCRIPTION
## Summary

Nextcloud sends chunks of `DELETE FROM oc_filecache WHERE parentid IN (....long list...)` and *sometimes* MariaDB does not seem to pick up the index. Apparently this may happen when the query analyzer thinks it's cheaper to scan the table than to traverse the index. If we put the data of the chunks closer together, we can hopefully convince the db that the index is the faster choice.

@juliushaertl @nickvergessen as it was suggested to us.

I don't know how to trigger this code with lots of data so this is more or less untested.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
