### PR TITLE
Fix Issue #44364 get rid of the additional margin 

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -108,3 +108,7 @@
 
 AddDefaultCharset utf-8
 Options -Indexes
+#### DO NOT CHANGE ANYTHING ABOVE THIS LINE ####
+
+ErrorDocument 403 /index.php/error/403
+ErrorDocument 404 /index.php/error/404

--- a/core/css/styles.scss
+++ b/core/css/styles.scss
@@ -79,7 +79,7 @@ a {
 }
 
 a.external {
-	margin: 0 3px;
+	margin: 0px;
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
* Resolves: #44364 

- Co-authored-by: JEEEEEEEEEEEEEEEEEEEEEED <jed.boulahya@medtech.tn> @jadjoud 

## Summary
fix the margin to make the link aligned with the other tasks by setting the margins for the links to 0px rather than 0 3px.

## before 
![Before](https://github.com/nextcloud/server/assets/130870871/e8fece3f-2559-4a0f-be1f-234550cd67e9)

## after
![after](https://github.com/nextcloud/server/assets/130870871/4bbf6bf8-8c71-4a12-9055-e7affd0c2317)

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
