### PR TITLE
fix: make `trusted_domains` and `overwrite.cli.url` sensitive config values

### DIFF
--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -64,6 +64,8 @@ class SystemConfig {
 		'zammad.secret' => true,
 		'github.client_id' => true,
 		'github.client_secret' => true,
+		'trusted_domains' => true,
+		'overwrite.cli.url' => true,
 		'log.condition' => [
 			'shared_secret' => true,
 		],


### PR DESCRIPTION
* Resolves: #45080 

## Summary

Add `trusted_domains` and `overwrite.cli.url` to the list of sensitive configuration parameters.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
