### PR TITLE
Education "bundle"

### DIFF
--- a/cypress/e2e/settings/apps.cy.ts
+++ b/cypress/e2e/settings/apps.cy.ts
@@ -123,7 +123,7 @@ describe('Settings: App management', { testIsolation: true }, () => {
 		cy.get('#app-category-your-bundles').find('.active').should('exist')
 		// I see the app bundles
 		cy.get('#apps-list').contains('tr', 'Enterprise bundle')
-		cy.get('#apps-list').contains('tr', 'Education Edition')
+		cy.get('#apps-list').contains('tr', 'Education bundle')
 		// I see that the "Enterprise bundle" is disabled
 		cy.get('#apps-list').contains('tr', 'Enterprise bundle').contains('button', 'Download and enable all')
 	})

--- a/lib/private/App/AppStore/Bundles/EducationBundle.php
+++ b/lib/private/App/AppStore/Bundles/EducationBundle.php
@@ -10,7 +10,7 @@ class EducationBundle extends Bundle {
 	 * {@inheritDoc}
 	 */
 	public function getName() {
-		return $this->l10n->t('Education Edition');
+		return $this->l10n->t('Education bundle');
 	}
 
 	/**

--- a/tests/lib/App/AppStore/Bundles/EducationBundleTest.php
+++ b/tests/lib/App/AppStore/Bundles/EducationBundleTest.php
@@ -13,7 +13,7 @@ class EducationBundleTest extends BundleBase {
 		parent::setUp();
 		$this->bundle = new EducationBundle($this->l10n);
 		$this->bundleIdentifier = 'EducationBundle';
-		$this->bundleName = 'Education Edition';
+		$this->bundleName = 'Education bundle';
 		$this->bundleAppIds = [
 			'dashboard',
 			'circles',


### PR DESCRIPTION
Because all other application groupings use the word “bundle”.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
