### PR TITLE
fix(search): show user search provider for deactivated and admin pages

### DIFF
--- a/apps/settings/lib/Search/UserSearch.php
+++ b/apps/settings/lib/Search/UserSearch.php
@@ -47,7 +47,7 @@ class UserSearch implements IProvider {
 	}
 
 	public function getOrder(string $route, array $routeParameters): ?int {
-		return $route === 'settings.Users.usersList'
+		return str_starts_with($route, 'settings.Users.usersList')
 			? 300
 			: null;
 	}


### PR DESCRIPTION
## Summary
Display user search provider in "Places" when browsing disabled and admin users

Backend part of #44936