### PR TITLE
fix(session): Avoid race condition for cache::get() vs. cache::hasKey()

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -192,11 +192,11 @@ class PublicKeyTokenProvider implements IProvider {
 	 */
 	private function getTokenFromCache(string $tokenHash): ?PublicKeyToken {
 		$serializedToken = $this->cache->get($tokenHash);
-		if ($serializedToken === null) {
-			if ($this->cache->hasKey($tokenHash)) {
-				throw new InvalidTokenException('Token does not exist: ' . $tokenHash);
-			}
+		if ($serializedToken === false) {
+			throw new InvalidTokenException('Token does not exist: ' . $tokenHash);
+		}
 
+		if ($serializedToken === null) {
 			return null;
 		}
 
@@ -211,9 +211,9 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->cache->set($token->getToken(), serialize($token), self::TOKEN_CACHE_TTL);
 	}
 
-	private function cacheInvalidHash(string $tokenHash) {
+	private function cacheInvalidHash(string $tokenHash): void {
 		// Invalid entries can be kept longer in cache since it’s unlikely to reuse them
-		$this->cache->set($tokenHash, null, self::TOKEN_CACHE_TTL * 2);
+		$this->cache->set($tokenHash, false, self::TOKEN_CACHE_TTL * 2);
 	}
 
 	public function getTokenById(int $tokenId): OCPIToken {


### PR DESCRIPTION
- Follow up to https://github.com/nextcloud/server/pull/44446


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
