### PR TITLE
[stable29] fix(files): Fix ownership transfer encrypted files detection

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -244,7 +244,7 @@ class OwnershipTransferService {
 
 		$encryptedFiles = [];
 		$this->walkFiles($view, $sourcePath,
-			function (FileInfo $fileInfo) use ($progress) {
+			function (FileInfo $fileInfo) use ($progress, &$encryptedFiles) {
 				if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
 					// only analyze into folders from main storage,
 					if (!$fileInfo->getStorage()->instanceOfStorage(IHomeStorage::class)) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Backport commit from #44533

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
