### PR TITLE
[stable29] fix(setupchecks): Fix opcache buffer check

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
+++ b/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
@@ -102,9 +102,11 @@ class PhpOpcacheSetup implements ISetupCheck {
 				$recommendations[] = $this->l10n->t('The OPcache buffer is nearly full. To assure that all scripts can be hold in cache, it is recommended to apply "opcache.memory_consumption" to your PHP configuration with a value higher than "%s".', [($this->iniGetWrapper->getNumeric('opcache.memory_consumption') ?: 'currently')]);
 			}
 
+			$interned_strings_buffer = $this->iniGetWrapper->getNumeric('opcache.interned_strings_buffer') ?? 0;
+			$memory_consumption = $this->iniGetWrapper->getNumeric('opcache.memory_consumption') ?? 0;
 			if (
 				// Do not recommend to raise the interned strings buffer size above a quarter of the total OPcache size
-				($this->iniGetWrapper->getNumeric('opcache.interned_strings_buffer') ?? $this->iniGetWrapper->getNumeric('opcache.memory_consumption') > 0 ?? 0 / 4) &&
+				($interned_strings_buffer < ($memory_consumption / 4)) &&
 				(
 					empty($status['interned_strings_usage']['free_memory']) ||
 					($status['interned_strings_usage']['used_memory'] / $status['interned_strings_usage']['free_memory'] > 9)


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Backport commit from #44533

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
