### PR TITLE
fix: Return a file element even if the rendered list does not contained one

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -1357,8 +1357,18 @@
 		 * @return {Object} jQuery object of the matching row
 		 */
 		findFileEl: function(fileName){
-			// use filterAttr to avoid escaping issues
-			return this.$fileList.find('tr').filterAttr('data-file', fileName);
+			var fileRow = this.$fileList.find('tr').filterAttr('data-file', fileName);
+			if (fileRow.length) {
+				return fileRow;
+			}
+
+			// The row we try to get might not have been rendered due to pagination,
+			// so in case we find the file in the file list return the rendered row instead
+			var fileData = this.files.find(function (el){
+				return el.name === fileName;
+			});
+
+			return fileData ? this._renderRow(fileData, {updateSummary: false, silent: true}) : fileRow;
 		},
 
 		/**

--- a/apps/files/tests/js/filelistSpec.js
+++ b/apps/files/tests/js/filelistSpec.js
@@ -825,7 +825,7 @@ describe('OCA.Files.FileList tests', function() {
 			// element is renamed before the request finishes
 			$tr = fileList.findFileEl('Tu_after_three.txt');
 			expect($tr.length).toEqual(1);
-			expect(fileList.findFileEl('One.txt').length).toEqual(0);
+			expect($('.files-fileList tr').find('[data-name="One.txt"]').length).toEqual(0);
 			// file actions are hidden
 			expect($tr.hasClass('busy')).toEqual(true);
 
@@ -1426,7 +1426,7 @@ describe('OCA.Files.FileList tests', function() {
 				name: 'File with index 28b.txt'
 			});
 			expect($('.files-fileList tr').length).toEqual(20);
-			expect(fileList.findFileEl('File with index 28b.txt').length).toEqual(0);
+			expect($('.files-fileList tr').find('[data-name="File with index 28b.txt"]').length).toEqual(0);
 			fileList._nextPage(true);
 			expect($('.files-fileList tr').length).toEqual(40);
 			expect(fileList.findFileEl('File with index 28b.txt').index()).toEqual(29);


### PR DESCRIPTION
Proper fix replacing https://github.com/nextcloud/server/pull/45031

When creating a file from a template we trigger a file action. This has a dependency on the file element `$el` that is used by some apps in <27 to get certain file attributes. Now while we wait for the file to be added to the file list, it might not be rendered if it is added at the end of the list outside the visible view.

This PR addresses it by adding a fallback to return the rendered row in case we could not find the element in the DOM.

Onlyoffice is one example using this https://github.com/ONLYOFFICE/onlyoffice-nextcloud/blob/master/src/main.js#L212 but there are potentially others out there as well.

Steps to reproduce:
- Setup onlyoffice
- Have a directory that has lots of files
- Create a new file Called "Z.docx" so it is put at the very end of the file list from a template

## Error before the change
<img width="1678" alt="Screenshot 2024-04-30 at 14 32 47" src="https://github.com/nextcloud/server/assets/3404133/e3652d3f-34d2-43e9-b8a4-f8cb31d07d8a">

