### PR TITLE
fix(querybuilder): Remove temporary internal method executeUpdate()

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -302,21 +302,6 @@ class QueryBuilder implements IQueryBuilder {
 		throw new \RuntimeException('Invalid return type for query');
 	}
 
-	/**
-	 * Monkey-patched compatibility layer for apps that were adapted for Nextcloud 22 before
-	 * the first beta, where executeStatement was named executeUpdate.
-	 *
-	 * Static analysis should catch those misuses, but until then let's try to keep things
-	 * running.
-	 *
-	 * @internal
-	 * @deprecated
-	 * @todo drop ASAP
-	 */
-	public function executeUpdate(): int {
-		return $this->executeStatement();
-	}
-
 	public function executeStatement(): int {
 		if ($this->getType() === \Doctrine\DBAL\Query\QueryBuilder::SELECT) {
 			throw new \RuntimeException('Invalid query type, expected INSERT, DELETE or UPDATE statement');


### PR DESCRIPTION
Couldn't find any reference anymore in any off the apps I have checked out locally.
Since it's "before first beta" I guess we are okay now to clear it

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
