### PR TITLE
fix(Authentication): correctly catch uniq constraint on token insert

### DIFF
--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -55,6 +55,7 @@ class Manager implements IProvider, OCPIProvider {
 	 * @param int $type token type
 	 * @param int $remember whether the session token should be used for remember-me
 	 * @return OCPIToken
+	 * @throws Exception
 	 */
 	public function generateToken(string $token,
 		string $uid,

--- a/tests/lib/Authentication/Token/ManagerTest.php
+++ b/tests/lib/Authentication/Token/ManagerTest.php
@@ -32,6 +32,7 @@ use OC\Authentication\Token\IToken;
 use OC\Authentication\Token\Manager;
 use OC\Authentication\Token\PublicKeyToken;
 use OC\Authentication\Token\PublicKeyTokenProvider;
+use OC\DB\Exceptions\DbalException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -79,8 +80,9 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGenerateConflictingToken() {
-		/** @var MockObject|UniqueConstraintViolationException $exception */
-		$exception = $this->createMock(UniqueConstraintViolationException::class);
+		/** @var MockObject|UniqueConstraintViolationException $parent */
+		$parent = $this->createMock(UniqueConstraintViolationException::class);
+		$exception = DbalException::wrap($parent);
 
 		$token = new PublicKeyToken();
 		$token->setUid('uid');


### PR DESCRIPTION
## TODO

- [x] Migrate from `UniqueConstraintViolationException` to `OCP\DB\Exception` in auth token manager

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
