### PR TITLE
fix(core): add fs_name_hash index to migration

### DIFF
--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -261,6 +261,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['storage', 'size', 'fileid'], 'fs_storage_size');
 			$table->addIndex(['fileid', 'storage', 'size'], 'fs_id_storage_size');
 			$table->addIndex(['parent'], 'fs_parent');
+			$table->addIndex(['name'], 'fs_name_hash');
 			$table->addIndex(['mtime'], 'fs_mtime');
 			$table->addIndex(['size'], 'fs_size');
 			if (!$schema->getDatabasePlatform() instanceof PostgreSQL94Platform) {


### PR DESCRIPTION
Automatically adds the `fs_name_hash` index for new installations. See https://github.com/nextcloud/server/pull/44586#issuecomment-2082281865