### PR TITLE
Refactors theming app - part 1

### DIFF
--- a/apps/theming/lib/Controller/IconController.php
+++ b/apps/theming/lib/Controller/IconController.php
@@ -43,33 +43,16 @@ use OCP\Files\NotFoundException;
 use OCP\IRequest;
 
 class IconController extends Controller {
-	/** @var ThemingDefaults */
-	private $themingDefaults;
-	/** @var IconBuilder */
-	private $iconBuilder;
-	/** @var ImageManager */
-	private $imageManager;
-	/** @var FileAccessHelper */
-	private $fileAccessHelper;
-	/** @var IAppManager */
-	private $appManager;
-
 	public function __construct(
 		$appName,
 		IRequest $request,
-		ThemingDefaults $themingDefaults,
-		IconBuilder $iconBuilder,
-		ImageManager $imageManager,
-		FileAccessHelper $fileAccessHelper,
-		IAppManager $appManager
+		private ThemingDefaults $themingDefaults,
+		private IconBuilder $iconBuilder,
+		private ImageManager $imageManager,
+		private FileAccessHelper $fileAccessHelper,
+		private IAppManager $appManager
 	) {
 		parent::__construct($appName, $request);
-
-		$this->themingDefaults = $themingDefaults;
-		$this->iconBuilder = $iconBuilder;
-		$this->imageManager = $imageManager;
-		$this->fileAccessHelper = $fileAccessHelper;
-		$this->appManager = $appManager;
 	}
 
 	/**

--- a/apps/theming/lib/Controller/UserThemeController.php
+++ b/apps/theming/lib/Controller/UserThemeController.php
@@ -54,33 +54,20 @@ use OCP\PreConditionNotMetException;
  * @psalm-import-type ThemingBackground from ResponseDefinitions
  */
 class UserThemeController extends OCSController {
-
 	protected ?string $userId = null;
 
-	private IConfig $config;
-	private IUserSession $userSession;
-	private ThemesService $themesService;
-	private ThemingDefaults $themingDefaults;
-	private BackgroundService $backgroundService;
-
-	public function __construct(string $appName,
+	public function __construct(
+		string $appName,
 		IRequest $request,
-		IConfig $config,
-		IUserSession $userSession,
-		ThemesService $themesService,
-		ThemingDefaults $themingDefaults,
-		BackgroundService $backgroundService) {
+		private IConfig $config,
+		private IUserSession $userSession,
+		private ThemesService $themesService,
+		private ThemingDefaults $themingDefaults,
+		private BackgroundService $backgroundService,
+	) {
 		parent::__construct($appName, $request);
-		$this->config = $config;
-		$this->userSession = $userSession;
-		$this->themesService = $themesService;
-		$this->themingDefaults = $themingDefaults;
-		$this->backgroundService = $backgroundService;
 
-		$user = $userSession->getUser();
-		if ($user !== null) {
-			$this->userId = $user->getUID();
-		}
+		$this->userId = $userSession->getUser()?->getUID();
 	}
 
 	/**

--- a/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
@@ -41,25 +41,13 @@ use Psr\Container\ContainerInterface;
 
 /** @template-implements IEventListener<BeforeTemplateRenderedEvent|BeforeLoginTemplateRenderedEvent> */
 class BeforeTemplateRenderedListener implements IEventListener {
-
-	private IInitialState $initialState;
-	private ContainerInterface $container;
-	private ThemeInjectionService $themeInjectionService;
-	private IUserSession $userSession;
-	private IConfig $config;
-
 	public function __construct(
-		IInitialState $initialState,
-		ContainerInterface $container,
-		ThemeInjectionService $themeInjectionService,
-		IUserSession $userSession,
-		IConfig $config
+		private IInitialState $initialState,
+		private ContainerInterface $container,
+		private ThemeInjectionService $themeInjectionService,
+		private IUserSession $userSession,
+		private IConfig $config,
 	) {
-		$this->initialState = $initialState;
-		$this->container = $container;
-		$this->themeInjectionService = $themeInjectionService;
-		$this->userSession = $userSession;
-		$this->config = $config;
 	}
 
 	public function handle(Event $event): void {


### PR DESCRIPTION
## Summary
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor), I have also made the required adjustments to the classes in the `theming` app.

I decided to split the changes into multiple PRs to make reviewing the changes easier.

The improvements in this PR include:

- Using PHP8's constructor property promotion
- Adding return types
- Removing redundant docblocks
- Replacing magic numbers with readable constants

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
