### PR TITLE
Refactors theming app - part 2

### DIFF
--- a/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
+++ b/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
@@ -31,18 +31,17 @@ use OCP\BackgroundJob\IJobList;
 use OCP\Migration\IOutput;
 
 class InitBackgroundImagesMigration implements \OCP\Migration\IRepairStep {
-
 	private IJobList $jobList;
 
 	public function __construct(IJobList $jobList) {
 		$this->jobList = $jobList;
 	}
 
-	public function getName() {
+	public function getName(): string {
 		return 'Initialize migration of background images from dashboard to theming app';
 	}
 
-	public function run(IOutput $output) {
+	public function run(IOutput $output): void {
 		$this->jobList->add(MigrateBackgroundImages::class, ['stage' => MigrateBackgroundImages::STAGE_PREPARE]);
 	}
 }

--- a/apps/theming/lib/Service/BackgroundService.php
+++ b/apps/theming/lib/Service/BackgroundService.php
@@ -183,11 +183,13 @@ class BackgroundService {
 	private string $userId;
 	private ThemingDefaults $themingDefaults;
 
-	public function __construct(IRootFolder $rootFolder,
+	public function __construct(
+		IRootFolder $rootFolder,
 		IAppData $appData,
 		IConfig $config,
 		?string $userId,
-		ThemingDefaults $themingDefaults) {
+		ThemingDefaults $themingDefaults,
+	) {
 		if ($userId === null) {
 			return;
 		}

--- a/apps/theming/lib/Service/JSDataService.php
+++ b/apps/theming/lib/Service/JSDataService.php
@@ -31,21 +31,12 @@ use OCA\Theming\Util;
 use OCP\IConfig;
 
 class JSDataService implements \JsonSerializable {
-	private ThemingDefaults $themingDefaults;
-	private Util $util;
-	private IConfig $appConfig;
-	private ThemesService $themesService;
-
 	public function __construct(
-		ThemingDefaults $themingDefaults,
-		Util $util,
-		IConfig $appConfig,
-		ThemesService $themesService
+		private ThemingDefaults $themingDefaults,
+		private Util $util,
+		private IConfig $appConfig,
+		private ThemesService $themesService,
 	) {
-		$this->themingDefaults = $themingDefaults;
-		$this->util = $util;
-		$this->appConfig = $appConfig;
-		$this->themesService = $themesService;
 	}
 
 	public function jsonSerialize(): array {

--- a/apps/theming/lib/Service/ThemeInjectionService.php
+++ b/apps/theming/lib/Service/ThemeInjectionService.php
@@ -30,31 +30,17 @@ use OCP\IURLGenerator;
 use OCP\IUserSession;
 
 class ThemeInjectionService {
+	private ?string $userId = null;
 
-	private IURLGenerator $urlGenerator;
-	private ThemesService $themesService;
-	private DefaultTheme $defaultTheme;
-	private Util $util;
-	private IConfig $config;
-	private ?string $userId;
-
-	public function __construct(IURLGenerator $urlGenerator,
-		ThemesService $themesService,
-		DefaultTheme $defaultTheme,
-		Util $util,
-		IConfig $config,
-		IUserSession $userSession) {
-		$this->urlGenerator = $urlGenerator;
-		$this->themesService = $themesService;
-		$this->defaultTheme = $defaultTheme;
-		$this->util = $util;
-		$this->config = $config;
-
-		if ($userSession->getUser() !== null) {
-			$this->userId = $userSession->getUser()->getUID();
-		} else {
-			$this->userId = null;
-		}
+	public function __construct(
+		private IURLGenerator $urlGenerator,
+		private ThemesService $themesService,
+		private DefaultTheme  $defaultTheme,
+		private Util $util,
+		private IConfig $config,
+		IUserSession $userSession,
+	) {
+		$this->userId = $userSession->getUser()?->getUID();
 	}
 
 	public function injectHeaders(): void {
@@ -69,12 +55,12 @@ class ThemeInjectionService {
 		$this->addThemeHeaders($defaultTheme);
 
 		// Themes applied by media queries
-		foreach($mediaThemes as $theme) {
+		foreach ($mediaThemes as $theme) {
 			$this->addThemeHeaders($theme, true, $theme->getMediaQuery());
 		}
 
 		// Themes
-		foreach($this->themesService->getThemes() as $theme) {
+		foreach ($this->themesService->getThemes() as $theme) {
 			// Ignore default theme as already processed first
 			if ($theme->getId() === $this->defaultTheme->getId()) {
 				continue;
@@ -116,9 +102,9 @@ class ThemeInjectionService {
 		$metaHeaders = [];
 
 		// Meta headers
-		foreach($this->themesService->getThemes() as $theme) {
+		foreach ($this->themesService->getThemes() as $theme) {
 			if (!empty($theme->getMeta())) {
-				foreach($theme->getMeta() as $meta) {
+				foreach ($theme->getMeta() as $meta) {
 					if (!isset($meta['name']) || !isset($meta['content'])) {
 						continue;
 					}
@@ -131,7 +117,7 @@ class ThemeInjectionService {
 			}
 		}
 
-		foreach($metaHeaders as $name => $content) {
+		foreach ($metaHeaders as $name => $content) {
 			\OCP\Util::addHeader('meta', [
 				'name' => $name,
 				'content' => join(' ', array_unique($content)),

--- a/apps/theming/lib/Service/ThemesService.php
+++ b/apps/theming/lib/Service/ThemesService.php
@@ -35,23 +35,19 @@ use OCP\IUser;
 use OCP\IUserSession;
 
 class ThemesService {
-	private IUserSession $userSession;
-	private IConfig $config;
-
 	/** @var ITheme[] */
 	private array $themesProviders;
 
-	public function __construct(IUserSession $userSession,
-		IConfig $config,
+	public function __construct(
+		private IUserSession $userSession,
+		private IConfig $config,
 		DefaultTheme $defaultTheme,
 		LightTheme $lightTheme,
 		DarkTheme $darkTheme,
 		HighContrastTheme $highContrastTheme,
 		DarkHighContrastTheme $darkHighContrastTheme,
-		DyslexiaFont $dyslexiaFont) {
-		$this->userSession = $userSession;
-		$this->config = $config;
-
+		DyslexiaFont $dyslexiaFont,
+	) {
 		// Register themes
 		$this->themesProviders = [
 			$defaultTheme->getId() => $defaultTheme,
@@ -86,7 +82,7 @@ class ThemesService {
 			return $themesIds;
 		}
 
-		/** @var ITheme[] */
+		/** @var ITheme[] $themeId */
 		$themes = array_filter(array_map(function ($themeId) {
 			return $this->getThemes()[$themeId];
 		}, $themesIds));
@@ -123,15 +119,13 @@ class ThemesService {
 			$this->setEnabledThemes($enabledThemes);
 			return $enabledThemes;
 		}
-		
+
 		return $themesIds;
 	}
 
 	/**
 	 * Check whether a theme is enabled or not
 	 * for the logged-in user
-	 *
-	 * @return bool
 	 */
 	public function isEnabled(ITheme $theme): bool {
 		$user = $this->userSession->getUser();


### PR DESCRIPTION
## Summary
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor), I have also made the required adjustments to the classes in the `theming` app.

I decided to split the changes into multiple PRs to make reviewing the changes easier.

The improvements in this PR include:

- Using PHP8's constructor property promotion
- Adding return types
- Removing redundant docblocks

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits