### PR TITLE
Refactors theming app - part 3

### DIFF
--- a/apps/theming/lib/Settings/Admin.php
+++ b/apps/theming/lib/Settings/Admin.php
@@ -40,7 +40,6 @@ use OCP\Settings\IDelegatedSettings;
 use OCP\Util;
 
 class Admin implements IDelegatedSettings {
-
 	public function __construct(
 		private string $appName,
 		private IConfig $config,

--- a/apps/theming/lib/Settings/AdminSection.php
+++ b/apps/theming/lib/Settings/AdminSection.php
@@ -27,33 +27,26 @@ use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
 
 class AdminSection implements IIconSection {
-	private string $appName;
-	private IL10N $l;
-	private IURLGenerator $url;
-
-	public function __construct(string $appName, IURLGenerator $url, IL10N $l) {
-		$this->appName = $appName;
-		$this->url = $url;
-		$this->l = $l;
+	public function __construct(
+		private string $appName,
+		private IURLGenerator $url,
+		private IL10N $l,
+	) {
 	}
 
 	/**
 	 * returns the ID of the section. It is supposed to be a lower case string,
 	 * e.g. 'ldap'
-	 *
-	 * @returns string
 	 */
-	public function getID() {
+	public function getID(): string {
 		return $this->appName;
 	}
 
 	/**
 	 * returns the translated name as it should be displayed, e.g. 'LDAP / AD
 	 * integration'. Use the L10N service to translate it.
-	 *
-	 * @return string
 	 */
-	public function getName() {
+	public function getName(): string {
 		return $this->l->t('Theming');
 	}
 
@@ -64,14 +57,14 @@ class AdminSection implements IIconSection {
 	 *
 	 * E.g.: 70
 	 */
-	public function getPriority() {
+	public function getPriority(): int {
 		return 30;
 	}
 
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getIcon() {
+	public function getIcon(): string {
 		return $this->url->imagePath($this->appName, 'app-dark.svg');
 	}
 }

--- a/apps/theming/lib/Settings/Personal.php
+++ b/apps/theming/lib/Settings/Personal.php
@@ -36,7 +36,6 @@ use OCP\Settings\ISettings;
 use OCP\Util;
 
 class Personal implements ISettings {
-
 	public function __construct(
 		protected string $appName,
 		private string $userId,

--- a/apps/theming/lib/Settings/PersonalSection.php
+++ b/apps/theming/lib/Settings/PersonalSection.php
@@ -28,39 +28,23 @@ use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
 
 class PersonalSection implements IIconSection {
-
-	/** @var string */
-	protected $appName;
-
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var IL10N */
-	private $l;
-
 	/**
 	 * Personal Section constructor.
-	 *
-	 * @param string $appName
-	 * @param IURLGenerator $urlGenerator
-	 * @param IL10N $l
 	 */
-	public function __construct(string $appName,
-		IURLGenerator $urlGenerator,
-		IL10N $l) {
-		$this->appName = $appName;
-		$this->urlGenerator = $urlGenerator;
-		$this->l = $l;
+	public function __construct(
+		protected string $appName,
+		private IURLGenerator $urlGenerator,
+		private IL10N $l,
+	) {
 	}
 
 	/**
 	 * returns the relative path to an 16*16 icon describing the section.
 	 * e.g. '/core/img/places/files.svg'
 	 *
-	 * @returns string
 	 * @since 13.0.0
 	 */
-	public function getIcon() {
+	public function getIcon(): string {
 		return $this->urlGenerator->imagePath($this->appName, 'accessibility-dark.svg');
 	}
 
@@ -68,10 +52,9 @@ class PersonalSection implements IIconSection {
 	 * returns the ID of the section. It is supposed to be a lower case string,
 	 * e.g. 'ldap'
 	 *
-	 * @returns string
 	 * @since 9.1
 	 */
-	public function getID() {
+	public function getID(): string {
 		return $this->appName;
 	}
 
@@ -79,10 +62,9 @@ class PersonalSection implements IIconSection {
 	 * returns the translated name as it should be displayed, e.g. 'LDAP / AD
 	 * integration'. Use the L10N service to translate it.
 	 *
-	 * @return string
 	 * @since 9.1
 	 */
-	public function getName() {
+	public function getName(): string {
 		return $this->l->t('Appearance and accessibility');
 	}
 
@@ -94,7 +76,7 @@ class PersonalSection implements IIconSection {
 	 * E.g.: 70
 	 * @since 9.1
 	 */
-	public function getPriority() {
+	public function getPriority(): int {
 		return 15;
 	}
 }

--- a/apps/theming/lib/SetupChecks/PhpImagickModule.php
+++ b/apps/theming/lib/SetupChecks/PhpImagickModule.php
@@ -51,13 +51,15 @@ class PhpImagickModule implements ISetupCheck {
 				$this->l10n->t('The PHP module "imagick" is not enabled although the theming app is. For favicon generation to work correctly, you need to install and enable this module.'),
 				$this->urlGenerator->linkToDocs('admin-php-modules')
 			);
-		} elseif (count(\Imagick::queryFormats('SVG')) === 0) {
+		}
+
+		if (count(\Imagick::queryFormats('SVG')) === 0) {
 			return SetupResult::info(
 				$this->l10n->t('The PHP module "imagick" in this instance has no SVG support. For better compatibility it is recommended to install it.'),
 				$this->urlGenerator->linkToDocs('admin-php-modules')
 			);
-		} else {
-			return SetupResult::success();
 		}
+
+		return SetupResult::success();
 	}
 }


### PR DESCRIPTION
## Summary
Following [previous PRs taking advantage of PHP8's constructor property promotion](https://github.com/nextcloud/server/pulls?q=is%3Apr+author%3Afsamapoor), I have also made the required adjustments to the classes in the `theming` app.

I decided to split the changes into multiple PRs to make reviewing the changes easier.

The improvements in this PR include:

- Using PHP8's constructor property promotion
- Adding return types
- Removing redundant docblocks

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits