### PR TITLE
docs: added customclient_fdroid key to the config.sample.php file

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1134,6 +1134,7 @@ $CONFIG = [
  * - Android client: ``https://play.google.com/store/apps/details?id=com.nextcloud.client``
  * - iOS client: ``https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8``
  * - iOS client app id: ``1125420102``
+ * - F-Droid client: ``https://f-droid.org/packages/com.nextcloud.client/``
  */
 'customclient_desktop' =>
 	'https://nextcloud.com/install/#install-clients',
@@ -1143,6 +1144,8 @@ $CONFIG = [
 	'https://itunes.apple.com/us/app/nextcloud/id1125420102?mt=8',
 'customclient_ios_appid' =>
 		'1125420102',
+'customclient_fdroid' =>
+	'https://f-droid.org/packages/com.nextcloud.client/',
 /**
  * Apps
  *


### PR DESCRIPTION
It appears that the `customclient_fdroid` key, responsible for storing the link to the Android app on the f-droid.org website, is absent from the config.sample.php file.

In this PR, I've included the `customclient_fdroid` config key in the `config.sample.php` file.