### PR TITLE
fix(OC_Image): Set correct return type for exif_imagetype stub

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -1148,7 +1148,7 @@ if (!function_exists('exif_imagetype')) {
 	 *
 	 * @link https://www.php.net/manual/en/function.exif-imagetype.php#80383
 	 * @param string $fileName
-	 * @return string|boolean
+	 * @return int|false
 	 */
 	function exif_imagetype(string $fileName) {
 		if (($info = getimagesize($fileName)) !== false) {


### PR DESCRIPTION
## Summary

The proper method returns `int|false` and the stub should do the same. I only noticed it now because psalm started complaining that `$info[2]` is not `string|boolean` but `int|false` like expected.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
