### PR TITLE
fix(settings): define a 'heartbeat' route, so SecurityHeaders can handle redirected root

### DIFF
--- a/core/routes.php
+++ b/core/routes.php
@@ -40,3 +40,5 @@ declare(strict_types=1);
 // Routing
 $this->create('core_ajax_update', '/core/ajax/update.php')
 	->actionInclude('core/ajax/update.php');
+
+$this->create('heartbeat', '/heartbeat')->get();

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -40,7 +40,10 @@ use Test\TestCase;
  * @package Test\Route
  */
 class RouterTest extends TestCase {
-	public function testGenerateConsecutively(): void {
+	/** @var Router */
+	private $router;
+	protected function setUp(): void {
+		parent::setUp();
 		/** @var LoggerInterface $logger */
 		$logger = $this->createMock(LoggerInterface::class);
 		$logger->method('info')
@@ -49,7 +52,7 @@ class RouterTest extends TestCase {
 					$this->fail('Unexpected info log: '.(string)($data['exception'] ?? $message));
 				}
 			);
-		$router = new Router(
+		$this->router = new Router(
 			$logger,
 			$this->createMock(IRequest::class),
 			$this->createMock(IConfig::class),
@@ -57,13 +60,20 @@ class RouterTest extends TestCase {
 			$this->createMock(ContainerInterface::class),
 			$this->createMock(IAppManager::class),
 		);
+	}
 
-		$this->assertEquals('/index.php/apps/files/', $router->generate('files.view.index'));
+	public function testHeartbeat(): void {
+		$this->assertEquals('/index.php/heartbeat', $this->router->generate('heartbeat'));
+	}
+
+	public function testGenerateConsecutively(): void {
+
+		$this->assertEquals('/index.php/apps/files/', $this->router->generate('files.view.index'));
 
 		// the OCS route is the prefixed one for the AppFramework - see /ocs/v1.php for routing details
-		$this->assertEquals('/index.php/ocsapp/apps/dav/api/v1/direct', $router->generate('ocs.dav.direct.getUrl'));
+		$this->assertEquals('/index.php/ocsapp/apps/dav/api/v1/direct', $this->router->generate('ocs.dav.direct.getUrl'));
 
 		// test caching
-		$this->assertEquals('/index.php/apps/files/', $router->generate('files.view.index'));
+		$this->assertEquals('/index.php/apps/files/', $this->router->generate('files.view.index'));
 	}
 }

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -40,8 +40,7 @@ use Test\TestCase;
  * @package Test\Route
  */
 class RouterTest extends TestCase {
-	/** @var Router */
-	private $router;
+	private Router $router;
 	protected function setUp(): void {
 		parent::setUp();
 		/** @var LoggerInterface $logger */


### PR DESCRIPTION
## Problem
On sites where the root (`/`) path is redirected (e.g. when using the [Social login plugin](https://github.com/zorn-v/nextcloud-social-login)), the Admin Overview page incorrectly shows errors about security headers not being set:

> Some headers are not set correctly on your instance - The `X-Robots-Tag` HTTP header is not set to `noindex,nofollow`. This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly. - The `X-Permitted-Cross-Domain-Policies` HTTP header is not set to `none`. This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly. For more details see the documentation ↗.

## Analysis
In `lib/base.php`, the request path `/heartbeat` is [handled specially by returning early](https://github.com/nextcloud/server/blob/c60de5bea094ff1b1791bb6bc630ab20df39553d/lib/base.php#L1003), but no formal route is defined for it.

`OCA\Settings\SetupChecks\SecurityHeaders` [calls `URLGenerator::linkToRoute('heartbeat')`](https://github.com/nextcloud/server/blob/c60de5bea094ff1b1791bb6bc630ab20df39553d/apps/settings/lib/SetupChecks/SecurityHeaders.php#L60), but the generated URL is emptystring, since there's no route defined by that name.

It then performs a request on the root (`/`) path (instead of the expected `/heartbeat` path).  On sites where the root path redirects, `SecurityHeaders` then incorrectly analyzes the headers _of the redirect_, instead of analyzing the headers _of the Nextcloud heartbeat page_.

## Proposed solution
Define a `heartbeat` route, so that `URLGenerator::linkToRoute('heartbeat')` returns `/heartbeat` as the `SecurityHeaders` test seems to expect.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [~] Screenshots before/after for front-end changes — N/A
- [~] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required — N/A
- [~] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) — N/A
