### PR TITLE
fix: Avoid updating size when calling touch on a file

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1182,7 +1182,7 @@ class View {
 					$this->writeUpdate($storage, $internalPath, null, $isCreateOperation ? $sizeDifference : null);
 				}
 				if ($result !== false && in_array('touch', $hooks)) {
-					$this->writeUpdate($storage, $internalPath, $extraParam);
+					$this->writeUpdate($storage, $internalPath, $extraParam, 0);
 				}
 
 				if ((in_array('write', $hooks) || in_array('delete', $hooks)) && ($operation !== 'fopen' || $result === false)) {


### PR DESCRIPTION
When trying to figure out a different issue I noticed that when calling touch to create an empty file we always calculate and update the size of parent folders. However as we know the file is just touched, we can pass the sizeDifference of 0 along for writing the update to the cache to avoid unneeded size calculation/updates.

Earlier change that introduced the shortcut https://github.com/nextcloud/server/pull/42597