### PR TITLE
Hide 'updater.server.url' As It May Contain Enterprise Key

### DIFF
--- a/lib/private/SystemConfig.php
+++ b/lib/private/SystemConfig.php
@@ -54,6 +54,7 @@ class SystemConfig {
 		'passwordsalt' => true,
 		'secret' => true,
 		'updater.secret' => true,
+		'updater.server.url' => true,
 		'trusted_proxies' => true,
 		'preview_imaginary_url' => true,
 		'proxyuserpwd' => true,


### PR DESCRIPTION
## Summary
Add "updater.server.url" to the privacy redacted values, as it may contain the enterprise key.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
