### PR TITLE
fix(setupCheck): Only warn when memcache present w/o memcached

### DIFF
--- a/apps/settings/lib/SetupChecks/MemcacheConfigured.php
+++ b/apps/settings/lib/SetupChecks/MemcacheConfigured.php
@@ -53,15 +53,16 @@ class MemcacheConfigured implements ISetupCheck {
 		$memcacheLocalClass = $this->config->getSystemValue('memcache.local', null);
 		$caches = array_filter([$memcacheDistributedClass,$memcacheLockingClass,$memcacheLocalClass]);
 		if (in_array(\OC\Memcache\Memcached::class, array_map(fn (string $class) => ltrim($class, '\\'), $caches))) {
-			if (extension_loaded('memcache')) {
+			// wrong PHP module is installed
+			if (extension_loaded('memcache') && !extension_loaded('memcached')) {
 				return SetupResult::warning(
-					$this->l10n->t('Memcached is configured as distributed cache, but the wrong PHP module "memcache" is installed. \\OC\\Memcache\\Memcached only supports "memcached" and not "memcache".'),
-					'https://code.google.com/p/memcached/wiki/PHPClientComparison'
+					$this->l10n->t('Memcached is configured as distributed cache, but the wrong PHP module ("memcache") is installed. Please install the PHP module "memcached".')
 				);
 			}
+			// required PHP module is missing
 			if (!extension_loaded('memcached')) {
 				return SetupResult::warning(
-					$this->l10n->t('Memcached is configured as distributed cache, but the PHP module "memcached" is not installed.')
+					$this->l10n->t('Memcached is configured as distributed cache, but the PHP module "memcached" is not installed. Please install the PHP module "memcached".')
 				);
 			}
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Fixes: https://help.nextcloud.com/t/update-to-28-0-5-memcached-error-now/190125

## Summary

Prior to #42812 the check for the common mistake of installing PHP modules `memcache` rather than `memcached` only warned if `memcached` was missing while `memcache` was installed. When the setup checks were moved to the new API, the logic was changed (probably accidentally) so that it warned *anytime* `memcache` was present. This means existing environments started getting a warning about a problem that really isn't a problem. 

Restores the old logic. Also removes the old ancient third-party doc link that isn't relevant and only creates confusion. Also tries to make the next step *super* obvious when this warning is triggered legitimately.

## TODO

- [x] Trigger backport to v29 & v28

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
