### PR TITLE
fix(ci): Align mariadb versions with list of supported versions

### DIFF
--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        mariadb-versions: ['10.3', '10.4', '10.5', '10.6', '10.11']
+        mariadb-versions: ['10.3', '10.5', '10.6', '10.11']
         include:
           - php-versions: '8.3'
             mariadb-versions: '10.6'


### PR DESCRIPTION
## Summary

We currently support 10.3, 10.5, 10.6 (old LTS) and 10.11 (current LTS) so we can drop 10.4 from CI and save a bit of CI time.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
