### PR TITLE
fix: getMountsForFileId may return an unordered list

### DIFF
--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -85,7 +85,7 @@ class FileUtils {
 			if (!$mounts) {
 				return null;
 			}
-			$mount = $mounts[0];
+			$mount = reset($mounts);
 			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
 			return $userFolder->getFirstNodeById((int)$fileInput);
 		} else {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: noid

## Summary

![Screenshot from 2024-05-09 19-19-37](https://github.com/nextcloud/server/assets/3902676/19297306-63e0-4c08-b7b4-7547d6c9838a)


## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
