### PR TITLE
fix(SetupChecks): Add reasoning/clarity to outdated PHP check

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpOutdated.php
+++ b/apps/settings/lib/SetupChecks/PhpOutdated.php
@@ -47,7 +47,7 @@ class PhpOutdated implements ISetupCheck {
 
 	public function run(): SetupResult {
 		if (PHP_VERSION_ID < 80200) {
-			return SetupResult::warning($this->l10n->t('You are currently running PHP %s. PHP 8.1 is now deprecated in Nextcloud 30. Nextcloud 31 may require at least PHP 8.2. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [PHP_VERSION]), 'https://secure.php.net/supported-versions.php');
+			return SetupResult::warning($this->l10n->t('PHP %s detected. PHP >= 8.2 and <= 8.3 is suggested for optimal performance, security, and stability with this version of Nextcloud. Additionally, the next major release of Nextcloud will likely require >= PHP 8.2.', [PHP_VERSION]), 'https://secure.php.net/supported-versions.php');
 		}
 		return SetupResult::success($this->l10n->t('You are currently running PHP %s.', [PHP_VERSION]));
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

* Add reasoning based on our [existing docs](https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html#why-we-drop-old-php-versions)
* Add specific version range suggested for the current Server version
* Tweak the language a bit for improved readability (fewer disparate version numbers)
* Eliminate need to update Server versions in the message before every major release

Note: Decided *not* to add upper bound check for now.

## TODO

Follow-up: A lot of these dependency min/max versions should be moved to constants (maybe in `version.php` (e.g. PHP, MariaDB, etc.) to ease our recurring release cycle tech debt.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
