### PR TITLE
fix: remove mention of disabling file locking from config sample

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2269,21 +2269,6 @@ $CONFIG = [
  */
 'max_filesize_animated_gifs_public_sharing' => 10,
 
-
-/**
- * Enables transactional file locking.
- * This is enabled by default.
- *
- * Prevents concurrent processes from accessing the same files
- * at the same time. Can help prevent side effects that would
- * be caused by concurrent operations. Mainly relevant for
- * very large installations with many users working with
- * shared files.
- *
- * Defaults to ``true``
- */
-'filelocking.enabled' => true,
-
 /**
  * Set the lock's time-to-live in seconds.
  *


### PR DESCRIPTION
Disabling transactional locking is almost always a bad idea and can easily lead to data corruption or another range of unexpected behavior.

Removing the mention of this footgun hopefully reduces the number of people disabling the locking without proper understanding.