### PR TITLE
fix: Extend SVG reference check

### DIFF
--- a/lib/private/Preview/SVG.php
+++ b/lib/private/Preview/SVG.php
@@ -50,7 +50,7 @@ class SVG extends ProviderV2 {
 			}
 
 			// Do not parse SVG files with references
-			if (stripos($content, 'xlink:href') !== false) {
+			if (preg_match('/["\s](xlink:)?href\s*=/i', $content)) {
 				return null;
 			}
 

--- a/tests/lib/Preview/SVGTest.php
+++ b/tests/lib/Preview/SVGTest.php
@@ -29,4 +29,33 @@ class SVGTest extends Provider {
 			$this->markTestSkipped('No SVG provider present');
 		}
 	}
+
+	public function dataGetThumbnailSVGHref(): array {
+		return [
+			['href'],
+			[' href'],
+			["\nhref"],
+			['xlink:href'],
+			[' xlink:href'],
+			["\nxlink:href"],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetThumbnailSVGHref
+	 * @requires extension imagick
+	 */
+	public function testGetThumbnailSVGHref(string $content): void {
+		$handle = fopen('php://temp', 'w+');
+		fwrite($handle, '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <image x="0" y="0"' . $content . '="fxlogo.png" height="100" width="100" />
+</svg>');
+		rewind($handle);
+
+		$file = $this->createMock(\OCP\Files\File::class);
+		$file->method('fopen')
+			->willReturn($handle);
+
+		self::assertNull($this->provider->getThumbnail($file, 512, 512));
+	}
 }


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
