### PR TITLE
fix(IRegistrationContext): Add missing TaskProcessing methods

### DIFF
--- a/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
+++ b/lib/public/AppFramework/Bootstrap/IRegistrationContext.php
@@ -410,4 +410,26 @@ interface IRegistrationContext {
 	 * @since 29.0.0
 	 */
 	public function registerDeclarativeSettings(string $declarativeSettingsClass): void;
+
+	/**
+	 * Register an implementation of \OCP\TaskProcessing\IProvider that
+	 * will handle the implementation of task processing
+	 *
+	 * @param string $taskProcessingProviderClass
+	 * @psalm-param class-string<\OCP\TaskProcessing\IProvider> $taskProcessingProviderClass
+	 * @return void
+	 * @since 30.0.0
+	 */
+	public function registerTaskProcessingProvider(string $taskProcessingProviderClass): void;
+
+	/**
+	 * Register an implementation of \OCP\TaskProcessing\ITaskType that
+	 * will handle the implementation of a task processing type
+	 *
+	 * @param string $taskProcessingTaskTypeClass
+	 * @psalm-param class-string<\OCP\TaskProcessing\ITaskType> $taskProcessingTaskTypeClass
+	 * @return void
+	 * @since 30.0.0
+	 */
+	public function registerTaskProcessingTaskType(string $taskProcessingTaskTypeClass): void;
 }


### PR DESCRIPTION
## Summary

Follow up for https://github.com/nextcloud/server/pull/45094. The methods are present in the implementation but not in the interface, so the interface is not complete and also psalm complains about it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
