### PR TITLE
fix: Only list remnants as disabled if option is enabled

### DIFF
--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -440,6 +440,9 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 	}
 
 	public function getDisabledUserList(?int $limit = null, int $offset = 0, string $search = ''): array {
+		if ((int)$this->getAccess(array_key_first($this->backends) ?? '')->connection->markRemnantsAsDisabled !== 1) {
+			return [];
+		}
 		$disabledUsers = $this->deletedUsersIndex->getUsers();
 		if ($search !== '') {
 			$disabledUsers = array_filter(


### PR DESCRIPTION
## Summary

In 28 a new config option was added to consider remnants as disabled users.
But they were appearing in the list of disabled users even if the new option was not used, which can be confusing.

With this PR remnants are back at being ghosts by default and will only appear in disabled user list if the option is checked.
One problem is that the option is only checked on the first LDAP configuration and applied to all of them regarding to listing disabled users, because there is no efficient way to do otherwise (all remnants are in the same place). We already have this kind of trick for other things and expect that LDAP configurations are not too different from one another on the same server usually.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
