### PR TITLE
fix: delete user credentials stored in storages_credentials when user gets deleted

### DIFF
--- a/lib/private/User/Listeners/BeforeUserDeletedListener.php
+++ b/lib/private/User/Listeners/BeforeUserDeletedListener.php
@@ -27,6 +27,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\NotFoundException;
 use OCP\IAvatarManager;
+use OCP\Security\ICredentialsManager;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use Psr\Log\LoggerInterface;
 
@@ -35,10 +36,12 @@ use Psr\Log\LoggerInterface;
  */
 class BeforeUserDeletedListener implements IEventListener {
 	private IAvatarManager $avatarManager;
+	private ICredentialsManager $credentialsManager;
 	private LoggerInterface $logger;
 
-	public function __construct(LoggerInterface $logger, IAvatarManager $avatarManager) {
+	public function __construct(LoggerInterface $logger, IAvatarManager $avatarManager, ICredentialsManager $credentialsManager) {
 		$this->avatarManager = $avatarManager;
+		$this->credentialsManager = $credentialsManager;
 		$this->logger = $logger;
 	}
 
@@ -61,5 +64,7 @@ class BeforeUserDeletedListener implements IEventListener {
 				'exception' => $e,
 			]);
 		}
+		// Delete storages credentials on user deletion
+		$this->credentialsManager->erase($user->getUID());
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
