### PR TITLE
feat: Add `forbidden_filename_characters` to JSConfig for use in frontend libraries

### DIFF
--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -169,6 +169,7 @@ class JSConfigHelper {
 		$config = [
 			'auto_logout' => $this->config->getSystemValue('auto_logout', false),
 			'blacklist_files_regex' => FileInfo::BLACKLIST_FILES_REGEX,
+			'forbidden_filename_characters' => Util::getForbiddenFileNameChars(),
 			'loglevel' => $this->config->getSystemValue('loglevel_frontend',
 				$this->config->getSystemValue('loglevel', ILogger::WARN)
 			),


### PR DESCRIPTION
* Part of #45151 but split for better reviewability (and move forward on the frontend)

## Summary

Add the filename restrictions to our JS config so we can create a common frontend library function to check filename validity (de-duplicate code).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
