### PR TITLE
fix(FileCache): mtime when not provided backend at zero

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -278,6 +278,12 @@ class Cache implements ICache {
 	 * @throws \RuntimeException
 	 */
 	public function insert($file, array $data) {
+		// Some storage always return mtime at 0.
+		// Use now as time if nothing else is provided
+		if (array_key_exists('mtime', $data) && $data["mtime"] === 0) {
+			$data["mtime"] = time();
+		}
+
 		// normalize file
 		$file = $this->normalize($file);
 
@@ -438,7 +444,8 @@ class Cache implements ICache {
 		$extensionFields = ['metadata_etag', 'creation_time', 'upload_time'];
 
 		$doNotCopyStorageMTime = false;
-		if (array_key_exists('mtime', $data) && $data['mtime'] === null) {
+		// some storage always have mtime null or zero, do use that
+		if (array_key_exists('mtime', $data) && ($data['mtime'] === null || $data['mtime'] === 0)) {
 			// this horrific magic tells it to not copy storage_mtime to mtime
 			unset($data['mtime']);
 			$doNotCopyStorageMTime = true;


### PR DESCRIPTION
* Resolves: # <!-- related github issue --> (no related issue found)

## Summary

Some external backend always send 0 as modTime.

Creating a file without explicit timestamp coming from client (as in just creating it now, without having a modTime coming along the data), the file will be created in the backend, and nextcloud will read the modTime from the backend and store it as created in 1970...

[More details here](https://github.com/nextcloud/server/pull/45396#issuecomment-2118460687)

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
