### PR TITLE
fix(db): Prevent data loss by temporarily disabling `db:convert-type`

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -179,7 +179,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		// WARNING:
 		// Leave in place until #45257 is addressed to prevent data loss (hopefully in time for the next maintenance release)
-		// 
+		//
 		throw new \InvalidArgumentException(
 			'This command is temporarily disabled (until the next maintenance release).'
 		);

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -177,6 +177,13 @@ class ConvertType extends Command implements CompletionAwareInterface {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		// WARNING:
+		// Leave in place until #45257 is addressed to prevent data loss (hopefully in time for the next maintenance release)
+		// 
+		throw new \InvalidArgumentException(
+			'This command is temporarily disabled (until the next maintenance release).'
+		);
+
 		$this->validateInput($input, $output);
 		$this->readPassword($input, $output);
 


### PR DESCRIPTION
## WARNING: Needed until #45257 is addressed to prevent data loss

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Targets but does *not* handle #45257

## Summary

Currently the bug described in #45257 (and related #45097) has a serious side effect/interaction with the `occ db:convert-type` command which results in dropping the source database. 

Based on preliminary analysis, this is likely a bug arising from changes made in #41998 that were released as part of 29.0.0.

If we're unable to address #45257  prior to the release of 29.0.1 in a few days, then I propose we disable `occ db:convert-type` temporarily (hopefully just until the next maintenance release) rather than risk people wiping out their database. That is the purpose of this PR.

This is a backup PR which I propose merging in `master` and backporting to 29.0.1 prior to it being published *if necessary*.

If it turns out to be unnecessary, all the better.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
