### PR TITLE
fix(profile): Avoid updating the config at each call

### DIFF
--- a/lib/private/Profile/ProfileManager.php
+++ b/lib/private/Profile/ProfileManager.php
@@ -341,12 +341,17 @@ class ProfileManager implements IProfileManager {
 				$config = $this->configMapper->get($targetUser->getUID());
 				$this->configCache[$targetUser->getUID()] = $config;
 			}
+
 			// Merge defaults with the existing config in case the defaults are missing
-			$config->setConfigArray(array_merge(
-				$defaultProfileConfig,
-				$this->filterNotStoredProfileConfig($config->getConfigArray()),
-			));
-			$this->configMapper->update($config);
+			$existingConfigArray = $this->filterNotStoredProfileConfig($config->getConfigArray());
+			$mergedConfigArray = array_merge($defaultProfileConfig, $existingConfigArray);
+
+			// Only update if the merged config is different from the existing config
+			if ($mergedConfigArray !== $existingConfigArray) {
+				$config->setConfigArray($mergedConfigArray);
+				$this->configMapper->update($config);
+			}
+
 			$configArray = $config->getConfigArray();
 		} catch (DoesNotExistException $e) {
 			// Create a new default config if it does not exist


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Updating the config at each call can be inefficient. Instead, check if the merged configuration is different from the existing one before performing the update. This optimization may reduce unnecessary database operations.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
