### PR TITLE
fix(dav): fall back to generated avatar in image export plugin

### DIFF
--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -39,6 +39,7 @@ use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
+use OCP\IAvatarManager;
 use Psr\Log\LoggerInterface;
 use Sabre\CardDAV\Plugin;
 
@@ -104,10 +105,13 @@ if ($debugging) {
 
 $server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 $server->addPlugin(new \Sabre\CardDAV\VCFExportPlugin());
-$server->addPlugin(new \OCA\DAV\CardDAV\ImageExportPlugin(new \OCA\DAV\CardDAV\PhotoCache(
-	\OC::$server->getAppDataDir('dav-photocache'),
-	\OC::$server->get(LoggerInterface::class)
-)));
+$server->addPlugin(new \OCA\DAV\CardDAV\ImageExportPlugin(
+	new \OCA\DAV\CardDAV\PhotoCache(
+		\OC::$server->getAppDataDir('dav-photocache'),
+		\OC::$server->get(LoggerInterface::class)
+	),
+	\OC::$server->get(IAvatarManager::class),
+));
 $server->addPlugin(new ExceptionLoggerPlugin('carddav', \OC::$server->get(LoggerInterface::class)));
 
 // And off we go!

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -80,6 +80,7 @@ use OCP\AppFramework\Http\Response;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\FilesMetadata\IFilesMetadataManager;
+use OCP\IAvatarManager;
 use OCP\ICacheFactory;
 use OCP\IRequest;
 use OCP\Profiler\IProfiler;
@@ -204,9 +205,12 @@ class Server {
 			$this->server->addPlugin(new VCFExportPlugin());
 			$this->server->addPlugin(new MultiGetExportPlugin());
 			$this->server->addPlugin(new HasPhotoPlugin());
-			$this->server->addPlugin(new ImageExportPlugin(new PhotoCache(
-				\OC::$server->getAppDataDir('dav-photocache'),
-				$logger)
+			$this->server->addPlugin(
+				new ImageExportPlugin(new PhotoCache(
+					\OC::$server->getAppDataDir('dav-photocache'),
+					$logger,
+				),
+				\OC::$server->get(IAvatarManager::class),
 			));
 		}
 

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -30,6 +30,7 @@ use OCA\DAV\CardDAV\ImageExportPlugin;
 use OCA\DAV\CardDAV\PhotoCache;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\IAvatarManager;
 use Sabre\CardDAV\Card;
 use Sabre\DAV\Node;
 use Sabre\DAV\Server;
@@ -51,6 +52,8 @@ class ImageExportPluginTest extends TestCase {
 	private $tree;
 	/** @var PhotoCache|\PHPUnit\Framework\MockObject\MockObject */
 	private $cache;
+	/** @var IAvatarManager|\PHPUnit\Framework\MockObject\MockObject */
+	private $avatarManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -61,10 +64,11 @@ class ImageExportPluginTest extends TestCase {
 		$this->tree = $this->createMock(Tree::class);
 		$this->server->tree = $this->tree;
 		$this->cache = $this->createMock(PhotoCache::class);
+		$this->avatarManager = $this->createMock(IAvatarManager::class);
 
 		$this->plugin = $this->getMockBuilder(ImageExportPlugin::class)
 			->setMethods(['getPhoto'])
-			->setConstructorArgs([$this->cache])
+			->setConstructorArgs([$this->cache, $this->avatarManager])
 			->getMock();
 		$this->plugin->initialize($this->server);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
