### PR TITLE
fix(files): Don't fail if dir exists

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -133,7 +133,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $fullPath);
 			$this->sendHooks(['preWrite', 'preCreate'], [$nonExisting]);
-			if (!$this->view->is_dir($fullPath) && !$this->view->mkdir($fullPath)) {
+			if (!$this->view->mkdir($fullPath) && !$this->view->is_dir($fullPath)) {
 				throw new NotPermittedException('Could not create folder "' . $fullPath . '"');
 			}
 			$parent = dirname($fullPath) === $this->getPath() ? $this : null;

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -133,7 +133,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $fullPath);
 			$this->sendHooks(['preWrite', 'preCreate'], [$nonExisting]);
-			if (!$this->view->mkdir($fullPath)) {
+			if (!$this->view->is_dir($fullPath) && !$this->view->mkdir($fullPath)) {
 				throw new NotPermittedException('Could not create folder "' . $fullPath . '"');
 			}
 			$parent = dirname($fullPath) === $this->getPath() ? $this : null;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

In some cases, `mkdir` is returning `false` because directory already exists on disk (_race condition?_)
Nevertheless, we shouldn't need to `throw` if folder exists.

```
Exception":"OCP\\Files\\NotPermittedException","Message":"Could not create folder \"/appdata_ocwfs52oscxg/preview/5/e/8/b/b/c/e/3685938\
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
