### PR TITLE
[stable27] fix(theming): stable 27 disable accessible color config switch

### DIFF
--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -82,6 +82,11 @@ class Util {
 	 * @return string
 	 */
 	public function elementColor($color, ?bool $brightBackground = null) {
+		// Disable color luminance check if the feature is disabled. 27 ONLY!
+		if ($this->config->getSystemValueBool('27-disable-accessible-theming-color') === true) {
+			return $color;
+		}
+
 		$luminance = $this->calculateLuminance($color);
 
 		if ($brightBackground !== false && $luminance > 0.8) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/39551

Only for 27! 28 and above have a different handling of themes and is fixed

## Apply this fix

1. add `'27-disable-accessible-theming-color' => true,` to your `config.php`
2. delete the `global` folder on your `data/appdata_xxxx/theming` directory (no need to delete the theming folder)
3. run an `occ files:scan-app-data theming`


## How to reproduce the issue

1. use a non accessible color like `#004352`
2. load the files app

| Before | After |
|:---------:|:------:|
|![localhost_8081_index php_apps_files__dir=_ fileid=2 (1)](https://github.com/nextcloud/server/assets/14975046/1b04d0b6-2717-4ac0-9962-83071fe565d6)|![localhost_8081_index php_apps_files__dir=_ fileid=2](https://github.com/nextcloud/server/assets/14975046/9b0c1331-b24a-407a-859e-d43804d049b6)|