### PR TITLE
feat(RichObjectStrings): Add missing Talk 'file' metadata fields

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -368,6 +368,30 @@ class Definitions {
 					'description' => 'The mtime of the file/folder as unix timestamp',
 					'example' => '1661854213',
 				],
+				'etag' => [
+					'since' => '25.0.0',
+					'required' => false,
+					'description' => 'The ETag of the file/folder',
+					'example' => 'abcdefghi',
+				],
+				'permissions' => [
+					'since' => '25.0.0',
+					'required' => false,
+					'description' => 'The permissions on the file/folder',
+					'example' => '3',
+				],
+				'width' => [
+					'since' => '29.0.0',
+					'required' => false,
+					'description' => 'The width in pixels if the file is an image',
+					'example' => '1920',
+				],
+				'height' => [
+					'since' => '29.0.0',
+					'required' => false,
+					'description' => 'The height in pixels if the file is an image',
+					'example' => '1080',
+				],
 			],
 		],
 		'forms-form' => [


### PR DESCRIPTION
## Summary

Clients should be able to rely on these fields, thus they should be documented in the definitions. These fields were added in https://github.com/nextcloud/spreed/pull/7776 and https://github.com/nextcloud/spreed/pull/11093.

I don't think backporting these changes is useful as this is only for documentation and validation purposes and doesn't fix any bug. For now I've set the `since` to the Server versions for the corresponding Talk releases, but it might make sense to set them only to `30.0.0` to avoid any confusion and instability.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
