### PR TITLE
fix(files): Add proper visual loading feedback for image preview

### DIFF
--- a/apps/files/src/components/FilesListVirtual.vue
+++ b/apps/files/src/components/FilesListVirtual.vue
@@ -550,12 +550,6 @@ export default defineComponent({
 				// Center and contain the preview
 				object-fit: contain;
 				object-position: center;
-
-				/* Preview not loaded animation effect */
-				&:not(.files-list__row-icon-preview--loaded) {
-					background: var(--color-loading-dark);
-					// animation: preview-gradient-fade 1.2s ease-in-out infinite;
-				}
 			}
 
 			&-favorite {


### PR DESCRIPTION
## Summary

Currently only a white square is shown while loading the icon, this add a loading indicator.
(Especially the previous one had a short flash when both the background and icon are shown at the same time).

### Screen recording

#### Before

https://github.com/nextcloud/server/assets/1855448/59344023-e738-4810-9a6f-7e43c105e5ec

#### After

https://github.com/nextcloud/server/assets/1855448/65329e3b-d342-4778-92a8-8fb7e129440e

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
