### PR TITLE
fix(INavigationManager): Fix psalm alias not set in the right place

### DIFF
--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -26,11 +26,13 @@ namespace OCA\Core;
  *
  * @psalm-type CoreNavigationEntry = array{
  *     id: string,
- *     order: int,
+ *     order?: int,
  *     href: string,
  *     icon: string,
  *     type: string,
  *     name: string,
+ *     app?: string,
+ *     default?: bool,
  *     active: bool,
  *     classes: string,
  *     unread: int,

--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -26,7 +26,7 @@ namespace OCA\Core;
  *
  * @psalm-type CoreNavigationEntry = array{
  *     id: string,
- *     order: int|string,
+ *     order: int,
  *     href: string,
  *     icon: string,
  *     type: string,

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -218,7 +218,6 @@
                 "type": "object",
                 "required": [
                     "id",
-                    "order",
                     "href",
                     "icon",
                     "type",
@@ -246,6 +245,12 @@
                     },
                     "name": {
                         "type": "string"
+                    },
+                    "app": {
+                        "type": "string"
+                    },
+                    "default": {
+                        "type": "boolean"
                     },
                     "active": {
                         "type": "boolean"

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -232,15 +232,8 @@
                         "type": "string"
                     },
                     "order": {
-                        "oneOf": [
-                            {
-                                "type": "integer",
-                                "format": "int64"
-                            },
-                            {
-                                "type": "string"
-                            }
-                        ]
+                        "type": "integer",
+                        "format": "int64"
                     },
                     "href": {
                         "type": "string"

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -95,7 +95,7 @@ class NavigationManager implements INavigationManager {
 			// This is the default app that will always be shown first
 			$entry['default'] = ($entry['app'] ?? false) === $this->defaultApp;
 			// Set order from user defined app order
-			$entry['order'] = $this->customAppOrder[$id]['order'] ?? $entry['order'] ?? 100;
+			$entry['order'] = (int)($this->customAppOrder[$id]['order'] ?? $entry['order'] ?? 100);
 		}
 
 		$this->entries[$id] = $entry;

--- a/lib/public/INavigationManager.php
+++ b/lib/public/INavigationManager.php
@@ -11,12 +11,10 @@
 namespace OCP;
 
 /**
- * @psalm-type NavigationEntry = array{id: string, order: int, href: string, name: string, app?: string, icon?: string, classes?: string, type?: string}
- */
-
-/**
  * Manages the ownCloud navigation
  * @since 6.0.0
+ *
+ * @psalm-type NavigationEntry = array{id: string, order: int, href: string, name: string, app?: string, icon?: string, classes?: string, type?: string}
  */
 interface INavigationManager {
 	/**


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/pull/41341 didn't set the type alias correctly as it needs to be on the same class to be "visible" (PHPStorm also displays that it can't resolve the type on the add method).

While looking at that I also found that the type for the endpoint is wrong and was missing some fields as well (guess who did that :sweat_smile:).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
