### PR TITLE
expose escapeLikeParameter trough query builder

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -1336,4 +1336,8 @@ class QueryBuilder implements IQueryBuilder {
 
 		return $this->helper->quoteColumnName($alias);
 	}
+
+	public function escapeLikeParameter(string $parameter): string {
+		return $this->connection->escapeLikeParameter($parameter);
+	}
 }


### PR DESCRIPTION
Makes it a bit easier to build `like` queries with the query builder.

Extracted from https://github.com/nextcloud/server/pull/43576