### PR TITLE
fix(setupChecks): Update Transactional File Locking instructions

### DIFF
--- a/apps/settings/lib/SetupChecks/FileLocking.php
+++ b/apps/settings/lib/SetupChecks/FileLocking.php
@@ -26,7 +26,7 @@ class FileLocking implements ISetupCheck {
 	}
 
 	public function getName(): string {
-		return $this->l10n->t('File locking');
+		return $this->l10n->t('Transactional File Locking');
 	}
 
 	public function getCategory(): string {
@@ -43,8 +43,8 @@ class FileLocking implements ISetupCheck {
 
 	public function run(): SetupResult {
 		if (!$this->hasWorkingFileLocking()) {
-			return SetupResult::warning(
-				$this->l10n->t('Transactional file locking is disabled, this might lead to issues with race conditions. Enable "filelocking.enabled" in config.php to avoid these problems.'),
+			return SetupResult::error(
+				$this->l10n->t('Transactional File Locking is disabled. This is not a a supported configuraton. It may lead to difficult to isolate problems including file corruption. Please remove the `\'filelocking.enabled\' => false` configuration entry from your `config.php` to avoid these problems.'),
 				$this->urlGenerator->linkToDocs('admin-transactional-locking')
 			);
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The `filelocking.enabled` toggle is no longer relevant today since TFL is now on by default and is no longer an experimental feature (hasn't been for nearly a decade). There is no good reason to disable it. The toggle only exists to be able to enable it, when it was still experimental. It's also been removed from the docs.

This PR: 

- makes the setup check firmer
- enhances the instructions
- changes from a warning to an error 
- renames check from "File Locking" -> "Transaction File Locking" for consistency with docs (and to distinguish from types)

Complements #45330 and nextcloud/documentation#11848 (does not depend on either)

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
