### PR TITLE
fix(db): Log long transaction times at debug level

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -680,7 +680,7 @@ class Connection extends PrimaryReadReplicaConnection {
 			$timeTook = microtime(true) - $this->transactionActiveSince;
 			$this->transactionActiveSince = null;
 			if ($timeTook > 1) {
-				$this->logger->warning('Transaction took ' . $timeTook . 's', ['exception' => new \Exception('Transaction took ' . $timeTook . 's')]);
+				$this->logger->debug('Transaction took ' . $timeTook . 's', ['exception' => new \Exception('Transaction took ' . $timeTook . 's')]);
 			}
 		}
 		return $result;
@@ -692,7 +692,7 @@ class Connection extends PrimaryReadReplicaConnection {
 			$timeTook = microtime(true) - $this->transactionActiveSince;
 			$this->transactionActiveSince = null;
 			if ($timeTook > 1) {
-				$this->logger->warning('Transaction rollback took longer than 1s: ' . $timeTook, ['exception' => new \Exception('Long running transaction rollback')]);
+				$this->logger->debug('Transaction rollback took longer than 1s: ' . $timeTook, ['exception' => new \Exception('Long running transaction rollback')]);
 			}
 		}
 		return $result;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #44627 
* Resolves: #45502
* Also various forum discussions since v29 came out

## Summary

This was added as part of #42345. Per [the implementation docs](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/performance.html#long-transactions) (plus what seems reasonable for non-dev/troubleshooting situations), these should not be logged at WARN level.

The PR's docs (nextcloud/documentation#11492) say DEBUG level. I suggest either DEBUG or, at most, INFO. I lean towards DEBUG so that's what I went with.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
