### PR TITLE
fix:Ensure security.txt file ends with a newline character

### DIFF
--- a/apps/settings/lib/WellKnown/SecurityTxtHandler.php
+++ b/apps/settings/lib/WellKnown/SecurityTxtHandler.php
@@ -42,7 +42,8 @@ Expires: 2024-08-31T23:00:00.000Z
 Acknowledgments: https://hackerone.com/nextcloud/thanks
 Acknowledgments: https://github.com/nextcloud/security-advisories/security/advisories
 Policy: https://hackerone.com/nextcloud
-Preferred-Languages: en";
+Preferred-Languages: en
+";
 
 		return new GenericResponse(new TextPlainResponse($response, 200));
 	}


### PR DESCRIPTION


* Resolves: #42611

## Summary
This commit addresses issue #42611 by ensuring that the generated `security.txt` file consistently ends with a newline character. This change aligns the file with the recommended best practices outlined in RFC 9116.

Additionally, the commit updates the relevant unit test to verify that the newline character is correctly added.


## TODO
- [ ] ...



 before  
![image](https://github.com/nextcloud/server/assets/125951234/16e85cc8-cd2b-4e6a-9bd0-b820f6fa0b4a)

after
![image](https://github.com/nextcloud/server/assets/125951234/42bd5555-8389-406e-bf2a-383a37f9d132)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
