### PR TITLE
fix: use different file name for generated dark avatars

### DIFF
--- a/lib/private/Avatar/UserAvatar.php
+++ b/lib/private/Avatar/UserAvatar.php
@@ -169,18 +169,20 @@ class UserAvatar extends Avatar {
 	 * @throws NotFoundException
 	 */
 	private function getExtension(bool $generated, bool $darkTheme): string {
-		if ($darkTheme && !$generated) {
-			if ($this->folder->fileExists('avatar-dark.jpg')) {
-				return 'jpg';
-			} elseif ($this->folder->fileExists('avatar-dark.png')) {
-				return 'png';
-			}
+		if ($darkTheme && $generated) {
+			$name = 'avatar-dark.';
+		} else {
+			$name = 'avatar.';
 		}
-		if ($this->folder->fileExists('avatar.jpg')) {
+
+		if ($this->folder->fileExists($name . 'jpg')) {
 			return 'jpg';
-		} elseif ($this->folder->fileExists('avatar.png')) {
+		}
+
+		if ($this->folder->fileExists($name . 'png')) {
 			return 'png';
 		}
+
 		throw new NotFoundException;
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: noid

## Summary

I wondered, while debugging an issue, about many write requests for my generated user avatar.

Likely the condition `$darkTheme && !$generated` should be `$darkTheme && $generated` to match the implementation in `UserAvatar.getFile`.

If you want to reproduce, make sure to NOT have a default generated avatar. 

Super edgy, no backports needed. 

https://github.com/nextcloud/server/blob/ae4a6e8d4454b7896d0e40f367096a26d999dbf0/lib/private/Avatar/UserAvatar.php#L172-L184



[Screencast from 2024-05-26 17-13-51.webm](https://github.com/nextcloud/server/assets/3902676/2c165220-147a-443d-a1c8-46ac5575dc89)




## TODO

- [x] CI
- [x] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
