### PR TITLE
chore: update .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+	"esversion": 11,
 	"camelcase": true,
 	"eqeqeq": true,
 	"immed": true,
@@ -11,10 +12,10 @@
 	"maxparams": 5,
 	"curly": true,
 	"jquery": true,
-	"maxlen": 120,
 	"indent": 4,
 	"browser": true,
 	"laxbreak": true,
+	"asi": true,
 	"globals": {
 		"console": true,
 		"it": true,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

Be able to enable the plugin in PHPStorm again without seeing 100s of irrelevant errors ...

Changes:
- `esversion: 11` We use bundlers so let's use a modern version of js
- `maxlen: 120` This should be enforced by linters if at all (the rule is deprected by jshintrc anyway: https://jshint.com/docs/options/#maxlen)
- `asi: true` Suppress warnings about missing semicolons (it's 2024 after all)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
