### PR TITLE
Implement action sub-menus in the multiple files actions bar

### DIFF
--- a/apps/files/src/components/FilesListTableHeaderActions.vue
+++ b/apps/files/src/components/FilesListTableHeaderActions.vue
@@ -27,18 +27,22 @@
 			:inline="inlineActions"
 			:menu-name="inlineActions <= 1 ? t('files', 'Actions') : null"
 			:open.sync="openedMenu">
-			<NcActionButton v-for="action in enabledToplevelMenuActions"
+			<NcActions v-for="action in enabledToplevelMenuActions"
 				:key="action.id"
-				:class="'files-list__row-actions-batch-' + action.id"
-				:close-after-click="false"
-				:is-menu="true"
-				@click="onActionClick(action)">
-				<template #icon>
-					<NcLoadingIcon v-if="loading === action.id" :size="18" />
-					<NcIconSvgWrapper v-else :svg="action.iconSvgInline(nodes, currentView)" />
-				</template>
-				{{ action.displayName(nodes, currentView) }}
-			</NcActionButton>
+				:menuName="action.displayName(nodes, currentView)" >
+				<NcActionButton v-for="action in enabledSubLevelMenuActions(action)"
+					:key="action.id"
+					:class="'files-list__row-actions-batch-' + action.id"
+					:close-after-click="true"
+					:is-menu="false"
+					@click="onActionClick(action)">
+					<template #icon>
+						<NcLoadingIcon v-if="loading === action.id" :size="18" />
+						<NcIconSvgWrapper v-else :svg="action.iconSvgInline(nodes, currentView)" />
+					</template>
+					{{ action.displayName(nodes, currentView) }}
+				</NcActionButton>
+			</NcActions>
 			<NcActionButton v-for="action in enabledToplevelNonMenuActions"
 				:key="action.id"
 				:class="'files-list__row-actions-batch-' + action.id"
@@ -104,7 +108,6 @@ export default defineComponent({
 		const actionsMenuStore = useActionsMenuStore()
 		const filesStore = useFilesStore()
 		const selectionStore = useSelectionStore()
-		console.log('CYRILLE', actions)
 		return {
 			actionsMenuStore,
 			filesStore,
@@ -132,7 +135,7 @@ export default defineComponent({
 
 		enabledToplevelMenuActions() {
 			return this.enabledActions
-				.filter(action => !action.parent)
+				.filter(action => typeof action.parent === 'undefined')
 				.filter(action => this.isMenu(action.id))
 				.sort((a, b) => (a.order || 0) - (b.order || 0))
 		},
@@ -202,6 +205,12 @@ export default defineComponent({
 
 		isMenu(id: string) {
 			return this.enabledSubmenuActions[id]?.length > 0
+		},
+
+		enabledSubLevelMenuActions(action) {
+			return this.enabledActions
+				.filter(subAction => subAction.parent === action.id)
+				.sort((a, b) => (a.order || 0) - (b.order || 0))
 		},
 
 		async onActionClick(action) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: [#45523](https://github.com/nextcloud/server/issues/45523)


## Summary

Implements submenus in multiple file actions bar

## TODO

- [X] Only show toplevel actions in bar
- [x] open menu when clicking on a menu action

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
