### PR TITLE
Allow LDAP search users with *term*

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1564,7 +1564,7 @@ class Access extends LDAPUtility {
 		if ($term === '') {
 			$result = '*';
 		} elseif ($allowEnum !== 'no') {
-			$result = $term . '*';
+			$result = '*' . $term . '*';
 		}
 		return $result;
 	}


### PR DESCRIPTION
Fix #11540 and #14153

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

Fix #11540 and #14153
This issues were close, but because the user "didn't use NextCloud anymore"

## Summary

In Database User Backend, search is based on "*term*". But in LDAP, it's only "term*". This is confusing for user experience.

## TODO


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [0] Screenshots before/after for front-end changes
       No front change
- [0] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
   This behaviour is not described in documentation

- [0] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
 
