### PR TITLE
add mapping for lock wait timeout

### DIFF
--- a/lib/private/DB/Exceptions/DbalException.php
+++ b/lib/private/DB/Exceptions/DbalException.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
 use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
 use Doctrine\DBAL\Exception\RetryableException;
@@ -82,6 +83,9 @@ class DbalException extends Exception {
 		/**
 		 * Other server errors
 		 */
+		if ($this->original instanceof LockWaitTimeoutException) {
+			return parent::REASON_LOCK_WAIT_TIMEOUT;
+		}
 		if ($this->original instanceof DatabaseObjectExistsException) {
 			return parent::REASON_DATABASE_OBJECT_EXISTS;
 		}

--- a/lib/public/DB/Exception.php
+++ b/lib/public/DB/Exception.php
@@ -121,6 +121,13 @@ class Exception extends BaseException {
 	public const REASON_UNIQUE_CONSTRAINT_VIOLATION = 14;
 
 	/**
+	 * The lock wait timeout was exceeded
+	 *
+	 * @since 30.0.0
+	 */
+	public const REASON_LOCK_WAIT_TIMEOUT = 15;
+
+	/**
 	 * @return int|null
 	 * @psalm-return Exception::REASON_*
 	 * @since 21.0.0

--- a/tests/lib/DB/Exception/DbalExceptionTest.php
+++ b/tests/lib/DB/Exception/DbalExceptionTest.php
@@ -17,6 +17,7 @@ use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\InvalidArgumentException;
 use Doctrine\DBAL\Exception\InvalidFieldNameException;
+use Doctrine\DBAL\Exception\LockWaitTimeoutException;
 use Doctrine\DBAL\Exception\NonUniqueFieldNameException;
 use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
 use Doctrine\DBAL\Exception\ServerException;
@@ -45,6 +46,7 @@ class DbalExceptionTest extends \Test\TestCase {
 
 	public function dataDriverException(): array {
 		return [
+			[LockWaitTimeoutException::class, DbalException::REASON_LOCK_WAIT_TIMEOUT],
 			[ForeignKeyConstraintViolationException::class, DbalException::REASON_FOREIGN_KEY_VIOLATION],
 			[NotNullConstraintViolationException::class, DbalException::REASON_NOT_NULL_CONSTRAINT_VIOLATION],
 			[UniqueConstraintViolationException::class, DbalException::REASON_UNIQUE_CONSTRAINT_VIOLATION],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: noid

## Summary

Add mapping for lock wait timeout.

## TODO

- [x] CI
- [x] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
