### PR TITLE
27.1.10

### DIFF
--- a/version.php
+++ b/version.php
@@ -30,10 +30,10 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [27, 1, 10, 1];
+$OC_Version = [27, 1, 10, 2];
 
 // The human-readable string
-$OC_VersionString = '27.1.10 RC2';
+$OC_VersionString = '27.1.10';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [


### PR DESCRIPTION
Could not find base or head reference on updater.



Could not find base or head reference on logreader.



Could not find base or head reference on twofactor_totp.



Could not find base or head reference on firstrunwizard.



Could not find base or head reference on password_policy.



Could not find base or head reference on notifications.



Could not find base or head reference on survey_client.



Could not find base or head reference on serverinfo.



Could not find base or head reference on files_pdfviewer.



Could not find base or head reference on nextcloud_announcements.



Could not find base or head reference on circles.



Could not find base or head reference on suspicious_login.



Could not find base or head reference on recommendations.



Could not find base or head reference on privacy.



Could not find base or head reference on viewer.



Could not find base or head reference on text.



Could not find base or head reference on photos.



Could not find base or head reference on related_resources.






## Pending PRs:
* @backportbot
  * [ ] #45444
