### PR TITLE
fix(Mailer): Allow to enforce strict email format

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\Mail;
 
 use Egulias\EmailValidator\EmailValidator;
+use Egulias\EmailValidator\Validation\NoRFCWarningsValidation;
 use Egulias\EmailValidator\Validation\RFCValidation;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -206,8 +207,10 @@ class Mailer implements IMailer {
 			// Shortcut: empty addresses are never valid
 			return false;
 		}
+
+		$strictMailCheck = $this->config->getAppValue('core', 'enforce_strict_email_check', 'yes') === 'yes';
 		$validator = new EmailValidator();
-		$validation = new RFCValidation();
+		$validation = $strictMailCheck ? new NoRFCWarningsValidation() : new RFCValidation();
 
 		return $validator->isValid($email, $validation);
 	}

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -38,7 +38,7 @@ class MailerTest extends TestCase {
 	private $l10n;
 	/** @var Mailer */
 	private $mailer;
-	/** @var IEventDispatcher */
+	/** @var IEventDispatcher&MockObject */
 	private $dispatcher;
 
 
@@ -193,6 +193,7 @@ class MailerTest extends TestCase {
 			]);
 		$this->expectException(\Exception::class);
 
+		/** @var Message&MockObject */
 		$message = $this->getMockBuilder('\OC\Mail\Message')
 			->disableOriginalConstructor()->getMock();
 		$message->expects($this->once())
@@ -207,20 +208,27 @@ class MailerTest extends TestCase {
 	 */
 	public function mailAddressProvider() {
 		return [
-			['lukas@owncloud.com', true],
-			['lukas@localhost', true],
-			['lukas@192.168.1.1', true],
-			['lukas@éxämplè.com', true],
-			['asdf', false],
-			['', false],
-			['lukas@owncloud.org@owncloud.com', false],
+			['lukas@owncloud.com', true, false],
+			['lukas@localhost', true, false],
+			['lukas@192.168.1.1', true, false],
+			['lukas@éxämplè.com', true, false],
+			['asdf', false, false],
+			['', false, false],
+			['lukas@owncloud.org@owncloud.com', false, false],
+			['test@localhost', true, false],
+			['test@localhost', false, true],
 		];
 	}
 
 	/**
 	 * @dataProvider mailAddressProvider
 	 */
-	public function testValidateMailAddress($email, $expected) {
+	public function testValidateMailAddress($email, $expected, $strict) {
+		$this->config
+			->expects($this->atMost(1))
+			->method('getAppValue')
+			->with('core', 'enforce_strict_email_check')
+			->willReturn($strict ? 'yes' : 'no');
 		$this->assertSame($expected, $this->mailer->validateMailAddress($email));
 	}
 

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -90,9 +90,25 @@ class UtilTest extends \Test\TestCase {
 		$this->assertEquals($expected, \OC_Util::fileInfoLoaded());
 	}
 
+	/**
+	 * Host is "localhost" this is a valid for emails,
+	 * but not for default strict email verification that requires a top level domain.
+	 * So we check that with strict email verification we fallback to the default
+	 */
+	public function testGetDefaultEmailAddressStrict() {
+		$email = \OCP\Util::getDefaultEmailAddress("no-reply");
+		$this->assertEquals('no-reply@localhost.localdomain', $email);
+	}
+
+	/**
+	 * If no strict email check is enabled "localhost" should validate as a valid email domain
+	 */
 	public function testGetDefaultEmailAddress() {
+		$config = \OC::$server->getConfig();
+		$config->setAppValue('core', 'enforce_strict_email_check', 'no');
 		$email = \OCP\Util::getDefaultEmailAddress("no-reply");
 		$this->assertEquals('no-reply@localhost', $email);
+		$config->deleteAppValue('core', 'enforce_strict_email_check');
 	}
 
 	public function testGetDefaultEmailAddressFromConfig() {


### PR DESCRIPTION
Alternative to https://github.com/nextcloud/server/pull/45425

But this one instead set the global email verification to strict.