### PR TITLE
fix: avoid duplicate tag inserts by checking if the mapping exists already in db

### DIFF
--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -126,11 +126,16 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
 		$existingTags = [];
-		foreach ($rows as $k => $row) {
+		foreach ($rows as $row) {
 			$existingTags[] = $row['systemtagid'];
 		}
 		//filter only tags that do not exist in db
 		$tagIds = array_diff($tagIds, $existingTags);
+		if (empty($tagIds)) {
+			// no tags to insert so return here
+			$this->connection->commit();
+			return;
+		}
 
 		$query = $this->connection->getQueryBuilder();
 		$query->insert(self::RELATION_TABLE)

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -117,6 +117,15 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		$this->assertTagsExist($tagIds);
 
 		$query = $this->connection->getQueryBuilder();
+		$query->select('systemtagid')
+			->from(self::RELATION_TABLE)
+			->where($query->expr()->in('systemtagid', $query->createNamedParameter($tagIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->andWhere($query->expr()->eq('objecttype', $query->createNamedParameter($objectType)))
+			->andWhere($query->expr()->eq('objectid', $query->createNamedParameter($objId)));
+		$result = $query->executeQuery();
+		$rows = $result->fetchAll();
+
+		$query = $this->connection->getQueryBuilder();
 		$query->insert(self::RELATION_TABLE)
 			->values([
 				'objectid' => $query->createNamedParameter($objId),
@@ -126,12 +135,17 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 
 		$tagsAssigned = [];
 		foreach ($tagIds as $tagId) {
-			try {
-				$query->setParameter('tagid', $tagId);
-				$query->execute();
-				$tagsAssigned[] = $tagId;
-			} catch (UniqueConstraintViolationException $e) {
-				// ignore existing relations
+			if(!in_array($tagId, array_column($rows, 'systemtagid'))) {
+				// tag not in db so create new one
+				try {
+					$query->setParameter('tagid', $tagId);
+					$query->execute();
+					$tagsAssigned[] = $tagId;
+				} catch (UniqueConstraintViolationException $e) {
+					// ignore existing relations
+				}
+			} else {
+				//tag exists already don't insert
 			}
 		}
 

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -115,6 +115,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		}
 
 		$this->assertTagsExist($tagIds);
+		$this->connection->beginTransaction();
 
 		$query = $this->connection->getQueryBuilder();
 		$query->select('systemtagid')
@@ -124,6 +125,12 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->andWhere($query->expr()->eq('objectid', $query->createNamedParameter($objId)));
 		$result = $query->executeQuery();
 		$rows = $result->fetchAll();
+		$existingTags = [];
+		foreach ($rows as $k => $row) {
+			$existingTags[] = $row['systemtagid'];
+		}
+		//filter only tags that do not exist in db
+		$tagIds = array_diff($tagIds, $existingTags);
 
 		$query = $this->connection->getQueryBuilder();
 		$query->insert(self::RELATION_TABLE)
@@ -135,20 +142,16 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 
 		$tagsAssigned = [];
 		foreach ($tagIds as $tagId) {
-			if(!in_array($tagId, array_column($rows, 'systemtagid'))) {
-				// tag not in db so create new one
-				try {
-					$query->setParameter('tagid', $tagId);
-					$query->execute();
-					$tagsAssigned[] = $tagId;
-				} catch (UniqueConstraintViolationException $e) {
-					// ignore existing relations
-				}
-			} else {
-				//tag exists already don't insert
+			try {
+				$query->setParameter('tagid', $tagId);
+				$query->execute();
+				$tagsAssigned[] = $tagId;
+			} catch (UniqueConstraintViolationException $e) {
+				// ignore existing relations
 			}
 		}
 
+		$this->connection->commit();
 		if (empty($tagsAssigned)) {
 			return;
 		}


### PR DESCRIPTION
fix: do a select in systemtag_object_mapping to see if tag exists already in db. if it does not exist alone insert the same or else do nothing

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
