### PR TITLE
delete background jobs by id when cleaning up

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -113,7 +113,7 @@ class JobList implements IJobList {
 		}
 	}
 
-	protected function removeById(int $id): void {
+	public function removeById(int $id): void {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('jobs')
 			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -61,6 +61,14 @@ interface IJobList {
 	public function remove($job, $argument = null): void;
 
 	/**
+	 * Remove a job from the list by id
+	 *
+	 * @param int $id
+	 * @since 30.0.0
+	 */
+	public function removeById(int $id): void;
+
+	/**
 	 * check if a job is in the list
 	 *
 	 * @param IJob|class-string<IJob> $job

--- a/lib/public/BackgroundJob/QueuedJob.php
+++ b/lib/public/BackgroundJob/QueuedJob.php
@@ -35,7 +35,11 @@ abstract class QueuedJob extends Job {
 	 * @since 25.0.0
 	 */
 	final public function start(IJobList $jobList): void {
-		$jobList->remove($this, $this->argument);
+		if ($this->id) {
+			$jobList->removeById($this->id);
+		} else {
+			$jobList->remove($this, $this->argument);
+		}
 		parent::start($jobList);
 	}
 }

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -26,6 +26,7 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	private array $reserved = [];
 
 	private int $last = 0;
+	private int $lastId = 0;
 
 	public function __construct() {
 	}
@@ -40,6 +41,8 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 			$job = \OCP\Server::get($job);
 		}
 		$job->setArgument($argument);
+		$job->setId($this->lastId);
+		$this->lastId++;
 		if (!$this->has($job, null)) {
 			$this->jobs[] = $job;
 		}
@@ -54,9 +57,20 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 	 * @param mixed $argument
 	 */
 	public function remove($job, $argument = null): void {
-		$index = array_search($job, $this->jobs);
-		if ($index !== false) {
-			unset($this->jobs[$index]);
+		foreach ($this->jobs as $index => $listJob) {
+			if (get_class($job) === get_class($listJob) && $job->getArgument() == $listJob->getArgument()) {
+				unset($this->jobs[$index]);
+				return;
+			}
+		}
+	}
+
+	public function removeById(int $id): void {
+		foreach ($this->jobs as $index => $listJob) {
+			if ($listJob->getId() === $id) {
+				unset($this->jobs[$index]);
+				return;
+			}
 		}
 	}
 
@@ -126,7 +140,7 @@ class DummyJobList extends \OC\BackgroundJob\JobList {
 		}
 	}
 
-	public function getById(int $id): IJob {
+	public function getById(int $id): ?IJob {
 		foreach ($this->jobs as $job) {
 			if ($job->getId() === $id) {
 				return $job;


### PR DESCRIPTION
Instead of deleting by job name and arguments.

This should both improve performance and reduce the risk of deadlocks