### PR TITLE
fix(core): Add missing null value possibility to Resource and Reference richObject

### DIFF
--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -53,7 +53,7 @@ namespace OCA\Core;
  *
  * @psalm-type CoreResource = array{
  *     richObjectType: string,
- *     richObject: array<string, mixed>,
+ *     richObject: array<string, ?mixed>,
  *     openGraphObject: CoreOpenGraphObject,
  *     accessible: bool,
  * }
@@ -66,7 +66,7 @@ namespace OCA\Core;
  *
  * @psalm-type CoreReference = array{
  *     richObjectType: string,
- *     richObject: array<string, mixed>,
+ *     richObject: array<string, ?mixed>,
  *     openGraphObject: CoreOpenGraphObject,
  *     accessible: bool,
  * }

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -358,7 +358,8 @@
                     "richObject": {
                         "type": "object",
                         "additionalProperties": {
-                            "type": "object"
+                            "type": "object",
+                            "nullable": true
                         }
                     },
                     "openGraphObject": {
@@ -416,7 +417,8 @@
                     "richObject": {
                         "type": "object",
                         "additionalProperties": {
-                            "type": "object"
+                            "type": "object",
+                            "nullable": true
                         }
                     },
                     "openGraphObject": {


### PR DESCRIPTION
## Summary

`mixed` apparently doesn't include `null` which I didn't know, so this was wrong.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
