### PR TITLE
feat(dbal): insert ignore conflict method for MySQL and SQLite

### DIFF
--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -76,4 +76,19 @@ class AdapterSqlite extends Adapter {
 			return 0;
 		}
 	}
+
+	public function insertIgnoreConflict(string $table, array $values): int {
+		$builder = $this->conn->getQueryBuilder();
+		$builder->insert($table);
+		$updates = [];
+		foreach ($values as $key => $value) {
+			$builder->setValue($key, $builder->createNamedParameter($value));
+		}
+
+		return $this->conn->executeStatement(
+			$builder->getSQL() . ' ON CONFLICT DO NOTHING',
+			$builder->getParameters(),
+			$builder->getParameterTypes()
+		);
+	}
 }

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\DB;
+
+use Test\TestCase;
+
+class AdapterTest extends TestCase {
+	private string $appId;
+	private $connection;
+
+	public function setUp(): void {
+		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->appId = uniqid('test_db_adapter', true);
+	}
+
+	public function tearDown(): void {
+		$qb = $this->connection->getQueryBuilder();
+
+		$qb->delete('appconfig')
+			->from('appconfig')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter($this->appId)))
+			->execute();
+	}
+
+	public function testInsertIgnoreOnConflictDuplicate(): void {
+		$configKey = uniqid('key', true);
+		$expected = [
+			[
+				'configkey' => $configKey,
+				'configvalue' => '1',
+			]
+		];
+		$result = $this->connection->insertIgnoreConflict('appconfig', [
+			'appid' => $this->appId,
+			'configkey' => $configKey,
+			'configvalue' => '1',
+		]);
+		$this->assertEquals(1, $result);
+		$rows = $this->getRows($configKey);
+		$this->assertSame($expected, $rows);
+
+
+		$result = $this->connection->insertIgnoreConflict('appconfig', [
+			'appid' => $this->appId,
+			'configkey' => $configKey,
+			'configvalue' => '2',
+		]);
+		$this->assertEquals(0, $result);
+		$rows = $this->getRows($configKey);
+		$this->assertSame($expected, $rows);
+	}
+
+	private function getRows(string $configKey): array {
+		$qb = $this->connection->getQueryBuilder();
+		return $qb->select(['configkey', 'configvalue'])
+			->from('appconfig')
+			->where($qb->expr()->eq('appid', $qb->createNamedParameter($this->appId)))
+			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($configKey)))
+			->execute()
+			->fetchAll();
+	}
+}


### PR DESCRIPTION
## Summary

Add ignore conflicts method for MySQL
Similar to PgSQL: https://github.com/nextcloud/server/blob/master/lib/private/DB/AdapterPgSql.php#L26-L37

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
