### PR TITLE
Avoid accessing unset argv index

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -23,7 +23,7 @@ use Psr\Log\LoggerInterface;
 try {
 	require_once __DIR__ . '/lib/base.php';
 
-	if ($argv[1] === '-h' || $argv[1] === '--help') {
+	if (isset($argv[1]) && ($argv[1] === '-h' || $argv[1] === '--help')) {
 		echo 'Description:
   Run the background job routine
 


### PR DESCRIPTION
This should avoid a lot of Php warnings.