### PR TITLE
fix(preview): ffmpeg gets stuck when getting video cover

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -96,55 +96,94 @@ class Movie extends ProviderV2 {
 
 		return $result;
 	}
-
 	private function generateThumbNail(int $maxX, int $maxY, string $absPath, int $second): ?IImage {
 		$tmpPath = \OC::$server->getTempManager()->getTemporaryFile();
-
 		$binaryType = substr(strrchr($this->binary, '/'), 1);
+		$cmd = $this->buildCommand($binaryType, $second, $absPath, $tmpPath);
 
-		if ($binaryType === 'avconv') {
-			$cmd = [$this->binary, '-y', '-ss', (string)$second,
-				'-i', $absPath,
-				'-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
-				$tmpPath];
-		} elseif ($binaryType === 'ffmpeg') {
-			$cmd = [$this->binary, '-y', '-ss', (string)$second,
-				'-i', $absPath,
-				'-f', 'mjpeg', '-vframes', '1',
-				$tmpPath];
-		} else {
-			// Not supported
+		if (!$cmd) {
 			unlink($tmpPath);
 			return null;
 		}
 
 		$proc = proc_open($cmd, [1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
-		$returnCode = -1;
-		$output = "";
-		if (is_resource($proc)) {
-			$stdout = trim(stream_get_contents($pipes[1]));
-			$stderr = trim(stream_get_contents($pipes[2]));
-			$returnCode = proc_close($proc);
-			$output = $stdout . $stderr;
+		if (!is_resource($proc)) {
+			unlink($tmpPath);
+			return null;
 		}
+
+		$output = $this->processPipes($pipes);
+		$status = proc_get_status($proc);
+
+		if ($status['running']) {
+			proc_terminate($proc, 9); // SIGKILL
+		}
+		
+		$returnCode = proc_close($proc);
 
 		if ($returnCode === 0) {
-			$image = new \OCP\Image();
-			$image->loadFromFile($tmpPath);
-			if ($image->valid()) {
-				unlink($tmpPath);
-				$image->scaleDownToFit($maxX, $maxY);
-
-				return $image;
-			}
+			return $this->handleSuccessfulThumbnailCreation($tmpPath, $maxX, $maxY);
 		}
 
-		if ($second === 0) {
-			$logger = \OC::$server->get(LoggerInterface::class);
-			$logger->info('Movie preview generation failed Output: {output}', ['app' => 'core', 'output' => $output]);
-		}
-
+		$this->logError($second, $output);
 		unlink($tmpPath);
 		return null;
 	}
+
+	private function buildCommand(string $binaryType, int $second, string $absPath, string $tmpPath): ?array {
+		if ($binaryType === 'avconv' || $binaryType === 'ffmpeg') {
+			// Faster seeking for ffmpeg
+			$fastSeek = ($binaryType === 'ffmpeg') ? ['-ss', (string)$second, '-i', $absPath] : ['-i', $absPath, '-ss', (string)$second];
+			return array_merge([$this->binary, '-y'], $fastSeek, ['-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1', $tmpPath]);
+		}
+		return null;
+	}
+
+	private function processPipes(array $pipes): string {
+		$output = "";
+		$endTime = time() + 10;
+
+		foreach ([1, 2] as $pipeNum) {
+			stream_set_blocking($pipes[$pipeNum], false);
+			stream_set_timeout($pipes[$pipeNum], 10);
+
+			while (!feof($pipes[$pipeNum])) {
+				$chunk = fread($pipes[$pipeNum], 8192);
+				if ($chunk === false || $chunk === "") {
+					$info = stream_get_meta_data($pipes[$pipeNum]);
+					if ($info['timed_out'] || $info['eof']) {
+						break;
+					}
+					if (time() > $endTime) {
+						break;
+					}
+					usleep(10000);
+				} else {
+					$output .= $chunk;
+				}
+			}
+			fclose($pipes[$pipeNum]);
+		}
+
+		return $output;
+	}
+
+
+
+	private function handleSuccessfulThumbnailCreation(string $tmpPath, int $maxX, int $maxY): ?IImage {
+		$image = new \OCP\Image();
+		$image->loadFromFile($tmpPath);
+		if ($image->valid()) {
+			unlink($tmpPath);
+			$image->scaleDownToFit($maxX, $maxY);
+			return $image;
+		}
+		return null;
+	}
+
+	private function logError(int $second, string $output): void {
+		$logger = \OC::$server->get(LoggerInterface::class);
+		$logger->info('Thumbnail generation failed at second {second}. Output: {output}', ['app' => 'core', 'second' => $second, 'output' => $output]);
+	}
+
 }

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -131,12 +131,24 @@ class Movie extends ProviderV2 {
 	}
 
 	private function buildCommand(string $binaryType, int $second, string $absPath, string $tmpPath): ?array {
-		if ($binaryType === 'avconv' || $binaryType === 'ffmpeg') {
-			// Faster seeking for ffmpeg
-			$fastSeek = ($binaryType === 'ffmpeg') ? ['-ss', (string)$second, '-i', $absPath] : ['-i', $absPath, '-ss', (string)$second];
-			return array_merge([$this->binary, '-y'], $fastSeek, ['-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1', $tmpPath]);
+		if ($binaryType === 'avconv') {
+			$cmd = [
+				$this->binary, '-y', '-ss', (string)$second,
+				'-i', $absPath,
+				'-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
+				$tmpPath
+			];
+		} elseif ($binaryType === 'ffmpeg') {
+			$cmd = [
+				$this->binary, '-y', '-ss', (string)$second,
+				'-i', $absPath,
+				'-f', 'mjpeg', '-vframes', '1',
+				$tmpPath
+			];
+		} else {
+			return null;
 		}
-		return null;
+		return $cmd;
 	}
 
 	private function processPipes(array $pipes): string {


### PR DESCRIPTION
Fixed the issue that ffmepg was stuck in getting the cover, which caused the PHP process to be blocked.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: nextcloud/server#43328

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
