### PR TITLE
fix restore of multiple folders with many files from trash_bin

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -691,7 +691,7 @@ class Cache implements ICache {
 				for ($i = 1; $i <= $retryLimit; $i++) {
 					try {
 						$this->connection->beginTransaction();
-						$query->executeStatement();
+						$query->execute();
 						break;
 					} catch (\OC\DatabaseException $e) {
 						$this->connection->rollBack();


### PR DESCRIPTION
## Summary

fixes restore from trash bin of multiple folders with many files inside them
switch the DB statement execution method

related to https://github.com/nextcloud/server/pull/44504

Some tests were carried, and this simple change seems to fix the issue.