### PR TITLE
Use isRetryable to catch retryable exceptions

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -7,8 +7,8 @@
  */
 namespace OC\Files\Cache;
 
-use Doctrine\DBAL\Exception\RetryableException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use OC\DB\Exceptions\DbalException;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Encryption;
@@ -696,7 +696,11 @@ class Cache implements ICache {
 					} catch (\OC\DatabaseException $e) {
 						$this->connection->rollBack();
 						throw $e;
-					} catch (RetryableException $e) {
+					} catch (DbalException $e) {
+						if (!$e->isRetryable()) {
+							throw $e;
+						}
+
 						// Simply throw if we already retried 4 times.
 						if ($i === $retryLimit) {
 							throw $e;


### PR DESCRIPTION
I probably tested before switching to the non deprecated method `executeStatement`.
This method wraps the exception in a `DbalException` which provides the handy `isRetryable` method.