### PR TITLE
test(logger): Fix `loglevel is not a valid integer` warnings

### DIFF
--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -34,6 +34,13 @@ class LoggerTest extends TestCase implements IWriter {
 		$this->config = $this->createMock(SystemConfig::class);
 		$this->registry = $this->createMock(IRegistry::class);
 		$this->logger = new Log($this, $this->config, null, $this->registry);
+
+		$this->config->expects($this->any())
+			->method('getValue')
+			->will(($this->returnValueMap([
+				['loglevel', ILogger::WARN, ILogger::WARN],
+				['log.condition', [], ['apps' => ['files']]]
+			])));
 	}
 
 	public function testInterpolation() {
@@ -45,12 +52,6 @@ class LoggerTest extends TestCase implements IWriter {
 	}
 
 	public function testAppCondition() {
-		$this->config->expects($this->any())
-			->method('getValue')
-			->will(($this->returnValueMap([
-				['loglevel', ILogger::WARN, ILogger::WARN],
-				['log.condition', [], ['apps' => ['files']]]
-			])));
 		$logger = $this->logger;
 
 		$logger->info('Don\'t display info messages');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

#44262 introduced a warning which is adding noise (x42 each run) to the logger unit tests: 

> `Nextcloud configuration: "loglevel" is not a valid integer`

This is happening because of the mocking for `SystemConfig::class` returning null for all `getValue()` calls for all but one of the Logger tests.

One lone test already had a stub in place for `getValue()` + `loglevel`.  I moved this existing stub into `setUp()` so all the tests could benefit from it. This cut out all 42 warnings.

I don't see any downsides, in this case, to this particular stub being shared across the Logger tests (i.e. the two specified values don't change the spirit of any of the existing tests).

If there's a better spot to stick stubs that are shared across a group of tests, let me know. 

Apologies if the above was super obvious to anyone reading this. I'm still getting familiar with the testing. :)

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
