### PR TITLE
fix(caldav): event links in shared calendar notifications

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Todo.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Todo.php
@@ -85,7 +85,7 @@ class Todo extends Event {
 					return [
 						'actor' => $this->generateUserParameter($parameters['actor']),
 						'calendar' => $this->generateCalendarParameter($parameters['calendar'], $this->l),
-						'todo' => $this->generateObjectParameter($parameters['object']),
+						'todo' => $this->generateObjectParameter($parameters['object'], $event->getAffectedUser()),
 					];
 				case self::SUBJECT_OBJECT_ADD . '_todo_self':
 				case self::SUBJECT_OBJECT_DELETE . '_todo_self':
@@ -94,7 +94,7 @@ class Todo extends Event {
 				case self::SUBJECT_OBJECT_UPDATE . '_todo_needs_action_self':
 					return [
 						'calendar' => $this->generateCalendarParameter($parameters['calendar'], $this->l),
-						'todo' => $this->generateObjectParameter($parameters['object']),
+						'todo' => $this->generateObjectParameter($parameters['object'], $event->getAffectedUser()),
 					];
 			}
 		}
@@ -106,13 +106,13 @@ class Todo extends Event {
 						'actor' => $this->generateUserParameter($parameters['actor']),
 						'sourceCalendar' => $this->generateCalendarParameter($parameters['sourceCalendar'], $this->l),
 						'targetCalendar' => $this->generateCalendarParameter($parameters['targetCalendar'], $this->l),
-						'todo' => $this->generateObjectParameter($parameters['object']),
+						'todo' => $this->generateObjectParameter($parameters['object'], $event->getAffectedUser()),
 					];
 				case self::SUBJECT_OBJECT_MOVE . '_todo_self':
 					return [
 						'sourceCalendar' => $this->generateCalendarParameter($parameters['sourceCalendar'], $this->l),
 						'targetCalendar' => $this->generateCalendarParameter($parameters['targetCalendar'], $this->l),
-						'todo' => $this->generateObjectParameter($parameters['object']),
+						'todo' => $this->generateObjectParameter($parameters['object'], $event->getAffectedUser()),
 					];
 			}
 		}
@@ -131,7 +131,7 @@ class Todo extends Event {
 				return [
 					'actor' => $this->generateUserParameter($parameters[0]),
 					'calendar' => $this->generateLegacyCalendarParameter($event->getObjectId(), $parameters[1]),
-					'todo' => $this->generateObjectParameter($parameters[2]),
+					'todo' => $this->generateObjectParameter($parameters[2], $event->getAffectedUser()),
 				];
 			case self::SUBJECT_OBJECT_ADD . '_todo_self':
 			case self::SUBJECT_OBJECT_DELETE . '_todo_self':
@@ -140,7 +140,7 @@ class Todo extends Event {
 			case self::SUBJECT_OBJECT_UPDATE . '_todo_needs_action_self':
 				return [
 					'calendar' => $this->generateLegacyCalendarParameter($event->getObjectId(), $parameters[1]),
-					'todo' => $this->generateObjectParameter($parameters[2]),
+					'todo' => $this->generateObjectParameter($parameters[2], $event->getAffectedUser()),
 				];
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/calendar/issues/5293

## Summary

The link in event notifications is invalid if a calendar is shared. An incoming shared calendar is belonging to sharee's principal with the custom name `<calendar>_shared_by_<sharer>`.

I implemented a hack to change the link in those cases to make the links in notifications work again.

### How to reproduce the bug?

1. Have 2 users: admin and user
2. Install and enable the Calendar app.
3. Log in as user and enable all push notifications regarding calendars (see screenshot below).
4. Log in as admin.
5. Create a calendar and share it with user.
6. Create an event in the calendar.
7. Log in as user.
8. Open the notifications (on the top right) and click on the event link.

**Here:** Clicking the link redirects to Calendar and opens the event.
**Master:** Clicking the link redirects to Calendar and shows an empty content `Event does not exist`.

![grafik](https://github.com/nextcloud/calendar/assets/1479486/1a2fe881-f4c1-4f03-9f3b-ad8c05ec4dee)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
