### PR TITLE
[stable24] fix: delete user credentials stored in storages_credentials when user gets deleted

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1559,6 +1559,7 @@ return array(
     'OC\\User\\Database' => $baseDir . '/lib/private/User/Database.php',
     'OC\\User\\DisplayNameCache' => $baseDir . '/lib/private/User/DisplayNameCache.php',
     'OC\\User\\LazyUser' => $baseDir . '/lib/private/User/LazyUser.php',
+	'OC\\User\\Listeners\\BeforeUserDeletedListener' => $baseDir . '/lib/private/User/Listeners/BeforeUserDeletedListener.php',
     'OC\\User\\LoginException' => $baseDir . '/lib/private/User/LoginException.php',
     'OC\\User\\Manager' => $baseDir . '/lib/private/User/Manager.php',
     'OC\\User\\NoUserException' => $baseDir . '/lib/private/User/NoUserException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1588,6 +1588,7 @@ class ComposerStaticInit53792487c5a8370acc0b06b1a864ff4c
         'OC\\User\\Database' => __DIR__ . '/../../..' . '/lib/private/User/Database.php',
         'OC\\User\\DisplayNameCache' => __DIR__ . '/../../..' . '/lib/private/User/DisplayNameCache.php',
         'OC\\User\\LazyUser' => __DIR__ . '/../../..' . '/lib/private/User/LazyUser.php',
+		'OC\\User\\Listeners\\BeforeUserDeletedListener' => __DIR__ . '/../../..' . '/lib/private/User/Listeners/BeforeUserDeletedListener.php',
         'OC\\User\\LoginException' => __DIR__ . '/../../..' . '/lib/private/User/LoginException.php',
         'OC\\User\\Manager' => __DIR__ . '/../../..' . '/lib/private/User/Manager.php',
         'OC\\User\\NoUserException' => __DIR__ . '/../../..' . '/lib/private/User/NoUserException.php',

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -151,6 +151,7 @@ use OC\SystemTag\ManagerFactory as SystemTagManagerFactory;
 use OC\Tagging\TagMapper;
 use OC\Talk\Broker;
 use OC\Template\JSCombiner;
+use OC\User\Listeners\BeforeUserDeletedListener;
 use OCA\Theming\ImageManager;
 use OCA\Theming\ThemingDefaults;
 use OCA\Theming\Util;
@@ -244,6 +245,7 @@ use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\Talk\IBroker;
 use OCP\User\Events\BeforePasswordUpdatedEvent;
+use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\BeforeUserLoggedInWithCookieEvent;
 use OCP\User\Events\BeforeUserLoggedOutEvent;
@@ -1522,6 +1524,8 @@ class Server extends ServerContainer implements IServerContainer {
 		$eventDispatched = $this->get(IEventDispatcher::class);
 		$eventDispatched->addServiceListener(LoginFailed::class, LoginFailedListener::class);
 		$eventDispatched->addServiceListener(PostLoginEvent::class, UserLoggedInListener::class);
+		$eventDispatched->addServiceListener(BeforeUserDeletedEvent::class, BeforeUserDeletedListener::class);
+
 	}
 
 	/**

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1525,7 +1525,6 @@ class Server extends ServerContainer implements IServerContainer {
 		$eventDispatched->addServiceListener(LoginFailed::class, LoginFailedListener::class);
 		$eventDispatched->addServiceListener(PostLoginEvent::class, UserLoggedInListener::class);
 		$eventDispatched->addServiceListener(BeforeUserDeletedEvent::class, BeforeUserDeletedListener::class);
-
 	}
 
 	/**

--- a/lib/private/User/Listeners/BeforeUserDeletedListener.php
+++ b/lib/private/User/Listeners/BeforeUserDeletedListener.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Carl Schwan <carl@carlschwan.eu>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OC\User\Listeners;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\NotFoundException;
+use OCP\IAvatarManager;
+use OCP\Security\ICredentialsManager;
+use OCP\User\Events\BeforeUserDeletedEvent;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @template-implements IEventListener<BeforeUserDeletedEvent>
+ */
+class BeforeUserDeletedListener implements IEventListener {
+	private IAvatarManager $avatarManager;
+	private ICredentialsManager $credentialsManager;
+	private LoggerInterface $logger;
+
+	public function __construct(LoggerInterface $logger, IAvatarManager $avatarManager, ICredentialsManager $credentialsManager) {
+		$this->avatarManager = $avatarManager;
+		$this->credentialsManager = $credentialsManager;
+		$this->logger = $logger;
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof BeforeUserDeletedEvent)) {
+			return;
+		}
+
+		$user = $event->getUser();
+
+		// Delete avatar on user deletion
+		try {
+			$avatar = $this->avatarManager->getAvatar($user->getUID());
+			$avatar->remove(true);
+		} catch (NotFoundException $e) {
+			// no avatar to remove
+		} catch (\Exception $e) {
+			// Ignore exceptions
+			$this->logger->info('Could not cleanup avatar of ' . $user->getUID(), [
+				'exception' => $e,
+			]);
+		}
+		// Delete storages credentials on user deletion
+		$this->credentialsManager->erase($user->getUID());
+	}
+}

--- a/lib/private/User/Listeners/BeforeUserDeletedListener.php
+++ b/lib/private/User/Listeners/BeforeUserDeletedListener.php
@@ -25,8 +25,6 @@ namespace OC\User\Listeners;
 
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\Files\NotFoundException;
-use OCP\IAvatarManager;
 use OCP\Security\ICredentialsManager;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use Psr\Log\LoggerInterface;
@@ -35,12 +33,10 @@ use Psr\Log\LoggerInterface;
  * @template-implements IEventListener<BeforeUserDeletedEvent>
  */
 class BeforeUserDeletedListener implements IEventListener {
-	private IAvatarManager $avatarManager;
 	private ICredentialsManager $credentialsManager;
 	private LoggerInterface $logger;
 
-	public function __construct(LoggerInterface $logger, IAvatarManager $avatarManager, ICredentialsManager $credentialsManager) {
-		$this->avatarManager = $avatarManager;
+	public function __construct(LoggerInterface $logger, ICredentialsManager $credentialsManager) {
 		$this->credentialsManager = $credentialsManager;
 		$this->logger = $logger;
 	}
@@ -51,19 +47,6 @@ class BeforeUserDeletedListener implements IEventListener {
 		}
 
 		$user = $event->getUser();
-
-		// Delete avatar on user deletion
-		try {
-			$avatar = $this->avatarManager->getAvatar($user->getUID());
-			$avatar->remove(true);
-		} catch (NotFoundException $e) {
-			// no avatar to remove
-		} catch (\Exception $e) {
-			// Ignore exceptions
-			$this->logger->info('Could not cleanup avatar of ' . $user->getUID(), [
-				'exception' => $e,
-			]);
-		}
 		// Delete storages credentials on user deletion
 		$this->credentialsManager->erase($user->getUID());
 	}


### PR DESCRIPTION
Backport of [#45355](https://github.com/nextcloud/server/pull/45355)
fix: merge conflict resolved and added BeforeUserDeletedListener.php and changed autoload files accordingly along with adding the listener in Server

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
