### PR TITLE
fix(caldav): allow VJOURNAL if no supported component set is specified

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -755,7 +755,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			'uri' => $calendarUri,
 			'synctoken' => 1,
 			'transparent' => 0,
-			'components' => 'VEVENT,VTODO',
+			'components' => 'VEVENT,VTODO,VJOURNAL',
 			'displayname' => $calendarUri
 		];
 

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -154,7 +154,7 @@ abstract class AbstractCalDavBackend extends TestCase {
 		$this->assertEquals(self::UNIT_TEST_USER, $calendars[0]['principaluri']);
 		/** @var SupportedCalendarComponentSet $components */
 		$components = $calendars[0]['{urn:ietf:params:xml:ns:caldav}supported-calendar-component-set'];
-		$this->assertEquals(['VEVENT','VTODO'], $components->getValue());
+		$this->assertEquals(['VEVENT','VTODO','VJOURNAL'], $components->getValue());
 		$color = $calendars[0]['{http://apple.com/ns/ical/}calendar-color'];
 		$this->assertEquals('#1C4587FF', $color);
 		$this->assertEquals('Example', $calendars[0]['uri']);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/45709

## Summary

The CalDAV RFC says:

> In the absence of this property [`supported-calendar-component-set`], the server MUST accept all component types, and the client can assume that all component types are accepted.

So collections that are created without `supported-calendar-component-set` should also support journals.

## TODO

- [x] Probably tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
