### PR TITLE
fix(cron): Log long running jobs

### DIFF
--- a/cron.php
+++ b/cron.php
@@ -154,14 +154,33 @@ Options:
 			$jobDetails = get_class($job) . ' (id: ' . $job->getId() . ', arguments: ' . json_encode($job->getArgument()) . ')';
 			$logger->debug('CLI cron call has selected job ' . $jobDetails, ['app' => 'cron']);
 
+			$timeBefore = time();
 			$memoryBefore = memory_get_usage();
 			$memoryPeakBefore = memory_get_peak_usage();
 
 			/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
 			$job->execute($jobList);
 
+			$timeAfter = time();
 			$memoryAfter = memory_get_usage();
 			$memoryPeakAfter = memory_get_peak_usage();
+
+			$cronInterval = 5 * 60;
+			$timeSpent = $timeAfter - $timeBefore;
+			if ($timeSpent > $cronInterval) {
+				$logLevel = match (true) {
+					$timeSpent > $cronInterval * 128 => \OCP\ILogger::FATAL,
+					$timeSpent > $cronInterval * 64 => \OCP\ILogger::ERROR,
+					$timeSpent > $cronInterval * 16 => \OCP\ILogger::WARN,
+					$timeSpent > $cronInterval * 8 => \OCP\ILogger::INFO,
+					default => \OCP\ILogger::DEBUG,
+				};
+				$logger->log(
+					$logLevel,
+					'Background job ' . $jobDetails . ' ran for ' . $timeSpent . ' seconds',
+					['app' => 'cron']
+				);
+			}
 
 			if ($memoryAfter - $memoryBefore > 10_000_000) {
 				$logger->warning('Used memory grew by more than 10 MB when executing job ' . $jobDetails . ': ' . Util::humanFileSize($memoryAfter). ' (before: ' . Util::humanFileSize($memoryBefore) . ')', ['app' => 'cron']);
@@ -178,7 +197,7 @@ Options:
 			$executedJobs[$job->getId()] = true;
 			unset($job);
 
-			if (time() > $endTime) {
+			if ($timeAfter > $endTime) {
 				break;
 			}
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: production instance with database transactions spanning for days. One theory is that it's a stuck cron job.

## Summary

If cron jobs take a very long time to complete they will start to run in parallel. That's because jobs are only reserved for 12h. Afterwards we just assume that the jobs failed and start the job again. In faulty situations that can lead to more and more server load.

Here is an example:

![Bildschirmfoto vom 2024-06-12 09-40-13](https://github.com/nextcloud/server/assets/1374172/3d9e66dd-da12-4269-84fa-38ce4a6ead14)
![Bildschirmfoto vom 2024-06-12 09-40-30](https://github.com/nextcloud/server/assets/1374172/9fe5d570-0f09-4ae8-9715-f4e43397217b)
![Bildschirmfoto vom 2024-06-12 09-40-35](https://github.com/nextcloud/server/assets/1374172/8c231aaf-d041-4e63-89c0-af42566e97f6)
![Bildschirmfoto vom 2024-06-12 09-40-38](https://github.com/nextcloud/server/assets/1374172/fc5914cf-9fa9-4cd5-b34f-71669a85dc4a)
![Bildschirmfoto vom 2024-06-12 09-40-43](https://github.com/nextcloud/server/assets/1374172/81d69900-4317-4180-a2ec-a4e8dd814783)
![Bildschirmfoto vom 2024-06-12 09-40-48](https://github.com/nextcloud/server/assets/1374172/0bc493d9-1ad4-4523-90fe-a4b32f0c2a6f)

It looks like a job executes an expensive query over and over. After 12h the query time doubles, after 24h it triplicates, after 36h it quadruples, etc. It's not clear if that is what is really happening.

I've tried to be reasonable with the log level so we don't spam the logs too much:

* Job executes longer than 5m -> debug
* Job executes longer than 20m -> info
* Job executes longer than 1h20m -> warning
* Job executes longer than 5h20m -> error
* Job executes longer than 10h40m -> fatal

## TODO

- [x] Add logging

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
