### PR TITLE
[stable29] fix(Token): make new scope future compatible

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -103,7 +103,7 @@ class PasswordConfirmationMiddleware extends Middleware {
 				return;
 			}
 			$scope = $token->getScopeAsArray();
-			if (isset($scope['sso-based-login']) && $scope['sso-based-login'] === true) {
+			if (isset($scope['password-unconfirmable']) && $scope['password-unconfirmable'] === true) {
 				// Users logging in from SSO backends cannot confirm their password by design
 				return;
 			}

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -312,6 +312,6 @@ class JSConfigHelper {
 			return true;
 		}
 		$scope = $token->getScopeAsArray();
-		return !isset($scope['sso-based-login']) || $scope['sso-based-login'] === false;
+		return !isset($scope['password-unconfirmable']) || $scope['password-unconfirmable'] === false;
 	}
 }

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -202,7 +202,7 @@ class OC_User {
 				if (empty($password)) {
 					$tokenProvider = \OC::$server->get(IProvider::class);
 					$token = $tokenProvider->getToken($userSession->getSession()->getId());
-					$token->setScope(['sso-based-login' => true]);
+					$token->setScope(['password-unconfirmable' => true]);
 					$tokenProvider->updateToken($token);
 				}
 

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -198,7 +198,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 
 		$token = $this->createMock(IToken::class);
 		$token->method('getScopeAsArray')
-			->willReturn(['sso-based-login' => true]);
+			->willReturn(['password-unconfirmable' => true]);
 		$this->tokenProvider->expects($this->once())
 			->method('getToken')
 			->with($sessionId)


### PR DESCRIPTION
## Summary

Addendum to https://github.com/nextcloud/server/pull/45705

 "password-unconfirmable" is the effective name for 30, but a draft name was backported.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
