### PR TITLE
Feat: add new clickable area variables

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -60,7 +60,9 @@
   /* Border radius of interactive elements such as buttons, input, navigation and list items. Available since Nextcloud 30. */
   --border-radius-element: 10px;
   --border-radius-pill: 100px;
-  --default-clickable-area: 44px;
+  --default-clickable-area: 34px;
+  --clickable-area-large: 48px;
+  --clickable-area-small: 24px;
   --default-line-height: 24px;
   --default-grid-baseline: 4px;
   --header-height: 50px;

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -172,7 +172,9 @@ class DefaultTheme implements ITheme {
 			// pill-style button, value is large so big buttons also have correct roundness
 			'--border-radius-pill' => '100px',
 
-			'--default-clickable-area' => '44px',
+			'--default-clickable-area' => '32px',
+			'--clickable-area-large' => '48px',
+			'--clickable-area-small' => '24px',
 			'--default-line-height' => '24px',
 			'--default-grid-baseline' => '4px',
 

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -172,7 +172,7 @@ class DefaultTheme implements ITheme {
 			// pill-style button, value is large so big buttons also have correct roundness
 			'--border-radius-pill' => '100px',
 
-			'--default-clickable-area' => '32px',
+			'--default-clickable-area' => '34px',
 			'--clickable-area-large' => '48px',
 			'--clickable-area-small' => '24px',
 			'--default-line-height' => '24px',


### PR DESCRIPTION
Add new variables for clickable areas and reduces size of `--default-clickable-area` 

Part of [#45657](https://github.com/nextcloud/server/issues/45657)