### PR TITLE
Feat: reduce border radius element to 8 px

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -58,7 +58,7 @@
   --border-radius-large: 10px;
   --border-radius-rounded: 28px;
   /* Border radius of interactive elements such as buttons, input, navigation and list items. Available since Nextcloud 30. */
-  --border-radius-element: 10px;
+  --border-radius-element: 8px;
   --border-radius-pill: 100px;
   --default-clickable-area: 44px;
   --default-line-height: 24px;

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -168,7 +168,7 @@ class DefaultTheme implements ITheme {
 			'--border-radius' => '3px',
 			'--border-radius-large' => '10px',
 			'--border-radius-rounded' => '28px',
-			'--border-radius-element' => '10px',
+			'--border-radius-element' => '8px',
 			// pill-style button, value is large so big buttons also have correct roundness
 			'--border-radius-pill' => '100px',
 


### PR DESCRIPTION
part of [#45657](https://github.com/nextcloud/server/issues/45657)

With smaller size clickable elements, we also need to dial down the border radius a bit.