### PR TITLE
feat(dav): add regex to match Gnome and KDE calendar user-agents

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
@@ -23,7 +23,7 @@ class Plugin extends ServerPlugin {
 	 * that do not support subscriptions on their own
 	 *
 	 * /^MSFT-WIN-3/ - Windows 10 Calendar
-     * /Evolution/ - Gnome Calendar/Evolution
+	 * /Evolution/ - Gnome Calendar/Evolution
 	 * /KIO/ - KDE PIM/Akonadi
 	 * @var string[]
 	 */

--- a/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Plugin.php
@@ -23,10 +23,14 @@ class Plugin extends ServerPlugin {
 	 * that do not support subscriptions on their own
 	 *
 	 * /^MSFT-WIN-3/ - Windows 10 Calendar
+     * /Evolution/ - Gnome Calendar/Evolution
+	 * /KIO/ - KDE PIM/Akonadi
 	 * @var string[]
 	 */
 	public const ENABLE_FOR_CLIENTS = [
-		"/^MSFT-WIN-3/"
+		"/^MSFT-WIN-3/",
+		"/Evolution/",
+		"/KIO/"
 	];
 
 	/**


### PR DESCRIPTION
* Resolves: #17754

## Summary
Original Pull Request by @msrn: https://github.com/nextcloud/server/pull/33729 which became stale.

Quote: "This pull requests adds Gnome Calendar/Evolution and KDE PIM/Akonadi calendars to the list of user-agents in WebCalCaching -plugin, and exposes subscribed calendars to these calendar clients.

User-agent of Gnome Calendar/Evolution
Evolution/3.40.3

KDE PIM/Akonadi user-agent
Mozilla/5.0 (X11; Linux x86_64) KIO/5.86 akonadi_davgroupware_resource_1/5.18.2 (21.08.2)"
