### PR TITLE
fix: rename split into two as before rename and after rename

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -26,6 +26,8 @@ use Psr\Log\LoggerInterface;
  * @package OCA\AdminAudit\Actions
  */
 class Files extends Action {
+
+	private array|null $renameParams = null;
 	/**
 	 * Logs file read actions
 	 *
@@ -68,12 +70,7 @@ class Files extends Action {
 			);
 			return;
 		}
-
-		$this->log(
-			'File with id "%s" renamed from "%s"',
-			$params,
-			array_keys($params)
-		);
+		$this->renameParams = $params;
 	}
 
 	/**
@@ -84,8 +81,10 @@ class Files extends Action {
 	public function afterRename(NodeRenamedEvent $event): void {
 		try {
 			$target = $event->getTarget();
+			$renameParams = $this->renameParams;
 			$params = [
 				'newid' => $target->getId(),
+				'oldpath' => $renameParams['oldpath'],
 				'newpath' => mb_substr($target->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
@@ -96,7 +95,7 @@ class Files extends Action {
 		}
 
 		$this->log(
-			'File with id "%s" renamed to "%s"',
+			'File renamed with id "%s" from "%s" to "%s"',
 			$params,
 			array_keys($params)
 		);

--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -181,16 +181,16 @@ class Application extends App implements IBootstrap {
 		);
 
 		$eventDispatcher->addListener(
-			NodeRenamedEvent::class,
-			function (NodeRenamedEvent $event) use ($fileActions) {
-				$fileActions->afterRename($event);
+			BeforeNodeRenamedEvent::class,
+			function (BeforeNodeRenamedEvent $event) use ($fileActions) {
+				$fileActions->beforeRename($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
-			BeforeNodeRenamedEvent::class,
-			function (BeforeNodeRenamedEvent $event) use ($fileActions) {
-				$fileActions->beforeRename($event);
+			NodeRenamedEvent::class,
+			function (NodeRenamedEvent $event) use ($fileActions) {
+				$fileActions->afterRename($event);
 			}
 		);
 

--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCP\Authentication\TwoFactorAuth\TwoFactorProviderChallengePassed;
 use OCP\Console\ConsoleEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\BeforeNodeReadEvent;
+use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
 use OCP\Files\Events\Node\NodeCopiedEvent;
 use OCP\Files\Events\Node\NodeCreatedEvent;
@@ -182,7 +183,14 @@ class Application extends App implements IBootstrap {
 		$eventDispatcher->addListener(
 			NodeRenamedEvent::class,
 			function (NodeRenamedEvent $event) use ($fileActions) {
-				$fileActions->rename($event);
+				$fileActions->afterRename($event);
+			}
+		);
+
+		$eventDispatcher->addListener(
+			BeforeNodeRenamedEvent::class,
+			function (BeforeNodeRenamedEvent $event) use ($fileActions) {
+				$fileActions->beforeRename($event);
 			}
 		);
 


### PR DESCRIPTION
rename logged as beforeRename and afterRename, and in both placegetInternalPath is used in place of getPath to make it consistent across the logs

The new log entry is 

{"reqId":"UWHQDoQKdUhE5aX27rdE","level":1,"time":"2024-06-13T12:02:04+00:00","remoteAddr":"192.168.21.5","user":"admin","app":"admin_audit","method":"MOVE","url":"/remote.php/dav/files/admin/nc.logs.txt","message":"File renamed with id \"2263\" from \"/nc.logs.txt\" to \"/nc2.logs.txt\"","userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36","version":"30.0.0.1","data":{"app":"admin_audit"}}

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
