### PR TITLE
chore(deps): Bump aws/aws-sdk-php from 3.240.8 to 3.311.2

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -11,7 +11,7 @@ use Aws\Credentials\Credentials;
 use Aws\Exception\CredentialsException;
 use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
-use GuzzleHttp\Promise;
+use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\RejectedPromise;
 use OCP\ICertificateManager;
 use Psr\Log\LoggerInterface;
@@ -178,7 +178,7 @@ trait S3ConnectionTrait {
 			$secret = empty($this->params['secret']) ? null : $this->params['secret'];
 
 			if ($key && $secret) {
-				return Promise\promise_for(
+				return Create::promiseFor(
 					new Credentials($key, $secret)
 				);
 			}

--- a/lib/private/Files/ObjectStore/S3Signature.php
+++ b/lib/private/Files/ObjectStore/S3Signature.php
@@ -93,7 +93,7 @@ class S3Signature implements SignatureInterface {
 			}
 		}
 
-		$queryString = http_build_query($query, null, '&', PHP_QUERY_RFC3986);
+		$queryString = http_build_query($query, '', '&', PHP_QUERY_RFC3986);
 
 		return $request->withUri($request->getUri()->withQuery($queryString));
 	}


### PR DESCRIPTION
* For https://github.com/nextcloud/3rdparty/pull/1850

## Summary


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
