### PR TITLE
fix: Avoid throwing errors for teams are unavailable

### DIFF
--- a/lib/private/Teams/TeamManager.php
+++ b/lib/private/Teams/TeamManager.php
@@ -36,6 +36,10 @@ class TeamManager implements ITeamManager {
 	}
 
 	public function getProviders(): array {
+		if (!$this->hasTeamSupport()) {
+			return [];
+		}
+
 		if ($this->providers !== null) {
 			return $this->providers;
 		}
@@ -62,6 +66,10 @@ class TeamManager implements ITeamManager {
 	}
 
 	public function getSharedWith(string $teamId, string $userId): array {
+		if (!$this->hasTeamSupport()) {
+			return [];
+		}
+
 		if ($this->getTeam($teamId, $userId) === null) {
 			return [];
 		}
@@ -76,6 +84,10 @@ class TeamManager implements ITeamManager {
 	}
 
 	public function getTeamsForResource(string $providerId, string $resourceId, string $userId): array {
+		if (!$this->hasTeamSupport()) {
+			return [];
+		}
+
 		$provider = $this->getProvider($providerId);
 		return array_values(array_filter(array_map(function ($teamId) use ($userId) {
 			$team = $this->getTeam($teamId, $userId);
@@ -92,6 +104,10 @@ class TeamManager implements ITeamManager {
 	}
 
 	private function getTeam(string $teamId, string $userId): ?Circle {
+		if (!$this->hasTeamSupport()) {
+			return null;
+		}
+
 		try {
 			$federatedUser = $this->circlesManager->getFederatedUser($userId, Member::TYPE_USER);
 			$this->circlesManager->startSession($federatedUser);


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/45715

In case the circles app is not enabled we do not need to check for any team related logic further.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
