### PR TITLE
fix: don't use custom certificate bundle if no customer certificates are configured

### DIFF
--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -204,17 +204,17 @@ class CertificateManager implements ICertificateManager {
 			if ($this->bundlePath === null) {
 				if (!$this->hasCertificates()) {
 					$this->bundlePath = \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
-				}
+				} else {
+					if ($this->needsRebundling()) {
+						$this->createCertificateBundle();
+					}
 
-				if ($this->needsRebundling()) {
-					$this->createCertificateBundle();
-				}
+					$certificateBundle = $this->getCertificateBundle();
+					$this->bundlePath = $this->view->getLocalFile($certificateBundle) ?: null;
 
-				$certificateBundle = $this->getCertificateBundle();
-				$this->bundlePath = $this->view->getLocalFile($certificateBundle) ?: null;
-
-				if ($this->bundlePath === null) {
-					throw new \RuntimeException('Unable to get certificate bundle "' . $certificateBundle . '".');
+					if ($this->bundlePath === null) {
+						throw new \RuntimeException('Unable to get certificate bundle "' . $certificateBundle . '".');
+					}
 				}
 			}
 			return $this->bundlePath;


### PR DESCRIPTION
Fixes a basic logic error :see_no_evil: 