### PR TITLE
feat: add command to export certificate bundle

### DIFF
--- a/core/Command/Security/ExportCertificates.php
+++ b/core/Command/Security/ExportCertificates.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+declare(strict_types=1);
+
+namespace OC\Core\Command\Security;
+
+use OC\Core\Command\Base;
+use OCP\ICertificateManager;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExportCertificates extends Base {
+	public function __construct(
+		protected ICertificateManager $certificateManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('security:certificates:export')
+			->setDescription('export the certificate bundle');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$bundlePath = $this->certificateManager->getAbsoluteBundlePath();
+		$bundle = file_get_contents($bundlePath);
+		$output->writeln($bundle);
+		return 0;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -136,6 +136,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Command\SystemTag\Edit::class));
 
 	$application->add(Server::get(Command\Security\ListCertificates::class));
+	$application->add(Server::get(Command\Security\ExportCertificates::class));
 	$application->add(Server::get(Command\Security\ImportCertificate::class));
 	$application->add(Server::get(Command\Security\RemoveCertificate::class));
 	$application->add(Server::get(Command\Security\BruteforceAttempts::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1206,6 +1206,7 @@ return array(
     'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => $baseDir . '/core/Command/Preview/ResetRenderedTexts.php',
     'OC\\Core\\Command\\Security\\BruteforceAttempts' => $baseDir . '/core/Command/Security/BruteforceAttempts.php',
     'OC\\Core\\Command\\Security\\BruteforceResetAttempts' => $baseDir . '/core/Command/Security/BruteforceResetAttempts.php',
+    'OC\\Core\\Command\\Security\\ExportCertificates' => $baseDir . '/core/Command/Security/ExportCertificates.php',
     'OC\\Core\\Command\\Security\\ImportCertificate' => $baseDir . '/core/Command/Security/ImportCertificate.php',
     'OC\\Core\\Command\\Security\\ListCertificates' => $baseDir . '/core/Command/Security/ListCertificates.php',
     'OC\\Core\\Command\\Security\\RemoveCertificate' => $baseDir . '/core/Command/Security/RemoveCertificate.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1239,6 +1239,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => __DIR__ . '/../../..' . '/core/Command/Preview/ResetRenderedTexts.php',
         'OC\\Core\\Command\\Security\\BruteforceAttempts' => __DIR__ . '/../../..' . '/core/Command/Security/BruteforceAttempts.php',
         'OC\\Core\\Command\\Security\\BruteforceResetAttempts' => __DIR__ . '/../../..' . '/core/Command/Security/BruteforceResetAttempts.php',
+        'OC\\Core\\Command\\Security\\ExportCertificates' => __DIR__ . '/../../..' . '/core/Command/Security/ExportCertificates.php',
         'OC\\Core\\Command\\Security\\ImportCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/ImportCertificate.php',
         'OC\\Core\\Command\\Security\\ListCertificates' => __DIR__ . '/../../..' . '/core/Command/Security/ListCertificates.php',
         'OC\\Core\\Command\\Security\\RemoveCertificate' => __DIR__ . '/../../..' . '/core/Command/Security/RemoveCertificate.php',


### PR DESCRIPTION
Can be useful for either debugging certificate issues or if you need to use the same bundle as nextcloud uses in any external program.