### PR TITLE
feat: add command to send raw commands to redis

### DIFF
--- a/core/Command/Memcache/RedisCommand.php
+++ b/core/Command/Memcache/RedisCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Robin Appelman <robin@icewind.nl>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Command\Memcache;
+
+use OC\Core\Command\Base;
+use OC\RedisFactory;
+use OCP\ICertificateManager;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class RedisCommand extends Base {
+	public function __construct(
+		protected ICertificateManager $certificateManager,
+		protected RedisFactory $redisFactory,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('memcache:redis:command')
+			->setDescription('Send raw redis command to the configured redis server')
+			->addArgument('redis-command', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'The command to run');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$command = $input->getArgument('redis-command');
+		if (!$this->redisFactory->isAvailable()) {
+			$output->writeln("<error>No redis server configured</error>");
+			return 1;
+		}
+		try {
+			$redis = $this->redisFactory->getInstance();
+		} catch (\Exception $e) {
+			$output->writeln('Failed to connect to redis: ' . $e->getMessage());
+			return 1;
+		}
+
+		$redis->setOption(\Redis::OPT_REPLY_LITERAL, true);
+		$result = $redis->rawCommand(...$command);
+		if ($result === false) {
+			$output->writeln("<error>Redis command failed</error>");
+			return 1;
+		}
+		$output->writeln($result);
+		return 0;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -147,6 +147,8 @@ if ($config->getSystemValueBool('installed', false)) {
 
 	$application->add(Server::get(Command\TaskProcessing\ListCommand::class));
 	$application->add(Server::get(Command\TaskProcessing\Statistics::class));
+
+	$application->add(Server::get(Command\Memcache\RedisCommand::class));
 } else {
 	$application->add(Server::get(Command\Maintenance\Install::class));
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1202,6 +1202,7 @@ return array(
     'OC\\Core\\Command\\Maintenance\\RepairShareOwnership' => $baseDir . '/core/Command/Maintenance/RepairShareOwnership.php',
     'OC\\Core\\Command\\Maintenance\\UpdateHtaccess' => $baseDir . '/core/Command/Maintenance/UpdateHtaccess.php',
     'OC\\Core\\Command\\Maintenance\\UpdateTheme' => $baseDir . '/core/Command/Maintenance/UpdateTheme.php',
+    'OC\\Core\\Command\\Memcache\\RedisCommand' => $baseDir . '/core/Command/Memcache/RedisCommand.php',
     'OC\\Core\\Command\\Preview\\Generate' => $baseDir . '/core/Command/Preview/Generate.php',
     'OC\\Core\\Command\\Preview\\Repair' => $baseDir . '/core/Command/Preview/Repair.php',
     'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => $baseDir . '/core/Command/Preview/ResetRenderedTexts.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1235,6 +1235,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Maintenance\\RepairShareOwnership' => __DIR__ . '/../../..' . '/core/Command/Maintenance/RepairShareOwnership.php',
         'OC\\Core\\Command\\Maintenance\\UpdateHtaccess' => __DIR__ . '/../../..' . '/core/Command/Maintenance/UpdateHtaccess.php',
         'OC\\Core\\Command\\Maintenance\\UpdateTheme' => __DIR__ . '/../../..' . '/core/Command/Maintenance/UpdateTheme.php',
+        'OC\\Core\\Command\\Memcache\\RedisCommand' => __DIR__ . '/../../..' . '/core/Command/Memcache/RedisCommand.php',
         'OC\\Core\\Command\\Preview\\Generate' => __DIR__ . '/../../..' . '/core/Command/Preview/Generate.php',
         'OC\\Core\\Command\\Preview\\Repair' => __DIR__ . '/../../..' . '/core/Command/Preview/Repair.php',
         'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => __DIR__ . '/../../..' . '/core/Command/Preview/ResetRenderedTexts.php',


### PR DESCRIPTION
This can be useful to using `redis-cli` because it ensures that the same redis configuration is used. Both making it potentially easier to run and removing any room for error of connecting to the wrong server.