### PR TITLE
fix(files): Properly handle denied ownership transfers

### DIFF
--- a/apps/files/lib/Controller/TransferOwnershipController.php
+++ b/apps/files/lib/Controller/TransferOwnershipController.php
@@ -189,19 +189,9 @@ class TransferOwnershipController extends OCSController {
 			->setObject('transfer', (string)$id);
 		$this->notificationManager->markProcessed($notification);
 
-		$notification = $this->notificationManager->createNotification();
-		$notification->setUser($transferOwnership->getSourceUser())
-			->setApp($this->appName)
-			->setDateTime($this->timeFactory->getDateTime())
-			->setSubject('transferownershipRequestDenied', [
-				'sourceUser' => $transferOwnership->getSourceUser(),
-				'targetUser' => $transferOwnership->getTargetUser(),
-				'nodeName' => $transferOwnership->getNodeName()
-			])
-			->setObject('transfer', (string)$transferOwnership->getId());
-		$this->notificationManager->notify($notification);
-
 		$this->mapper->delete($transferOwnership);
+
+		// A "request denied" notification will be created by Notifier::dismissNotification
 
 		return new DataResponse([], Http::STATUS_OK);
 	}

--- a/apps/files/lib/Notification/Notifier.php
+++ b/apps/files/lib/Notification/Notifier.php
@@ -69,23 +69,15 @@ class Notifier implements INotifier, IDismissableNotifier {
 			throw new \InvalidArgumentException('Unhandled app');
 		}
 
-		if ($notification->getSubject() === 'transferownershipRequest') {
-			return $this->handleTransferownershipRequest($notification, $languageCode);
-		}
-		if ($notification->getSubject() === 'transferOwnershipFailedSource') {
-			return $this->handleTransferOwnershipFailedSource($notification, $languageCode);
-		}
-		if ($notification->getSubject() === 'transferOwnershipFailedTarget') {
-			return $this->handleTransferOwnershipFailedTarget($notification, $languageCode);
-		}
-		if ($notification->getSubject() === 'transferOwnershipDoneSource') {
-			return $this->handleTransferOwnershipDoneSource($notification, $languageCode);
-		}
-		if ($notification->getSubject() === 'transferOwnershipDoneTarget') {
-			return $this->handleTransferOwnershipDoneTarget($notification, $languageCode);
-		}
-
-		throw new \InvalidArgumentException('Unhandled subject');
+		return match($notification->getSubject()) {
+			'transferownershipRequest' => $this->handleTransferownershipRequest($notification, $languageCode),
+			'transferownershipRequestDenied' => $this->handleTransferOwnershipRequestDenied($notification, $languageCode),
+			'transferOwnershipFailedSource' => $this->handleTransferOwnershipFailedSource($notification, $languageCode),
+			'transferOwnershipFailedTarget' => $this->handleTransferOwnershipFailedTarget($notification, $languageCode),
+			'transferOwnershipDoneSource' => $this->handleTransferOwnershipDoneSource($notification, $languageCode),
+			'transferOwnershipDoneTarget' => $this->handleTransferOwnershipDoneTarget($notification, $languageCode),
+			default => throw new \InvalidArgumentException('Unhandled subject')
+		};
 	}
 
 	public function handleTransferownershipRequest(INotification $notification, string $languageCode): INotification {
@@ -141,6 +133,29 @@ class Notifier implements INotifier, IDismissableNotifier {
 					]
 				]);
 
+		return $notification;
+	}
+
+	public function handleTransferOwnershipRequestDenied(INotification $notification, string $languageCode): INotification {
+		$l = $this->l10nFactory->get('files', $languageCode);
+		$param = $notification->getSubjectParameters();
+
+		$targetUser = $this->getUser($param['targetUser']);
+		$notification->setRichSubject($l->t('Ownership transfer denied'))
+			->setRichMessage(
+				$l->t('Your ownership transfer of {path} was denied by {user}.'),
+				[
+					'path' => [
+						'type' => 'highlight',
+						'id' => $param['targetUser'] . '::' . $param['nodeName'],
+						'name' => $param['nodeName'],
+					],
+					'user' => [
+						'type' => 'user',
+						'id' => $targetUser->getUID(),
+						'name' => $targetUser->getDisplayName(),
+					],
+				]);
 		return $notification;
 	}
 


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/45753

## Summary
When the receiver denies the transfer the notification handler was missing, so no notification was created for the transfer owner.

But also the internal notification was created two times:
1. When rejecting the transfer
2. By the reject function when dismissing the notification

This is fixed by only relying on the dismiss function.

---

![image](https://github.com/nextcloud/server/assets/1855448/62de3004-d5b7-4b52-8c75-b2d92b1e7af7)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
