### PR TITLE
[stable28] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8317,12 +8317,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -11368,9 +11368,9 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
-      "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.5.tgz",
+      "integrity": "sha512-C5Pn8Wk+1vKBoHghJODM63yk8MvrO9EWZUfkAt5HAqIgPE4/8FF0PEGHXtEd40l223+cE5ABWuPzm38PHFXfMA==",
       "dev": true,
       "dependencies": {
         "@types/cookie": "^0.4.1",
@@ -11382,7 +11382,7 @@
         "cors": "~2.8.5",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       },
       "engines": {
         "node": ">=10.2.0"
@@ -11398,16 +11398,16 @@
       }
     },
     "node_modules/engine.io/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -13507,9 +13507,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -24425,26 +24425,26 @@
       }
     },
     "node_modules/socket.io-adapter": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
-      "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dev": true,
       "dependencies": {
         "debug": "~4.3.4",
-        "ws": "~8.11.0"
+        "ws": "~8.17.1"
       }
     },
     "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 17 vulnerabilities found in your project.

## Updated dependencies
* [@jimp/core](#user-content-\@jimp\/core)
* [@jimp/custom](#user-content-\@jimp\/custom)
* [braces](#user-content-braces)
* [engine.io](#user-content-engine\.io)
* [load-bmfont](#user-content-load-bmfont)
* [node-vibrant](#user-content-node-vibrant)
* [phin](#user-content-phin)
* [puppeteer](#user-content-puppeteer)
* [puppeteer-core](#user-content-puppeteer-core)
* [select2](#user-content-select2)
* [socket.io-adapter](#user-content-socket\.io-adapter)
* [ws](#user-content-ws)
## Fixed vulnerabilities

### @jimp/core <a href="#user-content-\@jimp\/core" id="\@jimp\/core">#</a>
* Caused by vulnerable dependency:
  * [phin](#user-content-phin)
* Affected versions: <=0.21.4--canary.1163.d07ed6254d130e2995d24101e93427ec091016e6.0
* Package usage:
  * `node_modules/@jimp/core`

### @jimp/custom <a href="#user-content-\@jimp\/custom" id="\@jimp\/custom">#</a>
* Caused by vulnerable dependency:
  * [@jimp/core](#user-content-\@jimp\/core)
* Affected versions: <=0.21.4--canary.1163.d07ed6254d130e2995d24101e93427ec091016e6.0
* Package usage:
  * `node_modules/@jimp/custom`

### braces <a href="#user-content-braces" id="braces">#</a>
* Uncontrolled resource consumption in braces
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)
* Affected versions: <3.0.3
* Package usage:
  * `node_modules/braces`

### engine.io <a href="#user-content-engine\.io" id="engine\.io">#</a>
* Caused by vulnerable dependency:
  * [ws](#user-content-ws)
* Affected versions: 0.7.8 - 0.7.9 || 6.0.0 - 6.5.4
* Package usage:
  * `node_modules/engine.io`

### load-bmfont <a href="#user-content-load-bmfont" id="load-bmfont">#</a>
* Caused by vulnerable dependency:
  * [phin](#user-content-phin)
* Affected versions: >=1.4.0
* Package usage:
  * `node_modules/load-bmfont`

### node-vibrant <a href="#user-content-node-vibrant" id="node-vibrant">#</a>
* Caused by vulnerable dependency:
  * [@jimp/custom](#user-content-\@jimp\/custom)
* Affected versions: 3.1.5 - 3.1.6
* Package usage:
  * `node_modules/node-vibrant`

### phin <a href="#user-content-phin" id="phin">#</a>
* phin may include sensitive headers in subsequent requests after redirect
* Severity: **moderate** (CVSS 4.3)
* Reference: [https://github.com/advisories/GHSA-x565-32qp-m3vf](https://github.com/advisories/GHSA-x565-32qp-m3vf)
* Affected versions: <3.7.1
* Package usage:
  * `node_modules/phin`

### puppeteer <a href="#user-content-puppeteer" id="puppeteer">#</a>
* Caused by vulnerable dependency:
  * [puppeteer-core](#user-content-puppeteer-core)
* Affected versions: 18.2.0 - 22.11.1
* Package usage:
  * `node_modules/puppeteer`

### puppeteer-core <a href="#user-content-puppeteer-core" id="puppeteer-core">#</a>
* Caused by vulnerable dependency:
  * [ws](#user-content-ws)
* Affected versions: 11.0.0 - 22.11.1
* Package usage:
  * `node_modules/puppeteer-core`

### select2 <a href="#user-content-select2" id="select2">#</a>
* Improper Neutralization of Input During Web Page Generation in Select2
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-rf66-hmqf-q3fc](https://github.com/advisories/GHSA-rf66-hmqf-q3fc)
* Affected versions: <4.0.6
* Package usage:
  * `node_modules/select2`

### socket.io-adapter <a href="#user-content-socket\.io-adapter" id="socket\.io-adapter">#</a>
* Caused by vulnerable dependency:
  * [ws](#user-content-ws)
* Affected versions: 2.5.2 - 2.5.4
* Package usage:
  * `node_modules/socket.io-adapter`

### ws <a href="#user-content-ws" id="ws">#</a>
* ws affected by a DoS when handling a request with many HTTP headers
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-3h5v-q93c-6h6q](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)
* Affected versions: 8.0.0 - 8.17.0
* Package usage:
  * `node_modules/engine.io/node_modules/ws`
  * `node_modules/socket.io-adapter/node_modules/ws`
  * `node_modules/ws`