### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8412,12 +8412,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -13499,10 +13500,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -15486,6 +15488,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -26142,6 +26145,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },


### PR DESCRIPTION
# Audit report

This audit fix resolves 7 of the total 12 vulnerabilities found in your project.

## Updated dependencies
* [@jimp/core](#user-content-\@jimp\/core)
* [@jimp/custom](#user-content-\@jimp\/custom)
* [braces](#user-content-braces)
* [load-bmfont](#user-content-load-bmfont)
* [node-vibrant](#user-content-node-vibrant)
* [phin](#user-content-phin)
* [select2](#user-content-select2)
## Fixed vulnerabilities

### @jimp/core <a href="#user-content-\@jimp\/core" id="\@jimp\/core">#</a>
* Caused by vulnerable dependency:
  * [phin](#user-content-phin)
* Affected versions: <=0.21.4--canary.1163.d07ed6254d130e2995d24101e93427ec091016e6.0
* Package usage:
  * `node_modules/@jimp/core`

### @jimp/custom <a href="#user-content-\@jimp\/custom" id="\@jimp\/custom">#</a>
* Caused by vulnerable dependency:
  * [@jimp/core](#user-content-\@jimp\/core)
* Affected versions: <=0.21.4--canary.1163.d07ed6254d130e2995d24101e93427ec091016e6.0
* Package usage:
  * `node_modules/@jimp/custom`

### braces <a href="#user-content-braces" id="braces">#</a>
* Uncontrolled resource consumption in braces
* Severity: **high** (CVSS 7.5)
* Reference: [https://github.com/advisories/GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg)
* Affected versions: <3.0.3
* Package usage:
  * `node_modules/braces`

### load-bmfont <a href="#user-content-load-bmfont" id="load-bmfont">#</a>
* Caused by vulnerable dependency:
  * [phin](#user-content-phin)
* Affected versions: >=1.4.0
* Package usage:
  * `node_modules/load-bmfont`

### node-vibrant <a href="#user-content-node-vibrant" id="node-vibrant">#</a>
* Caused by vulnerable dependency:
  * [@jimp/custom](#user-content-\@jimp\/custom)
* Affected versions: 3.1.5 - 3.1.6
* Package usage:
  * `node_modules/node-vibrant`

### phin <a href="#user-content-phin" id="phin">#</a>
* phin may include sensitive headers in subsequent requests after redirect
* Severity: **moderate** (CVSS 4.3)
* Reference: [https://github.com/advisories/GHSA-x565-32qp-m3vf](https://github.com/advisories/GHSA-x565-32qp-m3vf)
* Affected versions: <3.7.1
* Package usage:
  * `node_modules/phin`

### select2 <a href="#user-content-select2" id="select2">#</a>
* Improper Neutralization of Input During Web Page Generation in Select2
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-rf66-hmqf-q3fc](https://github.com/advisories/GHSA-rf66-hmqf-q3fc)
* Affected versions: <4.0.6
* Package usage:
  * `node_modules/select2`