### PR TITLE
test(cypress): don't apply changes in CI

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -94,7 +94,10 @@ export default defineConfig({
 			config.baseUrl = `http://${ip}/index.php`
 			await waitOnNextcloud(ip)
 			await configureNextcloud()
-			await applyChangesToNextcloud()
+
+			if (!process.env.CI) {
+				await applyChangesToNextcloud()
+			}
 
 			// IMPORTANT: return the config otherwise cypress-split will not work
 			return config


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

Applying changes is not necessary in CI as there are no folder to copy anyway. See the screenshot below from #45889.

<img width="510" alt="image" src="https://github.com/nextcloud/server/assets/1580193/03b4990d-d977-4be8-9ce1-3c75f29396e8">

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
