### PR TITLE
[stable28] fix(deleteAction): Bump up delete requests concurrency to 5

### DIFF
--- a/apps/files/src/actions/deleteAction.ts
+++ b/apps/files/src/actions/deleteAction.ts
@@ -59,7 +59,7 @@ const isAllFolders = (nodes: Node[]) => {
 	return !nodes.some(node => node.type !== FileType.Folder)
 }
 
-const queue = new PQueue({ concurrency: 1 })
+const queue = new PQueue({ concurrency: 5 })
 
 export const action = new FileAction({
 	id: 'delete',


### PR DESCRIPTION
Manual backport : https://github.com/nextcloud/server/pull/45902