### PR TITLE
ci: use precise ref for 3rdparty check

### DIFF
--- a/.github/workflows/block-outdated-3rdparty.yml
+++ b/.github/workflows/block-outdated-3rdparty.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Last 3rdparty commit on target branch
         id: target
         run: |
-          echo "commit=$(git ls-remote https://github.com/nextcloud/3rdparty ${{ github.base_ref }} | awk '{ print $1}')" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git ls-remote https://github.com/nextcloud/3rdparty refs/heads/${{ github.base_ref }} | awk '{ print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Compare if 3rdparty commits are different
         run: |


### PR DESCRIPTION
On stable29 we get wrong results, because more branches meet "stable29"

```bash
$ git ls-remote https://github.com/nextcloud/3rdparty stable29 
1706802f48993629baa7eb5520d098fed6dfb222        refs/heads/backport/1863/stable29
164fb3b7760f5cd2b9b5c1bdad7c74da1bcd3b68        refs/heads/stable29
```

Prefixing `refs/heads/` solves this to provide the correct hash:

```bash
$ git ls-remote https://github.com/nextcloud/3rdparty refs/heads/stable29
164fb3b7760f5cd2b9b5c1bdad7c74da1bcd3b68        refs/heads/stable29
```

It will also work on master

```bash
$ git ls-remote https://github.com/nextcloud/3rdparty refs/heads/master
45d8fc9e09fbb4d3c4de5819afd9a6f72ce00f56        refs/heads/master
```

Provided the substitution still works  :sweat_smile: 