### PR TITLE
fix: Do not log an error when connecting to SFTP without a logged in user

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -194,12 +194,14 @@ class SFTP extends Common {
 	 */
 	private function hostKeysPath() {
 		try {
-			$storage_view = \OCP\Files::getStorage('files_external');
-			if ($storage_view) {
-				return \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') .
-					$storage_view->getAbsolutePath('') .
-					'ssh_hostKeys';
+			$userId = \OC_User::getUser();
+			if ($userId === false) {
+				return false;
 			}
+
+			$view = new \OC\Files\View('/' . $userId . '/files_external');
+
+			return $view->getLocalFile('ssh_hostKeys');
 		} catch (\Exception $e) {
 		}
 		return false;


### PR DESCRIPTION
When connecting to a SFTP server from a SFTP storage the host key is checked against the known host keys stored in a file in the data directory of the logged in Nextcloud user. The path to the file is (indirectly) got using `OC_App::getStorage`, which logs an error (`Can't get app storage, app files_external, user not logged in`) [if called when there is no logged in user](https://github.com/nextcloud/server/blob/dae7c159f728a90ffa53247d6e033abdae5d2bd6/lib/private/legacy/OC_App.php#L822-L831); this can happen, for example, if the storage is used from a background job or a command (like `occ files:scan`).

Not being able to read or write the file just causes the host key check to be skipped, but it has no other consequence. Moreover, even with logged in users it is likely that the file can not be read either and the check is also skipped, as the file needs to have been manually created by an admin (once created it will be updated with the host key when connecting to an SFTP server for the first time, but this will not happen unless the file was manually created first).

Due to all that now the path to the file is directly created using a `View` rather than relying on `OC_App::getStorage` to prevent the unneeded error from being logged.

Note that, in order to make it backporteable, this is just a backwards compatible* change that simply removes the error log; it does not address any of the issues mentioned in https://github.com/nextcloud/server/issues/14108

*Or, at least, it should be :-) But I am a bit lost with storages, mount points, views... so please check carefully ;-)

## How to test

- Setup a SSH server
- Enable external storages
- Open the external storages settings
- Add a new SFTP storage for the SSH server
- Run `occ files:scan --all`

### Result with this pull request

No errors are logged

### Result without this pull request

`Can't get app storage, app files_external, user not logged in` error is logged (several times if there are several Nextcloud users with access to the SFTP storage)
