### PR TITLE
perf: Avoid reusing previous migration steps

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -102,6 +102,8 @@ class Repair implements IOutput {
 				$this->dispatcher->dispatchTyped(new RepairErrorEvent($e->getMessage()));
 			}
 		}
+
+		$this->repairSteps = [];
 	}
 
 	/**

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -19,8 +19,10 @@ use OCP\App\ManagerEvent;
 use OCP\Authentication\IAlternativeLogin;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
+use OCP\Server;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Log\LoggerInterface;
+use function OCP\Log\logger;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the
@@ -777,16 +779,16 @@ class OC_App {
 		// load the app
 		self::loadApp($appId);
 
-		$dispatcher = \OC::$server->get(IEventDispatcher::class);
+		$dispatcher = Server::get(IEventDispatcher::class);
 
 		// load the steps
-		$r = \OCP\Server::get(Repair::class);
+		$r = Server::get(Repair::class);
 		foreach ($steps as $step) {
 			try {
 				$r->addStep($step);
 			} catch (Exception $ex) {
 				$dispatcher->dispatchTyped(new RepairErrorEvent($ex->getMessage()));
-				\OC::$server->getLogger()->logException($ex);
+				logger('core')->error('Failed to add app migration step ' . $step, ['exception' => $ex]);
 			}
 		}
 		// run the steps


### PR DESCRIPTION
When running an upgrade we have several stages that might trigger repair steps.

- [doUpgrade](https://github.com/nextcloud/server/blob/dae7c159f728a90ffa53247d6e033abdae5d2bd6/lib/private/Updater.php#L195) has the main execution flow
- pre-upgrade repair steps [`Repair::getBeforeUpgradeRepairSteps()`](https://github.com/nextcloud/server/blob/dae7c159f728a90ffa53247d6e033abdae5d2bd6/lib/private/Updater.php#L217)
- Do core upgrade
- Do [app upgrade](https://github.com/nextcloud/server/blob/ea9f2361ae5691a8d0eae8b38cd7e2fad55bdd55/lib/private/legacy/OC_App.php#L732) for each app that has a version changed
  - executeRepairSteps pre-migration
  - executeRepairSteps post-migration
  - setupLiveMigrations live-migration

The Repair class has no default migration steps and there are both a setRepair and addStep methods, however for the case when we upgrade an app we do not need to run core migrations again.

This fix will ensure that after running we always empty the list of repair steps stored in the Repair class instance.

I also checked usages and for all other places we tend to overwrite the array anyways.

Also if the app has no steps itself [it would skip the core migrations still around before this change anyways.](https://github.com/nextcloud/server/blob/ea9f2361ae5691a8d0eae8b38cd7e2fad55bdd55/lib/private/legacy/OC_App.php#L778)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
