### PR TITLE
Fix license information extracted from built assets

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -155,11 +155,11 @@ Files: apps/dav/tests/misc/caldav-search-limit-timerange-1.ics apps/dav/tests/mi
 Copyright: 2023 Nextcloud GmbH and Nextcloud contributors
 License: AGPL-3.0-or-later
 
-Files: apps/cloud_federation_api/l10n/*.js apps/cloud_federation_api/l10n/*.json apps/contactsinteraction/l10n/*.js apps/contactsinteraction/l10n/*.json apps/dashboard/l10n/*.js apps/dashboard/l10n/*.json apps/files_reminders/l10n/*.js apps/files_reminders/l10n/*.json apps/lookup_server_connector/l10n/*.js apps/lookup_server_connector/l10n/*.json apps/oauth2 apps/sharebymail/l10n/*.js apps/oauth2 apps/sharebymail/l10n/*.json apps/theming/l10n/*.js apps/theming/l10n/*.json apps/twofactor_backupcodes/l10n/*.js apps/twofactor_backupcodes/l10n/*.json apps/user_status/l10n/*.js apps/user_status/l10n/*.json apps/weather_status/l10n/*.js apps/weather_status/l10n/*.json apps/workflowengine/l10n/*.js apps/workflowengine/l10n/*.json
+Files: apps/cloud_federation_api/l10n/*.js apps/cloud_federation_api/l10n/*.json apps/contactsinteraction/l10n/*.js apps/contactsinteraction/l10n/*.json apps/dashboard/l10n/*.js apps/dashboard/l10n/*.json apps/files_reminders/l10n/*.js apps/files_reminders/l10n/*.json apps/lookup_server_connector/l10n/*.js apps/lookup_server_connector/l10n/*.json apps/sharebymail/l10n/*.js apps/oauth2/l10n/*.js apps/oauth2/l10n/*.json apps/sharebymail/l10n/*.json apps/theming/l10n/*.js apps/theming/l10n/*.json apps/twofactor_backupcodes/l10n/*.js apps/twofactor_backupcodes/l10n/*.json apps/user_status/l10n/*.js apps/user_status/l10n/*.json apps/weather_status/l10n/*.js apps/weather_status/l10n/*.json apps/workflowengine/l10n/*.js apps/workflowengine/l10n/*.json
 Copyright: 2016-2024 Nextcloud translators
 License: AGPL-3.0-or-later
 
-Files: .gitattributes composer.json composer.lock .github/CODEOWNERS __tests__/tsconfig.json tsconfig.json build/integration/composer.* build/integration/data/*.png vendor-bin/*/composer.json vendor-bin/*/composer.lock apps/*/composer/composer.json apps/*/composer/composer.lock apps/*/composer/composer/installed.json
+Files: composer.json composer.lock .github/CODEOWNERS __tests__/tsconfig.json tsconfig.json build/integration/composer.* vendor-bin/*/composer.json vendor-bin/*/composer.lock apps/*/composer/composer.json apps/*/composer/composer.lock apps/*/composer/composer/installed.json
 Copyright: 2011-2016 ownCloud, Inc., 2016-2024 Nextcloud GmbH and Nextcloud contributors
 License: AGPL-3.0-only OR AGPL-3.0-or-later
 

--- a/build/WebpackSPDXPlugin.js
+++ b/build/WebpackSPDXPlugin.js
@@ -198,8 +198,11 @@ class WebpackSPDXPlugin {
 				authors.add(pkg.author)
 				output += `\n- ${pkg.name}\n\t- version: ${pkg.version}\n\t- license: ${license}`
 			}
-			output += `\n\nSPDX-License-Identifier: ${[...licenses].sort().join(' AND ')}\n`
-			output += [...authors].sort().map((author) => `SPDX-FileCopyrightText: ${author}`).join('\n');
+			output += '\n\n'
+			for (const license of [...licenses].sort()) {
+				output += `SPDX-License-Identifier: ${license}\n`
+			}
+			output += [...authors].sort().map((author) => `SPDX-FileCopyrightText: ${author}`).join('\n')
 
 			compilation.emitAsset(
 				asset.split('?', 2)[0] + '.license',
@@ -208,9 +211,10 @@ class WebpackSPDXPlugin {
 		}
 
 		if (callback) {
-			return void callback()
+			return callback()
 		}
 	}
+
 }
 
-module.exports = WebpackSPDXPlugin;
+module.exports = WebpackSPDXPlugin

--- a/dist/1110-1110.js.license
+++ b/dist/1110-1110.js.license
@@ -1,5 +1,18 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -99,14 +112,3 @@ This file is generated from multiple sources. Included packages:
 - which-typed-array
 	- version: 1.1.14
 	- license: MIT
-
-SPDX-License-Identifier: GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/1439-1439.js.license
+++ b/dist/1439-1439.js.license
@@ -1,5 +1,18 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Austin Andrews
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/js
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -102,14 +115,3 @@ This file is generated from multiple sources. Included packages:
 - which-typed-array
 	- version: 1.1.14
 	- license: MIT
-
-SPDX-License-Identifier: Apache-2.0 AND ISC AND MIT
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/1521-1521.js.license
+++ b/dist/1521-1521.js.license
@@ -1,5 +1,28 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/js
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -17,7 +40,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -141,21 +164,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/1642-1642.js.license
+++ b/dist/1642-1642.js.license
@@ -1,5 +1,37 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +40,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -35,7 +67,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -186,30 +218,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/2452-2452.js.license
+++ b/dist/2452-2452.js.license
@@ -1,5 +1,36 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christopher Jeffrey
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +39,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -26,7 +57,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -177,29 +208,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christopher Jeffrey
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/3920-3920.js.license
+++ b/dist/3920-3920.js.license
@@ -1,5 +1,65 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +68,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -41,7 +101,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -327,58 +387,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/5390-5390.js.license
+++ b/dist/5390-5390.js.license
@@ -1,5 +1,28 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/js
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -17,7 +40,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -141,21 +164,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/5455-5455.js.license
+++ b/dist/5455-5455.js.license
@@ -1,5 +1,72 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Richie Bendall
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -29,7 +96,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -80,7 +147,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -522,62 +589,3 @@ This file is generated from multiple sources. Included packages:
 - zwitch
 	- version: 2.0.4
 	- license: MIT
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Richie Bendall
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/5528-5528.js.license
+++ b/dist/5528-5528.js.license
@@ -1,5 +1,57 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Richie Bendall
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -26,7 +78,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -59,7 +111,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -462,49 +514,3 @@ This file is generated from multiple sources. Included packages:
 - zwitch
 	- version: 2.0.4
 	- license: MIT
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Richie Bendall
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>

--- a/dist/6075-6075.js.license
+++ b/dist/6075-6075.js.license
@@ -1,5 +1,43 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan-Gabriel Muscalu <stefan.gabriel.muscalu@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +46,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -50,7 +88,7 @@ This file is generated from multiple sources. Included packages:
 	- license: AGPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -216,36 +254,3 @@ This file is generated from multiple sources. Included packages:
 - which-typed-array
 	- version: 1.1.14
 	- license: MIT
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John Molakvoæ <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Stefan-Gabriel Muscalu <stefan.gabriel.muscalu@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/7462-7462.js.license
+++ b/dist/7462-7462.js.license
@@ -1,5 +1,65 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +68,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -41,7 +101,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -327,58 +387,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/7883-7883.js.license
+++ b/dist/7883-7883.js.license
@@ -1,5 +1,30 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: CC-BY-4.0
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: dangreen
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Sergey Rubanov <chi187@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Kilian Valkhof
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Dmitry Soshnikov
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Briggs
+SPDX-FileCopyrightText: Andrey Sitnik <andrey@sitnik.ru>
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -147,23 +172,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND BSD-3-Clause AND CC-BY-4.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andrey Sitnik <andrey@sitnik.ru>
-SPDX-FileCopyrightText: Ben Briggs
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dmitry Soshnikov
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Kilian Valkhof
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sergey Rubanov <chi187@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: dangreen
-SPDX-FileCopyrightText: inherits developers

--- a/dist/8057-8057.js.license
+++ b/dist/8057-8057.js.license
@@ -1,5 +1,65 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +68,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -41,7 +101,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -327,58 +387,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/8377-8377.js.license
+++ b/dist/8377-8377.js.license
@@ -1,5 +1,41 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +44,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -41,7 +77,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -210,34 +246,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/857-857.js.license
+++ b/dist/857-857.js.license
@@ -1,8 +1,8 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-FileCopyrightText: Robert Kieffer
 
+
+This file is generated from multiple sources. Included packages:
 - mime
 	- version: 4.0.1
 	- license: MIT
-
-SPDX-License-Identifier: MIT
-SPDX-FileCopyrightText: Robert Kieffer

--- a/dist/8737-8737.js.license
+++ b/dist/8737-8737.js.license
@@ -1,5 +1,41 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/js
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -11,7 +47,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -38,7 +74,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vue/devtools-api
 	- version: 6.6.1
 	- license: MIT
@@ -207,33 +243,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/8821-8821.js.license
+++ b/dist/8821-8821.js.license
@@ -1,5 +1,60 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: p-queue developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Julius Härtl <jus@bitgrid.net>
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jerry Bendy <jerry@icewingcc.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Chen Fengyuan
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @chenfengyuan/vue-qrcode
 	- version: 1.0.2
 	- license: MIT
@@ -17,7 +72,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -65,7 +120,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -291,51 +346,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Chen Fengyuan
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: Jerry Bendy <jerry@icewingcc.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julius Härtl <jus@bitgrid.net>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: p-queue developers
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/comments-comments-app.js.license
+++ b/dist/comments-comments-app.js.license
@@ -1,5 +1,65 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +68,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -41,7 +101,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -330,58 +390,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/comments-comments-tab.js.license
+++ b/dist/comments-comments-tab.js.license
@@ -1,5 +1,52 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -255,45 +302,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/comments-init.js.license
+++ b/dist/comments-init.js.license
@@ -1,5 +1,27 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Alkemics
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -150,21 +172,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-common.js.license
+++ b/dist/core-common.js.license
@@ -1,5 +1,99 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: p-queue developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Yehuda Katz
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Richie Bendall
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christopher Jeffrey
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @babel/runtime
 	- version: 7.23.9
 	- license: MIT
@@ -32,7 +126,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -89,7 +183,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -660,89 +754,3 @@ This file is generated from multiple sources. Included packages:
 - zwitch
 	- version: 2.0.4
 	- license: MIT
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christopher Jeffrey
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Richie Bendall
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: Yehuda Katz
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: p-queue developers
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
-SPDX-FileCopyrightText: string_decoder developers
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/core-files_client.js.license
+++ b/dist/core-files_client.js.license
@@ -1,5 +1,19 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
 
+
+This file is generated from multiple sources. Included packages:
 - assert
 	- version: 2.1.0
 	- license: MIT
@@ -102,15 +116,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-files_fileinfo.js.license
+++ b/dist/core-files_fileinfo.js.license
@@ -1,8 +1,8 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
 
+
+This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors

--- a/dist/core-install.js.license
+++ b/dist/core-install.js.license
@@ -1,5 +1,27 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: jQuery Foundation and other contributors
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Morris Jobke
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -132,21 +154,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Morris Jobke
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jQuery Foundation and other contributors

--- a/dist/core-legacy-unified-search.js.license
+++ b/dist/core-legacy-unified-search.js.license
@@ -1,5 +1,43 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +46,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/capabilities
 	- version: 1.2.0
 	- license: GPL-3.0-or-later
@@ -38,7 +76,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -216,36 +254,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-login.js.license
+++ b/dist/core-login.js.license
@@ -1,5 +1,53 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Yehuda Katz
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeremy Ashkenas <jeremy@documentcloud.org>
+SPDX-FileCopyrightText: Jeremy Ashkenas
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evert Pot
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/svg
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -11,7 +59,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/capabilities
 	- version: 1.2.0
 	- license: GPL-3.0-or-later
@@ -59,7 +107,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -255,45 +303,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Evert Pot
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jeremy Ashkenas
-SPDX-FileCopyrightText: Jeremy Ashkenas <jeremy@documentcloud.org>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: Yehuda Katz
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-main.js.license
+++ b/dist/core-main.js.license
@@ -1,5 +1,66 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: clipboard developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Yehuda Katz
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Sebastian Tschan
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Morris Jobke
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Joey Andres
+SPDX-FileCopyrightText: Jeremy Ashkenas <jeremy@documentcloud.org>
+SPDX-FileCopyrightText: Jeremy Ashkenas
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Igor Vaynberg
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evert Pot
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Newman <bn@cs.stanford.edu>
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/svg
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -11,7 +72,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -62,7 +123,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -312,58 +373,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Ben Newman <bn@cs.stanford.edu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Evert Pot
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Igor Vaynberg
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeremy Ashkenas
-SPDX-FileCopyrightText: Jeremy Ashkenas <jeremy@documentcloud.org>
-SPDX-FileCopyrightText: Joey Andres
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Morris Jobke
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sebastian Tschan
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: Yehuda Katz
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: clipboard developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-maintenance.js.license
+++ b/dist/core-maintenance.js.license
@@ -1,5 +1,25 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +28,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -129,19 +149,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-profile.js.license
+++ b/dist/core-profile.js.license
@@ -1,5 +1,47 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +50,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -38,7 +80,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -240,40 +282,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-recommendedapps.js.license
+++ b/dist/core-recommendedapps.js.license
@@ -1,5 +1,30 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +33,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -32,7 +57,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - assert
 	- version: 2.1.0
 	- license: MIT
@@ -162,23 +187,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-systemtags.js.license
+++ b/dist/core-systemtags.js.license
@@ -1,5 +1,22 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Yehuda Katz
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/router
 	- version: 3.0.1
 	- license: GPL-3.0-or-later
@@ -114,17 +131,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Yehuda Katz
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-unified-search.js.license
+++ b/dist/core-unified-search.js.license
@@ -1,5 +1,69 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Richie Bendall
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -26,7 +90,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -65,7 +129,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -510,60 +574,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Richie Bendall
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/core-unsupported-browser-redirect.js.license
+++ b/dist/core-unsupported-browser-redirect.js.license
@@ -1,5 +1,21 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -108,16 +124,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/core-unsupported-browser.js.license
+++ b/dist/core-unsupported-browser.js.license
@@ -1,5 +1,36 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: CC-BY-4.0
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Sergey Rubanov <chi187@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Kilian Valkhof
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Dmitry Soshnikov
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Briggs
+SPDX-FileCopyrightText: Andrey Sitnik <andrey@sitnik.ru>
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -29,7 +60,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - assert
 	- version: 2.1.0
 	- license: MIT
@@ -174,28 +205,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND CC-BY-4.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andrey Sitnik <andrey@sitnik.ru>
-SPDX-FileCopyrightText: Ben Briggs
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dmitry Soshnikov
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Kilian Valkhof
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sergey Rubanov <chi187@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/dashboard-main.js.license
+++ b/dist/dashboard-main.js.license
@@ -1,5 +1,69 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: vuedraggable developers
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: sortablejs developers
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Richie Bendall
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -26,7 +90,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -62,7 +126,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -504,60 +568,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Richie Bendall
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
-SPDX-FileCopyrightText: sortablejs developers
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: vuedraggable developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/dav-settings-admin-caldav.js.license
+++ b/dist/dav-settings-admin-caldav.js.license
@@ -1,5 +1,32 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Andris Reinman
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +35,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -29,7 +56,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - assert
 	- version: 2.1.0
 	- license: MIT
@@ -165,25 +192,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/dav-settings-personal-availability.js.license
+++ b/dist/dav-settings-personal-availability.js.license
@@ -1,5 +1,73 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nick Singleton
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +82,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -59,7 +127,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -363,65 +431,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Nick Singleton
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers
-SPDX-FileCopyrightText: uuid developers

--- a/dist/federatedfilesharing-external.js.license
+++ b/dist/federatedfilesharing-external.js.license
@@ -1,5 +1,12 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/initial-state
 	- version: 2.1.0
 	- license: GPL-3.0-or-later
@@ -12,8 +19,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND GPL-3.0-or-later AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Tobias Koppers @sokra

--- a/dist/federatedfilesharing-vue-settings-admin.js.license
+++ b/dist/federatedfilesharing-vue-settings-admin.js.license
@@ -1,5 +1,40 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +43,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -41,7 +76,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -207,33 +242,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/federatedfilesharing-vue-settings-personal.js.license
+++ b/dist/federatedfilesharing-vue-settings-personal.js.license
@@ -1,5 +1,34 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -23,7 +52,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -177,28 +206,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files-init.js.license
+++ b/dist/files-init.js.license
@@ -1,5 +1,49 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: p-queue developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan-Gabriel Muscalu <stefan.gabriel.muscalu@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/svg
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -11,7 +55,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -56,7 +100,7 @@ This file is generated from multiple sources. Included packages:
 	- license: AGPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vue/devtools-api
 	- version: 6.6.1
 	- license: MIT
@@ -243,41 +287,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John Molakvoæ <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Stefan-Gabriel Muscalu <stefan.gabriel.muscalu@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: p-queue developers

--- a/dist/files-main.js.license
+++ b/dist/files-main.js.license
@@ -1,5 +1,56 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: p-queue developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan-Gabriel Muscalu <stefan.gabriel.muscalu@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/svg
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -11,7 +62,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -71,7 +122,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vue/devtools-api
 	- version: 6.6.1
 	- license: MIT
@@ -276,48 +327,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John Molakvoæ <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Stefan-Gabriel Muscalu <stefan.gabriel.muscalu@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: p-queue developers

--- a/dist/files-personal-settings.js.license
+++ b/dist/files-personal-settings.js.license
@@ -1,5 +1,48 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +57,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -50,7 +93,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -249,41 +292,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files-reference-files.js.license
+++ b/dist/files-reference-files.js.license
@@ -1,5 +1,61 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -26,7 +82,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -71,7 +127,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -498,53 +554,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>

--- a/dist/files-search.js.license
+++ b/dist/files-search.js.license
@@ -1,5 +1,33 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -26,7 +54,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -174,27 +202,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files-sidebar.js.license
+++ b/dist/files-sidebar.js.license
@@ -1,5 +1,73 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -17,7 +85,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -65,7 +133,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - is-svg
 	- version: 4.4.0
 	- license: MIT
@@ -366,65 +434,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/files_external-init.js.license
+++ b/dist/files_external-init.js.license
@@ -1,5 +1,41 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +44,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -44,7 +80,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -213,34 +249,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files_reminders-init.js.license
+++ b/dist/files_reminders-init.js.license
@@ -1,5 +1,41 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +44,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -41,7 +77,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -213,34 +249,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files_sharing-additionalScripts.js.license
+++ b/dist/files_sharing-additionalScripts.js.license
@@ -1,5 +1,22 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/capabilities
 	- version: 1.2.0
 	- license: GPL-3.0-or-later
@@ -117,17 +134,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files_sharing-collaboration.js.license
+++ b/dist/files_sharing-collaboration.js.license
@@ -1,12 +1,13 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
 
+
+This file is generated from multiple sources. Included packages:
 - webpack
 	- version: 5.91.0
 	- license: MIT
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Tobias Koppers @sokra

--- a/dist/files_sharing-files_sharing_tab.js.license
+++ b/dist/files_sharing-files_sharing_tab.js.license
@@ -1,5 +1,25 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -123,19 +143,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files_sharing-init.js.license
+++ b/dist/files_sharing-init.js.license
@@ -1,5 +1,33 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Alkemics
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/svg
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -11,7 +39,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -180,25 +208,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files_sharing-main.js.license
+++ b/dist/files_sharing-main.js.license
@@ -1,8 +1,8 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
 
+
+This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors

--- a/dist/files_sharing-personal-settings.js.license
+++ b/dist/files_sharing-personal-settings.js.license
@@ -1,5 +1,37 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +40,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -32,7 +64,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -195,30 +227,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/files_trashbin-main.js.license
+++ b/dist/files_trashbin-main.js.license
@@ -1,5 +1,65 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: Alkemics
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +68,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -47,7 +107,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -336,58 +396,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/files_versions-files_versions.js.license
+++ b/dist/files_versions-files_versions.js.license
@@ -1,5 +1,71 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @babel/runtime
 	- version: 7.23.9
 	- license: MIT
@@ -11,7 +77,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -56,7 +122,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -360,64 +426,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/oauth2-oauth2.js.license
+++ b/dist/oauth2-oauth2.js.license
@@ -1,5 +1,34 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Andris Reinman
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +37,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/capabilities
 	- version: 1.2.0
 	- license: GPL-3.0-or-later
@@ -32,7 +61,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - assert
 	- version: 2.1.0
 	- license: MIT
@@ -171,27 +200,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-apps-view-4529.js.license
+++ b/dist/settings-apps-view-4529.js.license
@@ -1,5 +1,53 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christopher Jeffrey
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -17,7 +65,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -53,7 +101,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vue/devtools-api
 	- version: 6.6.1
 	- license: MIT
@@ -261,45 +309,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christopher Jeffrey
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-apps.js.license
+++ b/dist/settings-apps.js.license
@@ -1,5 +1,25 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +28,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -129,19 +149,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-declarative-settings-forms.js.license
+++ b/dist/settings-declarative-settings-forms.js.license
@@ -1,5 +1,48 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +57,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -47,7 +90,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -246,41 +289,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-legacy-admin.js.license
+++ b/dist/settings-legacy-admin.js.license
@@ -1,8 +1,8 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
 
+
+This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors

--- a/dist/settings-users-3239.js.license
+++ b/dist/settings-users-3239.js.license
@@ -1,5 +1,64 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -17,7 +76,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -71,7 +130,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -306,55 +365,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/settings-vue-settings-admin-ai.js.license
+++ b/dist/settings-vue-settings-admin-ai.js.license
@@ -1,5 +1,48 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: vuedraggable developers
+SPDX-FileCopyrightText: sortablejs developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +57,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -44,7 +87,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -237,41 +280,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: sortablejs developers
-SPDX-FileCopyrightText: vuedraggable developers

--- a/dist/settings-vue-settings-admin-basic-settings.js.license
+++ b/dist/settings-vue-settings-admin-basic-settings.js.license
@@ -1,5 +1,43 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @mdi/js
 	- version: 7.4.47
 	- license: Apache-2.0
@@ -11,7 +49,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -50,7 +88,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -219,35 +257,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-vue-settings-admin-delegation.js.license
+++ b/dist/settings-vue-settings-admin-delegation.js.license
@@ -1,5 +1,47 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +56,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -50,7 +92,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -246,40 +288,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-vue-settings-admin-security.js.license
+++ b/dist/settings-vue-settings-admin-security.js.license
@@ -1,5 +1,51 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +60,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -59,7 +105,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -264,44 +310,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-vue-settings-admin-sharing.js.license
+++ b/dist/settings-vue-settings-admin-sharing.js.license
@@ -1,5 +1,69 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Richie Bendall
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -26,7 +90,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -65,7 +129,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -513,60 +577,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Richie Bendall
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/settings-vue-settings-apps-users-management.js.license
+++ b/dist/settings-vue-settings-apps-users-management.js.license
@@ -1,5 +1,48 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Alkemics
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @babel/runtime
 	- version: 7.23.9
 	- license: MIT
@@ -11,7 +54,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -62,7 +105,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vue/devtools-api
 	- version: 6.6.1
 	- license: MIT
@@ -255,41 +298,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christoph Wurst <christoph@winzerhof-wurst.at>
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-vue-settings-nextcloud-pdf.js.license
+++ b/dist/settings-vue-settings-nextcloud-pdf.js.license
@@ -1,5 +1,12 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/initial-state
 	- version: 2.1.0
 	- license: GPL-3.0-or-later
@@ -9,8 +16,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND GPL-3.0-or-later AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Tobias Koppers @sokra

--- a/dist/settings-vue-settings-personal-info.js.license
+++ b/dist/settings-vue-settings-personal-info.js.license
@@ -1,5 +1,76 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: BSD-2-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
+SPDX-FileCopyrightText: inline-style-parser developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: catamphetamine <purecatamphetamine@gmail.com>
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Richie Bendall
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: OpenJS Foundation and other contributors
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
+SPDX-FileCopyrightText: Mapbox
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Iftekhar Rifat
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Chen Fengyuan
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Andrea Giammarchi
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -29,7 +100,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -77,7 +148,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @ungap/structured-clone
 	- version: 1.2.0
 	- license: ISC
@@ -540,66 +611,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andrea Giammarchi
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Chen Fengyuan
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Iftekhar Rifat
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mapbox
-SPDX-FileCopyrightText: Mark <mark@remarkablemark.org>
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: OpenJS Foundation and other contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Richie Bendall
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: Victor Felder <victor@draft.li> (https://draft.li)
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: catamphetamine <purecatamphetamine@gmail.com>
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: inline-style-parser developers
-SPDX-FileCopyrightText: rhysd <lin90162@yahoo.co.jp>
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/settings-vue-settings-personal-password.js.license
+++ b/dist/settings-vue-settings-personal-password.js.license
@@ -1,5 +1,39 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +42,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -38,7 +72,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -204,32 +238,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-vue-settings-personal-security.js.license
+++ b/dist/settings-vue-settings-personal-security.js.license
@@ -1,5 +1,47 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: Guillaume Chau
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eduardo San Martin Morote
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Chen Fengyuan
+SPDX-FileCopyrightText: Austin Andrews
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @babel/runtime
 	- version: 7.23.9
 	- license: MIT
@@ -17,7 +59,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -53,7 +95,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vue/devtools-api
 	- version: 6.6.1
 	- license: MIT
@@ -231,39 +273,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND Apache-2.0 AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Austin Andrews
-SPDX-FileCopyrightText: Chen Fengyuan
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eduardo San Martin Morote
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: The Babel Team (https://babel.dev/team)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/settings-vue-settings-personal-webauthn.js.license
+++ b/dist/settings-vue-settings-personal-webauthn.js.license
@@ -1,5 +1,41 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +44,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -44,7 +80,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -213,34 +249,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/sharebymail-vue-settings-admin-sharebymail.js.license
+++ b/dist/sharebymail-vue-settings-admin-sharebymail.js.license
@@ -1,5 +1,40 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +43,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -41,7 +76,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -207,33 +242,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/systemtags-admin.js.license
+++ b/dist/systemtags-admin.js.license
@@ -1,5 +1,67 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +76,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -50,7 +112,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -339,60 +401,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/systemtags-init.js.license
+++ b/dist/systemtags-init.js.license
@@ -1,5 +1,52 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: string_decoder developers
+SPDX-FileCopyrightText: readable-stream developers
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: jden <jason@denizac.org>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Sindre Sorhus
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Julian Gruber
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John Hiesey
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Ben Drucker
+SPDX-FileCopyrightText: Arnout Kazemier
+SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
+SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
+SPDX-FileCopyrightText: Alkemics
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +55,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -276,45 +323,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Alkemics
-SPDX-FileCopyrightText: Amit Gupta (https://amitkumargupta.work/)
-SPDX-FileCopyrightText: Amit Gupta (https://solothought.com)
-SPDX-FileCopyrightText: Arnout Kazemier
-SPDX-FileCopyrightText: Ben Drucker
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Dylan Piercey <pierceydylan@gmail.com>
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Hiesey
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Julian Gruber
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nathan Rajlich <nathan@tootallnate.net> (http://n8.io/)
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Olivier Scherrer <pode.fr@gmail.com>
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Perry Mitchell <perry@perrymitchell.net>
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Sindre Sorhus
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: jden <jason@denizac.org>
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: readable-stream developers
-SPDX-FileCopyrightText: string_decoder developers

--- a/dist/theming-admin-theming.js.license
+++ b/dist/theming-admin-theming.js.license
@@ -1,5 +1,51 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +60,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -47,7 +93,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -255,44 +301,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>

--- a/dist/theming-personal-theming.js.license
+++ b/dist/theming-personal-theming.js.license
@@ -1,5 +1,47 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: qs developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: defunctzombie
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: akfish
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Mathias Bynens
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: James Halliday
+SPDX-FileCopyrightText: Hiroki Osame
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +50,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/dialogs
 	- version: 5.3.1
 	- license: GPL-3.0-or-later
@@ -32,7 +74,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -228,40 +270,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hiroki Osame
-SPDX-FileCopyrightText: James Halliday
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Mathias Bynens
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: akfish
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: defunctzombie
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: qs developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>

--- a/dist/twofactor_backupcodes-settings.js.license
+++ b/dist/twofactor_backupcodes-settings.js.license
@@ -1,5 +1,38 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +41,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -38,7 +71,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -195,31 +228,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/updatenotification-init.js.license
+++ b/dist/updatenotification-init.js.license
@@ -1,5 +1,26 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Christoph Wurst
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +29,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - semver
 	- version: 7.6.2
 	- license: ISC
@@ -135,20 +156,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/updatenotification-updatenotification.js.license
+++ b/dist/updatenotification-updatenotification.js.license
@@ -1,5 +1,49 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +58,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -50,7 +94,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -252,42 +296,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/updatenotification-view-changelog-page.js.license
+++ b/dist/updatenotification-view-changelog-page.js.license
@@ -1,5 +1,32 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Christopher Jeffrey
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -20,7 +47,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -159,26 +186,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Antoni Andre <antoniandre.web@gmail.com>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: Christopher Jeffrey
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/user-status-modal-5133.js.license
+++ b/dist/user-status-modal-5133.js.license
@@ -1,5 +1,50 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Borys Serebrov
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +59,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -50,7 +95,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -255,43 +300,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Borys Serebrov
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: xiaokai <kexiaokai@gmail.com>

--- a/dist/user_status-menu.js.license
+++ b/dist/user_status-menu.js.license
@@ -1,5 +1,40 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @nextcloud/auth
 	- version: 2.3.0
 	- license: GPL-3.0-or-later
@@ -8,7 +43,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/capabilities
 	- version: 1.2.0
 	- license: GPL-3.0-or-later
@@ -38,7 +73,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/core
 	- version: 10.9.0
 	- license: MIT
@@ -210,33 +245,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/dist/weather_status-weather-status.js.license
+++ b/dist/weather_status-weather-status.js.license
@@ -1,5 +1,55 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MPL-2.0
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: xiemengxiong
+SPDX-FileCopyrightText: uuid developers
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Philipp Kewisch
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +64,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -56,7 +106,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -270,47 +320,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT AND MPL-2.0
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Philipp Kewisch
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers
-SPDX-FileCopyrightText: uuid developers
-SPDX-FileCopyrightText: xiemengxiong

--- a/dist/workflowengine-workflowengine.js.license
+++ b/dist/workflowengine-workflowengine.js.license
@@ -1,5 +1,54 @@
-This file is generated from multiple sources. Included packages:
+SPDX-License-Identifier: MIT
+SPDX-License-Identifier: ISC
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-License-Identifier: BSD-3-Clause
+SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0)
+SPDX-FileCopyrightText: inherits developers
+SPDX-FileCopyrightText: escape-html developers
+SPDX-FileCopyrightText: debounce developers
+SPDX-FileCopyrightText: atomiks
+SPDX-FileCopyrightText: assert developers
+SPDX-FileCopyrightText: Varun A P
+SPDX-FileCopyrightText: Tobias Koppers @sokra
+SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+SPDX-FileCopyrightText: Tim Wood <washwithcare@gmail.com> (http://timwoodcreates.com/)
+SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
+SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
+SPDX-FileCopyrightText: Roeland Jago Douma
+SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
+SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
+SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
+SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
+SPDX-FileCopyrightText: Matt Zabriskie
+SPDX-FileCopyrightText: Joyent
+SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
+SPDX-FileCopyrightText: Jordan Harband
+SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
+SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
+SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
+SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
+SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
+SPDX-FileCopyrightText: Hypercontext
+SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
+SPDX-FileCopyrightText: GitHub Inc.
+SPDX-FileCopyrightText: Feross Aboukhadijeh
+SPDX-FileCopyrightText: Fangdun Cai <cfddream@gmail.com>
+SPDX-FileCopyrightText: Evan You
+SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
+SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
+SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
+SPDX-FileCopyrightText: Denis Pushkarev
+SPDX-FileCopyrightText: David Clark
+SPDX-FileCopyrightText: Christoph Wurst
+SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
+SPDX-FileCopyrightText: Andris Reinman
+SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
+SPDX-FileCopyrightText: @nextcloud/dialogs developers
 
+
+This file is generated from multiple sources. Included packages:
 - @floating-ui/core
 	- version: 1.6.0
 	- license: MIT
@@ -14,7 +63,7 @@ This file is generated from multiple sources. Included packages:
 	- license: GPL-3.0-or-later
 - @nextcloud/axios
 	- version: 2.4.0
-	- license: GPL-3.0
+	- license: GPL-3.0-or-later
 - @nextcloud/browser-storage
 	- version: 0.3.0
 	- license: GPL-3.0-or-later
@@ -56,7 +105,7 @@ This file is generated from multiple sources. Included packages:
 	- license: MIT
 - @nextcloud/vue
 	- version: 8.11.2
-	- license: AGPL-3.0
+	- license: AGPL-3.0-or-later
 - @vueuse/components
 	- version: 10.9.0
 	- license: MIT
@@ -270,47 +319,3 @@ This file is generated from multiple sources. Included packages:
 - nextcloud
 	- version: 1.0.0
 	- license: AGPL-3.0-or-later
-
-SPDX-License-Identifier: (MPL-2.0 OR Apache-2.0) AND AGPL-3.0 AND AGPL-3.0-or-later AND BSD-3-Clause AND GPL-3.0 AND GPL-3.0-or-later AND ISC AND MIT
-SPDX-FileCopyrightText: @nextcloud/dialogs developers
-SPDX-FileCopyrightText: @nextcloud/password-confirmation developers
-SPDX-FileCopyrightText: Andris Reinman
-SPDX-FileCopyrightText: Anthony Fu <https://github.com/antfu>
-SPDX-FileCopyrightText: Christoph Wurst
-SPDX-FileCopyrightText: David Clark
-SPDX-FileCopyrightText: Denis Pushkarev
-SPDX-FileCopyrightText: Dr.-Ing. Mario Heiderich, Cure53 <mario@cure53.de> (https://cure53.de/)
-SPDX-FileCopyrightText: Eric Norris (https://github.com/ericnorris)
-SPDX-FileCopyrightText: Eugene Sharygin <eush77@gmail.com>
-SPDX-FileCopyrightText: Evan You
-SPDX-FileCopyrightText: Fangdun Cai <cfddream@gmail.com>
-SPDX-FileCopyrightText: Feross Aboukhadijeh
-SPDX-FileCopyrightText: GitHub Inc.
-SPDX-FileCopyrightText: Guillaume Chau <guillaume.b.chau@gmail.com>
-SPDX-FileCopyrightText: Hypercontext
-SPDX-FileCopyrightText: Iskren Ivov Chernev <iskren.chernev@gmail.com> (https://github.com/ichernev)
-SPDX-FileCopyrightText: Jacob Clevenger<https://github.com/wheatjs>
-SPDX-FileCopyrightText: Jeff Sagal <sagalbot@gmail.com>
-SPDX-FileCopyrightText: John Molakvoæ (skjnldsv) <skjnldsv@protonmail.com>
-SPDX-FileCopyrightText: John-David Dalton <john.david.dalton@gmail.com> (http://allyoucanleet.com/)
-SPDX-FileCopyrightText: Jordan Harband
-SPDX-FileCopyrightText: Jordan Harband <ljharb@gmail.com>
-SPDX-FileCopyrightText: Joyent
-SPDX-FileCopyrightText: Matt Zabriskie
-SPDX-FileCopyrightText: Nextcloud GmbH and Nextcloud contributors
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorb.de> (http://vorb.de)
-SPDX-FileCopyrightText: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch)
-SPDX-FileCopyrightText: Raynos <raynos2@gmail.com>
-SPDX-FileCopyrightText: Rob Cresswell <robcresswell@pm.me>
-SPDX-FileCopyrightText: Roeland Jago Douma
-SPDX-FileCopyrightText: Roman Shtylman <shtylman@gmail.com>
-SPDX-FileCopyrightText: T. Jameson Little <t.jameson.little@gmail.com>
-SPDX-FileCopyrightText: Tim Wood <washwithcare@gmail.com> (http://timwoodcreates.com/)
-SPDX-FileCopyrightText: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
-SPDX-FileCopyrightText: Tobias Koppers @sokra
-SPDX-FileCopyrightText: Varun A P
-SPDX-FileCopyrightText: assert developers
-SPDX-FileCopyrightText: atomiks
-SPDX-FileCopyrightText: debounce developers
-SPDX-FileCopyrightText: escape-html developers
-SPDX-FileCopyrightText: inherits developers

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -243,6 +243,8 @@ module.exports = {
 		new WebpackSPDXPlugin({
 			override: {
 				select2: 'MIT',
+				'@nextcloud/axios': 'GPL-3.0-or-later',
+				'@nextcloud/vue': 'AGPL-3.0-or-later',
 			}
 		}),
 	],


### PR DESCRIPTION
… until new versions are published shipping the SPDX listed license strings

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # wrong SPDX license identifiers are overwritten
## Summary


## TODO

- [ ] compile

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)