### PR TITLE
chore: Add event to register mount providers more lazy

### DIFF
--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -60,6 +60,7 @@ return array(
     'OCA\\Files_Sharing\\Listener\\BeforeZipCreatedListener' => $baseDir . '/../lib/Listener/BeforeZipCreatedListener.php',
     'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => $baseDir . '/../lib/Listener/LoadAdditionalListener.php',
     'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => $baseDir . '/../lib/Listener/LoadSidebarListener.php',
+    'OCA\\Files_Sharing\\Listener\\RegisterMountProviderListener' => $baseDir . '/../lib/Listener/RegisterMountProviderListener.php',
     'OCA\\Files_Sharing\\Listener\\ShareInteractionListener' => $baseDir . '/../lib/Listener/ShareInteractionListener.php',
     'OCA\\Files_Sharing\\Listener\\UserAddedToGroupListener' => $baseDir . '/../lib/Listener/UserAddedToGroupListener.php',
     'OCA\\Files_Sharing\\Listener\\UserShareAcceptanceListener' => $baseDir . '/../lib/Listener/UserShareAcceptanceListener.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -75,6 +75,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Listener\\BeforeZipCreatedListener' => __DIR__ . '/..' . '/../lib/Listener/BeforeZipCreatedListener.php',
         'OCA\\Files_Sharing\\Listener\\LoadAdditionalListener' => __DIR__ . '/..' . '/../lib/Listener/LoadAdditionalListener.php',
         'OCA\\Files_Sharing\\Listener\\LoadSidebarListener' => __DIR__ . '/..' . '/../lib/Listener/LoadSidebarListener.php',
+        'OCA\\Files_Sharing\\Listener\\RegisterMountProviderListener' => __DIR__ . '/..' . '/../lib/Listener/RegisterMountProviderListener.php',
         'OCA\\Files_Sharing\\Listener\\ShareInteractionListener' => __DIR__ . '/..' . '/../lib/Listener/ShareInteractionListener.php',
         'OCA\\Files_Sharing\\Listener\\UserAddedToGroupListener' => __DIR__ . '/..' . '/../lib/Listener/UserAddedToGroupListener.php',
         'OCA\\Files_Sharing\\Listener\\UserShareAcceptanceListener' => __DIR__ . '/..' . '/../lib/Listener/UserShareAcceptanceListener.php',

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -19,13 +19,13 @@ use OCA\Files_Sharing\Listener\BeforeDirectFileDownloadListener;
 use OCA\Files_Sharing\Listener\BeforeZipCreatedListener;
 use OCA\Files_Sharing\Listener\LoadAdditionalListener;
 use OCA\Files_Sharing\Listener\LoadSidebarListener;
+use OCA\Files_Sharing\Listener\RegisterMountProviderListener;
 use OCA\Files_Sharing\Listener\ShareInteractionListener;
 use OCA\Files_Sharing\Listener\UserAddedToGroupListener;
 use OCA\Files_Sharing\Listener\UserShareAcceptanceListener;
 use OCA\Files_Sharing\Middleware\OCSShareAPIMiddleware;
 use OCA\Files_Sharing\Middleware\ShareInfoMiddleware;
 use OCA\Files_Sharing\Middleware\SharingCheckMiddleware;
-use OCA\Files_Sharing\MountProvider;
 use OCA\Files_Sharing\Notification\Listener;
 use OCA\Files_Sharing\Notification\Notifier;
 use OCA\Files_Sharing\ShareBackend\File;
@@ -37,9 +37,9 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent as ResourcesLoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudIdManager;
-use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\Events\BeforeZipCreatedEvent;
+use OCP\Files\Events\RegisterMountProviderEvent;
 use OCP\Group\Events\GroupChangedEvent;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
@@ -95,22 +95,17 @@ class Application extends App implements IBootstrap {
 		// Handle download events for view only checks
 		$context->registerEventListener(BeforeZipCreatedEvent::class, BeforeZipCreatedListener::class);
 		$context->registerEventListener(BeforeDirectFileDownloadEvent::class, BeforeDirectFileDownloadListener::class);
+
+		$context->registerEventListener(RegisterMountProviderEvent::class, RegisterMountProviderListener::class);
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn([$this, 'registerMountProviders']);
 		$context->injectFn([$this, 'registerEventsScripts']);
 
 		Helper::registerHooks();
 
 		Share::registerBackend('file', File::class);
 		Share::registerBackend('folder', Folder::class, 'file');
-	}
-
-
-	public function registerMountProviders(IMountProviderCollection $mountProviderCollection, MountProvider $mountProvider, ExternalMountProvider $externalMountProvider): void {
-		$mountProviderCollection->registerProvider($mountProvider);
-		$mountProviderCollection->registerProvider($externalMountProvider);
 	}
 
 	public function registerEventsScripts(IEventDispatcher $dispatcher): void {

--- a/apps/files_sharing/lib/Listener/RegisterMountProviderListener.php
+++ b/apps/files_sharing/lib/Listener/RegisterMountProviderListener.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Sharing\Listener;
+
+use OCA\Files_Sharing\External\MountProvider as ExternalMountProvider;
+use OCA\Files_Sharing\MountProvider;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Files\Events\RegisterMountProviderEvent;
+
+/** @template-implements IEventListener<RegisterMountProviderEvent> */
+class RegisterMountProviderListener implements IEventListener {
+
+	public function __construct(
+		private MountProvider $mountProvider,
+		private ExternalMountProvider $externalMountProvider,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!($event instanceof RegisterMountProviderEvent)) {
+			return;
+		}
+
+		$mountProviderCollection = $event->getProviderCollection();
+		$mountProviderCollection->registerProvider($this->mountProvider);
+		$mountProviderCollection->registerProvider($this->externalMountProvider);
+	}
+}

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -9,9 +9,6 @@ namespace OCA\Files_Sharing\Tests;
 use OC\Files\Filesystem;
 use OC\User\DisplayNameCache;
 use OCA\Files_Sharing\AppInfo\Application;
-use OCA\Files_Sharing\External\MountProvider as ExternalMountProvider;
-use OCA\Files_Sharing\MountProvider;
-use OCP\Files\Config\IMountProviderCollection;
 use OCP\Share\IShare;
 use Test\Traits\MountProviderTrait;
 
@@ -54,11 +51,6 @@ abstract class TestCase extends \Test\TestCase {
 		parent::setUpBeforeClass();
 
 		$app = new Application();
-		$app->registerMountProviders(
-			\OC::$server->get(IMountProviderCollection::class),
-			\OC::$server->get(MountProvider::class),
-			\OC::$server->get(ExternalMountProvider::class),
-		);
 
 		// reset backend
 		\OC_User::clearBackends();

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -370,6 +370,7 @@ return array(
     'OCP\\Files\\Events\\Node\\NodeRenamedEvent' => $baseDir . '/lib/public/Files/Events/Node/NodeRenamedEvent.php',
     'OCP\\Files\\Events\\Node\\NodeTouchedEvent' => $baseDir . '/lib/public/Files/Events/Node/NodeTouchedEvent.php',
     'OCP\\Files\\Events\\Node\\NodeWrittenEvent' => $baseDir . '/lib/public/Files/Events/Node/NodeWrittenEvent.php',
+    'OCP\\Files\\Events\\RegisterMountProviderEvent' => $baseDir . '/lib/public/Files/Events/RegisterMountProviderEvent.php',
     'OCP\\Files\\File' => $baseDir . '/lib/public/Files/File.php',
     'OCP\\Files\\FileInfo' => $baseDir . '/lib/public/Files/FileInfo.php',
     'OCP\\Files\\FileNameTooLongException' => $baseDir . '/lib/public/Files/FileNameTooLongException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -403,6 +403,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\Events\\Node\\NodeRenamedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/Node/NodeRenamedEvent.php',
         'OCP\\Files\\Events\\Node\\NodeTouchedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/Node/NodeTouchedEvent.php',
         'OCP\\Files\\Events\\Node\\NodeWrittenEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/Node/NodeWrittenEvent.php',
+        'OCP\\Files\\Events\\RegisterMountProviderEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/RegisterMountProviderEvent.php',
         'OCP\\Files\\File' => __DIR__ . '/../../..' . '/lib/public/Files/File.php',
         'OCP\\Files\\FileInfo' => __DIR__ . '/../../..' . '/lib/public/Files/FileInfo.php',
         'OCP\\Files\\FileNameTooLongException' => __DIR__ . '/../../..' . '/lib/public/Files/FileNameTooLongException.php',

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -889,7 +889,8 @@ class Server extends ServerContainer implements IServerContainer {
 			$loader = $c->get(IStorageFactory::class);
 			$mountCache = $c->get(IUserMountCache::class);
 			$eventLogger = $c->get(IEventLogger::class);
-			$manager = new MountProviderCollection($loader, $mountCache, $eventLogger);
+			$eventDispatcher = $c->get(IEventDispatcher::class);
+			$manager = new MountProviderCollection($loader, $mountCache, $eventLogger, $eventDispatcher);
 
 			// builtin providers
 

--- a/lib/public/Files/Events/RegisterMountProviderEvent.php
+++ b/lib/public/Files/Events/RegisterMountProviderEvent.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Files\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\Files\Config\IMountProviderCollection;
+
+/** @since 30.0.0 */
+class RegisterMountProviderEvent extends Event {
+	/**
+	 * @since 30.0.0
+	 */
+	public function __construct(
+		private IMountProviderCollection $mountProviderCollection,
+	) {
+	}
+
+	/**
+	 * Get the mount provider collection to register new providers
+	 * @since 30.0.0
+	 */
+	public function getProviderCollection(): IMountProviderCollection {
+		return $this->mountProviderCollection;
+	}
+}


### PR DESCRIPTION
Mount provider registration currently requires to obtain the MountProviderCollection and create instances of apps mount providers, which might pull in more heavy dependencies. While this is not a problem in files_sharing, other apps like circles or collectives have a larger tree of dependencies that the mount provider class is pulling in.

We don't need the mount providers always available so we can save those DI setup times for all requests that don't access the mount provider list through accessing the storage.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
