### PR TITLE
perf: Tell browsers to cache storage stats endpoint as it is cached

### DIFF
--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -238,7 +238,9 @@ class ApiController extends Controller {
 	 */
 	public function getStorageStats($dir = '/'): JSONResponse {
 		$storageInfo = \OC_Helper::getStorageInfo($dir ?: '/');
-		return new JSONResponse(['message' => 'ok', 'data' => $storageInfo]);
+		$response = new JSONResponse(['message' => 'ok', 'data' => $storageInfo]);
+		$response->cacheFor(5 * 60);
+		return $response;
 	}
 
 	/**


### PR DESCRIPTION
This way browsers can cache the request as the return value is stored in memcache anyways for 5 minutes

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
