### PR TITLE
Fix rmdir() to release possible directory lock prior to removing directory

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -117,6 +117,7 @@ class Local extends \OC\Files\Storage\Common {
 				}
 				$it->next();
 			}
+			unset ($it);
 			clearstatcache(true, $this->getSourcePath($path));
 			return rmdir($this->getSourcePath($path));
 		} catch (\UnexpectedValueException $e) {

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -117,7 +117,7 @@ class Local extends \OC\Files\Storage\Common {
 				}
 				$it->next();
 			}
-			unset ($it);
+			unset($it);
 			clearstatcache(true, $this->getSourcePath($path));
 			return rmdir($this->getSourcePath($path));
 		} catch (\UnexpectedValueException $e) {


### PR DESCRIPTION
As described in this [Nextcloud community issue](https://help.nextcloud.com/t/unable-to-delete-directories-text-file-busy/86468) some storage systems (such as VirtualBox shared folders) may lock a directory when traversing it using `opendir()` or a `DirectoryIterator`. This patch fixes `Local::rmdir()` to release such locks prior to removing a directory recursively, avoiding failure to do so with 'Text file busy" warnings.