### PR TITLE
fix(dav): Limit number of UPDATES for sync token created_at

### DIFF
--- a/apps/dav/lib/Migration/Version1025Date20240308063933.php
+++ b/apps/dav/lib/Migration/Version1025Date20240308063933.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Migration;
 
 use Closure;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\DB\Types;
@@ -19,10 +20,13 @@ use OCP\Migration\SimpleMigrationStep;
 
 class Version1025Date20240308063933 extends SimpleMigrationStep {
 
+	private IAppConfig $appConfig;
 	private IDBConnection $db;
 
-	public function __construct(IDBConnection $db) {
+	public function __construct(IAppConfig $appConfig,
+		IDBConnection $db) {
 		$this->db = $db;
+		$this->appConfig = $appConfig;
 	}
 
 	/**
@@ -50,7 +54,22 @@ class Version1025Date20240308063933 extends SimpleMigrationStep {
 	}
 
 	public function postSchemaChange(IOutput $output, \Closure $schemaClosure, array $options): void {
+		// The threshold is higher than the default of \OCA\DAV\BackgroundJob\PruneOutdatedSyncTokensJob
+		// but small enough to fit into a cluster transaction size.
+		// For a 50k users instance that would still keep 10 changes on average.
+		$limit = max(1, (int) $this->appConfig->getAppValue('totalNumberOfSyncTokensToKeep', '500000'));
+
 		foreach (['addressbookchanges', 'calendarchanges'] as $tableName) {
+			$thresholdSelect = $this->db->getQueryBuilder();
+			$thresholdSelect->select('id')
+				->from($tableName)
+				->orderBy('id', 'desc')
+				->setFirstResult($limit)
+				->setMaxResults(1);
+			$oldestIdResult = $thresholdSelect->executeQuery();
+			$oldestId = $oldestIdResult->fetchColumn();
+			$oldestIdResult->closeCursor();
+
 			$qb = $this->db->getQueryBuilder();
 
 			$update = $qb->update($tableName)
@@ -59,7 +78,15 @@ class Version1025Date20240308063933 extends SimpleMigrationStep {
 					$qb->expr()->eq('created_at', $qb->createNamedParameter(0, IQueryBuilder::PARAM_INT)),
 				);
 
+			// If there is a lot of data we only set timestamp for the most recent rows
+			// because the rest will be deleted by \OCA\DAV\BackgroundJob\PruneOutdatedSyncTokensJob
+			// anyway.
+			if ($oldestId !== false) {
+				$update->andWhere($qb->expr()->gt('id', $qb->createNamedParameter($oldestId, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT));
+			}
+
 			$updated = $update->executeStatement();
+
 			$output->debug('Added a default creation timestamp to ' . $updated . ' rows in ' . $tableName);
 		}
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Address book and calendar sync tokens have a created_at column in 26+ and we need to assign a current timestamp to the existing data at upgrade so the data isn't cleaned up immediately. Updating the full table is expensive and fails on clustered setups that limit transaction size. We don't need a timestamp for the oldest rows so we can skip updating them.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
