### PR TITLE
fix(caldav): lower scheduling table size warning

### DIFF
--- a/apps/settings/lib/SetupChecks/SchedulingTableSize.php
+++ b/apps/settings/lib/SetupChecks/SchedulingTableSize.php
@@ -14,6 +14,8 @@ use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
 class SchedulingTableSize implements ISetupCheck {
+	public const MAX_SCHEDULING_ENTRIES = 50000;
+
 	public function __construct(
 		private IL10N $l10n,
 		private IDBConnection $connection,
@@ -36,9 +38,11 @@ class SchedulingTableSize implements ISetupCheck {
 		$count = $query->fetchOne();
 		$query->closeCursor();
 
-		if ($count > 500000) {
+		if ($count > self::MAX_SCHEDULING_ENTRIES) {
 			return SetupResult::warning(
-				$this->l10n->t('You have more than 500 000 rows in the scheduling objects table. Please run the expensive repair jobs via occ maintenance:repair --include-expensive')
+				$this->l10n->t('You have more than %s rows in the scheduling objects table. Please run the expensive repair jobs via occ maintenance:repair --include-expensive.', [
+					self::MAX_SCHEDULING_ENTRIES,
+				])
 			);
 		}
 		return SetupResult::success(


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
 Reduce the size warning - the table is quite big even with just a 100k rows.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
