### PR TITLE
fix(theming): properly apply warning style to update output

### DIFF
--- a/apps/theming/lib/Command/UpdateConfig.php
+++ b/apps/theming/lib/Command/UpdateConfig.php
@@ -111,9 +111,9 @@ class UpdateConfig extends Command {
 			$value = $this->imageManager->updateImage($key, $value);
 			$key = $key . 'Mime';
 		}
-	
+
 		if ($key === 'color') {
-			$output->writeln('<warning>Using "color" is depreacted, use "primary_color" instead');
+			$output->writeln('<comment>Using "color" is deprecated, use "primary_color" instead</comment>');
 			$key = 'primary_color';
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

### Before
![Screenshot_20240619_155029](https://github.com/nextcloud/server/assets/1479486/a4a8aece-106f-4446-b041-78217a580f4d)

### After
![Screenshot_20240619_154955](https://github.com/nextcloud/server/assets/1479486/8364b18c-3d87-4bcd-b0da-b3281f12438a)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
