### PR TITLE
The "redirects" config allows configuring redirects from paths to routes

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2438,4 +2438,23 @@ $CONFIG = [
  * Defaults to ``true``
  */
 'enable_non-accessible_features' => true,
+
+/**
+ * Request path without /index.php/ maps to a controller path in the form
+ * <app name>.<controller name>.<handler>.
+ *
+ * - For a FooController.php the controller name is "foo" (lowercase)
+ * - A handler would be a method in FooController that was annotated with
+ *   - either #[FrontpageRoute] attribute
+ *   - or configured in routes.php
+ *
+ * Defaults to ``[]`` (no redirects)
+ */
+'redirects' => [
+   /**
+    * Example:
+    * '^\/settings' => 'acmesettings.page.index'
+    */
+],
+
 ];


### PR DESCRIPTION
## Summary
The "redirects" config allows configuring redirects from paths to routes.

### Example config

```
"redirects" => { "^/path/regexp" => "an.apps.controller.route.locator" }
```

### Use case

* An administrator can configure another app as target for certain paths.

### Differentiation from Apache redirects

* this allows configuring redirects in one place and avoids spreading
  the configuration in multiple places.
* the target route locator is more expressive/easier to trace than a
  path


## TODO

- [ ] Tests
- [ ] Documentation
- [ ] Backport to stable29

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting) :heavy_check_mark: 
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits :heavy_check_mark: 
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included :hourglass_flowing_sand: 
- ~Screenshots before/after for front-end changes~ _(not applicable)_
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required :hourglass_flowing_sand:/TBD
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
