### PR TITLE
fix(caldav): encode calendar URIs with umlauts for activities

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -76,14 +76,15 @@ class Event extends Base {
 				// The calendar app needs to be manually loaded for the routes to be loaded
 				OC_App::loadApp('calendar');
 				$linkData = $eventData['link'];
+				$calendarUri = $this->urlencodeLowerHex($linkData['calendar_uri']);
 				if ($affectedUser === $linkData['owner']) {
-					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $linkData['calendar_uri'] . '/' . $linkData['object_uri']);
+					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $linkData['owner'] . '/' . $calendarUri . '/' . $linkData['object_uri']);
 				} else {
 					// Can't use the "real" owner and calendar names here because we create a custom
 					// calendar for incoming shares with the name "<calendar>_shared_by_<sharer>".
 					// Hack: Fix the link by generating it for the incoming shared calendar instead,
 					//       as seen from the affected user.
-					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $affectedUser . '/' . $linkData['calendar_uri'] . '_shared_by_' . $linkData['owner'] . '/' . $linkData['object_uri']);
+					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $affectedUser . '/' . $calendarUri . '_shared_by_' . $linkData['owner'] . '/' . $linkData['object_uri']);
 				}
 				$link = [
 					'view' => 'dayGridMonth',
@@ -240,5 +241,17 @@ class Event extends Base {
 			$parameter['name'] = $this->l->t('Busy');
 		}
 		return $parameter;
+	}
+
+	/**
+	 * Return urlencoded string but with lower cased hex sequences.
+	 * The remaining casing will be untouched.
+	 */
+	private function urlencodeLowerHex(string $raw): string {
+		return preg_replace_callback(
+			'/%[0-9A-F]{2}/',
+			static fn (array $matches) => strtolower($matches[0]),
+			urlencode($raw),
+		);
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -129,17 +129,58 @@ class EventTest extends TestCase {
 		$this->assertEquals($result, $this->invokePrivate($this->provider, 'generateObjectParameter', [$objectParameter, $affectedUser]));
 	}
 
-	public function testGenerateObjectParameterWithSharedCalendar(): void {
-		$link = [
-			'object_uri' => 'someuuid.ics',
-			'calendar_uri' => 'personal',
-			'owner' => 'sharer'
+	public static function generateObjectParameterLinkEncodingDataProvider(): array {
+		return [
+			[ // Shared calendar
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'personal',
+					'owner' => 'sharer'
+				],
+				base64_encode('/remote.php/dav/calendars/sharee/personal_shared_by_sharer/someuuid.ics'),
+			],
+			[ // Shared calendar with umlauts
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'umlaut_äüöß',
+					'owner' => 'sharer'
+				],
+				base64_encode('/remote.php/dav/calendars/sharee/umlaut_%c3%a4%c3%bc%c3%b6%c3%9f_shared_by_sharer/someuuid.ics'),
+			],
+			[ // Shared calendar with umlauts and mixed casing
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'Umlaut_äüöß',
+					'owner' => 'sharer'
+				],
+				base64_encode('/remote.php/dav/calendars/sharee/Umlaut_%c3%a4%c3%bc%c3%b6%c3%9f_shared_by_sharer/someuuid.ics'),
+			],
+			[ // Owned calendar with umlauts
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'umlaut_äüöß',
+					'owner' => 'sharee'
+				],
+				base64_encode('/remote.php/dav/calendars/sharee/umlaut_%c3%a4%c3%bc%c3%b6%c3%9f/someuuid.ics'),
+			],
+			[ // Owned calendar with umlauts and mixed casing
+				[
+					'object_uri' => 'someuuid.ics',
+					'calendar_uri' => 'Umlaut_äüöß',
+					'owner' => 'sharee'
+				],
+				base64_encode('/remote.php/dav/calendars/sharee/Umlaut_%c3%a4%c3%bc%c3%b6%c3%9f/someuuid.ics'),
+			],
 		];
+	}
+
+	/** @dataProvider generateObjectParameterLinkEncodingDataProvider */
+	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId): void {
 		$generatedLink = [
 			'view' => 'dayGridMonth',
 			'timeRange' => 'now',
 			'mode' => 'sidebar',
-			'objectId' => base64_encode('/remote.php/dav/calendars/sharee/' . $link['calendar_uri'] . '_shared_by_sharer/' . $link['object_uri']),
+			'objectId' => $objectId,
 			'recurrenceId' => 'next'
 		];
 		$this->appManager->expects($this->once())


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/calendar/issues/6073

## Summary

Follow-up to https://github.com/nextcloud/server/pull/45775 to also handle umlauts in calendar URIs.

Umlauts have to be encoded with `urlencode()` but the escaped hex sequences have to be lower case to match what SabreDAV does. We need to leave uppercase characters untouched in calendar URIs though.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
