### PR TITLE
fix(dashboard): Correctly redirect guests to login page when opening dashboard

### DIFF
--- a/apps/dashboard/lib/Service/DashboardService.php
+++ b/apps/dashboard/lib/Service/DashboardService.php
@@ -14,7 +14,7 @@ use OCP\IConfig;
 class DashboardService {
 	public function __construct(
 		private IConfig $config,
-		private String $userId,
+		private ?string $userId,
 	) {
 
 	}


### PR DESCRIPTION
```
Message: OCA\Dashboard\Service\DashboardService::__construct(): Argument #2 ($userId) must be of type string, null given
File: /var/www/html/apps/dashboard/lib/Service/DashboardService.php
Line: 15
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
