### PR TITLE
fix: also use optimized getFirstNodeyIdInPath for Folder::getFirstNodeById

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -289,7 +289,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	}
 
 	public function getFirstNodeById(int $id): ?\OCP\Files\Node {
-		return current($this->getById($id)) ?: null;
+		return $this->root->getFirstNodeByIdInPath($id, $this->getPath());
 	}
 
 	public function getAppDataDirectoryName(): string {


### PR DESCRIPTION
This was missed in https://github.com/nextcloud/server/pull/43471 :see_no_evil: 