### PR TITLE
fix: don't persist previews used during blurhash generation

### DIFF
--- a/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
+++ b/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
@@ -70,7 +70,7 @@ class GenerateBlurhashMetadata implements IEventListener {
 		$image = false;
 		try {
 			// using preview image to generate the blurhash
-			$preview = $this->preview->getPreview($file, 256, 256);
+			$preview = $this->preview->getPreview($file, 256, 256, false, IPreview::MODE_FILL, null, true);
 			$image = @imagecreatefromstring($preview->getContent());
 		} catch (NotFoundException $e) {
 			// https://github.com/nextcloud/server/blob/9d70fd3e64b60a316a03fb2b237891380c310c58/lib/private/legacy/OC_Image.php#L668

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -351,9 +351,11 @@ class Generator {
 
 				if ($inMemory) {
 					if ($preview instanceof IStreamImage) {
-						return new InMemoryFile($path, $preview->resource());
+						$contents = stream_get_contents($preview->resource());
+					} else {
+						$contents = $preview->data();
 					}
-					return new InMemoryFile($path, $preview->data());
+					return new InMemoryFile($path, $contents);
 				}
 
 				try {

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -355,7 +355,7 @@ class Generator {
 					} else {
 						$contents = $preview->data();
 					}
-					return new InMemoryFile($path, $contents);
+					return $this->helper->createInMemoryFile($path, $contents);
 				}
 
 				try {
@@ -548,7 +548,7 @@ class Generator {
 		$path = $this->generatePath($width, $height, $crop, false, $preview->dataMimeType(), $prefix);
 
 		if ($inMemory) {
-			return new InMemoryFile($path, $preview->data());
+			return $this->helper->createInMemoryFile($path, $preview->data());
 		}
 
 		try {

--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -11,7 +11,6 @@ use OCP\Files\IAppData;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
-use OCP\Files\SimpleFS\InMemoryFile;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;

--- a/lib/private/Preview/GeneratorHelper.php
+++ b/lib/private/Preview/GeneratorHelper.php
@@ -7,6 +7,7 @@ namespace OC\Preview;
 
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
+use OCP\Files\SimpleFS\InMemoryFile;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IConfig;
 use OCP\IImage;
@@ -64,5 +65,9 @@ class GeneratorHelper {
 			$provider = new ProviderV1Adapter($provider);
 		}
 		return $provider;
+	}
+
+	public function createInMemoryFile(string $name, string $content): ISimpleFile {
+		return new InMemoryFile($name, $content);
 	}
 }

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -154,17 +154,18 @@ class PreviewManager implements IPreview {
 	 * @param bool $crop
 	 * @param string $mode
 	 * @param string $mimeType
+	 * @param bool $inMemory Don't persist the previews anywhere. Only keep them in memory.
 	 * @return ISimpleFile
 	 * @throws NotFoundException
 	 * @throws \InvalidArgumentException if the preview would be invalid (in case the original image is invalid)
 	 * @since 11.0.0 - \InvalidArgumentException was added in 12.0.0
 	 */
-	public function getPreview(File $file, $width = -1, $height = -1, $crop = false, $mode = IPreview::MODE_FILL, $mimeType = null) {
+	public function getPreview(File $file, $width = -1, $height = -1, $crop = false, $mode = IPreview::MODE_FILL, $mimeType = null, bool $inMemory = false) {
 		$this->throwIfPreviewsDisabled();
 		$previewConcurrency = $this->getGenerator()->getNumConcurrentPreviews('preview_concurrency_all');
 		$sem = Generator::guardWithSemaphore(Generator::SEMAPHORE_ID_ALL, $previewConcurrency);
 		try {
-			$preview = $this->getGenerator()->getPreview($file, $width, $height, $crop, $mode, $mimeType);
+			$preview = $this->getGenerator()->getPreview($file, $width, $height, $crop, $mode, $mimeType, $inMemory);
 		} finally {
 			Generator::unguardWithSemaphore($sem);
 		}

--- a/lib/public/IPreview.php
+++ b/lib/public/IPreview.php
@@ -71,12 +71,13 @@ interface IPreview {
 	 * @param bool $crop
 	 * @param string $mode
 	 * @param string $mimeType To force a given mimetype for the file (files_versions needs this)
+	 * @param bool $inMemory Don't persist the preview anywhere. Only keep it in memory.
 	 * @return ISimpleFile
 	 * @throws NotFoundException
 	 * @throws \InvalidArgumentException if the preview would be invalid (in case the original image is invalid)
 	 * @since 11.0.0 - \InvalidArgumentException was added in 12.0.0
 	 */
-	public function getPreview(File $file, $width = -1, $height = -1, $crop = false, $mode = IPreview::MODE_FILL, $mimeType = null);
+	public function getPreview(File $file, $width = -1, $height = -1, $crop = false, $mode = IPreview::MODE_FILL, $mimeType = null, bool $inMemory = false);
 
 	/**
 	 * Returns true if the passed mime type is supported


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/45654

## Summary

Generating and saving a preview file for every file is a bit too expensive on large instances. This PR will discard generated previews after generating a blurhash.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
