### PR TITLE
perf: delay getting (sub)admin status for user in the security middleware untill we need it

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -36,6 +36,7 @@ use OCP\Files\IAppData;
 use OCP\Group\ISubAdmin;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IInitialStateService;
 use OCP\IL10N;
 use OCP\ILogger;
@@ -228,8 +229,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				$server->get(LoggerInterface::class),
 				$c->get('AppName'),
 				$server->getUserSession()->isLoggedIn(),
-				$this->getUserId() !== null && $server->getGroupManager()->isAdmin($this->getUserId()),
-				$server->getUserSession()->getUser() !== null && $server->query(ISubAdmin::class)->isSubAdmin($server->getUserSession()->getUser()),
+				$c->get(IGroupManager::class),
+				$c->get(ISubAdmin::class),
 				$server->getAppManager(),
 				$server->getL10N('lib'),
 				$c->get(AuthorizedGroupMapper::class),

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -24,13 +24,16 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Group\ISubAdmin;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\IRequestId;
 use OCP\ISession;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Security\Ip\IRemoteAddress;
 use Psr\Log\LoggerInterface;
@@ -71,6 +74,9 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 
 		$this->authorizedGroupMapper = $this->createMock(AuthorizedGroupMapper::class);
 		$this->userSession = $this->createMock(Session::class);
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('test');
+		$this->userSession->method('getUser')->willReturn($user);
 		$this->request = $this->createMock(IRequest::class);
 		$this->controller = new SecurityMiddlewareController(
 			'test',
@@ -94,6 +100,13 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$remoteIpAddress = $this->createMock(IRemoteAddress::class);
 		$remoteIpAddress->method('allowsAdminActions')->willReturn(true);
 
+		$groupManager = $this->createMock(IGroupManager::class);
+		$groupManager->method('isAdmin')
+			->willReturn($isAdminUser);
+		$subAdminManager = $this->createMock(ISubAdmin::class);
+		$subAdminManager->method('isSubAdmin')
+			->willReturn($isSubAdmin);
+
 		return new SecurityMiddleware(
 			$this->request,
 			$this->reader,
@@ -102,8 +115,8 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 			$this->logger,
 			'files',
 			$isLoggedIn,
-			$isAdminUser,
-			$isSubAdmin,
+			$groupManager,
+			$subAdminManager,
 			$this->appManager,
 			$this->l10n,
 			$this->authorizedGroupMapper,


### PR DESCRIPTION
No need to check if we're admin for non-admin routes.

Should save 1 or 2 queries for most routes