### PR TITLE
fix(mail): Log hint when mail_from_address may be wrong

### DIFF
--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -310,7 +310,8 @@ class Util {
 			return $defaultEmailAddress;
 		}
 
-		// in case we cannot build a valid email address from the hostname let's fallback to 'localhost.localdomain'
+		// in case we cannot build a valid email address from the hostname we log an error and fallback to 'localhost.localdomain' for now
+		\OCP\Server::get(LoggerInterface::class)->error('Unable to determine default email address ("mail_from_address" may be wrong). Using ' . $user_part . '@localhost.localdomain for the time being.');
 		return $user_part.'@localhost.localdomain';
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #25162 <!-- related github issue -->

## Summary

Logging an error since it's likely a sign that there is a config problem. Otherwise still behave like we have previously.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
