### PR TITLE
Increase PHP memory limit for DevContainer to 512mb

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -52,6 +52,9 @@ RUN { \
 	echo "xdebug.start_with_request=yes"; \
 } >> /etc/php/8.3/apache2/conf.d/20-xdebug.ini
 
+# Increase PHP memory limit to 512mb
+RUN sed -i 's/memory_limit = .*/memory_limit = 512M/' /etc/php/8.3/apache2/php.ini
+
 # Docker
 RUN apt-get -y install \
     apt-transport-https \


### PR DESCRIPTION
We should increase the PHP memory limit to the recommended 512mb also for our VSCode DevContainer 