### PR TITLE
feat(CI): Speed up cs:check with parallelism

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -8,9 +8,11 @@ declare(strict_types=1);
 require_once './vendor-bin/cs-fixer/vendor/autoload.php';
 
 use Nextcloud\CodingStandard\Config;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
 
 $config = new Config();
 $config
+	->setParallelConfig(ParallelConfigFactory::detect())
 	->getFinder()
 	->ignoreVCSIgnored(true)
 	->exclude('config')


### PR DESCRIPTION
## Summary

Before: 
```
$ composer run cs:check -- --using-cache no
> php-cs-fixer fix --dry-run --diff '--using-cache' 'no'
PHP CS Fixer 3.58.1 (8fdc3d5) 7th Gear by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.1.29
Running analysis on 1 core sequentially.
You can enable parallel runner and speed up the analysis! Please see usage docs for more information.
Loaded config default from "…/server/.php-cs-fixer.dist.php".
 4376/4376 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Found 0 of 4376 files that can be fixed in 84.267 seconds, 70.00 MB memory used
```

After:
```
$ composer run cs:check -- --using-cache no
> php-cs-fixer fix --dry-run --diff '--using-cache' 'no'
PHP CS Fixer 3.58.1 (8fdc3d5) 7th Gear by Fabien Potencier, Dariusz Ruminski and contributors.
PHP runtime: 8.1.29
Running analysis on 8 cores with 10 files per process.
Parallel runner is an experimental feature and may be unstable, use it at your own risk. Feedback highly appreciated!
Loaded config default from "…/server/.php-cs-fixer.dist.php".
 4376/4376 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


Found 0 of 4376 files that can be fixed in 20.878 seconds, 54.00 MB memory used
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
