### PR TITLE
fix(Token): add FILESYSTEM scope with SCOPE_SKIP_PASSWORD_VALIDATION

### DIFF
--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -172,7 +172,10 @@ class OC_User {
 				if (empty($password)) {
 					$tokenProvider = \OC::$server->get(IProvider::class);
 					$token = $tokenProvider->getToken($userSession->getSession()->getId());
-					$token->setScope([IToken::SCOPE_SKIP_PASSWORD_VALIDATION => true]);
+					$token->setScope([
+						IToken::SCOPE_SKIP_PASSWORD_VALIDATION => true,
+						IToken::SCOPE_FILESYSTEM => true,
+					]);
 					$tokenProvider->updateToken($token);
 				}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #46070 

## Summary


The scope design requires scopes to be either not specified, or
specified explicitely. Therefore, when setting the
skip-password-validation scope for user authentication from mechanisms
like SAML, we also have to set the filesystem scope, otherwise they will
lack access to the filesystem.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
