### PR TITLE
fix: allows admin to edit global credentials

### DIFF
--- a/apps/files_external/lib/Controller/AjaxController.php
+++ b/apps/files_external/lib/Controller/AjaxController.php
@@ -84,15 +84,21 @@ class AjaxController extends Controller {
 	 */
 	public function saveGlobalCredentials($uid, $user, $password) {
 		$currentUser = $this->userSession->getUser();
+		if ($currentUser === null) {
+			return false;
+		}
 
 		// Non-admins can only edit their own credentials
-		$allowedToEdit = ($currentUser->getUID() === $uid);
+		// Admin can edit global credentials
+		$allowedToEdit = $uid === ''
+			? $this->groupManager->isAdmin($currentUser->getUID())
+			: $currentUser->getUID() === $uid;
 
 		if ($allowedToEdit) {
 			$this->globalAuth->saveAuth($uid, $user, $password);
 			return true;
-		} else {
-			return false;
 		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
## Summary
It's not possible to save global credentials in external storage anymore.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
