### PR TITLE
feat(webhooks): Add support for a userid filter

### DIFF
--- a/apps/webhook_listeners/lib/AppInfo/Application.php
+++ b/apps/webhook_listeners/lib/AppInfo/Application.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -40,9 +41,10 @@ class Application extends App implements IBootstrap {
 	): void {
 		/** @var WebhookListenerMapper */
 		$mapper = $container->get(WebhookListenerMapper::class);
+		$userSession = $container->get(IUserSession::class);
 
 		/* Listen to all events with at least one webhook configured */
-		$configuredEvents = $mapper->getAllConfiguredEvents();
+		$configuredEvents = $mapper->getAllConfiguredEvents($userSession->getUser()?->getUID());
 		foreach ($configuredEvents as $eventName) {
 			$logger->debug("Listening to {$eventName}");
 			$dispatcher->addServiceListener(

--- a/apps/webhook_listeners/lib/Controller/WebhooksController.php
+++ b/apps/webhook_listeners/lib/Controller/WebhooksController.php
@@ -126,6 +126,7 @@ class WebhooksController extends OCSController {
 		string $uri,
 		string $event,
 		?array $eventFilter,
+		?string $userIdFilter,
 		?array $headers,
 		?string $authMethod,
 		#[\SensitiveParameter]
@@ -150,6 +151,7 @@ class WebhooksController extends OCSController {
 				$uri,
 				$event,
 				$eventFilter,
+				$userIdFilter,
 				$headers,
 				$authMethod,
 				$authData,
@@ -193,6 +195,7 @@ class WebhooksController extends OCSController {
 		string $uri,
 		string $event,
 		?array $eventFilter,
+		?string $userIdFilter,
 		?array $headers,
 		?string $authMethod,
 		#[\SensitiveParameter]
@@ -218,6 +221,7 @@ class WebhooksController extends OCSController {
 				$uri,
 				$event,
 				$eventFilter,
+				$userIdFilter,
 				$headers,
 				$authMethod,
 				$authData,

--- a/apps/webhook_listeners/lib/Controller/WebhooksController.php
+++ b/apps/webhook_listeners/lib/Controller/WebhooksController.php
@@ -107,6 +107,7 @@ class WebhooksController extends OCSController {
 	 * @param string $uri Webhook URI endpoint
 	 * @param string $event Event class name to listen to
 	 * @param ?array<string,mixed> $eventFilter Mongo filter to apply to the serialized data to decide if firing
+	 * @param ?string $userIdFilter User id to filter on. The webhook will only be called by requests from this user. Empty or null means no filtering.
 	 * @param ?array<string,string> $headers Array of headers to send
 	 * @param "none"|"headers"|null $authMethod Authentication method to use
 	 * @param ?array<string,mixed> $authData Array of data for authentication
@@ -175,6 +176,7 @@ class WebhooksController extends OCSController {
 	 * @param string $uri Webhook URI endpoint
 	 * @param string $event Event class name to listen to
 	 * @param ?array<string,mixed> $eventFilter Mongo filter to apply to the serialized data to decide if firing
+	 * @param ?string $userIdFilter User id to filter on. The webhook will only be called by requests from this user. Empty or null means no filtering.
 	 * @param ?array<string,string> $headers Array of headers to send
 	 * @param "none"|"headers"|null $authMethod Authentication method to use
 	 * @param ?array<string,mixed> $authData Array of data for authentication

--- a/apps/webhook_listeners/lib/Db/WebhookListener.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListener.php
@@ -60,6 +60,12 @@ class WebhookListener extends Entity implements \JsonSerializable {
 	protected $eventFilter;
 
 	/**
+	 * @var string
+	 * If not empty, id of the user that needs to be connected for the webhook to trigger
+	 */
+	protected $userIdFilter;
+
+	/**
 	 * @var ?array
 	 */
 	protected $headers = null;
@@ -90,6 +96,7 @@ class WebhookListener extends Entity implements \JsonSerializable {
 		$this->addType('uri', 'string');
 		$this->addType('event', 'string');
 		$this->addType('eventFilter', 'json');
+		$this->addType('userIdFilter', 'string');
 		$this->addType('headers', 'json');
 		$this->addType('authMethod', 'string');
 		$this->addType('authData', 'string');

--- a/apps/webhook_listeners/lib/Db/WebhookListener.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListener.php
@@ -60,8 +60,9 @@ class WebhookListener extends Entity implements \JsonSerializable {
 	protected $eventFilter;
 
 	/**
-	 * @var string
+	 * @var ?string
 	 * If not empty, id of the user that needs to be connected for the webhook to trigger
+	 * @psalm-suppress PropertyNotSetInConstructor
 	 */
 	protected $userIdFilter;
 

--- a/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
@@ -25,7 +25,7 @@ use OCP\IDBConnection;
 class WebhookListenerMapper extends QBMapper {
 	public const TABLE_NAME = 'webhook_listeners';
 
-	private const EVENTS_CACHE_KEY = 'eventsUsedInWebhooks';
+	private const EVENTS_CACHE_KEY_PREFIX = 'eventsUsedInWebhooks';
 
 	private ?ICache $cache = null;
 
@@ -77,6 +77,7 @@ class WebhookListenerMapper extends QBMapper {
 		string $uri,
 		string $event,
 		?array $eventFilter,
+		?string $userIdFilter,
 		?array $headers,
 		AuthMethod $authMethod,
 		#[\SensitiveParameter]
@@ -95,12 +96,13 @@ class WebhookListenerMapper extends QBMapper {
 				'uri' => $uri,
 				'event' => $event,
 				'eventFilter' => $eventFilter ?? [],
+				'userIdFilter' => $userIdFilter ?? '',
 				'headers' => $headers,
 				'authMethod' => $authMethod->value,
 			]
 		);
 		$webhookListener->setAuthDataClear($authData);
-		$this->cache?->remove(self::EVENTS_CACHE_KEY);
+		$this->cache?->remove($this->buildCacheKey($userIdFilter));
 		return $this->insert($webhookListener);
 	}
 
@@ -115,6 +117,7 @@ class WebhookListenerMapper extends QBMapper {
 		string $uri,
 		string $event,
 		?array $eventFilter,
+		?string $userIdFilter,
 		?array $headers,
 		AuthMethod $authMethod,
 		#[\SensitiveParameter]
@@ -134,12 +137,13 @@ class WebhookListenerMapper extends QBMapper {
 				'uri' => $uri,
 				'event' => $event,
 				'eventFilter' => $eventFilter ?? [],
+				'userIdFilter' => $userIdFilter ?? '',
 				'headers' => $headers,
 				'authMethod' => $authMethod->value,
 			]
 		);
 		$webhookListener->setAuthDataClear($authData);
-		$this->cache?->remove(self::EVENTS_CACHE_KEY);
+		$this->cache?->remove($this->buildCacheKey($userIdFilter));
 		return $this->update($webhookListener);
 	}
 
@@ -159,11 +163,12 @@ class WebhookListenerMapper extends QBMapper {
 	 * @throws Exception
 	 * @return list<string>
 	 */
-	private function getAllConfiguredEventsFromDatabase(): array {
+	private function getAllConfiguredEventsFromDatabase(string $userId): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->selectDistinct('event')
-			->from($this->getTableName());
+			->from($this->getTableName())
+			->where($qb->expr()->in('user_id_filter', $qb->createNamedParameter(['',$userId], IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR));
 
 		$result = $qb->executeQuery();
 
@@ -181,14 +186,15 @@ class WebhookListenerMapper extends QBMapper {
 	 * @throws Exception
 	 * @return list<string>
 	 */
-	public function getAllConfiguredEvents(): array {
-		$events = $this->cache?->get(self::EVENTS_CACHE_KEY);
+	public function getAllConfiguredEvents(?string $userId = null): array {
+		$cacheKey = $this->buildCacheKey($userId);
+		$events = $this->cache?->get($cacheKey);
 		if ($events !== null) {
 			return json_decode($events);
 		}
-		$events = $this->getAllConfiguredEventsFromDatabase();
+		$events = $this->getAllConfiguredEventsFromDatabase($userId ?? '');
 		// cache for 5 minutes
-		$this->cache?->set(self::EVENTS_CACHE_KEY, json_encode($events), 300);
+		$this->cache?->set($cacheKey, json_encode($events), 300);
 		return $events;
 	}
 
@@ -216,5 +222,9 @@ class WebhookListenerMapper extends QBMapper {
 			->where($qb->expr()->eq('uri', $qb->createNamedParameter($uri, IQueryBuilder::PARAM_STR)));
 
 		return $this->findEntities($qb);
+	}
+
+	private function buildCacheKey(?string $userIdFilter = ''): string {
+		return self::EVENTS_CACHE_KEY_PREFIX.'_'.($userIdFilter ?? '');
 	}
 }

--- a/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
@@ -233,7 +233,7 @@ class WebhookListenerMapper extends QBMapper {
 		return $this->findEntities($qb);
 	}
 
-	private function buildCacheKey(?string $userIdFilter = ''): string {
+	private function buildCacheKey(?string $userIdFilter): string {
 		return self::EVENTS_CACHE_KEY_PREFIX.'_'.($userIdFilter ?? '');
 	}
 }

--- a/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
@@ -168,7 +168,10 @@ class WebhookListenerMapper extends QBMapper {
 
 		$qb->selectDistinct('event')
 			->from($this->getTableName())
-			->where($qb->expr()->in('user_id_filter', $qb->createNamedParameter(['',$userId], IQueryBuilder::PARAM_STR_ARRAY), IQueryBuilder::PARAM_STR));
+			->where($qb->expr()->in(
+				'user_id_filter',
+				$qb->createNamedParameter(array_unique(['',$userId]), IQueryBuilder::PARAM_STR_ARRAY),
+			));
 
 		$result = $qb->executeQuery();
 
@@ -201,12 +204,18 @@ class WebhookListenerMapper extends QBMapper {
 	/**
 	 * @throws Exception
 	 */
-	public function getByEvent(string $event): array {
+	public function getByEvent(string $event, ?string $userId = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')
 			->from($this->getTableName())
-			->where($qb->expr()->eq('event', $qb->createNamedParameter($event, IQueryBuilder::PARAM_STR)));
+			->where($qb->expr()->eq('event', $qb->createNamedParameter($event, IQueryBuilder::PARAM_STR)))
+			->andWhere(
+				$qb->expr()->in(
+					'user_id_filter',
+					$qb->createNamedParameter(array_unique(['',$userId ?? '']), IQueryBuilder::PARAM_STR_ARRAY),
+				)
+			);
 
 		return $this->findEntities($qb);
 	}

--- a/apps/webhook_listeners/lib/Listener/WebhooksEventListener.php
+++ b/apps/webhook_listeners/lib/Listener/WebhooksEventListener.php
@@ -34,8 +34,8 @@ class WebhooksEventListener implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		$webhookListeners = $this->mapper->getByEvent($event::class);
 		$user = $this->userSession->getUser();
+		$webhookListeners = $this->mapper->getByEvent($event::class, $user?->getUID());
 
 		foreach ($webhookListeners as $webhookListener) {
 			// TODO add group membership to be able to filter on it

--- a/apps/webhook_listeners/lib/Migration/Version1000Date20240527153425.php
+++ b/apps/webhook_listeners/lib/Migration/Version1000Date20240527153425.php
@@ -47,8 +47,9 @@ class Version1000Date20240527153425 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 4000,
 			]);
-			$table->addColumn('event', Types::TEXT, [
+			$table->addColumn('event', Types::STRING, [
 				'notnull' => true,
+				'length' => 4000,
 			]);
 			$table->addColumn('event_filter', Types::TEXT, [
 				'notnull' => false,

--- a/apps/webhook_listeners/lib/Migration/Version1000Date20240527153425.php
+++ b/apps/webhook_listeners/lib/Migration/Version1000Date20240527153425.php
@@ -54,7 +54,7 @@ class Version1000Date20240527153425 extends SimpleMigrationStep {
 				'notnull' => false,
 			]);
 			$table->addColumn('user_id_filter', Types::STRING, [
-				'notnull' => true,
+				'notnull' => false,
 				'length' => 64,
 			]);
 			$table->addColumn('headers', Types::TEXT, [

--- a/apps/webhook_listeners/lib/Migration/Version1000Date20240527153425.php
+++ b/apps/webhook_listeners/lib/Migration/Version1000Date20240527153425.php
@@ -53,6 +53,10 @@ class Version1000Date20240527153425 extends SimpleMigrationStep {
 			$table->addColumn('event_filter', Types::TEXT, [
 				'notnull' => false,
 			]);
+			$table->addColumn('user_id_filter', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
 			$table->addColumn('headers', Types::TEXT, [
 				'notnull' => false,
 			]);

--- a/apps/webhook_listeners/lib/ResponseDefinitions.php
+++ b/apps/webhook_listeners/lib/ResponseDefinitions.php
@@ -17,6 +17,7 @@ namespace OCA\WebhookListeners;
  *     uri: string,
  *     event?: string,
  *     eventFilter?: array<string,mixed>,
+ *     userIdFilter?: string,
  *     headers?: array<string,string>,
  *     authMethod: string,
  *     authData?: array<string,mixed>,

--- a/apps/webhook_listeners/openapi.json
+++ b/apps/webhook_listeners/openapi.json
@@ -75,6 +75,9 @@
                             "type": "object"
                         }
                     },
+                    "userIdFilter": {
+                        "type": "string"
+                    },
                     "headers": {
                         "type": "object",
                         "additionalProperties": {
@@ -222,6 +225,11 @@
                                         "additionalProperties": {
                                             "type": "object"
                                         }
+                                    },
+                                    "userIdFilter": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "User id to filter on. The webhook will only be called by requests from this user. Empty or null means no filtering."
                                     },
                                     "headers": {
                                         "type": "object",
@@ -500,6 +508,11 @@
                                         "additionalProperties": {
                                             "type": "object"
                                         }
+                                    },
+                                    "userIdFilter": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "description": "User id to filter on. The webhook will only be called by requests from this user. Empty or null means no filtering."
                                     },
                                     "headers": {
                                         "type": "object",

--- a/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
+++ b/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
@@ -58,6 +58,7 @@ class WebhookListenerMapperTest extends TestCase {
 			UserCreatedEvent::class,
 			null,
 			null,
+			null,
 			AuthMethod::None,
 			null,
 		);
@@ -70,6 +71,7 @@ class WebhookListenerMapperTest extends TestCase {
 			'POST',
 			'https://webhook.example.com/endpoint',
 			NodeWrittenEvent::class,
+			null,
 			null,
 			null,
 			AuthMethod::None,
@@ -92,6 +94,7 @@ class WebhookListenerMapperTest extends TestCase {
 			NodeWrittenEvent::class,
 			null,
 			null,
+			null,
 			AuthMethod::None,
 			null,
 		);
@@ -109,6 +112,7 @@ class WebhookListenerMapperTest extends TestCase {
 			'POST',
 			'https://webhook.example.com/endpoint',
 			NodeWrittenEvent::class,
+			null,
 			null,
 			null,
 			AuthMethod::Header,

--- a/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
+++ b/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
@@ -168,5 +168,6 @@ class WebhookListenerMapperTest extends TestCase {
 
 		$this->assertEquals([$listener1, $listener2], $this->mapper->getByEvent(NodeWrittenEvent::class, 'alice'));
 		$this->assertEquals([$listener2], $this->mapper->getByEvent(NodeWrittenEvent::class, 'otherUser'));
+		$this->assertEquals([$listener2], $this->mapper->getByEvent(NodeWrittenEvent::class));
 	}
 }

--- a/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
+++ b/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
@@ -124,4 +124,49 @@ class WebhookListenerMapperTest extends TestCase {
 		$listener1->resetUpdatedFields();
 		$this->assertEquals($listener1, $listener2);
 	}
+
+	public function testInsertListenerAndGetItByEventAndUser() {
+		$listener1 = $this->mapper->addWebhookListener(
+			null,
+			'bob',
+			'POST',
+			'https://webhook.example.com/endpoint',
+			NodeWrittenEvent::class,
+			null,
+			'alice',
+			null,
+			AuthMethod::None,
+			null,
+		);
+		$listener1->resetUpdatedFields();
+
+		$this->assertEquals([NodeWrittenEvent::class], $this->mapper->getAllConfiguredEvents('alice'));
+		$this->assertEquals([], $this->mapper->getAllConfiguredEvents(''));
+		$this->assertEquals([], $this->mapper->getAllConfiguredEvents('otherUser'));
+
+		$this->assertEquals([$listener1], $this->mapper->getByEvent(NodeWrittenEvent::class, 'alice'));
+		$this->assertEquals([], $this->mapper->getByEvent(NodeWrittenEvent::class, ''));
+		$this->assertEquals([], $this->mapper->getByEvent(NodeWrittenEvent::class, 'otherUser'));
+
+		/* Add a second listener with no user filter */
+		$listener2 = $this->mapper->addWebhookListener(
+			null,
+			'bob',
+			'POST',
+			'https://webhook.example.com/endpoint',
+			NodeWrittenEvent::class,
+			null,
+			'',
+			null,
+			AuthMethod::None,
+			null,
+		);
+		$listener2->resetUpdatedFields();
+
+		$this->assertEquals([NodeWrittenEvent::class], $this->mapper->getAllConfiguredEvents('alice'));
+		$this->assertEquals([NodeWrittenEvent::class], $this->mapper->getAllConfiguredEvents(''));
+
+		$this->assertEquals([$listener1, $listener2], $this->mapper->getByEvent(NodeWrittenEvent::class, 'alice'));
+		$this->assertEquals([$listener2], $this->mapper->getByEvent(NodeWrittenEvent::class, 'otherUser'));
+	}
 }


### PR DESCRIPTION
## Summary

This allows to register a userId to filter on along with the webhooks. This webhook will then only be triggered if the given userId is the one in session. This is more efficient than filtering by user in the event filter because the listener is not even registered if the user id does not match.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
