### PR TITLE
fix(settings): make trailing slash for caldav/carddav redirects optional

### DIFF
--- a/apps/settings/lib/SetupChecks/WellKnownUrls.php
+++ b/apps/settings/lib/SetupChecks/WellKnownUrls.php
@@ -63,7 +63,7 @@ class WellKnownUrls implements ISetupCheck {
 					if (!$works && $response->getStatusCode() === 401) {
 						$redirectHops = explode(',', $response->getHeader('X-Guzzle-Redirect-History'));
 						$effectiveUri = end($redirectHops);
-						$works = str_ends_with($effectiveUri, '/remote.php/dav/');
+						$works = str_ends_with(rtrim($effectiveUri, '/'), '/remote.php/dav');
 					}
 				}
 				// Skip the other requests if one works


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #45033 (partly)

## Summary

#43939 moved the CalDAV/CardDAV redirect checks from the frontend to a new backend API.

Since the backend does not send an authentication header, checking for the expected response code 207 of the DAV endpoint does not work anymore. Hence the URL of the last redirect is checked instead.

This URL is expected to contain a trailing slash, which was not required before, since the DAV endpoint works properly without it (when authenticated).

While a trailing slash in the redirect does no harm, it causes many setups to throw an admin panel warning, while in fact the redirects work properly. Furthermore, the proposed `"/.well-known/carddav" => "/remote.php/dav/"` redirect leads to double slashes, when doing a request to `"/.well-known/carddav/"`, which seems more wrong than right.

This change makes the trailing slash optional, hence old and adjusted setups won't throw the warning anymore, and the DAV endpoint works well in both cases.

The motivation behind the change is to prevent admins from doing practically unnecessary webserver config changes, after upgrading to Nextcloud 29, to mute the too strict setup warning.

## TODO

- [x] While documentation changes which added the trailing slash could be reverted, it is not required. It works either way.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)- [ ] 