### PR TITLE
feat(notifications): Migrate server INotifiers to new exceptions

### DIFF
--- a/apps/comments/lib/Notification/Notifier.php
+++ b/apps/comments/lib/Notification/Notifier.php
@@ -17,6 +17,7 @@ use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	public function __construct(
@@ -52,19 +53,19 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification was not prepared by a notifier
 	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
 	 * @since 9.0.0
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'comments') {
-			throw new \InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 		try {
 			$comment = $this->commentsManager->get($notification->getObjectId());
 		} catch (NotFoundException $e) {
 			// needs to be converted to InvalidArgumentException, otherwise none Notifications will be shown at all
-			throw new \InvalidArgumentException('Comment not found', 0, $e);
+			throw new UnknownNotificationException('Comment not found', 0, $e);
 		}
 		$l = $this->l10nFactory->get('comments', $languageCode);
 		$displayName = $comment->getActorId();
@@ -80,7 +81,7 @@ class Notifier implements INotifier {
 			case 'mention':
 				$parameters = $notification->getSubjectParameters();
 				if ($parameters[0] !== 'files') {
-					throw new \InvalidArgumentException('Unsupported comment object');
+					throw new UnknownNotificationException('Unsupported comment object');
 				}
 				$userFolder = $this->rootFolder->getUserFolder($notification->getUser());
 				$nodes = $userFolder->getById((int)$parameters[1]);
@@ -128,7 +129,7 @@ class Notifier implements INotifier {
 				break;
 
 			default:
-				throw new \InvalidArgumentException('Invalid subject');
+				throw new UnknownNotificationException('Invalid subject');
 		}
 	}
 

--- a/apps/comments/tests/Unit/Notification/NotifierTest.php
+++ b/apps/comments/tests/Unit/Notification/NotifierTest.php
@@ -16,7 +16,9 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
+use OCP\Notification\UnknownNotificationException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -304,7 +306,7 @@ class NotifierTest extends TestCase {
 
 
 	public function testPrepareDifferentApp() {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownNotificationException::class);
 
 		$this->folder
 			->expects($this->never())
@@ -341,7 +343,7 @@ class NotifierTest extends TestCase {
 
 
 	public function testPrepareNotFound() {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownNotificationException::class);
 
 		$this->folder
 			->expects($this->never())
@@ -379,7 +381,7 @@ class NotifierTest extends TestCase {
 
 
 	public function testPrepareDifferentSubject() {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownNotificationException::class);
 
 		$displayName = 'Huraga';
 
@@ -436,7 +438,7 @@ class NotifierTest extends TestCase {
 
 
 	public function testPrepareNotFiles() {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownNotificationException::class);
 
 		$displayName = 'Huraga';
 
@@ -494,7 +496,7 @@ class NotifierTest extends TestCase {
 
 
 	public function testPrepareUnresolvableFileID() {
-		$this->expectException(\OCP\Notification\AlreadyProcessedException::class);
+		$this->expectException(AlreadyProcessedException::class);
 
 		$displayName = 'Huraga';
 

--- a/apps/dav/lib/CalDAV/Reminder/Notifier.php
+++ b/apps/dav/lib/CalDAV/Reminder/Notifier.php
@@ -17,6 +17,7 @@ use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 /**
  * Class Notifier
@@ -78,12 +79,12 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws \Exception
+	 * @throws UnknownNotificationException
 	 */
 	public function prepare(INotification $notification,
 		string $languageCode):INotification {
 		if ($notification->getApp() !== Application::APP_ID) {
-			throw new \InvalidArgumentException('Notification not from this app');
+			throw new UnknownNotificationException('Notification not from this app');
 		}
 
 		// Read the language from the notification
@@ -95,7 +96,7 @@ class Notifier implements INotifier {
 				return $this->prepareReminderNotification($notification);
 
 			default:
-				throw new \InvalidArgumentException('Unknown subject');
+				throw new UnknownNotificationException('Unknown subject');
 
 		}
 	}

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
@@ -16,6 +16,7 @@ use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
+use OCP\Notification\UnknownNotificationException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -88,7 +89,7 @@ class NotifierTest extends TestCase {
 
 
 	public function testPrepareWrongApp(): void {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownNotificationException::class);
 		$this->expectExceptionMessage('Notification not from this app');
 
 		/** @var INotification|MockObject $notification */
@@ -105,7 +106,7 @@ class NotifierTest extends TestCase {
 
 
 	public function testPrepareWrongSubject(): void {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownNotificationException::class);
 		$this->expectExceptionMessage('Unknown subject');
 
 		/** @var INotification|MockObject $notification */

--- a/apps/federatedfilesharing/lib/Notifier.php
+++ b/apps/federatedfilesharing/lib/Notifier.php
@@ -15,6 +15,7 @@ use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	/** @var IFactory */
@@ -65,12 +66,12 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownNotificationException
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'files_sharing' || $notification->getObjectType() !== 'remote_share') {
 			// Not my app => throw
-			throw new \InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		// Read the language from the notification
@@ -141,7 +142,7 @@ class Notifier implements INotifier {
 
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new \InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 

--- a/apps/files/lib/Notification/Notifier.php
+++ b/apps/files/lib/Notification/Notifier.php
@@ -20,6 +20,7 @@ use OCP\Notification\IDismissableNotifier;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier, IDismissableNotifier {
 	/** @var IFactory */
@@ -62,11 +63,11 @@ class Notifier implements INotifier, IDismissableNotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification was not prepared by a notifier
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'files') {
-			throw new \InvalidArgumentException('Unhandled app');
+			throw new UnknownNotificationException('Unhandled app');
 		}
 
 		return match($notification->getSubject()) {
@@ -76,7 +77,7 @@ class Notifier implements INotifier, IDismissableNotifier {
 			'transferOwnershipFailedTarget' => $this->handleTransferOwnershipFailedTarget($notification, $languageCode),
 			'transferOwnershipDoneSource' => $this->handleTransferOwnershipDoneSource($notification, $languageCode),
 			'transferOwnershipDoneTarget' => $this->handleTransferOwnershipDoneTarget($notification, $languageCode),
-			default => throw new \InvalidArgumentException('Unhandled subject')
+			default => throw new UnknownNotificationException('Unhandled subject')
 		};
 	}
 
@@ -256,7 +257,7 @@ class Notifier implements INotifier, IDismissableNotifier {
 
 	public function dismissNotification(INotification $notification): void {
 		if ($notification->getApp() !== 'files') {
-			throw new \InvalidArgumentException('Unhandled app');
+			throw new UnknownNotificationException('Unhandled app');
 		}
 
 		// TODO: This should all be moved to a service that also the transferownershipController uses.

--- a/apps/files_reminders/lib/Notification/Notifier.php
+++ b/apps/files_reminders/lib/Notification/Notifier.php
@@ -9,16 +9,15 @@ declare(strict_types=1);
 
 namespace OCA\FilesReminders\Notification;
 
-use InvalidArgumentException;
 use OCA\FilesReminders\AppInfo\Application;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
-use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IAction;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	public function __construct(
@@ -37,14 +36,13 @@ class Notifier implements INotifier {
 	}
 
 	/**
-	 * @throws InvalidArgumentException
-	 * @throws AlreadyProcessedException
+	 * @throws UnknownNotificationException
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		$l = $this->l10nFactory->get(Application::APP_ID, $languageCode);
 
 		if ($notification->getApp() !== Application::APP_ID) {
-			throw new InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		switch ($notification->getSubject()) {
@@ -54,7 +52,7 @@ class Notifier implements INotifier {
 
 				$node = $this->root->getUserFolder($notification->getUser())->getFirstNodeById($fileId);
 				if (!$node) {
-					throw new InvalidArgumentException();
+					throw new UnknownNotificationException();
 				}
 
 				$path = rtrim($node->getPath(), '/');
@@ -92,8 +90,7 @@ class Notifier implements INotifier {
 				$this->addActionButton($notification, $label);
 				break;
 			default:
-				throw new InvalidArgumentException();
-				break;
+				throw new UnknownNotificationException();
 		}
 
 		return $notification;

--- a/apps/files_sharing/lib/Notification/Notifier.php
+++ b/apps/files_sharing/lib/Notification/Notifier.php
@@ -19,6 +19,7 @@ use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
@@ -78,7 +79,7 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification was not prepared by a notifier
 	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
 	 * @since 9.0.0
 	 */
@@ -86,7 +87,7 @@ class Notifier implements INotifier {
 		if ($notification->getApp() !== 'files_sharing' ||
 			($notification->getSubject() !== 'expiresTomorrow' &&
 				$notification->getObjectType() !== 'share')) {
-			throw new \InvalidArgumentException('Unhandled app or subject');
+			throw new UnknownNotificationException('Unhandled app or subject');
 		}
 
 		$l = $this->l10nFactory->get('files_sharing', $languageCode);
@@ -145,7 +146,7 @@ class Notifier implements INotifier {
 				throw new AlreadyProcessedException();
 			}
 		} else {
-			throw new \InvalidArgumentException('Invalid share type');
+			throw new UnknownNotificationException('Invalid share type');
 		}
 
 		switch ($notification->getSubject()) {
@@ -216,7 +217,7 @@ class Notifier implements INotifier {
 				break;
 
 			default:
-				throw new \InvalidArgumentException('Invalid subject');
+				throw new UnknownNotificationException('Invalid subject');
 		}
 
 		$notification->setRichSubject($subject, $subjectParameters)

--- a/apps/twofactor_backupcodes/lib/Notifications/Notifier.php
+++ b/apps/twofactor_backupcodes/lib/Notifications/Notifier.php
@@ -12,6 +12,7 @@ use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 
@@ -49,7 +50,7 @@ class Notifier implements INotifier {
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'twofactor_backupcodes') {
 			// Not my app => throw
-			throw new \InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		// Read the language from the notification
@@ -71,7 +72,7 @@ class Notifier implements INotifier {
 
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new \InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 }

--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -19,6 +19,7 @@ use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 use OCP\Util;
 
 class Notifier implements INotifier {
@@ -87,25 +88,24 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification was not prepared by a notifier
 	 * @throws AlreadyProcessedException When the notification is not needed anymore and should be deleted
 	 * @since 9.0.0
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'updatenotification') {
-			throw new \InvalidArgumentException('Unknown app id');
+			throw new UnknownNotificationException('Unknown app id');
 		}
 
 		if ($notification->getSubject() !== 'update_available' && $notification->getSubject() !== 'connection_error') {
-			throw new \InvalidArgumentException('Unknown subject');
+			throw new UnknownNotificationException('Unknown subject');
 		}
 
 		$l = $this->l10NFactory->get('updatenotification', $languageCode);
 		if ($notification->getSubject() === 'connection_error') {
 			$errors = (int) $this->config->getAppValue('updatenotification', 'update_check_errors', '0');
 			if ($errors === 0) {
-				$this->notificationManager->markProcessed($notification);
-				throw new \InvalidArgumentException('Update checked worked again');
+				throw new AlreadyProcessedException();
 			}
 
 			$notification->setParsedSubject($l->t('The update server could not be reached since %d days to check for new updates.', [$errors]))

--- a/apps/user_ldap/lib/Notification/Notifier.php
+++ b/apps/user_ldap/lib/Notification/Notifier.php
@@ -8,6 +8,7 @@ namespace OCA\User_LDAP\Notification;
 use OCP\L10N\IFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 
@@ -45,12 +46,12 @@ class Notifier implements INotifier {
 	 * @param INotification $notification
 	 * @param string $languageCode The code of the language that should be used to prepare the notification
 	 * @return INotification
-	 * @throws \InvalidArgumentException When the notification was not prepared by a notifier
+	 * @throws UnknownNotificationException When the notification was not prepared by a notifier
 	 */
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'user_ldap') {
 			// Not my app => throw
-			throw new \InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		// Read the language from the notification
@@ -76,7 +77,7 @@ class Notifier implements INotifier {
 
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new \InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 }

--- a/core/Notification/CoreNotifier.php
+++ b/core/Notification/CoreNotifier.php
@@ -14,6 +14,7 @@ use OCP\L10N\IFactory;
 use OCP\Notification\IAction;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class CoreNotifier implements INotifier {
 	public function __construct(
@@ -45,7 +46,7 @@ class CoreNotifier implements INotifier {
 
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'core') {
-			throw new \InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 		$l = $this->factory->get('core', $languageCode);
 
@@ -71,6 +72,6 @@ class CoreNotifier implements INotifier {
 			return $notification;
 		}
 
-		throw new \InvalidArgumentException('Invalid subject');
+		throw new UnknownNotificationException('Invalid subject');
 	}
 }

--- a/lib/private/Authentication/Notifications/Notifier.php
+++ b/lib/private/Authentication/Notifications/Notifier.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\Notifications;
 
-use InvalidArgumentException;
 use OCP\L10N\IFactory as IL10nFactory;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
+use OCP\Notification\UnknownNotificationException;
 
 class Notifier implements INotifier {
 	/** @var IL10nFactory */
@@ -27,7 +27,7 @@ class Notifier implements INotifier {
 	public function prepare(INotification $notification, string $languageCode): INotification {
 		if ($notification->getApp() !== 'auth') {
 			// Not my app => throw
-			throw new InvalidArgumentException();
+			throw new UnknownNotificationException();
 		}
 
 		// Read the language from the notification
@@ -52,7 +52,7 @@ class Notifier implements INotifier {
 				return $notification;
 			default:
 				// Unknown subject => Unknown notification => throw
-				throw new InvalidArgumentException();
+				throw new UnknownNotificationException();
 		}
 	}
 


### PR DESCRIPTION
* Ref #44770

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
