### PR TITLE
fix: Add `acceptShare` as an interface

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -704,6 +704,7 @@ return array(
     'OCP\\Share\\IShare' => $baseDir . '/lib/public/Share/IShare.php',
     'OCP\\Share\\IShareHelper' => $baseDir . '/lib/public/Share/IShareHelper.php',
     'OCP\\Share\\IShareProvider' => $baseDir . '/lib/public/Share/IShareProvider.php',
+    'OCP\\Share\\IShareProviderSupportsAccept' => $baseDir . '/lib/public/Share/IShareProviderSupportsAccept.php',
     'OCP\\Share\\IShareProviderWithNotification' => $baseDir . '/lib/public/Share/IShareProviderWithNotification.php',
     'OCP\\Share_Backend' => $baseDir . '/lib/public/Share_Backend.php',
     'OCP\\Share_Backend_Collection' => $baseDir . '/lib/public/Share_Backend_Collection.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -737,6 +737,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Share\\IShare' => __DIR__ . '/../../..' . '/lib/public/Share/IShare.php',
         'OCP\\Share\\IShareHelper' => __DIR__ . '/../../..' . '/lib/public/Share/IShareHelper.php',
         'OCP\\Share\\IShareProvider' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProvider.php',
+        'OCP\\Share\\IShareProviderSupportsAccept' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderSupportsAccept.php',
         'OCP\\Share\\IShareProviderWithNotification' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderWithNotification.php',
         'OCP\\Share_Backend' => __DIR__ . '/../../..' . '/lib/public/Share_Backend.php',
         'OCP\\Share_Backend_Collection' => __DIR__ . '/../../..' . '/lib/public/Share_Backend_Collection.php',

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -29,6 +29,7 @@ use OCP\Mail\IMailer;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
+use OCP\Share\IShareProviderSupportsAccept;
 use OCP\Share\IShareProviderWithNotification;
 use Psr\Log\LoggerInterface;
 use function str_starts_with;
@@ -38,7 +39,7 @@ use function str_starts_with;
  *
  * @package OC\Share20
  */
-class DefaultShareProvider implements IShareProviderWithNotification {
+class DefaultShareProvider implements IShareProviderWithNotification, IShareProviderSupportsAccept {
 	// Special share type for user modified group shares
 	public const SHARE_TYPE_USERGROUP = 2;
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -44,6 +44,7 @@ use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
+use OCP\Share\IShareProviderSupportsAccept;
 use OCP\Share\IShareProviderWithNotification;
 use Psr\Log\LoggerInterface;
 
@@ -905,17 +906,17 @@ class Manager implements IManager {
 	 * @param IShare $share
 	 * @param string $recipientId
 	 * @return IShare The share object
-	 * @throws \InvalidArgumentException
+	 * @throws \InvalidArgumentException Thrown if the provider does not implement `IShareProviderSupportsAccept`
 	 * @since 9.0.0
 	 */
 	public function acceptShare(IShare $share, string $recipientId): IShare {
 		[$providerId,] = $this->splitFullId($share->getFullId());
 		$provider = $this->factory->getProvider($providerId);
 
-		if (!method_exists($provider, 'acceptShare')) {
-			// TODO FIX ME
+		if (!($provider instanceof IShareProviderSupportsAccept)) {
 			throw new \InvalidArgumentException('Share provider does not support accepting');
 		}
+		/** @var IShareProvider&IShareProviderSupportsAccept $provider */
 		$provider->acceptShare($share, $recipientId);
 
 		$event = new ShareAcceptedEvent($share);

--- a/lib/public/Share/IShareProvider.php
+++ b/lib/public/Share/IShareProvider.php
@@ -45,16 +45,6 @@ interface IShareProvider {
 	public function update(\OCP\Share\IShare $share);
 
 	/**
-	 * Accept a share.
-	 *
-	 * @param IShare $share
-	 * @param string $recipient
-	 * @return IShare The share object
-	 * @since 17.0.0
-	 */
-	//	public function acceptShare(IShare $share, string $recipient): IShare;
-
-	/**
 	 * Delete a share
 	 *
 	 * @param \OCP\Share\IShare $share

--- a/lib/public/Share/IShareProviderSupportsAccept.php
+++ b/lib/public/Share/IShareProviderSupportsAccept.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Share;
+
+/**
+ * Interface IShareProviderSupportsAccept
+ *
+ * This interface allows to define IShareProvider that can handle the `acceptShare` method,
+ * which is available since Nextcloud 17.
+ *
+ * @since 30.0.0
+ */
+interface IShareProviderSupportsAccept extends IShareProvider {
+	/**
+	 * Accept a share.
+	 *
+	 * @param IShare $share
+	 * @param string $recipient
+	 * @return IShare The share object
+	 * @since 30.0.0
+	 */
+	public function acceptShare(IShare $share, string $recipient): IShare;
+}

--- a/lib/public/Share/IShareProviderWithNotification.php
+++ b/lib/public/Share/IShareProviderWithNotification.php
@@ -1,9 +1,8 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
- * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
- * SPDX-License-Identifier: AGPL-3.0-only
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 namespace OCP\Share;
 


### PR DESCRIPTION
## Summary

It was commented out because at that time no other share provider supported the `acceptShare` method. Today it is the same no other provider supports it, but we should make it discoverable by adding it to the public API as an additional interface.

5 years after no other provider supports it, so maybe an additional interface would be better like done here?
Ref: https://github.com/nextcloud/server/pull/16828#discussion_r321740211

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
