### PR TITLE
fix: token LocalCache to DistributedCache

### DIFF
--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -70,8 +70,8 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->logger = $logger;
 		$this->time = $time;
 
-		$this->cache = $cacheFactory->isLocalCacheAvailable()
-			? $cacheFactory->createLocal('authtoken_')
+		$this->cache = $cacheFactory->isAvailable()
+			? $cacheFactory->createDistributed('authtoken_')
 			: $cacheFactory->createInMemory();
 		$this->hasher = $hasher;
 	}


### PR DESCRIPTION
Fix #46165

In a load-balanced platform with multiple application servers, local token caching does not work effectively and leads to login loops. We believe that by making this change, we can use a distributed cache instead.

* Resolves: 
In a load-balanced platform without sticky sessions, local token caching does not work and causes a login loop.

## Summary
Currently, the token is stored in the local cache. In the case of a load-balanced Nextcloud platform without Sticky Sessions, it is necessary to store the token in the distributed cache if it exists.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
