### PR TITLE
fix(user_ldap): Avoid extra LDAP request when mapping a user for the first time

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -122,10 +122,10 @@ class Access extends LDAPUtility {
 	 *
 	 * @param string $dn the record in question
 	 * @param array $attrs the attributes that shall be retrieved
-	 *        if empty, just check the record's existence
+	 *                     if empty, just check the record's existence
 	 * @param string $filter
 	 * @return array|false an array of values on success or an empty
-	 *          array if $attr is empty, false otherwise
+	 *                     array if $attr is empty, false otherwise
 	 * @throws ServerNotAvailableException
 	 */
 	public function readAttributes(string $dn, array $attrs, string $filter = 'objectClass=*'): array|false {

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -117,6 +117,56 @@ class Access extends LDAPUtility {
 	}
 
 	/**
+	 * Reads several attributes for an LDAP record identified by a DN and a filter
+	 * No support for ranged attributes.
+	 *
+	 * @param string $dn the record in question
+	 * @param array $attrs the attributes that shall be retrieved
+	 *        if empty, just check the record's existence
+	 * @param string $filter
+	 * @return array|false an array of values on success or an empty
+	 *          array if $attr is empty, false otherwise
+	 * @throws ServerNotAvailableException
+	 */
+	public function readAttributes(string $dn, array $attrs, string $filter = 'objectClass=*'): array|false {
+		if (!$this->checkConnection()) {
+			$this->logger->warning(
+				'No LDAP Connector assigned, access impossible for readAttribute.',
+				['app' => 'user_ldap']
+			);
+			return false;
+		}
+		$cr = $this->connection->getConnectionResource();
+		$attrs = array_map(
+			fn (string $attr): string => mb_strtolower($attr, 'UTF-8'),
+			$attrs,
+		);
+
+		$values = [];
+		$record = $this->executeRead($dn, $attrs, $filter);
+		if (is_bool($record)) {
+			// when an exists request was run and it was successful, an empty
+			// array must be returned
+			return $record ? [] : false;
+		}
+
+		$result = [];
+		foreach ($attrs as $attr) {
+			$values = $this->extractAttributeValuesFromResult($record, $attr);
+			if (!empty($values)) {
+				$result[$attr] = $values;
+			}
+		}
+
+		if (!empty($result)) {
+			return $result;
+		}
+
+		$this->logger->debug('Requested attributes {attrs} not found for ' . $dn, ['app' => 'user_ldap', 'attrs' => $attrs]);
+		return false;
+	}
+
+	/**
 	 * reads a given attribute for an LDAP record identified by a DN
 	 *
 	 * @param string $dn the record in question
@@ -191,9 +241,9 @@ class Access extends LDAPUtility {
 	 *                    returned data on a successful usual operation
 	 * @throws ServerNotAvailableException
 	 */
-	public function executeRead(string $dn, string $attribute, string $filter) {
+	public function executeRead(string $dn, string|array $attribute, string $filter) {
 		$dn = $this->helper->DNasBaseParameter($dn);
-		$rr = @$this->invokeLDAPMethod('read', $dn, $filter, [$attribute]);
+		$rr = @$this->invokeLDAPMethod('read', $dn, $filter, (is_string($attribute) ? [$attribute] : $attribute));
 		if (!$this->ldap->isResource($rr)) {
 			if ($attribute !== '') {
 				//do not throw this message on userExists check, irritates
@@ -410,7 +460,7 @@ class Access extends LDAPUtility {
 	 * @return string|false with with the name to use in Nextcloud
 	 * @throws \Exception
 	 */
-	public function dn2username($fdn, $ldapName = null) {
+	public function dn2username($fdn) {
 		//To avoid bypassing the base DN settings under certain circumstances
 		//with the group support, check whether the provided DN matches one of
 		//the given Bases
@@ -418,7 +468,7 @@ class Access extends LDAPUtility {
 			return false;
 		}
 
-		return $this->dn2ocname($fdn, $ldapName, true);
+		return $this->dn2ocname($fdn, null, true);
 	}
 
 	/**
@@ -441,18 +491,44 @@ class Access extends LDAPUtility {
 		$newlyMapped = false;
 		if ($isUser) {
 			$mapper = $this->getUserMapper();
-			$nameAttribute = $this->connection->ldapUserDisplayName;
-			$filter = $this->connection->ldapUserFilter;
 		} else {
 			$mapper = $this->getGroupMapper();
-			$nameAttribute = $this->connection->ldapGroupDisplayName;
-			$filter = $this->connection->ldapGroupFilter;
 		}
 
 		//let's try to retrieve the Nextcloud name from the mappings table
 		$ncName = $mapper->getNameByDN($fdn);
 		if (is_string($ncName)) {
 			return $ncName;
+		}
+
+		if ($isUser) {
+			$nameAttribute = $this->connection->ldapUserDisplayName;
+			$filter = $this->connection->ldapUserFilter;
+			$uuidAttr = 'ldapUuidUserAttribute';
+			$uuidOverride = $this->connection->ldapExpertUUIDUserAttr;
+			$usernameAttribute = (string)$this->connection->ldapExpertUsernameAttr;
+			$attributesToRead = [$nameAttribute,$usernameAttribute];
+			// TODO fetch also display name attributes and cache them if the user is mapped
+		} else {
+			$nameAttribute = $this->connection->ldapGroupDisplayName;
+			$filter = $this->connection->ldapGroupFilter;
+			$uuidAttr = 'ldapUuidGroupAttribute';
+			$uuidOverride = $this->connection->ldapExpertUUIDGroupAttr;
+			$attributesToRead = [$nameAttribute];
+		}
+
+		if ($this->detectUuidAttribute($fdn, $isUser, false, $record)) {
+			$attributesToRead[] = $this->connection->$uuidAttr;
+		}
+
+		if ($record === null) {
+			/* No record was passed, fetch it */
+			$record = $this->readAttributes($fdn, $attributesToRead, $filter);
+			if ($record === false) {
+				$this->logger->debug('Cannot read attributes for ' . $fdn . '. Skipping.', ['filter' => $filter]);
+				$intermediates[($isUser ? 'user-' : 'group-') . $fdn] = true;
+				return false;
+			}
 		}
 
 		//second try: get the UUID and check if it is known. Then, update the DN and return the name.
@@ -469,20 +545,9 @@ class Access extends LDAPUtility {
 			return false;
 		}
 
-		if (is_null($ldapName)) {
-			$ldapName = $this->readAttribute($fdn, $nameAttribute, $filter);
-			if (!isset($ldapName[0]) || empty($ldapName[0])) {
-				$this->logger->debug('No or empty name for ' . $fdn . ' with filter ' . $filter . '.', ['app' => 'user_ldap']);
-				$intermediates[($isUser ? 'user-' : 'group-') . $fdn] = true;
-				return false;
-			}
-			$ldapName = $ldapName[0];
-		}
-
 		if ($isUser) {
-			$usernameAttribute = (string)$this->connection->ldapExpertUsernameAttr;
 			if ($usernameAttribute !== '') {
-				$username = $this->readAttribute($fdn, $usernameAttribute);
+				$username = $record[$usernameAttribute];
 				if (!isset($username[0]) || empty($username[0])) {
 					$this->logger->debug('No or empty username (' . $usernameAttribute . ') for ' . $fdn . '.', ['app' => 'user_ldap']);
 					return false;
@@ -504,6 +569,15 @@ class Access extends LDAPUtility {
 				return false;
 			}
 		} else {
+			if (is_null($ldapName)) {
+				$ldapName = $record[$nameAttribute];
+				if (!isset($ldapName[0]) || empty($ldapName[0])) {
+					$this->logger->debug('No or empty name for ' . $fdn . ' with filter ' . $filter . '.', ['app' => 'user_ldap']);
+					$intermediates['group-' . $fdn] = true;
+					return false;
+				}
+				$ldapName = $ldapName[0];
+			}
 			$intName = $this->sanitizeGroupIDCandidate($ldapName);
 		}
 
@@ -521,6 +595,7 @@ class Access extends LDAPUtility {
 			$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
 			$newlyMapped = $this->mapAndAnnounceIfApplicable($mapper, $fdn, $intName, $uuid, $isUser);
 			if ($newlyMapped) {
+				$this->logger->debug('Mapped {fdn} as {name}', ['fdn' => $fdn,'name' => $intName]);
 				return $intName;
 			}
 		}
@@ -535,7 +610,6 @@ class Access extends LDAPUtility {
 						'fdn' => $fdn,
 						'altName' => $altName,
 						'intName' => $intName,
-						'app' => 'user_ldap',
 					]
 				);
 				$newlyMapped = true;

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -734,6 +734,7 @@ class Access extends LDAPUtility {
 	 */
 	public function cacheUserExists(string $ocName): void {
 		$this->connection->writeToCache('userExists' . $ocName, true);
+		$this->connection->writeToCache('userExistsOnLDAP' . $ocName, true);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -502,15 +502,15 @@ class Access extends LDAPUtility {
 		}
 
 		if ($isUser) {
-			$nameAttribute = $this->connection->ldapUserDisplayName;
+			$nameAttribute = strtolower($this->connection->ldapUserDisplayName);
 			$filter = $this->connection->ldapUserFilter;
 			$uuidAttr = 'ldapUuidUserAttribute';
 			$uuidOverride = $this->connection->ldapExpertUUIDUserAttr;
-			$usernameAttribute = (string)$this->connection->ldapExpertUsernameAttr;
+			$usernameAttribute = strtolower($this->connection->ldapExpertUsernameAttr);
 			$attributesToRead = [$nameAttribute,$usernameAttribute];
 			// TODO fetch also display name attributes and cache them if the user is mapped
 		} else {
-			$nameAttribute = $this->connection->ldapGroupDisplayName;
+			$nameAttribute = strtolower($this->connection->ldapGroupDisplayName);
 			$filter = $this->connection->ldapGroupFilter;
 			$uuidAttr = 'ldapUuidGroupAttribute';
 			$uuidOverride = $this->connection->ldapExpertUUIDGroupAttr;

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -294,6 +294,27 @@ class Configuration {
 						break;
 					case 'ldapUserDisplayName2':
 					case 'ldapGroupDisplayName':
+					case 'ldapGidNumber':
+					case 'ldapGroupMemberAssocAttr':
+					case 'ldapQuotaAttribute':
+					case 'ldapEmailAttribute':
+					case 'ldapUuidUserAttribute':
+					case 'ldapUuidGroupAttribute':
+					case 'ldapExpertUsernameAttr':
+					case 'ldapExpertUUIDUserAttr':
+					case 'ldapExpertUUIDGroupAttr':
+					case 'ldapExtStorageHomeAttribute':
+					case 'ldapAttributePhone':
+					case 'ldapAttributeWebsite':
+					case 'ldapAttributeAddress':
+					case 'ldapAttributeTwitter':
+					case 'ldapAttributeFediverse':
+					case 'ldapAttributeOrganisation':
+					case 'ldapAttributeRole':
+					case 'ldapAttributeHeadline':
+					case 'ldapAttributeBiography':
+					case 'ldapAttributeBirthDate':
+					case 'ldapAttributeAnniversaryDate':
 						$readMethod = 'getLcValue';
 						break;
 					case 'ldapUserDisplayName':

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -106,6 +106,7 @@ class Manager {
 	/**
 	 * @brief checks whether the Access instance has been set
 	 * @throws \Exception if Access has not been set
+	 * @psalm-assert !null $this->access
 	 * @return null
 	 */
 	private function checkAccess() {
@@ -236,5 +237,40 @@ class Manager {
 		}
 
 		return $this->createInstancyByUserName($id);
+	}
+
+	/**
+	 * @brief Checks whether a User object by its DN or Nextcloud username exists
+	 * @param string $id the DN or username of the user
+	 * @throws \Exception when connection could not be established
+	 */
+	public function exists($id): bool {
+		$this->checkAccess();
+		$this->logger->debug('Checking if {id} exists', ['id' => $id]);
+		if (isset($this->usersByDN[$id])) {
+			return true;
+		} elseif (isset($this->usersByUid[$id])) {
+			return true;
+		}
+
+		if ($this->access->stringResemblesDN($id)) {
+			$this->logger->debug('{id} looks like a dn', ['id' => $id]);
+			$uid = $this->access->dn2username($id);
+			if ($uid !== false) {
+				return true;
+			}
+		}
+
+		// Most likely a uid. Check whether it is a deleted user
+		if ($this->isDeletedUser($id)) {
+			return true;
+		}
+		$this->logger->debug('username2dn({id})', ['id' => $id]);
+		$dn = $this->access->username2dn($id);
+		$this->logger->debug('end username2dn({id})', ['id' => $id]);
+		if ($dn !== false) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -265,9 +265,7 @@ class Manager {
 		if ($this->isDeletedUser($id)) {
 			return true;
 		}
-		$this->logger->debug('username2dn({id})', ['id' => $id]);
 		$dn = $this->access->username2dn($id);
-		$this->logger->debug('end username2dn({id})', ['id' => $id]);
 		if ($dn !== false) {
 			return true;
 		}

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -463,7 +463,6 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 				$this->access->connection->writeToCache($cacheKey, $displayName);
 			}
 			if ($user instanceof OfflineUser) {
-				/** @var OfflineUser $user */
 				$displayName = $user->getDisplayName();
 			}
 			return $displayName;
@@ -610,7 +609,6 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 							$uuid,
 							true
 						);
-						$this->access->cacheUserExists($username);
 					} else {
 						$this->logger->warning(
 							'Failed to map created LDAP user with userid {userid}, because UUID could not be determined',

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -322,10 +322,9 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 		if (!is_null($userExists)) {
 			return (bool)$userExists;
 		}
-		//getting dn, if false the user does not exist. If dn, he may be mapped only, requires more checking.
-		$user = $this->access->userManager->get($uid);
+		$userExists = $this->access->userManager->exists($uid);
 
-		if (is_null($user)) {
+		if (!$userExists) {
 			$this->logger->debug(
 				'No DN found for '.$uid.' on '.$this->access->connection->ldapHost,
 				['app' => 'user_ldap']

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -612,7 +612,8 @@ class AccessTest extends TestCase {
 
 		$this->prepareMocksForSearchTests($base, $fakeConnection, $fakeSearchResultResource, $fakeLdapEntries);
 
-		$this->connection->expects($this->exactly($fakeLdapEntries['count']))
+		// Called twice per user, for userExists and userExistsOnLdap
+		$this->connection->expects($this->exactly(2 * $fakeLdapEntries['count']))
 			->method('writeToCache')
 			->with($this->stringStartsWith('userExists'), true);
 


### PR DESCRIPTION
## Summary

Avoids using several LDAP searches to get UUID, display name and
 internal name, now gets all attributes at the same time.
Also avoids extra request to build an unused user object in userExists.

## TODO

- [x] ~~Avoid extra request to fetch the display name by directly caching it. (The display name is fetched by dav to update the calendar entry as soon as the user is mapped).~~ This is too complicated because of internal quirks, keeping an extra request for the display name for now.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
