### PR TITLE
feat(occ): Add a --debug option to output all log levels to the output

### DIFF
--- a/console.php
+++ b/console.php
@@ -75,13 +75,21 @@ try {
 	$eventLogger->start('console:build_application', 'Build Application instance and load commands');
 
 	$application = \OCP\Server::get(Application::class);
-	$application->loadCommands(new ArgvInput(), new ConsoleOutput());
+	$argv = $_SERVER['argv'];
+	if (($key = array_search('--debug', $argv)) !== false) {
+		// Remove --debug option if it was passed
+		unset($argv[$key]);
+		$argv = array_values($argv);
+	}
+
+	$input = new ArgvInput($argv);
+	$application->loadCommands($input, new ConsoleOutput());
 
 	$eventLogger->end('console:build_application');
 	$eventLogger->start('console:run', 'Run the command');
 
 	$application->setAutoExit(false);
-	$exitCode = $application->run();
+	$exitCode = $application->run($input);
 
 	$eventLogger->end('console:run');
 

--- a/console.php
+++ b/console.php
@@ -75,13 +75,8 @@ try {
 	$eventLogger->start('console:build_application', 'Build Application instance and load commands');
 
 	$application = \OCP\Server::get(Application::class);
+	/* base.php will have removed eventual debug options from argv in $_SERVER */
 	$argv = $_SERVER['argv'];
-	if (($key = array_search('--debug', $argv)) !== false) {
-		// Remove --debug option if it was passed
-		unset($argv[$key]);
-		$argv = array_values($argv);
-	}
-
 	$input = new ArgvInput($argv);
 	$application->loadCommands($input, new ConsoleOutput());
 

--- a/core/Listener/BeforeMessageLoggedEventListener.php
+++ b/core/Listener/BeforeMessageLoggedEventListener.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Listener;
+
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\Log\BeforeMessageLoggedEvent;
+
+/**
+ * Listen to log calls and output them to STDOUT for debug purposes
+ * @template-implements IEventListener<BeforeMessageLoggedEvent>
+ */
+class BeforeMessageLoggedEventListener implements IEventListener {
+	public function handle(Event $event): void {
+		if (!$event instanceof BeforeMessageLoggedEvent) {
+			return;
+		}
+		echo
+			match($event->getLevel()) {
+				0 => '[debug]',
+				1 => '[info]',
+				2 => '[warning]',
+				3 => '[error]',
+				4 => '[fatal]',
+				default => '['.$event->getLevel().']',
+			}
+		.' ['.$event->getApp().'] '
+		.$event->getMessage()['message']
+		."\n";
+	}
+}

--- a/core/Listener/BeforeMessageLoggedEventListener.php
+++ b/core/Listener/BeforeMessageLoggedEventListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\Core\Listener;
 
+use OCP\Console\ReservedOptions;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
@@ -54,10 +55,10 @@ class BeforeMessageLoggedEventListener implements IEventListener {
 		$argv = $_SERVER['argv'];
 		$level = 0;
 		foreach ($argv as $key => $arg) {
-			if ($arg === '--debug-log') {
+			if ($arg === '--'.ReservedOptions::DEBUG_LOG) {
 				unset($argv[$key]);
-			} elseif (str_starts_with($arg, '--debug-log-level=')) {
-				$level = (int)substr($arg, strlen('--debug-log-level='));
+			} elseif (str_starts_with($arg, '--'.ReservedOptions::DEBUG_LOG_LEVEL.'=')) {
+				$level = (int)substr($arg, strlen('--'.ReservedOptions::DEBUG_LOG_LEVEL.'='));
 				unset($argv[$key]);
 			}
 		}

--- a/lib/base.php
+++ b/lib/base.php
@@ -63,7 +63,6 @@ class OC {
 	 * check if Nextcloud runs in cli mode
 	 */
 	public static bool $CLI = false;
-	public static bool $CLI_DEBUG = false;
 
 	public static \OC\Autoloader $loader;
 
@@ -557,11 +556,6 @@ class OC {
 		self::$composerAutoloader = require_once OC::$SERVERROOT . '/lib/composer/autoload.php';
 		self::$composerAutoloader->setApcuPrefix(null);
 
-		if (self::$CLI && ($key = array_search('--debug', $_SERVER['argv'])) !== false) {
-			self::$CLI_DEBUG = true;
-		} else {
-			self::$CLI_DEBUG = false;
-		}
 
 		try {
 			self::initPaths();
@@ -585,9 +579,8 @@ class OC {
 		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);
 		self::$server->boot();
 
-		if (self::$CLI_DEBUG) {
-			$eventDispatcher = \OCP\Server::get(IEventDispatcher::class);
-			$eventDispatcher->addServiceListener(\OCP\Log\BeforeMessageLoggedEvent::class, \OC\Core\Listener\BeforeMessageLoggedEventListener::class);
+		if (self::$CLI && in_array('--debug-log', $_SERVER['argv'])) {
+			\OC\Core\Listener\BeforeMessageLoggedEventListener::setup();
 		}
 
 		$eventLogger = Server::get(\OCP\Diagnostics\IEventLogger::class);

--- a/lib/base.php
+++ b/lib/base.php
@@ -579,7 +579,7 @@ class OC {
 		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);
 		self::$server->boot();
 
-		if (self::$CLI && in_array('--debug-log', $_SERVER['argv'])) {
+		if (self::$CLI && in_array('--'.\OCP\Console\ReservedOptions::DEBUG_LOG, $_SERVER['argv'])) {
 			\OC\Core\Listener\BeforeMessageLoggedEventListener::setup();
 		}
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -220,6 +220,7 @@ return array(
     'OCP\\Config\\BeforePreferenceDeletedEvent' => $baseDir . '/lib/public/Config/BeforePreferenceDeletedEvent.php',
     'OCP\\Config\\BeforePreferenceSetEvent' => $baseDir . '/lib/public/Config/BeforePreferenceSetEvent.php',
     'OCP\\Console\\ConsoleEvent' => $baseDir . '/lib/public/Console/ConsoleEvent.php',
+    'OCP\\Console\\ReservedOptions' => $baseDir . '/lib/public/Console/ReservedOptions.php',
     'OCP\\Constants' => $baseDir . '/lib/public/Constants.php',
     'OCP\\Contacts\\ContactsMenu\\IAction' => $baseDir . '/lib/public/Contacts/ContactsMenu/IAction.php',
     'OCP\\Contacts\\ContactsMenu\\IActionFactory' => $baseDir . '/lib/public/Contacts/ContactsMenu/IActionFactory.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1236,6 +1236,7 @@ return array(
     'OC\\Core\\Events\\PasswordResetEvent' => $baseDir . '/core/Events/PasswordResetEvent.php',
     'OC\\Core\\Exception\\LoginFlowV2NotFoundException' => $baseDir . '/core/Exception/LoginFlowV2NotFoundException.php',
     'OC\\Core\\Exception\\ResetPasswordException' => $baseDir . '/core/Exception/ResetPasswordException.php',
+    'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => $baseDir . '/core/Listener/BeforeMessageLoggedEventListener.php',
     'OC\\Core\\Listener\\BeforeTemplateRenderedListener' => $baseDir . '/core/Listener/BeforeTemplateRenderedListener.php',
     'OC\\Core\\Middleware\\TwoFactorMiddleware' => $baseDir . '/core/Middleware/TwoFactorMiddleware.php',
     'OC\\Core\\Migrations\\Version13000Date20170705121758' => $baseDir . '/core/Migrations/Version13000Date20170705121758.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -253,6 +253,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Config\\BeforePreferenceDeletedEvent' => __DIR__ . '/../../..' . '/lib/public/Config/BeforePreferenceDeletedEvent.php',
         'OCP\\Config\\BeforePreferenceSetEvent' => __DIR__ . '/../../..' . '/lib/public/Config/BeforePreferenceSetEvent.php',
         'OCP\\Console\\ConsoleEvent' => __DIR__ . '/../../..' . '/lib/public/Console/ConsoleEvent.php',
+        'OCP\\Console\\ReservedOptions' => __DIR__ . '/../../..' . '/lib/public/Console/ReservedOptions.php',
         'OCP\\Constants' => __DIR__ . '/../../..' . '/lib/public/Constants.php',
         'OCP\\Contacts\\ContactsMenu\\IAction' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IAction.php',
         'OCP\\Contacts\\ContactsMenu\\IActionFactory' => __DIR__ . '/../../..' . '/lib/public/Contacts/ContactsMenu/IActionFactory.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1269,6 +1269,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Events\\PasswordResetEvent' => __DIR__ . '/../../..' . '/core/Events/PasswordResetEvent.php',
         'OC\\Core\\Exception\\LoginFlowV2NotFoundException' => __DIR__ . '/../../..' . '/core/Exception/LoginFlowV2NotFoundException.php',
         'OC\\Core\\Exception\\ResetPasswordException' => __DIR__ . '/../../..' . '/core/Exception/ResetPasswordException.php',
+        'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => __DIR__ . '/../../..' . '/core/Listener/BeforeMessageLoggedEventListener.php',
         'OC\\Core\\Listener\\BeforeTemplateRenderedListener' => __DIR__ . '/../../..' . '/core/Listener/BeforeTemplateRenderedListener.php',
         'OC\\Core\\Middleware\\TwoFactorMiddleware' => __DIR__ . '/../../..' . '/core/Middleware/TwoFactorMiddleware.php',
         'OC\\Core\\Migrations\\Version13000Date20170705121758' => __DIR__ . '/../../..' . '/core/Migrations/Version13000Date20170705121758.php',

--- a/lib/public/Console/ReservedOptions.php
+++ b/lib/public/Console/ReservedOptions.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Console;
+
+/**
+ * @since 30.0.0
+ */
+final class ReservedOptions {
+	/**
+	 * @since 30.0.0
+	 */
+	public const DEBUG_LOG = 'debug-log';
+	/**
+	 * @since 30.0.0
+	 */
+	public const DEBUG_LOG_LEVEL = 'debug-log-level';
+}


### PR DESCRIPTION
Related to #30989 

## Summary

Adds a universal option to pass to occ commands so that all levels of logs are printed in the output, even if the loglevel on the instance is higher.
This allows to inspect all the logging related to a command without having it mixed up with logs from other stuff going on in the server. Also allows to have logs and command output in the same place to see in which order things happen.
This is especially useful with user_ldap as all LDAP calls are logged in debug level.

## TODO

- [x] Decide on the correct naming for the option, currently `--debug` bug maybe this will cause conflicts too easily. **Changed to `--debug-log`**
- [ ] Decide whether to document the option in the usage output for classes based on `OC\Core\Command\Base`.
- [x] Determine whether the output format is the right one. (Do we want raw json instead?) **Abandoned this idea, there is not much data to put in json anyway**
- [x] Do we need to be able to do the same with an arbitrary loglevel, like --debug=1 to only show info and above? **Added support for `--debug-log-level` when `--debug-log` is used**
- [x] Should we activate the profiler when this option is used and output the profile? **Not automatically**
- [x] How can we make it output DB requests to the output as well? The profiler idea above would work. **Left as an exercise for later**

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
