### PR TITLE
ci: Adjust database versions to current LTS / supported versions

### DIFF
--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -56,10 +56,10 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        mariadb-versions: ['10.3', '10.5', '10.6', '10.11']
+        mariadb-versions: ['10.3', '10.6', '10.11', '11.4']
         include:
           - php-versions: '8.3'
-            mariadb-versions: '10.6'
+            mariadb-versions: '10.11'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: MariaDB ${{ matrix.mariadb-versions }} (PHP ${{ matrix.php-versions }}) - database tests
@@ -80,7 +80,7 @@ jobs:
           MYSQL_USER: oc_autotest
           MYSQL_PASSWORD: nextcloud
           MYSQL_DATABASE: oc_autotest
-        options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 5
+        options: --health-cmd="${{ matrix.mariadb-versions <= 10.4 && 'mysqladmin' || 'mariadb-admin'}} ping" --health-interval 5s --health-timeout 2s --health-retries 5
 
     steps:
       - name: Checkout server

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         php-versions: ['8.1']
-        mysql-versions: ['8.0', '8.3']
+        mysql-versions: ['8.0', '8.4']
         include:
           - mysql-versions: '8.0'
             php-versions: '8.3'

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -19,6 +19,12 @@ use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
 class SupportedDatabase implements ISetupCheck {
+
+	private const MIN_MARIADB = '10.6';
+	private const MAX_MARIADB = '11.4';
+	private const MIN_MYSQL = '8.0';
+	private const MAX_MYSQL = '8.4';
+
 	public function __construct(
 		private IL10N $l10n,
 		private IURLGenerator $urlGenerator,
@@ -48,13 +54,39 @@ class SupportedDatabase implements ISetupCheck {
 			$versionConcern = $major . '.' . $minor;
 			if (str_contains($versionlc, 'mariadb')) {
 				if (version_compare($versionConcern, '10.3', '=')) {
-					return SetupResult::info($this->l10n->t('MariaDB version 10.3 detected, this version is end-of-life and only supported as part of Ubuntu 20.04. MariaDB >=10.6 and <=11.4 is suggested for best performance, stability and functionality with this version of Nextcloud.'));
-				} elseif (version_compare($versionConcern, '10.6', '<') || version_compare($versionConcern, '11.4', '>')) {
-					return SetupResult::warning($this->l10n->t('MariaDB version "%s" detected. MariaDB >=10.6 and <=11.4 is suggested for best performance, stability and functionality with this version of Nextcloud.', $version));
+					return SetupResult::info(
+						$this->l10n->t(
+							'MariaDB version 10.3 detected, this version is end-of-life and only supported as part of Ubuntu 20.04. MariaDB >=%1$s and <=%2$s is suggested for best performance, stability and functionality with this version of Nextcloud.',
+							[
+								self::MIN_MARIADB,
+								self::MAX_MARIADB,
+							]
+						),
+					);
+				} elseif (version_compare($versionConcern, self::MIN_MARIADB, '<') || version_compare($versionConcern, self::MAX_MARIADB, '>')) {
+					return SetupResult::warning(
+						$this->l10n->t(
+							'MariaDB version "%1$s" detected. MariaDB >=%2$s and <=%3$s is suggested for best performance, stability and functionality with this version of Nextcloud.',
+							[
+								$version,
+								self::MIN_MARIADB,
+								self::MAX_MARIADB,
+							],
+						),
+					);
 				}
 			} else {
-				if (version_compare($versionConcern, '8.0', '<') || version_compare($versionConcern, '8.4', '>')) {
-					return SetupResult::warning($this->l10n->t('MySQL version "%s" detected. MySQL >=8.0 and <=8.4 is suggested for best performance, stability and functionality with this version of Nextcloud.', $version));
+				if (version_compare($versionConcern, self::MIN_MYSQL, '<') || version_compare($versionConcern, self::MAX_MYSQL, '>')) {
+					return SetupResult::warning(
+						$this->l10n->t(
+							'MySQL version "%1$s" detected. MySQL >=%2$s and <=%3$s is suggested for best performance, stability and functionality with this version of Nextcloud.',
+							[
+								$version,
+								self::MIN_MYSQL,
+								self::MAX_MYSQL,
+							],
+						),
+					);
 				}
 			}
 		} elseif ($databasePlatform instanceof PostgreSQLPlatform) {

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -38,8 +38,8 @@ class SupportedDatabase implements ISetupCheck {
 		$version = null;
 		$databasePlatform = $this->connection->getDatabasePlatform();
 		if ($databasePlatform instanceof MySQLPlatform) {
-			$result = $this->connection->prepare("SHOW VARIABLES LIKE 'version';");
-			$result->execute();
+			$statement = $this->connection->prepare("SHOW VARIABLES LIKE 'version';");
+			$result = $statement->execute();
 			$row = $result->fetch();
 			$version = $row['Value'];
 			$versionlc = strtolower($version);
@@ -47,17 +47,19 @@ class SupportedDatabase implements ISetupCheck {
 			[$major, $minor, ] = explode('.', $versionlc);
 			$versionConcern = $major . '.' . $minor;
 			if (str_contains($versionlc, 'mariadb')) {
-				if (version_compare($versionConcern, '10.3', '<') || version_compare($versionConcern, '10.11', '>')) {
-					return SetupResult::warning($this->l10n->t('MariaDB version "%s" detected. MariaDB >=10.3 and <=10.11 is suggested for best performance, stability and functionality with this version of Nextcloud.', $version));
+				if (version_compare($versionConcern, '10.3', '=')) {
+					return SetupResult::info($this->l10n->t('MariaDB version 10.3 detected, this version is end-of-life and only supported as part of Ubuntu 20.04. MariaDB >=10.6 and <=11.4 is suggested for best performance, stability and functionality with this version of Nextcloud.'));
+				} elseif (version_compare($versionConcern, '10.6', '<') || version_compare($versionConcern, '11.4', '>')) {
+					return SetupResult::warning($this->l10n->t('MariaDB version "%s" detected. MariaDB >=10.6 and <=11.4 is suggested for best performance, stability and functionality with this version of Nextcloud.', $version));
 				}
 			} else {
-				if (version_compare($versionConcern, '8.0', '<') || version_compare($versionConcern, '8.3', '>')) {
-					return SetupResult::warning($this->l10n->t('MySQL version "%s" detected. MySQL >=8.0 and <=8.3 is suggested for best performance, stability and functionality with this version of Nextcloud.', $version));
+				if (version_compare($versionConcern, '8.0', '<') || version_compare($versionConcern, '8.4', '>')) {
+					return SetupResult::warning($this->l10n->t('MySQL version "%s" detected. MySQL >=8.0 and <=8.4 is suggested for best performance, stability and functionality with this version of Nextcloud.', $version));
 				}
 			}
 		} elseif ($databasePlatform instanceof PostgreSQLPlatform) {
-			$result = $this->connection->prepare('SHOW server_version;');
-			$result->execute();
+			$statement = $this->connection->prepare('SHOW server_version;');
+			$result = $statement->execute();
 			$row = $result->fetch();
 			$version = $row['server_version'];
 			$versionlc = strtolower($version);

--- a/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
+++ b/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
@@ -46,7 +46,7 @@ class SupportedDatabaseTest extends TestCase {
 			/** SQlite always gets a warning */
 			$this->assertEquals(SetupResult::WARNING, $this->check->run()->getSeverity());
 		} else {
-			$this->assertEquals(SetupResult::SUCCESS, $this->check->run()->getSeverity());
+			$this->assertContains($this->check->run()->getSeverity(), [SetupResult::SUCCESS, SetupResult::INFO]);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

* MySQL tests
  * Minimum 8.0 (LTS)
  * Maximum 8.4 (LTS)
  * Drop 8.3 as we now test 8.4 and 8.3 was never LTS
* MariaDB tests
  * still supported version 10.3 (no LTS but for Ubuntu 20.04 support)
  * LTS 10.6
  * LTS 10.11
  * LTS 11.4
  * Drop 10.5 is was never LTS and we test 10.3 and 10.6

**Documentation** at https://github.com/nextcloud/documentation/pull/11934

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
