### PR TITLE
feat: Allow getting/setting the password hash of a user

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -799,6 +799,7 @@ return array(
     'OCP\\User\\Backend\\IGetHomeBackend' => $baseDir . '/lib/public/User/Backend/IGetHomeBackend.php',
     'OCP\\User\\Backend\\IGetRealUIDBackend' => $baseDir . '/lib/public/User/Backend/IGetRealUIDBackend.php',
     'OCP\\User\\Backend\\IPasswordConfirmationBackend' => $baseDir . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
+    'OCP\\User\\Backend\\IPasswordHashBackend' => $baseDir . '/lib/public/User/Backend/IPasswordHashBackend.php',
     'OCP\\User\\Backend\\IProvideAvatarBackend' => $baseDir . '/lib/public/User/Backend/IProvideAvatarBackend.php',
     'OCP\\User\\Backend\\IProvideEnabledStateBackend' => $baseDir . '/lib/public/User/Backend/IProvideEnabledStateBackend.php',
     'OCP\\User\\Backend\\ISearchKnownUsersBackend' => $baseDir . '/lib/public/User/Backend/ISearchKnownUsersBackend.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -832,6 +832,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\User\\Backend\\IGetHomeBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetHomeBackend.php',
         'OCP\\User\\Backend\\IGetRealUIDBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetRealUIDBackend.php',
         'OCP\\User\\Backend\\IPasswordConfirmationBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
+        'OCP\\User\\Backend\\IPasswordHashBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordHashBackend.php',
         'OCP\\User\\Backend\\IProvideAvatarBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IProvideAvatarBackend.php',
         'OCP\\User\\Backend\\IProvideEnabledStateBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IProvideEnabledStateBackend.php',
         'OCP\\User\\Backend\\ISearchKnownUsersBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ISearchKnownUsersBackend.php',

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -183,6 +183,9 @@ class Database extends ABackend implements
 		if (!$this->userExists($userId)) {
 			return null;
 		}
+		if (!empty($this->cache[$userId]['password'])) {
+			return $this->cache[$userId]['password'];
+		}
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->select('password')
 			->from($this->table)

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OC\User;
 
+use InvalidArgumentException;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -200,6 +201,9 @@ class Database extends ABackend implements
 	}
 
 	public function setPasswordHash(string $userId, string $passwordHash): bool {
+		if (!\OCP\Server::get(IHasher::class)->validate($passwordHash)) {
+			throw new InvalidArgumentException();
+		}
 		$this->fixDI();
 		$result = $this->updatePassword($userId, $passwordHash);
 		if (!$result) {

--- a/lib/private/User/LazyUser.php
+++ b/lib/private/User/LazyUser.php
@@ -73,6 +73,14 @@ class LazyUser implements IUser {
 		return $this->getUser()->setPassword($password, $recoveryPassword);
 	}
 
+	public function getPasswordHash(): ?string {
+		return $this->getUser()->getPasswordHash();
+	}
+
+	public function setPasswordHash(string $passwordHash): bool {
+		return $this->getUser()->setPasswordHash($passwordHash);
+	}
+
 	public function getHome() {
 		return $this->getUser()->getHome();
 	}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -25,6 +25,7 @@ use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Backend\IGetHomeBackend;
+use OCP\User\Backend\IPasswordHashBackend;
 use OCP\User\Backend\IProvideAvatarBackend;
 use OCP\User\Backend\IProvideEnabledStateBackend;
 use OCP\User\Backend\ISetDisplayNameBackend;
@@ -317,6 +318,20 @@ class User implements IUser {
 		} else {
 			return false;
 		}
+	}
+
+	public function getPasswordHash(): ?string {
+		if (!($this->backend instanceof IPasswordHashBackend)) {
+			return null;
+		}
+		return $this->backend->getPasswordHash($this->uid);
+	}
+
+	public function setPasswordHash(string $passwordHash): bool {
+		if (!($this->backend instanceof IPasswordHashBackend)) {
+			return false;
+		}
+		return $this->backend->setPasswordHash($this->uid, $passwordHash);
 	}
 
 	/**

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -77,6 +77,20 @@ interface IUser {
 	public function setPassword($password, $recoveryPassword = null);
 
 	/**
+	 * Get the password hash of the user
+	 *
+	 * @since 30.0.0
+	 */
+	public function getPasswordHash(): ?string;
+
+	/**
+	 * Set the password hash of the user
+	 *
+	 * @since 30.0.0
+	 */
+	public function setPasswordHash(string $passwordHash): bool;
+
+	/**
 	 * get the users home folder to mount
 	 *
 	 * @return string

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -79,6 +79,7 @@ interface IUser {
 	/**
 	 * Get the password hash of the user
 	 *
+	 * @return ?string the password hash hashed by `\OCP\Security\IHasher::hash()`
 	 * @since 30.0.0
 	 */
 	public function getPasswordHash(): ?string;
@@ -86,6 +87,8 @@ interface IUser {
 	/**
 	 * Set the password hash of the user
 	 *
+	 * @param string $passwordHash the password hash hashed by `\OCP\Security\IHasher::hash()`
+	 * @throws InvalidArgumentException when `$passwordHash` is not a valid hash
 	 * @since 30.0.0
 	 */
 	public function setPasswordHash(string $passwordHash): bool;

--- a/lib/public/User/Backend/IPasswordHashBackend.php
+++ b/lib/public/User/Backend/IPasswordHashBackend.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\User\Backend;
+
+/**
+ * @since 30.0.0
+ */
+interface IPasswordHashBackend {
+	/**
+	 * @since 30.0.0
+	 */
+	public function getPasswordHash(string $userId): ?string;
+
+	/**
+	 * @since 30.0.0
+	 */
+	public function setPasswordHash(string $userId, string $passwordHash): bool;
+}

--- a/lib/public/User/Backend/IPasswordHashBackend.php
+++ b/lib/public/User/Backend/IPasswordHashBackend.php
@@ -9,16 +9,21 @@ declare(strict_types=1);
 
 namespace OCP\User\Backend;
 
+use InvalidArgumentException;
+
 /**
  * @since 30.0.0
  */
 interface IPasswordHashBackend {
 	/**
+	 * @return ?string the password hash hashed by `\OCP\Security\IHasher::hash()`
 	 * @since 30.0.0
 	 */
 	public function getPasswordHash(string $userId): ?string;
 
 	/**
+	 * @param string $passwordHash the password hash hashed by `\OCP\Security\IHasher::hash()`
+	 * @throws InvalidArgumentException when `$passwordHash` is not a valid hash
 	 * @since 30.0.0
 	 */
 	public function setPasswordHash(string $userId, string $passwordHash): bool;


### PR DESCRIPTION
## Summary

- Allows getting/setting the password hash of a given user

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)