### PR TITLE
feat(cache): CLI should not fail if APCu is not available

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -64,14 +64,28 @@ class Factory implements ICacheFactory {
 		$missingCacheMessage = 'Memcache {class} not available for {use} cache';
 		$missingCacheHint = 'Is the matching PHP module installed and enabled?';
 		if (!class_exists($localCacheClass) || !$localCacheClass::isAvailable()) {
-			throw new \OCP\HintException(strtr($missingCacheMessage, [
-				'{class}' => $localCacheClass, '{use}' => 'local'
-			]), $missingCacheHint);
+			if (\OC::$CLI && !defined('PHPUNIT_RUN') && $localCacheClass === APCu::class) {
+				// CLI should not fail if APCu is not available but fallback to NullCache.
+				// This can be the case if APCu is used without apc.enable_cli=1.
+				// APCu however cannot be shared between PHP instances (CLI and web) anyway.
+				$localCacheClass = self::NULL_CACHE;
+			} else {
+				throw new \OCP\HintException(strtr($missingCacheMessage, [
+					'{class}' => $localCacheClass, '{use}' => 'local'
+				]), $missingCacheHint);
+			}
 		}
 		if (!class_exists($distributedCacheClass) || !$distributedCacheClass::isAvailable()) {
-			throw new \OCP\HintException(strtr($missingCacheMessage, [
-				'{class}' => $distributedCacheClass, '{use}' => 'distributed'
-			]), $missingCacheHint);
+			if (\OC::$CLI && !defined('PHPUNIT_RUN') && $distributedCacheClass === APCu::class) {
+				// CLI should not fail if APCu is not available but fallback to NullCache.
+				// This can be the case if APCu is used without apc.enable_cli=1.
+				// APCu however cannot be shared between Nextcloud (PHP) instances anyway.
+				$distributedCacheClass = self::NULL_CACHE;
+			} else {
+				throw new \OCP\HintException(strtr($missingCacheMessage, [
+					'{class}' => $distributedCacheClass, '{use}' => 'distributed'
+				]), $missingCacheHint);
+			}
 		}
 		if (!($lockingCacheClass && class_exists($lockingCacheClass) && $lockingCacheClass::isAvailable())) {
 			// don't fall back since the fallback might not be suitable for storing lock


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #27608

## Summary
CLI should not fail if APCu is not available but fallback to NullCache. This can be the case if APCu is used without `apc.enable_cli=1`. APCu however runs within the PHP instance and hence cannot be shared between CLI and web or used as distributed cache. The CLI call can hence only create or invalidate entries for itself. For short-living CLI calls, this is theoretically a downsides regarding performance and resource usage, and Nextcloud must not have any issues using the dummy NullCache instead of an isolated freshly created and destroyed APCu instance.

This partly reverts https://github.com/nextcloud/server/pull/25770. The fallback was removed, because CLI calls started to hang after https://github.com/nextcloud/server/pull/25440. The reason however was not that a cache is generally required for CLI calls, but because the previously logged warning invoked the user backend, which invoked again the caching backend, causing a loop.

This commit re-adds the fallback without logging a warning, and for APCu only. For mentioned reasons, it is okay to fallback to NullCache silently. If Redis or memcached are configured but not available, then the web UI would fail as well, and it makes sense to abort and inform CLI calls as well then.

The motivation is to make `apc.enable_cli=1` optional, and that hence the documentation about it can be removed. We should not enforce admins to enable APCu for CLI calls, which is reasonably disabled by default. This also reduces requirements for hosting providers to support Nextcloud.
__________________
I did some tests on a Raspberry Pi 2 with slow CPU and RAM, probably lowest end of hardware which can reasonably run a Nextcloud instance. I did some `occ help`, `occ status` and `cron.php` call loops with and without APCu, as well as with very large 256 MiB APCu size (PHP default is 32 MiB, my Nextcloud uses ~1 MiB). I could not find any performance differences. At least for those calls, building up and destroying the APCu cache did not take any significant time, compared to the ~2.5 seconds the whole processing for a single call (mostly loading all frameworks and scripts) took. But the `php` process memory usage raised by exactly the configured APCu size, which can make a difference if this leads to swapping. And it can push Linux I/O buffer/cache for regularly accessed files out of memory. So I find it reasonable to not use APCu for CLI calls in any case.

Since APCu and ArrayCache for the web instance cannot be invalidated from CLI, the documentation could mention this instead. Theoretically, config changes, Nextcloud or app upgrades can require a local cache invalidation. Hence, in case one faces issues, a PHP server restart could be required. The same is true when OPcache revalidation time is long or has been disabled. This commit however does not chance anything about this fact.

I dropped the idea to disable caching for CLI calls in the first place: With APCu for CLI disabled by default, this is practically no difference, but the fallback at least still allows admins to use APCu for CLI calls as well, whether for testing, debugging or whatever reason. And it does not hurt to have CLI use Redis/memcached, but it can then indeed be a performance benefit. And using these caching backends allows CLI to invalidate web cache, if required/beneficial in certain cases. However, at best, such requirements, if they really exist, are removed from Nextcloud, as of the impossibility to do this with APCu and ArrayCache. And dropping support for those fast (APCu) and simple caching options, which do not require to setup and run a dedicated caching server, is IMO raising the hurdle for setup Nextcloud too much.

## TODO

- [x] Remove/Replace `apc.enable_cli=1` warning from documentation: https://docs.nextcloud.com/server/29/admin_manual/configuration_server/caching_configuration.html#id1

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
