### PR TITLE
[stable28] fix(openapi): Regenerate OpenAPI after server changes

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -21,8 +21,9 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-          extensions: xml
+          extensions: ctype, curl, dom, fileinfo, gd, json, libxml, mbstring, openssl, pcntl, pdo, posix, session, simplexml, xml, xmlreader, xmlwriter, zip, zlib
           coverage: none
+          ini-file: development
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -657,6 +657,19 @@
                 ],
                 "parameters": [
                     {
+                        "name": "guestFallback",
+                        "in": "query",
+                        "description": "Fallback to guest avatar if not found",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    },
+                    {
                         "name": "userId",
                         "in": "path",
                         "description": "ID of the user",
@@ -696,6 +709,25 @@
                             }
                         }
                     },
+                    "201": {
+                        "description": "Avatar returned",
+                        "headers": {
+                            "X-NC-IsCustomAvatar": {
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            }
+                        },
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
                     "404": {
                         "description": "Avatar not found",
                         "content": {
@@ -703,6 +735,9 @@
                                 "schema": {}
                             }
                         }
+                    },
+                    "500": {
+                        "description": ""
                     }
                 }
             }
@@ -725,6 +760,19 @@
                 ],
                 "parameters": [
                     {
+                        "name": "guestFallback",
+                        "in": "query",
+                        "description": "Fallback to guest avatar if not found",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "enum": [
+                                0,
+                                1
+                            ]
+                        }
+                    },
+                    {
                         "name": "userId",
                         "in": "path",
                         "description": "ID of the user",
@@ -764,6 +812,25 @@
                             }
                         }
                     },
+                    "201": {
+                        "description": "Avatar returned",
+                        "headers": {
+                            "X-NC-IsCustomAvatar": {
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            }
+                        },
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            }
+                        }
+                    },
                     "404": {
                         "description": "Avatar not found",
                         "content": {
@@ -771,6 +838,9 @@
                                 "schema": {}
                             }
                         }
+                    },
+                    "500": {
+                        "description": ""
                     }
                 }
             }
@@ -814,6 +884,14 @@
                 "responses": {
                     "200": {
                         "description": "Custom avatar returned",
+                        "headers": {
+                            "X-NC-IsCustomAvatar": {
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            }
+                        },
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -825,6 +903,14 @@
                     },
                     "201": {
                         "description": "Avatar returned",
+                        "headers": {
+                            "X-NC-IsCustomAvatar": {
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            }
+                        },
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -893,6 +979,14 @@
                 "responses": {
                     "200": {
                         "description": "Custom avatar returned",
+                        "headers": {
+                            "X-NC-IsCustomAvatar": {
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            }
+                        },
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -904,6 +998,14 @@
                     },
                     "201": {
                         "description": "Avatar returned",
+                        "headers": {
+                            "X-NC-IsCustomAvatar": {
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            }
+                        },
                         "content": {
                             "*/*": {
                                 "schema": {


### PR DESCRIPTION
- Ref https://github.com/nextcloud/server/pull/45817

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
