### PR TITLE
Support profiler in occ commands

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -388,8 +388,8 @@ class AppManager implements IAppManager {
 		if ($appPath === false) {
 			return;
 		}
-		$eventLogger = \OC::$server->get(\OCP\Diagnostics\IEventLogger::class);
-		$eventLogger->start("bootstrap:load_app:$app", "Load $app");
+		$eventLogger = \OC::$server->get(IEventLogger::class);
+		$eventLogger->start("bootstrap:load_app:$app", "Load app: $app");
 
 		// in case someone calls loadApp() directly
 		\OC_App::registerAutoloading($app, $appPath);
@@ -400,8 +400,6 @@ class AppManager implements IAppManager {
 
 		$hasAppPhpFile = is_file($appPath . '/appinfo/app.php');
 
-		$eventLogger = \OC::$server->get(IEventLogger::class);
-		$eventLogger->start('bootstrap:load_app_' . $app, 'Load app: ' . $app);
 		if ($isBootable && $hasAppPhpFile) {
 			$this->logger->error('/appinfo/app.php is not loaded when \OCP\AppFramework\Bootstrap\IBootstrap on the application class is used. Migrate everything from app.php to the Application class.', [
 				'app' => $app,


### PR DESCRIPTION
## Summary

Enable the profiler for occ commands as well.
When profiler is enabled and debug is on, profiles for ran occ commands will also appear in the profiles list.
The Method is set to "occ" instead of an HTTP method and the URL field contains the command with its parameters instead.

Also fixed a problem in event logging about an application load event which was started twice with slightly different id and ended only once.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
