### PR TITLE
fix(Security): Don't attempt empty secret fallback on >=v3 ciphertext

### DIFF
--- a/tests/lib/Security/CryptoTest.php
+++ b/tests/lib/Security/CryptoTest.php
@@ -65,7 +65,7 @@ class CryptoTest extends \Test\TestCase {
 
 	public function testWrongParameters() {
 		$this->expectException(\Exception::class);
-		$this->expectExceptionMessage('Authenticated ciphertext could not be decoded.');
+		$this->expectExceptionMessage('Authenticated ciphertext could not be decoded (invalid format).');
 
 		$encryptedString = '1|2';
 		$this->crypto->decrypt($encryptedString, 'ThisIsAVeryS3cur3P4ssw0rd');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The v3 ciphertext format (added in #23496) has never worked with an empty secret/password. However, the v3 implementation was added prior to the existence of the empty secret fallback code added in #31499. 

While looking into #34012 I noted that the only reason the `hash_hkdf()` PHP ValueError is occurring is because the fallback is being attempted not only anytime the initial decrypt attempt fails, but also against newer ciphertext versions (where the fallback isn't relevant).

This PR adjusts the fallback logic to only run against <=2 versioned or non-versioned (which is even older) ciphertext.

Note: This does *not* fix the underlying cause of #34012 (which is probably in at least most cases a configuration problem), but it does:

- clean-up the logic to avoid the PHP error
- avoids doing the fallback on newer ciphertext where it's pointless (and most ciphertext is probably v3 at this point)

References:

- #31499
- #31492 
- #23496 
- #20915 

## TODO

- [x] Adjust the tests (since I also change one of the Exception strings)
- [ ] Add a test (for the fallback; I don't believe there is one but need to double-check again)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
