### PR TITLE
fix: Authorization header can be an empty string

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -185,7 +185,7 @@ class Auth extends AbstractBasic {
 				//Fix for broken webdav clients
 				($this->userSession->isLoggedIn() && is_null($this->session->get(self::DAV_AUTHENTICATED))) ||
 				//Well behaved clients that only send the cookie are allowed
-				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && $request->getHeader('Authorization') === null) ||
+				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && empty($request->getHeader('Authorization'))) ||
 				\OC_User::handleApacheAuth()
 			) {
 				$user = $this->userSession->getUser()->getUID();


### PR DESCRIPTION
On our instance we've noticed that macOS dav clients are actually sending tons of requests. When looking at the network dump of what is happening it turned out that every request is sent twice, one time with a cookie which fails with a 401 and once with basic auth then.

I've been stepping through such a request now and it turned out that our check to see if a `Authorization` header is sent along was not working as it is always filled with an empty string from `$_SERVER['HTTP_AUTHORIZATION']`

Turns out that once fixing this check, macOS is able to properly reuse the cookies it sends along.

<details>
<summary>Some screenshots from debugging to easier follow the code that leads to this </summary>

<img width="1680" alt="Screenshot 2024-06-27 at 20 25 14" src="https://github.com/nextcloud/server/assets/3404133/b4503077-2e0b-4d6f-afb3-d0cefb24ea2f">
<img width="1603" alt="Screenshot 2024-06-27 at 20 25 41" src="https://github.com/nextcloud/server/assets/3404133/a9f01889-6f06-4527-a0b2-bcdf8534c902">
<img width="1675" alt="Screenshot 2024-06-27 at 20 27 02" src="https://github.com/nextcloud/server/assets/3404133/5e0acd4c-620b-418e-b840-df39ad9c7f48">

</details>