### PR TITLE
feat: Add utility method to validate an IHasher hash

### DIFF
--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -79,7 +79,7 @@ class Hasher implements IHasher {
 	/**
 	 * Get the version and hash from a prefixedHash
 	 * @param string $prefixedHash
-	 * @return null|array Null if the hash is not prefixed, otherwise array('version' => 1, 'hash' => 'foo')
+	 * @return null|array{version: int, hash: string} Null if the hash is not prefixed, otherwise array('version' => 1, 'hash' => 'foo')
 	 */
 	protected function splitHash(string $prefixedHash): ?array {
 		$explodedString = explode('|', $prefixedHash, 2);

--- a/lib/private/Security/Hasher.php
+++ b/lib/private/Security/Hasher.php
@@ -190,4 +190,18 @@ class Hasher implements IHasher {
 
 		return $default;
 	}
+
+	public function validate(string $prefixedHash): bool {
+		$splitHash = $this->splitHash($prefixedHash);
+		if (empty($splitHash)) {
+			return false;
+		}
+		$validVersions = [3, 2, 1];
+		$version = $splitHash['version'];
+		if (!in_array($version, $validVersions, true)) {
+			return false;
+		}
+		$algoName = password_get_info($splitHash['hash'])['algoName'];
+		return $algoName !== 'unknown';
+	}
 }

--- a/lib/public/Security/IHasher.php
+++ b/lib/public/Security/IHasher.php
@@ -47,4 +47,11 @@ interface IHasher {
 	 * @since 8.0.0
 	 */
 	public function verify(string $message, string $hash, &$newHash = null): bool ;
+
+	/**
+	 * Check if the prefixed hash is valid
+	 *
+	 * @since 30.0.0
+	 */
+	public function validate(string $prefixedHash): bool;
 }

--- a/tests/lib/Security/HasherTest.php
+++ b/tests/lib/Security/HasherTest.php
@@ -264,4 +264,29 @@ class HasherTest extends \Test\TestCase {
 		$info = password_get_info($relativePath['hash']);
 		$this->assertEquals(PASSWORD_BCRYPT, $info['algo']);
 	}
+
+	public function testValidHash() {
+		$hash = '3|$argon2id$v=19$m=65536,t=4,p=1$czFCSjk3LklVdXppZ2VCWA$li0NgdXe2/jwSRxgteGQPWlzJU0E0xdtfHbCbrpych0';
+
+		$isValid = $this->hasher->validate($hash);
+
+		$this->assertTrue($isValid);
+	}
+
+	public function testValidGeneratedHash() {
+		$message = 'secret';
+		$hash = $this->hasher->hash($message);
+
+		$isValid = $this->hasher->validate($hash);
+
+		$this->assertTrue($isValid);
+	}
+
+	public function testInvalidHash() {
+		$invalidHash = 'someInvalidHash';
+
+		$isValid = $this->hasher->validate($invalidHash);
+
+		$this->assertFalse($isValid);
+	}
 }


### PR DESCRIPTION
## Summary

Adds a method for validating that a hashed password has been hashed by IHasher::hash()

This can be used when the original plain text password is not known, otherwise IHasher::verify() should be used

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)