### PR TITLE
fix(setupchecks): skip check when disk_free_space is disabled

### DIFF
--- a/apps/settings/lib/SetupChecks/TempSpaceAvailable.php
+++ b/apps/settings/lib/SetupChecks/TempSpaceAvailable.php
@@ -67,7 +67,11 @@ class TempSpaceAvailable implements ISetupCheck {
 			return SetupResult::error($this->l10n->t('Error while checking the temporary PHP path - it was not properly set to a directory. Returned value: %s', [$phpTempPath]));
 		}
 
-		$freeSpaceInTemp = function_exists('disk_free_space') ? disk_free_space($phpTempPath) : false;
+		if (!function_exists('disk_free_space')) {
+			return SetupResult::info($this->l10n->t('The PHP function "disk_free_space" is disabled, which prevents the check for enough space in the temporary directories.'));
+		}
+
+		$freeSpaceInTemp = disk_free_space($phpTempPath);
 		if ($freeSpaceInTemp === false) {
 			return SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$phpTempPath]));
 		}
@@ -76,7 +80,7 @@ class TempSpaceAvailable implements ISetupCheck {
 		$freeSpaceInTempInGB = $freeSpaceInTemp / 1024 / 1024 / 1024;
 		$spaceDetail = $this->l10n->t('- %.1f GiB available in %s (PHP temporary directory)', [round($freeSpaceInTempInGB, 1),$phpTempPath]);
 		if ($nextcloudTempPath !== $phpTempPath) {
-			$freeSpaceInNextcloudTemp = function_exists('disk_free_space') ? disk_free_space($nextcloudTempPath) : false;
+			$freeSpaceInNextcloudTemp = disk_free_space($nextcloudTempPath);
 			if ($freeSpaceInNextcloudTemp === false) {
 				return SetupResult::error($this->l10n->t('Error while checking the available disk space of temporary PHP path or no free disk space returned. Temporary path: %s', [$nextcloudTempPath]));
 			}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #45047 
 
## Summary

Make it easier to discover that the check failed because disk_free_space is disabled.

## TODO

- [x] CI
- [x] Review
- [x] Merge

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
