### PR TITLE
chore: remove EOL v27 from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -110,6 +110,7 @@ body:
         Select PHP engine version serving Nextcloud Server.
         _Describe in the "Additional info" section if you chose "Other"._
       options:
+        - "PHP 8.0"
         - "PHP 8.1"
         - "PHP 8.2"
         - "PHP 8.3"

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -86,7 +86,6 @@ body:
         Select Nextcloud Server version.
         _Versions not listed here are not maintained and not supported anymore_
       options:
-        - "27"
         - "28"
         - "29"
         - "master"
@@ -111,7 +110,6 @@ body:
         Select PHP engine version serving Nextcloud Server.
         _Describe in the "Additional info" section if you chose "Other"._
       options:
-        - "PHP 8.0"
         - "PHP 8.1"
         - "PHP 8.2"
         - "PHP 8.3"
@@ -148,8 +146,8 @@ body:
       description: |
         Select if bug is present after an update or on a fresh install.
       options:
-        - "Updated from a MINOR version (ex. 22.1 to 22.2)"
-        - "Upgraded to a MAJOR version (ex. 22 to 23)"
+        - "Updated from a MINOR version (ex. 28.0.1 to 28.0.2)"
+        - "Upgraded to a MAJOR version (ex. 28 to 29)"
         - "Fresh Nextcloud Server install"
   - type: dropdown
     id: encryption


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Remove EOL v27 from issue template

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)