### PR TITLE
[stable29] fix(theming): Also provide default image as background by absolut URL

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -117,14 +117,14 @@ class Capabilities implements IPublicCapability {
 			}
 			$colorText = $this->util->invertTextColor($color) ? '#000000' : '#ffffff';
 
-			$backgroundImage = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'background_image', BackgroundService::BACKGROUND_DEFAULT);
+			$backgroundImage = $this->config->getUserValue($user->getUID(), Application::APP_ID, 'background_image', BackgroundService::DEFAULT_BACKGROUND_IMAGE);
 			if ($backgroundImage === BackgroundService::BACKGROUND_CUSTOM) {
 				$backgroundPlain = false;
 				$background = $this->url->linkToRouteAbsolute('theming.userTheme.getBackground');
 			} elseif (isset(BackgroundService::SHIPPED_BACKGROUNDS[$backgroundImage])) {
 				$backgroundPlain = false;
-				$background = $this->url->linkTo(Application::APP_ID, "img/background/$backgroundImage");
-			} elseif ($backgroundImage !== BackgroundService::BACKGROUND_DEFAULT) {
+				$background = $this->url->getAbsoluteURL($this->url->linkTo(Application::APP_ID, "img/background/$backgroundImage"));
+			} else {
 				$backgroundPlain = true;
 				$background = $color;
 			}


### PR DESCRIPTION
## Summary

There was a regression that for the default theme the image was not set as the background. Also the background was not always an absolute URL, only for custom images it was absolute, for default images / shipped images it was relative.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
