### PR TITLE
fix(TaskProcessingApiController): Don't use + to merge non-assoc. arrays

### DIFF
--- a/core/Controller/TaskProcessingApiController.php
+++ b/core/Controller/TaskProcessingApiController.php
@@ -285,7 +285,7 @@ class TaskProcessingApiController extends \OCP\AppFramework\OCSController {
 				/** @var int|list<int> $inputSlot */
 				$inputSlot = $task->getInput()[$key];
 				if (is_array($inputSlot)) {
-					$ids += $inputSlot;
+					$ids = array_merge($inputSlot, $ids);
 				} else {
 					$ids[] = $inputSlot;
 				}
@@ -297,14 +297,14 @@ class TaskProcessingApiController extends \OCP\AppFramework\OCSController {
 					/** @var int|list<int> $outputSlot */
 					$outputSlot = $task->getOutput()[$key];
 					if (is_array($outputSlot)) {
-						$ids += $outputSlot;
+						$ids = array_merge($outputSlot, $ids);
 					} else {
 						$ids[] = $outputSlot;
 					}
 				}
 			}
 		}
-		return array_values($ids);
+		return $ids;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
I used `+` when I should have used `array_merge` :see_no_evil: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
