### PR TITLE
 fix(Wipe): Better handle missing tokens 

### DIFF
--- a/core/Controller/WipeController.php
+++ b/core/Controller/WipeController.php
@@ -42,8 +42,8 @@ class WipeController extends Controller {
 	 * 404: Device should not be wiped
 	 */
 	#[FrontpageRoute(verb: 'POST', url: '/core/wipe/check')]
-	public function checkWipe(string $token = ''): JSONResponse {
-		if ($token !== '') {
+	public function checkWipe(?string $token = ''): JSONResponse {
+		if (!empty($token)) {
 			try {
 				if ($this->remoteWipe->start($token)) {
 					return new JSONResponse([
@@ -76,8 +76,8 @@ class WipeController extends Controller {
 	 * 404: Device should not be wiped
 	 */
 	#[FrontpageRoute(verb: 'POST', url: '/core/wipe/success')]
-	public function wipeDone(string $token = ''): JSONResponse {
-		if ($token !== '') {
+	public function wipeDone(?string $token = ''): JSONResponse {
+		if (!empty($token)) {
 			try {
 				if ($this->remoteWipe->finish($token)) {
 					return new JSONResponse([]);

--- a/core/Controller/WipeController.php
+++ b/core/Controller/WipeController.php
@@ -42,18 +42,20 @@ class WipeController extends Controller {
 	 * 404: Device should not be wiped
 	 */
 	#[FrontpageRoute(verb: 'POST', url: '/core/wipe/check')]
-	public function checkWipe(string $token): JSONResponse {
-		try {
-			if ($this->remoteWipe->start($token)) {
-				return new JSONResponse([
-					'wipe' => true
-				]);
+	public function checkWipe(string $token = ''): JSONResponse {
+		if ($token !== '') {
+			try {
+				if ($this->remoteWipe->start($token)) {
+					return new JSONResponse([
+						'wipe' => true
+					]);
+				}
+			} catch (InvalidTokenException $e) {
+				// do nothing special, handled below
 			}
-
-			return new JSONResponse([], Http::STATUS_NOT_FOUND);
-		} catch (InvalidTokenException $e) {
-			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
+
+		return new JSONResponse([], Http::STATUS_NOT_FOUND);
 	}
 
 
@@ -74,15 +76,17 @@ class WipeController extends Controller {
 	 * 404: Device should not be wiped
 	 */
 	#[FrontpageRoute(verb: 'POST', url: '/core/wipe/success')]
-	public function wipeDone(string $token): JSONResponse {
-		try {
-			if ($this->remoteWipe->finish($token)) {
-				return new JSONResponse([]);
+	public function wipeDone(string $token = ''): JSONResponse {
+		if ($token !== '') {
+			try {
+				if ($this->remoteWipe->finish($token)) {
+					return new JSONResponse([]);
+				}
+			} catch (InvalidTokenException $e) {
+				// do nothing special, handled below
 			}
-
-			return new JSONResponse([], Http::STATUS_NOT_FOUND);
-		} catch (InvalidTokenException $e) {
-			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
+		
+		return new JSONResponse([], Http::STATUS_NOT_FOUND);
 	}
 }

--- a/tests/Core/Controller/WipeControllerTest.php
+++ b/tests/Core/Controller/WipeControllerTest.php
@@ -55,6 +55,12 @@ class WipeControllerTest extends TestCase {
 			$this->remoteWipe->method('start')
 				->with('mytoken')
 				->willThrowException(new InvalidTokenException());
+			$this->remoteWipe->method('start')
+				->with('')
+				->willThrowException(new InvalidTokenException());
+			$this->remoteWipe->method('start')
+				->with(NULL)
+				->willThrowException(new InvalidTokenException());
 		} else {
 			$this->remoteWipe->method('start')
 				->with('mytoken')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Check for non-empty token string to avoid 500/internal server errors in the Remote wipe API endpoints due to `Argument \#1 ($token) must be of type string, null given`.

Changed:

- Refactor slightly to streamline code
- Make `$token` nullable in both `checkWipe()` and `wipeDone()` then check for an empty value to avoid 500 error
- Expand test coverage

(arose after reproducing an issue initially reported in the community forum triggered by what seems to the iOS client sending us a null `token` sometimes, which is an issue for the client to address but better error handling in Server seemed a good idea too)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
