### PR TITLE
Drop "featured" apps

### DIFF
--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -434,7 +434,7 @@ class AppSettingsController extends Controller {
 					$nextCloudVersionDependencies,
 					$phpDependencies
 				),
-				'level' => ($app['isFeatured'] === true) ? 200 : 100,
+				'level' => 100,
 				'missingMaxOwnCloudVersion' => false,
 				'missingMinOwnCloudVersion' => false,
 				'canInstall' => true,

--- a/apps/settings/src/components/AppList.vue
+++ b/apps/settings/src/components/AppList.vue
@@ -206,7 +206,7 @@ export default {
 			}
 			if (this.category === 'featured') {
 				// An app level of `200` will be set for apps featured on the app store
-				return apps.filter(app => app.level <= 200)
+				return apps.filter(app => app.level <= 300)
 			}
 
 			// filter app store categories

--- a/apps/settings/src/components/AppList.vue
+++ b/apps/settings/src/components/AppList.vue
@@ -206,7 +206,7 @@ export default {
 			}
 			if (this.category === 'featured') {
 				// An app level of `200` will be set for apps featured on the app store
-				return apps.filter(app => app.level === 200)
+				return apps.filter(app => app.level <= 200)
 			}
 
 			// filter app store categories

--- a/apps/settings/src/components/AppList/AppLevelBadge.vue
+++ b/apps/settings/src/components/AppList/AppLevelBadge.vue
@@ -3,7 +3,7 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 <template>
-	<span v-if="isSupported || isFeatured"
+	<span v-if="isSupported"
 		class="app-level-badge"
 		:class="{ 'app-level-badge--supported': isSupported }"
 		:title="badgeTitle">
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 import NcIconSvgWrapper from '@nextcloud/vue/dist/Components/NcIconSvgWrapper.js'
 
-import { mdiCheck, mdiStarShooting } from '@mdi/js'
+import { mdiStarShooting } from '@mdi/js'
 import { translate as t } from '@nextcloud/l10n'
 import { computed } from 'vue'
 
@@ -27,12 +27,9 @@ const props = defineProps<{
 }>()
 
 const isSupported = computed(() => props.level === 300)
-const isFeatured = computed(() => props.level === 200)
-const badgeIcon = computed(() => isSupported.value ? mdiStarShooting : mdiCheck)
-const badgeText = computed(() => isSupported.value ? t('settings', 'Supported') : t('settings', 'Featured'))
-const badgeTitle = computed(() => isSupported.value
-	? t('settings', 'This app is supported via your current Nextcloud subscription.')
-	: t('settings', 'Featured apps are developed by and within the community. They offer central functionality and are ready for production use.'))
+const badgeIcon = computed(() => isSupported.value ? mdiStarShooting : '')
+const badgeText = computed(() => isSupported.value ? t('settings', 'Supported') : '')
+const badgeTitle = computed(() => isSupported.value ? t('settings', 'This app is supported via your current Nextcloud subscription.') : '')
 </script>
 
 <style scoped lang="scss">

--- a/apps/settings/src/views/AppStoreNavigation.vue
+++ b/apps/settings/src/views/AppStoreNavigation.vue
@@ -68,13 +68,6 @@
 						<NcIconSvgWrapper :path="APPSTORE_CATEGORY_ICONS.supported" />
 					</template>
 				</NcAppNavigationItem>
-				<NcAppNavigationItem id="app-category-featured"
-					:to="{ name: 'apps-category', params: { category: 'featured' } }"
-					:name="APPS_SECTION_ENUM.featured">
-					<template #icon>
-						<NcIconSvgWrapper :path="APPSTORE_CATEGORY_ICONS.featured" />
-					</template>
-				</NcAppNavigationItem>
 
 				<NcAppNavigationItem v-for="category in categories"
 					:id="`app-category-${category.id}`"


### PR DESCRIPTION
As i reported in #46102

> I would like to hide featured apps from the apps list.
Because most of the time i want to ignore them, as someone else decided they should be "featured" and not the community as a whole.

The l10n strings say:
> Featured apps are developed by and within the community. They offer central functionality and are ready for production use.

Yet there are way more production use apps developed by the community.
So this PR removes the conflicting "Featured".