### PR TITLE
fix(dependabot): add back npm patch upgrades for stable branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,7 +116,7 @@ updates:
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Disable automatic rebasing because without a build CI will likely fail anyway
   rebase-strategy: "disabled"
 
@@ -136,7 +136,7 @@ updates:
   ignore:
     # ignore all GitHub linguist patch updates
     - dependency-name: "*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Disable automatic rebasing because without a build CI will likely fail anyway
   rebase-strategy: "disabled"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,7 +114,6 @@ updates:
   reviewers:
     - "nextcloud/server-dependabot"
   ignore:
-    # ignore all GitHub linguist patch updates
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Disable automatic rebasing because without a build CI will likely fail anyway
@@ -134,7 +133,6 @@ updates:
   reviewers:
     - "nextcloud/server-dependabot"
   ignore:
-    # ignore all GitHub linguist patch updates
     - dependency-name: "*"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]
   # Disable automatic rebasing because without a build CI will likely fail anyway


### PR DESCRIPTION
Seems like copy/pasting went wrong at some point :'(

oringaly from https://github.com/nextcloud/server/pull/31216 by @blizzz 
