### PR TITLE
fix: add option to remove the webroot for setup checks and don't chec…

### DIFF
--- a/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
+++ b/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
@@ -35,36 +35,49 @@ trait CheckServerResponseTrait {
 
 	/**
 	 * Get all possible URLs that need to be checked for a local request test.
+	 * This takes all `trusted_domains` and the CLI overwrite URL into account.
 	 *
-	 * @param string $url The relative URL to test
+	 * @param string $url The relative URL to test starting with a /
 	 * @return string[] List of possible absolute URLs
 	 */
 	protected function getTestUrls(string $url, bool $removeWebroot): array {
 		$testUrls = [];
 
-		$webroot = $this->urlGenerator->getWebroot();
+		$webroot = rtrim($this->urlGenerator->getWebroot(), '/');
 
+		/* Try overwrite.cli.url first, it’s supposed to be how the server contacts itself */
+		$cliUrl = $this->config->getSystemValueString('overwrite.cli.url', '');
+
+		if ($cliUrl !== '') {
+			$cliUrl = $this->normalizeUrl(
+				$cliUrl,
+				$webroot,
+				$removeWebroot
+			);
+
+			$testUrls[] = $cliUrl . $url;
+		}
+
+		/* Try URL generator second */
 		$baseUrl = $this->normalizeUrl(
 			$this->urlGenerator->getBaseUrl(),
 			$webroot,
 			$removeWebroot
 		);
 
-		$testUrls[] = $baseUrl . $url;
-
-		$cliUrl = $this->config->getSystemValueString('overwrite.cli.url', '');
-		if ($cliUrl === '') {
-			return $testUrls;
+		if ($baseUrl !== $cliUrl) {
+			$testUrls[] = $baseUrl . $url;
 		}
 
-		$cliUrl = $this->normalizeUrl(
-			$cliUrl,
-			$webroot,
-			$removeWebroot
-		);
-
-		if ($cliUrl !== $baseUrl) {
-			$testUrls[] = $cliUrl . $url;
+		/* Last resort: trusted domains */
+		$hosts = $this->config->getSystemValue('trusted_domains', []);
+		foreach ($hosts as $host) {
+			if (str_contains($host, '*')) {
+				/* Ignore domains with a wildcard */
+				continue;
+			}
+			$hosts[] = 'https://' . $host . $url;
+			$hosts[] = 'http://' . $host . $url;
 		}
 
 		return $testUrls;
@@ -74,7 +87,8 @@ trait CheckServerResponseTrait {
 	 * Strip a trailing slash and remove the webroot if requested.
 	 */
 	protected function normalizeUrl(string $url, string $webroot, bool $removeWebroot): string {
-		if ($removeWebroot && str_contains($url, $webroot)) {
+		$url = rtrim($url, '/');
+		if ($removeWebroot && str_ends_with($url, $webroot)) {
 			$url = substr($url, -strlen($webroot));
 		}
 		return rtrim($url, '/');

--- a/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
+++ b/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
@@ -35,24 +35,49 @@ trait CheckServerResponseTrait {
 
 	/**
 	 * Get all possible URLs that need to be checked for a local request test.
-	 * This takes all `trusted_domains` and the CLI overwrite URL into account.
 	 *
 	 * @param string $url The relative URL to test
 	 * @return string[] List of possible absolute URLs
 	 */
-	protected function getTestUrls(string $url): array {
-		$hosts = $this->config->getSystemValue('trusted_domains', []);
-		$cliUrl = $this->config->getSystemValue('overwrite.cli.url', '');
-		if ($cliUrl !== '') {
-			$hosts[] = $cliUrl;
-		}
+	protected function getTestUrls(string $url, bool $removeWebroot): array {
+		$testUrls = [];
 
-		$testUrls = array_merge(
-			[$this->urlGenerator->getAbsoluteURL($url)],
-			array_map(fn (string $host): string => $host . $url, $hosts),
+		$webroot = $this->urlGenerator->getWebroot();
+
+		$baseUrl = $this->normalizeUrl(
+			$this->urlGenerator->getBaseUrl(),
+			$webroot,
+			$removeWebroot
 		);
 
+		$testUrls[] = $baseUrl . $url;
+
+		$cliUrl = $this->config->getSystemValueString('overwrite.cli.url', '');
+		if ($cliUrl === '') {
+			return $testUrls;
+		}
+
+		$cliUrl = $this->normalizeUrl(
+			$cliUrl,
+			$webroot,
+			$removeWebroot
+		);
+
+		if ($cliUrl !== $baseUrl) {
+			$testUrls[] = $cliUrl . $url;
+		}
+
 		return $testUrls;
+	}
+
+	/**
+	 * Strip a trailing slash and remove the webroot if requested.
+	 */
+	protected function normalizeUrl(string $url, string $webroot, bool $removeWebroot): string {
+		if ($removeWebroot && str_contains($url, $webroot)) {
+			$url = substr($url, -strlen($webroot));
+		}
+		return rtrim($url, '/');
 	}
 
 	/**
@@ -69,14 +94,14 @@ trait CheckServerResponseTrait {
 	 *
 	 * @return Generator<int, IResponse>
 	 */
-	protected function runRequest(string $method, string $url, array $options = []): Generator {
+	protected function runRequest(string $method, string $url, array $options = [], bool $removeWebroot = false): Generator {
 		$options = array_merge(['ignoreSSL' => true, 'httpErrors' => true], $options);
 
 		$client = $this->clientService->newClient();
 		$requestOptions = $this->getRequestOptions($options['ignoreSSL'], $options['httpErrors']);
 		$requestOptions = array_merge($requestOptions, $options['options'] ?? []);
 
-		foreach ($this->getTestUrls($url) as $testURL) {
+		foreach ($this->getTestUrls($url, $removeWebroot) as $testURL) {
 			try {
 				yield $client->request($method, $testURL, $requestOptions);
 			} catch (\Throwable $e) {

--- a/apps/settings/lib/SetupChecks/OcxProviders.php
+++ b/apps/settings/lib/SetupChecks/OcxProviders.php
@@ -51,7 +51,7 @@ class OcxProviders implements ISetupCheck {
 		];
 
 		foreach ($providers as $provider) {
-			foreach ($this->runRequest('HEAD', $this->urlGenerator->getWebroot() . $provider, ['httpErrors' => false]) as $response) {
+			foreach ($this->runRequest('HEAD', $provider, ['httpErrors' => false]) as $response) {
 				$testedProviders[$provider] = true;
 				if ($response->getStatusCode() === 200) {
 					$workingProviders[] = $provider;

--- a/apps/settings/lib/SetupChecks/WellKnownUrls.php
+++ b/apps/settings/lib/SetupChecks/WellKnownUrls.php
@@ -52,7 +52,7 @@ class WellKnownUrls implements ISetupCheck {
 
 		foreach ($urls as [$verb,$url,$validStatuses,$checkCustomHeader]) {
 			$works = null;
-			foreach ($this->runRequest($verb, $url, ['httpErrors' => false, 'options' => ['allow_redirects' => ['track_redirects' => true]]]) as $response) {
+			foreach ($this->runRequest($verb, $url, ['httpErrors' => false, 'options' => ['allow_redirects' => ['track_redirects' => true]]], removeWebroot: true) as $response) {
 				// Check that the response status matches
 				$works = in_array($response->getStatusCode(), $validStatuses);
 				// and (if needed) the custom Nextcloud header is set


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* For https://github.com/nextcloud/server/issues/45033

## Summary

fix: add option to remove the webroot for setup checks and don't check trusted_domains.

1) The checks for well-known urls should always run against the root domain and therefore the option to remove the webroot.

2) For trusted domains, the available protocol is unknown, and thus some guesswork would be needed to make that work. I've decided for now to not consider them anymore to reduce false-positives.


## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
