### PR TITLE
Match input height with clickable area

### DIFF
--- a/core/css/inputs.scss
+++ b/core/css/inputs.scss
@@ -17,7 +17,6 @@ input, textarea, select, button, div[contenteditable=true], div[contenteditable=
 	background-image: unset !important;
 }
 
-$default-height: 36px;
 $opacity-disabled: .7;
 
 /* Simple selector to allow easy overriding */
@@ -32,7 +31,7 @@ textarea,
 div[contenteditable=true],
 div[contenteditable=false] {
 	width: 130px;
-	min-height: $default-height;
+	min-height: var(--default-clickable-area);
 	box-sizing: border-box;
 }
 
@@ -175,7 +174,7 @@ input {
 		-moz-appearance: textfield;
 		appearance: textfield;
 		// force height for inline elements like inputs (not textarea, contenteditable...)
-		height: $default-height;
+		height: var(--default-clickable-area);
 	}
 	&[type='radio'],
 	&[type='checkbox'],
@@ -215,7 +214,7 @@ input[type='reset'] {
 	padding: 8px 14px;
 	font-size: var(--default-font-size);
 	width: auto;
-	min-height: $default-height;
+	min-height: var(--default-clickable-area);
 	cursor: pointer;
 	box-sizing: border-box;
 	background-color: var(--color-background-dark);
@@ -352,8 +351,8 @@ input {
 			/* Avoid background under border */
 			background-color: var(--color-main-background) !important;
 			opacity: 1;
-			height: $default-height;
-			width: $default-height;
+			height: var(--default-clickable-area);
+			width: var(--default-clickable-area);
 			padding: 7px 6px;
 			cursor: pointer;
 			margin-right: 0;


### PR DESCRIPTION
Brings it from hardcoded 36 px to current default (34px)