### PR TITLE
Fix: Make out of office replacement nullable

### DIFF
--- a/apps/dav/lib/Controller/OutOfOfficeController.php
+++ b/apps/dav/lib/Controller/OutOfOfficeController.php
@@ -105,8 +105,8 @@ class OutOfOfficeController extends OCSController {
 	 * @param string $lastDay Last day of the absence in format `YYYY-MM-DD`
 	 * @param string $status Short text that is set as user status during the absence
 	 * @param string $message Longer multiline message that is shown to others during the absence
-	 * @param string $replacementUserId User id of the replacement user
-	 * @param string $replacementUserDisplayName Display name of the replacement user
+	 * @param ?string $replacementUserId User id of the replacement user
+	 * @param ?string $replacementUserDisplayName Display name of the replacement user
 	 * @return DataResponse<Http::STATUS_OK, DAVOutOfOfficeData, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{error: 'firstDay'}, array{}>|DataResponse<Http::STATUS_UNAUTHORIZED, null, array{}>|DataResponse<Http::STATUS_NOT_FOUND, null, array{}>
 	 *
 	 * 200: Absence data
@@ -120,8 +120,8 @@ class OutOfOfficeController extends OCSController {
 		string $lastDay,
 		string $status,
 		string $message,
-		string $replacementUserId = '',
-		string $replacementUserDisplayName = ''
+		?string $replacementUserId,
+		?string $replacementUserDisplayName
 
 	): DataResponse {
 		$user = $this->userSession?->getUser();
@@ -129,7 +129,7 @@ class OutOfOfficeController extends OCSController {
 			return new DataResponse(null, Http::STATUS_UNAUTHORIZED);
 		}
 
-		if ($replacementUserId !== '') {
+		if ($replacementUserId !== null) {
 			$replacementUser = $this->userManager->get($replacementUserId);
 			if ($replacementUser === null) {
 				return new DataResponse(null, Http::STATUS_NOT_FOUND);

--- a/apps/dav/lib/Db/Absence.php
+++ b/apps/dav/lib/Db/Absence.php
@@ -30,9 +30,9 @@ use OCP\User\IOutOfOfficeData;
  * @method string getMessage()
  * @method void setMessage(string $message)
  * @method string getReplacementUserId()
- * @method void setReplacementUserId(string $replacementUserId)
+ * @method void setReplacementUserId(?string $replacementUserId)
  * @method string getReplacementUserDisplayName()
- * @method void setReplacementUserDisplayName(string $replacementUserDisplayName)
+ * @method void setReplacementUserDisplayName(?string $replacementUserDisplayName)
  */
 class Absence extends Entity implements JsonSerializable {
 	protected string $userId = '';
@@ -47,9 +47,9 @@ class Absence extends Entity implements JsonSerializable {
 
 	protected string $message = '';
 
-	protected string $replacementUserId = '';
+	protected ?string $replacementUserId = null;
 
-	protected string $replacementUserDisplayName = '';
+	protected ?string $replacementUserDisplayName = null;
 
 	public function __construct() {
 		$this->addType('userId', 'string');

--- a/apps/dav/lib/ResponseDefinitions.php
+++ b/apps/dav/lib/ResponseDefinitions.php
@@ -13,8 +13,8 @@ namespace OCA\DAV;
  * @psalm-type DAVOutOfOfficeDataCommon = array{
  *      userId: string,
  *      message: string,
- *      replacementUserId: string,
- *      replacementUserDisplayName: string,
+ *      replacementUserId: ?string,
+ *      replacementUserDisplayName: ?string,
  *  }
  *
  * @psalm-type DAVOutOfOfficeData = DAVOutOfOfficeDataCommon&array{

--- a/apps/dav/lib/Service/AbsenceService.php
+++ b/apps/dav/lib/Service/AbsenceService.php
@@ -61,8 +61,8 @@ class AbsenceService {
 		$absence->setLastDay($lastDay);
 		$absence->setStatus($status);
 		$absence->setMessage($message);
-		$absence->setReplacementUserId($replacementUserId ?? '');
-		$absence->setReplacementUserDisplayName($replacementUserDisplayName ?? '');
+		$absence->setReplacementUserId($replacementUserId);
+		$absence->setReplacementUserDisplayName($replacementUserDisplayName);
 
 		if ($absence->getId() === null) {
 			$absence = $this->absenceMapper->insert($absence);

--- a/apps/dav/openapi.json
+++ b/apps/dav/openapi.json
@@ -145,10 +145,12 @@
                         "type": "string"
                     },
                     "replacementUserId": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "replacementUserDisplayName": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             }
@@ -578,12 +580,12 @@
                                     },
                                     "replacementUserId": {
                                         "type": "string",
-                                        "default": "",
+                                        "nullable": true,
                                         "description": "User id of the replacement user"
                                     },
                                     "replacementUserDisplayName": {
                                         "type": "string",
-                                        "default": "",
+                                        "nullable": true,
                                         "description": "Display name of the replacement user"
                                     }
                                 }

--- a/lib/private/User/OutOfOfficeData.php
+++ b/lib/private/User/OutOfOfficeData.php
@@ -19,8 +19,8 @@ class OutOfOfficeData implements IOutOfOfficeData {
 		private int $endDate,
 		private string $shortMessage,
 		private string $message,
-		private string $replacementUserId,
-		private string $replacementUserDisplayName) {
+		private ?string $replacementUserId,
+		private ?string $replacementUserDisplayName) {
 	}
 
 	public function getId(): string {
@@ -47,11 +47,11 @@ class OutOfOfficeData implements IOutOfOfficeData {
 		return $this->message;
 	}
 
-	public function getReplacementUserId(): string {
+	public function getReplacementUserId(): ?string {
 		return $this->replacementUserId;
 	}
 
-	public function getReplacementUserDisplayName(): string {
+	public function getReplacementUserDisplayName(): ?string {
 		return $this->replacementUserDisplayName;
 	}
 

--- a/lib/public/User/IOutOfOfficeData.php
+++ b/lib/public/User/IOutOfOfficeData.php
@@ -22,8 +22,8 @@ use OCP\IUser;
  *      endDate: int,
  *      shortMessage: string,
  *      message: string,
- * 		replacementUserId: string,
- * 		replacementUserDisplayName: string
+ * 		replacementUserId: ?string,
+ * 		replacementUserDisplayName: ?string
  * }
  *
  * @since 28.0.0
@@ -76,14 +76,14 @@ interface IOutOfOfficeData extends JsonSerializable {
 	 *
 	 * @since 30.0.0
 	 */
-	public function getReplacementUserId(): string;
+	public function getReplacementUserId(): ?string;
 
 	/**
 	 * Get the replacement user displayName for auto responders and similar
 	 *
 	 * @since 30.0.0
 	 */
-	public function getReplacementUserDisplayName(): string;
+	public function getReplacementUserDisplayName(): ?string;
 
 	/**
 	 * @return OutOfOfficeData


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Part of #40398

## Summary
Make `$replacementUserId` and `replacementUserDisplayName ` nullable 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
