### PR TITLE
chore(mp3info): apply upstream patch for invalid array access

### DIFF
--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -9,8 +9,8 @@ namespace OC\Preview;
 
 use OCP\Files\File;
 use OCP\IImage;
-use Psr\Log\LoggerInterface;
 use wapmorgan\Mp3Info\Mp3Info;
+use function OCP\Log\logger;
 
 class MP3 extends ProviderV2 {
 	/**
@@ -31,9 +31,9 @@ class MP3 extends ProviderV2 {
 			/** @var string|null|false $picture */
 			$picture = $audio->getCover();
 		} catch (\Throwable $e) {
-			\OC::$server->get(LoggerInterface::class)->info($e->getMessage(), [
-				'exception' => $e,
-				'app' => 'core',
+			logger('core')->info('Error while getting cover from mp3 file: ' . $e->getMessage(), [
+				'fileId' => $file->getId(),
+				'filePath' => $file->getPath(),
 			]);
 			return null;
 		} finally {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/44573

## Summary

Patch: wapmorgan/Mp3Info#36



## TODO

- [x] Merge https://github.com/nextcloud/3rdparty/pull/1888
- [x] CI
- [x] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
