### PR TITLE
fix(tests): Remove output when running tests

### DIFF
--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -36,7 +36,16 @@ class LoggerTest extends TestCase implements IWriter {
 		$this->logger = new Log($this, $this->config, null, $this->registry);
 	}
 
+	private function mockDefaultLogLevel(): void {
+		$this->config->expects($this->any())
+			->method('getValue')
+			->will(($this->returnValueMap([
+				['loglevel', ILogger::WARN, ILogger::WARN],
+			])));
+	}
+
 	public function testInterpolation() {
+		$this->mockDefaultLogLevel();
 		$logger = $this->logger;
 		$logger->warning('{Message {nothing} {user} {foo.bar} a}', ['user' => 'Bob', 'foo.bar' => 'Bar']);
 
@@ -65,6 +74,7 @@ class LoggerTest extends TestCase implements IWriter {
 	}
 
 	public function testLoggingWithDataArray(): void {
+		$this->mockDefaultLogLevel();
 		$writerMock = $this->createMock(IWriter::class);
 		$logFile = new Log($writerMock, $this->config);
 		$writerMock->expects($this->once())->method('write')->with('no app in context', ['something' => 'extra', 'message' => 'Testing logging with john']);
@@ -100,6 +110,7 @@ class LoggerTest extends TestCase implements IWriter {
 	 * @dataProvider userAndPasswordData
 	 */
 	public function testDetectlogin(string $user, string $password): void {
+		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
@@ -122,6 +133,7 @@ class LoggerTest extends TestCase implements IWriter {
 	 * @dataProvider userAndPasswordData
 	 */
 	public function testDetectcheckPassword(string $user, string $password): void {
+		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
@@ -144,6 +156,7 @@ class LoggerTest extends TestCase implements IWriter {
 	 * @dataProvider userAndPasswordData
 	 */
 	public function testDetectvalidateUserPass(string $user, string $password): void {
+		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
@@ -166,6 +179,7 @@ class LoggerTest extends TestCase implements IWriter {
 	 * @dataProvider userAndPasswordData
 	 */
 	public function testDetecttryLogin(string $user, string $password): void {
+		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
 		$this->registry->expects($this->once())
 			->method('delegateReport')
@@ -188,6 +202,7 @@ class LoggerTest extends TestCase implements IWriter {
 	 * @dataProvider userAndPasswordData
 	 */
 	public function testDetectclosure(string $user, string $password): void {
+		$this->mockDefaultLogLevel();
 		$a = function ($user, $password) {
 			throw new \Exception('test');
 		};


### PR DESCRIPTION
## Summary

Remove accidental output during unit tests:
```
 Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
...........................................................  6549 / 11342 ( 57%)
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
Nextcloud configuration: "loglevel" is not a valid integer
```
