### PR TITLE
fix(TaskProcessing): Set task status to running when processing via ISynchronousProvider

### DIFF
--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -15,6 +15,7 @@ use OC\TaskProcessing\Db\TaskMapper;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\BackgroundJob\IJobList;
+use OCP\DB\Exception;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\File;
@@ -869,5 +870,15 @@ class Manager implements IManager {
 		}
 		$task->setStatus(Task::STATUS_RUNNING);
 		return true;
+	}
+
+	/**
+	 * @throws \JsonException
+	 * @throws Exception
+	 */
+	public function setTaskStatus(Task $task, int $status): void {
+		$task->setStatus($status);
+		$taskEntity = \OC\TaskProcessing\Db\Task::fromPublicTask($task);
+		$this->taskMapper->update($taskEntity);
 	}
 }

--- a/lib/private/TaskProcessing/SynchronousBackgroundJob.php
+++ b/lib/private/TaskProcessing/SynchronousBackgroundJob.php
@@ -18,6 +18,7 @@ use OCP\TaskProcessing\Exception\ProcessingException;
 use OCP\TaskProcessing\Exception\ValidationException;
 use OCP\TaskProcessing\IManager;
 use OCP\TaskProcessing\ISynchronousProvider;
+use OCP\TaskProcessing\Task;
 use Psr\Log\LoggerInterface;
 
 class SynchronousBackgroundJob extends QueuedJob {
@@ -61,6 +62,7 @@ class SynchronousBackgroundJob extends QueuedJob {
 					return;
 				}
 				try {
+					$this->taskProcessingManager->setTaskStatus($task, Task::STATUS_RUNNING);
 					$output = $provider->process($task->getUserId(), $input, fn (float $progress) => $this->taskProcessingManager->setTaskProgress($task->getId(), $progress));
 				} catch (ProcessingException $e) {
 					$this->logger->warning('Failed to process a TaskProcessing task with synchronous provider ' . $provider->getId(), ['exception' => $e]);

--- a/lib/public/TaskProcessing/IManager.php
+++ b/lib/public/TaskProcessing/IManager.php
@@ -172,4 +172,14 @@ interface IManager {
 	 * @since 30.0.0
 	 */
 	public function lockTask(Task $task): bool;
+
+	/**
+	 * @param Task $task
+	 * @psalm-param Task::STATUS_* $status
+	 * @param int $status
+	 * @throws \JsonException
+	 * @throws Exception
+	 * @since 30.0.0
+	 */
+	public function setTaskStatus(Task $task, int $status): void;
 }


### PR DESCRIPTION
## Summary
When processing an ISynchronousProvider in a background job the task would not be set to running status. This PR fixes that.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
