### PR TITLE
[stable28] fix(SetupCheck): jsm test shall not give up with first no-response

### DIFF
--- a/apps/settings/lib/SetupChecks/JavaScriptModules.php
+++ b/apps/settings/lib/SetupChecks/JavaScriptModules.php
@@ -61,6 +61,7 @@ class JavaScriptModules implements ISetupCheck {
 			array_map(fn (string $host): string => $host . $testFile, $this->config->getSystemValue('trusted_domains', []))
 		);
 
+		$gotResponse = false;
 		foreach ($testURLs as $testURL) {
 			try {
 				$client = $this->clientService->newClient();
@@ -73,13 +74,16 @@ class JavaScriptModules implements ISetupCheck {
 						'allow_local_address' => true,
 					],
 				]);
+				$gotResponse = true;
 				if (preg_match('/(text|application)\/javascript/i', $response->getHeader('Content-Type'))) {
 					return SetupResult::success();
 				}
 			} catch (\Throwable $e) {
 				$this->logger->debug('Can not connect to local server for checking JavaScript modules support', ['exception' => $e, 'url' => $testURL]);
-				return SetupResult::warning($this->l10n->t('Could not check for JavaScript support. Please check manually if your webserver serves `.mjs` files using the JavaScript MIME type.'));
 			}
+		}
+		if (!$gotResponse) {
+			return SetupResult::warning($this->l10n->t('Could not check for JavaScript support. Please check manually if your webserver serves `.mjs` files using the JavaScript MIME type.'));
 		}
 		return SetupResult::error($this->l10n->t('Your webserver does not serve `.mjs` files using the JavaScript MIME type. This will break some apps by preventing browsers from executing the JavaScript files. You should configure your webserver to serve `.mjs` files with either the `text/javascript` or `application/javascript` MIME type.'));
 	}


### PR DESCRIPTION
## Summary

The JavaScript Module check is failing when testing the first out of multiple possible URLs. The change let's it try the others first – as is it currently done on master and 29.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
