### PR TITLE
feat: Store user which has downloaded file in activity feed

### DIFF
--- a/apps/files_sharing/lib/Listener/BeforeNodeReadListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeNodeReadListener.php
@@ -23,6 +23,8 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IRequest;
 use OCP\ISession;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Share\IShare;
 
 /**
@@ -30,6 +32,7 @@ use OCP\Share\IShare;
  */
 class BeforeNodeReadListener implements IEventListener {
 	private ICache $cache;
+	private ?IUser $currentUser = null;
 
 	public function __construct(
 		private ISession $session,
@@ -37,8 +40,10 @@ class BeforeNodeReadListener implements IEventListener {
 		private \OCP\Activity\IManager $activityManager,
 		private IRequest $request,
 		ICacheFactory $cacheFactory,
+		IUserSession $userSession,
 	) {
 		$this->cache = $cacheFactory->createDistributed('files_sharing_activity_events');
+		$this->currentUser = $userSession->getUser();
 	}
 
 	public function handle(Event $event): void {
@@ -156,6 +161,7 @@ class BeforeNodeReadListener implements IEventListener {
 			$dateTime = $dateTime->format('Y-m-d H');
 			$remoteAddressHash = md5($dateTime . '-' . $remoteAddress);
 			$parameters[] = $remoteAddressHash;
+			$parameters[] = $this->currentUser?->getUID();
 		} else {
 			return;
 		}


### PR DESCRIPTION
## Summary
I've added information about user which downloaded file via public link (if this user was logged in)

![image](https://github.com/nextcloud/server/assets/191082/59345c5c-bf90-4f7e-8d7c-f9f04b71ffd5)

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
