### PR TITLE
fix(cypress): wait for apps list fetch for better testing stability

### DIFF
--- a/cypress/e2e/settings/apps.cy.ts
+++ b/cypress/e2e/settings/apps.cy.ts
@@ -17,8 +17,15 @@ describe('Settings: App management', { testIsolation: true }, () => {
 
 		// I am logged in as the admin
 		cy.login(admin)
+
+		// Intercept the apps list request
+		cy.intercept('GET', '*/settings/apps/list').as('fetchAppsList')
+
 		// I open the Apps management
 		cy.visit('/settings/apps/installed')
+
+		// Wait for the apps list to load
+		cy.wait('@fetchAppsList')
 	})
 
 	it('Can enable an installed app', () => {


### PR DESCRIPTION
Seems to fail randomly sometimes on github/our runners

See https://github.com/nextcloud/server/pull/46283#issuecomment-2209315318

![image](https://github.com/nextcloud/server/assets/14975046/3df5de3e-cfa1-40c2-b761-2e0bcf2907ce)
