### PR TITLE
fix(s3): Don't wait indefinitely for S3 to return

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -14,6 +14,7 @@ use Aws\S3\S3Client;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\RejectedPromise;
 use OCP\ICertificateManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 trait S3ConnectionTrait {
@@ -98,7 +99,11 @@ trait S3ConnectionTrait {
 			'signature_provider' => \Aws\or_chain([self::class, 'legacySignatureProvider'], ClientResolver::_default_signature_provider()),
 			'csm' => false,
 			'use_arn_region' => false,
-			'http' => ['verify' => $this->getCertificateBundlePath()],
+			'http' => [
+				'verify' => $this->getCertificateBundlePath(),
+				// Timeout for the connection to S3 server, not for the request.
+				'connect_timeout' => 5
+			],
 			'use_aws_shared_config_files' => false,
 		];
 
@@ -116,35 +121,38 @@ trait S3ConnectionTrait {
 		}
 		$this->connection = new S3Client($options);
 
-		if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
-			$logger = \OC::$server->get(LoggerInterface::class);
-			$logger->debug('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
-				['app' => 'objectstore']);
-		}
-
-		if ($this->params['verify_bucket_exists'] && !$this->connection->doesBucketExist($this->bucket)) {
-			$logger = \OC::$server->get(LoggerInterface::class);
-			try {
-				$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
-				if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
-					throw new \Exception("The bucket will not be created because the name is not dns compatible, please correct it: " . $this->bucket);
-				}
-				$this->connection->createBucket(['Bucket' => $this->bucket]);
-				$this->testTimeout();
-			} catch (S3Exception $e) {
-				$logger->debug('Invalid remote storage.', [
-					'exception' => $e,
-					'app' => 'objectstore',
-				]);
-				if ($e->getAwsErrorCode() !== "BucketAlreadyOwnedByYou") {
-					throw new \Exception('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
+		try {
+			$logger = Server::get(LoggerInterface::class);
+			if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
+				$logger->debug('Bucket "' . $this->bucket . '" This bucket name is not dns compatible, it may contain invalid characters.',
+					['app' => 'objectstore']);
+			}
+	
+			if ($this->params['verify_bucket_exists'] && !$this->connection->doesBucketExist($this->bucket)) {
+				try {
+					$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
+					if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
+						throw new \Exception("The bucket will not be created because the name is not dns compatible, please correct it: " . $this->bucket);
+					}
+					$this->connection->createBucket(['Bucket' => $this->bucket]);
+					$this->testTimeout();
+				} catch (S3Exception $e) {
+					$logger->debug('Invalid remote storage.', [
+						'exception' => $e,
+						'app' => 'objectstore',
+					]);
+					if ($e->getAwsErrorCode() !== 'BucketAlreadyOwnedByYou') {
+						throw new \Exception('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
+					}
 				}
 			}
-		}
-
-		// google cloud's s3 compatibility doesn't like the EncodingType parameter
-		if (strpos($base_url, 'storage.googleapis.com')) {
-			$this->connection->getHandlerList()->remove('s3.auto_encode');
+	
+			// google cloud's s3 compatibility doesn't like the EncodingType parameter
+			if (strpos($base_url, 'storage.googleapis.com')) {
+				$this->connection->getHandlerList()->remove('s3.auto_encode');
+			}
+		} catch (S3Exception $e) {
+			throw new \Exception('S3 service is unable to handle request: ' . $e->getMessage());
 		}
 
 		return $this->connection;
@@ -193,7 +201,7 @@ trait S3ConnectionTrait {
 			// since we store the certificate bundles on the primary storage, we can't get the bundle while setting up the primary storage
 			if (!isset($this->params['primary_storage'])) {
 				/** @var ICertificateManager $certManager */
-				$certManager = \OC::$server->get(ICertificateManager::class);
+				$certManager = Server::get(ICertificateManager::class);
 				return $certManager->getAbsoluteBundlePath();
 			} else {
 				return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/46303

## Summary

By default, SDK never timeout. Insert some sane defaults.
https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#config-http

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
