### PR TITLE
Fix/update share entry quick select

### DIFF
--- a/apps/files_sharing/src/components/SharingEntry.vue
+++ b/apps/files_sharing/src/components/SharingEntry.vue
@@ -63,6 +63,20 @@ export default {
 	},
 
 	mixins: [SharesMixin, ShareDetails],
+	props: {
+    share: {
+      type: Object,
+      required: true,
+    },
+    fileInfo: {
+      type: Object,
+      required: true,
+    },
+    isUnique: {
+      type: Boolean,
+      required: true,
+    },
+  },
 
 	computed: {
 		title() {
@@ -118,6 +132,11 @@ export default {
 		onMenuClose() {
 			this.onNoteSubmit()
 		},
+	},
+	watch: {
+		share(newShare) {
+			console.log('Shareeeeee prop changed:', newShare)
+		}
 	},
 }
 </script>

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -180,7 +180,7 @@
 						{{ t('files_sharing', 'Custom permissions') }}
 					</NcCheckboxRadioSwitch>
 					<section v-if="setCustomPermissions" class="custom-permissions-group">
-						<NcCheckboxRadioSwitch :disabled="!allowsFileDrop && share.type === SHARE_TYPES.SHARE_TYPE_LINK"
+						<NcCheckboxRadioSwitch :disabled="!canRemoveReadPermission"
 							:checked.sync="hasRead"
 							data-cy-files-sharing-share-permissions-checkbox="read">
 							{{ t('files_sharing', 'Read') }}
@@ -602,6 +602,9 @@ export default {
 			// allowed to revoke it too (but not to grant it again).
 			return (this.fileInfo.canDownload() || this.canDownload)
 		},
+		canRemoveReadPermission() {
+			return this.allowsFileDrop && this.share.type === this.SHARE_TYPES.SHARE_TYPE_LINK
+		},
 		// if newPassword exists, but is empty, it means
 		// the user deleted the original password
 		hasUnsavedPassword() {
@@ -821,6 +824,10 @@ export default {
 					this.advancedSectionAccordionExpanded = true
 					this.setCustomPermissions = true
 				}
+			}
+			// Read permission required for share creation
+			if (!this.canRemoveReadPermission) {
+				this.hasRead = true
 			}
 		},
 		handleCustomPermissions() {

--- a/apps/files_sharing/src/views/SharingList.vue
+++ b/apps/files_sharing/src/views/SharingList.vue
@@ -53,5 +53,10 @@ export default {
 			}
 		},
 	},
+	watch: {
+		shares(old, newShares) {
+			console.log('Shares prop changed:', old, newShares)
+		}
+	}
 }
 </script>

--- a/apps/files_sharing/src/views/SharingTab.vue
+++ b/apps/files_sharing/src/views/SharingTab.vue
@@ -77,6 +77,7 @@
 			:share="shareDetailsData.share"
 			@close-sharing-details="toggleShareDetailsView"
 			@add:share="addShare"
+			@update:share="handleShareUpdated"
 			@remove:share="removeShare" />
 	</div>
 </template>
@@ -398,6 +399,27 @@ export default {
 					this.returnFocusElement?.focus()
 					this.returnFocusElement = null
 				})
+			}
+		},
+
+		handleShareUpdated(updatedShare) {
+			// Check if the updated share is in the `shares` list
+			let index = this.shares.findIndex(share => share.id === updatedShare.id)
+			if (index !== -1) {
+				console.log("Let us see", this.shares[index].permissions, updatedShare.permissions)
+				// Update the share in the `shares` list
+				this.$set(this.shares, index, updatedShare)
+				console.log('Updated???', updatedShare)
+				console.log("Let us see (AFTER)", this.shares[index].permissions, updatedShare.permissions)
+			} else {
+				// Check if the updated share is in the `linkShares` list
+				index = this.linkShares.findIndex(share => share.id === updatedShare.id)
+				if (index !== -1) {
+					// Update the share in the `linkShares` list
+					this.$set(this.linkShares, index, updatedShare)
+					this.linkShares[index] = updatedShare
+					console.log('Updated link???', updatedShare)
+				}
 			}
 		},
 	},


### PR DESCRIPTION
`SharingEntryQuickSelect` should respond to changes and reflect the new state of shares when updates are done in the `SharingDetailsTab`
