### PR TITLE
fix(previews): Stop returning true when `getimagesize()` fails

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -569,7 +569,7 @@ class OC_Image implements \OCP\IImage {
 	private function checkImageSize($path) {
 		$size = @getimagesize($path);
 		if (!$size) {
-			return true;
+			return false;
 		}
 
 		$width = $size[0];
@@ -590,7 +590,7 @@ class OC_Image implements \OCP\IImage {
 	private function checkImageDataSize($data) {
 		$size = @getimagesizefromstring($data);
 		if (!$size) {
-			return true;
+			return false;
 		}
 
 		$width = $size[0];
@@ -637,7 +637,7 @@ class OC_Image implements \OCP\IImage {
 					if (!$this->checkImageSize($imagePath)) {
 						return false;
 					}
-					if (getimagesize($imagePath) !== false) {
+					if (@getimagesize($imagePath) !== false) {
 						$this->resource = @imagecreatefromjpeg($imagePath);
 					} else {
 						$this->logger->debug('OC_Image->loadFromFile, JPG image not valid: ' . $imagePath, ['app' => 'core']);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #45899 

## Summary

Our `checkImageSize()` & `checkImageDataSize()` methods always return `true` if an image is corrupt/invalid[^1] (or unreadable). However, when  `getimagesize()` returns `false` so should `checkImage*()` IMO.

This current behavior causes already detected invalid images to not only bypass the `checkImageMemory()` check (as intended), but to continue to be processed in other ways even though they'll fail.

This impacts all formats, not just jpeg (though most are covered by suppressors at this point).

One could argue the current situation is valid behavior since the intention of the `checkImage*` methods isn't to detect other types of image problems, so it's a bit of an overloaded use. But in all cases I can conceive of, other image manipulations are going to fail anyhow if `getimagesize()` does. And we're immediately calling `getimagesize()` once again in many cases.

P.S. With the fix to `checkImageSize()`, the line with the suppressor shouldn't even be executed any longer. The suppressor added here is just for good measure and to be consistent with the other image formats. If the behavior of the `checkImage*()` methods is desired to be retained as-is, I can eliminate those changes and keep only the suppressor.

[^1]: (or at least corrupt enough their image data can't be retrieved by gd) 

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
