### PR TITLE
fix(setupchecks): Skip checking for OPcache settings if running checks from CLI

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
+++ b/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
@@ -114,6 +114,11 @@ class PhpOpcacheSetup implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
+		// Skip OPcache checks if running from CLI
+		if (PHP_SAPI === 'cli') {
+			return SetupResult::success($this->l10n->t('Checking from CLI, OPcache checks have been skipped.'));
+		}
+
 		[$level,$recommendations] = $this->getOpcacheSetupRecommendations();
 		if (!empty($recommendations)) {
 			return match($level) {

--- a/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
+++ b/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
@@ -115,7 +115,7 @@ class PhpOpcacheSetup implements ISetupCheck {
 
 	public function run(): SetupResult {
 		// Skip OPcache checks if running from CLI
-		if (PHP_SAPI === 'cli') {
+		if (OC::$CLI && !$this->iniGetWrapper->getBool('opcache.enable_cli')) {
 			return SetupResult::success($this->l10n->t('Checking from CLI, OPcache checks have been skipped.'));
 		}
 

--- a/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
+++ b/apps/settings/lib/SetupChecks/PhpOpcacheSetup.php
@@ -115,7 +115,7 @@ class PhpOpcacheSetup implements ISetupCheck {
 
 	public function run(): SetupResult {
 		// Skip OPcache checks if running from CLI
-		if (OC::$CLI && !$this->iniGetWrapper->getBool('opcache.enable_cli')) {
+		if (\OC::$CLI && !$this->iniGetWrapper->getBool('opcache.enable_cli')) {
 			return SetupResult::success($this->l10n->t('Checking from CLI, OPcache checks have been skipped.'));
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/46351

## Summary

We don't recommend to enable OPcache on CLI, so disable the checks in this case.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
