### PR TITLE
feat(occ): Add support for iterable in Base and use it in group:list and user:list

### DIFF
--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -37,17 +37,17 @@ class Base extends Command implements CompletionAwareInterface {
 		;
 	}
 
-	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, array $items, string $prefix = '  - '): void {
+	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, iterable $items, string $prefix = '  - '): void {
 		switch ($input->getOption('output')) {
 			case self::OUTPUT_FORMAT_JSON:
-				$output->writeln(json_encode($items));
+				$output->writeln(json_encode(iterator_to_array($items)));
 				break;
 			case self::OUTPUT_FORMAT_JSON_PRETTY:
-				$output->writeln(json_encode($items, JSON_PRETTY_PRINT));
+				$output->writeln(json_encode(iterator_to_array($items), JSON_PRETTY_PRINT));
 				break;
 			default:
 				foreach ($items as $key => $item) {
-					if (is_array($item)) {
+					if (is_iterable($item)) {
 						$output->writeln($prefix . $key . ':');
 						$this->writeArrayInOutputFormat($input, $output, $item, '  ' . $prefix);
 						continue;

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -40,10 +40,12 @@ class Base extends Command implements CompletionAwareInterface {
 	protected function writeArrayInOutputFormat(InputInterface $input, OutputInterface $output, iterable $items, string $prefix = '  - '): void {
 		switch ($input->getOption('output')) {
 			case self::OUTPUT_FORMAT_JSON:
-				$output->writeln(json_encode(iterator_to_array($items)));
+				$items = (is_array($items) ? $items : iterator_to_array($items));
+				$output->writeln(json_encode($items));
 				break;
 			case self::OUTPUT_FORMAT_JSON_PRETTY:
-				$output->writeln(json_encode(iterator_to_array($items), JSON_PRETTY_PRINT));
+				$items = (is_array($items) ? $items : iterator_to_array($items));
+				$output->writeln(json_encode($items, JSON_PRETTY_PRINT));
 				break;
 			default:
 				foreach ($items as $key => $item) {

--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -68,25 +68,18 @@ class ListCommand extends Base {
 
 	/**
 	 * @param IGroup[] $groups
-	 * @return array
 	 */
-	private function formatGroups(array $groups, bool $addInfo = false) {
-		$keys = array_map(function (IGroup $group) {
-			return $group->getGID();
-		}, $groups);
-
-		if ($addInfo) {
-			$values = array_map(function (IGroup $group) {
-				return [
+	private function formatGroups(array $groups, bool $addInfo = false): \Generator {
+		foreach ($groups as $group) {
+			if ($addInfo) {
+				$value = [
 					'backends' => $group->getBackendNames(),
 					'users' => $this->usersForGroup($group),
 				];
-			}, $groups);
-		} else {
-			$values = array_map(function (IGroup $group) {
-				return $this->usersForGroup($group);
-			}, $groups);
+			} else {
+				$value = $this->usersForGroup($group);
+			}
+			yield $group->getGID() => $value;
 		}
-		return array_combine($keys, $values);
 	}
 }

--- a/core/Command/User/ListCommand.php
+++ b/core/Command/User/ListCommand.php
@@ -69,18 +69,13 @@ class ListCommand extends Base {
 
 	/**
 	 * @param IUser[] $users
-	 * @param bool [$detailed=false]
-	 * @return array
+	 * @return \Generator<string,string|array>
 	 */
-	private function formatUsers(array $users, bool $detailed = false) {
-		$keys = array_map(function (IUser $user) {
-			return $user->getUID();
-		}, $users);
-
-		$values = array_map(function (IUser $user) use ($detailed) {
+	private function formatUsers(array $users, bool $detailed = false): \Generator {
+		foreach ($users as $user) {
 			if ($detailed) {
 				$groups = $this->groupManager->getUserGroupIds($user);
-				return [
+				$value = [
 					'user_id' => $user->getUID(),
 					'display_name' => $user->getDisplayName(),
 					'email' => (string)$user->getSystemEMailAddress(),
@@ -92,9 +87,10 @@ class ListCommand extends Base {
 					'user_directory' => $user->getHome(),
 					'backend' => $user->getBackendClassName()
 				];
+			} else {
+				$value = $user->getDisplayName();
 			}
-			return $user->getDisplayName();
-		}, $users);
-		return array_combine($keys, $values);
+			yield $user->getUID() => $value;
+		}
 	}
 }

--- a/tests/Core/Command/Group/ListCommandTest.php
+++ b/tests/Core/Command/Group/ListCommandTest.php
@@ -90,18 +90,20 @@ class ListCommandTest extends TestCase {
 			->with(
 				$this->equalTo($this->input),
 				$this->equalTo($this->output),
-				[
-					'group1' => [
-						'user1',
-						'user2',
-					],
-					'group2' => [
-					],
-					'group3' => [
-						'user1',
-						'user3',
+				$this->callback(
+					fn ($iterator) => iterator_to_array($iterator) === [
+						'group1' => [
+							'user1',
+							'user2',
+						],
+						'group2' => [
+						],
+						'group3' => [
+							'user1',
+							'user3',
+						]
 					]
-				]
+				)
 			);
 
 		$this->invokePrivate($this->command, 'execute', [$this->input, $this->output]);
@@ -166,26 +168,28 @@ class ListCommandTest extends TestCase {
 			->with(
 				$this->equalTo($this->input),
 				$this->equalTo($this->output),
-				[
-					'group1' => [
-						'backends' => ['Database'],
-						'users' => [
-							'user1',
-							'user2',
+				$this->callback(
+					fn ($iterator) => iterator_to_array($iterator) === [
+						'group1' => [
+							'backends' => ['Database'],
+							'users' => [
+								'user1',
+								'user2',
+							],
 						],
-					],
-					'group2' => [
-						'backends' => ['Database'],
-						'users' => [],
-					],
-					'group3' => [
-						'backends' => ['LDAP'],
-						'users' => [
-							'user1',
-							'user3',
+						'group2' => [
+							'backends' => ['Database'],
+							'users' => [],
 						],
+						'group3' => [
+							'backends' => ['LDAP'],
+							'users' => [
+								'user1',
+								'user3',
+							],
+						]
 					]
-				]
+				)
 			);
 
 		$this->invokePrivate($this->command, 'execute', [$this->input, $this->output]);


### PR DESCRIPTION
## Summary

This adds support for iterable in `OC\Core\Command\Base::writeArrayInOutputFormat` when output format is not json and takes advantage of it to make `group:list` output more fluid.
For `user:list` the impact is less noticable because the user array is prepared first and that takes up most of the time.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
