### PR TITLE
refactor: Use `IFilenameValidator` for all filename validation and remove other validation code

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -122,12 +122,11 @@ abstract class Node implements \Sabre\DAV\INode {
 
 		[$parentPath,] = \Sabre\Uri\split($this->path);
 		[, $newName] = \Sabre\Uri\split($name);
-
-		// verify path of the target
-		$this->verifyPath();
-
 		$newPath = $parentPath . '/' . $newName;
 
+		// verify path of the target
+		$this->verifyPath($newPath);
+		
 		if (!$this->fileView->rename($this->path, $newPath)) {
 			throw new \Sabre\DAV\Exception('Failed to rename '. $this->path . ' to ' . $newPath);
 		}
@@ -355,10 +354,12 @@ abstract class Node implements \Sabre\DAV\INode {
 		return $this->info->getOwner();
 	}
 
-	protected function verifyPath() {
+	protected function verifyPath(?string $path = null): void {
+		$path = $path ?? $this->info->getPath();
 		try {
-			$fileName = basename($this->info->getPath());
-			$this->fileView->verifyPath($this->path, $fileName);
+			$filename = basename($path);
+			$dirname = dirname($path);
+			$this->fileView->verifyPath($dirname, $filename);
 		} catch (\OCP\Files\InvalidPathException $ex) {
 			throw new InvalidPath($ex->getMessage());
 		}

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -397,7 +397,7 @@ class DirectoryTest extends \Test\TestCase {
 
 	public function moveFailedInvalidCharsProvider() {
 		return [
-			['a/b', 'a/*', ['a' => true, 'a/b' => true, 'a/c*' => false], []],
+			['a/b', 'a/	', ['a' => true, 'a/b' => true, 'a/c	' => false], []],
 		];
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -570,7 +570,7 @@ class FileTest extends TestCase {
 			->method('getRelativePath')
 			->willReturnArgument(0);
 
-		$info = new \OC\Files\FileInfo('/*', $this->getMockStorage(), null, [
+		$info = new \OC\Files\FileInfo("/\n", $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
@@ -611,14 +611,13 @@ class FileTest extends TestCase {
 			->method('getRelativePath')
 			->willReturnArgument(0);
 
-		$info = new \OC\Files\FileInfo('/*', $this->getMockStorage(), null, [
+		$info = new \OC\Files\FileInfo('/super', $this->getMockStorage(), null, [
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
-		$file->setName('/super*star.txt');
+		$file->setName("/super\nstar.txt");
 	}
-
 
 	public function testUploadAbort(): void {
 		// setup

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -15,6 +15,7 @@ use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\ObjectTree;
 use OCP\Files\Mount\IMountManager;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class ObjectTreeTest
@@ -205,12 +206,11 @@ class ObjectTreeTest extends \Test\TestCase {
 		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
 
 		$path = '/foo\bar';
-
-
 		$storage = new Temporary([]);
 
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
-			->setMethods(['resolvePath'])
+			->onlyMethods(['resolvePath'])
 			->getMock();
 		$view->expects($this->once())
 			->method('resolvePath')
@@ -218,6 +218,7 @@ class ObjectTreeTest extends \Test\TestCase {
 				return [$storage, ltrim($path, '/')];
 			});
 
+		/** @var Directory&MockObject */
 		$rootNode = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -23,6 +23,7 @@ use OCP\Federation\ICloudFederationProvider;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Federation\ICloudFederationShare;
 use OCP\Federation\ICloudIdManager;
+use OCP\Files\IFilenameValidator;
 use OCP\Files\NotFoundException;
 use OCP\HintException;
 use OCP\IConfig;
@@ -59,6 +60,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 		private IConfig $config,
 		private Manager $externalShareManager,
 		private LoggerInterface $logger,
+		private IFilenameValidator $filenameValidator,
 	) {
 	}
 
@@ -115,7 +117,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 		}
 
 		if ($remote && $token && $name && $owner && $remoteId && $shareWith) {
-			if (!Util::isValidFileName($name)) {
+			if (!$this->filenameValidator->isFilenameValid($name)) {
 				throw new ProviderCouldNotAddShareException('The mountpoint name contains invalid characters.', '', Http::STATUS_BAD_REQUEST);
 			}
 
@@ -732,7 +734,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 		}
 
 		try {
-			$slaveService = Server::get(\OCA\GlobalSiteSelector\Service\SlaveService::class);
+			$slaveService = Server::get('\OCA\GlobalSiteSelector\Service\SlaveService');
 		} catch (\Throwable $e) {
 			Server::get(LoggerInterface::class)->error(
 				$e->getMessage(),

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -187,10 +187,8 @@ class AvatarController extends Controller {
 				);
 			}
 		} elseif (!is_null($files)) {
-			if (
-				$files['error'][0] === 0 &&
-				 is_uploaded_file($files['tmp_name'][0]) &&
-				!\OC\Files\Filesystem::isFileBlacklisted($files['tmp_name'][0])
+			if ($files['error'][0] === 0
+				&& is_uploaded_file($files['tmp_name'][0])
 			) {
 				if ($files['size'][0] > 20 * 1024 * 1024) {
 					return new JSONResponse(

--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -29,9 +29,6 @@ class Filesystem {
 
 	private static ?CappedMemoryCache $normalizedPathCache = null;
 
-	/** @var string[]|null */
-	private static ?array $blacklist = null;
-
 	/**
 	 * classname which used for hooks handling
 	 * used as signalclass in OC_Hooks::emit()
@@ -426,21 +423,6 @@ class Filesystem {
 			return false;
 		}
 		return true;
-	}
-
-	/**
-	 * @param string $filename
-	 * @return bool
-	 */
-	public static function isFileBlacklisted($filename) {
-		$filename = self::normalizePath($filename);
-
-		if (self::$blacklist === null) {
-			self::$blacklist = \OC::$server->getConfig()->getSystemValue('blacklisted_files', ['.htaccess']);
-		}
-
-		$filename = strtolower(basename($filename));
-		return in_array($filename, self::$blacklist);
 	}
 
 	/**

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -18,6 +18,7 @@ use OCP\Diagnostics\IEventLogger;
 use OCP\Files\FileInfo;
 use OCP\Files\ForbiddenException;
 use OCP\Files\IMimeTypeDetector;
+use OCP\Files\InvalidPathException;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClientService;
@@ -561,7 +562,9 @@ class DAV extends Common {
 	}
 
 	public function getMetaData($path) {
-		if (Filesystem::isFileBlacklisted($path)) {
+		try {
+			$this->verifyPath($path, basename($path));
+		} catch (InvalidPathException) {
 			throw new ForbiddenException('Invalid path: ' . $path, false);
 		}
 		$response = $this->propfind($path);

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -321,7 +321,9 @@ class Local extends \OC\Files\Storage\Common {
 		/** @var \SplFileInfo $file */
 		foreach ($iterator as $file) {
 			if (!$this->getFilenameValidator()->isFilenameValid($file->getBasename())) {
-				throw new ForbiddenException('Invalid path: ' . $file->getPathname(), false);
+				// Do not leak data dir
+				$filePath = substr($file->getPathname(), strlen($this->datadir));
+				throw new ForbiddenException('Invalid path: ' . $filePath, false);
 			}
 		}
 	}

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -10,6 +10,7 @@ namespace OC\Security;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\Files\IFilenameValidator;
 use OCP\ICertificate;
 use OCP\ICertificateManager;
 use OCP\IConfig;
@@ -27,6 +28,7 @@ class CertificateManager implements ICertificateManager {
 		protected IConfig $config,
 		protected LoggerInterface $logger,
 		protected ISecureRandom $random,
+		protected IFilenameValidator $filenameValidator,
 	) {
 	}
 
@@ -150,7 +152,7 @@ class CertificateManager implements ICertificateManager {
 	 * @throws \Exception If the certificate could not get added
 	 */
 	public function addCertificate(string $certificate, string $name): ICertificate {
-		if (!Filesystem::isValidPath($name) or Filesystem::isFileBlacklisted($name)) {
+		if (!$this->filenameValidator->isFilenameValid($name)) {
 			throw new \Exception('Filename is not valid');
 		}
 		$this->bundlePath = null;

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\Files\FilenameValidator;
 use OC\Files\Filesystem;
 use OCP\Files\Mount\IMountPoint;
 use OCP\IBinaryFinder;
@@ -126,8 +127,11 @@ class OC_Helper {
 					self::copyr("$src/$file", "$dest/$file");
 				}
 			}
-		} elseif (file_exists($src) && !\OC\Files\Filesystem::isFileBlacklisted($src)) {
-			copy($src, $dest);
+		} elseif (file_exists($src)) {
+			$validator = \OCP\Server::get(FilenameValidator::class);
+			if (!$validator->isForbidden(\basename($src))) {
+				copy($src, $dest);
+			}
 		}
 	}
 
@@ -499,7 +503,7 @@ class OC_Helper {
 
 		// TODO: need a better way to get total space from storage
 		if ($sourceStorage->instanceOfStorage('\OC\Files\Storage\Wrapper\Quota')) {
-			/** @var \OC\Files\Storage\Wrapper\Quota $storage */
+			/** @var \OC\Files\Storage\Wrapper\Quota $sourceStorage */
 			$quota = $sourceStorage->getQuota();
 		}
 		try {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -1037,35 +1037,6 @@ class OC_Util {
 	}
 
 	/**
-	 * Returns whether the given file name is valid
-	 *
-	 * @param string $file file name to check
-	 * @return bool true if the file name is valid, false otherwise
-	 * @deprecated use \OC\Files\View::verifyPath()
-	 */
-	public static function isValidFileName($file) {
-		$trimmed = trim($file);
-		if ($trimmed === '') {
-			return false;
-		}
-		if (\OC\Files\Filesystem::isIgnoredDir($trimmed)) {
-			return false;
-		}
-
-		// detect part files
-		if (preg_match('/' . \OCP\Files\FileInfo::BLACKLIST_FILES_REGEX . '/', $trimmed) !== 0) {
-			return false;
-		}
-
-		foreach (\OCP\Util::getForbiddenFileNameChars() as $char) {
-			if (str_contains($trimmed, $char)) {
-				return false;
-			}
-		}
-		return true;
-	}
-
-	/**
 	 * Check whether the instance needs to perform an upgrade,
 	 * either when the core version is higher or any app requires
 	 * an upgrade.

--- a/lib/public/Files/FileInfo.php
+++ b/lib/public/Files/FileInfo.php
@@ -48,6 +48,7 @@ interface FileInfo {
 	/**
 	 * @const \OCP\Files\FileInfo::BLACKLIST_FILES_REGEX Return regular expression to test filenames against (blacklisting)
 	 * @since 12.0.0
+	 * @deprecated 30.0.0 Use \OCP\Files\Storage\IStorage::verifyPath()
 	 */
 	public const BLACKLIST_FILES_REGEX = '\.(part|filepart)$';
 

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -510,18 +510,6 @@ class Util {
 	}
 
 	/**
-	 * Returns whether the given file name is valid
-	 * @param string $file file name to check
-	 * @return bool true if the file name is valid, false otherwise
-	 * @deprecated 8.1.0 use OCP\Files\Storage\IStorage::verifyPath()
-	 * @since 7.0.0
-	 * @suppress PhanDeprecatedFunction
-	 */
-	public static function isValidFileName($file) {
-		return \OC_Util::isValidFileName($file);
-	}
-
-	/**
 	 * Compare two strings to provide a natural sort
 	 * @param string $a first string to compare
 	 * @param string $b second string to compare

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -18,7 +18,6 @@ use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Share\IManager;
 use Psr\Container\ContainerExceptionInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * This class provides different helper functions to make the life of a developer easier
@@ -486,27 +485,6 @@ class Util {
 	 */
 	public static function uploadLimit(): int|float {
 		return \OC_Helper::uploadLimit();
-	}
-
-	/**
-	 * Get a list of characters forbidden in file names
-	 * @return string[]
-	 * @since 29.0.0
-	 */
-	public static function getForbiddenFileNameChars(): array {
-		// Get always forbidden characters
-		$invalidChars = str_split(\OCP\Constants::FILENAME_INVALID_CHARS);
-		if ($invalidChars === false) {
-			$invalidChars = [];
-		}
-
-		// Get admin defined invalid characters
-		$additionalChars = \OCP\Server::get(IConfig::class)->getSystemValue('forbidden_chars', []);
-		if (!is_array($additionalChars)) {
-			\OCP\Server::get(LoggerInterface::class)->error('Invalid system config value for "forbidden_chars" is ignored.');
-			$additionalChars = [];
-		}
-		return array_merge($invalidChars, $additionalChars);
 	}
 
 	/**

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -258,28 +258,6 @@ class FilesystemTest extends \Test\TestCase {
 		$this->assertSame($expected, \OC\Files\Filesystem::isValidPath($path));
 	}
 
-	public function isFileBlacklistedData() {
-		return [
-			['/etc/foo/bar/foo.txt', false],
-			['\etc\foo/bar\foo.txt', false],
-			['.htaccess', true],
-			['.htaccess/', true],
-			['.htaccess\\', true],
-			['/etc/foo\bar/.htaccess\\', true],
-			['/etc/foo\bar/.htaccess/', true],
-			['/etc/foo\bar/.htaccess/foo', false],
-			['//foo//bar/\.htaccess/', true],
-			['\foo\bar\.HTAccess', true],
-		];
-	}
-
-	/**
-	 * @dataProvider isFileBlacklistedData
-	 */
-	public function testIsFileBlacklisted($path, $expected) {
-		$this->assertSame($expected, \OC\Files\Filesystem::isFileBlacklisted($path));
-	}
-
 	public function testNormalizePathUTF8() {
 		if (!class_exists('Patchwork\PHP\Shim\Normalizer')) {
 			$this->markTestSkipped('UTF8 normalizer Patchwork was not found');

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -115,12 +115,16 @@ class PathVerificationTest extends \Test\TestCase {
 		$storage = new Local(['datadir' => '']);
 
 		$fileName = " 123{$fileName}456 ";
-		self::invokePrivate($storage, 'verifyPosixPath', [$fileName]);
+		$storage->verifyPath('', $fileName);
 	}
 
 	public function providesInvalidCharsPosix() {
 		return [
+			// posix forbidden
 			[\chr(0)],
+			['/'],
+			['\\'],
+			// We restrict also ascii 1-31
 			[\chr(1)],
 			[\chr(2)],
 			[\chr(3)],
@@ -152,8 +156,6 @@ class PathVerificationTest extends \Test\TestCase {
 			[\chr(29)],
 			[\chr(30)],
 			[\chr(31)],
-			['/'],
-			['\\'],
 		];
 	}
 

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -8,7 +8,9 @@
 namespace Test\Files\Storage;
 
 use OC\Files\Cache\Watcher;
+use OC\Files\FilenameValidator;
 use OCP\Files\Storage\IWriteStreamStorage;
+use PHPUnit\Framework\MockObject\MockObject;
 
 abstract class Storage extends \Test\TestCase {
 	/**
@@ -16,6 +18,22 @@ abstract class Storage extends \Test\TestCase {
 	 */
 	protected $instance;
 	protected $waitDelay = 0;
+
+	protected FilenameValidator&MockObject $filenameValidator;
+
+	protected function setUp(): void {
+		$this->filenameValidator = $this->createMock(FilenameValidator::class);
+		$this->filenameValidator->method('isFilenameValid')->willReturn(true);
+		$this->filenameValidator->method('isForbidden')->willReturn(false);
+		$this->overwriteService(FilenameValidator::class, $this->filenameValidator);
+
+		parent::setUp();
+	}
+
+	protected function tearDown(): void {
+		$this->restoreService(FilenameValidator::class);
+		parent::tearDown();
+	}
 
 	/**
 	 * Sleep for the number of seconds specified in the

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -138,64 +138,6 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider filenameValidationProvider
-	 */
-	public function testFilenameValidation($file, $valid) {
-		// private API
-		$this->assertEquals($valid, \OC_Util::isValidFileName($file));
-		// public API
-		$this->assertEquals($valid, \OCP\Util::isValidFileName($file));
-	}
-
-	public function filenameValidationProvider() {
-		return [
-			// valid names
-			['boringname', true],
-			['something.with.extension', true],
-			['now with spaces', true],
-			['.a', true],
-			['..a', true],
-			['.dotfile', true],
-			['single\'quote', true],
-			['  spaces before', true],
-			['spaces after   ', true],
-			['allowed chars including the crazy ones $%&_-^@!,()[]{}=;#', true],
-			['汉字也能用', true],
-			['und Ümläüte sind auch willkommen', true],
-			// disallowed names
-			['', false],
-			['     ', false],
-			['.', false],
-			['..', false],
-			['back\\slash', false],
-			['sl/ash', false],
-			['lt<lt', true],
-			['gt>gt', true],
-			['col:on', true],
-			['double"quote', true],
-			['pi|pe', true],
-			['dont?ask?questions?', true],
-			['super*star', true],
-			['new\nline', false],
-
-			// better disallow these to avoid unexpected trimming to have side effects
-			[' ..', false],
-			['.. ', false],
-			['. ', false],
-			[' .', false],
-
-			// part files not allowed
-			['.part', false],
-			['notallowed.part', false],
-			['neither.filepart', false],
-
-			// part in the middle is ok
-			['super movie part one.mkv', true],
-			['super.movie.part.mkv', true],
-		];
-	}
-
-	/**
 	 * Test needUpgrade() when the core version is increased
 	 */
 	public function testNeedUpgradeCore() {


### PR DESCRIPTION
* [x] Chained on #46371 
* For #44963 

## Summary

This will migrate all filename validation from custom code to `IFilenameValidator`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
