### PR TITLE
fix: `OCP\Files\Node\Folder::search` was not setting the owner

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -12,6 +12,7 @@ use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchOrder;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Utils\PathHelper;
+use OC\User\LazyUser;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
 use OCP\Files\Mount\IMountPoint;
@@ -26,6 +27,9 @@ use OCP\Files\Search\ISearchQuery;
 use OCP\IUserManager;
 
 class Folder extends Node implements \OCP\Files\Folder {
+
+	private ?IUserManager $userManager = null;
+
 	/**
 	 * Creates a Folder that represents a non-existing path
 	 *
@@ -245,7 +249,26 @@ class Folder extends Node implements \OCP\Files\Folder {
 		$cacheEntry['internalPath'] = $cacheEntry['path'];
 		$cacheEntry['path'] = rtrim($appendRoot . $cacheEntry->getPath(), '/');
 		$subPath = $cacheEntry['path'] !== '' ? '/' . $cacheEntry['path'] : '';
-		return new \OC\Files\FileInfo($this->path . $subPath, $mount->getStorage(), $cacheEntry['internalPath'], $cacheEntry, $mount);
+		$storage = $mount->getStorage();
+
+		$owner = null;
+		$ownerId = $storage->getOwner($cacheEntry['internalPath']);
+		if (!empty($ownerId)) {
+			// Cache the user manager (for performance)
+			if ($this->userManager === null) {
+				$this->userManager = \OCP\Server::get(IUserManager::class);
+			}
+			$owner = new LazyUser($ownerId, $this->userManager);
+		}
+
+		return new \OC\Files\FileInfo(
+			$this->path . $subPath,
+			$storage,
+			$cacheEntry['internalPath'],
+			$cacheEntry,
+			$mount,
+			$owner,
+		);
 	}
 
 	/**

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -29,6 +29,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOrder;
 use OCP\Files\Storage;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class FolderTest
@@ -290,7 +291,7 @@ class FolderTest extends NodeTest {
 			->getMock();
 		$root->method('getUser')
 			->willReturn($this->user);
-		/** @var Storage\IStorage $storage */
+		/** @var Storage\IStorage&MockObject $storage */
 		$storage = $this->createMock(Storage\IStorage::class);
 		$storage->method('getId')->willReturn('test::1');
 		$cache = new Cache($storage);
@@ -298,10 +299,17 @@ class FolderTest extends NodeTest {
 		$storage->method('getCache')
 			->willReturn($cache);
 
+		$storage->expects($this->atLeastOnce())
+			->method('getOwner')
+			->with('qwerty')
+			->willReturn(false);
+
 		$mount = $this->createMock(IMountPoint::class);
-		$mount->method('getStorage')
+		$mount->expects($this->atLeastOnce())
+			->method('getStorage')
 			->willReturn($storage);
-		$mount->method('getInternalPath')
+		$mount->expects($this->atLeastOnce())
+			->method('getInternalPath')
 			->willReturn('foo');
 
 		$cache->insert('foo', ['size' => 200, 'mtime' => 55, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);


### PR DESCRIPTION
* Fixed Ticket#9663948

## Summary

The owner was not set on the file info causing e.g. webdav searches to never return the known owner.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
