### PR TITLE
fix: set default TTL for APCu cache as per docs

### DIFF
--- a/lib/private/Memcache/APCu.php
+++ b/lib/private/Memcache/APCu.php
@@ -25,6 +25,9 @@ class APCu extends Cache implements IMemcache {
 	}
 
 	public function set($key, $value, $ttl = 0) {
+		if ($ttl === 0) {
+			$ttl = self::DEFAULT_TTL;
+		}
 		return apcu_store($this->getPrefix() . $key, $value, $ttl);
 	}
 
@@ -56,6 +59,9 @@ class APCu extends Cache implements IMemcache {
 	 * @return bool
 	 */
 	public function add($key, $value, $ttl = 0) {
+		if ($ttl === 0) {
+			$ttl = self::DEFAULT_TTL;
+		}
 		return apcu_add($this->getPrefix() . $key, $value, $ttl);
 	}
 

--- a/lib/private/Memcache/APCu.php
+++ b/lib/private/Memcache/APCu.php
@@ -73,22 +73,8 @@ class APCu extends Cache implements IMemcache {
 	 * @return int | bool
 	 */
 	public function inc($key, $step = 1) {
-		$this->add($key, 0);
-		/**
-		 * TODO - hack around a PHP 7 specific issue in APCu
-		 *
-		 * on PHP 7 the apcu_inc method on a non-existing object will increment
-		 * "0" and result in "1" as value - therefore we check for existence
-		 * first
-		 *
-		 * on PHP 5.6 this is not the case
-		 *
-		 * see https://github.com/krakjoe/apcu/issues/183#issuecomment-244038221
-		 * for details
-		 */
-		return apcu_exists($this->getPrefix() . $key)
-			? apcu_inc($this->getPrefix() . $key, $step)
-			: false;
+		$success = null;
+		return apcu_inc($this->getPrefix() . $key, $step, $success, self::DEFAULT_TTL);
 	}
 
 	/**
@@ -99,18 +85,6 @@ class APCu extends Cache implements IMemcache {
 	 * @return int | bool
 	 */
 	public function dec($key, $step = 1) {
-		/**
-		 * TODO - hack around a PHP 7 specific issue in APCu
-		 *
-		 * on PHP 7 the apcu_dec method on a non-existing object will decrement
-		 * "0" and result in "-1" as value - therefore we check for existence
-		 * first
-		 *
-		 * on PHP 5.6 this is not the case
-		 *
-		 * see https://github.com/krakjoe/apcu/issues/183#issuecomment-244038221
-		 * for details
-		 */
 		return apcu_exists($this->getPrefix() . $key)
 			? apcu_dec($this->getPrefix() . $key, $step)
 			: false;

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -29,7 +29,6 @@ class Redis extends Cache implements IMemcacheTTL {
 		],
 	];
 
-	private const DEFAULT_TTL = 24 * 60 * 60; // 1 day
 	private const MAX_TTL = 30 * 24 * 60 * 60; // 1 month
 
 	/**

--- a/lib/public/ICache.php
+++ b/lib/public/ICache.php
@@ -16,6 +16,11 @@ namespace OCP;
  */
 interface ICache {
 	/**
+	 * @since 30.0.0
+	 */
+	public const DEFAULT_TTL = 24 * 60 * 60;
+
+	/**
 	 * Get a value from the user cache
 	 * @param string $key
 	 * @return mixed

--- a/lib/public/IMemcache.php
+++ b/lib/public/IMemcache.php
@@ -30,6 +30,9 @@ interface IMemcache extends ICache {
 	/**
 	 * Increase a stored number
 	 *
+	 * If no value is stored with the key, it will behave as if a 0 was stored.
+	 * If a non-numeric value is stored, the operation will fail and `false` is returned.
+	 *
 	 * @param string $key
 	 * @param int $step
 	 * @return int | bool
@@ -39,6 +42,9 @@ interface IMemcache extends ICache {
 
 	/**
 	 * Decrease a stored number
+	 *
+	 *  If no value is stored with the key, the operation will fail and `false` is returned.
+	 *  If a non-numeric value is stored, the operation will fail and `false` is returned.
 	 *
 	 * @param string $key
 	 * @param int $step

--- a/psalm.xml
+++ b/psalm.xml
@@ -151,5 +151,12 @@
 				<referencedClass name="OCA\GlobalSiteSelector\Service\SlaveService"/>
 			</errorLevel>
 		</UndefinedDocblockClass>
+		<AmbiguousConstantInheritance>
+			<errorLevel type="suppress">
+				<!-- false positive: https://github.com/vimeo/psalm/issues/7818 -->
+				<referencedConstant name="OC\Memcache\Redis::DEFAULT_TTL" />
+				<referencedConstant name="OC\Memcache\LoggerWrapperCache::DEFAULT_TTL" />
+			</errorLevel>
+		</AmbiguousConstantInheritance>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
Make the method behavior match the description