### PR TITLE
feat: allow inspecting the parts of the composite expression builder

### DIFF
--- a/lib/private/DB/QueryBuilder/CompositeExpression.php
+++ b/lib/private/DB/QueryBuilder/CompositeExpression.php
@@ -5,21 +5,19 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\DB\QueryBuilder;
 
 use OCP\DB\QueryBuilder\ICompositeExpression;
 
 class CompositeExpression implements ICompositeExpression, \Countable {
-	/** @var \Doctrine\DBAL\Query\Expression\CompositeExpression */
-	protected $compositeExpression;
+	public const TYPE_AND = 'AND';
+	public const TYPE_OR = 'OR';
 
-	/**
-	 * Constructor.
-	 *
-	 * @param \Doctrine\DBAL\Query\Expression\CompositeExpression $compositeExpression
-	 */
-	public function __construct(\Doctrine\DBAL\Query\Expression\CompositeExpression $compositeExpression) {
-		$this->compositeExpression = $compositeExpression;
+	public function __construct(
+		private string $type,
+		private array  $parts = []
+	) {
 	}
 
 	/**
@@ -30,7 +28,9 @@ class CompositeExpression implements ICompositeExpression, \Countable {
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
 	public function addMultiple(array $parts = []): ICompositeExpression {
-		$this->compositeExpression->addMultiple($parts);
+		foreach ($parts as $part) {
+			$this->add($part);
+		}
 
 		return $this;
 	}
@@ -43,7 +43,15 @@ class CompositeExpression implements ICompositeExpression, \Countable {
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
 	public function add($part): ICompositeExpression {
-		$this->compositeExpression->add($part);
+		if ($part === null) {
+			return $this;
+		}
+
+		if ($part instanceof self && count($part) === 0) {
+			return $this;
+		}
+
+		$this->parts[] = $part;
 
 		return $this;
 	}
@@ -54,7 +62,7 @@ class CompositeExpression implements ICompositeExpression, \Countable {
 	 * @return integer
 	 */
 	public function count(): int {
-		return $this->compositeExpression->count();
+		return count($this->parts);
 	}
 
 	/**
@@ -63,7 +71,7 @@ class CompositeExpression implements ICompositeExpression, \Countable {
 	 * @return string
 	 */
 	public function getType(): string {
-		return $this->compositeExpression->getType();
+		return $this->type;
 	}
 
 	/**
@@ -72,6 +80,13 @@ class CompositeExpression implements ICompositeExpression, \Countable {
 	 * @return string
 	 */
 	public function __toString(): string {
-		return (string) $this->compositeExpression;
+		if ($this->count() === 1) {
+			return (string)$this->parts[0];
+		}
+		return '(' . implode(') ' . $this->type . ' (', $this->parts) . ')';
+	}
+
+	public function getParts(): array {
+		return $this->parts;
 	}
 }

--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/ExpressionBuilder.php
@@ -63,8 +63,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
 	public function andX(...$x): ICompositeExpression {
-		$compositeExpression = call_user_func_array([$this->expressionBuilder, 'andX'], $x);
-		return new CompositeExpression($compositeExpression);
+		return new CompositeExpression(CompositeExpression::TYPE_AND, $x);
 	}
 
 	/**
@@ -82,8 +81,7 @@ class ExpressionBuilder implements IExpressionBuilder {
 	 * @return \OCP\DB\QueryBuilder\ICompositeExpression
 	 */
 	public function orX(...$x): ICompositeExpression {
-		$compositeExpression = call_user_func_array([$this->expressionBuilder, 'orX'], $x);
-		return new CompositeExpression($compositeExpression);
+		return new CompositeExpression(CompositeExpression::TYPE_OR, $x);
 	}
 
 	/**


### PR DESCRIPTION
DBAL's `CompositeExpression` doesn't allow getting the parts of the expression for introspection.

This replaces the logic of the `CompositeExpression` with a custom so that our code can inspect the expression.

Extracted from, and needed for the sharding work.