### PR TITLE
fix(Session): avoid race conditions on clustered setups

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2881,6 +2881,9 @@
       <code><![CDATA[$request->server]]></code>
       <code><![CDATA[$request->server]]></code>
     </NoInterfaceProperties>
+    <RedundantCondition>
+      <code><![CDATA[$this->manager instanceof PublicEmitter]]></code>
+    </RedundantCondition>
   </file>
   <file src="lib/private/User/User.php">
     <UndefinedInterfaceMethod>

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -171,7 +171,7 @@ class PublicKeyTokenProvider implements IProvider {
 	private function getTokenFromCache(string $tokenHash): ?PublicKeyToken {
 		$serializedToken = $this->cache->get($tokenHash);
 		if ($serializedToken === false) {
-			throw new InvalidTokenException('Token does not exist: ' . $tokenHash);
+			return null;
 		}
 
 		if ($serializedToken === null) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -506,7 +506,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(ISecureRandom::class),
 				$c->get('LockdownManager'),
 				$c->get(LoggerInterface::class),
-				$c->get(IEventDispatcher::class)
+				$c->get(IEventDispatcher::class),
 			);
 			/** @deprecated 21.0.0 use BeforeUserCreatedEvent event with the IEventDispatcher instead */
 			$userSession->listen('\OC\User', 'preCreateUser', function ($uid, $password) {


### PR DESCRIPTION
* Resolves: #46165

## Summary

- re-stablishes old behaviour with cache to return null instead of throwing an InvalidTokenException when the token is cached as non-existing
- token invalidation and re-generation are bundled in a DB transaction now

Maybe that is not the final solution to this problem. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
