### PR TITLE
fix: use non-mocked app manager for router test

### DIFF
--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -8,13 +8,18 @@ declare(strict_types=1);
 
 namespace Test\Route;
 
+use OC\App\AppManager;
 use OC\Route\Router;
-use OCP\App\IAppManager;
 use OCP\Diagnostics\IEventLogger;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Test\TestCase;
 
 /**
@@ -36,13 +41,27 @@ class RouterTest extends TestCase {
 					$this->fail('Unexpected info log: '.(string)($data['exception'] ?? $message));
 				}
 			);
+
+		/**
+		 * The router needs to resolve an app id to an app path.
+		 * A non-mocked AppManager instance is required.
+		 */
+		$appManager = new AppManager(
+			$this->createMock(IUserSession::class),
+			$this->createMock(IConfig::class),
+			$this->createMock(IGroupManager::class),
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
+			new NullLogger(),
+		);
+
 		$this->router = new Router(
 			$logger,
 			$this->createMock(IRequest::class),
 			$this->createMock(IConfig::class),
 			$this->createMock(IEventLogger::class),
 			$this->createMock(ContainerInterface::class),
-			$this->createMock(IAppManager::class),
+			$appManager,
 		);
 	}
 

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -65,10 +65,18 @@ class RouterTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function testHeartbeat(): void {
 		$this->assertEquals('/index.php/heartbeat', $this->router->generate('heartbeat'));
 	}
 
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
 	public function testGenerateConsecutively(): void {
 
 		$this->assertEquals('/index.php/apps/files/', $this->router->generate('files.view.index'));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: noid

## Summary

The mocked version of IAppManager will return null for getAppPath and thus parts of the tests are not executed.

To avoid more mocking a "partly" mocked IAppManager instanced is used.


## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
