### PR TITLE
fix(mail): Fix big logos in mail templates for Outlook

### DIFF
--- a/apps/settings/tests/Mailer/NewUserMailHelperTest.php
+++ b/apps/settings/tests/Mailer/NewUserMailHelperTest.php
@@ -57,6 +57,8 @@ class NewUserMailHelperTest extends TestCase {
 			$this->defaults,
 			$this->urlGenerator,
 			$this->l10nFactory,
+			null,
+			null,
 			'test.TestTemplate',
 			[]
 		);

--- a/apps/theming/lib/ImageManager.php
+++ b/apps/theming/lib/ImageManager.php
@@ -194,6 +194,10 @@ class ImageManager {
 		} catch (NotFoundException $e) {
 		} catch (NotPermittedException $e) {
 		}
+
+		if ($key === 'logo') {
+			$this->config->deleteAppValue('theming', 'logoDimensions');
+		}
 	}
 
 	public function updateImage(string $key, string $tmpFile): string {
@@ -265,6 +269,25 @@ class ImageManager {
 		}
 
 		$target->putContent(file_get_contents($tmpFile));
+
+		if ($key === 'logo') {
+			$content = file_get_contents($tmpFile);
+			$newImage = @imagecreatefromstring($content);
+			if ($newImage !== false) {
+				$this->config->setAppValue('theming', 'logoDimensions', imagesx($newImage) . 'x' . imagesy($newImage));
+			} elseif (str_starts_with($detectedMimeType, 'image/svg')) {
+				$matched = preg_match('/viewbox=["\']\d* \d* (\d*\.?\d*) (\d*\.?\d*)["\']/i', $content, $matches);
+				if ($matched) {
+					$this->config->setAppValue('theming', 'logoDimensions', $matches[1] . 'x' . $matches[2]);
+				} else {
+					$this->logger->warning('Could not read logo image dimensions to optimize for mail header');
+					$this->config->deleteAppValue('theming', 'logoDimensions');
+				}
+			} else {
+				$this->logger->warning('Could not read logo image dimensions to optimize for mail header');
+				$this->config->deleteAppValue('theming', 'logoDimensions');
+			}
+		}
 
 		return $detectedMimeType;
 	}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1757,6 +1757,7 @@ return array(
     'OC\\Repair\\RemoveLinkShares' => $baseDir . '/lib/private/Repair/RemoveLinkShares.php',
     'OC\\Repair\\RepairDavShares' => $baseDir . '/lib/private/Repair/RepairDavShares.php',
     'OC\\Repair\\RepairInvalidShares' => $baseDir . '/lib/private/Repair/RepairInvalidShares.php',
+    'OC\\Repair\\RepairLogoDimension' => $baseDir . '/lib/private/Repair/RepairLogoDimension.php',
     'OC\\Repair\\RepairMimeTypes' => $baseDir . '/lib/private/Repair/RepairMimeTypes.php',
     'OC\\RichObjectStrings\\Validator' => $baseDir . '/lib/private/RichObjectStrings/Validator.php',
     'OC\\Route\\CachingRouter' => $baseDir . '/lib/private/Route/CachingRouter.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1790,6 +1790,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Repair\\RemoveLinkShares' => __DIR__ . '/../../..' . '/lib/private/Repair/RemoveLinkShares.php',
         'OC\\Repair\\RepairDavShares' => __DIR__ . '/../../..' . '/lib/private/Repair/RepairDavShares.php',
         'OC\\Repair\\RepairInvalidShares' => __DIR__ . '/../../..' . '/lib/private/Repair/RepairInvalidShares.php',
+        'OC\\Repair\\RepairLogoDimension' => __DIR__ . '/../../..' . '/lib/private/Repair/RepairLogoDimension.php',
         'OC\\Repair\\RepairMimeTypes' => __DIR__ . '/../../..' . '/lib/private/Repair/RepairMimeTypes.php',
         'OC\\RichObjectStrings\\Validator' => __DIR__ . '/../../..' . '/lib/private/RichObjectStrings/Validator.php',
         'OC\\Route\\CachingRouter' => __DIR__ . '/../../..' . '/lib/private/Route/CachingRouter.php',

--- a/lib/private/Mail/EMailTemplate.php
+++ b/lib/private/Mail/EMailTemplate.php
@@ -76,7 +76,7 @@ EOF;
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="background-color:%s;min-width:175px;max-height:175px; padding:35px 0px;border-radius:200px">
-									<img class="logo float-center" src="%s" alt="%s" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto">
+									<img class="logo float-center" src="%s" alt="%s" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto"%s>
 								</center>
 							</tr>
 							</tbody>
@@ -308,6 +308,8 @@ EOF;
 		protected Defaults $themingDefaults,
 		protected IURLGenerator $urlGenerator,
 		protected IFactory $l10nFactory,
+		protected ?int $logoWidth,
+		protected ?int $logoHeight,
 		protected string $emailId,
 		protected array $data,
 	) {
@@ -330,8 +332,14 @@ EOF;
 		}
 		$this->headerAdded = true;
 
+		$logoSizeDimensions = '';
+		if ($this->logoWidth && $this->logoHeight) {
+			// Provide a logo size when we have the dimensions so that it displays nicely in Outlook
+			$logoSizeDimensions = ' width="' . $this->logoWidth . '" height="' . $this->logoHeight . '"';
+		}
+
 		$logoUrl = $this->urlGenerator->getAbsoluteURL($this->themingDefaults->getLogo(false));
-		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getDefaultColorPrimary(), $logoUrl, $this->themingDefaults->getName()]);
+		$this->htmlBody .= vsprintf($this->header, [$this->themingDefaults->getDefaultColorPrimary(), $logoUrl, $this->themingDefaults->getName(), $logoSizeDimensions]);
 	}
 
 	/**

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -52,6 +52,12 @@ use Symfony\Component\Mime\Exception\RfcComplianceException;
  * @package OC\Mail
  */
 class Mailer implements IMailer {
+	// Do not move this block or change it's content without contacting the release crew
+	public const DEFAULT_DIMENSIONS = '252x120';
+	// Do not move this block or change it's content without contacting the release crew
+
+	public const MAX_LOGO_SIZE = 105;
+
 	private ?MailerInterface $instance = null;
 
 	public function __construct(
@@ -109,10 +115,37 @@ class Mailer implements IMailer {
 			);
 		}
 
+		$logoDimensions = $this->config->getAppValue('theming', 'logoDimensions', self::DEFAULT_DIMENSIONS);
+		if (str_contains($logoDimensions, 'x')) {
+			[$width, $height] = explode('x', $logoDimensions);
+			$width = (int) $width;
+			$height = (int) $height;
+
+			if ($width > self::MAX_LOGO_SIZE || $height > self::MAX_LOGO_SIZE) {
+				if ($width === $height) {
+					$logoWidth = self::MAX_LOGO_SIZE;
+					$logoHeight = self::MAX_LOGO_SIZE;
+				} elseif ($width > $height) {
+					$logoWidth = self::MAX_LOGO_SIZE;
+					$logoHeight = (int) (($height / $width) * self::MAX_LOGO_SIZE);
+				} else {
+					$logoWidth = (int) (($width / $height) * self::MAX_LOGO_SIZE);
+					$logoHeight = self::MAX_LOGO_SIZE;
+				}
+			} else {
+				$logoWidth = $width;
+				$logoHeight = $height;
+			}
+		} else {
+			$logoWidth = $logoHeight = null;
+		}
+
 		return new EMailTemplate(
 			$this->defaults,
 			$this->urlGenerator,
 			$this->l10nFactory,
+			$logoWidth,
+			$logoHeight,
 			$emailId,
 			$data
 		);

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -52,6 +52,7 @@ use OC\Repair\Owncloud\UpdateLanguageCodes;
 use OC\Repair\RemoveLinkShares;
 use OC\Repair\RepairDavShares;
 use OC\Repair\RepairInvalidShares;
+use OC\Repair\RepairLogoDimension;
 use OC\Repair\RepairMimeTypes;
 use OC\Template\JSCombiner;
 use OCA\DAV\Migration\DeleteSchedulingObjects;
@@ -187,6 +188,7 @@ class Repair implements IOutput {
 			\OCP\Server::get(AddRemoveOldTasksBackgroundJob::class),
 			\OCP\Server::get(AddMetadataGenerationJob::class),
 			\OCP\Server::get(AddAppConfigLazyMigration::class),
+			\OCP\Server::get(RepairLogoDimension::class),
 		];
 	}
 

--- a/lib/private/Repair/RepairLogoDimension.php
+++ b/lib/private/Repair/RepairLogoDimension.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Repair;
+
+use OCA\Theming\ImageManager;
+use OCP\IConfig;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use OCP\Server;
+
+class RepairLogoDimension implements IRepairStep {
+	public function __construct(
+		protected IConfig $config,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Cache logo dimension to fix size in emails on Outlook';
+	}
+
+	public function run(IOutput $output): void {
+		$logoDimensions = $this->config->getAppValue('theming', 'logoDimensions');
+		if (preg_match('/^\d+x\d+$/', $logoDimensions)) {
+			$output->info('Logo dimensions are already known');
+			return;
+		}
+
+		try {
+			/** @var ImageManager $imageManager */
+			$imageManager = Server::get(ImageManager::class);
+		} catch (\Throwable) {
+			$output->info('Theming is disabled');
+			return;
+		}
+
+		if (!$imageManager->hasImage('logo')) {
+			$output->info('Theming is not used to provide a logo');
+			return;
+		}
+
+		$simpleFile = $imageManager->getImage('logo', false);
+
+		$image = @imagecreatefromstring($simpleFile->getContent());
+
+		$dimensions = '';
+		if ($image !== false) {
+			$dimensions = imagesx($image) . 'x' . imagesy($image);
+		} elseif (str_starts_with($simpleFile->getMimeType(), 'image/svg')) {
+			$matched = preg_match('/viewbox=["\']\d* \d* (\d*\.?\d*) (\d*\.?\d*)["\']/i', $simpleFile->getContent(), $matches);
+			if ($matched) {
+				$dimensions = $matches[1] . 'x' . $matches[2];
+			}
+		}
+
+		if (!$dimensions) {
+			$output->warning('Failed to read dimensions from logo');
+			$this->config->deleteAppValue('theming', 'logoDimensions');
+			return;
+		}
+
+		$dimensions = imagesx($image) . 'x' . imagesy($image);
+		$this->config->setAppValue('theming', 'logoDimensions', $dimensions);
+		$output->info('Updated logo dimensions: ' . $dimensions);
+	}
+}

--- a/tests/data/emails/new-account-email-custom.html
+++ b/tests/data/emails/new-account-email-custom.html
@@ -23,7 +23,7 @@
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="background-color:#0082c9;min-width:175px;max-height:175px; padding:35px 0px;border-radius:200px">
-									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto">
+									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto" width="252" height="120">
 								</center>
 							</tr>
 							</tbody>

--- a/tests/data/emails/new-account-email-single-button.html
+++ b/tests/data/emails/new-account-email-single-button.html
@@ -23,7 +23,7 @@
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="background-color:#0082c9;min-width:175px;max-height:175px; padding:35px 0px;border-radius:200px">
-									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto">
+									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto" width="252" height="120">
 								</center>
 							</tr>
 							</tbody>

--- a/tests/data/emails/new-account-email.html
+++ b/tests/data/emails/new-account-email.html
@@ -23,7 +23,7 @@
 							<tbody>
 							<tr style="padding:0;text-align:left;vertical-align:top">
 								<center data-parsed="" style="background-color:#0082c9;min-width:175px;max-height:175px; padding:35px 0px;border-radius:200px">
-									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto">
+									<img class="logo float-center" src="https://example.org/img/logo-mail-header.png" alt="TestCloud" align="center" style="-ms-interpolation-mode:bicubic;clear:both;display:block;float:none;margin:0 auto;outline:0;text-align:center;text-decoration:none;max-height:105px;max-width:105px;width:auto;height:auto" width="252" height="120">
 								</center>
 							</tr>
 							</tbody>

--- a/tests/lib/Mail/EMailTemplateTest.php
+++ b/tests/lib/Mail/EMailTemplateTest.php
@@ -38,6 +38,8 @@ class EMailTemplateTest extends TestCase {
 			$this->defaults,
 			$this->urlGenerator,
 			$this->l10n,
+			252,
+			120,
 			'test.TestTemplate',
 			[]
 		);

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -236,6 +236,9 @@ class MailerTest extends TestCase {
 		$this->config->method('getSystemValueString')
 			->with('mail_template_class', '')
 			->willReturnArgument(1);
+		$this->config->method('getAppValue')
+			->with('theming', 'logoDimensions', Mailer::DEFAULT_DIMENSIONS)
+			->willReturn(Mailer::DEFAULT_DIMENSIONS);
 
 		$this->assertSame(EMailTemplate::class, get_class($this->mailer->createEMailTemplate('tests.MailerTest')));
 	}


### PR DESCRIPTION
Case | Before | After
---|---|---
Huge image | ![3308-1758-max](https://github.com/nextcloud/server/assets/213943/1c8d05ca-849c-49fc-8267-e06545647898) | ![2188-710-max](https://github.com/nextcloud/server/assets/213943/f4c9c759-082d-42e2-ae9b-f3c6a0e3ec35)
Mini image | |![2188-740-max2](https://github.com/nextcloud/server/assets/213943/2da65ed2-603b-4709-a422-73afd38bc3c4)

## Todo
- [x] Create repair step to cache the image size on update
- [ ] Adjustments for enterprise logo

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
