### PR TITLE
fix(theming): Don't reset the cachebuster value when we reset theming

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -437,7 +437,11 @@ class ThemingDefaults extends \OC_Defaults {
 	 * Revert all settings to the default value
 	 */
 	public function undoAll(): void {
+		// Remember the current cachebuster value, as we do not want to reset this value
+		// Otherwise this can lead to caching issues as the value might be known to a browser already
+		$cacheBusterKey = $this->config->getAppValue('theming', 'cachebuster', '0');
 		$this->config->deleteAppValues('theming');
+		$this->config->setAppValue('theming', 'cachebuster', $cacheBusterKey);
 		$this->increaseCacheBuster();
 	}
 


### PR DESCRIPTION
- Resolves cypress failures after merge of https://github.com/nextcloud/server/pull/46320

## Summary

From the other PR:
> By default there is a Pragma: no-cache header set due to the default
value no-cache of session.cache-limiter, which will cause Chrome and
iOS to not cache even with a different Cache-Control header set on the
response.

After the PR was merged the cypress-tests `theming/AdminSettings` kept failing. Since we now don't have a `pragma: no-cache` header anymore, we now rely on `cache-control` header and our cachebuster implementation to make sure that we get the correct files. For some files, we rely on a cachebuster based on appVersion and cachebuster value: 

https://github.com/nextcloud/server/blob/b97c7dfe7f162680ffd9720ece12cdcd3ab656cd/lib/private/TemplateLayout.php#L298-L331

To make sure individual tests are reliable, we reset the theming settings completely before each test:

https://github.com/nextcloud/server/blob/b97c7dfe7f162680ffd9720ece12cdcd3ab656cd/apps/theming/lib/ThemingDefaults.php#L439-L442

This also results in a removed cachebuster value and therefore we get the same urls in different tests which (with the changes of the other PR) results in electron to use a cached version of the file, instead of requesting the latest one.
To fix this, we keep the cachebuster value when resetting theming and increase it afterwards.

## TODO

- [x] Don't increase twice

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
