### PR TITLE
feat., Imaginary: disable document processing by default

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1308,8 +1308,8 @@ $CONFIG = [
 'preview_imaginary_key' => 'secret',
 
 /**
- * Due to security concerns, Imaginary does not process document files by default.
- * The following mimetypes are always processed:
+ * Imaginary can, but does not, process PDF and Illustrator files by default.
+ * The following MIME types are always processed:
  * bmp, x-bitmap, png, jpeg, gif, heic, heif, svg+xml, tiff and webp
  * 
  * Set to ``true``  to enable processing of documents of type pdf and illustrator.

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1308,6 +1308,17 @@ $CONFIG = [
 'preview_imaginary_key' => 'secret',
 
 /**
+ * Due to security concerns, Imaginary does not process document files by default.
+ * The following mimetypes are always processed:
+ * bmp, x-bitmap, png, jpeg, gif, heic, heif, svg+xml, tiff and webp
+ * 
+ * Set to ``true``  to enable processing of documents of type pdf and illustrator.
+ * 
+ * Defaults to ``false``
+ */
+'imaginary_process_documents' => false,
+
+/**
  * Only register providers that have been explicitly enabled
  *
  * The following providers are disabled by default due to performance or privacy

--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -40,7 +40,15 @@ class Imaginary extends ProviderV2 {
 	}
 
 	public static function supportedMimeTypes(): string {
-		return '/(image\/(bmp|x-bitmap|png|jpeg|gif|heic|heif|svg\+xml|tiff|webp)|application\/(pdf|illustrator))/';
+		$config = \OC::$server->getConfig();
+		// Check if processing of documents is enabled
+		$processDocuments = $config->getSystemValueBool('imaginary_process_documents', false);
+
+		if ($processDocuments) {
+			return '/(image\/(bmp|x-bitmap|png|jpeg|gif|heic|heif|svg\+xml|tiff|webp)|application\/(pdf|illustrator))/';
+		} else {
+			return '/(image\/(bmp|x-bitmap|png|jpeg|gif|heic|heif|svg\+xml|tiff|webp))/';
+		}
 	}
 
 	public function getCroppedThumbnail(File $file, int $maxX, int $maxY, bool $crop): ?IImage {
@@ -81,8 +89,17 @@ class Imaginary extends ProviderV2 {
 				$mimeType = 'png';
 				break;
 			case 'image/svg+xml':
+				$convert = true;
+				// Converted files do not need to be autorotated
+				$autorotate = false;
+				$mimeType = 'png';
+				break;
 			case 'application/pdf':
 			case 'application/illustrator':
+				// Check if processing of documents is enabled
+				if (!$this->config->getSystemValueBool('imaginary_process_documents', false)) {
+					return null;
+				}
 				$convert = true;
 				// Converted files do not need to be autorotated
 				$autorotate = false;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: /nextcloud/server/issues/42175

## Summary

Document previews often appear as minimal, almost blank "miniatures" that can inadvertently reveal content, which may not always be desired.
Many users prefer having document icons instead of these previews.
The classic preview provider settings have considered this preference.
This feature reintroduces this choice for Imaginary.
Given that it is easier to generate previews than to remove existing ones, the default value is set to 'false'.

ernolf
## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
