### PR TITLE
fix(settings/SetupChecks): Don't follow redirects

### DIFF
--- a/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
+++ b/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
@@ -98,6 +98,7 @@ trait CheckServerResponseTrait {
 
 	protected function getRequestOptions(bool $ignoreSSL, bool $httpErrors): array {
 		$requestOptions = [
+			'allow_redirects' => false,
 			'connect_timeout' => 10,
 			'http_errors' => $httpErrors,
 			'nextcloud' => [


### PR DESCRIPTION
## Summary
In some cases the reverse proxy config redirects to login when accessing unknown URLs like .ocdata. Login, however, returns a HTTP 200, which is taken to be a failure by the datadirectory protection setup check.

- [ ] Is this a good idea?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
