### PR TITLE
fix(files_metadata): Don't run generation job on every upgrade

### DIFF
--- a/core/BackgroundJobs/GenerateMetadataJob.php
+++ b/core/BackgroundJobs/GenerateMetadataJob.php
@@ -15,14 +15,14 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\FilesMetadata\Exceptions\FilesMetadataNotFoundException;
 use OCP\FilesMetadata\IFilesMetadataManager;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IUserManager;
 use Psr\Log\LoggerInterface;
 
 class GenerateMetadataJob extends TimedJob {
 	public function __construct(
 		ITimeFactory $time,
-		private IConfig $config,
+		private IAppConfig $appConfig,
 		private IRootFolder $rootFolder,
 		private IUserManager $userManager,
 		private IFilesMetadataManager $filesMetadataManager,
@@ -36,8 +36,13 @@ class GenerateMetadataJob extends TimedJob {
 	}
 
 	protected function run(mixed $argument): void {
+		if ($this->appConfig->getValueBool('core', 'metadataGenerationDone', false)) {
+			return;
+		}
+
+		$lastHandledUser = $this->appConfig->getValueString('core', 'metadataGenerationLastHandledUser', '');
+
 		$users = $this->userManager->search('');
-		$lastHandledUser = $this->config->getAppValue('core', 'metadataGenerationLastHandledUser', '');
 
 		// we'll only start timer once we have found a valid user to handle
 		// meaning NOW if we have not handled any user from a previous run
@@ -53,7 +58,7 @@ class GenerateMetadataJob extends TimedJob {
 				continue;
 			}
 
-			$this->config->setAppValue('core', 'metadataGenerationLastHandledUser', $userId);
+			$this->appConfig->setValueString('core', 'metadataGenerationLastHandledUser', $userId);
 			$this->scanFilesForUser($user->getUID());
 
 			// Stop if execution time is more than one hour.
@@ -62,8 +67,8 @@ class GenerateMetadataJob extends TimedJob {
 			}
 		}
 
-		$this->jobList->remove(GenerateMetadataJob::class);
-		$this->config->deleteAppValue('core', 'metadataGenerationLastHandledUser');
+		$this->appConfig->deleteKey('core', 'metadataGenerationLastHandledUser');
+		$this->appConfig->setValueBool('core', 'metadataGenerationDone', true);
 	}
 
 	private function scanFilesForUser(string $userId): void {


### PR DESCRIPTION
The repair steps adds the background job on every upgrade, so not having an flag to indicated that it's done will make it start again every time.