### PR TITLE
fix(files_versions): Don't try to create version entity if it exists

### DIFF
--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -222,8 +222,11 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 	}
 
 	public function createVersionEntity(File $file): void {
-		$versionEntityExists = $this->versionsMapper->findVersionForFileId($file->getId(), $file->getMTime());
-		if (!$versionEntityExists) {
+		try {
+			$versionEntityExists = $this->versionsMapper->findVersionForFileId($file->getId(), $file->getMTime());
+		} catch (\Exception $e) {
+			// If an exception is caught, it means the version entity
+			// does not exist so we proceed creating it
 			$versionEntity = new VersionEntity();
 			$versionEntity->setFileId($file->getId());
 			$versionEntity->setTimestamp($file->getMTime());

--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -222,13 +222,16 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 	}
 
 	public function createVersionEntity(File $file): void {
-		$versionEntity = new VersionEntity();
-		$versionEntity->setFileId($file->getId());
-		$versionEntity->setTimestamp($file->getMTime());
-		$versionEntity->setSize($file->getSize());
-		$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
-		$versionEntity->setMetadata([]);
-		$this->versionsMapper->insert($versionEntity);
+		$versionEntityExists = $this->versionsMapper->findVersionForFileId($file->getId(), $file->getMTime());
+		if (!$versionEntityExists) {
+			$versionEntity = new VersionEntity();
+			$versionEntity->setFileId($file->getId());
+			$versionEntity->setTimestamp($file->getMTime());
+			$versionEntity->setSize($file->getSize());
+			$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
+			$versionEntity->setMetadata([]);
+			$this->versionsMapper->insert($versionEntity);
+		}
 	}
 
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Avoid possible race conditions and hitting a `UniqueConstraintViolationException` on `files_versions_uniq_index` by searching an existing entity by its primary key (`fileId` and `timestamp`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
