### PR TITLE
fix(CI): Require compilation check when touching version.php

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -42,6 +42,7 @@ jobs:
               - '**.vue'
               - 'core/css/*'
               - 'core/img/**'
+              - 'version.php'
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
NPM is using version.php as app version and that seems to be part of the dist files now

- Ref https://github.com/nextcloud/server/pull/46469

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
