### PR TITLE
fix(files): Update displayname on rename

### DIFF
--- a/apps/files/src/components/FileEntry/FileEntryName.vue
+++ b/apps/files/src/components/FileEntry/FileEntryName.vue
@@ -299,6 +299,13 @@ export default defineComponent({
 					},
 				})
 
+				if (oldName === this.source.attributes?.displayname) {
+					// We have to assume that the displayname is not set but just the Nextcloud fallback to the basename
+					// so we need to adjust this as well
+					// eslint-disable-next-line vue/no-mutating-props
+					this.source.attributes.displayname = this.source.basename
+				}
+
 				// Success 🎉
 				emit('files:node:updated', this.source)
 				emit('files:node:renamed', this.source)

--- a/cypress/e2e/files/files-rename.cy.ts
+++ b/cypress/e2e/files/files-rename.cy.ts
@@ -1,0 +1,46 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getRowForFile, renameFile } from './FilesUtils.ts'
+
+describe('Files: Can rename files', { testIsolation: false }, () => {
+	before(() => {
+		cy.createRandomUser().then((user) => {
+			cy.uploadContent(user, new Blob(), 'text/plain', '/foo.txt')
+			cy.login(user)
+			cy.visit('/apps/files/')
+		})
+	})
+
+	it('See that the file is named correctly', () => {
+		getRowForFile('foo.txt')
+			.should('be.visible')
+			.should('contain.text', 'foo.txt')
+	})
+
+	it('Can rename the file', () => {
+		cy.intercept('MOVE', /\/remote.php\/dav\/files\//).as('renameFile')
+
+		renameFile('foo.txt', 'bar.txt')
+		cy.wait('@renameFile')
+
+		getRowForFile('bar.txt')
+			.should('be.visible')
+	})
+
+	it('See that the name is correctly shown', () => {
+		getRowForFile('bar.txt')
+			.should('be.visible')
+			.should('contain.text', 'bar.txt')
+	})
+
+	it('See that the name preserved on reload', () => {
+		cy.reload()
+
+		getRowForFile('bar.txt')
+			.should('be.visible')
+			.should('contain.text', 'bar.txt')
+	})
+})


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/46604

## Summary

Nextcloud always sets the `displayname` attribute, with fallback to the basename. So if we move or rename a file the old displayname will still be used as we only update the basename but not the displayname. Safest would be re-fetch, but if displayname and basename is equal we can safe one request and set the displayname to the new basename.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
