### PR TITLE
fix(Mailer): Fix sendmail binary fallback

### DIFF
--- a/apps/settings/lib/Settings/Admin/Mail.php
+++ b/apps/settings/lib/Settings/Admin/Mail.php
@@ -6,6 +6,7 @@
 namespace OCA\Settings\Settings\Admin;
 
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IBinaryFinder;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\Settings\IDelegatedSettings;
@@ -32,7 +33,7 @@ class Mail implements IDelegatedSettings {
 	public function getForm() {
 		$parameters = [
 			// Mail
-			'sendmail_is_available' => (bool)\OC_Helper::findBinaryPath('sendmail'),
+			'sendmail_is_available' => (bool)\OCP\Server::get(IBinaryFinder::class)->findBinaryPath('sendmail'),
 			'mail_domain' => $this->config->getSystemValue('mail_domain', ''),
 			'mail_from_address' => $this->config->getSystemValue('mail_from_address', ''),
 			'mail_smtpmode' => $this->config->getSystemValue('mail_smtpmode', ''),

--- a/apps/settings/tests/Settings/Admin/MailTest.php
+++ b/apps/settings/tests/Settings/Admin/MailTest.php
@@ -7,6 +7,7 @@ namespace OCA\Settings\Tests\Settings\Admin;
 
 use OCA\Settings\Settings\Admin\Mail;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IBinaryFinder;
 use OCP\IConfig;
 use OCP\IL10N;
 use Test\TestCase;
@@ -51,7 +52,7 @@ class MailTest extends TestCase {
 			'settings',
 			'settings/admin/additional-mail',
 			[
-				'sendmail_is_available' => (bool)\OC_Helper::findBinaryPath('sendmail'),
+				'sendmail_is_available' => (bool)\OCP\Server::get(IBinaryFinder::class)->findBinaryPath('sendmail'),
 				'mail_domain' => 'mx.nextcloud.com',
 				'mail_from_address' => 'no-reply@nextcloud.com',
 				'mail_smtpmode' => 'smtp',

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -334,8 +334,10 @@ class Mailer implements IMailer {
 				break;
 			default:
 				$sendmail = \OCP\Server::get(IBinaryFinder::class)->findBinaryPath('sendmail');
-				if ($sendmail === null) {
+				if ($sendmail === false) {
+					// fallback (though not sure what good it'll do)
 					$sendmail = '/usr/sbin/sendmail';
+					$this->logger->debug('sendmail binary search failed, using fallback ' . $sendmail, ['app' => 'core']);
 				}
 				$binaryPath = $sendmail;
 				break;
@@ -346,6 +348,7 @@ class Mailer implements IMailer {
 			default => ' -bs',
 		};
 
+		$this->logger->debug('Using sendmail binary: ' . $binaryPath, ['app' => 'core']);
 		return new SendmailTransport($binaryPath . $binaryParam, null, $this->logger);
 	}
 }

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -12,6 +12,7 @@ use OC\Mail\Mailer;
 use OC\Mail\Message;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IBinaryFinder;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -86,7 +87,7 @@ class MailerTest extends TestCase {
 				['mail_sendmailmode', 'smtp', $sendmailMode],
 			]);
 
-		$path = \OC_Helper::findBinaryPath('sendmail');
+		$path = \OCP\Server::get(IBinaryFinder::class)->findBinaryPath('sendmail');
 		if ($path === false) {
 			$path = '/usr/sbin/sendmail';
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves #46457

## Summary

The non-deprecated BinaryFinder returns `false` not `null` when the fallback is needed (versus the deprecated one in `OC_Helper`):

https://github.com/nextcloud/server/blob/465ad2f4ec42b45b119b12b8fbab8db006a4f0f8/lib/private/BinaryFinder.php#L45

Also add debug logging of which binary is found and fix test.

Some historical context: 

- #33593 

## TODO

- [x] Maybe: update tests to catch this sort of thing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
