### PR TITLE
feat(preview): introducing new class ImaginaryPDF

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1296,7 +1296,13 @@ $CONFIG = [
 
 /**
  * Set the URL of the Imaginary service to send image previews to.
- * Also requires the ``OC\Preview\Imaginary`` provider to be enabled.
+ * Also requires the
+ *  - ``OC\Preview\Imaginary``
+ * provider to be enabled in the 'enabledPreviewProviders' array, to create previews for these mimetypes:
+ * bmp, x-bitmap, png, jpeg, gif, heic, heif, svg+xml, tiff, webp and illustrator.
+ * If you want Imaginary to also create preview images from PDF Documents, you have to add
+ *  - ``OC\Preview\ImaginaryPDF``
+ * provider as well.
  *
  * See https://github.com/h2non/imaginary
  */

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1689,6 +1689,7 @@ return array(
     'OC\\Preview\\Illustrator' => $baseDir . '/lib/private/Preview/Illustrator.php',
     'OC\\Preview\\Image' => $baseDir . '/lib/private/Preview/Image.php',
     'OC\\Preview\\Imaginary' => $baseDir . '/lib/private/Preview/Imaginary.php',
+    'OC\\Preview\\ImaginaryPDF' => $baseDir . '/lib/private/Preview/ImaginaryPDF.php',
     'OC\\Preview\\JPEG' => $baseDir . '/lib/private/Preview/JPEG.php',
     'OC\\Preview\\Krita' => $baseDir . '/lib/private/Preview/Krita.php',
     'OC\\Preview\\MP3' => $baseDir . '/lib/private/Preview/MP3.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1722,6 +1722,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Preview\\Illustrator' => __DIR__ . '/../../..' . '/lib/private/Preview/Illustrator.php',
         'OC\\Preview\\Image' => __DIR__ . '/../../..' . '/lib/private/Preview/Image.php',
         'OC\\Preview\\Imaginary' => __DIR__ . '/../../..' . '/lib/private/Preview/Imaginary.php',
+        'OC\\Preview\\ImaginaryPDF' => __DIR__ . '/../../..' . '/lib/private/Preview/ImaginaryPDF.php',
         'OC\\Preview\\JPEG' => __DIR__ . '/../../..' . '/lib/private/Preview/JPEG.php',
         'OC\\Preview\\Krita' => __DIR__ . '/../../..' . '/lib/private/Preview/Krita.php',
         'OC\\Preview\\MP3' => __DIR__ . '/../../..' . '/lib/private/Preview/MP3.php',

--- a/lib/private/Preview/Imaginary.php
+++ b/lib/private/Preview/Imaginary.php
@@ -40,7 +40,7 @@ class Imaginary extends ProviderV2 {
 	}
 
 	public static function supportedMimeTypes(): string {
-		return '/(image\/(bmp|x-bitmap|png|jpeg|gif|heic|heif|svg\+xml|tiff|webp)|application\/(pdf|illustrator))/';
+		return '/(image\/(bmp|x-bitmap|png|jpeg|gif|heic|heif|svg\+xml|tiff|webp)|application\/illustrator)/';
 	}
 
 	public function getCroppedThumbnail(File $file, int $maxX, int $maxY, bool $crop): ?IImage {

--- a/lib/private/Preview/ImaginaryPDF.php
+++ b/lib/private/Preview/ImaginaryPDF.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Preview;
+
+class ImaginaryPDF extends Imaginary {
+	public static function supportedMimeTypes(): string {
+		return '/application\/pdf/';
+	}
+}

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -346,6 +346,7 @@ class PreviewManager implements IPreview {
 		$this->registerCoreProvider(Preview\MP3::class, '/audio\/mpeg/');
 		$this->registerCoreProvider(Preview\OpenDocument::class, '/application\/vnd.oasis.opendocument.*/');
 		$this->registerCoreProvider(Preview\Imaginary::class, Preview\Imaginary::supportedMimeTypes());
+		$this->registerCoreProvider(Preview\ImaginaryPDF::class, Preview\ImaginaryPDF::supportedMimeTypes());
 
 		// SVG and Bitmap require imagick
 		if ($this->imagickSupport->hasExtension()) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #42175

* Replaces: #46447

## Summary
Document previews often appear as minimal, almost blank "miniatures" that can inadvertently reveal content, which may not always be desired.
Many users prefer having document icons instead of these previews.
The classic preview provider settings have considered this preference.

feat: Add separate provider for Imaginary PDF handling

- Refactor Imaginary to handle only image mimetypes.
- Introduce ImaginaryPDF class to handle PDF mimetypes.
- Register ImaginaryPDF in PreviewManager.

This allows for more granular control over which mimetypes are processed by Imaginary.

The approach from #46447 was too cumbersome and deviated too much from the uniform handling of preview providers. This approach has now fully implemented the suggestions and ideas from there.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
