### PR TITLE
feat: hide caldav server settings if no app uses the caldav backend

### DIFF
--- a/apps/dav/lib/Settings/CalDAVSettings.php
+++ b/apps/dav/lib/Settings/CalDAVSettings.php
@@ -6,6 +6,7 @@
 namespace OCA\DAV\Settings;
 
 use OCA\DAV\AppInfo\Application;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
@@ -21,6 +22,7 @@ class CalDAVSettings implements IDelegatedSettings {
 	private $initialState;
 
 	private IURLGenerator $urlGenerator;
+	private IAppManager $appManager;
 
 	private const defaults = [
 		'sendInvitations' => 'yes',
@@ -36,10 +38,11 @@ class CalDAVSettings implements IDelegatedSettings {
 	 * @param IConfig $config
 	 * @param IInitialState $initialState
 	 */
-	public function __construct(IConfig $config, IInitialState $initialState, IURLGenerator $urlGenerator) {
+	public function __construct(IConfig $config, IInitialState $initialState, IURLGenerator $urlGenerator, IAppManager $appManager) {
 		$this->config = $config;
 		$this->initialState = $initialState;
 		$this->urlGenerator = $urlGenerator;
+		$this->appManager = $appManager;
 	}
 
 	public function getForm(): TemplateResponse {
@@ -51,10 +54,11 @@ class CalDAVSettings implements IDelegatedSettings {
 		return new TemplateResponse(Application::APP_ID, 'settings-admin-caldav');
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getSection() {
+	public function getSection(): ?string {
+		if (!$this->appManager->isBackendRequired(IAppManager::BACKEND_CALDAV)) {
+			return null;
+		}
+
 		return 'groupware';
 	}
 

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -6,6 +6,7 @@
 namespace OCA\DAV\Tests\Unit\DAV\Settings;
 
 use OCA\DAV\Settings\CalDAVSettings;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
@@ -24,6 +25,9 @@ class CalDAVSettingsTest extends TestCase {
 	/** @var IURLGenerator|MockObject */
 	private $urlGenerator;
 
+	/** @var IAppManager|MockObject */
+	private $appManager;
+
 	private CalDAVSettings $settings;
 
 	protected function setUp(): void {
@@ -32,7 +36,8 @@ class CalDAVSettingsTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		$this->settings = new CalDAVSettings($this->config, $this->initialState, $this->urlGenerator);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->settings = new CalDAVSettings($this->config, $this->initialState, $this->urlGenerator, $this->appManager);
 	}
 
 	public function testGetForm(): void {
@@ -65,10 +70,23 @@ class CalDAVSettingsTest extends TestCase {
 	}
 
 	public function testGetSection(): void {
+		$this->appManager->expects(self::once())
+			->method('isBackendRequired')
+			->with(IAppManager::BACKEND_CALDAV)
+			->willReturn(true);
 		$this->assertEquals('groupware', $this->settings->getSection());
+	}
+
+	public function testGetSectionWithoutCaldavBackend(): void {
+		$this->appManager->expects(self::once())
+			->method('isBackendRequired')
+			->with(IAppManager::BACKEND_CALDAV)
+			->willReturn(false);
+		$this->assertEquals(null, $this->settings->getSection());
 	}
 
 	public function testGetPriority(): void {
 		$this->assertEquals(10, $this->settings->getPriority());
 	}
+
 }

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -875,4 +875,16 @@ class AppManager implements IAppManager {
 
 		$this->config->setSystemValue('defaultapp', join(',', $defaultApps));
 	}
+
+	public function isBackendRequired(string $backend): bool {
+		foreach ($this->appInfos as $appInfo) {
+			foreach ($appInfo['dependencies']['backend'] as $appBackend) {
+				if ($backend === $appBackend) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 }

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -113,6 +113,12 @@ class InfoParser {
 		if (!array_key_exists('personal-section', $array['settings'])) {
 			$array['settings']['personal-section'] = [];
 		}
+		if (!array_key_exists('dependencies', $array)) {
+			$array['dependencies'] = [];
+		}
+		if (!array_key_exists('backend', $array['dependencies'])) {
+			$array['dependencies']['backend'] = [];
+		}
 
 		if (array_key_exists('types', $array)) {
 			if (is_array($array['types'])) {
@@ -177,9 +183,11 @@ class InfoParser {
 		if (isset($array['settings']['personal-section']) && !is_array($array['settings']['personal-section'])) {
 			$array['settings']['personal-section'] = [$array['settings']['personal-section']];
 		}
-
 		if (isset($array['navigations']['navigation']) && $this->isNavigationItem($array['navigations']['navigation'])) {
 			$array['navigations']['navigation'] = [$array['navigations']['navigation']];
+		}
+		if (isset($array['dependencies']['backend']) && !is_array($array['dependencies']['backend'])) {
+			$array['dependencies']['backend'] = [$array['dependencies']['backend']];
 		}
 
 		if ($this->cache !== null) {

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -20,6 +20,11 @@ use OCP\IUser;
  */
 interface IAppManager {
 	/**
+	 * @since 30.0.0
+	 */
+	public const BACKEND_CALDAV = 'caldav';
+
+	/**
 	 * Returns the app information from "appinfo/info.xml".
 	 *
 	 * @param string|null $lang
@@ -261,4 +266,14 @@ interface IAppManager {
 	 * @since 28.0.0
 	 */
 	public function setDefaultApps(array $defaultApps): void;
+
+	/**
+	 * Check whether the given backend is required by at least one app.
+	 *
+	 * @param self::BACKEND_* $backend Name of the backend, one of `self::BACKEND_*`
+	 * @return bool True if at least one app requires the backend
+	 *
+	 * @since 30.0.0
+	 */
+	public function isBackendRequired(string $backend): bool;
 }

--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -575,6 +575,8 @@
                         maxOccurs="1"/>
             <xs:element name="architecture" type="architecture" minOccurs="0"
                         maxOccurs="unbounded"/>
+            <xs:element name="backend" type="backend" minOccurs="0"
+                        maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -757,4 +759,9 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="backend">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="caldav"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -563,6 +563,8 @@
                         maxOccurs="1"/>
             <xs:element name="architecture" type="architecture" minOccurs="0"
                         maxOccurs="unbounded"/>
+            <xs:element name="backend" type="backend" minOccurs="0"
+                        maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -735,6 +737,12 @@
         <xs:restriction base="xs:string">
             <xs:pattern
                     value="[a-zA-Z_][0-9a-zA-Z_]*(\\[a-zA-Z_][0-9a-zA-Z_]*)*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="backend">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="caldav"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -65,7 +65,10 @@
 				"min-version": "7.0.1",
 				"max-version": "8"
 			}
-		}
+		},
+		"backend": [
+			"caldav"
+		]
 	},
 	"repair-steps": {
 		"install": [],

--- a/tests/data/app/navigation-one-item.json
+++ b/tests/data/app/navigation-one-item.json
@@ -29,7 +29,8 @@
         "min-version": "16",
         "max-version": "16"
       }
-    }
+    },
+    "backend": []
   },
   "background-jobs": [
     "OCA\\Activity\\BackgroundJob\\EmailNotification",

--- a/tests/data/app/navigation-two-items.json
+++ b/tests/data/app/navigation-two-items.json
@@ -29,7 +29,8 @@
         "min-version": "16",
         "max-version": "16"
       }
-    }
+    },
+    "backend": []
   },
   "background-jobs": [
     "OCA\\Activity\\BackgroundJob\\EmailNotification",

--- a/tests/data/app/valid-info.xml
+++ b/tests/data/app/valid-info.xml
@@ -34,5 +34,6 @@
 		<lib>curl</lib>
 		<os>Linux</os>
 		<owncloud min-version="7.0.1" max-version="8" />
+		<backend>caldav</backend>
 	</dependencies>
 </info>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

This PR introduces a dependency type to `info.xml` called `backends` which can be used by apps to express their intent to use a specific server-side backend. Currently, the only backend to be required is `caldav`.

The caldav server admin settings will be hidden if no app is requiring the `caldav` backend.

### Exemplary `info.xml`

```xml
<?xml version="1.0"?>
<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
	<id>calendar</id>
	<name>Calendar</name>
	<summary>A Calendar app for Nextcloud</summary>
	<version>4.8.0-alpha.1</version>
	<namespace>Calendar</namespace>
	<!-- [...] -->
	<dependencies>
		<php min-version="8.0" max-version="8.3" />
		<nextcloud min-version="27" max-version="30" />
		<backend>caldav</backend>
	</dependencies>
	<!-- [...] -->
</info>

```

### Hidden settings section

![grafik](https://github.com/user-attachments/assets/942a5001-2b00-424a-b520-0a5d51310ce4)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
