### PR TITLE
[master] Fix npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8850,6 +8850,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/centra": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
+      "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -18803,16 +18812,17 @@
       }
     },
     "node_modules/load-bmfont": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
-      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
+      "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
+      "license": "MIT",
       "dependencies": {
         "buffer-equal": "0.0.1",
         "mime": "^1.3.4",
         "parse-bmfont-ascii": "^1.0.3",
         "parse-bmfont-binary": "^1.0.5",
         "parse-bmfont-xml": "^1.1.4",
-        "phin": "^2.9.1",
+        "phin": "^3.7.1",
         "xhr": "^2.0.1",
         "xtend": "^4.0.0"
       }
@@ -18826,6 +18836,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/load-bmfont/node_modules/phin": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
+      "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "centra": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/loader-runner": {
@@ -23213,6 +23235,7 @@
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.7.tgz",
       "integrity": "sha512-DouTG8T1WanGok6Qjg2SXuCMzszOo0eHeH9hDZ5Y4x8Je+9JB38HdTLT4/VA8OaUhBa0JPVHJ0pyBkM1z+pDsw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "r_js": "bin/r.js",
         "r.js": "bin/r.js"


### PR DESCRIPTION
# Audit report

This audit fix resolves 12 of the total 15 vulnerabilities found in your project.

## Updated dependencies
* [@jimp/core](#user-content-\@jimp\/core)
* [@jimp/custom](#user-content-\@jimp\/custom)
* [@testing-library/vue](#user-content-\@testing-library\/vue)
* [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* [@vue/test-utils](#user-content-\@vue\/test-utils)
* [load-bmfont](#user-content-load-bmfont)
* [node-vibrant](#user-content-node-vibrant)
* [phin](#user-content-phin)
* [postcss](#user-content-postcss)
* [requirejs](#user-content-requirejs)
* [select2](#user-content-select2)
* [vue-loader](#user-content-vue-loader)
## Fixed vulnerabilities

### @jimp/core <a href="#user-content-\@jimp\/core" id="\@jimp\/core">#</a>
* Caused by vulnerable dependency:
  * [phin](#user-content-phin)
* Affected versions: <=0.21.4--canary.1163.d07ed6254d130e2995d24101e93427ec091016e6.0
* Package usage:
  * `node_modules/@jimp/core`

### @jimp/custom <a href="#user-content-\@jimp\/custom" id="\@jimp\/custom">#</a>
* Caused by vulnerable dependency:
  * [@jimp/core](#user-content-\@jimp\/core)
* Affected versions: <=0.21.4--canary.1163.d07ed6254d130e2995d24101e93427ec091016e6.0
* Package usage:
  * `node_modules/@jimp/custom`

### @testing-library/vue <a href="#user-content-\@testing-library\/vue" id="\@testing-library\/vue">#</a>
* Caused by vulnerable dependency:
  * [@vue/test-utils](#user-content-\@vue\/test-utils)
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=5.9.0
* Package usage:
  * `node_modules/@testing-library/vue`

### @vue/component-compiler-utils <a href="#user-content-\@vue\/component-compiler-utils" id="\@vue\/component-compiler-utils">#</a>
* Caused by vulnerable dependency:
  * [postcss](#user-content-postcss)
* Affected versions: *
* Package usage:
  * `node_modules/@vue/component-compiler-utils`

### @vue/test-utils <a href="#user-content-\@vue\/test-utils" id="\@vue\/test-utils">#</a>
* Caused by vulnerable dependency:
  * [vue-template-compiler](#user-content-vue-template-compiler)
* Affected versions: <=1.3.6
* Package usage:
  * `node_modules/@vue/test-utils`

### load-bmfont <a href="#user-content-load-bmfont" id="load-bmfont">#</a>
* Caused by vulnerable dependency:
  * [phin](#user-content-phin)
* Affected versions: 1.4.0 - 1.4.1
* Package usage:
  * `node_modules/load-bmfont`

### node-vibrant <a href="#user-content-node-vibrant" id="node-vibrant">#</a>
* Caused by vulnerable dependency:
  * [@jimp/custom](#user-content-\@jimp\/custom)
* Affected versions: 3.1.5 - 3.1.6
* Package usage:
  * `node_modules/node-vibrant`

### phin <a href="#user-content-phin" id="phin">#</a>
* phin may include sensitive headers in subsequent requests after redirect
* Severity: **moderate** (CVSS 4.3)
* Reference: [https://github.com/advisories/GHSA-x565-32qp-m3vf](https://github.com/advisories/GHSA-x565-32qp-m3vf)
* Affected versions: <3.7.1
* Package usage:
  * `node_modules/phin`

### postcss <a href="#user-content-postcss" id="postcss">#</a>
* PostCSS line return parsing error
* Severity: **moderate** (CVSS 5.3)
* Reference: [https://github.com/advisories/GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j)
* Affected versions: <8.4.31
* Package usage:
  * `node_modules/@vue/component-compiler-utils/node_modules/postcss`

### requirejs <a href="#user-content-requirejs" id="requirejs">#</a>
* jrburke requirejs vulnerable to prototype pollution
* Severity: **high** (CVSS 10)
* Reference: [https://github.com/advisories/GHSA-x3m3-4wpv-5vgc](https://github.com/advisories/GHSA-x3m3-4wpv-5vgc)
* Affected versions: <=2.3.6
* Package usage:
  * `node_modules/requirejs`

### select2 <a href="#user-content-select2" id="select2">#</a>
* Improper Neutralization of Input During Web Page Generation in Select2
* Severity: **moderate** (CVSS 6.1)
* Reference: [https://github.com/advisories/GHSA-rf66-hmqf-q3fc](https://github.com/advisories/GHSA-rf66-hmqf-q3fc)
* Affected versions: <4.0.6
* Package usage:
  * `node_modules/select2`

### vue-loader <a href="#user-content-vue-loader" id="vue-loader">#</a>
* Caused by vulnerable dependency:
  * [@vue/component-compiler-utils](#user-content-\@vue\/component-compiler-utils)
* Affected versions: 15.0.0-beta.1 - 15.11.1
* Package usage:
  * `node_modules/vue-loader`