### PR TITLE
feat(search): allows to search by parent ID

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -82,6 +82,7 @@ class FileSearchBackend implements ISearchBackend {
 			new SearchPropertyDefinition('{DAV:}displayname', true, true, true),
 			new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true),
 			new SearchPropertyDefinition('{DAV:}getlastmodified', true, true, true, SearchPropertyDefinition::DATATYPE_DATETIME),
+			new SearchPropertyDefinition('{DAV:}parentid', true, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
 			new SearchPropertyDefinition(FilesPlugin::SIZE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
 			new SearchPropertyDefinition(TagsPlugin::FAVORITE_PROPERTYNAME, true, true, true, SearchPropertyDefinition::DATATYPE_BOOLEAN),
 			new SearchPropertyDefinition(FilesPlugin::INTERNAL_FILEID_PROPERTYNAME, true, true, false, SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER),
@@ -443,6 +444,8 @@ class FileSearchBackend implements ISearchBackend {
 		switch ($property->name) {
 			case '{DAV:}displayname':
 				return 'name';
+			case '{DAV:}parentid':
+				return 'parentid';
 			case '{DAV:}getcontenttype':
 				return 'mimetype';
 			case '{DAV:}getlastmodified':

--- a/lib/private/Files/Cache/SearchBuilder.php
+++ b/lib/private/Files/Cache/SearchBuilder.php
@@ -62,6 +62,7 @@ class SearchBuilder {
 		'share_with' => 'string',
 		'share_type' => 'integer',
 		'owner' => 'string',
+		'parentid' => 'integer',
 	];
 
 	/** @var array<string, int> */
@@ -239,6 +240,8 @@ class SearchBuilder {
 			$value = md5((string)$value);
 		} elseif ($field === 'owner') {
 			$field = 'uid_owner';
+		} elseif ($field === 'parentid') {
+			$field = 'parent';
 		}
 		return [$field, $value, $type, $paramType];
 	}
@@ -258,6 +261,7 @@ class SearchBuilder {
 			'share_with' => ['eq'],
 			'share_type' => ['eq'],
 			'owner' => ['eq'],
+			'parentid' => ['eq'],
 		];
 
 		if (!isset(self::$fieldTypes[$operator->getField()])) {

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -73,6 +73,7 @@ class DAV extends Common {
 		'{DAV:}getlastmodified',
 		'{DAV:}getcontentlength',
 		'{DAV:}getcontenttype',
+		'{DAV:}parentid',
 		'{http://owncloud.org/ns}permissions',
 		'{http://open-collaboration-services.org/ns}share-permissions',
 		'{DAV:}resourcetype',


### PR DESCRIPTION
## Summary

Allows to filter on parent ID in a `SEARCH` request

```xml
<?xml version="1.0" encoding="UTF-8"?>
<d:searchrequest xmlns:d="DAV:" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns" xmlns:ns="https://github.com/icewind1991/SearchDAV/ns">
  <d:basicsearch>
    <d:select>
      <d:prop>
        <d:displayname/>
        <d:getcontentlength/>
        <d:getcontenttype/>
      </d:prop>
    </d:select>
    <d:from>
      <d:scope>
        <d:href>/files/admin/Media</d:href> <!-- Filter from path -->
        <d:depth>1</d:depth>
      </d:scope>
    </d:from>
    <d:where>
      <d:eq>
        <d:prop>
          <d:parentid/>  <!-- Filter on parentid -->
        </d:prop>
        <d:literal>3</d:literal> <!-- Filter value (oc:fileid of parent directory) -->
      </d:eq>
    </d:where>
    <d:limit>
      <d:nresults>2</d:nresults>
      <ns:firstresult>0</ns:firstresult>
    </d:limit>
  </d:basicsearch>
</d:searchrequest>
```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
