### PR TITLE
fix(ci): Use ubuntu-latest for object storage test

### DIFF
--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -38,7 +38,7 @@ jobs:
               - '**.php'
 
   s3-primary-tests-minio:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: changes
 
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}


### PR DESCRIPTION
Running the object store S3 tests on `ubuntu-latest` seems to work in general. The 8.3 test seems a bit flaky and needed a restart, but it also failed randomly at other runs on GitHub (e.g. https://github.com/nextcloud/server/actions/runs/9696569223/job/26759168974), so might be independent of GitHub vs garm. 

Any opinions ?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
