### PR TITLE
Sort events by descending date

### DIFF
--- a/apps/dav/lib/Search/EventsSearchProvider.php
+++ b/apps/dav/lib/Search/EventsSearchProvider.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\DAV\Search;
 
 use OCA\DAV\CalDAV\CalDavBackend;
@@ -28,7 +29,8 @@ use function array_map;
  *
  * @package OCA\DAV\Search
  */
-class EventsSearchProvider extends ACalendarSearchProvider implements IFilteringProvider {
+class EventsSearchProvider extends ACalendarSearchProvider implements IFilteringProvider
+{
 	/**
 	 * @var string[]
 	 */
@@ -57,21 +59,24 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 	/**
 	 * @inheritDoc
 	 */
-	public function getId(): string {
+	public function getId(): string
+	{
 		return 'calendar';
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getName(): string {
+	public function getName(): string
+	{
 		return $this->l10n->t('Events');
 	}
 
 	/**
 	 * @inheritDoc
 	 */
-	public function getOrder(string $route, array $routeParameters): ?int {
+	public function getOrder(string $route, array $routeParameters): ?int
+	{
 		if ($this->appManager->isEnabledForUser('calendar')) {
 			return $route === 'calendar.View.index' ? -1 : 30;
 		}
@@ -115,6 +120,7 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 				]
 			);
 		}
+
 		/** @var IUser|null $person */
 		$person = $query->getFilter('person')?->get();
 		$personDisplayName = $person?->getDisplayName();
@@ -147,6 +153,16 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 				$searchResults[] = $attendeeResult;
 			}
 		}
+
+		// Sorting the search results by event start date (DTSTART)
+		usort($searchResults, function ($a, $b) {
+			$componentA = $this->getPrimaryComponent($a['calendardata'], self::$componentType);
+			$componentB = $this->getPrimaryComponent($b['calendardata'], self::$componentType);
+			$dateA = $componentA->DTSTART->getDateTime();
+			$dateB = $componentB->DTSTART->getDateTime();
+			return $dateB <=> $dateA;
+		});
+
 		$formattedResults = \array_map(function (array $eventRow) use ($calendarsById, $subscriptionsById): SearchResultEntry {
 			$component = $this->getPrimaryComponent($eventRow['calendardata'], self::$componentType);
 			$title = (string)($component->SUMMARY ?? $this->l10n->t('Untitled event'));
@@ -186,8 +202,8 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 		// This route will automatically figure out what recurrence-id to open
 		return $this->urlGenerator->getAbsoluteURL(
 			$this->urlGenerator->linkToRoute('calendar.view.index')
-			. 'edit/'
-			. base64_encode($davUrl)
+				. 'edit/'
+				. base64_encode($davUrl)
 		);
 	}
 
@@ -204,7 +220,8 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 			. $calendarObjectUri;
 	}
 
-	protected function generateSubline(Component $eventComponent): string {
+	protected function generateSubline(Component $eventComponent): string
+	{
 		$dtStart = $eventComponent->DTSTART;
 		$dtEnd = $this->getDTEndForEvent($eventComponent);
 		$isAllDayEvent = $dtStart instanceof Property\ICalendar\Date;
@@ -234,7 +251,8 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 		return "$formattedStartDate $formattedStartTime - $formattedEndDate $formattedEndTime";
 	}
 
-	protected function getDTEndForEvent(Component $eventComponent):Property {
+	protected function getDTEndForEvent(Component $eventComponent): Property
+	{
 		if (isset($eventComponent->DTEND)) {
 			$end = $eventComponent->DTEND;
 		} elseif (isset($eventComponent->DURATION)) {
@@ -263,7 +281,8 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 		return $dtStart->format('Y-m-d') === $dtEnd->format('Y-m-d');
 	}
 
-	public function getSupportedFilters(): array {
+	public function getSupportedFilters(): array
+	{
 		return [
 			'term',
 			'person',
@@ -272,11 +291,13 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 		];
 	}
 
-	public function getAlternateIds(): array {
+	public function getAlternateIds(): array
+	{
 		return [];
 	}
 
-	public function getCustomFilters(): array {
+	public function getCustomFilters(): array
+	{
 		return [];
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #27353

## Summary
Implemented sorting of events by descending start date in the EventsSearchProvider class.
This ensures that the most recent events appear first in the search results.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
