### PR TITLE
feat: PHP-FPM setup check / max_children check

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -115,6 +115,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\PhpOpcacheSetup' => $baseDir . '/../lib/SetupChecks/PhpOpcacheSetup.php',
     'OCA\\Settings\\SetupChecks\\PhpOutdated' => $baseDir . '/../lib/SetupChecks/PhpOutdated.php',
     'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => $baseDir . '/../lib/SetupChecks/PhpOutputBuffering.php',
+    'OCA\\Settings\\SetupChecks\\PhpSAPI' => $baseDir . '/../lib/SetupChecks/PhpSAPI.php',
     'OCA\\Settings\\SetupChecks\\PushService' => $baseDir . '/../lib/SetupChecks/PushService.php',
     'OCA\\Settings\\SetupChecks\\RandomnessSecure' => $baseDir . '/../lib/SetupChecks/RandomnessSecure.php',
     'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => $baseDir . '/../lib/SetupChecks/ReadOnlyConfig.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -130,6 +130,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\PhpOpcacheSetup' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpOpcacheSetup.php',
         'OCA\\Settings\\SetupChecks\\PhpOutdated' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpOutdated.php',
         'OCA\\Settings\\SetupChecks\\PhpOutputBuffering' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpOutputBuffering.php',
+        'OCA\\Settings\\SetupChecks\\PhpSAPI' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpSAPI.php',
         'OCA\\Settings\\SetupChecks\\PushService' => __DIR__ . '/..' . '/../lib/SetupChecks/PushService.php',
         'OCA\\Settings\\SetupChecks\\RandomnessSecure' => __DIR__ . '/..' . '/../lib/SetupChecks/RandomnessSecure.php',
         'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ReadOnlyConfig.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -58,6 +58,7 @@ use OCA\Settings\SetupChecks\PhpModules;
 use OCA\Settings\SetupChecks\PhpOpcacheSetup;
 use OCA\Settings\SetupChecks\PhpOutdated;
 use OCA\Settings\SetupChecks\PhpOutputBuffering;
+use OCA\Settings\SetupChecks\PhpSAPI;
 use OCA\Settings\SetupChecks\PushService;
 use OCA\Settings\SetupChecks\RandomnessSecure;
 use OCA\Settings\SetupChecks\ReadOnlyConfig;
@@ -190,6 +191,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(PhpOpcacheSetup::class);
 		$context->registerSetupCheck(PhpOutdated::class);
 		$context->registerSetupCheck(PhpOutputBuffering::class);
+		$context->registerSetupCheck(PhpSAPI::class);
 		$context->registerSetupCheck(RandomnessSecure::class);
 		$context->registerSetupCheck(ReadOnlyConfig::class);
 		$context->registerSetupCheck(SecurityHeaders::class);

--- a/apps/settings/lib/SetupChecks/PhpSAPI.php
+++ b/apps/settings/lib/SetupChecks/PhpSAPI.php
@@ -36,7 +36,9 @@ class PhpSAPI implements ISetupCheck {
 			if ($sapi_max_children_reached === 1) {
 				$sapi_max_children_reached_actual = fpm_get_status()['max-active-processes'];
 				return SetupResult::error($this->l10n->t('Your PHP-FPM pool reached it\'s maximum number of allowed processes (' . $sapi_max_children_reached_actual . ') at least once since your last restart. You may want to increase your pm.max_children value in your PHP-FPM pool configuration to avoid problems such as Gateway Timeouts, client connection errors, and slow performance.'), $this->urlGenerator->linkToDocs('admin-php-fpm'));
+			}
 		}
+
 		return SetupResult::success();
 	}
 }

--- a/apps/settings/lib/SetupChecks/PhpSAPI.php
+++ b/apps/settings/lib/SetupChecks/PhpSAPI.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Settings\SetupChecks;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class PhpSAPI implements ISetupCheck {
+	public function __construct(
+		private IL10N $l10n,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('PHP SAPI');
+	}
+
+	public function getCategory(): string {
+		return 'php';
+	}
+
+	public function run(): SetupResult {
+		$sapi_type = php_sapi_name();
+
+		if ($sapi_type === 'fpm-fcgi') {
+			$sapi_max_children_reached = fpm_get_status()['max-children-reached']; // since last restart
+			if ($sapi_max_children_reached === 1) {
+				$sapi_max_children_reached_actual = fpm_get_status()['max-active-processes'];
+				return SetupResult::error($this->l10n->t('Your PHP-FPM pool reached it\'s maximum number of allowed processes (' . $sapi_max_children_reached_actual . ') at least once since your last restart. You may want to increase your pm.max_children value in your PHP-FPM pool configuration to avoid problems such as Gateway Timeouts, client connection errors, and slow performance.'), $this->urlGenerator->linkToDocs('admin-php-fpm'));
+		}
+		return SetupResult::success();
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Establishes an setup check that warns if `pm.max_children` has been reached since the last restart. Since this can cause various problems, let's give a hint to the admin.

## TODO

- [ ] Update the go link used for the docs (pending: nextcoud/documentation#12023

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
