### PR TITLE
feat: Add global rate limiting config

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -277,7 +277,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 					$c->get(IUserSession::class),
 					$c->get(IControllerMethodReflector::class),
 					$c->get(OC\Security\RateLimiting\Limiter::class),
-					$c->get(ISession::class)
+					$c->get(ISession::class),
+					$c->get(IConfig::class)
 				)
 			);
 			$dispatcher->registerMiddleware(


### PR DESCRIPTION
## Summary

Request bursts are a regular problem and can cause a Nextcloud server to become unavailable. We already have rate limiting on a per controller annotation but for general bursts we don't have any way to handle them. 

This PR proposes as general rate limit config that admins can set and we should probably have some sane defaults.


## TODO

- [ ] See if the defaults make sense
- [ ] Check if we also not only want to apply based on the controller method identifier but also globally per user/annon user

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
