### PR TITLE
feat: allow for ExApps to call Admin endpoints marked with specific attr

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -44,6 +44,7 @@ return array(
     'OCP\\AppFramework\\Http\\Attribute\\ARateLimit' => $baseDir . '/lib/public/AppFramework/Http/Attribute/ARateLimit.php',
     'OCP\\AppFramework\\Http\\Attribute\\AnonRateLimit' => $baseDir . '/lib/public/AppFramework/Http/Attribute/AnonRateLimit.php',
     'OCP\\AppFramework\\Http\\Attribute\\ApiRoute' => $baseDir . '/lib/public/AppFramework/Http/Attribute/ApiRoute.php',
+    'OCP\\AppFramework\\Http\\Attribute\\AppApiAdminAccessWithoutUser' => $baseDir . '/lib/public/AppFramework/Http/Attribute/AppApiAdminAccessWithoutUser.php',
     'OCP\\AppFramework\\Http\\Attribute\\AuthorizedAdminSetting' => $baseDir . '/lib/public/AppFramework/Http/Attribute/AuthorizedAdminSetting.php',
     'OCP\\AppFramework\\Http\\Attribute\\BruteForceProtection' => $baseDir . '/lib/public/AppFramework/Http/Attribute/BruteForceProtection.php',
     'OCP\\AppFramework\\Http\\Attribute\\CORS' => $baseDir . '/lib/public/AppFramework/Http/Attribute/CORS.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -77,6 +77,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\AppFramework\\Http\\Attribute\\ARateLimit' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/ARateLimit.php',
         'OCP\\AppFramework\\Http\\Attribute\\AnonRateLimit' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/AnonRateLimit.php',
         'OCP\\AppFramework\\Http\\Attribute\\ApiRoute' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/ApiRoute.php',
+        'OCP\\AppFramework\\Http\\Attribute\\AppApiAdminAccessWithoutUser' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/AppApiAdminAccessWithoutUser.php',
         'OCP\\AppFramework\\Http\\Attribute\\AuthorizedAdminSetting' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/AuthorizedAdminSetting.php',
         'OCP\\AppFramework\\Http\\Attribute\\BruteForceProtection' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/BruteForceProtection.php',
         'OCP\\AppFramework\\Http\\Attribute\\CORS' => __DIR__ . '/../../..' . '/lib/public/AppFramework/Http/Attribute/CORS.php',

--- a/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SecurityMiddleware.php
@@ -21,6 +21,7 @@ use OC\User\Session;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AppApiAdminAccessWithoutUser;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\ExAppRequired;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -136,11 +137,19 @@ class SecurityMiddleware extends Middleware {
 				throw new ExAppRequiredException();
 			}
 		} elseif (!$isPublicPage) {
-			if (!$this->isLoggedIn) {
+			$authorized = false;
+			if ($this->hasAnnotationOrAttribute($reflectionMethod, null, AppApiAdminAccessWithoutUser::class)) {
+				// this attribute allows ExApp to access admin endpoints only if "userId" is "null"
+				if ($this->userSession instanceof Session && $this->userSession->getSession()->get('app_api') === true && $this->userSession->getUser() === null) {
+					$authorized = true;
+				}
+			}
+
+			if (!$authorized && !$this->isLoggedIn) {
 				throw new NotLoggedInException();
 			}
-			$authorized = false;
-			if ($this->hasAnnotationOrAttribute($reflectionMethod, 'AuthorizedAdminSetting', AuthorizedAdminSetting::class)) {
+
+			if (!$authorized && $this->hasAnnotationOrAttribute($reflectionMethod, 'AuthorizedAdminSetting', AuthorizedAdminSetting::class)) {
 				$authorized = $this->isAdminUser;
 
 				if (!$authorized && $this->hasAnnotationOrAttribute($reflectionMethod, 'SubAdminRequired', SubAdminRequired::class)) {
@@ -233,16 +242,16 @@ class SecurityMiddleware extends Middleware {
 	 * @template T
 	 *
 	 * @param ReflectionMethod $reflectionMethod
-	 * @param string $annotationName
+	 * @param ?string $annotationName
 	 * @param class-string<T> $attributeClass
 	 * @return boolean
 	 */
-	protected function hasAnnotationOrAttribute(ReflectionMethod $reflectionMethod, string $annotationName, string $attributeClass): bool {
+	protected function hasAnnotationOrAttribute(ReflectionMethod $reflectionMethod, ?string $annotationName, string $attributeClass): bool {
 		if (!empty($reflectionMethod->getAttributes($attributeClass))) {
 			return true;
 		}
 
-		if ($this->reflector->hasAnnotation($annotationName)) {
+		if ($annotationName && $this->reflector->hasAnnotation($annotationName)) {
 			$this->logger->debug($reflectionMethod->getDeclaringClass()->getName() . '::' . $reflectionMethod->getName() . ' uses the @' . $annotationName . ' annotation and should use the #[' . $attributeClass . '] attribute instead');
 			return true;
 		}

--- a/lib/public/AppFramework/Http/Attribute/AppApiAdminAccessWithoutUser.php
+++ b/lib/public/AppFramework/Http/Attribute/AppApiAdminAccessWithoutUser.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\AppFramework\Http\Attribute;
+
+use Attribute;
+
+/**
+ * Attribute for (sub)administrator controller methods that allow access for ExApps when the User is not set.
+ *
+ * @since 30.0.0
+ */
+#[Attribute]
+class AppApiAdminAccessWithoutUser {
+}


### PR DESCRIPTION
## Summary

This is for the Workflow Engine Project, and not only.

The option of duplicating ednpoints where they do not require the admin flag to be set seems to us not quite the right solution; sometimes for ExApps you still need to check whether the user is an administrator or not.

If you need to check the user for ExApp and it works in the user’s context, it sets the userId and everything works as it did.
Only if the request comes from ExApp and the user is not set in the session, then the check for the attributes "AuthorizedAdminSetting" and "SubAdminRequired" is skipped.

Original discussion here: https://github.com/nextcloud/server/pull/46539

Important comment: https://github.com/nextcloud/server/pull/46539#pullrequestreview-2182378157

```
Since this opens a wide angle on our APIs, we should make sure that logging (and admin audit logging) is also aware of $this->userSession->getSession()->get('app_api') and properly logs that an action was performed "on behalf of a user" and not "by a user".

But be very careful in the logging so it never fails (catch throwable, etc.) as otherwise logging breaks completely.
```


This should go in the separate PR a bit later.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
