### PR TITLE
feat: allow for ExApps to use webhook_listeners without user context

### DIFF
--- a/apps/webhook_listeners/appinfo/info.xml
+++ b/apps/webhook_listeners/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Nextcloud webhook support</name>
 	<summary>Nextcloud webhook support</summary>
 	<description>Nextcloud webhook support</description>
-	<version>1.0.0-dev</version>
+	<version>1.1.0-dev</version>
 	<licence>agpl</licence>
 	<author>Côme Chilliet</author>
 	<namespace>WebhookListeners</namespace>

--- a/apps/webhook_listeners/composer/composer/autoload_classmap.php
+++ b/apps/webhook_listeners/composer/composer/autoload_classmap.php
@@ -16,6 +16,7 @@ return array(
     'OCA\\WebhookListeners\\Db\\WebhookListenerMapper' => $baseDir . '/../lib/Db/WebhookListenerMapper.php',
     'OCA\\WebhookListeners\\Listener\\WebhooksEventListener' => $baseDir . '/../lib/Listener/WebhooksEventListener.php',
     'OCA\\WebhookListeners\\Migration\\Version1000Date20240527153425' => $baseDir . '/../lib/Migration/Version1000Date20240527153425.php',
+    'OCA\\WebhookListeners\\Migration\\Version1001Date20240716184935' => $baseDir . '/../lib/Migration/Version1001Date20240716184935.php',
     'OCA\\WebhookListeners\\ResponseDefinitions' => $baseDir . '/../lib/ResponseDefinitions.php',
     'OCA\\WebhookListeners\\Service\\PHPMongoQuery' => $baseDir . '/../lib/Service/PHPMongoQuery.php',
     'OCA\\WebhookListeners\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',

--- a/apps/webhook_listeners/composer/composer/autoload_static.php
+++ b/apps/webhook_listeners/composer/composer/autoload_static.php
@@ -31,6 +31,7 @@ class ComposerStaticInitWebhookListeners
         'OCA\\WebhookListeners\\Db\\WebhookListenerMapper' => __DIR__ . '/..' . '/../lib/Db/WebhookListenerMapper.php',
         'OCA\\WebhookListeners\\Listener\\WebhooksEventListener' => __DIR__ . '/..' . '/../lib/Listener/WebhooksEventListener.php',
         'OCA\\WebhookListeners\\Migration\\Version1000Date20240527153425' => __DIR__ . '/..' . '/../lib/Migration/Version1000Date20240527153425.php',
+        'OCA\\WebhookListeners\\Migration\\Version1001Date20240716184935' => __DIR__ . '/..' . '/../lib/Migration/Version1001Date20240716184935.php',
         'OCA\\WebhookListeners\\ResponseDefinitions' => __DIR__ . '/..' . '/../lib/ResponseDefinitions.php',
         'OCA\\WebhookListeners\\Service\\PHPMongoQuery' => __DIR__ . '/..' . '/../lib/Service/PHPMongoQuery.php',
         'OCA\\WebhookListeners\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',

--- a/apps/webhook_listeners/lib/Controller/WebhooksController.php
+++ b/apps/webhook_listeners/lib/Controller/WebhooksController.php
@@ -17,6 +17,7 @@ use OCA\WebhookListeners\Settings\Admin;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
+use OCP\AppFramework\Http\Attribute\AppApiAdminAccessWithoutUser;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\DataResponse;
@@ -56,6 +57,7 @@ class WebhooksController extends OCSController {
 	 */
 	#[ApiRoute(verb: 'GET', url: '/api/v1/webhooks')]
 	#[AuthorizedAdminSetting(settings:Admin::class)]
+	#[AppApiAdminAccessWithoutUser]
 	public function index(?string $uri = null): DataResponse {
 		try {
 			if ($uri !== null) {
@@ -89,6 +91,7 @@ class WebhooksController extends OCSController {
 	 */
 	#[ApiRoute(verb: 'GET', url: '/api/v1/webhooks/{id}')]
 	#[AuthorizedAdminSetting(settings:Admin::class)]
+	#[AppApiAdminAccessWithoutUser]
 	public function show(int $id): DataResponse {
 		try {
 			return new DataResponse($this->mapper->getById($id)->jsonSerialize());
@@ -122,6 +125,7 @@ class WebhooksController extends OCSController {
 	 */
 	#[ApiRoute(verb: 'POST', url: '/api/v1/webhooks')]
 	#[AuthorizedAdminSetting(settings:Admin::class)]
+	#[AppApiAdminAccessWithoutUser]
 	public function create(
 		string $httpMethod,
 		string $uri,
@@ -143,8 +147,6 @@ class WebhooksController extends OCSController {
 			throw new OCSBadRequestException('This auth method does not exist');
 		}
 		try {
-			/* We can never reach here without a user in session */
-			assert(is_string($this->userId));
 			$webhookListener = $this->mapper->addWebhookListener(
 				$appId,
 				$this->userId,
@@ -191,6 +193,7 @@ class WebhooksController extends OCSController {
 	 */
 	#[ApiRoute(verb: 'POST', url: '/api/v1/webhooks/{id}')]
 	#[AuthorizedAdminSetting(settings:Admin::class)]
+	#[AppApiAdminAccessWithoutUser]
 	public function update(
 		int $id,
 		string $httpMethod,
@@ -213,8 +216,6 @@ class WebhooksController extends OCSController {
 			throw new OCSBadRequestException('This auth method does not exist');
 		}
 		try {
-			/* We can never reach here without a user in session */
-			assert(is_string($this->userId));
 			$webhookListener = $this->mapper->updateWebhookListener(
 				$id,
 				$appId,
@@ -254,6 +255,7 @@ class WebhooksController extends OCSController {
 	 */
 	#[ApiRoute(verb: 'DELETE', url: '/api/v1/webhooks/{id}')]
 	#[AuthorizedAdminSetting(settings:Admin::class)]
+	#[AppApiAdminAccessWithoutUser]
 	public function destroy(int $id): DataResponse {
 		try {
 			$deleted = $this->mapper->deleteById($id);

--- a/apps/webhook_listeners/lib/Db/WebhookListener.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListener.php
@@ -13,9 +13,9 @@ use OCP\AppFramework\Db\Entity;
 use OCP\Security\ICrypto;
 
 /**
- * @method void setUserId(string $userId)
+ * @method void setUserId(?string $userId)
  * @method ?string getAppId()
- * @method string getUserId()
+ * @method ?string getUserId()
  * @method string getHttpMethod()
  * @method string getUri()
  * @method ?array getHeaders()
@@ -31,10 +31,10 @@ class WebhookListener extends Entity implements \JsonSerializable {
 	protected $appId = null;
 
 	/**
-	 * @var string id of the user who added the webhook listener
+	 * @var ?string id of the user who added the webhook listener
 	 * @psalm-suppress PropertyNotSetInConstructor
 	 */
-	protected $userId;
+	protected $userId = null;
 
 	/**
 	 * @var string

--- a/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
@@ -72,7 +72,7 @@ class WebhookListenerMapper extends QBMapper {
 	 */
 	public function addWebhookListener(
 		?string $appId,
-		string $userId,
+		?string $userId,
 		string $httpMethod,
 		string $uri,
 		string $event,
@@ -112,7 +112,7 @@ class WebhookListenerMapper extends QBMapper {
 	public function updateWebhookListener(
 		int $id,
 		?string $appId,
-		string $userId,
+		?string $userId,
 		string $httpMethod,
 		string $uri,
 		string $event,

--- a/apps/webhook_listeners/lib/Migration/Version1001Date20240716184935.php
+++ b/apps/webhook_listeners/lib/Migration/Version1001Date20240716184935.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\WebhookListeners\Migration;
+
+use Closure;
+use OCA\WebhookListeners\Db\WebhookListenerMapper;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version1001Date20240716184935 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable(WebhookListenerMapper::TABLE_NAME)) {
+			$table = $schema->getTable(WebhookListenerMapper::TABLE_NAME);
+			$table->getColumn('user_id')->setNotnull(false)->setDefault(null);
+			return $schema;
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

For the Workflow Engine project, we need to register webhooks from the background job, where we do not have a userId.

This will also be useful in other ExApps in the future.

This special attribute that allows you to do this was added today:

https://github.com/nextcloud/server/pull/46607

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
