### PR TITLE
fix(settings): Don't permit duplicate groups in `occ admin-delegation:add`

### DIFF
--- a/apps/settings/lib/Command/AdminDelegation/Add.php
+++ b/apps/settings/lib/Command/AdminDelegation/Add.php
@@ -40,14 +40,22 @@ class Add extends Base {
 		$io = new SymfonyStyle($input, $output);
 		$settingClass = $input->getArgument('settingClass');
 		if (!in_array(IDelegatedSettings::class, (array) class_implements($settingClass), true)) {
-			$io->error('The specified class isn’t a valid delegated setting.');
+			$io->error('The specified class is not a valid delegated setting.');
 			return 2;
 		}
 
 		$groupId = $input->getArgument('groupId');
 		if (!$this->groupManager->groupExists($groupId)) {
-			$io->error('The specified group didn’t exist.');
+			$io->error('The specified group does not exist.');
 			return 3;
+		}
+
+		$groups = $this->authorizedGroupService->findExistingGroupsForClass($settingClass);
+		foreach ($groups as $group) {
+			if ($group->getGroupId() === $groupId) {
+				$io->error('The specified group has already been delegated to.');
+				return 4;
+			}
 		}
 
 		$this->authorizedGroupService->create($groupId, $settingClass);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #46609 <!-- related github issue -->

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
