### PR TITLE
feat(core): Expose app versions, API versions and features supported by the instance

### DIFF
--- a/apps/dashboard/appinfo/info.xml
+++ b/apps/dashboard/appinfo/info.xml
@@ -13,6 +13,9 @@
 The Nextcloud Dashboard is your starting point of the day, giving you an overview of your upcoming appointments, urgent emails, chat messages, incoming tickets, latest tweets and much more! People can add the widgets they like and change the background to their liking.]]>
 	</description>
 	<version>7.10.0</version>
+	<api-version>1</api-version>
+	<api-version>2</api-version>
+	<api-version>3</api-version>
 	<licence>agpl</licence>
 	<author>Julius Härtl</author>
 	<namespace>Dashboard</namespace>

--- a/apps/dashboard/composer/composer/autoload_classmap.php
+++ b/apps/dashboard/composer/composer/autoload_classmap.php
@@ -7,6 +7,8 @@ $baseDir = $vendorDir;
 
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
+    'OCA\\Dashboard\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\Dashboard\\Capabilities' => $baseDir . '/../lib/Capabilities.php',
     'OCA\\Dashboard\\Controller\\DashboardApiController' => $baseDir . '/../lib/Controller/DashboardApiController.php',
     'OCA\\Dashboard\\Controller\\DashboardController' => $baseDir . '/../lib/Controller/DashboardController.php',
     'OCA\\Dashboard\\ResponseDefinitions' => $baseDir . '/../lib/ResponseDefinitions.php',

--- a/apps/dashboard/composer/composer/autoload_static.php
+++ b/apps/dashboard/composer/composer/autoload_static.php
@@ -22,6 +22,8 @@ class ComposerStaticInitDashboard
 
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
+        'OCA\\Dashboard\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\Dashboard\\Capabilities' => __DIR__ . '/..' . '/../lib/Capabilities.php',
         'OCA\\Dashboard\\Controller\\DashboardApiController' => __DIR__ . '/..' . '/../lib/Controller/DashboardApiController.php',
         'OCA\\Dashboard\\Controller\\DashboardController' => __DIR__ . '/..' . '/../lib/Controller/DashboardController.php',
         'OCA\\Dashboard\\ResponseDefinitions' => __DIR__ . '/..' . '/../lib/ResponseDefinitions.php',

--- a/apps/dashboard/lib/AppInfo/Application.php
+++ b/apps/dashboard/lib/AppInfo/Application.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Dashboard\AppInfo;
+
+use OCA\Dashboard\Capabilities;
+use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
+
+class Application extends App implements IBootstrap {
+	public const APP_ID = 'dashboard';
+
+	public function __construct(array $urlParams = []) {
+		parent::__construct(self::APP_ID, $urlParams);
+	}
+
+	public function register(IRegistrationContext $context): void {
+		$context->registerCapability(Capabilities::class);
+	}
+
+	public function boot(IBootContext $context): void {
+	}
+}

--- a/apps/dashboard/lib/Capabilities.php
+++ b/apps/dashboard/lib/Capabilities.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Dashboard;
+
+use OCP\Capabilities\ICapability;
+use OCP\Capabilities\IFeature;
+
+class Capabilities implements ICapability, IFeature {
+	/**
+	 * @return array{dashboard: array{enabled: bool}}
+	 */
+	public function getCapabilities(): array {
+		return [
+			'dashboard' => [
+				'enabled' => true,
+			],
+		];
+	}
+
+	public function getFeatures(): array {
+		return [
+			'dashboard' => [
+				'widgets-v1',
+				'widget-items-v1',
+				'widget-items-v2',
+				'layout-v3',
+				'statuses-v3',
+			],
+		];
+	}
+}

--- a/apps/dashboard/openapi.json
+++ b/apps/dashboard/openapi.json
@@ -20,6 +20,25 @@
             }
         },
         "schemas": {
+            "Capabilities": {
+                "type": "object",
+                "required": [
+                    "dashboard"
+                ],
+                "properties": {
+                    "dashboard": {
+                        "type": "object",
+                        "required": [
+                            "enabled"
+                        ],
+                        "properties": {
+                            "enabled": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                }
+            },
             "OCSMeta": {
                 "type": "object",
                 "required": [

--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -5,9 +5,6 @@
  */
 namespace OCA\User_LDAP\Controller;
 
-use OC\CapabilitiesManager;
-use OC\Core\Controller\OCSController;
-use OC\Security\IdentityProof\Manager;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\ConnectionFactory;
 use OCA\User_LDAP\Helper;
@@ -16,31 +13,19 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\AppFramework\OCSController;
 use OCP\IRequest;
-use OCP\IUserManager;
-use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
 class ConfigAPIController extends OCSController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		CapabilitiesManager $capabilitiesManager,
-		IUserSession $userSession,
-		IUserManager $userManager,
-		Manager $keyManager,
 		private Helper $ldapHelper,
 		private LoggerInterface $logger,
 		private ConnectionFactory $connectionFactory
 	) {
-		parent::__construct(
-			$appName,
-			$request,
-			$capabilitiesManager,
-			$userSession,
-			$userManager,
-			$keyManager
-		);
+		parent::__construct($appName, $request);
 	}
 
 	/**

--- a/core/Controller/WhatsNewController.php
+++ b/core/Controller/WhatsNewController.php
@@ -5,17 +5,15 @@
  */
 namespace OC\Core\Controller;
 
-use OC\CapabilitiesManager;
-use OC\Security\IdentityProof\Manager;
 use OC\Updater\ChangesCheck;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\ApiRoute;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
 use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IRequest;
-use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 
@@ -23,16 +21,13 @@ class WhatsNewController extends OCSController {
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		CapabilitiesManager $capabilitiesManager,
 		private IUserSession $userSession,
-		IUserManager $userManager,
-		Manager $keyManager,
 		private IConfig $config,
 		private ChangesCheck $whatsNewService,
 		private IFactory $langFactory,
 		private Defaults $defaults,
 	) {
-		parent::__construct($appName, $request, $capabilitiesManager, $userSession, $userManager, $keyManager);
+		parent::__construct($appName, $request);
 	}
 
 	/**

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -2724,7 +2724,9 @@
                                                     "type": "object",
                                                     "required": [
                                                         "version",
-                                                        "capabilities"
+                                                        "capabilities",
+                                                        "features",
+                                                        "apps"
                                                     ],
                                                     "properties": {
                                                         "version": {
@@ -2765,6 +2767,36 @@
                                                             "type": "object",
                                                             "additionalProperties": {
                                                                 "type": "object"
+                                                            }
+                                                        },
+                                                        "features": {
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        },
+                                                        "apps": {
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                    "version",
+                                                                    "api_versions"
+                                                                ],
+                                                                "properties": {
+                                                                    "version": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "api_versions": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
                                                             }
                                                         }
                                                     }

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -2724,7 +2724,9 @@
                                                     "type": "object",
                                                     "required": [
                                                         "version",
-                                                        "capabilities"
+                                                        "capabilities",
+                                                        "features",
+                                                        "apps"
                                                     ],
                                                     "properties": {
                                                         "version": {
@@ -2765,6 +2767,36 @@
                                                             "type": "object",
                                                             "additionalProperties": {
                                                                 "type": "object"
+                                                            }
+                                                        },
+                                                        "features": {
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        },
+                                                        "apps": {
+                                                            "type": "object",
+                                                            "additionalProperties": {
+                                                                "type": "object",
+                                                                "required": [
+                                                                    "version",
+                                                                    "api_versions"
+                                                                ],
+                                                                "properties": {
+                                                                    "version": {
+                                                                        "type": "string"
+                                                                    },
+                                                                    "api_versions": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "type": "string"
+                                                                        }
+                                                                    }
+                                                                }
                                                             }
                                                         }
                                                     }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -178,6 +178,7 @@ return array(
     'OCP\\Calendar\\Room\\IRoom' => $baseDir . '/lib/public/Calendar/Room/IRoom.php',
     'OCP\\Calendar\\Room\\IRoomMetadata' => $baseDir . '/lib/public/Calendar/Room/IRoomMetadata.php',
     'OCP\\Capabilities\\ICapability' => $baseDir . '/lib/public/Capabilities/ICapability.php',
+    'OCP\\Capabilities\\IFeature' => $baseDir . '/lib/public/Capabilities/IFeature.php',
     'OCP\\Capabilities\\IInitialStateExcludedCapability' => $baseDir . '/lib/public/Capabilities/IInitialStateExcludedCapability.php',
     'OCP\\Capabilities\\IPublicCapability' => $baseDir . '/lib/public/Capabilities/IPublicCapability.php',
     'OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent' => $baseDir . '/lib/public/Collaboration/AutoComplete/AutoCompleteEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -211,6 +211,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Calendar\\Room\\IRoom' => __DIR__ . '/../../..' . '/lib/public/Calendar/Room/IRoom.php',
         'OCP\\Calendar\\Room\\IRoomMetadata' => __DIR__ . '/../../..' . '/lib/public/Calendar/Room/IRoomMetadata.php',
         'OCP\\Capabilities\\ICapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/ICapability.php',
+        'OCP\\Capabilities\\IFeature' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IFeature.php',
         'OCP\\Capabilities\\IInitialStateExcludedCapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IInitialStateExcludedCapability.php',
         'OCP\\Capabilities\\IPublicCapability' => __DIR__ . '/../../..' . '/lib/public/Capabilities/IPublicCapability.php',
         'OCP\\Collaboration\\AutoComplete\\AutoCompleteEvent' => __DIR__ . '/../../..' . '/lib/public/Collaboration/AutoComplete/AutoCompleteEvent.php',

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -119,6 +119,9 @@ class InfoParser {
 		if (!array_key_exists('backend', $array['dependencies'])) {
 			$array['dependencies']['backend'] = [];
 		}
+		if (!array_key_exists('api-version', $array)) {
+			$array['api-version'] = [];
+		}
 
 		if (array_key_exists('types', $array)) {
 			if (is_array($array['types'])) {

--- a/lib/public/Capabilities/IFeature.php
+++ b/lib/public/Capabilities/IFeature.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OCP\Capabilities;
+
+/**
+ * Interface for apps to expose their available features.
+ *
+ * @since 30.0.0
+ */
+interface IFeature {
+	/**
+	 * Returns the available features.
+	 *
+	 * ```php
+	 * return [
+	 *   'myapp' => [
+	 *     'feature1',
+	 *     'feature2',
+	 *   ],
+	 *   'otherapp' => [
+	 *     'feature3',
+	 *   ],
+	 * ];
+	 * ```
+	 *
+	 * @return array<string, list<string>>
+	 * @since 30.0.0
+	 */
+	public function getFeatures(): array;
+}

--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -18,6 +18,8 @@
                             maxOccurs="unbounded"/>
                 <xs:element name="version" type="semver"
                             minOccurs="1" maxOccurs="1"/>
+                <xs:element name="api-version" type="semver"
+                            minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="licence" type="licence" minOccurs="1"
                             maxOccurs="unbounded"/>
                 <xs:element name="author" type="author" minOccurs="1"

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -18,6 +18,8 @@
                             maxOccurs="unbounded"/>
                 <xs:element name="version" type="semver"
                             minOccurs="1" maxOccurs="1"/>
+                <xs:element name="api-version" type="semver"
+                            minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="licence" type="licence" minOccurs="1"
                             maxOccurs="unbounded"/>
                 <xs:element name="author" type="author" minOccurs="1"

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -79,6 +79,7 @@
 	},
 	"background-jobs": [],
 	"two-factor-providers": [],
+	"api-version": [1, 2],
 	"commands": [],
 	"activity": {
 		"filters": [],

--- a/tests/data/app/navigation-one-item.json
+++ b/tests/data/app/navigation-one-item.json
@@ -82,5 +82,6 @@
     "live-migration": [],
     "uninstall": []
   },
-  "two-factor-providers": []
+  "two-factor-providers": [],
+  "api-version": []
 }

--- a/tests/data/app/navigation-two-items.json
+++ b/tests/data/app/navigation-two-items.json
@@ -88,5 +88,6 @@
     "live-migration": [],
     "uninstall": []
   },
-  "two-factor-providers": []
+  "two-factor-providers": [],
+  "api-version": []
 }

--- a/tests/data/app/valid-info.xml
+++ b/tests/data/app/valid-info.xml
@@ -36,4 +36,6 @@
 		<owncloud min-version="7.0.1" max-version="8" />
 		<backend>caldav</backend>
 	</dependencies>
+	<api-version>1</api-version>
+	<api-version>2</api-version>
 </info>


### PR DESCRIPTION
## Summary

The idea behind this is to have a standardized way for apps to declare their API versions and supported features. Many apps with an externally accessible API already do this to some degree using capabilities or dedicated endpoints, but all of them do it differently.

This API makes it easier for clients to figure out if they support the software running on the server, either by looking at the app version, the API versions or the list of features. The features list is not a concept that is widely used, but Talk has this as well and in my opinion this is the best way to check if a certain operation is supported on the server, since the app doesn't need to compare the app or API versions which prevents mistakes and possibly extends the range of supported versions if not all features are required.

To show it works I added the respective entries for the dashboard app, but ideally we'd add it for all apps with an API.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
