### PR TITLE
fix(caldav): fixed initial sync and double processing

### DIFF
--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -207,6 +207,33 @@ EOD;
 		return $uri0;
 	}
 
+	protected function modifyEvent($calendarId, $objectId, $start = '20130912T130000Z', $end = '20130912T140000Z') {
+		$randomPart = self::getUniqueID();
+
+		$calData = <<<EOD
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:ownCloud Calendar
+BEGIN:VEVENT
+CREATED;VALUE=DATE-TIME:20130910T125139Z
+UID:47d15e3ec8-$randomPart
+LAST-MODIFIED;VALUE=DATE-TIME:20130910T125139Z
+DTSTAMP;VALUE=DATE-TIME:20130910T125139Z
+SUMMARY:Test Event
+DTSTART;VALUE=DATE-TIME:$start
+DTEND;VALUE=DATE-TIME:$end
+CLASS:PUBLIC
+END:VEVENT
+END:VCALENDAR
+EOD;
+
+		$this->backend->updateCalendarObject($calendarId, $objectId, $calData);
+	}
+
+	protected function deleteEvent($calendarId, $objectId) {
+		$this->backend->deleteCalendarObject($calendarId, $objectId);
+	}
+
 	protected function assertAcl($principal, $privilege, $acl) {
 		foreach ($acl as $a) {
 			if ($a['principal'] === $principal && $a['privilege'] === $privilege) {


### PR DESCRIPTION
* Resolves: #44127

## Summary
- Initial sync no longer returns deleted items
- fixed double processing of results when doing a follow up sync