### PR TITLE
fix(Token): take over scope in token refresh with login by cookie

### DIFF
--- a/lib/private/Authentication/Token/IProvider.php
+++ b/lib/private/Authentication/Token/IProvider.php
@@ -35,7 +35,9 @@ interface IProvider {
 		?string $password,
 		string $name,
 		int $type = OCPIToken::TEMPORARY_TOKEN,
-		int $remember = OCPIToken::DO_NOT_REMEMBER): OCPIToken;
+		int $remember = OCPIToken::DO_NOT_REMEMBER,
+		?array $scope = null,
+	): OCPIToken;
 
 	/**
 	 * Get a token by token id

--- a/lib/private/Authentication/Token/Manager.php
+++ b/lib/private/Authentication/Token/Manager.php
@@ -42,7 +42,9 @@ class Manager implements IProvider, OCPIProvider {
 		$password,
 		string $name,
 		int $type = OCPIToken::TEMPORARY_TOKEN,
-		int $remember = OCPIToken::DO_NOT_REMEMBER): OCPIToken {
+		int $remember = OCPIToken::DO_NOT_REMEMBER,
+		?array $scope = null,
+	): OCPIToken {
 		if (mb_strlen($name) > 128) {
 			$name = mb_substr($name, 0, 120) . '…';
 		}
@@ -55,7 +57,8 @@ class Manager implements IProvider, OCPIProvider {
 				$password,
 				$name,
 				$type,
-				$remember
+				$remember,
+				$scope,
 			);
 		} catch (UniqueConstraintViolationException $e) {
 			// It's rare, but if two requests of the same session (e.g. env-based SAML)

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -85,7 +85,9 @@ class PublicKeyTokenProvider implements IProvider {
 		?string $password,
 		string $name,
 		int $type = OCPIToken::TEMPORARY_TOKEN,
-		int $remember = OCPIToken::DO_NOT_REMEMBER): OCPIToken {
+		int $remember = OCPIToken::DO_NOT_REMEMBER,
+		?array $scope = null,
+	): OCPIToken {
 		if (strlen($token) < self::TOKEN_MIN_LENGTH) {
 			$exception = new InvalidTokenException('Token is too short, minimum of ' . self::TOKEN_MIN_LENGTH . ' characters is required, ' . strlen($token) . ' characters given');
 			$this->logger->error('Invalid token provided when generating new token', ['exception' => $exception]);
@@ -105,6 +107,10 @@ class PublicKeyTokenProvider implements IProvider {
 
 		if ($oldTokenMatches) {
 			$dbToken->setPasswordHash($randomOldToken->getPasswordHash());
+		}
+
+		if ($scope !== null) {
+			$dbToken->setScope($scope);
 		}
 
 		$this->mapper->insert($dbToken);
@@ -234,6 +240,8 @@ class PublicKeyTokenProvider implements IProvider {
 				$privateKey = $this->decrypt($token->getPrivateKey(), $oldSessionId);
 				$password = $this->decryptPassword($token->getPassword(), $privateKey);
 			}
+
+			$scope = $token->getScope() === '' ? null : $token->getScopeAsArray();
 			$newToken = $this->generateToken(
 				$sessionId,
 				$token->getUID(),
@@ -241,9 +249,9 @@ class PublicKeyTokenProvider implements IProvider {
 				$password,
 				$token->getName(),
 				OCPIToken::TEMPORARY_TOKEN,
-				$token->getRemember()
+				$token->getRemember(),
+				$scope,
 			);
-			$newToken->setScope($token->getScopeAsArray());
 			$this->cacheToken($newToken);
 
 			$this->cacheInvalidHash($token->getToken());


### PR DESCRIPTION
## Summary

When logging via cookie, the token was refreshed, but while doing so, the scope was not kept. It was applied from the old token, but not saved in session. This could be typically reproduced per:

1. Having SAML configured
2. In any Google browser, log in via SAML
3. Close the browser
4. Open the browser again

When running this query `SELECT id, scope from oc_authtoken where uid ='USERID'` the scope would be empty instead of '{"password-unconfirmable":true,"filesystem":true}'. So, after a while a password confirmation dialogue would open at specific actions, where it is not possible to verify it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
