### PR TITLE
fix: cast to bigint on postgresql

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/PgSqlExpressionBuilder.php
@@ -23,7 +23,7 @@ class PgSqlExpressionBuilder extends ExpressionBuilder {
 	public function castColumn($column, $type): IQueryFunction {
 		switch ($type) {
 			case IQueryBuilder::PARAM_INT:
-				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS INT)');
+				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS BIGINT)');
 			case IQueryBuilder::PARAM_STR:
 				return new QueryFunction('CAST(' . $this->helper->quoteColumnName($column) . ' AS TEXT)');
 			default:

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -73,6 +73,8 @@ class BackgroundCleanupJob extends TimedJob {
 			->where(
 				$qb->expr()->isNull('b.fileid')
 			)->andWhere(
+				$qb->expr()->eq('a.storage', $qb->createNamedParameter($this->previewFolder->getStorageId()))
+			)->andWhere(
 				$qb->expr()->eq('a.parent', $qb->createNamedParameter($this->previewFolder->getId()))
 			)->andWhere(
 				$qb->expr()->like('a.name', $qb->createNamedParameter('__%'))

--- a/tests/lib/Preview/BackgroundCleanupJobTest.php
+++ b/tests/lib/Preview/BackgroundCleanupJobTest.php
@@ -180,9 +180,11 @@ class BackgroundCleanupJobTest extends \Test\TestCase {
 		$f1->newFile('foo.jpg', 'foo');
 		$f2 = $appdata->newFolder('123456782');
 		$f2->newFile('foo.jpg', 'foo');
+		$f2 = $appdata->newFolder((string)PHP_INT_MAX - 1);
+		$f2->newFile('foo.jpg', 'foo');
 
 		$appdata = \OC::$server->getAppDataDir('preview');
-		$this->assertSame(2, count($appdata->getDirectoryListing()));
+		$this->assertSame(3, count($appdata->getDirectoryListing()));
 
 		$job = new BackgroundCleanupJob($this->timeFactory, $this->connection, $this->getRoot(), $this->mimeTypeLoader, true);
 		$job->run([]);


### PR DESCRIPTION
Ensure that queries casting to fileids work with >32bit fileids.

Comes with bonus "prepare query for sharding" change.