### PR TITLE
fix(files): Disable tags editing for shared files/folders with view only permission

### DIFF
--- a/apps/files/src/services/FileInfo.js
+++ b/apps/files/src/services/FileInfo.js
@@ -24,6 +24,7 @@ export default async function(url) {
 	// TODO remove when no more legacy backbone is used
 	fileInfo.get = (key) => fileInfo[key]
 	fileInfo.isDirectory = () => fileInfo.mimetype === 'httpd/unix-directory'
+	fileInfo.canEdit = () => Boolean(fileInfo.permissions & OC.PERMISSION_UPDATE)
 
 	return fileInfo
 }

--- a/apps/files/src/views/Sidebar.vue
+++ b/apps/files/src/views/Sidebar.vue
@@ -30,6 +30,7 @@
 			<div class="sidebar__description">
 				<SystemTags v-if="isSystemTagsEnabled && showTagsDefault"
 					v-show="showTags"
+					:disabled="!fileInfo?.canEdit()"
 					:file-id="fileInfo.id"
 					@has-tags="value => showTags = value" />
 				<LegacyView v-for="view in views"

--- a/apps/systemtags/src/components/SystemTags.vue
+++ b/apps/systemtags/src/components/SystemTags.vue
@@ -15,6 +15,7 @@
 				:options="sortedTags"
 				:value="selectedTags"
 				:create-option="createOption"
+				:disabled="disabled"
 				:taggable="true"
 				:passthru="true"
 				:fetch-tags="false"
@@ -64,6 +65,10 @@ export default Vue.extend({
 		fileId: {
 			type: Number,
 			required: true,
+		},
+		disabled: {
+			type: Boolean,
+			default: false,
 		},
 	},
 


### PR DESCRIPTION
## How to reproduce
1. Create file/folder and assign some tags to it
2. Share it with another user "user" with view only permission
3. Open it by "user"

Expected result: user not able remove/add tags
Actual result: user able remove/add tags on UI (we have http 403 on the server side, but UI allows this actions)

<details><summary>:mag: Folder details for admin</summary>
<p>

![image](https://github.com/user-attachments/assets/b7040f29-4ec5-4cba-8b88-89db70d77a16)
</p>
</details> 


<details><summary>:mag: Folder details for user</summary>
<p>

![image](https://github.com/user-attachments/assets/9d80a534-ae1d-496d-beaf-07456f7f60ae)
</p>
</details> 




## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
