### PR TITLE
Avoid using partial file info as valid one

### DIFF
--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -93,6 +93,10 @@ class ApiController extends Controller {
 				throw new NotFoundException();
 			}
 
+			if ($file->getId() <= 0) {
+				return new DataResponse(['message' => 'File not found.'], Http::STATUS_NOT_FOUND);
+			}
+
 			/** @var File $file */
 			$preview = $this->previewManager->getPreview($file, $x, $y, true);
 

--- a/apps/files/tests/Controller/ApiControllerTest.php
+++ b/apps/files/tests/Controller/ApiControllerTest.php
@@ -157,6 +157,7 @@ class ApiControllerTest extends TestCase {
 
 	public function testGetThumbnailInvalidImage() {
 		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(123);
 		$this->userFolder->method('get')
 			->with($this->equalTo('unknown.jpg'))
 			->willReturn($file);
@@ -168,8 +169,19 @@ class ApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->apiController->getThumbnail(10, 10, 'unknown.jpg'));
 	}
 
+	public function testGetThumbnailInvalidPartFile() {
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(0);
+		$this->userFolder->method('get')
+			->with($this->equalTo('unknown.jpg'))
+			->willReturn($file);
+		$expected = new DataResponse(['message' => 'File not found.'], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $this->apiController->getThumbnail(10, 10, 'unknown.jpg'));
+	}
+
 	public function testGetThumbnail() {
 		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(123);
 		$this->userFolder->method('get')
 			->with($this->equalTo('known.jpg'))
 			->willReturn($file);

--- a/core/Controller/PreviewController.php
+++ b/core/Controller/PreviewController.php
@@ -141,6 +141,10 @@ class PreviewController extends Controller {
 			return new DataResponse([], Http::STATUS_FORBIDDEN);
 		}
 
+		if ($node->getId() <= 0) {
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
+		}
+
 		$storage = $node->getStorage();
 		if ($storage->instanceOfStorage(SharedStorage::class)) {
 			/** @var SharedStorage $storage */

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1338,9 +1338,6 @@ class View {
 		if (!Filesystem::isValidPath($path)) {
 			return false;
 		}
-		if (Cache\Scanner::isPartialFile($path)) {
-			return $this->getPartFileInfo($path);
-		}
 		$relativePath = $path;
 		$path = Filesystem::normalizePath($this->fakeRoot . '/' . $path);
 
@@ -1351,6 +1348,10 @@ class View {
 			$data = $this->getCacheEntry($storage, $internalPath, $relativePath);
 
 			if (!$data instanceof ICacheEntry) {
+				if (Cache\Scanner::isPartialFile($relativePath)) {
+					return $this->getPartFileInfo($relativePath);
+				}
+
 				return false;
 			}
 

--- a/tests/Core/Controller/PreviewControllerTest.php
+++ b/tests/Core/Controller/PreviewControllerTest.php
@@ -187,6 +187,7 @@ class PreviewControllerTest extends \Test\TestCase {
 			->willReturn($userFolder);
 
 		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(123);
 		$userFolder->method('get')
 			->with($this->equalTo('file'))
 			->willReturn($file);


### PR DESCRIPTION
- **fix: Ignore preview requests for invalid file ids**
- **fix: Do not return partial file info if we have a cache entry**

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

This introduces a fix for object storage where partial file info could have lead to using 0 as a file id for partial files. In addition the second commit will make sure that instead of the partial one if we have (which is always the case with object storage as we create the file info before writing to storage). 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
