### PR TITLE
feat: add config flag to toggle persistent redis connections

### DIFF
--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -55,6 +55,7 @@ class RedisFactory {
 		// # TLS support
 		// # https://github.com/phpredis/phpredis/issues/1600
 		$connectionParameters = $this->getSslContext($config);
+		$persistent = $this->config->getValue('redis.persistent', true);
 
 		// cluster config
 		if ($isCluster) {
@@ -64,9 +65,9 @@ class RedisFactory {
 
 			// Support for older phpredis versions not supporting connectionParameters
 			if ($connectionParameters !== null) {
-				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, true, $auth, $connectionParameters);
+				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, $persistent, $auth, $connectionParameters);
 			} else {
-				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, true, $auth);
+				$this->instance = new \RedisCluster(null, $config['seeds'], $timeout, $readTimeout, $persistent, $auth);
 			}
 
 			if (isset($config['failover_mode'])) {
@@ -85,17 +86,25 @@ class RedisFactory {
 				$connectionParameters = [
 					'stream' => $this->getSslContext($config)
 				];
-				/**
-				 * even though the stubs and documentation don't want you to know this,
-				 * pconnect does have the same $connectionParameters argument connect has
-				 *
-				 * https://github.com/phpredis/phpredis/blob/0264de1824b03fb2d0ad515b4d4ec019cd2dae70/redis.c#L710-L730
-				 *
-				 * @psalm-suppress TooManyArguments
-				 */
-				$this->instance->pconnect($host, $port, $timeout, null, 0, $readTimeout, $connectionParameters);
+				if ($persistent) {
+					/**
+					 * even though the stubs and documentation don't want you to know this,
+					 * pconnect does have the same $connectionParameters argument connect has
+					 *
+					 * https://github.com/phpredis/phpredis/blob/0264de1824b03fb2d0ad515b4d4ec019cd2dae70/redis.c#L710-L730
+					 *
+					 * @psalm-suppress TooManyArguments
+					 */
+					$this->instance->pconnect($host, $port, $timeout, null, 0, $readTimeout, $connectionParameters);
+				} else {
+					$this->instance->connect($host, $port, $timeout, null, 0, $readTimeout, $connectionParameters);
+				}
 			} else {
-				$this->instance->pconnect($host, $port, $timeout, null, 0, $readTimeout);
+				if ($persistent) {
+					$this->instance->pconnect($host, $port, $timeout, null, 0, $readTimeout);
+				} else {
+					$this->instance->connect($host, $port, $timeout, null, 0, $readTimeout);
+				}
 			}
 
 


### PR DESCRIPTION
Persistent redis connections were introduced with https://github.com/nextcloud/server/pull/30959 but looks like they might cause issues in some load-balanced setups.