### PR TITLE
fix: keep previous exception when wrapping dav exceptions

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -144,11 +144,11 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 				throw new \Sabre\DAV\Exception\Forbidden('Could not create directory ' . $newPath);
 			}
 		} catch (\OCP\Files\StorageNotAvailableException $e) {
-			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage(), 0, $e);
 		} catch (InvalidPathException $ex) {
-			throw new InvalidPath($ex->getMessage());
+			throw new InvalidPath($ex->getMessage(), false, $ex);
 		} catch (ForbiddenException $ex) {
-			throw new Forbidden($ex->getMessage(), $ex->getRetry());
+			throw new Forbidden($ex->getMessage(), $ex->getRetry(), $ex);
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
@@ -176,11 +176,11 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 				$this->fileView->verifyPath($this->path, $name);
 				$info = $this->fileView->getFileInfo($path);
 			} catch (\OCP\Files\StorageNotAvailableException $e) {
-				throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage());
+				throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage(), 0, $e);
 			} catch (InvalidPathException $ex) {
-				throw new InvalidPath($ex->getMessage());
+				throw new InvalidPath($ex->getMessage(), false, $ex);
 			} catch (ForbiddenException $e) {
-				throw new \Sabre\DAV\Exception\Forbidden();
+				throw new \Sabre\DAV\Exception\Forbidden($e->getMessage(), $e->getCode(), $e);
 			}
 		}
 
@@ -418,9 +418,9 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 				throw new \Sabre\DAV\Exception\Forbidden('');
 			}
 		} catch (StorageNotAvailableException $e) {
-			throw new ServiceUnavailable($e->getMessage());
+			throw new ServiceUnavailable($e->getMessage(), $e->getCode(), $e);
 		} catch (ForbiddenException $ex) {
-			throw new Forbidden($ex->getMessage(), $ex->getRetry());
+			throw new Forbidden($ex->getMessage(), $ex->getRetry(), $ex);
 		} catch (LockedException $e) {
 			throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 		}
@@ -447,9 +447,9 @@ class Directory extends \OCA\DAV\Connector\Sabre\Node implements \Sabre\DAV\ICol
 
 				return $this->fileView->copy($sourcePath, $destinationPath);
 			} catch (StorageNotAvailableException $e) {
-				throw new ServiceUnavailable($e->getMessage());
+				throw new ServiceUnavailable($e->getMessage(), $e->getCode(), $e);
 			} catch (ForbiddenException $ex) {
-				throw new Forbidden($ex->getMessage(), $ex->getRetry());
+				throw new Forbidden($ex->getMessage(), $ex->getRetry(), $ex);
 			} catch (LockedException $e) {
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}


### PR DESCRIPTION
No need to throw away valuable context