### PR TITLE
fix: FileInfo from `View` should have the correct name of a mountpoint

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1357,6 +1357,10 @@ class View {
 			if ($mount instanceof MoveableMount && $internalPath === '') {
 				$data['permissions'] |= \OCP\Constants::PERMISSION_DELETE;
 			}
+			if ($internalPath === '' && $data['name']) {
+				$data['name'] = basename($path);
+			}
+
 			$ownerId = $storage->getOwner($internalPath);
 			$owner = null;
 			if ($ownerId !== null && $ownerId !== false) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/groupfolders/issues/3068
* Resolves https://github.com/nextcloud/server/issues/37541
* Resolves https://github.com/nextcloud/server/issues/46670

## Summary

If a mountpoint is returned from a `View` the name must match the view scoped name and not the global name.
For example group folders have a name like `1` or `2` (the ID), but the name of the FileInfo returned fro mthe View should be the mount point name, like `First groupfolder` or similar.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
