### PR TITLE
fix: Add .whiteboard alias for .excalidraw files

### DIFF
--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -215,6 +215,7 @@
 	"webloc": ["application/internet-shortcut"],
 	"webm": ["video/webm"],
 	"webp": ["image/webp"],
+	"whiteboard": ["application/vnd.excalidraw+json"],
 	"wmv": ["video/x-ms-wmv"],
 	"woff": ["application/font-woff"],
 	"wpd": ["application/vnd.wordperfect"],


### PR DESCRIPTION
Additionally expose .whiteboard as a file extension in addition to .excalidraw as this should be the default instead.