### PR TITLE
docs: update docs for ocp events

### DIFF
--- a/lib/public/Accounts/UserUpdatedEvent.php
+++ b/lib/public/Accounts/UserUpdatedEvent.php
@@ -12,6 +12,8 @@ use OCP\EventDispatcher\Event;
 use OCP\IUser;
 
 /**
+ * This event is triggered when the account data of a user was updated.
+ *
  * @since 28.0.0
  */
 class UserUpdatedEvent extends Event {

--- a/lib/public/App/Events/AppDisableEvent.php
+++ b/lib/public/App/Events/AppDisableEvent.php
@@ -11,6 +11,8 @@ namespace OCP\App\Events;
 use OCP\EventDispatcher\Event;
 
 /**
+ * This event is triggered when an app is disabled.
+ *
  * @since 27.0.0
  */
 class AppDisableEvent extends Event {

--- a/lib/public/App/Events/AppEnableEvent.php
+++ b/lib/public/App/Events/AppEnableEvent.php
@@ -11,6 +11,8 @@ namespace OCP\App\Events;
 use OCP\EventDispatcher\Event;
 
 /**
+ * This event is triggered when an app is enabled.
+ *
  * @since 27.0.0
  */
 class AppEnableEvent extends Event {

--- a/lib/public/App/Events/AppUpdateEvent.php
+++ b/lib/public/App/Events/AppUpdateEvent.php
@@ -11,6 +11,8 @@ namespace OCP\App\Events;
 use OCP\EventDispatcher\Event;
 
 /**
+ * This event is triggered when an app is updated.
+ *
  * @since 27.0.0
  */
 class AppUpdateEvent extends Event {

--- a/lib/public/Collaboration/Reference/RenderReferenceEvent.php
+++ b/lib/public/Collaboration/Reference/RenderReferenceEvent.php
@@ -11,8 +11,10 @@ namespace OCP\Collaboration\Reference;
 use OCP\EventDispatcher\Event;
 
 /**
- * Event that apps can emit on their page rendering to trigger loading of aditional
- * scripts for reference widget rendering
+ * Event emitted when apps might render references like link previews or smart picker widgets.
+ *
+ * This can be used to inject scripts for extending that.
+ * Further details can be found in the :ref:`Reference providers` deep dive.
  *
  * @since 25.0.0
  */

--- a/lib/public/Preview/BeforePreviewFetchedEvent.php
+++ b/lib/public/Preview/BeforePreviewFetchedEvent.php
@@ -11,7 +11,12 @@ use OCP\Files\Node;
 use OCP\IPreview;
 
 /**
+ * Emitted before a file preview is being fetched.
+ *
+ * It can be used to block preview rendering by throwing a ``OCP\Files\NotFoundException``
+ *
  * @since 25.0.1
+ * @since 28.0.0 the constructor arguments ``$width``, ``$height``, ``$crop`` and ``$mode`` are no longer nullable.
  */
 class BeforePreviewFetchedEvent extends \OCP\EventDispatcher\Event {
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: missing documentation

## Summary

I'm updating the list of [available OCP events](https://docs.nextcloud.com/server/latest/developer_manual/basics/events.html#available-events) for a customer. 

I've scripted the process because they are many events missing: https://github.com/kesselb/nextcloud-ocp-events/

While reviewing the generated result, I noticed some descriptions in the documentation which are not in our source code. 


## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
