### PR TITLE
fix: Use timestamp instead of revision id in files_versions metadata API

### DIFF
--- a/apps/files_versions/lib/Sabre/VersionFile.php
+++ b/apps/files_versions/lib/Sabre/VersionFile.php
@@ -75,7 +75,7 @@ class VersionFile implements IFile {
 		$backend = $this->version->getBackend();
 
 		if ($backend instanceof IMetadataVersionBackend) {
-			$backend->setMetadataValue($this->version->getSourceFile(), $this->version->getRevisionId(), $key, $value);
+			$backend->setMetadataValue($this->version->getSourceFile(), $this->version->getTimestamp(), $key, $value);
 			return true;
 		} elseif ($key === 'label' && $backend instanceof INameableVersionBackend) {
 			$backend->setVersionLabel($this->version, $value);


### PR DESCRIPTION
I originally thought that the timestamp was always the same as revision ID, but it is not the case with files_versions_s3.

- Needed for https://github.com/nextcloud/files_versions_s3/pull/41