### PR TITLE
fix(AppFramework): Allow requests with OCS-APIRequest header to pass CSRF checks

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -426,6 +426,10 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 			return false;
 		}
 
+		if ($this->getHeader('OCS-APIRequest') !== '') {
+			return true;
+		}
+
 		if (isset($this->items['get']['requesttoken'])) {
 			$token = $this->items['get']['requesttoken'];
 		} elseif (isset($this->items['post']['requesttoken'])) {

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -2256,4 +2256,24 @@ class RequestTest extends \Test\TestCase {
 
 		$this->assertFalse($request->passesCSRFCheck());
 	}
+
+	public function testPassesCSRFCheckWithOCSAPIRequestHeader() {
+		/** @var Request $request */
+		$request = $this->getMockBuilder('\OC\AppFramework\Http\Request')
+			->setMethods(['getScriptName'])
+			->setConstructorArgs([
+				[
+					'server' => [
+						'HTTP_OCS_APIREQUEST' => 'true',
+					],
+				],
+				$this->requestId,
+				$this->config,
+				$this->csrfTokenManager,
+				$this->stream
+			])
+			->getMock();
+
+		$this->assertTrue($request->passesCSRFCheck());
+	}
 }


### PR DESCRIPTION
## Summary

Minimal fix extracted from https://github.com/nextcloud/server/pull/43699.
OCS APIs use the custom header to prevent CSRF attacks as described in https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#employing-custom-request-headers-for-ajaxapi:

> Both the synchronizer token and the double-submit cookie are used to prevent forgery of form data, but they can be tricky to implement and degrade usability. Many modern web applications do not use \<form> tags to submit data. A user-friendly defense that is particularly well suited for AJAX or API endpoints is the use of a custom request header. No token is needed for this approach.

While it is possible for clients to obtain CSRF tokens, it is a lot easier sending the custom header and not maintaining any state.

Using the same method for non-OCS endpoints is safe and simply allows using endpoints that require CSRF protection at the moment.
Usually external clients do not need to send the CSRF token as the cookie check will skip the token check, but if the client needs to send cookies because it also has to call APIs that are session aware (e.g. Talk room join/leave) or it runs in a browser, where the cookies are sent automatically, this measure is necessary. The existing CORS protection will prevent hijacks as it will requests with the header.

Ideally the two CSRF protections would be aligned and merged into a single implementation as there is no reason to have separate implementations of this protection, but this can be done in the future.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
