### PR TITLE
fix(core): Document CSRF token endpoint

### DIFF
--- a/core/Controller/CSRFTokenController.php
+++ b/core/Controller/CSRFTokenController.php
@@ -12,11 +12,9 @@ use OC\Security\CSRF\CsrfTokenManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
-use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
-#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class CSRFTokenController extends Controller {
 	public function __construct(
 		string $appName,
@@ -27,9 +25,16 @@ class CSRFTokenController extends Controller {
 	}
 
 	/**
+	 * Returns a new CSRF token.
+	 *
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 * @PublicPage
+	 *
+	 * @return JSONResponse<Http::STATUS_OK, array{token: string}, array{}>|JSONResponse<Http::STATUS_FORBIDDEN, array<empty>, array{}>
+	 *
+	 * 200: CSRF token returned
+	 * 403: Strict cookie check failed
 	 */
 	#[FrontpageRoute(verb: 'GET', url: '/csrftoken')]
 	public function index(): JSONResponse {

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -7731,6 +7731,52 @@
                 }
             }
         },
+        "/index.php/csrftoken": {
+            "get": {
+                "operationId": "csrf_token-index",
+                "summary": "Returns a new CSRF token.",
+                "tags": [
+                    "csrf_token"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CSRF token returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "token"
+                                    ],
+                                    "properties": {
+                                        "token": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Strict cookie check failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/login/v2/poll": {
             "post": {
                 "operationId": "client_flow_login_v2-poll",

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -7731,6 +7731,52 @@
                 }
             }
         },
+        "/index.php/csrftoken": {
+            "get": {
+                "operationId": "csrf_token-index",
+                "summary": "Returns a new CSRF token.",
+                "tags": [
+                    "csrf_token"
+                ],
+                "security": [
+                    {},
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "CSRF token returned",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "token"
+                                    ],
+                                    "properties": {
+                                        "token": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Strict cookie check failed",
+                        "content": {
+                            "application/json": {
+                                "schema": {}
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/index.php/login/v2/poll": {
             "post": {
                 "operationId": "client_flow_login_v2-poll",


### PR DESCRIPTION
## Summary

Exposes the endpoint to OpenAPI as it is necessary to receive a token for calling CSRF-protected endpoints.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
