### PR TITLE
style(settings): align icons at legacy help navigation

### DIFF
--- a/apps/settings/css/help.css
+++ b/apps/settings/css/help.css
@@ -7,8 +7,16 @@
 	overflow: hidden !important;
 }
 
+.help-list__link {
+	display: flex;
+	align-items: center;
+	height: var(--default-clickable-area);
+	margin: 0 8px;
+	background-position: left center;
+}
+
 .help-list__text {
-	margin-left: 24px;
+	margin-left: 20px;
 }
 
 .help-iframe {

--- a/apps/settings/templates/help.php
+++ b/apps/settings/templates/help.php
@@ -9,7 +9,7 @@
 	<div id="app-navigation" role="navigation" tabindex="0">
 		<ul>
 			<li>
-				<a class="icon-user <?php if ($_['mode'] === 'user') {
+				<a class="help-list__link icon-user <?php if ($_['mode'] === 'user') {
 					p('active');
 				} ?>" <?php if ($_['mode'] === 'user') {
 					print_unescaped('aria-current="page"');
@@ -22,7 +22,7 @@
 			</li>
 		<?php if ($_['admin']) { ?>
 			<li>
-				<a class="icon-user-admin <?php if ($_['mode'] === 'admin') {
+				<a class="help-list__link icon-user-admin <?php if ($_['mode'] === 'admin') {
 					p('active');
 				} ?>" <?php if ($_['mode'] === 'admin') {
 					print_unescaped('aria-current="page"');
@@ -36,14 +36,14 @@
 		<?php } ?>
 
 			<li>
-				<a href="https://docs.nextcloud.com" class="icon-category-office" target="_blank" rel="noreferrer noopener">
+				<a href="https://docs.nextcloud.com" class="help-list__link icon-category-office" target="_blank" rel="noreferrer noopener">
 					<span class="help-list__text">
 						<?php p($l->t('Documentation')); ?> ↗
 					</span>
 				</a>
 			</li>
 			<li>
-				<a href="https://help.nextcloud.com" class="icon-comment" target="_blank" rel="noreferrer noopener">
+				<a href="https://help.nextcloud.com" class="help-list__link icon-comment" target="_blank" rel="noreferrer noopener">
 					<span class="help-list__text">
 						<?php p($l->t('Forum')); ?> ↗
 					</span>


### PR DESCRIPTION
## Summary

* Ref: #40784
* This fixes alignment of link icons at legacy help format (set in config `'knowledgebase.embedded' => true`)

Before | After
-- | --
![image](https://github.com/user-attachments/assets/8470c327-df68-48c5-8e50-a83494774eaf) | ![image](https://github.com/user-attachments/assets/a4e70da2-d191-4b51-b4ad-926cb78152e9)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
