### PR TITLE
chore: deprecate old AI APIs

### DIFF
--- a/lib/public/SpeechToText/Events/AbstractTranscriptionEvent.php
+++ b/lib/public/SpeechToText/Events/AbstractTranscriptionEvent.php
@@ -13,6 +13,7 @@ use OCP\Files\File;
 
 /**
  * @since 27.0.0
+ * @deprecated 30.0.0
  */
 abstract class AbstractTranscriptionEvent extends Event {
 	/**

--- a/lib/public/SpeechToText/Events/TranscriptionFailedEvent.php
+++ b/lib/public/SpeechToText/Events/TranscriptionFailedEvent.php
@@ -15,6 +15,7 @@ use OCP\Files\File;
 /**
  * This Event is emitted if a transcription of a media file using a Speech-To-Text provider failed
  * @since 27.0.0
+ * @deprecated 30.0.0
  */
 class TranscriptionFailedEvent extends AbstractTranscriptionEvent {
 	/**

--- a/lib/public/SpeechToText/Events/TranscriptionSuccessfulEvent.php
+++ b/lib/public/SpeechToText/Events/TranscriptionSuccessfulEvent.php
@@ -15,6 +15,7 @@ use OCP\Files\File;
 /**
  * This Event is emitted when a transcription of a media file happened successfully
  * @since 27.0.0
+ * @deprecated 30.0.0
  */
 class TranscriptionSuccessfulEvent extends AbstractTranscriptionEvent {
 	/**

--- a/lib/public/SpeechToText/ISpeechToTextManager.php
+++ b/lib/public/SpeechToText/ISpeechToTextManager.php
@@ -17,6 +17,7 @@ use RuntimeException;
 
 /**
  * @since 27.0.0
+ * @deprecated 30.0.0
  */
 interface ISpeechToTextManager {
 	/**

--- a/lib/public/SpeechToText/ISpeechToTextProvider.php
+++ b/lib/public/SpeechToText/ISpeechToTextProvider.php
@@ -15,6 +15,7 @@ use RuntimeException;
 
 /**
  * @since 27.0.0
+ * @deprecated 30.0.0
  */
 interface ISpeechToTextProvider {
 	/**

--- a/lib/public/SpeechToText/ISpeechToTextProviderWithId.php
+++ b/lib/public/SpeechToText/ISpeechToTextProviderWithId.php
@@ -8,6 +8,7 @@ namespace OCP\SpeechToText;
 
 /**
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 interface ISpeechToTextProviderWithId extends ISpeechToTextProvider {
 

--- a/lib/public/SpeechToText/ISpeechToTextProviderWithUserId.php
+++ b/lib/public/SpeechToText/ISpeechToTextProviderWithUserId.php
@@ -12,6 +12,7 @@ namespace OCP\SpeechToText;
 
 /**
  * @since 29.0.0
+ * @deprecated 30.0.0
  */
 interface ISpeechToTextProviderWithUserId extends ISpeechToTextProvider {
 	/**

--- a/lib/public/TextProcessing/Events/AbstractTextProcessingEvent.php
+++ b/lib/public/TextProcessing/Events/AbstractTextProcessingEvent.php
@@ -13,6 +13,7 @@ use OCP\TextProcessing\Task;
 
 /**
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 abstract class AbstractTextProcessingEvent extends Event {
 	/**

--- a/lib/public/TextProcessing/Events/TaskFailedEvent.php
+++ b/lib/public/TextProcessing/Events/TaskFailedEvent.php
@@ -10,6 +10,7 @@ use OCP\TextProcessing\Task;
 
 /**
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 class TaskFailedEvent extends AbstractTextProcessingEvent {
 	/**

--- a/lib/public/TextProcessing/Events/TaskSuccessfulEvent.php
+++ b/lib/public/TextProcessing/Events/TaskSuccessfulEvent.php
@@ -8,6 +8,7 @@ namespace OCP\TextProcessing\Events;
 
 /**
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 class TaskSuccessfulEvent extends AbstractTextProcessingEvent {
 }

--- a/lib/public/TextProcessing/Exception/TaskFailureException.php
+++ b/lib/public/TextProcessing/Exception/TaskFailureException.php
@@ -9,6 +9,7 @@ namespace OCP\TextProcessing\Exception;
 /**
  * Exception thrown when a task failed
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 class TaskFailureException extends \RuntimeException {
 }

--- a/lib/public/TextProcessing/FreePromptTaskType.php
+++ b/lib/public/TextProcessing/FreePromptTaskType.php
@@ -15,6 +15,7 @@ use OCP\L10N\IFactory;
 /**
  * This is the text processing task type for free prompting
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 class FreePromptTaskType implements ITaskType {
 	private IL10N $l;

--- a/lib/public/TextProcessing/HeadlineTaskType.php
+++ b/lib/public/TextProcessing/HeadlineTaskType.php
@@ -15,6 +15,7 @@ use OCP\L10N\IFactory;
 /**
  * This is the text processing task type for creating headline
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 class HeadlineTaskType implements ITaskType {
 	private IL10N $l;

--- a/lib/public/TextProcessing/IManager.php
+++ b/lib/public/TextProcessing/IManager.php
@@ -20,6 +20,7 @@ use RuntimeException;
  * API surface for apps interacting with and making use of LanguageModel providers
  * without known which providers are installed
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 interface IManager {
 	/**

--- a/lib/public/TextProcessing/IProvider.php
+++ b/lib/public/TextProcessing/IProvider.php
@@ -17,6 +17,7 @@ use RuntimeException;
  * implement a text processing provider
  * @psalm-template-covariant  T of ITaskType
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 interface IProvider {
 	/**

--- a/lib/public/TextProcessing/IProviderWithExpectedRuntime.php
+++ b/lib/public/TextProcessing/IProviderWithExpectedRuntime.php
@@ -15,6 +15,7 @@ namespace OCP\TextProcessing;
  * @since 28.0.0
  * @template T of ITaskType
  * @template-extends IProvider<T>
+ * @deprecated 30.0.0
  */
 interface IProviderWithExpectedRuntime extends IProvider {
 	/**

--- a/lib/public/TextProcessing/IProviderWithId.php
+++ b/lib/public/TextProcessing/IProviderWithId.php
@@ -13,6 +13,7 @@ namespace OCP\TextProcessing;
  * @since 28.0.0
  * @extends IProvider<T>
  * @template T of ITaskType
+ * @deprecated 30.0.0
  */
 interface IProviderWithId extends IProvider {
 	/**

--- a/lib/public/TextProcessing/IProviderWithUserId.php
+++ b/lib/public/TextProcessing/IProviderWithUserId.php
@@ -15,6 +15,7 @@ namespace OCP\TextProcessing;
  * @since 28.0.0
  * @template T of ITaskType
  * @template-extends IProvider<T>
+ * @deprecated 30.0.0
  */
 interface IProviderWithUserId extends IProvider {
 	/**

--- a/lib/public/TextProcessing/ITaskType.php
+++ b/lib/public/TextProcessing/ITaskType.php
@@ -13,6 +13,7 @@ namespace OCP\TextProcessing;
  * This is a task type interface that is implemented by text processing
  * task types
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 interface ITaskType {
 	/**

--- a/lib/public/TextProcessing/SummaryTaskType.php
+++ b/lib/public/TextProcessing/SummaryTaskType.php
@@ -15,6 +15,7 @@ use OCP\L10N\IFactory;
 /**
  * This is the text processing task type for summaries
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 class SummaryTaskType implements ITaskType {
 	private IL10N $l;

--- a/lib/public/TextProcessing/Task.php
+++ b/lib/public/TextProcessing/Task.php
@@ -13,6 +13,7 @@ namespace OCP\TextProcessing;
  * This is a text processing task
  * @since 27.1.0
  * @psalm-template-covariant T of ITaskType
+ * @deprecated 30.0.0
  */
 final class Task implements \JsonSerializable {
 	protected ?int $id = null;

--- a/lib/public/TextProcessing/TopicsTaskType.php
+++ b/lib/public/TextProcessing/TopicsTaskType.php
@@ -15,6 +15,7 @@ use OCP\L10N\IFactory;
 /**
  * This is the text processing task type for topics extraction
  * @since 27.1.0
+ * @deprecated 30.0.0
  */
 class TopicsTaskType implements ITaskType {
 	private IL10N $l;

--- a/lib/public/TextToImage/Events/AbstractTextToImageEvent.php
+++ b/lib/public/TextToImage/Events/AbstractTextToImageEvent.php
@@ -14,6 +14,7 @@ use OCP\TextToImage\Task;
 
 /**
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 abstract class AbstractTextToImageEvent extends Event {
 	/**

--- a/lib/public/TextToImage/Events/TaskFailedEvent.php
+++ b/lib/public/TextToImage/Events/TaskFailedEvent.php
@@ -13,6 +13,7 @@ use OCP\TextToImage\Task;
 
 /**
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 class TaskFailedEvent extends AbstractTextToImageEvent {
 	/**

--- a/lib/public/TextToImage/Events/TaskSuccessfulEvent.php
+++ b/lib/public/TextToImage/Events/TaskSuccessfulEvent.php
@@ -11,6 +11,7 @@ namespace OCP\TextToImage\Events;
 
 /**
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 class TaskSuccessfulEvent extends AbstractTextToImageEvent {
 }

--- a/lib/public/TextToImage/Exception/TaskFailureException.php
+++ b/lib/public/TextToImage/Exception/TaskFailureException.php
@@ -9,6 +9,7 @@ namespace OCP\TextToImage\Exception;
 
 /**
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 class TaskFailureException extends TextToImageException {
 }

--- a/lib/public/TextToImage/Exception/TaskNotFoundException.php
+++ b/lib/public/TextToImage/Exception/TaskNotFoundException.php
@@ -9,6 +9,7 @@ namespace OCP\TextToImage\Exception;
 
 /**
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 class TaskNotFoundException extends TextToImageException {
 }

--- a/lib/public/TextToImage/Exception/TextToImageException.php
+++ b/lib/public/TextToImage/Exception/TextToImageException.php
@@ -9,6 +9,7 @@ namespace OCP\TextToImage\Exception;
 
 /**
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 class TextToImageException extends \Exception {
 }

--- a/lib/public/TextToImage/IManager.php
+++ b/lib/public/TextToImage/IManager.php
@@ -20,6 +20,7 @@ use RuntimeException;
  * API surface for apps interacting with and making use of TextToImage providers
  * without knowing which providers are installed
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 interface IManager {
 	/**

--- a/lib/public/TextToImage/IProvider.php
+++ b/lib/public/TextToImage/IProvider.php
@@ -15,6 +15,7 @@ use RuntimeException;
  * This is the interface that is implemented by apps that
  * implement a text to image provider
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 interface IProvider {
 	/**

--- a/lib/public/TextToImage/IProviderWithUserId.php
+++ b/lib/public/TextToImage/IProviderWithUserId.php
@@ -9,6 +9,7 @@ namespace OCP\TextToImage;
 
 /**
  * @since 29.0.0
+ * @deprecated 30.0.0
  */
 interface IProviderWithUserId extends IProvider {
 	/**

--- a/lib/public/TextToImage/Task.php
+++ b/lib/public/TextToImage/Task.php
@@ -20,6 +20,7 @@ use OCP\Image;
  * This is a text to image task
  *
  * @since 28.0.0
+ * @deprecated 30.0.0
  */
 final class Task implements \JsonSerializable {
 	protected ?int $id = null;

--- a/lib/public/Translation/CouldNotTranslateException.php
+++ b/lib/public/Translation/CouldNotTranslateException.php
@@ -11,6 +11,7 @@ namespace OCP\Translation;
 
 /**
  * @since 27.0.0
+ * @deprecated 30.0.0
  */
 class CouldNotTranslateException extends \RuntimeException {
 	/**

--- a/lib/public/Translation/IDetectLanguageProvider.php
+++ b/lib/public/Translation/IDetectLanguageProvider.php
@@ -12,6 +12,7 @@ namespace OCP\Translation;
 
 /**
  * @since 26.0.0
+ * @deprecated 30.0.0
  */
 interface IDetectLanguageProvider {
 	/**

--- a/lib/public/Translation/ITranslationManager.php
+++ b/lib/public/Translation/ITranslationManager.php
@@ -15,6 +15,7 @@ use OCP\PreConditionNotMetException;
 
 /**
  * @since 26.0.0
+ * @deprecated 30.0.0
  */
 interface ITranslationManager {
 	/**

--- a/lib/public/Translation/ITranslationProvider.php
+++ b/lib/public/Translation/ITranslationProvider.php
@@ -14,6 +14,7 @@ use RuntimeException;
 
 /**
  * @since 26.0.0
+ * @deprecated 30.0.0
  */
 interface ITranslationProvider {
 	/**

--- a/lib/public/Translation/ITranslationProviderWithId.php
+++ b/lib/public/Translation/ITranslationProviderWithId.php
@@ -12,6 +12,7 @@ namespace OCP\Translation;
 
 /**
  * @since 29.0.0
+ * @deprecated 30.0.0
  */
 interface ITranslationProviderWithId extends ITranslationProvider {
 	/**

--- a/lib/public/Translation/ITranslationProviderWithUserId.php
+++ b/lib/public/Translation/ITranslationProviderWithUserId.php
@@ -12,6 +12,7 @@ namespace OCP\Translation;
 
 /**
  * @since 29.0.0
+ * @deprecated 30.0.0
  */
 interface ITranslationProviderWithUserId extends ITranslationProvider {
 	/**

--- a/lib/public/Translation/LanguageTuple.php
+++ b/lib/public/Translation/LanguageTuple.php
@@ -14,6 +14,7 @@ use JsonSerializable;
 
 /**
  * @since 26.0.0
+ * @deprecated 30.0.0
  */
 class LanguageTuple implements JsonSerializable {
 	/**


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
