### PR TITLE
fix(testing): Make Testing TextProcessing providers unicode safe

### DIFF
--- a/apps/testing/lib/Provider/FakeTextProcessingProvider.php
+++ b/apps/testing/lib/Provider/FakeTextProcessingProvider.php
@@ -18,10 +18,21 @@ class FakeTextProcessingProvider implements IProvider {
 	}
 
 	public function process(string $prompt): string {
-		return strrev($prompt) . ' (done with FakeTextProcessingProvider)';
+		return $this->mb_strrev($prompt) . ' (done with FakeTextProcessingProvider)';
 	}
 
 	public function getTaskType(): string {
 		return FreePromptTaskType::class;
+	}
+
+	/**
+	 * Reverse a miltibyte string.
+	 *
+	 * @param string $string The string to be reversed.
+	 * @return string The reversed string
+	 */
+	private function mb_strrev(string $string): string {
+		$chars = mb_str_split($string, 1);
+		return implode('', array_reverse($chars));
 	}
 }

--- a/apps/testing/lib/Provider/FakeTextProcessingProviderSync.php
+++ b/apps/testing/lib/Provider/FakeTextProcessingProviderSync.php
@@ -20,7 +20,7 @@ class FakeTextProcessingProviderSync implements IProviderWithExpectedRuntime {
 	}
 
 	public function process(string $prompt): string {
-		return strrev($prompt) . ' (done with FakeTextProcessingProviderSync)';
+		return $this->mb_strrev($prompt) . ' (done with FakeTextProcessingProviderSync)';
 	}
 
 	public function getTaskType(): string {
@@ -29,5 +29,16 @@ class FakeTextProcessingProviderSync implements IProviderWithExpectedRuntime {
 
 	public function getExpectedRuntime(): int {
 		return 1;
+	}
+
+	/**
+	 * Reverse a miltibyte string.
+	 *
+	 * @param string $string The string to be reversed.
+	 * @return string The reversed string
+	 */
+	private function mb_strrev(string $string): string {
+		$chars = mb_str_split($string, 1);
+		return implode('', array_reverse($chars));
 	}
 }


### PR DESCRIPTION
## Summary
The Fake TextProcessing providers implemented in the testing app would fail when used in the TaskProcessing API because they do not produce valid unicode. This PR fixes that.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
