### PR TITLE
chore: bump cypress workers to 8

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -92,10 +92,10 @@ jobs:
       matrix:
         # Run multiple copies of the current job in parallel
         # Please increase the number or runners as your tests suite grows (0 based index for e2e tests)
-        containers: ["component", '0', '1', '2', '3', '4', '5']
+        containers: ["component", '0', '1', '2', '3', '4', '5', '6', '7']
         # Hack as strategy.job-total includes the component and GitHub does not allow math expressions
         # Always align this number with the total of e2e runners (max. index + 1)
-        total-containers: [6]
+        total-containers: [8]
 
     name: runner ${{ matrix.containers }}
 


### PR DESCRIPTION
With added cypress tests over the last weeks, this should speed things a bit :)