### PR TITLE
refactor(federation): Replace security annotations with respective attributes

### DIFF
--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -10,7 +10,10 @@ namespace OCA\Federation\Controller;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCSController;
@@ -63,10 +66,6 @@ class OCSAuthAPIController extends OCSController {
 	/**
 	 * Request received to ask remote server for a shared secret, for legacy end-points
 	 *
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 * @BruteForceProtection(action=federationSharedSecret)
-	 *
 	 * @param string $url URL of the server
 	 * @param string $token Token of the server
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
@@ -74,6 +73,9 @@ class OCSAuthAPIController extends OCSController {
 	 *
 	 * 200: Shared secret requested successfully
 	 */
+	#[NoCSRFRequired]
+	#[PublicPage]
+	#[BruteForceProtection(action: 'federationSharedSecret')]
 	public function requestSharedSecretLegacy(string $url, string $token): DataResponse {
 		return $this->requestSharedSecret($url, $token);
 	}
@@ -82,10 +84,6 @@ class OCSAuthAPIController extends OCSController {
 	/**
 	 * Create shared secret and return it, for legacy end-points
 	 *
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 * @BruteForceProtection(action=federationSharedSecret)
-	 *
 	 * @param string $url URL of the server
 	 * @param string $token Token of the server
 	 * @return DataResponse<Http::STATUS_OK, array{sharedSecret: string}, array{}>
@@ -93,16 +91,15 @@ class OCSAuthAPIController extends OCSController {
 	 *
 	 * 200: Shared secret returned
 	 */
+	#[NoCSRFRequired]
+	#[PublicPage]
+	#[BruteForceProtection(action: 'federationSharedSecret')]
 	public function getSharedSecretLegacy(string $url, string $token): DataResponse {
 		return $this->getSharedSecret($url, $token);
 	}
 
 	/**
 	 * Request received to ask remote server for a shared secret
-	 *
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 * @BruteForceProtection(action=federationSharedSecret)
 	 *
 	 * @param string $url URL of the server
 	 * @param string $token Token of the server
@@ -111,6 +108,9 @@ class OCSAuthAPIController extends OCSController {
 	 *
 	 * 200: Shared secret requested successfully
 	 */
+	#[NoCSRFRequired]
+	#[PublicPage]
+	#[BruteForceProtection(action: 'federationSharedSecret')]
 	public function requestSharedSecret(string $url, string $token): DataResponse {
 		if ($this->trustedServers->isTrustedServer($url) === false) {
 			$this->throttler->registerAttempt('federationSharedSecret', $this->request->getRemoteAddress());
@@ -144,10 +144,6 @@ class OCSAuthAPIController extends OCSController {
 	/**
 	 * Create shared secret and return it
 	 *
-	 * @NoCSRFRequired
-	 * @PublicPage
-	 * @BruteForceProtection(action=federationSharedSecret)
-	 *
 	 * @param string $url URL of the server
 	 * @param string $token Token of the server
 	 * @return DataResponse<Http::STATUS_OK, array{sharedSecret: string}, array{}>
@@ -155,6 +151,9 @@ class OCSAuthAPIController extends OCSController {
 	 *
 	 * 200: Shared secret returned
 	 */
+	#[NoCSRFRequired]
+	#[PublicPage]
+	#[BruteForceProtection(action: 'federationSharedSecret')]
 	public function getSharedSecret(string $url, string $token): DataResponse {
 		if ($this->trustedServers->isTrustedServer($url) === false) {
 			$this->throttler->registerAttempt('federationSharedSecret', $this->request->getRemoteAddress());

--- a/apps/federation/lib/Controller/SettingsController.php
+++ b/apps/federation/lib/Controller/SettingsController.php
@@ -7,8 +7,10 @@
  */
 namespace OCA\Federation\Controller;
 
+use OCA\Federation\Settings\Admin;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\HintException;
 use OCP\IL10N;
@@ -32,9 +34,9 @@ class SettingsController extends Controller {
 	/**
 	 * Add server to the list of trusted Nextclouds.
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\Federation\Settings\Admin)
 	 * @throws HintException
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	public function addServer(string $url): DataResponse {
 		$this->checkServer($url);
 		$id = $this->trustedServers->addServer($url);
@@ -48,9 +50,8 @@ class SettingsController extends Controller {
 
 	/**
 	 * Add server to the list of trusted Nextclouds.
-	 *
-	 * @AuthorizedAdminSetting(settings=OCA\Federation\Settings\Admin)
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	public function removeServer(int $id): DataResponse {
 		$this->trustedServers->removeServer($id);
 		return new DataResponse();
@@ -59,9 +60,9 @@ class SettingsController extends Controller {
 	/**
 	 * Check if the server should be added to the list of trusted servers or not.
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\Federation\Settings\Admin)
 	 * @throws HintException
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	protected function checkServer(string $url): bool {
 		if ($this->trustedServers->isTrustedServer($url) === true) {
 			$message = 'Server is already in the list of trusted servers.';


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/nextcloud/server/pull/46606

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
