### PR TITLE
refactor(provisioning_api): Replace security annotations with respective attributes

### DIFF
--- a/apps/provisioning_api/lib/Controller/AppConfigController.php
+++ b/apps/provisioning_api/lib/Controller/AppConfigController.php
@@ -11,6 +11,8 @@ namespace OCA\Provisioning_API\Controller;
 use OC\AppConfig;
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\IAppConfig;
@@ -93,9 +95,7 @@ class AppConfigController extends OCSController {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
 	 * @NoSubAdminRequired
-	 * @NoAdminRequired
 	 *
 	 * Update the config value of an app
 	 *
@@ -107,6 +107,8 @@ class AppConfigController extends OCSController {
 	 * 200: Value updated successfully
 	 * 403: App or key is not allowed
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function setValue(string $app, string $key, string $value): DataResponse {
 		$user = $this->userSession->getUser();
 		if ($user === null) {
@@ -130,8 +132,6 @@ class AppConfigController extends OCSController {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Delete a config key of an app
 	 *
 	 * @param string $app ID of the app
@@ -141,6 +141,7 @@ class AppConfigController extends OCSController {
 	 * 200: Key deleted successfully
 	 * 403: App or key is not allowed
 	 */
+	#[PasswordConfirmationRequired]
 	public function deleteKey(string $app, string $key): DataResponse {
 		try {
 			$this->verifyAppId($app);

--- a/apps/provisioning_api/lib/Controller/AppsController.php
+++ b/apps/provisioning_api/lib/Controller/AppsController.php
@@ -12,6 +12,7 @@ use OC_App;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCSController;
@@ -84,8 +85,6 @@ class AppsController extends OCSController {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Enable an app
 	 *
 	 * @param string $app ID of the app
@@ -94,6 +93,7 @@ class AppsController extends OCSController {
 	 *
 	 * 200: App enabled successfully
 	 */
+	#[PasswordConfirmationRequired]
 	public function enable(string $app): DataResponse {
 		try {
 			$this->appManager->enableApp($app);
@@ -104,8 +104,6 @@ class AppsController extends OCSController {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Disable an app
 	 *
 	 * @param string $app ID of the app
@@ -113,6 +111,7 @@ class AppsController extends OCSController {
 	 *
 	 * 200: App disabled successfully
 	 */
+	#[PasswordConfirmationRequired]
 	public function disable(string $app): DataResponse {
 		$this->appManager->disableApp($app);
 		return new DataResponse();

--- a/apps/provisioning_api/lib/Controller/GroupsController.php
+++ b/apps/provisioning_api/lib/Controller/GroupsController.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 namespace OCA\Provisioning_API\Controller;
 
 use OCA\Provisioning_API\ResponseDefinitions;
+use OCA\Settings\Settings\Admin\Sharing;
 use OCA\Settings\Settings\Admin\Users;
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
@@ -60,8 +63,6 @@ class GroupsController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get a list of groups
 	 *
 	 * @param string $search Text to search for
@@ -71,6 +72,7 @@ class GroupsController extends AUserData {
 	 *
 	 * 200: Groups returned
 	 */
+	#[NoAdminRequired]
 	public function getGroups(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
 		$groups = array_map(function ($group) {
@@ -82,9 +84,6 @@ class GroupsController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Sharing)
-	 *
 	 * Get a list of groups details
 	 *
 	 * @param string $search Text to search for
@@ -94,6 +93,8 @@ class GroupsController extends AUserData {
 	 *
 	 * 200: Groups details returned
 	 */
+	#[NoAdminRequired]
+	#[AuthorizedAdminSetting(settings: Sharing::class)]
 	public function getGroupsDetails(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
 		$groups = array_map(function ($group) {
@@ -112,8 +113,6 @@ class GroupsController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get a list of users in the specified group
 	 *
 	 * @param string $groupId ID of the group
@@ -124,13 +123,12 @@ class GroupsController extends AUserData {
 	 *
 	 * 200: Group users returned
 	 */
+	#[NoAdminRequired]
 	public function getGroup(string $groupId): DataResponse {
 		return $this->getGroupUsers($groupId);
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get a list of users in the specified group
 	 *
 	 * @param string $groupId ID of the group
@@ -141,6 +139,7 @@ class GroupsController extends AUserData {
 	 *
 	 * 200: User IDs returned
 	 */
+	#[NoAdminRequired]
 	public function getGroupUsers(string $groupId): DataResponse {
 		$groupId = urldecode($groupId);
 
@@ -173,8 +172,6 @@ class GroupsController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get a list of users details in the specified group
 	 *
 	 * @param string $groupId ID of the group
@@ -187,6 +184,7 @@ class GroupsController extends AUserData {
 	 *
 	 * 200: Group users details returned
 	 */
+	#[NoAdminRequired]
 	public function getGroupUsersDetails(string $groupId, string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$groupId = urldecode($groupId);
 		$currentUser = $this->userSession->getUser();
@@ -231,8 +229,6 @@ class GroupsController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Create a new group
 	 *
 	 * @param string $groupid ID of the group
@@ -243,6 +239,7 @@ class GroupsController extends AUserData {
 	 * 200: Group created successfully
 	 */
 	#[AuthorizedAdminSetting(settings:Users::class)]
+	#[PasswordConfirmationRequired]
 	public function addGroup(string $groupid, string $displayname = ''): DataResponse {
 		// Validate name
 		if (empty($groupid)) {
@@ -264,8 +261,6 @@ class GroupsController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Update a group
 	 *
 	 * @param string $groupId ID of the group
@@ -277,6 +272,7 @@ class GroupsController extends AUserData {
 	 * 200: Group updated successfully
 	 */
 	#[AuthorizedAdminSetting(settings:Users::class)]
+	#[PasswordConfirmationRequired]
 	public function updateGroup(string $groupId, string $key, string $value): DataResponse {
 		$groupId = urldecode($groupId);
 
@@ -296,8 +292,6 @@ class GroupsController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Delete a group
 	 *
 	 * @param string $groupId ID of the group
@@ -307,6 +301,7 @@ class GroupsController extends AUserData {
 	 * 200: Group deleted successfully
 	 */
 	#[AuthorizedAdminSetting(settings:Users::class)]
+	#[PasswordConfirmationRequired]
 	public function deleteGroup(string $groupId): DataResponse {
 		$groupId = urldecode($groupId);
 

--- a/apps/provisioning_api/lib/Controller/PreferencesController.php
+++ b/apps/provisioning_api/lib/Controller/PreferencesController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Provisioning_API\Controller;
 
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 use OCP\Config\BeforePreferenceDeletedEvent;
@@ -39,7 +40,6 @@ class PreferencesController extends OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Update multiple preference values of an app
@@ -52,6 +52,7 @@ class PreferencesController extends OCSController {
 	 * 200: Preferences updated successfully
 	 * 400: Preference invalid
 	 */
+	#[NoAdminRequired]
 	public function setMultiplePreferences(string $appId, array $configs): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();
 
@@ -84,7 +85,6 @@ class PreferencesController extends OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Update a preference value of an app
@@ -97,6 +97,7 @@ class PreferencesController extends OCSController {
 	 * 200: Preference updated successfully
 	 * 400: Preference invalid
 	 */
+	#[NoAdminRequired]
 	public function setPreference(string $appId, string $configKey, string $configValue): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();
 
@@ -125,7 +126,6 @@ class PreferencesController extends OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Delete multiple preferences for an app
@@ -137,6 +137,7 @@ class PreferencesController extends OCSController {
 	 * 200: Preferences deleted successfully
 	 * 400: Preference invalid
 	 */
+	#[NoAdminRequired]
 	public function deleteMultiplePreference(string $appId, array $configKeys): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();
 
@@ -167,7 +168,6 @@ class PreferencesController extends OCSController {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Delete a preference for an app
@@ -179,6 +179,7 @@ class PreferencesController extends OCSController {
 	 * 200: Preference deleted successfully
 	 * 400: Preference invalid
 	 */
+	#[NoAdminRequired]
 	public function deletePreference(string $appId, string $configKey): DataResponse {
 		$userId = $this->userSession->getUser()->getUID();
 

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -22,6 +22,9 @@ use OCP\Accounts\IAccountProperty;
 use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
+use OCP\AppFramework\Http\Attribute\UserRateLimit;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
@@ -85,8 +88,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get a list of users
 	 *
 	 * @param string $search Text to search for
@@ -96,6 +97,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Users returned
 	 */
+	#[NoAdminRequired]
 	public function getUsers(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$user = $this->userSession->getUser();
 		$users = [];
@@ -128,8 +130,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get a list of users and their details
 	 *
 	 * @param string $search Text to search for
@@ -139,6 +139,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Users details returned
 	 */
+	#[NoAdminRequired]
 	public function getUsersDetails(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$currentUser = $this->userSession->getUser();
 		$users = [];
@@ -191,8 +192,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get the list of disabled users and their details
 	 *
 	 * @param string $search Text to search for
@@ -202,6 +201,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Disabled users details returned
 	 */
+	#[NoAdminRequired]
 	public function getDisabledUsersDetails(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$currentUser = $this->userSession->getUser();
 		if ($currentUser === null) {
@@ -332,7 +332,6 @@ class UsersController extends AUserData {
 
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Search users by their phone numbers
@@ -344,6 +343,7 @@ class UsersController extends AUserData {
 	 * 200: Users returned
 	 * 400: Invalid location
 	 */
+	#[NoAdminRequired]
 	public function searchByPhoneNumbers(string $location, array $search): DataResponse {
 		if ($this->phoneNumberUtil->getCountryCodeForRegion($location) === null) {
 			// Not a valid region code
@@ -423,9 +423,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 * @NoAdminRequired
-	 *
 	 * Create a new user
 	 *
 	 * @param string $userid ID of the user
@@ -443,6 +440,8 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User added successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function addUser(
 		string $userid,
 		string $password = '',
@@ -633,7 +632,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Get the details of a user
@@ -644,6 +642,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User returned
 	 */
+	#[NoAdminRequired]
 	public function getUser(string $userId): DataResponse {
 		$includeScopes = false;
 		$currentUser = $this->userSession->getUser();
@@ -660,7 +659,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Get the details of the current user
@@ -670,6 +668,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Current user returned
 	 */
+	#[NoAdminRequired]
 	public function getCurrentUser(): DataResponse {
 		$user = $this->userSession->getUser();
 		if ($user) {
@@ -682,7 +681,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Get a list of fields that are editable for the current user
@@ -692,6 +690,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Editable fields returned
 	 */
+	#[NoAdminRequired]
 	public function getEditableFields(): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
 		if (!$currentLoggedInUser instanceof IUser) {
@@ -702,7 +701,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Get a list of fields that are editable for a user
@@ -713,6 +711,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Editable fields for user returned
 	 */
+	#[NoAdminRequired]
 	public function getEditableFieldsForUser(string $userId): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
 		if (!$currentLoggedInUser instanceof IUser) {
@@ -767,10 +766,7 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
-	 * @UserRateThrottle(limit=5, period=60)
 	 *
 	 * Update multiple values of the user's details
 	 *
@@ -783,6 +779,9 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User values edited successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 5, period: 60)]
 	public function editUserMultiValue(
 		string $userId,
 		string $collectionName,
@@ -870,10 +869,7 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
-	 * @UserRateThrottle(limit=50, period=600)
 	 *
 	 * Update a value of the user's details
 	 *
@@ -885,6 +881,9 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User value edited successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
+	#[UserRateLimit(limit: 50, period: 60)]
 	public function editUser(string $userId, string $key, string $value): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
 
@@ -1206,9 +1205,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 * @NoAdminRequired
-	 *
 	 * Wipe all devices of a user
 	 *
 	 * @param string $userId ID of the user
@@ -1219,6 +1215,8 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Wiped all user devices successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function wipeUserDevices(string $userId): DataResponse {
 		/** @var IUser $currentLoggedInUser */
 		$currentLoggedInUser = $this->userSession->getUser();
@@ -1247,9 +1245,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 * @NoAdminRequired
-	 *
 	 * Delete a user
 	 *
 	 * @param string $userId ID of the user
@@ -1258,6 +1253,8 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User deleted successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function deleteUser(string $userId): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
 
@@ -1288,9 +1285,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 * @NoAdminRequired
-	 *
 	 * Disable a user
 	 *
 	 * @param string $userId ID of the user
@@ -1299,14 +1293,13 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User disabled successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function disableUser(string $userId): DataResponse {
 		return $this->setEnabled($userId, false);
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 * @NoAdminRequired
-	 *
 	 * Enable a user
 	 *
 	 * @param string $userId ID of the user
@@ -1315,6 +1308,8 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User enabled successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function enableUser(string $userId): DataResponse {
 		return $this->setEnabled($userId, true);
 	}
@@ -1347,7 +1342,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * Get a list of groups the user belongs to
@@ -1358,6 +1352,7 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Users groups returned
 	 */
+	#[NoAdminRequired]
 	public function getUsersGroups(string $userId): DataResponse {
 		$loggedInUser = $this->userSession->getUser();
 
@@ -1398,9 +1393,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 * @NoAdminRequired
-	 *
 	 * Add a user to a group
 	 *
 	 * @param string $userId ID of the user
@@ -1410,6 +1402,8 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User added to group successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function addToGroup(string $userId, string $groupid = ''): DataResponse {
 		if ($groupid === '') {
 			throw new OCSException('', 101);
@@ -1439,9 +1433,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 * @NoAdminRequired
-	 *
 	 * Remove a user from a group
 	 *
 	 * @param string $userId ID of the user
@@ -1451,6 +1442,8 @@ class UsersController extends AUserData {
 	 *
 	 * 200: User removed from group successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function removeFromGroup(string $userId, string $groupid): DataResponse {
 		$loggedInUser = $this->userSession->getUser();
 
@@ -1507,8 +1500,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Make a user a subadmin of a group
 	 *
 	 * @param string $userId ID of the user
@@ -1519,6 +1510,7 @@ class UsersController extends AUserData {
 	 * 200: User added as group subadmin successfully
 	 */
 	#[AuthorizedAdminSetting(settings:Users::class)]
+	#[PasswordConfirmationRequired]
 	public function addSubAdmin(string $userId, string $groupid): DataResponse {
 		$group = $this->groupManager->get($groupid);
 		$user = $this->userManager->get($userId);
@@ -1548,8 +1540,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * Remove a user from the subadmins of a group
 	 *
 	 * @param string $userId ID of the user
@@ -1560,6 +1550,7 @@ class UsersController extends AUserData {
 	 * 200: User removed as group subadmin successfully
 	 */
 	#[AuthorizedAdminSetting(settings:Users::class)]
+	#[PasswordConfirmationRequired]
 	public function removeSubAdmin(string $userId, string $groupid): DataResponse {
 		$group = $this->groupManager->get($groupid);
 		$user = $this->userManager->get($userId);
@@ -1599,9 +1590,6 @@ class UsersController extends AUserData {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @PasswordConfirmationRequired
-	 *
 	 * Resend the welcome message
 	 *
 	 * @param string $userId ID if the user
@@ -1610,6 +1598,8 @@ class UsersController extends AUserData {
 	 *
 	 * 200: Resent welcome message successfully
 	 */
+	#[PasswordConfirmationRequired]
+	#[NoAdminRequired]
 	public function resendWelcomeMessage(string $userId): DataResponse {
 		$currentLoggedInUser = $this->userSession->getUser();
 

--- a/apps/provisioning_api/lib/Controller/VerificationController.php
+++ b/apps/provisioning_api/lib/Controller/VerificationController.php
@@ -13,6 +13,9 @@ use InvalidArgumentException;
 use OC\Security\Crypto;
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IL10N;
@@ -58,10 +61,10 @@ class VerificationController extends Controller {
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function showVerifyMail(string $token, string $userId, string $key): TemplateResponse {
 		if ($this->userSession->getUser()->getUID() !== $userId) {
 			// not a public page, hence getUser() must return an IUser
@@ -78,10 +81,10 @@ class VerificationController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @BruteForceProtection(action=emailVerification)
 	 */
+	#[NoAdminRequired]
+	#[BruteForceProtection(action: 'emailVerification')]
 	public function verifyMail(string $token, string $userId, string $key): TemplateResponse {
 		$throttle = false;
 		try {


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/nextcloud/server/pull/46606

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
