### PR TITLE
refactor(settings): Replace security annotations with respective attributes

### DIFF
--- a/apps/settings/lib/Controller/AISettingsController.php
+++ b/apps/settings/lib/Controller/AISettingsController.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
  */
 namespace OCA\Settings\Controller;
 
+use OCA\Settings\Settings\Admin\ArtificialIntelligence;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -31,11 +33,10 @@ class AISettingsController extends Controller {
 	/**
 	 * Sets the email settings
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\ArtificialIntelligence)
-	 *
 	 * @param array $settings
 	 * @return DataResponse
 	 */
+	#[AuthorizedAdminSetting(settings: ArtificialIntelligence::class)]
 	public function update($settings) {
 		$keys = ['ai.stt_provider', 'ai.textprocessing_provider_preferences', 'ai.taskprocessing_provider_preferences', 'ai.translation_provider_preferences', 'ai.text2image_provider'];
 		foreach ($keys as $key) {

--- a/apps/settings/lib/Controller/AdminSettingsController.php
+++ b/apps/settings/lib/Controller/AdminSettingsController.php
@@ -7,6 +7,8 @@ namespace OCA\Settings\Controller;
 
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -46,12 +48,12 @@ class AdminSettingsController extends Controller {
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 * We are checking the permissions in the getSettings method. If there is no allowed
 	 * settings for the given section. The user will be gretted by an error message.
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function index(string $section): TemplateResponse {
 		return $this->getIndexResponse('admin', $section);
 	}

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -19,7 +19,10 @@ use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
+use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\JSONResponse;
@@ -74,10 +77,9 @@ class AppSettingsController extends Controller {
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 *
 	 * @return TemplateResponse
 	 */
+	#[NoCSRFRequired]
 	public function viewApps(): TemplateResponse {
 		$this->navigationManager->setActiveEntry('core_apps');
 
@@ -100,23 +102,21 @@ class AppSettingsController extends Controller {
 
 	/**
 	 * Get all active entries for the app discover section
-	 *
-	 * @NoCSRFRequired
 	 */
+	#[NoCSRFRequired]
 	public function getAppDiscoverJSON(): JSONResponse {
 		$data = $this->discoverFetcher->get(true);
 		return new JSONResponse($data);
 	}
 
 	/**
-	 * @PublicPage
-	 * @NoCSRFRequired
-	 *
 	 * Get a image for the app discover section - this is proxied for privacy and CSP reasons
 	 *
 	 * @param string $image
 	 * @throws \Exception
 	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
 	public function getAppDiscoverMedia(string $fileName): Response {
 		$etag = $this->discoverFetcher->getETag() ?? date('Y-m');
 		$folder = null;
@@ -455,12 +455,11 @@ class AppSettingsController extends Controller {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * @param string $appId
 	 * @param array $groups
 	 * @return JSONResponse
 	 */
+	#[PasswordConfirmationRequired]
 	public function enableApp(string $appId, array $groups = []): JSONResponse {
 		return $this->enableApps([$appId], $groups);
 	}
@@ -470,11 +469,11 @@ class AppSettingsController extends Controller {
 	 *
 	 * apps will be enabled for specific groups only if $groups is defined
 	 *
-	 * @PasswordConfirmationRequired
 	 * @param array $appIds
 	 * @param array $groups
 	 * @return JSONResponse
 	 */
+	#[PasswordConfirmationRequired]
 	public function enableApps(array $appIds, array $groups = []): JSONResponse {
 		try {
 			$updateRequired = false;
@@ -522,21 +521,19 @@ class AppSettingsController extends Controller {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * @param string $appId
 	 * @return JSONResponse
 	 */
+	#[PasswordConfirmationRequired]
 	public function disableApp(string $appId): JSONResponse {
 		return $this->disableApps([$appId]);
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * @param array $appIds
 	 * @return JSONResponse
 	 */
+	#[PasswordConfirmationRequired]
 	public function disableApps(array $appIds): JSONResponse {
 		try {
 			foreach ($appIds as $appId) {
@@ -551,11 +548,10 @@ class AppSettingsController extends Controller {
 	}
 
 	/**
-	 * @PasswordConfirmationRequired
-	 *
 	 * @param string $appId
 	 * @return JSONResponse
 	 */
+	#[PasswordConfirmationRequired]
 	public function uninstallApp(string $appId): JSONResponse {
 		$appId = OC_App::cleanAppId($appId);
 		$result = $this->installer->removeApp($appId);

--- a/apps/settings/lib/Controller/AuthSettingsController.php
+++ b/apps/settings/lib/Controller/AuthSettingsController.php
@@ -17,6 +17,8 @@ use OCA\Settings\Activity\Provider;
 use OCP\Activity\IManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\Authentication\Exceptions\ExpiredTokenException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
@@ -88,13 +90,13 @@ class AuthSettingsController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
 	 *
 	 * @param string $name
 	 * @return JSONResponse
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function create($name) {
 		if ($this->checkAppToken()) {
 			return $this->getServiceNotAvailableResponse();
@@ -169,12 +171,12 @@ class AuthSettingsController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * @param int $id
 	 * @return array|JSONResponse
 	 */
+	#[NoAdminRequired]
 	public function destroy($id) {
 		if ($this->checkAppToken()) {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
@@ -195,7 +197,6 @@ class AuthSettingsController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 *
 	 * @param int $id
@@ -203,6 +204,7 @@ class AuthSettingsController extends Controller {
 	 * @param string $name
 	 * @return array|JSONResponse
 	 */
+	#[NoAdminRequired]
 	public function update($id, array $scope, string $name) {
 		if ($this->checkAppToken()) {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
@@ -276,15 +278,15 @@ class AuthSettingsController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
 	 *
 	 * @param int $id
 	 * @return JSONResponse
 	 * @throws InvalidTokenException
 	 * @throws ExpiredTokenException
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function wipe(int $id): JSONResponse {
 		if ($this->checkAppToken()) {
 			return new JSONResponse([], Http::STATUS_BAD_REQUEST);

--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -13,6 +13,9 @@ use OC\Group\Manager as GroupManager;
 use OC\User\Session;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\BruteForceProtection;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\HintException;
 use OCP\IGroupManager;
@@ -49,10 +52,10 @@ class ChangePasswordController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @BruteForceProtection(action=changePersonalPassword)
 	 */
+	#[NoAdminRequired]
+	#[BruteForceProtection(action: 'changePersonalPassword')]
 	public function changePersonalPassword(string $oldpassword = '', ?string $newpassword = null): JSONResponse {
 		$loginName = $this->userSession->getLoginName();
 		/** @var IUser $user */
@@ -97,10 +100,8 @@ class ChangePasswordController extends Controller {
 		]);
 	}
 
-	/**
-	 * @NoAdminRequired
-	 * @PasswordConfirmationRequired
-	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function changeUserPassword(?string $username = null, ?string $password = null, ?string $recoveryPassword = null): JSONResponse {
 		if ($username === null) {
 			return new JSONResponse([

--- a/apps/settings/lib/Controller/CheckSetupController.php
+++ b/apps/settings/lib/Controller/CheckSetupController.php
@@ -9,7 +9,11 @@ namespace OCA\Settings\Controller;
 
 use OC\AppFramework\Http;
 use OC\IntegrityCheck\Checker;
+use OCA\Settings\Settings\Admin\Overview;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
@@ -54,19 +58,19 @@ class CheckSetupController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
 	 * @return DataResponse
 	 */
+	#[NoCSRFRequired]
+	#[NoAdminRequired]
 	public function setupCheckManager(): DataResponse {
 		return new DataResponse($this->setupCheckManager->runAll());
 	}
 
 	/**
-	 * @NoCSRFRequired
 	 * @return RedirectResponse
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
 	 */
+	#[NoCSRFRequired]
+	#[AuthorizedAdminSetting(settings: Overview::class)]
 	public function rescanFailedIntegrityCheck(): RedirectResponse {
 		$this->checker->runInstanceVerification();
 		return new RedirectResponse(
@@ -74,10 +78,8 @@ class CheckSetupController extends Controller {
 		);
 	}
 
-	/**
-	 * @NoCSRFRequired
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
-	 */
+	#[NoCSRFRequired]
+	#[AuthorizedAdminSetting(settings: Overview::class)]
 	public function getFailedIntegrityCheckFiles(): DataDisplayResponse {
 		if (!$this->checker->isCodeCheckEnforced()) {
 			return new DataDisplayResponse('Integrity checker has been disabled. Integrity cannot be verified.');
@@ -137,8 +139,8 @@ Raw output
 
 	/**
 	 * @return DataResponse
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
 	 */
+	#[AuthorizedAdminSetting(settings: Overview::class)]
 	public function check() {
 		return new DataResponse(
 			[

--- a/apps/settings/lib/Controller/HelpController.php
+++ b/apps/settings/lib/Controller/HelpController.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace OCA\Settings\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -65,10 +67,10 @@ class HelpController extends Controller {
 	/**
 	 * @return TemplateResponse
 	 *
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 */
+	#[NoCSRFRequired]
+	#[NoAdminRequired]
 	public function help(string $mode = 'user'): TemplateResponse {
 		$this->navigationManager->setActiveEntry('help');
 		$pageTitle = $this->l10n->t('Administrator documentation');

--- a/apps/settings/lib/Controller/LogSettingsController.php
+++ b/apps/settings/lib/Controller/LogSettingsController.php
@@ -10,6 +10,7 @@ namespace OCA\Settings\Controller;
 use OC\Log;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\StreamResponse;
 use OCP\IRequest;
 
@@ -26,14 +27,13 @@ class LogSettingsController extends Controller {
 	/**
 	 * download logfile
 	 *
-	 * @NoCSRFRequired
-	 *
 	 * @psalm-suppress MoreSpecificReturnType The value of Content-Disposition is not relevant
 	 * @psalm-suppress LessSpecificReturnStatement The value of Content-Disposition is not relevant
 	 * @return StreamResponse<Http::STATUS_OK, array{Content-Type: 'application/octet-stream', 'Content-Disposition': string}>
 	 *
 	 * 200: Logfile returned
 	 */
+	#[NoCSRFRequired]
 	public function download() {
 		if (!$this->log instanceof Log) {
 			throw new \UnexpectedValueException('Log file not available');

--- a/apps/settings/lib/Controller/MailSettingsController.php
+++ b/apps/settings/lib/Controller/MailSettingsController.php
@@ -6,8 +6,11 @@
  */
 namespace OCA\Settings\Controller;
 
+use OCA\Settings\Settings\Admin\Overview;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -56,9 +59,6 @@ class MailSettingsController extends Controller {
 	/**
 	 * Sets the email settings
 	 *
-	 * @PasswordConfirmationRequired
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
-	 *
 	 * @param string $mail_domain
 	 * @param string $mail_from_address
 	 * @param string $mail_smtpmode
@@ -68,6 +68,8 @@ class MailSettingsController extends Controller {
 	 * @param string $mail_smtpport
 	 * @return DataResponse
 	 */
+	#[AuthorizedAdminSetting(settings: Overview::class)]
+	#[PasswordConfirmationRequired]
 	public function setMailSettings($mail_domain,
 		$mail_from_address,
 		$mail_smtpmode,
@@ -98,13 +100,12 @@ class MailSettingsController extends Controller {
 	/**
 	 * Store the credentials used for SMTP in the config
 	 *
-	 * @PasswordConfirmationRequired
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
-	 *
 	 * @param string $mail_smtpname
 	 * @param string $mail_smtppassword
 	 * @return DataResponse
 	 */
+	#[AuthorizedAdminSetting(settings: Overview::class)]
+	#[PasswordConfirmationRequired]
 	public function storeCredentials($mail_smtpname, $mail_smtppassword) {
 		if ($mail_smtppassword === '********') {
 			return new DataResponse($this->l10n->t('Invalid SMTP password.'), Http::STATUS_BAD_REQUEST);
@@ -122,9 +123,9 @@ class MailSettingsController extends Controller {
 
 	/**
 	 * Send a mail to test the settings
-	 * @AuthorizedAdminSetting(settings=OCA\Settings\Settings\Admin\Overview)
 	 * @return DataResponse
 	 */
+	#[AuthorizedAdminSetting(settings: Overview::class)]
 	public function sendTestMail() {
 		$email = $this->config->getUserValue($this->userSession->getUser()->getUID(), $this->appName, 'email', '');
 		if (!empty($email)) {

--- a/apps/settings/lib/Controller/PersonalSettingsController.php
+++ b/apps/settings/lib/Controller/PersonalSettingsController.php
@@ -6,6 +6,8 @@
 namespace OCA\Settings\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -44,10 +46,10 @@ class PersonalSettingsController extends Controller {
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function index(string $section): TemplateResponse {
 		return $this->getIndexResponse('personal', $section);
 	}

--- a/apps/settings/lib/Controller/ReasonsController.php
+++ b/apps/settings/lib/Controller/ReasonsController.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace OCA\Settings\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\DataDisplayResponse;
 
@@ -16,10 +18,10 @@ use OCP\AppFramework\Http\DataDisplayResponse;
 class ReasonsController extends Controller {
 
 	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function getPdf() {
 		$data = file_get_contents(__DIR__ . '/../../data/Reasons to use Nextcloud.pdf');
 

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -27,7 +27,10 @@ use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -72,25 +75,23 @@ class UsersController extends Controller {
 
 
 	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
-	 *
 	 * Display users list template
 	 *
 	 * @return TemplateResponse
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function usersListByGroup(): TemplateResponse {
 		return $this->usersList();
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 * @NoAdminRequired
-	 *
 	 * Display users list template
 	 *
 	 * @return TemplateResponse
 	 */
+	#[NoAdminRequired]
+	#[NoCSRFRequired]
 	public function usersList(): TemplateResponse {
 		$user = $this->userSession->getUser();
 		$uid = $user->getUID();
@@ -293,9 +294,7 @@ class UsersController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
 	 *
 	 * @param string|null $avatarScope
 	 * @param string|null $displayname
@@ -317,6 +316,8 @@ class UsersController extends Controller {
 	 *
 	 * @return DataResponse
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function setUserSettings(?string $avatarScope = null,
 		?string $displayname = null,
 		?string $displaynameScope = null,
@@ -475,14 +476,14 @@ class UsersController extends Controller {
 	/**
 	 * Set the mail address of a user
 	 *
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
 	 *
 	 * @param string $account
 	 * @param bool $onlyVerificationCode only return verification code without updating the data
 	 * @return DataResponse
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function getVerificationCode(string $account, bool $onlyVerificationCode): DataResponse {
 		$user = $this->userSession->getUser();
 

--- a/apps/settings/lib/Controller/WebAuthnController.php
+++ b/apps/settings/lib/Controller/WebAuthnController.php
@@ -12,7 +12,11 @@ use OC\Authentication\WebAuthn\Manager;
 use OCA\Settings\AppInfo\Application;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
+use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\ISession;
@@ -35,12 +39,12 @@ class WebAuthnController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
-	 * @UseSession
-	 * @NoCSRFRequired
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
+	#[UseSession]
+	#[NoCSRFRequired]
 	public function startRegistration(): JSONResponse {
 		$this->logger->debug('Starting WebAuthn registration');
 
@@ -53,11 +57,11 @@ class WebAuthnController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
-	 * @UseSession
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
+	#[UseSession]
 	public function finishRegistration(string $name, string $data): JSONResponse {
 		$this->logger->debug('Finishing WebAuthn registration');
 
@@ -75,10 +79,10 @@ class WebAuthnController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
 	 * @NoSubAdminRequired
-	 * @PasswordConfirmationRequired
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function deleteRegistration(int $id): JSONResponse {
 		$this->logger->debug('Finishing WebAuthn registration');
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/nextcloud/server/pull/46606

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
