### PR TITLE
refactor(twofactor_backupcodes): Replace security annotations with respective attributes

### DIFF
--- a/apps/twofactor_backupcodes/lib/Controller/SettingsController.php
+++ b/apps/twofactor_backupcodes/lib/Controller/SettingsController.php
@@ -10,6 +10,8 @@ namespace OCA\TwoFactorBackupCodes\Controller;
 
 use OCA\TwoFactorBackupCodes\Service\BackupCodeStorage;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
@@ -35,11 +37,10 @@ class SettingsController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 * @PasswordConfirmationRequired
-	 *
 	 * @return JSONResponse
 	 */
+	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function createCodes(): JSONResponse {
 		$user = $this->userSession->getUser();
 		$codes = $this->storage->createCodes($user);


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/nextcloud/server/pull/46606

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
