### PR TITLE
refactor(user_ldap): Replace security annotations with respective attributes

### DIFF
--- a/apps/user_ldap/lib/Controller/ConfigAPIController.php
+++ b/apps/user_ldap/lib/Controller/ConfigAPIController.php
@@ -11,7 +11,9 @@ use OC\Security\IdentityProof\Manager;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\ConnectionFactory;
 use OCA\User_LDAP\Helper;
+use OCA\User_LDAP\Settings\Admin;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
@@ -46,12 +48,12 @@ class ConfigAPIController extends OCSController {
 	/**
 	 * Create a new (empty) configuration and return the resulting prefix
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\User_LDAP\Settings\Admin)
 	 * @return DataResponse<Http::STATUS_OK, array{configID: string}, array{}>
 	 * @throws OCSException
 	 *
 	 * 200: Config created successfully
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	public function create() {
 		try {
 			$configPrefix = $this->ldapHelper->getNextServerConfigurationPrefix();
@@ -68,7 +70,6 @@ class ConfigAPIController extends OCSController {
 	/**
 	 * Delete a LDAP configuration
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\User_LDAP\Settings\Admin)
 	 * @param string $configID ID of the config
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
 	 * @throws OCSException
@@ -76,6 +77,7 @@ class ConfigAPIController extends OCSController {
 	 *
 	 * 200: Config deleted successfully
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	public function delete($configID) {
 		try {
 			$this->ensureConfigIDExists($configID);
@@ -95,7 +97,6 @@ class ConfigAPIController extends OCSController {
 	/**
 	 * Modify a configuration
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\User_LDAP\Settings\Admin)
 	 * @param string $configID ID of the config
 	 * @param array<string, mixed> $configData New config
 	 * @return DataResponse<Http::STATUS_OK, array<empty>, array{}>
@@ -105,6 +106,7 @@ class ConfigAPIController extends OCSController {
 	 *
 	 * 200: Config returned
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	public function modify($configID, $configData) {
 		try {
 			$this->ensureConfigIDExists($configID);
@@ -200,7 +202,6 @@ class ConfigAPIController extends OCSController {
 	 *   </data>
 	 * </ocs>
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\User_LDAP\Settings\Admin)
 	 * @param string $configID ID of the config
 	 * @param bool $showPassword Whether to show the password
 	 * @return DataResponse<Http::STATUS_OK, array<string, mixed>, array{}>
@@ -209,6 +210,7 @@ class ConfigAPIController extends OCSController {
 	 *
 	 * 200: Config returned
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	public function show($configID, $showPassword = false) {
 		try {
 			$this->ensureConfigIDExists($configID);
@@ -237,10 +239,10 @@ class ConfigAPIController extends OCSController {
 	/**
 	 * If the given config ID is not available, an exception is thrown
 	 *
-	 * @AuthorizedAdminSetting(settings=OCA\User_LDAP\Settings\Admin)
 	 * @param string $configID
 	 * @throws OCSNotFoundException
 	 */
+	#[AuthorizedAdminSetting(settings: Admin::class)]
 	private function ensureConfigIDExists($configID): void {
 		$prefixes = $this->ldapHelper->getServerConfigurationPrefixes();
 		if (!in_array($configID, $prefixes, true)) {

--- a/apps/user_ldap/lib/Controller/RenewPasswordController.php
+++ b/apps/user_ldap/lib/Controller/RenewPasswordController.php
@@ -6,7 +6,10 @@
 namespace OCA\User_LDAP\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\Attribute\UseSession;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\HintException;
@@ -49,24 +52,22 @@ class RenewPasswordController extends Controller {
 	}
 
 	/**
-	 * @PublicPage
-	 * @NoCSRFRequired
-	 *
 	 * @return RedirectResponse
 	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
 	public function cancel() {
 		return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
 	}
 
 	/**
-	 * @PublicPage
-	 * @NoCSRFRequired
-	 * @UseSession
-	 *
 	 * @param string $user
 	 *
 	 * @return TemplateResponse|RedirectResponse
 	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[UseSession]
 	public function showRenewPasswordForm($user) {
 		if ($this->config->getUserValue($user, 'user_ldap', 'needsPasswordReset') !== 'true') {
 			return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
@@ -102,15 +103,14 @@ class RenewPasswordController extends Controller {
 	}
 
 	/**
-	 * @PublicPage
-	 * @UseSession
-	 *
 	 * @param string $user
 	 * @param string $oldPassword
 	 * @param string $newPassword
 	 *
 	 * @return RedirectResponse
 	 */
+	#[PublicPage]
+	#[UseSession]
 	public function tryRenewPassword($user, $oldPassword, $newPassword) {
 		if ($this->config->getUserValue($user, 'user_ldap', 'needsPasswordReset') !== 'true') {
 			return new RedirectResponse($this->urlGenerator->linkToRouteAbsolute('core.login.showLoginForm'));
@@ -146,12 +146,11 @@ class RenewPasswordController extends Controller {
 	}
 
 	/**
-	 * @PublicPage
-	 * @NoCSRFRequired
-	 * @UseSession
-	 *
 	 * @return RedirectResponse
 	 */
+	#[PublicPage]
+	#[NoCSRFRequired]
+	#[UseSession]
 	public function showLoginFormInvalidPassword($user) {
 		$args = !is_null($user) ? ['user' => $user] : [];
 		$this->session->set('loginMessages', [


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/nextcloud/server/pull/46606

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
