### PR TITLE
build(psalm): Enforce named attribute arguments

### DIFF
--- a/build/psalm/AttributeNamedParameters.php
+++ b/build/psalm/AttributeNamedParameters.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use PhpParser\Node\Attribute;
+use Psalm\CodeLocation;
+use Psalm\FileSource;
+use Psalm\Issue\InvalidDocblock;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+
+class AttributeNamedParameters implements Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface {
+	public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event): void {
+		$stmt = $event->getStmt();
+		$statementsSource = $event->getStatementsSource();
+
+		foreach ($stmt->attrGroups as $attrGroup) {
+			foreach ($attrGroup->attrs as $attr) {
+				self::checkAttribute($attr, $statementsSource);
+			}
+		}
+
+		foreach ($stmt->getMethods() as $method) {
+			foreach ($method->attrGroups as $attrGroup) {
+				foreach ($attrGroup->attrs as $attr) {
+					self::checkAttribute($attr, $statementsSource);
+				}
+			}
+		}
+	}
+
+	private static function checkAttribute(Attribute $stmt, FileSource $statementsSource): void {
+		if ($stmt->name->getLast() === 'Attribute') {
+			return;
+		}
+
+		foreach ($stmt->args as $arg) {
+			if ($arg->name === null) {
+				IssueBuffer::maybeAdd(
+					new InvalidDocblock(
+						'Attribute arguments must be named.',
+						new CodeLocation($statementsSource, $stmt)
+					)
+				);
+			}
+		}
+	}
+}

--- a/core/Controller/AppPasswordController.php
+++ b/core/Controller/AppPasswordController.php
@@ -168,7 +168,7 @@ class AppPasswordController extends \OCP\AppFramework\OCSController {
 	 * 403: Password confirmation failed
 	 */
 	#[NoAdminRequired]
-	#[BruteForceProtection('sudo')]
+	#[BruteForceProtection(action: 'sudo')]
 	#[UseSession]
 	#[ApiRoute(verb: 'PUT', url: '/apppassword/confirm', root: '/core')]
 	public function confirmUserPassword(string $password): DataResponse {

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -274,7 +274,7 @@ class LoginController extends Controller {
 	 */
 	#[NoCSRFRequired]
 	#[PublicPage]
-	#[BruteForceProtection('login')]
+	#[BruteForceProtection(action: 'login')]
 	#[UseSession]
 	#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 	#[FrontpageRoute(verb: 'POST', url: '/login')]
@@ -387,7 +387,7 @@ class LoginController extends Controller {
 	 * 403: Password confirmation failed
 	 */
 	#[NoAdminRequired]
-	#[BruteForceProtection('sudo')]
+	#[BruteForceProtection(action: 'sudo')]
 	#[UseSession]
 	#[NoCSRFRequired]
 	#[FrontpageRoute(verb: 'POST', url: '/login/confirm')]

--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -81,8 +81,8 @@ class LostController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	#[BruteForceProtection('passwordResetEmail')]
-	#[AnonRateLimit(10, 300)]
+	#[BruteForceProtection(action: 'passwordResetEmail')]
+	#[AnonRateLimit(limit: 10, period: 300)]
 	#[FrontpageRoute(verb: 'GET', url: '/lostpassword/reset/form/{token}/{userId}')]
 	public function resetform(string $token, string $userId): TemplateResponse {
 		try {
@@ -144,8 +144,8 @@ class LostController extends Controller {
 	}
 
 	#[PublicPage]
-	#[BruteForceProtection('passwordResetEmail')]
-	#[AnonRateLimit(10, 300)]
+	#[BruteForceProtection(action: 'passwordResetEmail')]
+	#[AnonRateLimit(limit: 10, period: 300)]
 	#[FrontpageRoute(verb: 'POST', url: '/lostpassword/email')]
 	public function email(string $user): JSONResponse {
 		if ($this->config->getSystemValue('lost_password_link', '') !== '') {
@@ -180,8 +180,8 @@ class LostController extends Controller {
 	}
 
 	#[PublicPage]
-	#[BruteForceProtection('passwordResetEmail')]
-	#[AnonRateLimit(10, 300)]
+	#[BruteForceProtection(action: 'passwordResetEmail')]
+	#[AnonRateLimit(limit: 10, period: 300)]
 	#[FrontpageRoute(verb: 'POST', url: '/lostpassword/set/{token}/{userId}')]
 	public function setPassword(string $token, string $userId, string $password, bool $proceed): JSONResponse {
 		if ($this->encryptionManager->isEnabled() && !$proceed) {

--- a/core/Controller/OCSController.php
+++ b/core/Controller/OCSController.php
@@ -77,7 +77,7 @@ class OCSController extends \OCP\AppFramework\OCSController {
 	}
 
 	#[PublicPage]
-	#[BruteForceProtection('login')]
+	#[BruteForceProtection(action: 'login')]
 	#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 	#[ApiRoute(verb: 'POST', url: '/check', root: '/person')]
 	public function personCheck(string $login = '', string $password = ''): DataResponse {

--- a/core/Controller/ProfileApiController.php
+++ b/core/Controller/ProfileApiController.php
@@ -53,7 +53,7 @@ class ProfileApiController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[PasswordConfirmationRequired]
-	#[UserRateLimit(40, 600)]
+	#[UserRateLimit(limit: 40, period: 600)]
 	#[ApiRoute(verb: 'PUT', url: '/{targetUserId}', root: '/profile')]
 	public function setVisibility(string $targetUserId, string $paramId, string $visibility): DataResponse {
 		$requestingUser = $this->userSession->getUser();

--- a/core/Controller/TranslationApiController.php
+++ b/core/Controller/TranslationApiController.php
@@ -62,8 +62,8 @@ class TranslationApiController extends \OCP\AppFramework\OCSController {
 	 * 412: Translating is not possible
 	 */
 	#[PublicPage]
-	#[UserRateLimit(25, 120)]
-	#[AnonRateLimit(10, 120)]
+	#[UserRateLimit(limit: 25, period: 120)]
+	#[AnonRateLimit(limit: 10, period: 120)]
 	#[ApiRoute(verb: 'POST', url: '/translate', root: '/translation')]
 	public function translate(string $text, ?string $fromLanguage, string $toLanguage): DataResponse {
 		try {

--- a/core/Controller/WipeController.php
+++ b/core/Controller/WipeController.php
@@ -40,7 +40,7 @@ class WipeController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	#[AnonRateLimit(10, 300)]
+	#[AnonRateLimit(limit: 10, period: 300)]
 	#[FrontpageRoute(verb: 'POST', url: '/core/wipe/check')]
 	public function checkWipe(string $token): JSONResponse {
 		try {
@@ -69,7 +69,7 @@ class WipeController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	#[AnonRateLimit(10, 300)]
+	#[AnonRateLimit(limit: 10, period: 300)]
 	#[FrontpageRoute(verb: 'POST', url: '/core/wipe/success')]
 	public function wipeDone(string $token): JSONResponse {
 		try {

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,7 @@
 >
 	<plugins>
 		<plugin filename="build/psalm/AppFrameworkTainter.php" />
+		<plugin filename="build/psalm/AttributeNamedParameters.php" />
 	</plugins>
 	<projectFiles>
 		<directory name="apps/admin_audit"/>


### PR DESCRIPTION
## Summary

Enforces the rule that all attribute arguments should be named.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
