### PR TITLE
fix(files): Don't try to use missing cache entries

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -870,7 +870,7 @@ class Cache implements ICache {
 			}
 			if ($isBackgroundScan) {
 				$parentData = $this->get($parent);
-				if ($parentData['size'] !== -1 && $this->getIncompleteChildrenCount($parentData['fileid']) === 0) {
+				if ($parentData !== false && $parentData['size'] !== -1 && $this->getIncompleteChildrenCount($parentData['fileid']) === 0) {
 					$this->correctFolderSize($parent, $parentData, $isBackgroundScan);
 				}
 			} else {


### PR DESCRIPTION
## Summary
The `Cache::get()` function can return `ICacheEntry` or `false`. Added check ensures that `false` return value is not used as an array. This silences: `Trying to access array offset on value of type bool` errors.
