### PR TITLE
fix(psalm): named attribute argument

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -423,7 +423,7 @@ class ThemingController extends Controller {
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]
-	#[BruteForceProtection('manifest')]
+	#[BruteForceProtection(action: 'manifest')]
 	public function getManifest(string $app): JSONResponse {
 		$cacheBusterValue = $this->config->getAppValue('theming', 'cachebuster', '0');
 		if ($app === 'core' || $app === 'settings') {


### PR DESCRIPTION
fix an error displayed during psalm static code analysis from https://github.com/nextcloud/server/pull/46476:

```
Error: apps/theming/lib/Controller/ThemingController.php:426:4: InvalidDocblock: Attribute arguments must be named. (see https://psalm.dev/008)

```

origin: https://github.com/nextcloud/server/pull/46819
