### PR TITLE
fix: fix recursive share check

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -151,10 +151,10 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 				$this->cache = new FailedCache();
 				$this->rootPath = '';
 			} else {
+				$this->nonMaskedStorage = $ownerNode->getStorage();
 				if ($this->nonMaskedStorage instanceof Wrapper && $this->nonMaskedStorage->isWrapperOf($this)) {
 					throw new \Exception('recursive share detected');
 				}
-				$this->nonMaskedStorage = $ownerNode->getStorage();
 				$this->sourcePath = $ownerNode->getPath();
 				$this->rootPath = $ownerNode->getInternalPath();
 				$this->storage = new PermissionsMask([


### PR DESCRIPTION
Don't check the `nonMaskedStorage` before we set it 