### PR TITLE
fix: don't persist previews used during blurhash generation - take 2

### DIFF
--- a/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
+++ b/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
@@ -15,12 +15,10 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\GenericFileException;
-use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\FilesMetadata\AMetadataEvent;
 use OCP\FilesMetadata\Event\MetadataBackgroundEvent;
 use OCP\FilesMetadata\Event\MetadataLiveEvent;
-use OCP\IPreview;
 use OCP\Lock\LockedException;
 
 /**
@@ -33,11 +31,6 @@ class GenerateBlurhashMetadata implements IEventListener {
 
 	private const COMPONENTS_X = 4;
 	private const COMPONENTS_Y = 3;
-
-	public function __construct(
-		private IPreview $preview,
-	) {
-	}
 
 	/**
 	 * @throws NotPermittedException
@@ -67,20 +60,12 @@ class GenerateBlurhashMetadata implements IEventListener {
 			return;
 		}
 
-		$image = false;
-		try {
-			// using preview image to generate the blurhash
-			$preview = $this->preview->getPreview($file, 256, 256);
-			$image = @imagecreatefromstring($preview->getContent());
-		} catch (NotFoundException $e) {
-			// https://github.com/nextcloud/server/blob/9d70fd3e64b60a316a03fb2b237891380c310c58/lib/private/legacy/OC_Image.php#L668
-			// The preview system can fail on huge picture, in that case we use our own image resizer.
-			if (str_starts_with($file->getMimetype(), 'image/')) {
-				$image = $this->resizedImageFromFile($file);
-			}
+		if (!str_starts_with($file->getMimetype(), 'image/')) {
+			return;
 		}
 
-		if ($image === false) {
+		$image = $this->resizedImageFromFile($file);
+		if (!$image) {
 			return;
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/45654

## Summary

When an instance is updated to 29 or 30, a blurhash is generated for every image in the background. For performance reasons, the blurhash generator requests a scaled preview instead of the full image. On large instances this is a problem because a preview will be generated and persisted for **every** image on the server.

Now, the preview is generated on the fly and not persisted to disk.

A cleaner alternative to https://github.com/nextcloud/server/pull/46864.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
