### PR TITLE
chore(core): wrap initial state into hidden container

### DIFF
--- a/core/templates/layout.base.php
+++ b/core/templates/layout.base.php
@@ -23,9 +23,7 @@
 	</head>
 	<body id="body-public" class="layout-base">
 		<?php include 'layout.noscript.warning.php'; ?>
-		<?php foreach ($_['initialStates'] as $app => $initialState) { ?>
-			<input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
-		<?php }?>
+		<?php include 'layout.initial-state.php'; ?>
 		<div id="content" class="app-public" role="main">
 			<?php print_unescaped($_['content']); ?>
 		</div>

--- a/core/templates/layout.guest.php
+++ b/core/templates/layout.guest.php
@@ -34,9 +34,7 @@ p($theme->getTitle());
 	</head>
 	<body id="<?php p($_['bodyid']);?>">
 		<?php include 'layout.noscript.warning.php'; ?>
-		<?php foreach ($_['initialStates'] as $app => $initialState) { ?>
-			<input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
-		<?php }?>
+		<?php include 'layout.initial-state.php'; ?>
 		<div class="wrapper">
 			<div class="v-align">
 				<?php if ($_['bodyid'] === 'body-login'): ?>

--- a/core/templates/layout.initial-state.php
+++ b/core/templates/layout.initial-state.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+<div id="initial-state-container" style="display: none;">
+    <?php foreach ($_['initialStates'] as $app => $initialState) { ?>
+        <input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
+    <?php }?>
+</div>

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -33,10 +33,8 @@ p($theme->getTitle());
 	<?php print_unescaped($_['headers']); ?>
 </head>
 <body id="<?php p($_['bodyid']);?>">
-<?php include('layout.noscript.warning.php'); ?>
-<?php foreach ($_['initialStates'] as $app => $initialState) { ?>
-	<input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
-<?php }?>
+	<?php include('layout.noscript.warning.php'); ?>
+	<?php include('layout.initial-state.php'); ?>
 	<div id="skip-actions">
 		<?php if ($_['id-app-content'] !== null) { ?><a href="<?php p($_['id-app-content']); ?>" class="button primary skip-navigation skip-content"><?php p($l->t('Skip to main content')); ?></a><?php } ?>
 		<?php if ($_['id-app-navigation'] !== null) { ?><a href="<?php p($_['id-app-navigation']); ?>" class="button primary skip-navigation"><?php p($l->t('Skip to navigation of app')); ?></a><?php } ?>

--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -51,11 +51,8 @@ p($theme->getTitle());
 	<body id="<?php p($_['bodyid']);?>" <?php foreach ($_['enabledThemes'] as $themeId) {
 		p("data-theme-$themeId ");
 	}?> data-themes=<?php p(join(',', $_['enabledThemes'])) ?>>
-	<?php include 'layout.noscript.warning.php'; ?>
-
-		<?php foreach ($_['initialStates'] as $app => $initialState) { ?>
-			<input type="hidden" id="initial-state-<?php p($app); ?>" value="<?php p(base64_encode($initialState)); ?>">
-		<?php }?>
+		<?php include 'layout.noscript.warning.php'; ?>
+		<?php include 'layout.initial-state.php'; ?>
 
 		<div id="skip-actions">
 			<?php if ($_['id-app-content'] !== null) { ?><a href="<?php p($_['id-app-content']); ?>" class="button primary skip-navigation skip-content"><?php p($l->t('Skip to main content')); ?></a><?php } ?>


### PR DESCRIPTION
## Summary

Sometimes it's quite annoying during debug that there are tons of elements in the document's root for initial state.

I propose to wrap it in a hidden container.

Before | After
---|---
![image](https://github.com/user-attachments/assets/a147088e-d14e-46d3-b5b4-e15147b8407a) | ![image](https://github.com/user-attachments/assets/5d59b887-45a2-46d8-b2b6-25bfba912739)
![image](https://github.com/user-attachments/assets/399a23e1-5d18-426a-9622-2555e9c9bff9) | ![image](https://github.com/user-attachments/assets/fc0c8b4b-8472-4359-be85-40ebfdf5069b)

## TODO

- [x] Wrap all `<input id="initial-state-..." />` into a hidden `div` container
- [x] Move it to a new file for reuse

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
