### PR TITLE
ci: Fix summary condition

### DIFF
--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -184,4 +184,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.files-external-s3-minio.result != 'success' && needs.files-external-s3-localstack.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && (needs.files-external-s3-minio.result != 'success' || needs.files-external-s3-localstack.result != 'success') }}; then exit 1; fi

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -170,4 +170,4 @@ jobs:
 
     steps:
       - name: Summary status
-        run: if ${{ needs.changes.outputs.src != 'false' && needs.test.result != 'success' && needs.jsunit.result != 'success' && needs.handlebars.result != 'success' }}; then exit 1; fi
+        run: if ${{ needs.changes.outputs.src != 'false' && (needs.test.result != 'success' || needs.jsunit.result != 'success' || needs.handlebars.result != 'success') }}; then exit 1; fi


### PR DESCRIPTION
Fix boolean logic to decide when the summary should be green
Noticed in https://github.com/nextcloud/server/actions/runs/10161408874/job/28102320453?pr=46871

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
