### PR TITLE
fix: ensure array returned from getMountsForFileId is continious

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -362,9 +362,9 @@ class UserMountCache implements IUserMountCache {
 			return $internalMountPath === '' || str_starts_with($internalPath, $internalMountPath . '/');
 		});
 
-		$filteredMounts = array_filter($filteredMounts, function (ICachedMountInfo $mount) {
+		$filteredMounts = array_values(array_filter($filteredMounts, function (ICachedMountInfo $mount) {
 			return $this->userManager->userExists($mount->getUser()->getUID());
-		});
+		}));
 
 		return array_map(function (ICachedMountInfo $mount) use ($internalPath) {
 			return new CachedMountFileInfo(


### PR DESCRIPTION
Makes it harder for people to hold the api wrong