### PR TITLE
fix(files_versions): Catch constraint error on version insertion

### DIFF
--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -228,7 +228,27 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 		$versionEntity->setSize($file->getSize());
 		$versionEntity->setMimetype($this->mimeTypeLoader->getId($file->getMimetype()));
 		$versionEntity->setMetadata([]);
-		$this->versionsMapper->insert($versionEntity);
+
+		$tries = 1;
+		while ($tries < 5) {
+			try {
+				$this->versionsMapper->insert($versionEntity);
+				/* No errors, get out of the method */
+				return;
+			} catch (\OCP\DB\Exception $e) {
+				if (!in_array($e->getReason(), [
+					\OCP\DB\Exception::REASON_CONSTRAINT_VIOLATION,
+					\OCP\DB\Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION,
+				])
+				) {
+					throw $e;
+				}
+				/* Conflict with another version, increase mtime and try again */
+				$versionEntity->setTimestamp($versionEntity->getTimestamp() + 1);
+				$tries++;
+				$this->logger->warning('Constraint violation while inserting version, retrying with increased timestamp', ['exception' => $e]);
+			}
+		}
 	}
 
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Catch errors when inserting a version with same fileid and timestamp as the previous one, and retry with incremented timestamp.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
