### PR TITLE
feat: enable bruteforcesettings app by default

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -52,6 +52,7 @@
   ],
   "defaultEnabled": [
     "activity",
+    "bruteforcesettings",
     "circles",
     "comments",
     "contactsinteraction",


### PR DESCRIPTION

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Brute force protection is already automatically enabled. The settings app for it should be enabled by default too. Already shipped and app can still be disabled if desired.

## TODO

- [x] Update docs chapter 
  - related (but not the fix; just an update to fix a mistake about current behavior): nextcloud/documentation#12066

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
