### PR TITLE
fix(trashbin): Improve documentation of since/until timestamps of res…

### DIFF
--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -88,13 +88,13 @@ class RestoreAllFiles extends Base {
 				'since',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'Only restore files deleted after the given timestamp'
+				'Only restore files deleted after the given date and time, see https://www.php.net/manual/en/function.strtotime.php for more information on supported formats'
 			)
 			->addOption(
 				'until',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'Only restore files deleted before the given timestamp'
+				'Only restore files deleted before the given date and time, see https://www.php.net/manual/en/function.strtotime.php for more information on supported formats'
 			)
 			->addOption(
 				'dry-run',


### PR DESCRIPTION
…tore trashbin

### Resolves

- If even I as a nerd fail to "guess" the format, it needs explanation
- Other option would be to name `YYYY-MM-DD HH:mm:ss` and `@timestamp` as those should be the most common ones

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
