### PR TITLE
revert: chore(files): cleanup old templates

### DIFF
--- a/apps/files/templates/fileexists.html
+++ b/apps/files/templates/fileexists.html
@@ -1,0 +1,35 @@
+<!--
+ - SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ - SPDX-License-Identifier: AGPL-3.0-only
+ -->
+<div id="{dialog_name}" title="{title}" class="fileexists">
+	<span class="why">{why}<!-- Which files do you want to keep --></span><br/>
+	<span class="what">{what}<!-- If you select both versions, the copied file will have a number added to its name. --></span><br/>
+	<br/>
+	<table>
+		<th><input id="checkbox-allnewfiles" class="allnewfiles checkbox" type="checkbox" /><label for="checkbox-allnewfiles">{allnewfiles}<span class="count"></span></label></th>
+		<th><input id="checkbox-allexistingfiles" class="allexistingfiles checkbox" type="checkbox" /><label for="checkbox-allexistingfiles">{allexistingfiles}<span class="count"></span></label></th>
+	</table>
+	<div class="conflicts">
+		<div class="template">
+			<div class="filename"></div>
+			<div class="replacement">
+				<input type="checkbox" class="checkbox u-left"/>
+				<label>
+				<span class="svg icon"></span>
+				<div class="mtime"></div>
+				<div class="size"></div>
+				</label>
+			</div>
+			<div class="original">
+				<input type="checkbox" class="checkbox u-left" />
+				<label>
+				<span class="svg icon"></span>
+				<div class="mtime"></div>
+				<div class="size"></div>
+				<div class="message"></div>
+				</label>
+			</div>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/46848

## Summary

Partially revert https://github.com/nextcloud/server/pull/43104 as the template is still needed for `OC.dialogs.fileexists`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
