### PR TITLE
tests: don't reuse the query builder for multiple tables in CardDavBackendTest

### DIFF
--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -676,6 +676,7 @@ class CardDavBackendTest extends TestCase {
 			$vCardIds[] = $query->getLastInsertId();
 		}
 
+		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
 				[
@@ -687,6 +688,7 @@ class CardDavBackendTest extends TestCase {
 				]
 			);
 		$query->execute();
+		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
 				[
@@ -698,6 +700,7 @@ class CardDavBackendTest extends TestCase {
 				]
 			);
 		$query->execute();
+		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
 				[
@@ -709,6 +712,7 @@ class CardDavBackendTest extends TestCase {
 				]
 			);
 		$query->execute();
+		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
 				[
@@ -720,6 +724,7 @@ class CardDavBackendTest extends TestCase {
 				]
 			);
 		$query->execute();
+		$query = $this->db->getQueryBuilder();
 		$query->insert($this->dbCardsPropertiesTable)
 			->values(
 				[


### PR DESCRIPTION
needed for sharding compatibility