### PR TITLE
fix(files): do not show legacy `edit locally` action on public pages

### DIFF
--- a/apps/files/js/fileactions.js
+++ b/apps/files/js/fileactions.js
@@ -722,7 +722,7 @@
 				});
 			}
 
-			if (!/Android|iPhone|iPad|iPod/i.test(navigator.userAgent)) {
+			if (!/Android|iPhone|iPad|iPod/i.test(navigator.userAgent) && !!window.oc_current_user) {
 				this.registerAction({
 					name: 'EditLocally',
 					displayName: function(context) {


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/43555

Will be fixed once we have #45652. In the meantime, let's make sure the user is logged in 