### PR TITLE
fix: fix passing additional db connection parameters in factory

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -54,16 +54,10 @@ class ConnectionFactory {
 		],
 	];
 
-	/** @var SystemConfig */
-	private $config;
 
-	/**
-	 * ConnectionFactory constructor.
-	 *
-	 * @param SystemConfig $systemConfig
-	 */
-	public function __construct(SystemConfig $systemConfig) {
-		$this->config = $systemConfig;
+	public function __construct(
+		private SystemConfig $config
+	) {
 		if ($this->config->getValue('mysql.utf8mb4', false)) {
 			$this->defaultConnectionParams['mysql']['charset'] = 'utf8mb4';
 		}
@@ -101,49 +95,49 @@ class ConnectionFactory {
 	 * @param array $additionalConnectionParams Additional connection parameters
 	 * @return \OC\DB\Connection
 	 */
-	public function getConnection($type, $additionalConnectionParams) {
+	public function getConnection(string $type, array $additionalConnectionParams): Connection {
 		$normalizedType = $this->normalizeType($type);
 		$eventManager = new EventManager();
 		$eventManager->addEventSubscriber(new SetTransactionIsolationLevel());
-		$additionalConnectionParams = array_merge($this->createConnectionParams(), $additionalConnectionParams);
+		$connectionParams = $this->createConnectionParams('', $additionalConnectionParams);
 		switch ($normalizedType) {
 			case 'pgsql':
 				// pg_connect used by Doctrine DBAL does not support URI notation (enclosed in brackets)
 				$matches = [];
-				if (preg_match('/^\[([^\]]+)\]$/', $additionalConnectionParams['host'], $matches)) {
+				if (preg_match('/^\[([^\]]+)\]$/', $connectionParams['host'], $matches)) {
 					// Host variable carries a port or socket.
-					$additionalConnectionParams['host'] = $matches[1];
+					$connectionParams['host'] = $matches[1];
 				}
 				break;
 
 			case 'oci':
 				$eventManager->addEventSubscriber(new OracleSessionInit);
 				// the driverOptions are unused in dbal and need to be mapped to the parameters
-				if (isset($additionalConnectionParams['driverOptions'])) {
-					$additionalConnectionParams = array_merge($additionalConnectionParams, $additionalConnectionParams['driverOptions']);
+				if (isset($connectionParams['driverOptions'])) {
+					$connectionParams = array_merge($connectionParams, $connectionParams['driverOptions']);
 				}
-				$host = $additionalConnectionParams['host'];
-				$port = $additionalConnectionParams['port'] ?? null;
-				$dbName = $additionalConnectionParams['dbname'];
+				$host = $connectionParams['host'];
+				$port = $connectionParams['port'] ?? null;
+				$dbName = $connectionParams['dbname'];
 
 				// we set the connect string as dbname and unset the host to coerce doctrine into using it as connect string
 				if ($host === '') {
-					$additionalConnectionParams['dbname'] = $dbName; // use dbname as easy connect name
+					$connectionParams['dbname'] = $dbName; // use dbname as easy connect name
 				} else {
-					$additionalConnectionParams['dbname'] = '//' . $host . (!empty($port) ? ":{$port}" : "") . '/' . $dbName;
+					$connectionParams['dbname'] = '//' . $host . (!empty($port) ? ":{$port}" : "") . '/' . $dbName;
 				}
-				unset($additionalConnectionParams['host']);
+				unset($connectionParams['host']);
 				break;
 
 			case 'sqlite3':
-				$journalMode = $additionalConnectionParams['sqlite.journal_mode'];
-				$additionalConnectionParams['platform'] = new OCSqlitePlatform();
+				$journalMode = $connectionParams['sqlite.journal_mode'];
+				$connectionParams['platform'] = new OCSqlitePlatform();
 				$eventManager->addEventSubscriber(new SQLiteSessionInit(true, $journalMode));
 				break;
 		}
 		/** @var Connection $connection */
 		$connection = DriverManager::getConnection(
-			$additionalConnectionParams,
+			$connectionParams,
 			new Configuration(),
 			$eventManager
 		);
@@ -176,7 +170,7 @@ class ConnectionFactory {
 	 * @param string $configPrefix
 	 * @return array
 	 */
-	public function createConnectionParams(string $configPrefix = '') {
+	public function createConnectionParams(string $configPrefix = '', array $additionalConnectionParams = []) {
 		$type = $this->config->getValue('dbtype', 'sqlite');
 
 		$connectionParams = array_merge($this->getDefaultConnectionParams($type), [
@@ -220,6 +214,7 @@ class ConnectionFactory {
 		if ($this->config->getValue('dbpersistent', false)) {
 			$connectionParams['persistent'] = true;
 		}
+		$connectionParams = array_merge($connectionParams, $additionalConnectionParams);
 
 		$replica = $this->config->getValue($configPrefix . 'dbreplica', $this->config->getValue('dbreplica', [])) ?: [$connectionParams];
 		return array_merge($connectionParams, [


### PR DESCRIPTION
From what I can tell, the added logic for the primary/replica broke passing additional query parameters as the `$additionalConnectionParams` got merged with the `['primary' => ..., 'replica' => ...]` array, not the actual connection parameters.