### PR TITLE
fix(AdminSettings/AI): show pref list of only the enabled translation providers

### DIFF
--- a/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
+++ b/apps/settings/lib/Settings/Admin/ArtificialIntelligence.php
@@ -148,7 +148,12 @@ class ArtificialIntelligence implements IDelegatedSettings {
 						$value = array_merge($defaultValue, $value);
 						break;
 					case 'ai.translation_provider_preferences':
-						$value += array_diff($defaultValue, $value); // Add entries from $defaultValue that are not in $value to the end of $value
+						// Only show entries from $value (saved pref list) that are in $defaultValue (enabled providers)
+						// and add all providers that are enabled but not in the pref list
+						if (!is_array($defaultValue)) {
+							break;
+						}
+						$value = array_values(array_unique(array_merge(array_intersect($value, $defaultValue), $defaultValue), SORT_STRING));
 						break;
 					default:
 						break;


### PR DESCRIPTION
… providers

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Only show providers in the machine translations preference list if the provider is enabled.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
