### PR TITLE
fix(files_sharing): show proper share not found error message

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -294,11 +294,11 @@ class ShareController extends AuthPublicShareController {
 		} catch (ShareNotFound $e) {
 			// The share does not exists, we do not emit an ShareLinkAccessedEvent
 			$this->emitAccessShareHook($this->getToken(), 404, 'Share not found');
-			throw new NotFoundException();
+			throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
 		}
 
 		if (!$this->validateShare($share)) {
-			throw new NotFoundException();
+			throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
 		}
 
 		$shareNode = $share->getNode();
@@ -309,7 +309,7 @@ class ShareController extends AuthPublicShareController {
 		} catch (NotFoundException $e) {
 			$this->emitAccessShareHook($share, 404, 'Share not found');
 			$this->emitShareAccessEvent($share, ShareController::SHARE_ACCESS, 404, 'Share not found');
-			throw new NotFoundException();
+			throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
 		}
 
 		// We can't get the path of a file share
@@ -317,7 +317,7 @@ class ShareController extends AuthPublicShareController {
 			if ($shareNode instanceof \OCP\Files\File && $path !== '') {
 				$this->emitAccessShareHook($share, 404, 'Share not found');
 				$this->emitShareAccessEvent($share, self::SHARE_ACCESS, 404, 'Share not found');
-				throw new NotFoundException();
+				throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
 			}
 		} catch (\Exception $e) {
 			$this->emitAccessShareHook($share, 404, 'Share not found');

--- a/apps/files_sharing/templates/sharenotfound.php
+++ b/apps/files_sharing/templates/sharenotfound.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use OCP\IURLGenerator;
+use OCP\Server;
+
+$urlGenerator = Server::get(IURLGenerator::class);
+?>
+<div class="body-login-container update">
+	<div>
+		<svg xmlns="http://www.w3.org/2000/svg" height="70" viewBox="0 -960 960 960" width="70">
+			<path fill="currentColor" d="m674-456-50-50 69-70-69-69 50-51 70 70 69-70 51 51-70 69 70 70-51 50-69-69-70 69Zm-290-24q-60 0-102-42t-42-102q0-60 42-102t102-42q60 0 102 42t42 102q0 60-42 102t-102 42ZM96-192v-92q0-26 12.5-47.5T143-366q55-32 116-49t125-17q64 0 125 17t116 49q22 13 34.5 34.5T672-284v92H96Z"/>
+		</svg>
+	</div>
+	<h2><?php p($l->t('Share not found')); ?></h2>
+	<p class="infogroup"><?php p($_['message'] ?: $l->t('This share does not exist or is no longer available')); ?></p>
+	<p><a class="button primary" href="<?php p($urlGenerator->linkTo('', 'index.php')) ?>">
+		<?php p($l->t('Back to %s', [$theme->getName()])); ?>
+	</a></p>
+</div>

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -288,7 +288,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				new OC\AppFramework\Middleware\PublicShare\PublicShareMiddleware(
 					$c->get(IRequest::class),
 					$c->get(ISession::class),
-					$c->get(\OCP\IConfig::class),
+					$c->get(IConfig::class),
 					$c->get(IThrottler::class)
 				)
 			);

--- a/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
+++ b/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
@@ -6,8 +6,10 @@
 namespace OC\AppFramework\Middleware\PublicShare;
 
 use OC\AppFramework\Middleware\PublicShare\Exceptions\NeedAuthenticationException;
+use OCA\Files_Sharing\AppInfo\Application;
 use OCP\AppFramework\AuthPublicShareController;
-use OCP\AppFramework\Http\NotFoundResponse;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Middleware;
 use OCP\AppFramework\PublicShareController;
 use OCP\Files\NotFoundException;
@@ -17,23 +19,13 @@ use OCP\ISession;
 use OCP\Security\Bruteforce\IThrottler;
 
 class PublicShareMiddleware extends Middleware {
-	/** @var IRequest */
-	private $request;
 
-	/** @var ISession */
-	private $session;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var IThrottler */
-	private $throttler;
-
-	public function __construct(IRequest $request, ISession $session, IConfig $config, IThrottler $throttler) {
-		$this->request = $request;
-		$this->session = $session;
-		$this->config = $config;
-		$this->throttler = $throttler;
+	public function __construct(
+		private IRequest $request,
+		private ISession $session,
+		private IConfig $config,
+		private IThrottler $throttler
+	) {
 	}
 
 	public function beforeController($controller, $methodName) {
@@ -92,7 +84,9 @@ class PublicShareMiddleware extends Middleware {
 		}
 
 		if ($exception instanceof NotFoundException) {
-			return new NotFoundResponse();
+			return new TemplateResponse(Application::APP_ID, 'sharenotfound', [
+				'message' => $exception->getMessage(),
+			], 'guest', Http::STATUS_NOT_FOUND);
 		}
 
 		if ($controller instanceof AuthPublicShareController && $exception instanceof NeedAuthenticationException) {

--- a/tests/lib/AppFramework/Middleware/PublicShare/PublicShareMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/PublicShare/PublicShareMiddlewareTest.php
@@ -10,8 +10,9 @@ use OC\AppFramework\Middleware\PublicShare\Exceptions\NeedAuthenticationExceptio
 use OC\AppFramework\Middleware\PublicShare\PublicShareMiddleware;
 use OCP\AppFramework\AuthPublicShareController;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\NotFoundResponse;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\PublicShareController;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
@@ -236,7 +237,8 @@ class PublicShareMiddlewareTest extends \Test\TestCase {
 		$exception = new NotFoundException();
 
 		$result = $this->middleware->afterException($controller, 'method', $exception);
-		$this->assertInstanceOf(NotFoundResponse::class, $result);
+		$this->assertInstanceOf(TemplateResponse::class, $result);
+		$this->assertEquals($result->getStatus(), Http::STATUS_NOT_FOUND);
 	}
 
 	public function testAfterExceptionPublicShareController() {


### PR DESCRIPTION
When trying to access a share token which doesn't exists or is expired
https://dev.domain.com/s/oiqAxS8tzdPNBzN

| Before | After |
|:---------:|:------:|
|![2024-08-01_22-27](https://github.com/user-attachments/assets/e040e9b3-4e61-4071-ba36-6e8e0d400e57)|![image](https://github.com/user-attachments/assets/992b3c51-e11c-4769-bcd1-fe3e3988f0c4)|

Not the best, but a bit cleaner as far as error page goes

@nextcloud/designers 