### PR TITLE
fix(ProvisioningAPI): set typed config values by via API

### DIFF
--- a/apps/provisioning_api/lib/Controller/AppConfigController.php
+++ b/apps/provisioning_api/lib/Controller/AppConfigController.php
@@ -126,8 +126,17 @@ class AppConfigController extends OCSController {
 			return new DataResponse(['data' => ['message' => $e->getMessage()]], Http::STATUS_FORBIDDEN);
 		}
 
+		$configDetails = $this->appConfig->getDetails($app, $key);
 		/** @psalm-suppress InternalMethod */
-		$this->appConfig->setValueMixed($app, $key, $value);
+		match ($configDetails['type']) {
+			IAppConfig::VALUE_BOOL => $this->appConfig->setValueBool($app, $key, (bool)$value),
+			IAppConfig::VALUE_FLOAT => $this->appConfig->setValueFloat($app, $key, (float)$value),
+			IAppConfig::VALUE_INT => $this->appConfig->setValueInt($app, $key, (int)$value),
+			IAppConfig::VALUE_STRING => $this->appConfig->setValueString($app, $key, $value),
+			IAppConfig::VALUE_ARRAY => $this->appConfig->setValueArray($app, $key, \json_decode($value, true)),
+			default => $this->appConfig->setValueMixed($app, $key, $value),
+		};
+
 		return new DataResponse();
 	}
 

--- a/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
@@ -17,6 +17,8 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Settings\IManager;
 use Test\TestCase;
+use function json_decode;
+use function json_encode;
 
 /**
  * Class AppConfigControllerTest
@@ -184,6 +186,12 @@ class AppConfigControllerTest extends TestCase {
 			['app1', 'key', 'default', new \InvalidArgumentException('error1'), null, Http::STATUS_FORBIDDEN],
 			['app2', 'key', 'default', null, new \InvalidArgumentException('error2'), Http::STATUS_FORBIDDEN],
 			['app2', 'key', 'default', null, null, Http::STATUS_OK],
+			['app2', 'key', '1', null, null, Http::STATUS_OK, IAppConfig::VALUE_BOOL],
+			['app2', 'key', '42', null, null, Http::STATUS_OK, IAppConfig::VALUE_INT],
+			['app2', 'key', '4.2', null, null, Http::STATUS_OK, IAppConfig::VALUE_FLOAT],
+			['app2', 'key', '42', null, null, Http::STATUS_OK, IAppConfig::VALUE_STRING],
+			['app2', 'key', 'secret', null, null, Http::STATUS_OK, IAppConfig::VALUE_STRING | IAppConfig::VALUE_SENSITIVE],
+			['app2', 'key', json_encode([4, 2]), null, null, Http::STATUS_OK, IAppConfig::VALUE_ARRAY],
 		];
 	}
 
@@ -196,7 +204,7 @@ class AppConfigControllerTest extends TestCase {
 	 * @param \Exception|null $keyThrows
 	 * @param int $status
 	 */
-	public function testSetValue($app, $key, $value, $appThrows, $keyThrows, $status) {
+	public function testSetValue($app, $key, $value, $appThrows, $keyThrows, $status, int $type = IAppConfig::VALUE_MIXED) {
 		$adminUser = $this->createMock(IUser::class);
 		$adminUser->expects($this->once())
 			->method('getUid')
@@ -240,8 +248,30 @@ class AppConfigControllerTest extends TestCase {
 				->with($app, $key);
 
 			$this->appConfig->expects($this->once())
-				->method('setValueMixed')
-				->with($app, $key, $value);
+				->method('getDetails')
+				->with($app, $key)
+				->willReturn([
+					'app' => $app,
+					'key' => $key,
+					'value' => '', // 🤷
+					'type' => $type,
+					'lazy' => false,
+					'typeString' => (string)$type, // this is not accurate, but acceptable
+					'sensitive' => ($type & IAppConfig::VALUE_SENSITIVE) !== 0,
+				]);
+
+			$configValueSetter = match ($type) {
+				IAppConfig::VALUE_BOOL => 'setValueBool',
+				IAppConfig::VALUE_FLOAT => 'setValueFloat',
+				IAppConfig::VALUE_INT => 'setValueInt',
+				IAppConfig::VALUE_STRING => 'setValueString',
+				IAppConfig::VALUE_ARRAY => 'setValueArray',
+				default => 'setValueMixed',
+			};
+
+			$this->appConfig->expects($this->once())
+				->method($configValueSetter)
+				->with($app, $key, $configValueSetter === 'setValueArray' ? json_decode($value, true) : $value);
 		}
 
 		$result = $api->setValue($app, $key, $value);


### PR DESCRIPTION
* Resolves: #45083

## Summary

On Javascript side we have one method at hand to set an app config value: `CP.AppConfig.setValue()`. As value it takes a `string` and sends this over the Provisioning API to the server. 

Meanwhile we have typed configuration entries. All existing entries are default to the `IAppConfig::VALUE_MIXED` type. New entries however are bound to their type. For instance a new boolean value cannot be set via JavaScript anymore.

This fix solves this on API level. All clients may still send strings, and the Provisioning API's Controller tries to cast the provided value into the target type.

I see this sort of critical myself as there is not good validation of the casted value. On the other hand I do not think it can do much harm, only fail in a different way. Still, an alternative would be to have also dedicated setter on the JS side, and endpoints for each acceptable type. Personally I don't have the time for this approach today anymore. I am totally fine to discard this PR in favor of a better replacement :)

## Todo

* [ ] check were backports are necessary

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
