### PR TITLE
fix: Do not skip handleOpenFile calls on initial load

### DIFF
--- a/apps/files/src/components/FilesListVirtual.vue
+++ b/apps/files/src/components/FilesListVirtual.vue
@@ -247,10 +247,6 @@ export default defineComponent({
 		 * @param fileId File to open
 		 */
 		handleOpenFile(fileId: number|null) {
-			if (!this.openFile) {
-				return
-			}
-
 			if (fileId === null || this.openFileId === fileId) {
 				return
 			}


### PR DESCRIPTION
Steps to reproduce:
- Open a internal file link /index.php/f/1234
- See that the file is not opening automatically

We noticed this in text cypress last week:

Good server commit: 57ed738af27d0346c1b20b9d188079f3eda0b094
Bad server commit: 97ea95714aeec2d23567ae5d85b28fd6b688b1cc

From the diff could be related to https://github.com/nextcloud/server/pull/45708

It would be really great to have tests for this in server, but as viewer is a separate app we would need to have it enabled for the cypress tests in server to achieve that.