### PR TITLE
fix(inherited-shares): ignore top root folder

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1078,8 +1078,11 @@ class ShareAPIController extends OCSController {
 		// generate node list for each parent folders
 		/** @var Node[] $nodes */
 		$nodes = [];
-		while ($node->getPath() !== $basePath) {
+		while (true) {
 			$node = $node->getParent();
+			if ($node->getPath() === $basePath) {
+				break;
+			}
 			$nodes[] = $node;
 		}
 


### PR DESCRIPTION
- Root folder can be ignored as never shared.
- Fix an issue with node id converted to 0 when browsing inherited shares, requesting too many resources. 
- Fix an issue with inherited shares on external filesystem returning too many entries