### PR TITLE
fix: Ensure database connection is setup when getting group details

### DIFF
--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -507,6 +507,8 @@ class Database extends ABackend implements
 		$notFoundGids = [];
 		$details = [];
 
+		$this->fixDI();
+
 		// In case the data is already locally accessible, not need to do SQL query
 		// or do a SQL query but with a smaller in clause
 		foreach ($gids as $gid) {


### PR DESCRIPTION
## Summary

This class is super weird, I like the `fixme` since 2016 ^^
Noticed this will running `circles:sync` on Nextcloud 28

```
An unhandled exception has been thrown:
Error: Call to a member function getQueryBuilder() on null in /var/www/html/lib/private/Group/Database.php:543
Stack trace:
#0 /var/www/html/lib/private/Group/Manager.php(233): OC\Group\Database->getGroupsDetails(Array)
#1 /var/www/html/lib/private/Group/Manager.php(324): OC\Group\Manager->getGroupsObjects(Array)
#2 /var/www/html/apps/circles/lib/Service/SyncService.php(261): OC\Group\Manager->search('')
#3 /var/www/html/apps/circles/lib/Service/SyncService.php(174): OCA\Circles\Service\SyncService->syncNextcloudGroups()
#4 /var/www/html/apps/circles/lib/Command/CirclesSync.php(146): OCA\Circles\Service\SyncService->sync(63)
#5 /var/www/html/3rdparty/symfony/console/Command/Command.php(298): OCA\Circles\Command\CirclesSync->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#6 /var/www/html/core/Command/Base.php(177): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#7 /var/www/html/3rdparty/symfony/console/Application.php(1040): OC\Core\Command\Base->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 /var/www/html/3rdparty/symfony/console/Application.php(301): Symfony\Component\Console\Application->doRunCommand(Object(OCA\Circles\Command\CirclesSync), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#9 /var/www/html/3rdparty/symfony/console/Application.php(171): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#10 /var/www/html/lib/private/Console/Application.php(213): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /var/www/html/console.php(100): OC\Console\Application->run()
#12 /var/www/html/occ(11): require_once('/var/www/html/c...')
```

