### PR TITLE
fix(admin_audit): Do not log errors for new files

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  */
 namespace OCA\AdminAudit\Actions;
 
+use OC\Files\Node\NonExistingFile;
 use OCP\Files\Events\Node\BeforeNodeReadEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
 use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
@@ -35,9 +36,10 @@ class Files extends Action {
 	 */
 	public function read(BeforeNodeReadEvent $event): void {
 		try {
+			$node = $event->getNode();
 			$params = [
-				'id' => $event->getNode()->getId(),
-				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
+				'id' => $node instanceof NonExistingFile ? null : $node->getId(),
+				'path' => mb_substr($node->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(


### PR DESCRIPTION
Avoid logging an error for cases when the audit log is triggered on a new file during the BeforeNodeReadEvent as in this case we get an NonExistingFile as the file has no file id yet

Sample error trace:

<img width="940" alt="Screenshot 2024-08-06 at 14 54 11" src="https://github.com/user-attachments/assets/6ef1c8b8-6799-44bb-8b45-52cf3ccfd987">


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
