### PR TITLE
Fixed Chinese email authentication translation error

### DIFF
--- a/apps/settings/l10n/zh_CN.js
+++ b/apps/settings/l10n/zh_CN.js
@@ -689,7 +689,7 @@ OC.L10N.register(
     "Port" : "端口",
     "Authentication" : "身份认证",
     "Authentication required" : "需要认证",
-    "Credentials" : "证书",
+    "Credentials" : "身分验证",
     "SMTP Password" : "SMTP 密码",
     "Save" : "保存",
     "Test and verify email settings" : "测试并验证电子邮箱设置",


### PR DESCRIPTION
Fixed Chinese email authentication translation error

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
