### PR TITLE
fix: Fix failing test for group listing

### DIFF
--- a/tests/Core/Command/Group/ListCommandTest.php
+++ b/tests/Core/Command/Group/ListCommandTest.php
@@ -112,10 +112,13 @@ class ListCommandTest extends TestCase {
 	public function testInfo() {
 		$group1 = $this->createMock(IGroup::class);
 		$group1->method('getGID')->willReturn('group1');
+		$group1->method('getDisplayName')->willReturn('Group 1');
 		$group2 = $this->createMock(IGroup::class);
 		$group2->method('getGID')->willReturn('group2');
+		$group2->method('getDisplayName')->willReturn('Group 2');
 		$group3 = $this->createMock(IGroup::class);
 		$group3->method('getGID')->willReturn('group3');
+		$group3->method('getDisplayName')->willReturn('Group 3');
 
 		$user = $this->createMock(IUser::class);
 
@@ -171,6 +174,7 @@ class ListCommandTest extends TestCase {
 				$this->callback(
 					fn ($iterator) => iterator_to_array($iterator) === [
 						'group1' => [
+							'displayName' => 'Group 1',
 							'backends' => ['Database'],
 							'users' => [
 								'user1',
@@ -178,10 +182,12 @@ class ListCommandTest extends TestCase {
 							],
 						],
 						'group2' => [
+							'displayName' => 'Group 2',
 							'backends' => ['Database'],
 							'users' => [],
 						],
 						'group3' => [
+							'displayName' => 'Group 3',
 							'backends' => ['LDAP'],
 							'users' => [
 								'user1',


### PR DESCRIPTION
Tests were not adjusted in https://github.com/nextcloud/server/pull/40427 and it was merged with failing CI, small fix to make it pass again