### PR TITLE
fix(theming): make cache buster depend on the app version

### DIFF
--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -311,12 +311,14 @@ class Util {
 		if (!is_null($user)) {
 			$userId = $user->getUID();
 		}
+		$serverVersion = \OC_Util::getVersionString();
+		$themingAppVersion = $this->appManager->getAppVersion('theming');
 		$userCacheBuster = '';
 		if ($userId) {
 			$userCacheBusterValue = (int)$this->config->getUserValue($userId, 'theming', 'userCacheBuster', '0');
 			$userCacheBuster = $userId . '_' . $userCacheBusterValue;
 		}
 		$systemCacheBuster = $this->config->getAppValue('theming', 'cachebuster', '0');
-		return substr(sha1($userCacheBuster . $systemCacheBuster), 0, 8);
+		return substr(sha1($serverVersion . $themingAppVersion . $userCacheBuster . $systemCacheBuster), 0, 8);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Due to the new design, many css variables changed. However, the cache buster value does not increase on Theming/Nextcloud upgrades which causes old theming stylesheets to remain cached. Thus, some apps on the Nextcloud instance look broken after an upgrade (to 30) until the cache is cleared.

### How to reproduce?

1. Clear browser data, open dev tools and make sure to enable caching.
2. Install Nextcloud `stable29` and Calendar `stable4.7`.
3. Disable `debug` mode in config.php!
4. Navigate to Calendar.
5. Upgrade Nextcloud to `master` and Calendar to `main`.
6. Upgrade your Nextcloud instance using occ.
7. Navigate to Calendar in a new tab.
8. Observe broken styling.
9. Clear cache and reload Calendar.
10. Observe working styling.

Between steps 7 and 9 you can also observe that the content of theming stylesheets changes but not their cache buster hash (`?v=[...]`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
