### PR TITLE
[WIP] Make router interface reactive while being framework agnostic

### DIFF
--- a/apps/files/src/components/FilesListVirtual.vue
+++ b/apps/files/src/components/FilesListVirtual.vue
@@ -4,7 +4,7 @@
 -->
 <template>
 	<VirtualList ref="table"
-		:data-component="userConfig.grid_view ? FileEntryGrid : FileEntry"
+		:data-component="fileEntryComponent"
 		:data-key="'source'"
 		:data-sources="nodes"
 		:grid-mode="userConfig.grid_view"
@@ -132,8 +132,6 @@ export default defineComponent({
 
 	data() {
 		return {
-			FileEntry,
-			FileEntryGrid,
 			headers: getFileListHeaders(),
 			scrollToIndex: 0,
 			openFileId: null as number|null,
@@ -141,6 +139,13 @@ export default defineComponent({
 	},
 
 	computed: {
+		/**
+		 * The Vue component to use for file list entries
+		 */
+		fileEntryComponent() {
+			return this.userConfig.grid_view ? FileEntryGrid : FileEntry
+		},
+
 		userConfig(): UserConfig {
 			return this.userConfigStore.userConfig
 		},
@@ -218,6 +223,11 @@ export default defineComponent({
 	},
 
 	methods: {
+		reset() {
+			this.scrollToIndex = 0
+			this.openFileId = null
+		},
+
 		// Open the file sidebar if we have the room for it
 		// but don't open the sidebar for the current folder
 		openSidebarForFile(fileId) {
@@ -236,6 +246,10 @@ export default defineComponent({
 			if (fileId) {
 				const index = this.nodes.findIndex(node => node.fileid === fileId)
 				if (warn && index === -1 && fileId !== this.currentFolder.fileid) {
+					logger.error('File to scroll to not found', {
+						folder: this.currentFolder,
+						fileId,
+					})
 					showError(this.t('files', 'File not found'))
 				}
 				this.scrollToIndex = Math.max(0, index)

--- a/apps/files/src/views/FilesList.vue
+++ b/apps/files/src/views/FilesList.vue
@@ -397,7 +397,7 @@ export default defineComponent({
 
 		showCustomEmptyView() {
 			return !this.loading && this.isEmptyDir && this.currentView?.emptyView !== undefined
-		}
+		},
 	},
 
 	watch: {
@@ -657,7 +657,7 @@ export default defineComponent({
 		filterDirContent() {
 			let nodes = this.dirContents
 			for (const filter of this.filtersStore.sortedFilters) {
-				nodes = filter.filter(nodes)
+				nodes = filter.filter(nodes) as Node[]
 			}
 			this.dirContentsFiltered = nodes
 		},

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "snap.js": "^2.0.9",
     "strengthify": "github:nextcloud/strengthify#0.5.9",
     "throttle-debounce": "^5.0.2",
+    "typescript-event-target": "^1.1.1",
     "underscore": "1.13.6",
     "url-search-params-polyfill": "^8.1.1",
     "v-click-outside": "^3.2.0",


### PR DESCRIPTION
Currently it is only reactive when used within the files app, because the files app can access the vue router directly, problem is when other apps use it, then it is not reactive anymore as they have a different Vue.
Also if you do not use Vue but vanilla JS or something else, the router params and query would not be reactive.

Problem that this is solving: React to route changes only, watching current view and query will trigger on different time frames causing invalid states.
e.g. changing the view from A to B and the query from `/foo` to `/` will cause:
1. View change
2. query change

But after 1 the query is invalid and cause issues.

So this changes will allow listening the route change which is combined 1 & 2 -> valid state.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
