### PR TITLE
Apply group limit on remove from group

### DIFF
--- a/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
+++ b/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
@@ -29,11 +29,15 @@ describe('Limit to sharing to people in the same group', () => {
 	let randomFileName1 = ''
 	let randomFileName2 = ''
 	let randomGroupName = ''
+	let randomGroupName2 = ''
+	let randomGroupName3 = ''
 
 	before(() => {
 		randomFileName1 = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
 		randomFileName2 = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
 		randomGroupName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+		randomGroupName2 = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+		randomGroupName3 = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
 
 		cy.runOccCommand('config:app:set core shareapi_only_share_with_group_members --value yes')
 
@@ -46,8 +50,13 @@ describe('Limit to sharing to people in the same group', () => {
 				bob = user
 
 				cy.runOccCommand(`group:add ${randomGroupName}`)
+				cy.runOccCommand(`group:add ${randomGroupName2}`)
+				cy.runOccCommand(`group:add ${randomGroupName3}`)
 				cy.runOccCommand(`group:adduser ${randomGroupName} ${alice.userId}`)
 				cy.runOccCommand(`group:adduser ${randomGroupName} ${bob.userId}`)
+				cy.runOccCommand(`group:adduser ${randomGroupName2} ${alice.userId}`)
+				cy.runOccCommand(`group:adduser ${randomGroupName2} ${bob.userId}`)
+				cy.runOccCommand(`group:adduser ${randomGroupName3} ${bob.userId}`)
 
 				cy.uploadContent(alice, new Blob(['share to bob'], { type: 'text/plain' }), 'text/plain', `/${randomFileName1}`)
 				cy.uploadContent(bob, new Blob(['share by bob'], { type: 'text/plain' }), 'text/plain', `/${randomFileName2}`)
@@ -77,9 +86,27 @@ describe('Limit to sharing to people in the same group', () => {
 		cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${randomFileName1}"]`).should('exist')
 	})
 
-	context('Bob is removed from the group', () => {
+	context('Bob is removed from the first group', () => {
 		before(() => {
 			cy.runOccCommand(`group:removeuser ${randomGroupName} ${bob.userId}`)
+		})
+
+		it('Alice can see the shared file', () => {
+			cy.login(alice)
+			cy.visit('/apps/files')
+			cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${randomFileName2}"]`).should('exist')
+		})
+
+		it('Bob can see the shared file', () => {
+			cy.login(alice)
+			cy.visit('/apps/files')
+			cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${randomFileName1}"]`).should('exist')
+		})
+	})
+
+	context('Bob is removed from the second group', () => {
+		before(() => {
+			cy.runOccCommand(`group:removeuser ${randomGroupName2} ${bob.userId}`)
 		})
 
 		it('Alice cannot see the shared file', () => {

--- a/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
+++ b/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
@@ -1,0 +1,97 @@
+/**
+ * @copyright Copyright (c) 2024 Louis Chmn <louis@chmn.me>
+ *
+ * @author Louis Chmn <louis@chmn.me>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import { User } from "@nextcloud/cypress"
+import { createShare } from "./filesSharingUtils"
+
+describe('Limit to sharing to people in the same group', () => {
+	let alice: User
+	let bob: User
+	let randomFileName1 = ''
+	let randomFileName2 = ''
+	let randomGroupName = ''
+
+	before(() => {
+		randomFileName1 = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
+		randomFileName2 = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10) + '.txt'
+		randomGroupName = Math.random().toString(36).replace(/[^a-z]+/g, '').substring(0, 10)
+
+		cy.runOccCommand('config:app:set core shareapi_only_share_with_group_members --value yes')
+
+		cy.createRandomUser()
+			.then(user => {
+				alice = user
+				cy.createRandomUser()
+			})
+			.then(user => {
+				bob = user
+
+				cy.runOccCommand(`group:add ${randomGroupName}`)
+				cy.runOccCommand(`group:adduser ${randomGroupName} ${alice.userId}`)
+				cy.runOccCommand(`group:adduser ${randomGroupName} ${bob.userId}`)
+
+				cy.uploadContent(alice, new Blob(['share to bob'], { type: 'text/plain' }), 'text/plain', `/${randomFileName1}`)
+				cy.uploadContent(bob, new Blob(['share by bob'], { type: 'text/plain' }), 'text/plain', `/${randomFileName2}`)
+
+				cy.login(alice)
+				cy.visit('/apps/files')
+				createShare(randomFileName1, bob.userId)
+				cy.login(bob)
+				cy.visit('/apps/files')
+				createShare(randomFileName2, alice.userId)
+			})
+	})
+
+	after(() => {
+		cy.runOccCommand('config:app:set core shareapi_only_share_with_group_members --value no')
+	})
+
+	it('Alice can see the shared file', () => {
+		cy.login(alice)
+		cy.visit('/apps/files')
+		cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${randomFileName2}"]`).should('exist')
+	})
+
+	it('Bob can see the shared file', () => {
+		cy.login(alice)
+		cy.visit('/apps/files')
+		cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${randomFileName1}"]`).should('exist')
+	})
+
+	context('Bob is removed from the group', () => {
+		before(() => {
+			cy.runOccCommand(`group:removeuser ${randomGroupName} ${bob.userId}`)
+		})
+
+		it('Alice cannot see the shared file', () => {
+			cy.login(alice)
+			cy.visit('/apps/files')
+		cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${randomFileName2}"]`).should('not.exist')
+		})
+
+		it('Bob cannot see the shared file', () => {
+			cy.login(alice)
+			cy.visit('/apps/files')
+		cy.get(`[data-cy-files-list] [data-cy-files-list-row-name="${randomFileName1}"]`).should('not.exist')
+		})
+	})
+})

--- a/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
+++ b/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
@@ -1,23 +1,6 @@
 /**
- * @copyright Copyright (c) 2024 Louis Chmn <louis@chmn.me>
- *
- * @author Louis Chmn <louis@chmn.me>
- *
- * @license AGPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 import { User } from "@nextcloud/cypress"

--- a/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
+++ b/cypress/e2e/files_sharing/limit_to_same_group.cy.ts
@@ -4,7 +4,7 @@
  */
 
 import { User } from "@nextcloud/cypress"
-import { createShare } from "./filesSharingUtils"
+import { createShare } from "./FilesSharingUtils.ts"
 
 describe('Limit to sharing to people in the same group', () => {
 	let alice: User

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -28,6 +28,7 @@ use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IAttributes;
+use OCP\Share\IManager;
 use OCP\Share\IShare;
 use OCP\Share\IShareProviderSupportsAccept;
 use OCP\Share\IShareProviderWithNotification;
@@ -54,6 +55,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 		private IURLGenerator $urlGenerator,
 		private ITimeFactory $timeFactory,
 		private LoggerInterface $logger,
+		private IManager $shareManager,
 	) {
 	}
 
@@ -1234,7 +1236,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_GROUP)))
 			->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($gid)));
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$ids = [];
 		while ($row = $cursor->fetch()) {
 			$ids[] = (int)$row['id'];
@@ -1251,8 +1253,50 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 					->where($qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_USERGROUP)))
 					->andWhere($qb->expr()->eq('share_with', $qb->createNamedParameter($uid)))
 					->andWhere($qb->expr()->in('parent', $qb->createNamedParameter($chunk, IQueryBuilder::PARAM_INT_ARRAY)));
-				$qb->execute();
+				$qb->executeStatement();
 			}
+		}
+
+		if ($this->shareManager->shareWithGroupMembersOnly()) {
+			$deleteQuery = $this->dbConn->getQueryBuilder();
+			$deleteQuery->delete('share')
+				->where($deleteQuery->expr()->in('id', $deleteQuery->createParameter('id')));
+
+			// Delete direct shares received by the user from users in the group.
+			$selectInboundShares = $this->dbConn->getQueryBuilder();
+			$selectInboundShares->select('id')
+				->from('share', 's')
+				->join('s', 'group_user', 'g', 's.uid_initiator = g.uid')
+				->where($selectInboundShares->expr()->eq('share_type', $selectInboundShares->createNamedParameter(IShare::TYPE_USER)))
+				->andWhere($selectInboundShares->expr()->eq('share_with', $selectInboundShares->createNamedParameter($uid)))
+				->andWhere($selectInboundShares->expr()->eq('gid', $selectInboundShares->createNamedParameter($gid)))
+				->setMaxResults(1000)
+				->executeQuery();
+
+			do {
+				$rows = $selectInboundShares->executeQuery();
+				$ids = $rows->fetchAll();
+				$deleteQuery->setParameter('id', array_column($ids, 'id'), IQueryBuilder::PARAM_INT_ARRAY);
+				$deleteQuery->executeStatement();
+			} while (count($ids) > 0);
+
+			// Delete direct shares from the user to users in the group.
+			$selectOutboundShares = $this->dbConn->getQueryBuilder();
+			$selectOutboundShares->select('id')
+				->from('share', 's')
+				->join('s', 'group_user', 'g', 's.share_with = g.uid')
+				->where($selectOutboundShares->expr()->eq('share_type', $selectOutboundShares->createNamedParameter(IShare::TYPE_USER)))
+				->andWhere($selectOutboundShares->expr()->eq('uid_initiator', $selectOutboundShares->createNamedParameter($uid)))
+				->andWhere($selectOutboundShares->expr()->eq('gid', $selectOutboundShares->createNamedParameter($gid)))
+				->setMaxResults(1000)
+				->executeQuery();
+
+			do {
+				$rows = $selectOutboundShares->executeQuery();
+				$ids = $rows->fetchAll();
+				$deleteQuery->setParameter('id', array_column($ids, 'id'), IQueryBuilder::PARAM_INT_ARRAY);
+				$deleteQuery->executeStatement();
+			} while (count($ids) > 0);
 		}
 	}
 

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1225,6 +1225,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 	 *
 	 * @param string $uid
 	 * @param string $gid
+	 * @return void
 	 */
 	public function userDeletedFromGroup($uid, $gid) {
 		/*
@@ -1258,45 +1259,42 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 		}
 
 		if ($this->shareManager->shareWithGroupMembersOnly()) {
-			$deleteQuery = $this->dbConn->getQueryBuilder();
-			$deleteQuery->delete('share')
-				->where($deleteQuery->expr()->in('id', $deleteQuery->createParameter('id')));
+			$user = $this->userManager->get($uid);
+			if ($user === null) {
+				return;
+			}
+			$userGroups = $this->groupManager->getUserGroupIds($user);
+			$userGroups = array_diff($userGroups, $this->shareManager->shareWithGroupMembersOnlyExcludeGroupsList());
 
-			// Delete direct shares received by the user from users in the group.
-			$selectInboundShares = $this->dbConn->getQueryBuilder();
-			$selectInboundShares->select('id')
-				->from('share', 's')
-				->join('s', 'group_user', 'g', 's.uid_initiator = g.uid')
-				->where($selectInboundShares->expr()->eq('share_type', $selectInboundShares->createNamedParameter(IShare::TYPE_USER)))
-				->andWhere($selectInboundShares->expr()->eq('share_with', $selectInboundShares->createNamedParameter($uid)))
-				->andWhere($selectInboundShares->expr()->eq('gid', $selectInboundShares->createNamedParameter($gid)))
-				->setMaxResults(1000)
-				->executeQuery();
+			// Delete user shares received by the user from users in the group.
+			$userReceivedShares = $this->shareManager->getSharedWith($uid, IShare::TYPE_USER, null, -1);
+			foreach ($userReceivedShares as $share) {
+				$owner = $this->userManager->get($share->getSharedBy());
+				if ($owner === null) {
+					continue;
+				}
+				$ownerGroups = $this->groupManager->getUserGroupIds($owner);
+				$mutualGroups = array_intersect($userGroups, $ownerGroups);
 
-			do {
-				$rows = $selectInboundShares->executeQuery();
-				$ids = $rows->fetchAll();
-				$deleteQuery->setParameter('id', array_column($ids, 'id'), IQueryBuilder::PARAM_INT_ARRAY);
-				$deleteQuery->executeStatement();
-			} while (count($ids) > 0);
+				if (count($mutualGroups) === 0) {
+					$this->shareManager->deleteShare($share);
+				}
+			}
 
-			// Delete direct shares from the user to users in the group.
-			$selectOutboundShares = $this->dbConn->getQueryBuilder();
-			$selectOutboundShares->select('id')
-				->from('share', 's')
-				->join('s', 'group_user', 'g', 's.share_with = g.uid')
-				->where($selectOutboundShares->expr()->eq('share_type', $selectOutboundShares->createNamedParameter(IShare::TYPE_USER)))
-				->andWhere($selectOutboundShares->expr()->eq('uid_initiator', $selectOutboundShares->createNamedParameter($uid)))
-				->andWhere($selectOutboundShares->expr()->eq('gid', $selectOutboundShares->createNamedParameter($gid)))
-				->setMaxResults(1000)
-				->executeQuery();
+			// Delete user shares from the user to users in the group.
+			$userEmittedShares = $this->shareManager->getSharesBy($uid, IShare::TYPE_USER, null, true, -1);
+			foreach ($userEmittedShares as $share) {
+				$recipient = $this->userManager->get($share->getSharedWith());
+				if ($recipient === null) {
+					continue;
+				}
+				$recipientGroups = $this->groupManager->getUserGroupIds($recipient);
+				$mutualGroups = array_intersect($userGroups, $recipientGroups);
 
-			do {
-				$rows = $selectOutboundShares->executeQuery();
-				$ids = $rows->fetchAll();
-				$deleteQuery->setParameter('id', array_column($ids, 'id'), IQueryBuilder::PARAM_INT_ARRAY);
-				$deleteQuery->executeStatement();
-			} while (count($ids) > 0);
+				if (count($mutualGroups) === 0) {
+					$this->shareManager->deleteShare($share);
+				}
+			}
 		}
 	}
 

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -88,6 +88,7 @@ class ProviderFactory implements IProviderFactory {
 				$this->serverContainer->getURLGenerator(),
 				$this->serverContainer->query(ITimeFactory::class),
 				$this->serverContainer->get(LoggerInterface::class),
+				$this->serverContainer->get(IManager::class),
 			);
 		}
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -72,6 +72,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	/** @var LoggerInterface|MockObject */
 	protected $logger;
 
+	protected IShareManager&MockObject $shareManager;
+
 	protected function setUp(): void {
 		$this->dbConn = \OC::$server->getDatabaseConnection();
 		$this->userManager = $this->createMock(IUserManager::class);
@@ -84,6 +86,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->shareManager = $this->createMock(IShareManager::class);
 
 		$this->userManager->expects($this->any())->method('userExists')->willReturn(true);
 		$this->timeFactory->expects($this->any())->method('now')->willReturn(new \DateTimeImmutable("2023-05-04 00:00 Europe/Berlin"));
@@ -101,7 +104,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			$this->l10nFactory,
 			$this->urlGenerator,
 			$this->timeFactory,
-			$this->logger
+			$this->logger,
+			$this->shareManager,
 		);
 	}
 
@@ -464,7 +468,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				$this->l10nFactory,
 				$this->urlGenerator,
 				$this->timeFactory,
-				$this->logger
+				$this->logger,
+				$this->shareManager,
 			])
 			->setMethods(['getShareById'])
 			->getMock();
@@ -560,7 +565,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				$this->l10nFactory,
 				$this->urlGenerator,
 				$this->timeFactory,
-				$this->logger
+				$this->logger,
+				$this->shareManager,
 			])
 			->setMethods(['getShareById'])
 			->getMock();
@@ -2529,7 +2535,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			$this->l10nFactory,
 			$this->urlGenerator,
 			$this->timeFactory,
-			$this->logger
+			$this->logger,
+			$this->shareManager,
 		);
 
 		$password = md5(time());
@@ -2628,7 +2635,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			$this->l10nFactory,
 			$this->urlGenerator,
 			$this->timeFactory,
-			$this->logger
+			$this->logger,
+			$this->shareManager,
 		);
 
 		$u1 = $userManager->createUser('testShare1', 'test');
@@ -2725,7 +2733,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			$this->l10nFactory,
 			$this->urlGenerator,
 			$this->timeFactory,
-			$this->logger
+			$this->logger,
+			$this->shareManager,
 		);
 
 		$u1 = $userManager->createUser('testShare1', 'test');


### PR DESCRIPTION
## Summary

When removing a user from a group, remove shares which would not be creatable anymore according to group limit on sharing.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
