### PR TITLE
fix(userstatus): trigger absence start job even for absences starting in the past

### DIFF
--- a/apps/dav/tests/unit/Service/AbsenceServiceTest.php
+++ b/apps/dav/tests/unit/Service/AbsenceServiceTest.php
@@ -252,14 +252,21 @@ class AbsenceServiceTest extends TestCase {
 			->method('getUserTimezone')
 			->with('user')
 			->willReturn($tz->getName());
+		$time = (new DateTimeImmutable('2023-01-07', $tz))->getTimestamp();
 		$this->timeFactory->expects(self::once())
 			->method('getTime')
-			->willReturn((new DateTimeImmutable('2023-01-07', $tz))->getTimestamp());
-		$this->jobList->expects(self::once())
+			->willReturn($time);
+		$this->jobList->expects(self::exactly(2))
 			->method('scheduleAfter')
-			->with(OutOfOfficeEventDispatcherJob::class, $endDate->getTimestamp() + 3600 * 23 + 59 * 60, [
-				'id' => '1',
-				'event' => OutOfOfficeEventDispatcherJob::EVENT_END,
+			->willReturnMap([
+				[OutOfOfficeEventDispatcherJob::class, $time, [
+					'id' => '1',
+					'event' => OutOfOfficeEventDispatcherJob::EVENT_START,
+				]],
+				[OutOfOfficeEventDispatcherJob::class, $endDate->getTimestamp() + 3600 * 23 + 59 * 60, [
+					'id' => '1',
+					'event' => OutOfOfficeEventDispatcherJob::EVENT_END,
+				]],
 			]);
 
 		$this->absenceService->createOrUpdateAbsence(
@@ -391,14 +398,21 @@ class AbsenceServiceTest extends TestCase {
 			->method('getUserTimezone')
 			->with('user')
 			->willReturn($tz->getName());
+		$time = (new DateTimeImmutable('2023-01-07', $tz))->getTimestamp();
 		$this->timeFactory->expects(self::once())
 			->method('getTime')
-			->willReturn((new DateTimeImmutable('2023-01-07', $tz))->getTimestamp());
-		$this->jobList->expects(self::once())
+			->willReturn($time);
+		$this->jobList->expects(self::exactly(2))
 			->method('scheduleAfter')
-			->with(OutOfOfficeEventDispatcherJob::class, $endDate->getTimestamp() + 23 * 3600 + 59 * 60, [
-				'id' => '1',
-				'event' => OutOfOfficeEventDispatcherJob::EVENT_END,
+			->willReturnMap([
+				[OutOfOfficeEventDispatcherJob::class, $time, [
+					'id' => '1',
+					'event' => OutOfOfficeEventDispatcherJob::EVENT_START,
+				]],
+				[OutOfOfficeEventDispatcherJob::class, $endDate->getTimestamp() + 3600 * 23 + 59 * 60, [
+					'id' => '1',
+					'event' => OutOfOfficeEventDispatcherJob::EVENT_END,
+				]],
 			]);
 
 		$this->absenceService->createOrUpdateAbsence(


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/47058

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The absence start job was not created for absences in the past - which could also mean an absence starting today (absence timestamp is midnight, but time for `$now` is larger).

Since absences that start in the past and are still ongoing should be considered nonetheless, absences are now only evaluated by their end date. if that is in the past, no jobs are created.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [ ] ~~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required~~
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
