### PR TITLE
feat: added TextToImageSingle TaskType to the TaskProcessingAPI

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -774,6 +774,7 @@ return array(
     'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',
     'OCP\\TaskProcessing\\TaskTypes\\GenerateEmoji' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToImage' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToImage.php',
+    'OCP\\TaskProcessing\\TaskTypes\\TextToImageSingle' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToImageSingle.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToText' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToText.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextChat' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextChat.php',
     'OCP\\TaskProcessing\\TaskTypes\\TextToTextFormalization' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -807,6 +807,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',
         'OCP\\TaskProcessing\\TaskTypes\\GenerateEmoji' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToImage' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToImage.php',
+        'OCP\\TaskProcessing\\TaskTypes\\TextToImageSingle' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToImageSingle.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToText' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToText.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextChat' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextChat.php',
         'OCP\\TaskProcessing\\TaskTypes\\TextToTextFormalization' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php',

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -488,6 +488,7 @@ class Manager implements IManager {
 			\OCP\TaskProcessing\TaskTypes\TextToTextTranslate::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToTextTranslate::class),
 			\OCP\TaskProcessing\TaskTypes\TextToTextReformulation::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToTextReformulation::class),
 			\OCP\TaskProcessing\TaskTypes\TextToImage::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToImage::class),
+			\OCP\TaskProcessing\TaskTypes\TextToImageSingle::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToImageSingle::class),
 			\OCP\TaskProcessing\TaskTypes\AudioToText::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\AudioToText::class),
 			\OCP\TaskProcessing\TaskTypes\ContextWrite::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\ContextWrite::class),
 			\OCP\TaskProcessing\TaskTypes\GenerateEmoji::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\GenerateEmoji::class),

--- a/lib/public/TaskProcessing/TaskTypes/TextToImageSingle.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToImageSingle.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\TaskProcessing\TaskTypes;
+
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\ShapeDescriptor;
+
+/**
+ * This is the task processing task type for image generation
+ * @since 30.0.0
+ */
+class TextToImageSingle implements ITaskType {
+	/**
+	 * @since 30.0.0
+	 */
+	public const ID = 'core:text2image:single';
+
+	private IL10N $l;
+
+	/**
+	 * @param IFactory $l10nFactory
+	 * @since 30.0.0
+	 */
+	public function __construct(
+		IFactory $l10nFactory,
+	) {
+		$this->l = $l10nFactory->get('core');
+	}
+
+
+	/**
+	 * @inheritDoc
+	 * @since 30.0.0
+	 */
+	public function getName(): string {
+		return $this->l->t('Generate image');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 30.0.0
+	 */
+	public function getDescription(): string {
+		return $this->l->t('Generate an image from a text prompt');
+	}
+
+	/**
+	 * @return string
+	 * @since 30.0.0
+	 */
+	public function getId(): string {
+		return self::ID;
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 30.0.0
+	 */
+	public function getInputShape(): array {
+		return [
+			'input' => new ShapeDescriptor(
+				$this->l->t('Prompt'),
+				$this->l->t('Describe the image you want to generate'),
+				EShapeType::Text
+			)
+		];
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 30.0.0
+	 */
+	public function getOutputShape(): array {
+		return [
+			'image' => new ShapeDescriptor(
+				$this->l->t('Output image'),
+				$this->l->t('The generated image'),
+				EShapeType::Image
+			),
+		];
+	}
+}


### PR DESCRIPTION
## Summary

We need a default task type for image generation tasks that do not support "count" (which is actually a "batch" parameter)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
