### PR TITLE
fix(federation): Return the used userID to allow the inviting server …

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -173,15 +173,18 @@ class RequestHandlerController extends Controller {
 			);
 		}
 
-		$user = $this->userManager->get($shareWith);
-		$recipientDisplayName = '';
-		if ($user) {
-			$recipientDisplayName = $user->getDisplayName();
+		$responseData = ['recipientDisplayName' => ''];
+		if ($shareType === 'user') {
+			$user = $this->userManager->get($shareWith);
+			if ($user) {
+				$responseData = [
+					'recipientDisplayName' => $user->getDisplayName(),
+					'recipientUserId' => $user->getUID(),
+				];
+			}
 		}
 
-		return new JSONResponse(
-			['recipientDisplayName' => $recipientDisplayName],
-			Http::STATUS_CREATED);
+		return new JSONResponse($responseData, Http::STATUS_CREATED);
 	}
 
 	/**

--- a/apps/cloud_federation_api/lib/ResponseDefinitions.php
+++ b/apps/cloud_federation_api/lib/ResponseDefinitions.php
@@ -12,6 +12,7 @@ namespace OCA\CloudFederationAPI;
 /**
  * @psalm-type CloudFederationAPIAddShare = array{
  *     recipientDisplayName: string,
+ *     recipientUserId?: string,
  * }
  *
  * @psalm-type CloudFederationAPIError = array{

--- a/apps/cloud_federation_api/openapi.json
+++ b/apps/cloud_federation_api/openapi.json
@@ -28,6 +28,9 @@
                 "properties": {
                     "recipientDisplayName": {
                         "type": "string"
+                    },
+                    "recipientUserId": {
+                        "type": "string"
                     }
                 }
             },


### PR DESCRIPTION
…to react to the famous `mapUid` result

* Resolves issues when e.g. inviting `<email>@server` on a server like c.nc.c

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
