### PR TITLE
do not init navigation data too soon

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -70,7 +70,6 @@ class NavigationManager implements INavigationManager {
 			$this->closureEntries[] = $entry;
 			return;
 		}
-		$this->init();
 
 		$id = $entry['id'];
 


### PR DESCRIPTION
do not run `init()` during `add()`:

- if an app calls `NavigationManager::add()` during the registration process of `Application.php`, the route generated (using `IUrlGenerator`) for apps using `<navigations>` in `info.xml` could be empty if app is not fully loaded when `init()` is called.
- `getAll()` that returns data filled by `add()` will call `init()` anyway and generate the correct data using the right routes as all apps are loaded at that point.

Because `$this->entries` is only read during `getAll()`, it should not be an issue to not `init()` during `add()`

Fixes https://github.com/nextcloud/fulltextsearch/issues/842