### PR TITLE
fix(core): Limit valid avatar sizes

### DIFF
--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -55,7 +55,7 @@ class AvatarController extends Controller {
 	 * Get the dark avatar
 	 *
 	 * @param string $userId ID of the user
-	 * @param int $size Size of the avatar
+	 * @param 64|512 $size Size of the avatar
 	 * @param bool $guestFallback Fallback to guest avatar if not found
 	 * @return FileDisplayResponse<Http::STATUS_OK|Http::STATUS_CREATED, array{Content-Type: string, X-NC-IsCustomAvatar: int}>|JSONResponse<Http::STATUS_NOT_FOUND, array<empty>, array{}>|Response<Http::STATUS_INTERNAL_SERVER_ERROR, array{}>
 	 *
@@ -89,7 +89,7 @@ class AvatarController extends Controller {
 			);
 		} catch (\Exception $e) {
 			if ($guestFallback) {
-				return $this->guestAvatarController->getAvatarDark($userId, (string)$size);
+				return $this->guestAvatarController->getAvatarDark($userId, $size);
 			}
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
@@ -106,7 +106,7 @@ class AvatarController extends Controller {
 	 * Get the avatar
 	 *
 	 * @param string $userId ID of the user
-	 * @param int $size Size of the avatar
+	 * @param 64|512 $size Size of the avatar
 	 * @param bool $guestFallback Fallback to guest avatar if not found
 	 * @return FileDisplayResponse<Http::STATUS_OK|Http::STATUS_CREATED, array{Content-Type: string, X-NC-IsCustomAvatar: int}>|JSONResponse<Http::STATUS_NOT_FOUND, array<empty>, array{}>|Response<Http::STATUS_INTERNAL_SERVER_ERROR, array{}>
 	 *
@@ -140,7 +140,7 @@ class AvatarController extends Controller {
 			);
 		} catch (\Exception $e) {
 			if ($guestFallback) {
-				return $this->guestAvatarController->getAvatar($userId, (string)$size);
+				return $this->guestAvatarController->getAvatar($userId, $size);
 			}
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}

--- a/core/Controller/GuestAvatarController.php
+++ b/core/Controller/GuestAvatarController.php
@@ -36,7 +36,7 @@ class GuestAvatarController extends Controller {
 	 * Returns a guest avatar image response
 	 *
 	 * @param string $guestName The guest name, e.g. "Albert"
-	 * @param string $size The desired avatar size, e.g. 64 for 64x64px
+	 * @param 64|512 $size The desired avatar size, e.g. 64 for 64x64px
 	 * @param bool|null $darkTheme Return dark avatar
 	 * @return FileDisplayResponse<Http::STATUS_OK|Http::STATUS_CREATED, array{Content-Type: string, X-NC-IsCustomAvatar: int}>|Response<Http::STATUS_INTERNAL_SERVER_ERROR, array{}>
 	 *
@@ -46,8 +46,7 @@ class GuestAvatarController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[FrontpageRoute(verb: 'GET', url: '/avatar/guest/{guestName}/{size}')]
-	public function getAvatar(string $guestName, string $size, ?bool $darkTheme = false) {
-		$size = (int) $size;
+	public function getAvatar(string $guestName, int $size, ?bool $darkTheme = false) {
 		$darkTheme = $darkTheme ?? false;
 
 		if ($size <= 64) {
@@ -89,7 +88,7 @@ class GuestAvatarController extends Controller {
 	 * Returns a dark guest avatar image response
 	 *
 	 * @param string $guestName The guest name, e.g. "Albert"
-	 * @param string $size The desired avatar size, e.g. 64 for 64x64px
+	 * @param 64|512 $size The desired avatar size, e.g. 64 for 64x64px
 	 * @return FileDisplayResponse<Http::STATUS_OK|Http::STATUS_CREATED, array{Content-Type: string, X-NC-IsCustomAvatar: int}>|Response<Http::STATUS_INTERNAL_SERVER_ERROR, array{}>
 	 *
 	 * 200: Custom avatar returned
@@ -98,7 +97,7 @@ class GuestAvatarController extends Controller {
 	#[PublicPage]
 	#[NoCSRFRequired]
 	#[FrontpageRoute(verb: 'GET', url: '/avatar/guest/{guestName}/{size}/dark')]
-	public function getAvatarDark(string $guestName, string $size) {
+	public function getAvatarDark(string $guestName, int $size) {
 		return $this->getAvatar($guestName, $size, true);
 	}
 }

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -7567,7 +7567,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],
@@ -7674,7 +7678,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],
@@ -7914,7 +7922,12 @@
                         "description": "The desired avatar size, e.g. 64 for 64x64px",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],
@@ -7995,7 +8008,12 @@
                         "description": "The desired avatar size, e.g. 64 for 64x64px",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -7567,7 +7567,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],
@@ -7674,7 +7678,11 @@
                         "required": true,
                         "schema": {
                             "type": "integer",
-                            "format": "int64"
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],
@@ -7914,7 +7922,12 @@
                         "description": "The desired avatar size, e.g. 64 for 64x64px",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],
@@ -7995,7 +8008,12 @@
                         "description": "The desired avatar size, e.g. 64 for 64x64px",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "integer",
+                            "format": "int64",
+                            "enum": [
+                                64,
+                                512
+                            ]
                         }
                     }
                 ],


### PR DESCRIPTION
## Summary

The code already limits the sizes to 64 and 512, so it can be properly documented for the API too.
The change from `string` to `int` in the GuestAvatarController is not a breaking change because the parameters is part of the path and thus always serialized the same regardless if it is a `string` or an `int`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
