### PR TITLE
fix: Allow to disable ssl verification for object storage

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -51,6 +51,7 @@ trait S3ConnectionTrait {
 			$params['port'] = (isset($params['use_ssl']) && $params['use_ssl'] === false) ? 80 : 443;
 		}
 		$params['verify_bucket_exists'] = $params['verify_bucket_exists'] ?? true;
+		$params['ssl_verify'] = $params['ssl_verify'] ?? true;
 
 		if ($params['s3-accelerate']) {
 			$params['verify_bucket_exists'] = false;
@@ -100,7 +101,7 @@ trait S3ConnectionTrait {
 			'csm' => false,
 			'use_arn_region' => false,
 			'http' => [
-				'verify' => $this->getCertificateBundlePath(),
+				'verify' => $this->params['ssl_verify'] ? $this->getCertificateBundlePath() : false,
 				// Timeout for the connection to S3 server, not for the request.
 				'connect_timeout' => 5
 			],

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -54,13 +54,18 @@ trait S3ObjectTrait {
 				'http' => [
 					'protocol_version' => $request->getProtocolVersion(),
 					'header' => $headers,
-				]
+				],
+				'ssl' => [],
 			];
 			$bundle = $this->getCertificateBundlePath();
 			if ($bundle) {
 				$opts['ssl'] = [
 					'cafile' => $bundle
 				];
+			}
+
+			if ($this->params['ssl_verify'] === false) {
+				$opts['ssl']['verify_peer'] = false;
 			}
 
 			if ($this->getProxy()) {


### PR DESCRIPTION
In some setups having a valid certificate is not feasible, so this PR adds a config option to disable peer verification for object storage configurations.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
