### PR TITLE
fix(webauthn): Increase database column for public key id

### DIFF
--- a/core/Migrations/Version19000Date20200211083441.php
+++ b/core/Migrations/Version19000Date20200211083441.php
@@ -35,7 +35,7 @@ class Version19000Date20200211083441 extends SimpleMigrationStep {
 			]);
 			$table->addColumn('public_key_credential_id', 'string', [
 				'notnull' => true,
-				'length' => 255
+				'length' => 512
 			]);
 			$table->addColumn('data', 'text', [
 				'notnull' => true,

--- a/core/Migrations/Version30000Date20240814180800.php
+++ b/core/Migrations/Version30000Date20240814180800.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version30000Date20240814180800 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('webauthn');
+		$column = $table->getColumn('public_key_credential_id');
+
+		/**
+		 * There is no maximum length defined in the standard,
+		 * most common the length is between 128 and 200 characters,
+		 * but as we store it not in plain data but base64 encoded the length can grow about 1/3.
+		 * We had a regression with 'Nitrokey 3' which created IDs with 196 byte length -> 262 bytes encoded base64.
+		 * So to be save we increase the size to 512 bytes.
+		 */
+		if ($column->getLength() < 512) {
+			$column->setLength(512);
+		}
+
+		return $schema;
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1365,6 +1365,7 @@ return array(
     'OC\\Core\\Migrations\\Version30000Date20240429122720' => $baseDir . '/core/Migrations/Version30000Date20240429122720.php',
     'OC\\Core\\Migrations\\Version30000Date20240708160048' => $baseDir . '/core/Migrations/Version30000Date20240708160048.php',
     'OC\\Core\\Migrations\\Version30000Date20240717111406' => $baseDir . '/core/Migrations/Version30000Date20240717111406.php',
+    'OC\\Core\\Migrations\\Version30000Date20240814180800' => $baseDir . '/core/Migrations/Version30000Date20240814180800.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\ResponseDefinitions' => $baseDir . '/core/ResponseDefinitions.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1398,6 +1398,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version30000Date20240429122720' => __DIR__ . '/../../..' . '/core/Migrations/Version30000Date20240429122720.php',
         'OC\\Core\\Migrations\\Version30000Date20240708160048' => __DIR__ . '/../../..' . '/core/Migrations/Version30000Date20240708160048.php',
         'OC\\Core\\Migrations\\Version30000Date20240717111406' => __DIR__ . '/../../..' . '/core/Migrations/Version30000Date20240717111406.php',
+        'OC\\Core\\Migrations\\Version30000Date20240814180800' => __DIR__ . '/../../..' . '/core/Migrations/Version30000Date20240814180800.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\ResponseDefinitions' => __DIR__ . '/../../..' . '/core/ResponseDefinitions.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/34476
* Fixed version of https://github.com/nextcloud/server/pull/36769

## Summary

There is no maximum length defined in the standard, most common the length is between 128 and 200 characters, but as we store it not in plain data but base64 encoded the length can grow about 1/3.

We had a regression with 'Nitrokey 3' which created IDs with 196 byte length -> 262 bytes encoded base64. So to be save we increase the size to 512 bytes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
