### PR TITLE
fix(adminaudit): Don't crash when creating folder

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -159,10 +159,11 @@ class Files extends Action {
 	 * @param BeforeNodeWrittenEvent $event
 	 */
 	public function write(BeforeNodeWrittenEvent $event): void {
+		$node = $event->getNode();
 		try {
 			$params = [
-				'id' => $event->getNode()->getId(),
-				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
+				'id' => $node instanceof NonExistingFile ? null : $node->getId(),
+				'path' => mb_substr($node->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(


### PR DESCRIPTION
- Similar to #47071
- Regression from #44871

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
