### PR TITLE
feat(share): make sharelink token length configurable

### DIFF
--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -63,7 +63,10 @@ class Constants {
 
 	public const RESPONSE_FORMAT = 'json'; // default response format for ocs calls
 
-	public const TOKEN_LENGTH = 15; // old (oc7) length is 32, keep token length in db at least that for compatibility
+	public const MIN_TOKEN_LENGTH = 6; // 19,770,609,664 different possible variations
+	public const DEFAULT_TOKEN_LENGTH = 15; // 54,960,434,128,018,667,122,720,768 different possible variations
+	public const MAX_TOKEN_LENGTH = 32; // 8,167,835,760,036,914,488,254,418,108,462,708,901,695,678,621,570,564,096 different possible variations
+	public const TOKEN_LENGTH = self::DEFAULT_TOKEN_LENGTH; // old (oc7) length is 32, keep token length in db at least that for compatibility
 
 	protected static $shareTypeUserAndGroups = -1;
 	protected static $shareTypeGroupUserUnique = 2;

--- a/lib/private/Share/Helper.php
+++ b/lib/private/Share/Helper.php
@@ -126,4 +126,13 @@ class Helper extends \OC\Share\Constants {
 
 		return false;
 	}
+
+	public static function getTokenLength(): int {
+		$config = \OCP\Server::get(\OCP\IAppConfig::class);
+		$tokenLength = $config->getValueInt('core', 'shareapi_token_length', self::DEFAULT_TOKEN_LENGTH);
+		$tokenLength = $tokenLength ?: self::DEFAULT_TOKEN_LENGTH;
+
+		// Token length should be within the defined min and max limits
+		return max(self::MIN_TOKEN_LENGTH, min($tokenLength, self::MAX_TOKEN_LENGTH));
+	}
 }

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -656,13 +656,43 @@ class Manager implements IManager {
 				$this->linkCreateChecks($share);
 				$this->setLinkParent($share);
 
-				// For now ignore a set token.
-				$share->setToken(
-					$this->secureRandom->generate(
-						\OC\Share\Constants::TOKEN_LENGTH,
-						\OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE
-					)
-				);
+				// Initial token length
+				$tokenLength = \OC\Share\Helper::getTokenLength();
+
+				do {
+					$tokenExists = false;
+
+					for ($i = 0; $i <= 2; $i++) {
+						// Generate a new token
+						$token = $this->secureRandom->generate(
+							$tokenLength,
+							\OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE
+						);
+
+						try {
+							// Try to fetch a share with the generated token
+							$this->getShareByToken($token);
+							$tokenExists = true; // Token exists, we need to try again
+						} catch (\OCP\Share\Exceptions\ShareNotFound $e) {
+							// Token is unique, exit the loop
+							$tokenExists = false;
+							break;
+						}
+					}
+
+					// If we've reached the maximum attempts and the token still exists, increase the token length
+					if ($tokenExists) {
+						$tokenLength++;
+
+						// Check if the token length exceeds the maximum allowed length
+						if ($tokenLength > \OC\Share\Constants::MAX_TOKEN_LENGTH) {
+							throw new \Exception('Unable to generate a unique share token. Maximum token length exceeded.');
+						}
+					}
+				} while ($tokenExists);
+
+				// Set the unique token
+				$share->setToken($token);
 
 				// Verify the expiration date
 				$share = $this->validateExpirationDateLink($share);


### PR DESCRIPTION
* Resolves: #419 

## Summary
The share-token length is currently fixed at 15 characters as a constant.
This length allows for $52^{15}$ (54,960,434,128,018,667,122,720,768) possible token variations using CHAR_HUMAN_READABLE:
https://github.com/nextcloud/server/blob/dcdb4bbf8ab2d618e789a631a410ad70829766aa/lib/public/Security/ISecureRandom.php#L55
This level of variation can be considered Military Grade High Entropy and is often much more than sufficient for many use cases. Reducing the token length requires direct code modifications.

## Changes
This Pull Request introduces the ability to configure the token length for the Share API.
Administrators can set the token length dynamically through the database in a range from 6 up to 32:

```bash
occ config:app:set --value=8 -- core shareapi_token_length
```
This example sets the token length to 8 characters. 
If no changes are made, the default value of 15 will continue to be used, ensuring backward compatibility.

Even at the minimum length of 6, there are still $52^6$ (19,770,609,664) possible variations.

## Security Consideration
Reducing the token length increases the chance of token collisions, as it drastically reduces the number of possible combinations. It’s important to note that when a variable token length is used, this does not automatically mean, that the security decreases, since the total number of possible variations **increases** significantly. This is because, for shorter tokens, we must sum the possible variations for each length from 6 up to the maximum configured length to get the number of theoretically possible variations.
I have been using a token length of 8 for a long time now, although there are still 53,459,728,531,456 different possible variations. Absolutely sufficient for my use case where music producers share music samples and the shares have a very short ttl..
Shorter token lengths can be very helpful in cases where a lot of work is done with short-lived shares.
The admin is therefore responsible for assessing which security requirements he attaches to the token length. Therefore, this PR makes it possible not only to decrease- but to increase the token length up to a maximum of 32 as well, which corresponds to 8,167,835,760,036,914,488,254,418,108,462,708,901,695,678,621,570,564,096 possible variations, which is absolutely an increase in security.

---
**EDIT:**
Added the values:

~* "max" for the maximum token length (32)~  *)
~* "min" for the minimum token length (6)~  *)
* '0' and any other non-numerical value (like "default") for the default token length (15)

This ensures that the token length is "idiot-proof," defaulting to a safe (the default) value not only when the input is empty but also when any invalid value is provided. This makes it more robust and prevents potential errors.

*) simplified with https://github.com/nextcloud/server/pull/47265/commits/ee24fdd276df5ec44323aec6105577e623348b01

---
**EDIT 2:**

I had mistakenly assumed A-Za-z0-9 instead of CHAR_HUMAN_READABLE

---
## Todo
Consideration must be given to how this should be documented.