### PR TITLE
Clean-up some remaining readdir calls with undesirable false evaluati…

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -261,7 +261,7 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 
 		$dh = $this->opendir($path);
-		while ($file = readdir($dh)) {
+		while (($file = readdir($dh)) !== false) {
 			if (\OC\Files\Filesystem::isIgnoredDir($file)) {
 				continue;
 			}
@@ -527,7 +527,7 @@ class Swift extends \OC\Files\Storage\Common {
 			}
 
 			$dh = $this->opendir($source);
-			while ($file = readdir($dh)) {
+			while (($file = readdir($dh)) !== false) {
 				if (\OC\Files\Filesystem::isIgnoredDir($file)) {
 					continue;
 				}

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -1114,7 +1114,7 @@ class Trashbin {
 	public static function isEmpty($user) {
 		$view = new View('/' . $user . '/files_trashbin');
 		if ($view->is_dir('/files') && $dh = $view->opendir('/files')) {
-			while ($file = readdir($dh)) {
+			while (($file = readdir($dh)) !== false) {
 				if (!Filesystem::isIgnoredDir($file)) {
 					return false;
 				}

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -228,7 +228,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 			$this->remove($target);
 			$dir = $this->opendir($source);
 			$this->mkdir($target);
-			while ($file = readdir($dir)) {
+			while (($file = readdir($dir)) !== false) {
 				if (!Filesystem::isIgnoredDir($file)) {
 					if (!$this->copy($source . '/' . $file, $target . '/' . $file)) {
 						closedir($dir);

--- a/lib/private/Files/Storage/PolyFill/CopyDirectory.php
+++ b/lib/private/Files/Storage/PolyFill/CopyDirectory.php
@@ -86,7 +86,7 @@ trait CopyDirectory {
 	protected function copyRecursive($source, $target) {
 		$dh = $this->opendir($source);
 		$result = true;
-		while ($file = readdir($dh)) {
+		while (($file = readdir($dh)) !== false) {
 			if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
 				if ($this->is_dir($source . '/' . $file)) {
 					$this->mkdir($target . '/' . $file);

--- a/tests/apps.php
+++ b/tests/apps.php
@@ -14,7 +14,7 @@ function loadDirectory($path) {
 		return;
 	}
 	if ($dh = opendir($path)) {
-		while ($name = readdir($dh)) {
+		while (($name = readdir($dh)) !== false) {
 			if ($name[0] !== '.') {
 				$file = $path . '/' . $name;
 				if (is_dir($file)) {

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -81,7 +81,7 @@ abstract class Storage extends \Test\TestCase {
 
 		$dh = $this->instance->opendir('/');
 		$content = [];
-		while ($file = readdir($dh)) {
+		while (($file = readdir($dh)) !== false) {
 			if ($file != '.' and $file != '..') {
 				$content[] = $file;
 			}
@@ -113,7 +113,7 @@ abstract class Storage extends \Test\TestCase {
 
 		$dh = $this->instance->opendir('/');
 		$content = [];
-		while ($file = readdir($dh)) {
+		while (($file = readdir($dh)) !== false) {
 			if ($file != '.' and $file != '..') {
 				$content[] = $file;
 			}

--- a/tests/lib/Files/Storage/Wrapper/EncodingTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncodingTest.php
@@ -209,7 +209,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 
 		$dh = $this->instance->opendir('/test');
 		$content = [];
-		while ($file = readdir($dh)) {
+		while (($file = readdir($dh)) !== false) {
 			if ($file != '.' and $file != '..') {
 				$content[] = $file;
 			}

--- a/tests/lib/Files/Storage/Wrapper/JailTest.php
+++ b/tests/lib/Files/Storage/Wrapper/JailTest.php
@@ -28,7 +28,7 @@ class JailTest extends \Test\Files\Storage\Storage {
 		// test that nothing outside our jail is touched
 		$contents = [];
 		$dh = $this->sourceStorage->opendir('');
-		while ($file = readdir($dh)) {
+		while (($file = readdir($dh)) !== false) {
 			if (!\OC\Files\Filesystem::isIgnoredDir($file)) {
 				$contents[] = $file;
 			}


### PR DESCRIPTION
…on potential

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
