### PR TITLE
fix: Do not throw if appstore is unavailable during upgrade

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -86,7 +86,8 @@ abstract class Fetcher {
 			$response = $client->get($this->getEndpoint(), $options);
 		} catch (ConnectException $e) {
 			$this->config->setAppValue('settings', 'appstore-fetcher-lastFailure', (string)time());
-			throw $e;
+			$this->logger->error('Failed to connect to the app store', ['exception' => $e]);
+			return [];
 		}
 
 		$responseJson = [];


### PR DESCRIPTION
Instead of throwing an error we just return an empty list as it is also done if there was a previous error a few lines above and instead just log it.

Otherwise this may leave apps disabled that used to be enabled before: https://github.com/nextcloud/server/blob/dae7c159f728a90ffa53247d6e033abdae5d2bd6/lib/private/Updater.php#L386-L393

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
