### PR TITLE
fix: Prevent crash when refreshing metadata for files without an owner

### DIFF
--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -104,7 +104,7 @@ class FilesMetadataManager implements IFilesMetadataManager {
 				return $this->refreshMetadata($node, self::PROCESS_BACKGROUND);
 			}
 
-			$this->jobList->add(UpdateSingleMetadata::class, [$node->getOwner()->getUID(), $node->getId()]);
+			$this->jobList->add(UpdateSingleMetadata::class, [$node->getOwner()?->getUID(), $node->getId()]);
 		}
 
 		return $metadata;


### PR DESCRIPTION
This crash was mostly happening when using external storages combined with for example the command "occ memories:migrate-google-takeout", or other commands.