### PR TITLE
feat: Provide RFC 5424 compliant `\OCP\LogLevel` with PSR-3 support

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -559,6 +559,7 @@ return array(
     'OCP\\Lock\\LockedException' => $baseDir . '/lib/public/Lock/LockedException.php',
     'OCP\\Lock\\ManuallyLockedException' => $baseDir . '/lib/public/Lock/ManuallyLockedException.php',
     'OCP\\Lockdown\\ILockdownManager' => $baseDir . '/lib/public/Lockdown/ILockdownManager.php',
+    'OCP\\LogLevel' => $baseDir . '/lib/public/LogLevel.php',
     'OCP\\Log\\Audit\\CriticalActionPerformedEvent' => $baseDir . '/lib/public/Log/Audit/CriticalActionPerformedEvent.php',
     'OCP\\Log\\BeforeMessageLoggedEvent' => $baseDir . '/lib/public/Log/BeforeMessageLoggedEvent.php',
     'OCP\\Log\\IDataLogger' => $baseDir . '/lib/public/Log/IDataLogger.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -592,6 +592,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Lock\\LockedException' => __DIR__ . '/../../..' . '/lib/public/Lock/LockedException.php',
         'OCP\\Lock\\ManuallyLockedException' => __DIR__ . '/../../..' . '/lib/public/Lock/ManuallyLockedException.php',
         'OCP\\Lockdown\\ILockdownManager' => __DIR__ . '/../../..' . '/lib/public/Lockdown/ILockdownManager.php',
+        'OCP\\LogLevel' => __DIR__ . '/../../..' . '/lib/public/LogLevel.php',
         'OCP\\Log\\Audit\\CriticalActionPerformedEvent' => __DIR__ . '/../../..' . '/lib/public/Log/Audit/CriticalActionPerformedEvent.php',
         'OCP\\Log\\BeforeMessageLoggedEvent' => __DIR__ . '/../../..' . '/lib/public/Log/BeforeMessageLoggedEvent.php',
         'OCP\\Log\\IDataLogger' => __DIR__ . '/../../..' . '/lib/public/Log/IDataLogger.php',

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -448,9 +448,11 @@ class Log implements ILogger, IDataLogger {
 	 * This is required as we currently only support 5 levels from 8 levels specified in the RFC.
 	 */
 	protected function sanitizeLogLevel(int|LogLevel $level): int {
+		// If the log level is an integer and outside of the internal supported range, try if it is just the value of the `LogLevel` enum
 		if (is_int($level) && ($level < ILogger::DEBUG || $level > ILogger::FATAL)) {
 			$level = LogLevel::tryFrom($level);
 		}
+		// If the level is a case of the `LogLevel` enum convert to the supported internal log level (map 0-7 to 0-4)
 		if ($level instanceof LogLevel) {
 			return match ($level) {
 				LogLevel::DEBUG => ILogger::DEBUG,

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -448,7 +448,7 @@ class Log implements ILogger, IDataLogger {
 	 * This is required as we currently only support 5 levels from 8 levels specified in the RFC.
 	 */
 	protected function sanitizeLogLevel(int|LogLevel $level): int {
-		if ($level < ILogger::DEBUG || $level > ILogger::FATAL) {
+		if (is_int($level) && ($level < ILogger::DEBUG || $level > ILogger::FATAL)) {
 			$level = LogLevel::tryFrom($level);
 		}
 		if ($level instanceof LogLevel) {

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -465,6 +465,7 @@ class Log implements ILogger, IDataLogger {
 				LogLevel::EMERGENCY => ILogger::FATAL,
 			};
 		}
+		// If the log level is not a valid internal log level the `tryFrom` has returned `null` so we fall back to the default log level (which is `warning`).
 		return $level ?? ILogger::WARN;
 	}
 }

--- a/lib/private/Log/PsrLoggerAdapter.php
+++ b/lib/private/Log/PsrLoggerAdapter.php
@@ -10,8 +10,8 @@ namespace OC\Log;
 
 use OC\Log;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\ILogger;
 use OCP\Log\IDataLogger;
+use OCP\LogLevel;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -41,11 +41,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function emergency($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::FATAL,
+					'level' => LogLevel::EMERGENCY,
 				],
-				$context
 			));
 		} else {
 			$this->logger->emergency((string)$message, $context);
@@ -64,11 +64,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function alert($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::ERROR,
+					'level' => LogLevel::ALERT,
 				],
-				$context
 			));
 		} else {
 			$this->logger->alert((string)$message, $context);
@@ -86,11 +86,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function critical($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::ERROR,
+					'level' => LogLevel::CRITICAL,
 				],
-				$context
 			));
 		} else {
 			$this->logger->critical((string)$message, $context);
@@ -107,11 +107,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function error($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::ERROR,
+					'level' => LogLevel::ERROR,
 				],
-				$context
 			));
 		} else {
 			$this->logger->error((string)$message, $context);
@@ -130,11 +130,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function warning($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::WARN,
+					'level' => LogLevel::WARNING,
 				],
-				$context
 			));
 		} else {
 			$this->logger->warning((string)$message, $context);
@@ -150,11 +150,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function notice($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::INFO,
+					'level' => LogLevel::NOTICE,
 				],
-				$context
 			));
 		} else {
 			$this->logger->notice((string)$message, $context);
@@ -172,11 +172,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function info($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::INFO,
+					'level' => LogLevel::INFO,
 				],
-				$context
 			));
 		} else {
 			$this->logger->info((string)$message, $context);
@@ -192,11 +192,11 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	public function debug($message, array $context = []): void {
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
-					'level' => ILogger::DEBUG,
+					'level' => LogLevel::DEBUG,
 				],
-				$context
 			));
 		} else {
 			$this->logger->debug((string)$message, $context);
@@ -213,16 +213,22 @@ final class PsrLoggerAdapter implements LoggerInterface, IDataLogger {
 	 * @throws InvalidArgumentException
 	 */
 	public function log($level, $message, array $context = []): void {
-		if (!is_int($level) || $level < ILogger::DEBUG || $level > ILogger::FATAL) {
-			throw new InvalidArgumentException('Nextcloud allows only integer log levels');
+		if (is_int($level)) {
+			$level = LogLevel::tryFrom($level);
+		} elseif (is_string($level)) {
+			$level = LogLevel::fromPsrLogLevel($level);
 		}
+		if (!($level instanceof LogLevel)) {
+			throw new InvalidArgumentException('Nextcloud allows only PSR-3 and integer log levels');
+		}
+
 		if ($this->containsThrowable($context)) {
 			$this->logger->logException($context['exception'], array_merge(
+				$context,
 				[
 					'message' => (string)$message,
 					'level' => $level,
 				],
-				$context
 			));
 		} else {
 			$this->logger->log($level, (string)$message, $context);

--- a/lib/public/ILogger.php
+++ b/lib/public/ILogger.php
@@ -19,27 +19,27 @@ namespace OCP;
 interface ILogger {
 	/**
 	 * @since 14.0.0
-	 * @deprecated 20.0.0
+	 * @deprecated 20.0.0 - use \OCP\LogLevel::DEBUG
 	 */
 	public const DEBUG = 0;
 	/**
 	 * @since 14.0.0
-	 * @deprecated 20.0.0
+	 * @deprecated 20.0.0 - use \OCP\LogLevel::INFO
 	 */
 	public const INFO = 1;
 	/**
 	 * @since 14.0.0
-	 * @deprecated 20.0.0
+	 * @deprecated 20.0.0 - use \OCP\LogLevel::WARN
 	 */
 	public const WARN = 2;
 	/**
 	 * @since 14.0.0
-	 * @deprecated 20.0.0
+	 * @deprecated 20.0.0 - use \OCP\LogLevel::ERROR
 	 */
 	public const ERROR = 3;
 	/**
 	 * @since 14.0.0
-	 * @deprecated 20.0.0
+	 * @deprecated 20.0.0 - use \OCP\LogLevel::FATAL
 	 */
 	public const FATAL = 4;
 
@@ -135,14 +135,14 @@ interface ILogger {
 	/**
 	 * Logs with an arbitrary level.
 	 *
-	 * @param int $level
+	 * @param int|LogLevel $level
 	 * @param string $message
 	 * @param array $context
 	 * @return mixed
 	 * @since 7.0.0
 	 * @deprecated 20.0.0 use \Psr\Log\LoggerInterface::log
 	 */
-	public function log(int $level, string $message, array $context = []);
+	public function log(int|LogLevel $level, string $message, array $context = []);
 
 	/**
 	 * Logs an exception very detailed

--- a/lib/public/ILogger.php
+++ b/lib/public/ILogger.php
@@ -29,7 +29,7 @@ interface ILogger {
 	public const INFO = 1;
 	/**
 	 * @since 14.0.0
-	 * @deprecated 20.0.0 - use \OCP\LogLevel::WARN
+	 * @deprecated 20.0.0 - use \OCP\LogLevel::WARNING
 	 */
 	public const WARN = 2;
 	/**

--- a/lib/public/LogLevel.php
+++ b/lib/public/LogLevel.php
@@ -53,6 +53,7 @@ enum LogLevel: int {
 
 	/**
 	 * Convert this log level to a PSR-3 `\Psr\Log\LogLevel`
+	 * @since 31.0.0
 	 */
 	public function toPsrLogLevel(): string {
 		return match($this) {

--- a/lib/public/LogLevel.php
+++ b/lib/public/LogLevel.php
@@ -36,6 +36,7 @@ enum LogLevel: int {
 	 * Create new `\OCP\LogLevel` from a given PSR-3 LogLevel
 	 * @param string $level the PSR-3 log level to convert
 	 * @throws InvalidArgumentException If the `$level` is not a PSR log level
+	 * @since 31.0.0
 	 */
 	public static function fromPsrLogLevel(string $level): self {
 		return match($level) {

--- a/lib/public/LogLevel.php
+++ b/lib/public/LogLevel.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP;
+
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel as PsrLogLevel;
+
+/**
+ * Logging levels according to RFC 5424
+ * @since 31.0.0
+ */
+enum LogLevel: int {
+	/** Detailed debug information */
+	case DEBUG = 0;
+	/** Interesting events */
+	case INFO = 1;
+	/** Normal but significant events */
+	case NOTICE = 2;
+	/** Exceptional occurrences that are not errors */
+	case WARNING = 3;
+	/** Runtime errors that do not require immediate action but should typically be logged and monitored */
+	case ERROR = 4;
+	/** Critical conditions */
+	case CRITICAL = 5;
+	/** Action must be taken immediately */
+	case ALERT = 6;
+	/** System is unusable */
+	case EMERGENCY = 7;
+
+	/**
+	 * Create new `\OCP\LogLevel` from a given PSR-3 LogLevel
+	 * @param string $level the PSR-3 log level to convert
+	 * @throws InvalidArgumentException If the `$level` is not a PSR log level
+	 */
+	public static function fromPsrLogLevel(string $level): self {
+		return match($level) {
+			PsrLogLevel::DEBUG => self::DEBUG,
+			PsrLogLevel::INFO => self::INFO,
+			PsrLogLevel::NOTICE => self::NOTICE,
+			PsrLogLevel::WARNING => self::WARNING,
+			PsrLogLevel::ERROR => self::ERROR,
+			PsrLogLevel::CRITICAL => self::CRITICAL,
+			PsrLogLevel::ALERT => self::ALERT,
+			PsrLogLevel::EMERGENCY => self::EMERGENCY,
+			default => throw new InvalidArgumentException($level . ' is not a valid PSR log level'),
+		};
+	}
+
+	/**
+	 * Convert this log level to a PSR-3 `\Psr\Log\LogLevel`
+	 */
+	public function toPsrLogLevel(): string {
+		return match($this) {
+			self::DEBUG => PsrLogLevel::DEBUG,
+			self::INFO => PsrLogLevel::INFO,
+			self::NOTICE => PsrLogLevel::NOTICE,
+			self::WARNING => PsrLogLevel::WARNING,
+			self::ERROR => PsrLogLevel::ERROR,
+			self::CRITICAL => PsrLogLevel::CRITICAL,
+			self::ALERT => PsrLogLevel::ALERT,
+			self::EMERGENCY => PsrLogLevel::EMERGENCY,
+		};
+	}
+}


### PR DESCRIPTION
## Summary
(This is an alternative to the PSR loglevel PR)

Make our logging system PSR-3 compliant by supporting the `\Psr\Log\LogLevel` and publish our supported the log levels in OCP so we can now possibly remove `\OCP\ILogger`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
