### PR TITLE
perf(core): Add index for jobs last_checked, reserved_at, time_sensitive

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -191,8 +191,8 @@ class Application extends App {
 
 			$event->addMissingIndex(
 				'jobs',
-				'job_lastcheck_reserved',
-				['last_checked', 'reserved_at']
+				'job_last_reserved_sensitive',
+				['last_checked', 'reserved_at', 'time_sensitive']
 			);
 
 			$event->addMissingIndex(

--- a/core/Migrations/Version31000Date20240819122840.php
+++ b/core/Migrations/Version31000Date20240819122840.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version31000Date20240819122840 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('jobs');
+
+		# Remove previous indices
+		if ($table->hasIndex('job_lastcheck_reserved')) {
+			$table->dropIndex('job_lastcheck_reserved');
+		}
+		if ($table->hasIndex('jobs_time_sensitive')) {
+			$table->dropIndex('jobs_time_sensitive');
+		}
+
+		# Add updated index
+		if (!$table->hasIndex('job_last_reserved_sensitive')) {
+			$table->addIndex(['last_checked', 'reserved_at', 'time_sensitive'], 'job_last_reserved_sensitive');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1368,6 +1368,7 @@ return array(
     'OC\\Core\\Migrations\\Version30000Date20240717111406' => $baseDir . '/core/Migrations/Version30000Date20240717111406.php',
     'OC\\Core\\Migrations\\Version30000Date20240814180800' => $baseDir . '/core/Migrations/Version30000Date20240814180800.php',
     'OC\\Core\\Migrations\\Version30000Date20240815080800' => $baseDir . '/core/Migrations/Version30000Date20240815080800.php',
+    'OC\\Core\\Migrations\\Version31000Date20240819122840' => $baseDir . '/core/Migrations/Version31000Date20240819122840.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\ResponseDefinitions' => $baseDir . '/core/ResponseDefinitions.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1401,6 +1401,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version30000Date20240717111406' => __DIR__ . '/../../..' . '/core/Migrations/Version30000Date20240717111406.php',
         'OC\\Core\\Migrations\\Version30000Date20240814180800' => __DIR__ . '/../../..' . '/core/Migrations/Version30000Date20240814180800.php',
         'OC\\Core\\Migrations\\Version30000Date20240815080800' => __DIR__ . '/../../..' . '/core/Migrations/Version30000Date20240815080800.php',
+        'OC\\Core\\Migrations\\Version31000Date20240819122840' => __DIR__ . '/../../..' . '/core/Migrations/Version31000Date20240819122840.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\ResponseDefinitions' => __DIR__ . '/../../..' . '/core/ResponseDefinitions.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [31, 0, 0, 1];
+$OC_Version = [31, 0, 0, 2];
 
 // The human-readable string
 $OC_VersionString = '31.0.0 dev';


### PR DESCRIPTION
* Resolves: #46126

## Summary

Replaces the two existing indices with a single shared index saving some time on queries previously using both separate indices.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
