### PR TITLE
fix(caldav): allow renaming of birthday calendars

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -46,7 +46,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 
 		parent::__construct($caldavBackend, $calendarInfo);
 
-		if ($this->getName() === BirthdayService::BIRTHDAY_CALENDAR_URI) {
+		if ($this->getName() === BirthdayService::BIRTHDAY_CALENDAR_URI && strcasecmp($this->calendarInfo['{DAV:}displayname'], 'Contact birthdays') === 0) {
 			$this->calendarInfo['{DAV:}displayname'] = $l10n->t('Contact birthdays');
 		}
 		if ($this->getName() === CalDavBackend::PERSONAL_CALENDAR_URI &&

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -113,6 +113,7 @@ class CalendarTest extends TestCase {
 			'principaluri' => 'principals/users/user1',
 			'id' => 666,
 			'uri' => 'contact_birthdays',
+			'{DAV:}displayname' => 'Test',
 		];
 
 		$c = new Calendar($backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
@@ -182,6 +183,7 @@ class CalendarTest extends TestCase {
 			'id' => 666,
 			'uri' => $uri
 		];
+		$calendarInfo['{DAV:}displayname'] = 'Test';
 		if (!is_null($readOnlyValue)) {
 			$calendarInfo['{http://owncloud.org/ns}read-only'] = $readOnlyValue;
 		}

--- a/apps/dav/tests/unit/Command/DeleteCalendarTest.php
+++ b/apps/dav/tests/unit/Command/DeleteCalendarTest.php
@@ -126,7 +126,7 @@ class DeleteCalendarTest extends TestCase {
 		$calendar = [
 			'id' => $id,
 			'principaluri' => 'principals/users/' . self::USER,
-			'uri' => self::NAME
+			'uri' => self::NAME,
 		];
 
 		$this->userManager->expects($this->once())
@@ -187,7 +187,8 @@ class DeleteCalendarTest extends TestCase {
 		$calendar = [
 			'id' => $id,
 			'principaluri' => 'principals/users/' . self::USER,
-			'uri' => BirthdayService::BIRTHDAY_CALENDAR_URI
+			'uri' => BirthdayService::BIRTHDAY_CALENDAR_URI,
+			'{DAV:}displayname' => 'Test',
 		];
 
 		$this->userManager->expects($this->once())
@@ -216,7 +217,8 @@ class DeleteCalendarTest extends TestCase {
 		$calendar = [
 			'id' => 1234,
 			'principaluri' => 'principals/users/' . self::USER,
-			'uri' => BirthdayService::BIRTHDAY_CALENDAR_URI
+			'uri' => BirthdayService::BIRTHDAY_CALENDAR_URI,
+			'{DAV:}displayname' => 'Test',
 		];
 		$this->userManager->expects($this->once())
 			->method('userExists')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/47330

## Summary

Default Birthday Calendars use a translation to show the correct default name for all languages.

Only use the translation if a user hasn't renamed their calendar.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
