### PR TITLE
fix(federation): Do not overwrite certificate bundle

### DIFF
--- a/lib/private/Federation/CloudFederationProviderManager.php
+++ b/lib/private/Federation/CloudFederationProviderManager.php
@@ -106,13 +106,9 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 
 		$client = $this->httpClientService->newClient();
 		try {
-			$response = $client->post($ocmProvider->getEndPoint() . '/shares', [
+			$response = $client->post($ocmProvider->getEndPoint() . '/shares', array_merge($this->getDefaultRequestOptions(), [
 				'body' => json_encode($share->getShare()),
-				'headers' => ['content-type' => 'application/json'],
-				'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false),
-				'timeout' => 10,
-				'connect_timeout' => 10,
-			]);
+			]));
 
 			if ($response->getStatusCode() === Http::STATUS_CREATED) {
 				$result = json_decode($response->getBody(), true);
@@ -143,13 +139,9 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 
 		$client = $this->httpClientService->newClient();
 		try {
-			return $client->post($ocmProvider->getEndPoint() . '/shares', [
+			return $client->post($ocmProvider->getEndPoint() . '/shares', array_merge($this->getDefaultRequestOptions(), [
 				'body' => json_encode($share->getShare()),
-				'headers' => ['content-type' => 'application/json'],
-				'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false),
-				'timeout' => 10,
-				'connect_timeout' => 10,
-			]);
+			]));
 		} catch (\Throwable $e) {
 			$this->logger->error('Error while sending share to federation server: ' . $e->getMessage(), ['exception' => $e]);
 			try {
@@ -175,13 +167,9 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 
 		$client = $this->httpClientService->newClient();
 		try {
-			$response = $client->post($ocmProvider->getEndPoint() . '/notifications', [
+			$response = $client->post($ocmProvider->getEndPoint() . '/notifications', array_merge($this->getDefaultRequestOptions(), [
 				'body' => json_encode($notification->getMessage()),
-				'headers' => ['content-type' => 'application/json'],
-				'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false),
-				'timeout' => 10,
-				'connect_timeout' => 10,
-			]);
+			]));
 			if ($response->getStatusCode() === Http::STATUS_CREATED) {
 				$result = json_decode($response->getBody(), true);
 				return (is_array($result)) ? $result : [];
@@ -205,13 +193,9 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 
 		$client = $this->httpClientService->newClient();
 		try {
-			return $client->post($ocmProvider->getEndPoint() . '/notifications', [
+			return $client->post($ocmProvider->getEndPoint() . '/notifications', array_merge($this->getDefaultRequestOptions(), [
 				'body' => json_encode($notification->getMessage()),
-				'headers' => ['content-type' => 'application/json'],
-				'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false),
-				'timeout' => 10,
-				'connect_timeout' => 10,
-			]);
+			]));
 		} catch (\Throwable $e) {
 			$this->logger->error('Error while sending notification to federation server: ' . $e->getMessage(), ['exception' => $e]);
 			try {
@@ -229,5 +213,18 @@ class CloudFederationProviderManager implements ICloudFederationProviderManager 
 	 */
 	public function isReady() {
 		return $this->appManager->isEnabledForUser('cloud_federation_api');
+	}
+
+	private function getDefaultRequestOptions(): array {
+		$options = [
+			'headers' => ['content-type' => 'application/json'],
+			'timeout' => 10,
+			'connect_timeout' => 10,
+		];
+
+		if ($this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates')) {
+			$options['verify'] = false;
+		}
+		return $options;
 	}
 }

--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -66,13 +66,16 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 
 		$client = $this->clientService->newClient();
 		try {
+			$options = [
+				'timeout' => 10,
+				'connect_timeout' => 10,
+			];
+			if ($this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates') === true) {
+				$options['verify'] = false;
+			}
 			$response = $client->get(
 				$remote . '/ocm-provider/',
-				[
-					'timeout' => 10,
-					'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates'),
-					'connect_timeout' => 10,
-				]
+				$options,
 			);
 
 			if ($response->getStatusCode() === Http::STATUS_OK) {


### PR DESCRIPTION
Signed-off-by: Julius Härtl <jus@bitgrid.net>

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

One might still want to verify self-signed certificates and not disable verification entirely. Before this change the `verify` option was always overwritten with true which means that the system certificate store was used instead of the Nextcloud built in one. We should only pass verify if we actually intent to disable verification, else the http client is injecting the cert bundle properly in https://github.com/nextcloud/server/blob/dae7c159f728a90ffa53247d6e033abdae5d2bd6/lib/private/Http/Client/Client.php#L55


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
