### PR TITLE
fix: don't recalculate folder size in Cache::delete if the entry didn't exist

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -150,9 +150,6 @@ class Updater implements IUpdater {
 			$this->propagator->propagateChange($path, time(), -$entry->getSize());
 		} else {
 			$this->propagator->propagateChange($path, time());
-			if ($this->cache instanceof Cache) {
-				$this->cache->correctFolderSize($parent);
-			}
 		}
 	}
 


### PR DESCRIPTION
I think just removing this is fine, let's see if ci agrees