### PR TITLE
store the mountpoint of storages in the mount options and use it to find the encryption keys

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -107,8 +107,9 @@ class SetupManager {
 		$prevLogging = Filesystem::logWarningWhenAddingStorageWrapper(false);
 
 		Filesystem::addStorageWrapper('mount_options', function ($mountPoint, IStorage $storage, IMountPoint $mount) {
-			if ($mount->getOptions() && $storage->instanceOfStorage(Common::class)) {
-				$storage->setMountOptions($mount->getOptions());
+			if ($storage->instanceOfStorage(Common::class)) {
+				$options = array_merge($mount->getOptions(), ['mount_point' => $mountPoint]);
+				$storage->setMountOptions($options);
 			}
 			return $storage;
 		});

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -14,6 +14,7 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Filesystem;
 use OC\Files\Mount\Manager;
 use OC\Files\ObjectStore\ObjectStoreStorage;
+use OC\Files\Storage\Common;
 use OC\Files\Storage\LocalTempFileTrait;
 use OC\Memcache\ArrayCache;
 use OCP\Cache\CappedMemoryCache;
@@ -776,9 +777,8 @@ class Encryption extends Wrapper {
 
 		// first copy the keys that we reuse the existing file key on the target location
 		// and don't create a new one which would break versions for example.
-		$mount = $this->mountManager->findByStorageId($sourceStorage->getId());
-		if (count($mount) >= 1) {
-			$mountPoint = $mount[0]->getMountPoint();
+		if ($sourceStorage->instanceOfStorage(Common::class) && $sourceStorage->getMountOption('mount_point')) {
+			$mountPoint = $sourceStorage->getMountOption('mount_point');
 			$source = $mountPoint . '/' . $sourceInternalPath;
 			$target = $this->getFullPath($targetInternalPath);
 			$this->copyKeys($source, $target);


### PR DESCRIPTION
No matter how much I find storages knowing their own mountpoint wrong from ideological level. In practice this info is needed in various places so might as well create a more universal solution for it.