### PR TITLE
fix(build): Allow update-apps.sh script to work with non-master branches

### DIFF
--- a/build/update-apps.sh
+++ b/build/update-apps.sh
@@ -10,9 +10,23 @@
 # It automatically:
 # - goes through all apps which are not shipped via server
 # - shows the app name in bold and uses whitespace for separation
-# - changes to master and pulls quietly
+# - changes to master/main and pulls quietly
 # - shows the 3 most recent commits for context
-# - removes branches merged into master
+# - removes branches merged into master/main
 # - … could even do the build steps if they are consistent for the apps (like `make`)
 
-find apps* -maxdepth 2 -name .git -exec sh -c 'cd {}/../ && printf "\n\033[1m${PWD##*/}\033[0m\n" && git checkout master && git pull --quiet -p && git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s" && printf "\n" && git branch --merged master | grep -v "master$" | xargs git branch -d && cd ..' \;
+set -euo pipefail
+
+for path in apps*/*/.git; do
+	(
+		path="$(dirname "$path")"
+		cd "$path"
+		printf "\n\033[1m${PWD##*/}\033[0m\n"
+		branch="$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"
+		git checkout "$branch"
+		git pull --quiet -p
+		git --no-pager log -3 --pretty=format:"%h %Cblue%ar%x09%an %Creset%s"
+		printf "\n"
+		git branch --merged "$branch" | grep -v "$branch$" | xargs git branch -d || true
+	)
+done


### PR DESCRIPTION
## Summary

The script only worked for apps which use master as their main branch.
This change also makes the script easier to read and also catch errors properly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
