### PR TITLE
chore: Add webhook_listeners to list of shipped apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@
 /apps/user_ldap/appinfo/info.xml              @come-nc @blizzz
 /apps/user_status/appinfo/info.xml            @Antreesy @nickvergessen
 /apps/weather_status/appinfo/info.xml         @julien-nc @juliushaertl
+/apps/webhook_listeners/appinfo/info.xml      @come-nc @julien-nc
 /apps/workflowengine/appinfo/info.xml         @blizzz @juliushaertl
 
 # Frontend expertise

--- a/.tx/config
+++ b/.tx/config
@@ -176,6 +176,12 @@ source_file = translationfiles/templates/weather_status.pot
 source_lang = en
 type        = PO
 
+[o:nextcloud:p:nextcloud:r:webhook_listeners]
+file_filter = translationfiles/<lang>/webhook_listeners.po
+source_file = translationfiles/templates/webhook_listeners.pot
+source_lang = en
+type        = PO
+
 [o:nextcloud:p:nextcloud:r:workflowengine]
 file_filter = translationfiles/<lang>/workflowengine.po
 source_file = translationfiles/templates/workflowengine.pot

--- a/core/shipped.json
+++ b/core/shipped.json
@@ -49,6 +49,7 @@
     "user_status",
     "viewer",
     "weather_status",
+    "webhook_listeners",
     "workflowengine"
   ],
   "defaultEnabled": [


### PR DESCRIPTION
## Summary

Add webhook_listeners to list of shipped apps
As well as CODEOWNERS and l10n

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
