### PR TITLE
fix(ShareSidebar): Remove unknown property from share object proccessing

### DIFF
--- a/apps/files_sharing/src/views/SharingTab.vue
+++ b/apps/files_sharing/src/views/SharingTab.vue
@@ -264,7 +264,7 @@ export default {
 				const shares = data.ocs.data
 					.map(share => new Share(share))
 					.sort((a, b) => {
-						const localCompare = a.title.localeCompare(b.title)
+						const localCompare = a.shareWithDisplayName.localeCompare(b.shareWithDisplayName)
 						if (localCompare !== 0) {
 							return localCompare
 						}


### PR DESCRIPTION
Fix share processing (when guests shares are present)... There is no share property such as title.

Resolves : https://github.com/nextcloud/server/issues/47368