### PR TITLE
fix: `FilenameValidator::isForbidden` should only check forbidden files

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2008,8 +2008,9 @@ $CONFIG = [
 'updatedirectory' => '',
 
 /**
- * Block a specific file or files and disallow the upload of files
- * with this name. ``.htaccess`` is blocked by default.
+ * Block a specific file or files and disallow the upload of files with this name.
+ * This blocks any access to those files (read and write).
+ * ``.htaccess`` is blocked by default.
  *
  * WARNING: USE THIS ONLY IF YOU KNOW WHAT YOU ARE DOING.
  *
@@ -2021,6 +2022,7 @@ $CONFIG = [
 
 /**
  * Disallow the upload of files with specific basenames.
+ * Matching existing files can no longer be updated and in matching folders no files can be created anymore.
  *
  * The basename is the name of the file without the extension,
  * e.g. for "archive.tar.gz" the basename would be "archive".
@@ -2034,6 +2036,7 @@ $CONFIG = [
 /**
  * Block characters from being used in filenames. This is useful if you
  * have a filesystem or OS which does not support certain characters like windows.
+ * Matching existing files can no longer be updated and in matching folders no files can be created anymore.
  *
  * The '/' and '\' characters are always forbidden, as well as all characters in the ASCII range [0-31].
  *
@@ -2046,6 +2049,7 @@ $CONFIG = [
 
 /**
  * Deny extensions from being used for filenames.
+ * Matching existing files can no longer be updated and in matching folders no files can be created anymore.
  * 
  * The '.part' extension is always forbidden, as this is used internally by Nextcloud.
  * 

--- a/tests/lib/Files/FilenameValidatorTest.php
+++ b/tests/lib/Files/FilenameValidatorTest.php
@@ -252,15 +252,13 @@ class FilenameValidatorTest extends TestCase {
 	/**
 	 * @dataProvider dataIsForbidden
 	 */
-	public function testIsForbidden(string $filename, array $forbiddenNames, array $forbiddenBasenames, bool $expected): void {
+	public function testIsForbidden(string $filename, array $forbiddenNames, bool $expected): void {
 		/** @var FilenameValidator&MockObject */
 		$validator = $this->getMockBuilder(FilenameValidator::class)
-			->onlyMethods(['getForbiddenFilenames', 'getForbiddenBasenames'])
+			->onlyMethods(['getForbiddenFilenames'])
 			->setConstructorArgs([$this->l10n, $this->database, $this->config, $this->logger])
 			->getMock();
 
-		$validator->method('getForbiddenBasenames')
-			->willReturn($forbiddenBasenames);
 		$validator->method('getForbiddenFilenames')
 			->willReturn($forbiddenNames);
 
@@ -270,27 +268,19 @@ class FilenameValidatorTest extends TestCase {
 	public function dataIsForbidden(): array {
 		return [
 			'valid name' => [
-				'a: b.txt', ['.htaccess'], [], false
+				'a: b.txt', ['.htaccess'], false
 			],
 			'valid name with some more parameters' => [
-				'a: b.txt', ['.htaccess'], [], false
+				'a: b.txt', ['.htaccess'], false
 			],
 			'valid name as only full forbidden should be matched' => [
-				'.htaccess.sample', ['.htaccess'], [], false,
+				'.htaccess.sample', ['.htaccess'], false,
 			],
 			'forbidden name' => [
-				'.htaccess', ['.htaccess'], [], true
+				'.htaccess', ['.htaccess'], true
 			],
 			'forbidden name - name is case insensitive' => [
-				'COM1', ['.htaccess', 'com1'], [], true,
-			],
-			'forbidden name - basename is checked' => [
-				// needed for Windows namespaces
-				'com1.suffix', ['.htaccess'], ['com1'], true
-			],
-			'forbidden name - basename is checked also with multiple extensions' => [
-				// needed for Windows namespaces
-				'com1.tar.gz', ['.htaccess'], ['com1'], true
+				'COM1', ['.htaccess', 'com1'], true,
 			],
 		];
 	}


### PR DESCRIPTION
* Split from https://github.com/nextcloud/server/pull/47185

## Summary
`FilenameValidator::isForbidden` should only check forbidden files and not forbidden basenames as this is used for different purposes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
