### PR TITLE
fix(theming): Make getImage() call save against missing non-SVG version

### DIFF
--- a/lib/private/Repair/RepairLogoDimension.php
+++ b/lib/private/Repair/RepairLogoDimension.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace OC\Repair;
 
 use OCA\Theming\ImageManager;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
@@ -44,9 +46,18 @@ class RepairLogoDimension implements IRepairStep {
 			return;
 		}
 
-		$simpleFile = $imageManager->getImage('logo', false);
-
-		$image = @imagecreatefromstring($simpleFile->getContent());
+		try {
+			try {
+				$simpleFile = $imageManager->getImage('logo', false);
+				$image = @imagecreatefromstring($simpleFile->getContent());
+			} catch (NotFoundException|NotPermittedException) {
+				$simpleFile = $imageManager->getImage('logo');
+				$image = false;
+			}
+		} catch (NotFoundException|NotPermittedException) {
+			$output->info('Theming is not used to provide a logo');
+			return;
+		}
 
 		$dimensions = '';
 		if ($image !== false) {


### PR DESCRIPTION
* Resolves: #47366

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
