### PR TITLE
ci: Skip flaky test on PHP 8.3

### DIFF
--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -134,6 +134,10 @@ class S3Test extends ObjectStoreTest {
 
 	/** @dataProvider dataFileSizes */
 	public function testFileSizes($size) {
+		if (str_starts_with(PHP_VERSION, '8.3') && getenv('CI')) {
+			$this->markTestSkipped('Test is unreliable and skipped on 8.3');
+		}
+
 		$this->cleanupAfter('testfilesizes');
 		$s3 = $this->getInstance();
 


### PR DESCRIPTION
The test is flaky all the time, some samples:
- https://github.com/nextcloud/server/actions/runs/10487823438/job/29049209769
- https://github.com/nextcloud/server/actions/runs/10487718614/job/29048705728
- https://github.com/nextcloud/server/actions/runs/10487643747/job/29048452319

It's now skipped only on [CI](https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/) for this PHP version, so devs can still see it locally and we get to automatically check it again when 8.4 is coming

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
