### PR TITLE
fix: expand select and group by for calendar reminder backend

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/Backend.php
+++ b/apps/dav/lib/CalDAV/Reminder/Backend.php
@@ -44,12 +44,12 @@ class Backend {
 	 */
 	public function getRemindersToProcess():array {
 		$query = $this->db->getQueryBuilder();
-		$query->select(['cr.*', 'co.calendardata', 'c.displayname', 'c.principaluri','cr.notification_date', 'cr.event_hash', 'cr.type'])
+		$query->select(['cr.id', 'cr.calendar_id','cr.object_id','cr.is_recurring','cr.uid','cr.recurrence_id','cr.is_recurrence_exception','cr.event_hash','cr.alarm_hash','cr.type','cr.is_relative','cr.notification_date','cr.is_repeat_based','co.calendardata', 'c.displayname', 'c.principaluri'])
 			->from('calendar_reminders', 'cr')
 			->where($query->expr()->lte('cr.notification_date', $query->createNamedParameter($this->timeFactory->getTime())))
 			->join('cr', 'calendarobjects', 'co', $query->expr()->eq('cr.object_id', 'co.id'))
 			->join('cr', 'calendars', 'c', $query->expr()->eq('cr.calendar_id', 'c.id'))
-			->groupBy('cr.event_hash', 'cr.notification_date', 'cr.type');
+			->groupBy('cr.event_hash', 'cr.notification_date', 'cr.type', 'cr.id', 'cr.calendar_id', 'cr.object_id', 'cr.is_recurring', 'cr.uid', 'cr.recurrence_id', 'cr.is_recurrence_exception', 'cr.alarm_hash', 'cr.is_relative', 'cr.is_repeat_based', 'co.calendardata', 'c.displayname', 'c.principaluri');
 		$stmt = $query->execute();
 
 		return array_map(

--- a/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/BackendTest.php
@@ -118,24 +118,7 @@ class BackendTest extends TestCase {
 		unset($rows[0]['id']);
 		unset($rows[1]['id']);
 
-		$this->assertEquals($rows[0], [
-			'calendar_id' => 1,
-			'object_id' => 1,
-			'uid' => 'asd',
-			'is_recurring' => false,
-			'recurrence_id' => 123458,
-			'is_recurrence_exception' => false,
-			'event_hash' => 'asd123',
-			'alarm_hash' => 'asd567',
-			'type' => 'AUDIO',
-			'is_relative' => true,
-			'notification_date' => 123456,
-			'is_repeat_based' => false,
-			'calendardata' => 'Calendar data 123',
-			'displayname' => 'Displayname 123',
-			'principaluri' => 'principals/users/user001',
-		]);
-		$this->assertEquals($rows[1], [
+		$expected1 = [
 			'calendar_id' => 1,
 			'object_id' => 1,
 			'uid' => 'asd',
@@ -151,7 +134,26 @@ class BackendTest extends TestCase {
 			'calendardata' => 'Calendar data 123',
 			'displayname' => 'Displayname 123',
 			'principaluri' => 'principals/users/user001',
-		]);
+		];
+		$expected2 = [
+			'calendar_id' => 1,
+			'object_id' => 1,
+			'uid' => 'asd',
+			'is_recurring' => false,
+			'recurrence_id' => 123458,
+			'is_recurrence_exception' => false,
+			'event_hash' => 'asd123',
+			'alarm_hash' => 'asd567',
+			'type' => 'AUDIO',
+			'is_relative' => true,
+			'notification_date' => 123456,
+			'is_repeat_based' => false,
+			'calendardata' => 'Calendar data 123',
+			'displayname' => 'Displayname 123',
+			'principaluri' => 'principals/users/user001',
+		];
+
+		$this->assertEqualsCanonicalizing([$rows[0],$rows[1]], [$expected1,$expected2]);
 	}
 
 	public function testGetAllScheduledRemindersForEvent(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #47275

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
