### PR TITLE
feat(files_sharing): reminder for link shares with expiration date

### DIFF
--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -14,7 +14,7 @@
 Turning the feature off removes shared files and folders on the server for all share recipients, and also on the sync clients and mobile apps. More information is available in the Nextcloud Documentation.
 
 	</description>
-	<version>1.23.0</version>
+	<version>1.23.1</version>
 	<licence>agpl</licence>
 	<author>Michael Gapczynski</author>
 	<author>Bjoern Schiessle</author>
@@ -33,6 +33,7 @@ Turning the feature off removes shared files and folders on the server for all s
 	<background-jobs>
 		<job>OCA\Files_Sharing\DeleteOrphanedSharesJob</job>
 		<job>OCA\Files_Sharing\ExpireSharesJob</job>
+		<job>OCA\Files_Sharing\SharesReminderJob</job>
 		<job>OCA\Files_Sharing\BackgroundJob\FederatedSharesDiscoverJob</job>
 	</background-jobs>
 

--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -76,6 +76,7 @@ return array(
     'OCA\\Files_Sharing\\Migration\\Version22000Date20210216084241' => $baseDir . '/../lib/Migration/Version22000Date20210216084241.php',
     'OCA\\Files_Sharing\\Migration\\Version24000Date20220208195521' => $baseDir . '/../lib/Migration/Version24000Date20220208195521.php',
     'OCA\\Files_Sharing\\Migration\\Version24000Date20220404142216' => $baseDir . '/../lib/Migration/Version24000Date20220404142216.php',
+    'OCA\\Files_Sharing\\Migration\\Version31000Date20240821142813' => $baseDir . '/../lib/Migration/Version31000Date20240821142813.php',
     'OCA\\Files_Sharing\\MountProvider' => $baseDir . '/../lib/MountProvider.php',
     'OCA\\Files_Sharing\\Notification\\Listener' => $baseDir . '/../lib/Notification/Listener.php',
     'OCA\\Files_Sharing\\Notification\\Notifier' => $baseDir . '/../lib/Notification/Notifier.php',
@@ -87,6 +88,7 @@ return array(
     'OCA\\Files_Sharing\\ShareBackend\\Folder' => $baseDir . '/../lib/ShareBackend/Folder.php',
     'OCA\\Files_Sharing\\SharedMount' => $baseDir . '/../lib/SharedMount.php',
     'OCA\\Files_Sharing\\SharedStorage' => $baseDir . '/../lib/SharedStorage.php',
+    'OCA\\Files_Sharing\\SharesReminderJob' => $baseDir . '/../lib/SharesReminderJob.php',
     'OCA\\Files_Sharing\\Updater' => $baseDir . '/../lib/Updater.php',
     'OCA\\Files_Sharing\\ViewOnly' => $baseDir . '/../lib/ViewOnly.php',
 );

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -91,6 +91,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Migration\\Version22000Date20210216084241' => __DIR__ . '/..' . '/../lib/Migration/Version22000Date20210216084241.php',
         'OCA\\Files_Sharing\\Migration\\Version24000Date20220208195521' => __DIR__ . '/..' . '/../lib/Migration/Version24000Date20220208195521.php',
         'OCA\\Files_Sharing\\Migration\\Version24000Date20220404142216' => __DIR__ . '/..' . '/../lib/Migration/Version24000Date20220404142216.php',
+        'OCA\\Files_Sharing\\Migration\\Version31000Date20240821142813' => __DIR__ . '/..' . '/../lib/Migration/Version31000Date20240821142813.php',
         'OCA\\Files_Sharing\\MountProvider' => __DIR__ . '/..' . '/../lib/MountProvider.php',
         'OCA\\Files_Sharing\\Notification\\Listener' => __DIR__ . '/..' . '/../lib/Notification/Listener.php',
         'OCA\\Files_Sharing\\Notification\\Notifier' => __DIR__ . '/..' . '/../lib/Notification/Notifier.php',
@@ -102,6 +103,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\ShareBackend\\Folder' => __DIR__ . '/..' . '/../lib/ShareBackend/Folder.php',
         'OCA\\Files_Sharing\\SharedMount' => __DIR__ . '/..' . '/../lib/SharedMount.php',
         'OCA\\Files_Sharing\\SharedStorage' => __DIR__ . '/..' . '/../lib/SharedStorage.php',
+        'OCA\\Files_Sharing\\SharesReminderJob' => __DIR__ . '/..' . '/../lib/SharesReminderJob.php',
         'OCA\\Files_Sharing\\Updater' => __DIR__ . '/..' . '/../lib/Updater.php',
         'OCA\\Files_Sharing\\ViewOnly' => __DIR__ . '/..' . '/../lib/ViewOnly.php',
     );

--- a/apps/files_sharing/lib/Migration/Version31000Date20240821142813.php
+++ b/apps/files_sharing/lib/Migration/Version31000Date20240821142813.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Sharing\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version31000Date20240821142813 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+		$table = $schema->getTable('share');
+		$table->addColumn('reminder_sent', Types::BOOLEAN, [
+			'notnull' => false,
+			'default' => false,
+		]);
+		return $schema;
+	}
+
+}

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -132,6 +132,9 @@ class SharesReminderJob extends TimedJob {
 		$reminderInfo = [];
 		if ($share->getShareType() == IShare::TYPE_USER) {
 			$user = $this->userManager->get($sharedWith);
+			if ($user === null) {
+				return null;
+			}
 			$reminderInfo['email'] = $user->getEMailAddress();
 			$reminderInfo['userLang'] = $this->l10nFactory->getUserLanguage($user);
 			$reminderInfo['folderLink'] = $this->urlGenerator->linkToRouteAbsolute('files.view.index', [

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -32,6 +32,7 @@ use Psr\Log\LoggerInterface;
  */
 class SharesReminderJob extends TimedJob {
 	private const SECONDS_BEFORE_REMINDER = 86400;
+	private const CHUNK_SIZE = 1000;
 
 	public function __construct(
 		ITimeFactory                     $time,
@@ -56,43 +57,51 @@ class SharesReminderJob extends TimedJob {
 	 * @throws Exception if a database error occurs
 	 */
 	public function run(mixed $argument): void {
-		$shares = $this->getShares();
-		[$foldersByEmail, $langByEmail] = $this->prepareReminders($shares);
-		$this->sendReminders($foldersByEmail, $langByEmail);
+		foreach ($this->getShares() as $share) {
+			$reminderInfo = $this->prepareReminder($share);
+			$this->sendReminder($reminderInfo);
+		}
 	}
 
 	/**
-	 * Finds all folder shares of type user or email with expiration dates within the specified timeframe.
-	 * This method returns only those shares that have not yet received the reminder.
+	 * Finds all shares of empty folders, for which the user has write permissions.
+	 * The returned shares are of type user or email only, have expiration dates within the specified time frame
+	 * and have not yet received a reminder.
 	 *
-	 * @return array<IShare>
+	 * @return array<IShare>|\Iterator
 	 * @throws Exception if a database error occurs
 	 */
-	private function getShares(): array {
+	private function getShares(): array|\Iterator {
 		$minDate = new \DateTime();
 		$maxDate = new \DateTime();
 		$maxDate->setTimestamp($maxDate->getTimestamp() + self::SECONDS_BEFORE_REMINDER);
 
 		$qb = $this->db->getQueryBuilder();
-		$qb->select('id', 'share_type')
-			->from('share')
+		$qb->select('s.id', 's.share_type')
+			->from('share', 's')
+			->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('f.parent', 's.file_source'))
 			->where(
 				$qb->expr()->andX(
 					$qb->expr()->orX(
-						$qb->expr()->eq('share_type', $qb->expr()->literal(IShare::TYPE_USER)),
-						$qb->expr()->eq('share_type', $qb->expr()->literal(IShare::TYPE_EMAIL))
+						$qb->expr()->eq('s.share_type', $qb->expr()->literal(IShare::TYPE_USER)),
+						$qb->expr()->eq('s.share_type', $qb->expr()->literal(IShare::TYPE_EMAIL))
 					),
-					$qb->expr()->eq('item_type', $qb->expr()->literal('folder')),
-					$qb->expr()->gte('expiration', $qb->createNamedParameter($minDate->format('Y-m-d H:i:s'))),
-					$qb->expr()->lt('expiration', $qb->createNamedParameter($maxDate->format('Y-m-d H:i:s'))),
-					$qb->expr()->eq('reminder_sent', $qb->createNamedParameter(
+					$qb->expr()->eq('s.item_type', $qb->expr()->literal('folder')),
+					$qb->expr()->gte('s.expiration', $qb->createNamedParameter($minDate->format('Y-m-d H:i:s'))),
+					$qb->expr()->lt('s.expiration', $qb->createNamedParameter($maxDate->format('Y-m-d H:i:s'))),
+					$qb->expr()->eq('s.reminder_sent', $qb->createNamedParameter(
 						false, IQueryBuilder::PARAM_BOOL
-					))
+					)),
+					$qb->expr()->eq(
+						$qb->expr()->bitwiseAnd('s.permissions', Constants::PERMISSION_CREATE),
+						$qb->createNamedParameter(Constants::PERMISSION_CREATE, IQueryBuilder::PARAM_INT)
+					),
+					$qb->expr()->isNull('f.fileid')
 				)
-			);
+			)
+			->setMaxResults(SharesReminderJob::CHUNK_SIZE);
 
 		$sharesResult = $qb->executeQuery();
-		$shares = [];
 		while ($share = $sharesResult->fetch()) {
 			if ((int)$share['share_type'] === IShare::TYPE_EMAIL) {
 				$id = "ocMailShare:$share[id]";
@@ -101,122 +110,78 @@ class SharesReminderJob extends TimedJob {
 			}
 
 			try {
-				$shares[] = $this->shareManager->getShareById($id);
+				yield $this->shareManager->getShareById($id);
 			} catch (ShareNotFound) {
 				$this->logger->error("Share with ID $id not found.");
 			}
 		}
 		$sharesResult->closeCursor();
-		return $shares;
 	}
 
 	/**
-	 * Checks if the user should be reminded about this share.
-	 * If so, it will retrieve and return all the necessary data for this.
+	 * Retrieves and returns all the necessary data before sending a reminder.
 	 * It also updates the reminder sent flag for the affected shares (to avoid multiple reminders).
 	 *
-	 * @param array<IShare> $shares Shares that were obtained with {@link getShares}
-	 * @return array<array> A tuple consisting of two dictionaries: folders and languages by email
-	 * @throws Exception if the reminder sent flag could not be saved
+	 * @param IShare $share Share that was obtained with {@link getShares}
+	 * @return array|null Info needed to send a reminder
 	 */
-	private function prepareReminders(array $shares): array {
-		// This dictionary stores email addresses as keys and folder lists as values.
-		// It is used to ensure that each user receives no more than one email notification.
-		// The email will include the names and links of the folders that the user should be reminded of.
-		$foldersByEmail = [];
-		// Similar to the previous one, this variable stores the language for each email (if provided)
-		$langByEmail = [];
-
-		/** @var IShare $share */
-		foreach ($shares as $share) {
-			if (!$this->shouldRemindOfThisShare($share)) {
-				continue;
-			}
-
-			$sharedWith = $share->getSharedWith();
-			if ($share->getShareType() == IShare::TYPE_USER) {
-				$user = $this->userManager->get($sharedWith);
-				$mailTo = $user->getEMailAddress();
-				$lang = $this->l10nFactory->getUserLanguage($user);
-				$link = $this->urlGenerator->linkToRouteAbsolute('files.view.index', [
-					'dir' => $share->getTarget()
-				]);
-			} else {
-				$mailTo = $sharedWith;
-				$lang = '';
-				$link = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', [
-					'token' => $share->getToken()
-				]);
-			}
-			if (empty($mailTo)) {
-				continue;
-			}
-
-			if (!empty($lang)) {
-				$langByEmail[$mailTo] ??= $lang;
-			}
-			if (!isset($foldersByEmail[$mailTo])) {
-				$foldersByEmail[$mailTo] = [];
-			}
-			$foldersByEmail[$mailTo][] = ['name' => $share->getNode()->getName(), 'link' => $link];
-
-			$share->setReminderSent(true);
-			$qb = $this->db->getQueryBuilder();
-			$qb->update('share')
-				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
-				->set('reminder_sent', $qb->createNamedParameter($share->getReminderSent()))
-				->execute();
+	private function prepareReminder(IShare $share): array|null {
+		$sharedWith = $share->getSharedWith();
+		$reminderInfo = [];
+		if ($share->getShareType() == IShare::TYPE_USER) {
+			$user = $this->userManager->get($sharedWith);
+			$reminderInfo['email'] = $user->getEMailAddress();
+			$reminderInfo['userLang'] = $this->l10nFactory->getUserLanguage($user);
+			$reminderInfo['folderLink'] = $this->urlGenerator->linkToRouteAbsolute('files.view.index', [
+				'dir' => $share->getTarget()
+			]);
+		} else {
+			$reminderInfo['email'] = $sharedWith;
+			$reminderInfo['folderLink'] = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', [
+				'token' => $share->getToken()
+			]);
+		}
+		if (empty($reminderInfo['email'])) {
+			return null;
 		}
 
-		return [$foldersByEmail, $langByEmail];
-	}
-
-	/**
-	 * Checks if user has write permission and folder is empty
-	 *
-	 * @param IShare $share Share to check
-	 * @return bool
-	 */
-	private function shouldRemindOfThisShare(IShare $share): bool {
 		try {
-			$folder = $share->getNode();
-			$fileCount = count($folder->getDirectoryListing());
+			$reminderInfo['folderName'] = $share->getNode()->getName();
 		} catch (NotFoundException) {
 			$id = $share->getFullId();
-			$this->logger->debug("File by share ID $id not found.");
-			return false;
+			$this->logger->error("File by share ID $id not found.");
 		}
-		$permissions = $share->getPermissions();
-		$hasCreatePermission = ($permissions & Constants::PERMISSION_CREATE) === Constants::PERMISSION_CREATE;
-		return ($fileCount == 0 && $hasCreatePermission);
+		$share->setReminderSent(true);
+		$this->shareManager->updateShare($share);
+		return $reminderInfo;
 	}
 
 	/**
-	 * This method accepts data obtained by {@link prepareReminders} and sends reminder emails.
+	 * This method accepts data obtained by {@link prepareReminder} and sends reminder email.
 	 *
-	 * @param array $foldersByEmail
-	 * @param array $langByEmail
+	 * @param array $reminderInfo
 	 * @return void
 	 */
-	private function sendReminders(array $foldersByEmail, array $langByEmail): void {
+	private function sendReminder(array $reminderInfo): void {
 		$instanceName = $this->defaults->getName();
 		$from = [Util::getDefaultEmailAddress($instanceName) => $instanceName];
-		foreach ($foldersByEmail as $email => $folders) {
-			$l = $this->l10nFactory->get('files_sharing', $langByEmail[$email] ?? null);
-			$emailTemplate = $this->generateEMailTemplate($l, $folders);
-			$message = $this->mailer->createMessage();
-			$message->setFrom($from);
-			$message->setTo([$email]);
-			$message->useTemplate($emailTemplate);
-			$errorText = "Sending email with share reminder to $email failed.";
-			try {
-				$failedRecipients = $this->mailer->send($message);
-				if (count($failedRecipients) > 0) {
-					$this->logger->error($errorText);
-				}
-			} catch (\Exception) {
+		$l = $this->l10nFactory->get('files_sharing', $reminderInfo['userLang'] ?? null);
+		$emailTemplate = $this->generateEMailTemplate($l, [
+			'link' => $reminderInfo['folderLink'], 'name' => $reminderInfo['folderName']
+		]);
+
+		$message = $this->mailer->createMessage();
+		$message->setFrom($from);
+		$message->setTo([$reminderInfo['email']]);
+		$message->useTemplate($emailTemplate);
+		$errorText = "Sending email with share reminder to $reminderInfo[email] failed.";
+		try {
+			$failedRecipients = $this->mailer->send($message);
+			if (count($failedRecipients) > 0) {
 				$this->logger->error($errorText);
 			}
+		} catch (\Exception) {
+			$this->logger->error($errorText);
 		}
 	}
 
@@ -224,37 +189,24 @@ class SharesReminderJob extends TimedJob {
 	 * Returns the reminder email template
 	 *
 	 * @param IL10N $l
-	 * @param array<array> $folders Folders the user should be reminded of
+	 * @param array $folder Folder the user should be reminded of
 	 * @return IEMailTemplate
 	 */
-	private function generateEMailTemplate(IL10N $l, array $folders): IEMailTemplate {
+	private function generateEMailTemplate(IL10N $l, array $folder): IEMailTemplate {
 		$emailTemplate = $this->mailer->createEMailTemplate('files_sharing.SharesReminder', [
-			'folders' => $folders,
+			'folder' => $folder,
 		]);
-
 		$emailTemplate->addHeader();
-		if (count($folders) == 1) {
-			$emailTemplate->setSubject(
-				$l->t('Remember to upload the files to %s', [$folders[0]['name']])
-			);
-			$emailTemplate->addBodyText($l->t(
-				'We would like to kindly remind you that you have not yet uploaded any files to the shared folder.'
-			));
-		} else {
-			$emailTemplate->setSubject(
-				$l->t('Remember to upload the files to shared folders')
-			);
-			$emailTemplate->addBodyText($l->t(
-				'We would like to kindly remind you that you have not yet uploaded any files to the shared folders.'
-			));
-		}
-
-		foreach ($folders as $folder) {
-			$emailTemplate->addBodyButton(
-				$l->t('Open "%s"', [$folder['name']]),
-				$folder['link']
-			);
-		}
+		$emailTemplate->setSubject(
+			$l->t('Remember to upload the files to %s', [$folder['name']])
+		);
+		$emailTemplate->addBodyText($l->t(
+			'We would like to kindly remind you that you have not yet uploaded any files to the shared folder.'
+		));
+		$emailTemplate->addBodyButton(
+			$l->t('Open "%s"', [$folder['name']]),
+			$folder['link']
+		);
 		$emailTemplate->addFooter();
 		return $emailTemplate;
 	}

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -59,7 +59,9 @@ class SharesReminderJob extends TimedJob {
 	public function run(mixed $argument): void {
 		foreach ($this->getShares() as $share) {
 			$reminderInfo = $this->prepareReminder($share);
-			$this->sendReminder($reminderInfo);
+			if ($reminderInfo !== null) {
+				$this->sendReminder($reminderInfo);
+			}
 		}
 	}
 

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files_Sharing;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\Constants;
+use OCP\DB\Exception;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Defaults;
+use OCP\Files\NotFoundException;
+use OCP\IDBConnection;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Mail\IEMailTemplate;
+use OCP\Mail\IMailer;
+use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use OCP\Util;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Send a reminder via email to the sharee(s) if the folder is still empty a predefined time before the expiration date
+ */
+class SharesReminderJob extends TimedJob {
+	private const SECONDS_BEFORE_REMINDER = 86400;
+
+	public function __construct(
+		ITimeFactory                     $time,
+		private readonly IDBConnection   $db,
+		private readonly IManager        $shareManager,
+		private readonly IUserManager    $userManager,
+		private readonly LoggerInterface $logger,
+		private readonly IURLGenerator   $urlGenerator,
+		private readonly IFactory        $l10nFactory,
+		private readonly IMailer         $mailer,
+		private readonly Defaults        $defaults,
+	) {
+		parent::__construct($time);
+		$this->setInterval(3600);
+	}
+
+
+	/**
+	 * Makes the background job do its work
+	 *
+	 * @param array $argument unused argument
+	 * @throws Exception if a database error occurs
+	 */
+	public function run(mixed $argument): void {
+		$shares = $this->getShares();
+		[$foldersByEmail, $langByEmail] = $this->prepareReminders($shares);
+		$this->sendReminders($foldersByEmail, $langByEmail);
+	}
+
+	/**
+	 * Finds all folder shares of type user or email with expiration dates within the specified timeframe.
+	 * This method returns only those shares that have not yet received the reminder.
+	 *
+	 * @return array<IShare>
+	 * @throws Exception if a database error occurs
+	 */
+	private function getShares(): array {
+		$minDate = new \DateTime();
+		$maxDate = new \DateTime();
+		$maxDate->setTimestamp($maxDate->getTimestamp() + self::SECONDS_BEFORE_REMINDER);
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('id', 'share_type')
+			->from('share')
+			->where(
+				$qb->expr()->andX(
+					$qb->expr()->orX(
+						$qb->expr()->eq('share_type', $qb->expr()->literal(IShare::TYPE_USER)),
+						$qb->expr()->eq('share_type', $qb->expr()->literal(IShare::TYPE_EMAIL))
+					),
+					$qb->expr()->eq('item_type', $qb->expr()->literal('folder')),
+					$qb->expr()->gte('expiration', $qb->createNamedParameter($minDate->format('Y-m-d H:i:s'))),
+					$qb->expr()->lt('expiration', $qb->createNamedParameter($maxDate->format('Y-m-d H:i:s'))),
+					$qb->expr()->eq('reminder_sent', $qb->createNamedParameter(
+						false, IQueryBuilder::PARAM_BOOL
+					))
+				)
+			);
+
+		$sharesResult = $qb->executeQuery();
+		$shares = [];
+		while ($share = $sharesResult->fetch()) {
+			if ((int)$share['share_type'] === IShare::TYPE_EMAIL) {
+				$id = "ocMailShare:$share[id]";
+			} else {
+				$id = "ocinternal:$share[id]";
+			}
+
+			try {
+				$shares[] = $this->shareManager->getShareById($id);
+			} catch (ShareNotFound) {
+				$this->logger->error("Share with ID $id not found.");
+			}
+		}
+		$sharesResult->closeCursor();
+		return $shares;
+	}
+
+	/**
+	 * Checks if the user should be reminded about this share.
+	 * If so, it will retrieve and return all the necessary data for this.
+	 * It also updates the reminder sent flag for the affected shares (to avoid multiple reminders).
+	 *
+	 * @param array<IShare> $shares Shares that were obtained with {@link getShares}
+	 * @return array<array> A tuple consisting of two dictionaries: folders and languages by email
+	 * @throws Exception if the reminder sent flag could not be saved
+	 */
+	private function prepareReminders(array $shares): array {
+		// This dictionary stores email addresses as keys and folder lists as values.
+		// It is used to ensure that each user receives no more than one email notification.
+		// The email will include the names and links of the folders that the user should be reminded of.
+		$foldersByEmail = [];
+		// Similar to the previous one, this variable stores the language for each email (if provided)
+		$langByEmail = [];
+
+		/** @var IShare $share */
+		foreach ($shares as $share) {
+			if (!$this->shouldRemindOfThisShare($share)) {
+				continue;
+			}
+
+			$sharedWith = $share->getSharedWith();
+			if ($share->getShareType() == IShare::TYPE_USER) {
+				$user = $this->userManager->get($sharedWith);
+				$mailTo = $user->getEMailAddress();
+				$lang = $this->l10nFactory->getUserLanguage($user);
+				$link = $this->urlGenerator->linkToRouteAbsolute('files.view.index', [
+					'dir' => $share->getTarget()
+				]);
+			} else {
+				$mailTo = $sharedWith;
+				$lang = '';
+				$link = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', [
+					'token' => $share->getToken()
+				]);
+			}
+			if (empty($mailTo)) {
+				continue;
+			}
+
+			if (!empty($lang)) {
+				$langByEmail[$mailTo] ??= $lang;
+			}
+			if (!isset($foldersByEmail[$mailTo])) {
+				$foldersByEmail[$mailTo] = [];
+			}
+			$foldersByEmail[$mailTo][] = ['name' => $share->getNode()->getName(), 'link' => $link];
+
+			$share->setReminderSent(true);
+			$qb = $this->db->getQueryBuilder();
+			$qb->update('share')
+				->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
+				->set('reminder_sent', $qb->createNamedParameter($share->getReminderSent()))
+				->execute();
+		}
+
+		return [$foldersByEmail, $langByEmail];
+	}
+
+	/**
+	 * Checks if user has write permission and folder is empty
+	 *
+	 * @param IShare $share Share to check
+	 * @return bool
+	 */
+	private function shouldRemindOfThisShare(IShare $share): bool {
+		try {
+			$folder = $share->getNode();
+			$fileCount = count($folder->getDirectoryListing());
+		} catch (NotFoundException) {
+			$id = $share->getFullId();
+			$this->logger->debug("File by share ID $id not found.");
+			return false;
+		}
+		$permissions = $share->getPermissions();
+		$hasCreatePermission = ($permissions & Constants::PERMISSION_CREATE) === Constants::PERMISSION_CREATE;
+		return ($fileCount == 0 && $hasCreatePermission);
+	}
+
+	/**
+	 * This method accepts data obtained by {@link prepareReminders} and sends reminder emails.
+	 *
+	 * @param array $foldersByEmail
+	 * @param array $langByEmail
+	 * @return void
+	 */
+	private function sendReminders(array $foldersByEmail, array $langByEmail): void {
+		$instanceName = $this->defaults->getName();
+		$from = [Util::getDefaultEmailAddress($instanceName) => $instanceName];
+		foreach ($foldersByEmail as $email => $folders) {
+			$l = $this->l10nFactory->get('files_sharing', $langByEmail[$email] ?? null);
+			$emailTemplate = $this->generateEMailTemplate($l, $folders);
+			$message = $this->mailer->createMessage();
+			$message->setFrom($from);
+			$message->setTo([$email]);
+			$message->useTemplate($emailTemplate);
+			$errorText = "Sending email with share reminder to $email failed.";
+			try {
+				$failedRecipients = $this->mailer->send($message);
+				if (count($failedRecipients) > 0) {
+					$this->logger->error($errorText);
+				}
+			} catch (\Exception) {
+				$this->logger->error($errorText);
+			}
+		}
+	}
+
+	/**
+	 * Returns the reminder email template
+	 *
+	 * @param IL10N $l
+	 * @param array<array> $folders Folders the user should be reminded of
+	 * @return IEMailTemplate
+	 */
+	private function generateEMailTemplate(IL10N $l, array $folders): IEMailTemplate {
+		$emailTemplate = $this->mailer->createEMailTemplate('files_sharing.SharesReminder', [
+			'folders' => $folders,
+		]);
+
+		$emailTemplate->addHeader();
+		if (count($folders) == 1) {
+			$emailTemplate->setSubject(
+				$l->t('Remember to upload the files to %s', [$folders[0]['name']])
+			);
+			$emailTemplate->addBodyText($l->t(
+				'We would like to kindly remind you that you have not yet uploaded any files to the shared folder.'
+			));
+		} else {
+			$emailTemplate->setSubject(
+				$l->t('Remember to upload the files to shared folders')
+			);
+			$emailTemplate->addBodyText($l->t(
+				'We would like to kindly remind you that you have not yet uploaded any files to the shared folders.'
+			));
+		}
+
+		foreach ($folders as $folder) {
+			$emailTemplate->addBodyButton(
+				$l->t('Open "%s"', [$folder['name']]),
+				$folder['link']
+			);
+		}
+		$emailTemplate->addFooter();
+		return $emailTemplate;
+	}
+}

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -184,13 +184,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 			->with([$email ?: $this->userManager->get($this->user2)->getSystemEMailAddress()]);
 		$this->assertSame(false, $share->getReminderSent());
 		$this->job->run([]);
-		$qb = $this->db->getQueryBuilder();
-		$reminderSent = $qb
-			->select('reminder_sent')
-			->from('share')
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
-			->executeQuery()
-			->fetch()["reminder_sent"];
-		$this->assertEquals($shouldBeReminded, $reminderSent);
+		$share = $this->shareManager->getShareById($share->getFullId());
+		$this->assertEquals($shouldBeReminded, $share->getReminderSent());
 	}
 }

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -158,7 +158,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 		$testFolder = $user1Folder->newFolder('test');
 
 		if (!$isEmpty) {
-			$testFolder->newFile("some_file.txt");
+			$testFolder->newFile('some_file.txt');
 		}
 
 		$share = $this->shareManager->newShare();

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files_Sharing\Tests;
+
+use OC\SystemConfig;
+use OCA\Files_Sharing\SharesReminderJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Constants;
+use OCP\Defaults;
+use OCP\Files\IRootFolder;
+use OCP\IDBConnection;
+use OCP\IURLGenerator;
+use OCP\IUserManager;
+use OCP\L10N\IFactory;
+use OCP\Mail\IMailer;
+use OCP\Mail\IMessage;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class SharesReminderJobTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files_Sharing\Tests
+ */
+class SharesReminderJobTest extends \Test\TestCase {
+	private SharesReminderJob $job;
+	private IDBConnection $db;
+	private IManager $shareManager;
+	private IUserManager $userManager;
+	private IMailer|MockObject $mailer;
+	private string $user1;
+	private string $user2;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->db = \OC::$server->get(IDBConnection::class);
+		$this->shareManager = \OC::$server->get(IManager::class);
+		$this->userManager = \OC::$server->get(IUserManager::class);
+		$this->mailer = $this->createMock(IMailer::class);
+
+		// Clear occasional leftover shares from other tests
+		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
+
+		$this->user1 = $this->getUniqueID('user1_');
+		$this->user2 = $this->getUniqueID('user2_');
+
+		$user1 = $this->userManager->createUser($this->user1, 'longrandompassword');
+		$user2 = $this->userManager->createUser($this->user2, 'longrandompassword');
+		$user1->setSystemEMailAddress('user1@test.com');
+		$user2->setSystemEMailAddress('user2@test.com');
+
+		\OC::registerShareHooks(\OC::$server->get(SystemConfig::class));
+
+		$this->job = new SharesReminderJob(
+			\OC::$server->get(ITimeFactory::class),
+			$this->db,
+			\OC::$server->get(IManager::class),
+			$this->userManager,
+			\OC::$server->get(LoggerInterface::class),
+			\OC::$server->get(IURLGenerator::class),
+			\OC::$server->get(IFactory::class),
+			$this->mailer,
+			\OC::$server->get(Defaults::class),
+		);
+	}
+
+	protected function tearDown(): void {
+		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
+
+		$userManager = \OC::$server->get(IUserManager::class);
+		$user1 = $userManager->get($this->user1);
+		if ($user1) {
+			$user1->delete();
+		}
+		$user2 = $userManager->get($this->user2);
+		if ($user2) {
+			$user2->delete();
+		}
+
+		$this->logout();
+
+		parent::tearDown();
+	}
+
+	public function dataSharesReminder() {
+		$someMail = 'test@test.com';
+		$noExpirationDate = null;
+		$today = new \DateTime();
+		// For expiration dates, the time is always automatically set to zero by ShareAPIController
+		$today->setTime(0, 0);
+		$nearFuture = new \DateTime();
+		$nearFuture->setTimestamp($today->getTimestamp() + 86400 * 1);
+		$farFuture = new \DateTime();
+		$farFuture->setTimestamp($today->getTimestamp() + 86400 * 2);
+		$permissionRead = Constants::PERMISSION_READ;
+		$permissionCreate = $permissionRead | Constants::PERMISSION_CREATE;
+		$permissionUpdate = $permissionRead | Constants::PERMISSION_UPDATE;
+		$permissionDelete = $permissionRead | Constants::PERMISSION_DELETE;
+		$permissionAll = Constants::PERMISSION_ALL;
+
+		return [
+			// No reminders for folders without expiration date
+			[$noExpirationDate, '', false, $permissionRead, false],
+			[$noExpirationDate, '', false, $permissionCreate, false],
+			[$noExpirationDate, '', true, $permissionDelete, false],
+			[$noExpirationDate, '', true, $permissionCreate, false],
+			[$noExpirationDate, $someMail, false, $permissionUpdate, false],
+			[$noExpirationDate, $someMail, false, $permissionCreate, false],
+			[$noExpirationDate, $someMail, true, $permissionRead, false],
+			[$noExpirationDate, $someMail, true, $permissionAll, false],
+			// No reminders for folders with expiration date in the far future
+			[$farFuture, '', false, $permissionRead, false],
+			[$farFuture, '', false, $permissionCreate, false],
+			[$farFuture, '', true, $permissionDelete, false],
+			[$farFuture, '', true, $permissionCreate, false],
+			[$farFuture, $someMail, false, $permissionUpdate, false],
+			[$farFuture, $someMail, false, $permissionCreate, false],
+			[$farFuture, $someMail, true, $permissionRead, false],
+			[$farFuture, $someMail, true, $permissionAll, false],
+			/* Should send reminders for folders with expiration date in the near future
+			if the folder is empty and the user has write permission */
+			[$nearFuture, '', false, $permissionRead, false],
+			[$nearFuture, '', false, $permissionCreate, false],
+			[$nearFuture, '', true, $permissionDelete, false],
+			[$nearFuture, '', true, $permissionCreate, true],
+			[$nearFuture, $someMail, false, $permissionUpdate, false],
+			[$nearFuture, $someMail, false, $permissionCreate, false],
+			[$nearFuture, $someMail, true, $permissionRead, false],
+			[$nearFuture, $someMail, true, $permissionAll, true],
+		];
+	}
+
+	/**
+	 * @dataProvider dataSharesReminder
+	 *
+	 * @param \DateTime|null $expirationDate Share expiration date
+	 * @param string $email Share with this email. If empty, the share is of type TYPE_USER and the sharee is user2
+	 * @param bool $isEmpty Is share folder empty?
+	 * @param int $permissions
+	 * @param bool $shouldBeReminded
+	 */
+	public function testSharesReminder(
+		\DateTime|null $expirationDate, string $email, bool $isEmpty, int $permissions, bool $shouldBeReminded
+	): void {
+		$this->loginAsUser($this->user1);
+
+		$user1Folder = \OC::$server->get(IRootFolder::class)->getUserFolder($this->user1);
+		$testFolder = $user1Folder->newFolder('test');
+
+		if (!$isEmpty) {
+			$testFolder->newFile("some_file.txt");
+		}
+
+		$share = $this->shareManager->newShare();
+
+		$share->setNode($testFolder)
+			->setShareType(($email ? IShare::TYPE_EMAIL : IShare::TYPE_USER))
+			->setPermissions($permissions)
+			->setSharedBy($this->user1)
+			->setSharedWith(($email ?: $this->user2))
+			->setExpirationDate($expirationDate);
+		$share = $this->shareManager->createShare($share);
+
+		$this->logout();
+		$messageMock = $this->createMock(IMessage::class);
+		$this->mailer->method('createMessage')->willReturn($messageMock);
+		$this->mailer
+			->expects(($shouldBeReminded ? $this->once() : $this->never()))
+			->method('send')
+			->with($messageMock);
+		$messageMock
+			->expects(($shouldBeReminded ? $this->once() : $this->never()))
+			->method('setTo')
+			->with([$email ?: $this->userManager->get($this->user2)->getSystemEMailAddress()]);
+		$this->assertSame(false, $share->getReminderSent());
+		$this->job->run([]);
+		$qb = $this->db->getQueryBuilder();
+		$reminderSent = $qb
+			->select('reminder_sent')
+			->from('share')
+			->where($qb->expr()->eq('id', $qb->createNamedParameter($share->getId())))
+			->executeQuery()
+			->fetch()["reminder_sent"];
+		$this->assertEquals($shouldBeReminded, $reminderSent);
+	}
+}

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -756,6 +756,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->set('hide_download', $qb->createNamedParameter((int)$share->getHideDownload(), IQueryBuilder::PARAM_INT))
 			->set('attributes', $qb->createNamedParameter($shareAttributes))
 			->set('mail_send', $qb->createNamedParameter((int)$share->getMailSend(), IQueryBuilder::PARAM_INT))
+			->set('reminder_sent', $qb->createNamedParameter((int)$share->getReminderSent(), IQueryBuilder::PARAM_INT))
 			->executeStatement();
 
 		if ($originalShare->getNote() !== $share->getNote() && $share->getNote() !== '') {
@@ -987,7 +988,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 	}
 
 	/**
-	 * Create a share object from an database row
+	 * Create a share object from a database row
 	 *
 	 * @throws InvalidShare
 	 * @throws ShareNotFound
@@ -1012,6 +1013,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		$share->setLabel($data['label']);
 		$share->setSendPasswordByTalk((bool)$data['password_by_talk']);
 		$share->setHideDownload((bool)$data['hide_download']);
+		$share->setReminderSent((bool)$data['reminder_sent']);
 
 		if ($data['uid_initiator'] !== null) {
 			$share->setShareOwner($data['uid_owner']);

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -756,7 +756,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->set('hide_download', $qb->createNamedParameter((int)$share->getHideDownload(), IQueryBuilder::PARAM_INT))
 			->set('attributes', $qb->createNamedParameter($shareAttributes))
 			->set('mail_send', $qb->createNamedParameter((int)$share->getMailSend(), IQueryBuilder::PARAM_INT))
-			->set('reminder_sent', $qb->createNamedParameter((int)$share->getReminderSent(), IQueryBuilder::PARAM_INT))
+			->set('reminder_sent', $qb->createNamedParameter($share->getReminderSent(), IQueryBuilder::PARAM_BOOL))
 			->executeStatement();
 
 		if ($originalShare->getNote() !== $share->getNote() && $share->getNote() !== '') {

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -97,6 +97,8 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 			if ($expirationDate !== null) {
 				$qb->setValue('expiration', $qb->createNamedParameter($expirationDate, 'datetime'));
 			}
+
+			$qb->setValue('reminder_sent', $qb->createNamedParameter($share->getReminderSent() ? 1 : 0, IQueryBuilder::PARAM_INT));
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			//Set the GID of the group we share with
 			$qb->setValue('share_with', $qb->createNamedParameter($share->getSharedWith()));
@@ -223,6 +225,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 				->set('expiration', $qb->createNamedParameter($expirationDate, IQueryBuilder::PARAM_DATE))
 				->set('note', $qb->createNamedParameter($share->getNote()))
 				->set('accepted', $qb->createNamedParameter($share->getStatus()))
+				->set('reminder_sent', $qb->createNamedParameter($share->getReminderSent()))
 				->execute();
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			$qb = $this->dbConn->getQueryBuilder();
@@ -1006,7 +1009,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 	}
 
 	/**
-	 * Create a share object from an database row
+	 * Create a share object from a database row
 	 *
 	 * @param mixed[] $data
 	 * @return \OCP\Share\IShare
@@ -1068,6 +1071,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 
 		$share->setProviderId($this->identifier());
 		$share->setHideDownload((int)$data['hide_download'] === 1);
+		$share->setReminderSent((int)$data['reminder_sent'] === 1);
 
 		return $share;
 	}

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -98,7 +98,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 				$qb->setValue('expiration', $qb->createNamedParameter($expirationDate, 'datetime'));
 			}
 
-			$qb->setValue('reminder_sent', $qb->createNamedParameter($share->getReminderSent() ? 1 : 0, IQueryBuilder::PARAM_INT));
+			$qb->setValue('reminder_sent', $qb->createNamedParameter($share->getReminderSent(), IQueryBuilder::PARAM_BOOL));
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			//Set the GID of the group we share with
 			$qb->setValue('share_with', $qb->createNamedParameter($share->getSharedWith()));
@@ -225,7 +225,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 				->set('expiration', $qb->createNamedParameter($expirationDate, IQueryBuilder::PARAM_DATE))
 				->set('note', $qb->createNamedParameter($share->getNote()))
 				->set('accepted', $qb->createNamedParameter($share->getStatus()))
-				->set('reminder_sent', $qb->createNamedParameter($share->getReminderSent()))
+				->set('reminder_sent', $qb->createNamedParameter($share->getReminderSent(), IQueryBuilder::PARAM_BOOL))
 				->execute();
 		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			$qb = $this->dbConn->getQueryBuilder();
@@ -1071,7 +1071,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 
 		$share->setProviderId($this->identifier());
 		$share->setHideDownload((int)$data['hide_download'] === 1);
-		$share->setReminderSent((int)$data['reminder_sent'] === 1);
+		$share->setReminderSent((bool)$data['reminder_sent']);
 
 		return $share;
 	}

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -72,8 +72,7 @@ class Share implements IShare {
 	private $nodeCacheEntry;
 	/** @var bool */
 	private $hideDownload = false;
-	/** @var bool */
-	private $reminderSent = false;
+	private bool $reminderSent = false;
 
 	private bool $noExpirationDate = false;
 

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -72,6 +72,8 @@ class Share implements IShare {
 	private $nodeCacheEntry;
 	/** @var bool */
 	private $hideDownload = false;
+	/** @var bool */
+	private $reminderSent = false;
 
 	private bool $noExpirationDate = false;
 
@@ -612,5 +614,14 @@ class Share implements IShare {
 
 	public function getHideDownload(): bool {
 		return $this->hideDownload;
+	}
+
+	public function setReminderSent(bool $reminderSent): IShare {
+		$this->reminderSent = $reminderSent;
+		return $this;
+	}
+
+	public function getReminderSent(): bool {
+		return $this->reminderSent;
 	}
 }

--- a/lib/public/Share/IShare.php
+++ b/lib/public/Share/IShare.php
@@ -617,4 +617,20 @@ interface IShare {
 	 * @since 15.0.0
 	 */
 	public function getHideDownload(): bool;
+
+	/**
+	 * Sets a flag that stores whether a reminder via email has been sent
+	 *
+	 * @return self The modified object
+	 * @since 31.0.0
+	 */
+	public function setReminderSent(bool $reminderSent): IShare;
+
+	/**
+	 * Gets a flag that stores whether a reminder via email has been sent
+	 *
+	 * @return bool
+	 * @since 31.0.0
+	 */
+	public function getReminderSent(): bool;
 }


### PR DESCRIPTION
* Resolves: #45676

## Summary

This pull request implements the feature as described in the associated issue. A cron job runs hourly to check if any empty folders have less than a day remaining before their expiration date. The feature supports two types of shares: user shares and email shares.

Additionally, a migration was added to include a 'reminder sent' flag, ensuring that reminders are neither skipped nor sent multiple times when the job runs at irregular intervals, especially when using webcron or ajax instead of cron.

This solution can be easily extended to send reminders for link shares without an expiration date (e.g. after 4 days), if the maintainers choose to implement this feature.

![grafik](https://github.com/user-attachments/assets/e74c9483-3382-45ef-a1df-61cd50475a14)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
