### PR TITLE
test(admin_audit): add test for user management listener 

### DIFF
--- a/apps/admin_audit/tests/Listener/UserManagementEventListenerTest.php
+++ b/apps/admin_audit/tests/Listener/UserManagementEventListenerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\AdminAudit\Tests\Actions;
+
+use OCA\AdminAudit\IAuditLogger;
+use OCA\AdminAudit\Listener\UserManagementEventListener;
+use OCP\IUser;
+use OCP\User\Events\UserChangedEvent;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class UserManagementEventListenerTest extends TestCase {
+	private IAuditLogger&MockObject $logger;
+
+	private UserManagementEventListener $listener;
+
+	private MockObject&IUser $user;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->logger = $this->createMock(IAuditLogger::class);
+		$this->listener = new UserManagementEventListener($this->logger);
+
+		$this->user = $this->createMock(IUser::class);
+		$this->user->method('getUID')->willReturn('alice');
+		$this->user->method('getDisplayName')->willReturn('Alice');
+	}
+
+	public function testSkipUnsupported(): void {
+		$this->logger->expects($this->never())
+			->method('info');
+
+		$event = new UserChangedEvent(
+			$this->user,
+			'unsupported',
+			'value',
+		);
+
+		$this->listener->handle($event);
+	}
+
+	public function testUserEnabled(): void {
+		$this->logger->expects($this->once())
+			->method('info')
+			->with('User enabled: "alice"', ['app' => 'admin_audit']);
+
+		$event = new UserChangedEvent(
+			$this->user,
+			'enabled',
+			true,
+			false,
+		);
+
+		$this->listener->handle($event);
+	}
+
+	public function testUserDisabled(): void {
+		$this->logger->expects($this->once())
+			->method('info')
+			->with('User disabled: "alice"', ['app' => 'admin_audit']);
+
+		$event = new UserChangedEvent(
+			$this->user,
+			'enabled',
+			false,
+			true,
+		);
+
+		$this->listener->handle($event);
+	}
+
+	public function testEmailChanged(): void {
+		$this->logger->expects($this->once())
+			->method('info')
+			->with('Email address changed for user alice', ['app' => 'admin_audit']);
+
+		$event = new UserChangedEvent(
+			$this->user,
+			'eMailAddress',
+			'alice@alice.com',
+			'',
+		);
+
+		$this->listener->handle($event);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: technical debt

## Summary

The migration to event listener was done by https://github.com/nextcloud/server/pull/47865.

~Good bye hooks, hello event listener (at least for one case)~

~Test cases:~

~- Enable admin_audit~
~- Enable user => see log line in audit log~
~- Change email for user => see log line in audit log~

## TODO

- [x] CI
- [ ] Review
- [ ] Merge

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
