### PR TITLE
fix(files): Create non-existent parents of mountpoints

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1496,6 +1496,15 @@ class View {
 					if ($pos = strpos($relativePath, '/')) {
 						//mountpoint inside subfolder add size to the correct folder
 						$entryName = substr($relativePath, 0, $pos);
+
+						// Create parent folders if the mountpoint is inside a subfolder that doesn't exist yet
+						if (!isset($files[$entryName]) && $this->mkdir($path . '/' . $entryName) !== false) {
+							$info = $this->getFileInfo($path . '/' . $entryName);
+							if ($info !== false) {
+								$files[$entryName] = $info;
+							}
+						}
+
 						if (isset($files[$entryName])) {
 							$files[$entryName]->addSubEntry($rootEntry, $mountPoint);
 						}

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2743,4 +2743,35 @@ class ViewTest extends \Test\TestCase {
 
 		$this->assertFalse($cache->inCache('foo.txt'));
 	}
+
+	public function testMountpointParentsCreated() {
+		$storage1 = $this->getTestStorage();
+		Filesystem::mount($storage1, [], '/');
+
+		$storage2 = $this->getTestStorage();
+		Filesystem::mount($storage2, [], '/A/B/C');
+
+		$rootView = new View('');
+
+		$folderData = $rootView->getDirectoryContent('/');
+		$this->assertCount(4, $folderData);
+		$this->assertEquals('folder', $folderData[0]['name']);
+		$this->assertEquals('foo.png', $folderData[1]['name']);
+		$this->assertEquals('foo.txt', $folderData[2]['name']);
+		$this->assertEquals('A', $folderData[3]['name']);
+
+		$folderData = $rootView->getDirectoryContent('/A');
+		$this->assertCount(1, $folderData);
+		$this->assertEquals('B', $folderData[0]['name']);
+
+		$folderData = $rootView->getDirectoryContent('/A/B');
+		$this->assertCount(1, $folderData);
+		$this->assertEquals('C', $folderData[0]['name']);
+
+		$folderData = $rootView->getDirectoryContent('/A/B/C');
+		$this->assertCount(3, $folderData);
+		$this->assertEquals('folder', $folderData[0]['name']);
+		$this->assertEquals('foo.png', $folderData[1]['name']);
+		$this->assertEquals('foo.txt', $folderData[2]['name']);
+	}
 }


### PR DESCRIPTION
* Resolves: #47341

## Summary

For storages mounted inside subfolders the parents were missing, so it was impossible to reach the storage unless the parent folders were created manually.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
