### PR TITLE
fix: promote re-shares when deleting the parent share

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -147,16 +147,6 @@ class OwnershipTransferService {
 			$output
 		);
 
-		$destinationPath = $finalTarget . '/' . $path;
-		// restore the shares
-		$this->restoreShares(
-			$sourceUid,
-			$destinationUid,
-			$destinationPath,
-			$shares,
-			$output
-		);
-
 		// transfer the incoming shares
 		if ($transferIncomingShares === true) {
 			$sourceShares = $this->collectIncomingShares(
@@ -181,6 +171,16 @@ class OwnershipTransferService {
 				$move
 			);
 		}
+
+		$destinationPath = $finalTarget . '/' . $path;
+		// restore the shares
+		$this->restoreShares(
+			$sourceUid,
+			$destinationUid,
+			$destinationPath,
+			$shares,
+			$output
+		);
 	}
 
 	private function sanitizeFolderName(string $name): string {
@@ -467,9 +467,6 @@ class OwnershipTransferService {
 				}
 			} catch (\OCP\Files\NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
-			} catch (\OCP\Share\Exceptions\GenericShareException $e) {
-				$output->writeln('<error>Share with id ' . $share->getId() . ' is broken, deleting</error>');
-				$this->shareManager->deleteShare($share);
 			} catch (\Throwable $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getMessage() . ' : ' . $e->getTraceAsString() . '</error>');
 			}

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -467,6 +467,9 @@ class OwnershipTransferService {
 				}
 			} catch (\OCP\Files\NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
+			} catch (\OCP\Share\Exceptions\GenericShareException $e) {
+				$output->writeln('<error>Share with id ' . $share->getId() . ' is broken, deleting</error>');
+				$this->shareManager->deleteShare($share);
 			} catch (\Throwable $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getMessage() . ' : ' . $e->getTraceAsString() . '</error>');
 			}

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -277,8 +277,7 @@ class EtagPropagationTest extends PropagationTestCase {
 			self::TEST_FILES_SHARING_API_USER2,
 		]);
 
-		$this->assertEtagsNotChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER3]);
-		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER4]);
+		$this->assertAllUnchanged();
 	}
 
 	public function testOwnerUnsharesFlatReshares(): void {

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -277,7 +277,8 @@ class EtagPropagationTest extends PropagationTestCase {
 			self::TEST_FILES_SHARING_API_USER2,
 		]);
 
-		$this->assertAllUnchanged();
+		$this->assertEtagsNotChanged([self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER3]);
+		$this->assertEtagsChanged([self::TEST_FILES_SHARING_API_USER4]);
 	}
 
 	public function testOwnerUnsharesFlatReshares(): void {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -783,6 +783,7 @@ class Manager implements IManager {
 	 * @param IShare $share
 	 * @return IShare The share object
 	 * @throws \InvalidArgumentException
+	 * @throws GenericShareException
 	 */
 	public function updateShare(IShare $share) {
 		$expirationDateUpdated = false;
@@ -1040,7 +1041,8 @@ class Manager implements IManager {
 		return $deletedShares;
 	}
 
-	protected function deleteReshares(IShare $share): void {
+	/* Promote reshares into direct shares so that target user keeps access */
+	protected function promoteReshares(IShare $share): void {
 		try {
 			$node = $share->getNode();
 		} catch (NotFoundException) {
@@ -1058,7 +1060,7 @@ class Manager implements IManager {
 
 			foreach ($users as $user) {
 				/* Skip share owner */
-				if ($user->getUID() === $share->getShareOwner()) {
+				if ($user->getUID() === $share->getShareOwner() || $user->getUID() === $share->getSharedBy()) {
 					continue;
 				}
 				$userIds[] = $user->getUID();
@@ -1101,8 +1103,14 @@ class Manager implements IManager {
 			try {
 				$this->generalCreateChecks($child);
 			} catch (GenericShareException $e) {
-				$this->logger->debug('Delete reshare because of exception '.$e->getMessage(), ['exception' => $e]);
-				$this->deleteShare($child);
+				/* The check is invalid, promote it to a direct share from the sharer of parent share */
+				$this->logger->debug('Promote reshare because of exception ' . $e->getMessage(), ['exception' => $e, 'fullId' => $child->getFullId()]);
+				try {
+					$child->setSharedBy($share->getSharedBy());
+					$this->updateShare($child);
+				} catch (GenericShareException|\InvalidArgumentException $e) {
+					$this->logger->warning('Failed to promote reshare because of exception ' . $e->getMessage(), ['exception' => $e, 'fullId' => $child->getFullId()]);
+				}
 			}
 		}
 	}
@@ -1132,8 +1140,8 @@ class Manager implements IManager {
 
 		$this->dispatcher->dispatchTyped(new ShareDeletedEvent($share));
 
-		// Delete reshares of the deleted share
-		$this->deleteReshares($share);
+		// Promote reshares of the deleted share
+		$this->promoteReshares($share);
 	}
 
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1082,16 +1082,23 @@ class Manager implements IManager {
 		foreach ($userIds as $userId) {
 			foreach ($shareTypes as $shareType) {
 				$provider = $this->factory->getProviderForType($shareType);
-				$shares = $provider->getSharesBy($userId, $shareType, $node, false, -1, 0);
-				foreach ($shares as $child) {
-					$reshareRecords[] = $child;
-				}
-			}
+				if ($node instanceof Folder) {
+					/* We need to get all shares by this user to get subshares */
+					$shares = $provider->getSharesBy($userId, $shareType, null, false, -1, 0);
 
-			if ($node instanceof Folder) {
-				$sharesInFolder = $this->getSharesInFolder($userId, $node, false);
-
-				foreach ($sharesInFolder as $shares) {
+					foreach ($shares as $share) {
+						try {
+							$path = $share->getNode()->getPath();
+						} catch (NotFoundException) {
+							/* Ignore share of non-existing node */
+							continue;
+						}
+						if (str_starts_with($path, $node->getPath() . '/') || ($path === $node->getPath())) {
+							$reshareRecords[] = $share;
+						}
+					}
+				} else {
+					$shares = $provider->getSharesBy($userId, $shareType, $node, false, -1, 0);
 					foreach ($shares as $child) {
 						$reshareRecords[] = $child;
 					}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1093,7 +1093,8 @@ class Manager implements IManager {
 							/* Ignore share of non-existing node */
 							continue;
 						}
-						if (str_starts_with($path, $node->getPath() . '/') || ($path === $node->getPath())) {
+						if ($node->getRelativePath($path) !== null) {
+							/* If relative path is not null it means the shared node is the same or in a subfolder */
 							$reshareRecords[] = $share;
 						}
 					}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1101,6 +1101,7 @@ class Manager implements IManager {
 
 		foreach ($reshareRecords as $child) {
 			try {
+				/* Check if the share is still valid (means the resharer still has access to the file through another mean) */
 				$this->generalCreateChecks($child);
 			} catch (GenericShareException $e) {
 				/* The check is invalid, promote it to a direct share from the sharer of parent share */

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1041,7 +1041,7 @@ class Manager implements IManager {
 		return $deletedShares;
 	}
 
-	/* Promote reshares into direct shares so that target user keeps access */
+	/** Promote re-shares into direct shares so that target user keeps access */
 	protected function promoteReshares(IShare $share): void {
 		try {
 			$node = $share->getNode();

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1040,31 +1040,32 @@ class Manager implements IManager {
 		return $deletedShares;
 	}
 
-	public function deleteReshare(IShare $share) {
-		// Skip if node not found
+	protected function deleteReshares(IShare $share): void {
 		try {
 			$node = $share->getNode();
 		} catch (NotFoundException) {
+			/* Skip if node not found */
 			return;
 		}
 
 		$userIds = [];
 
-		if  ($share->getShareType() === IShare::TYPE_USER) {
+		if ($share->getShareType() === IShare::TYPE_USER) {
 			$userIds[] = $share->getSharedWith();
-		}
-
-		if ($share->getShareType() === IShare::TYPE_GROUP) {
+		} elseif ($share->getShareType() === IShare::TYPE_GROUP) {
 			$group = $this->groupManager->get($share->getSharedWith());
-			$users = $group->getUsers();
+			$users = $group?->getUsers() ?? [];
 
 			foreach ($users as $user) {
-				// Skip if share owner is member of shared group
+				/* Skip share owner */
 				if ($user->getUID() === $share->getShareOwner()) {
 					continue;
 				}
 				$userIds[] = $user->getUID();
 			}
+		} else {
+			/* We only support user and group shares */
+			return;
 		}
 
 		$reshareRecords = [];
@@ -1073,7 +1074,7 @@ class Manager implements IManager {
 			IShare::TYPE_USER,
 			IShare::TYPE_LINK,
 			IShare::TYPE_REMOTE,
-			IShare::TYPE_EMAIL
+			IShare::TYPE_EMAIL,
 		];
 
 		foreach ($userIds as $userId) {
@@ -1085,8 +1086,8 @@ class Manager implements IManager {
 				}
 			}
 
-			if ($share->getNodeType() === 'folder') {
-				$sharesInFolder = $this->getSharesInFolder($userId, $node, true);
+			if ($node instanceof Folder) {
+				$sharesInFolder = $this->getSharesInFolder($userId, $node, false);
 
 				foreach ($sharesInFolder as $shares) {
 					foreach ($shares as $child) {
@@ -1100,6 +1101,7 @@ class Manager implements IManager {
 			try {
 				$this->generalCreateChecks($child);
 			} catch (GenericShareException $e) {
+				$this->logger->debug('Delete reshare because of exception '.$e->getMessage(), ['exception' => $e]);
 				$this->deleteShare($child);
 			}
 		}
@@ -1128,10 +1130,10 @@ class Manager implements IManager {
 		$provider = $this->factory->getProviderForType($share->getShareType());
 		$provider->delete($share);
 
-		// Delete shares that shared by the "share with user/group"
-		$this->deleteReshare($share);
-
 		$this->dispatcher->dispatchTyped(new ShareDeletedEvent($share));
+
+		// Delete reshares of the deleted share
+		$this->deleteReshares($share);
 	}
 
 

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -9,6 +9,7 @@ namespace Test\Share20;
 
 use DateTimeZone;
 use OC\Files\Mount\MoveableMount;
+use OC\Files\Utils\PathHelper;
 use OC\KnownUser\KnownUserService;
 use OC\Share20\DefaultShareProvider;
 use OC\Share20\Exception;
@@ -199,6 +200,14 @@ class ManagerTest extends \Test\TestCase {
 			]);
 	}
 
+	private function createFolderMock(string $folderPath): MockObject&Folder {
+		$folder = $this->createMock(Folder::class);
+		$folder->method('getPath')->willReturn($folderPath);
+		$folder->method('getRelativePath')->willReturnCallback(
+			fn (string $path): ?string => PathHelper::getRelativePath($folderPath, $path)
+		);
+		return $folder;
+	}
 
 	public function testDeleteNoShareId(): void {
 		$this->expectException(\InvalidArgumentException::class);
@@ -514,14 +523,11 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods(['updateShare', 'getSharesInFolder', 'generalCreateChecks'])
 			->getMock();
 
-		$folder = $this->createMock(Folder::class);
-		$folder->method('getPath')->willReturn('/path/to/folder');
+		$folder = $this->createFolderMock('/path/to/folder');
 
-		$subFolder = $this->createMock(Folder::class);
-		$subFolder->method('getPath')->willReturn('/path/to/folder/sub');
+		$subFolder = $this->createFolderMock('/path/to/folder/sub');
 
-		$otherFolder = $this->createMock(Folder::class);
-		$otherFolder->method('getPath')->willReturn('/path/to/otherfolder/');
+		$otherFolder = $this->createFolderMock('/path/to/otherfolder/');
 
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
@@ -567,8 +573,7 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods(['updateShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
 			->getMock();
 
-		$folder = $this->createMock(Folder::class);
-		$folder->method('getPath')->willReturn('/path/to/folder');
+		$folder = $this->createFolderMock('/path/to/folder');
 
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
@@ -596,8 +601,7 @@ class ManagerTest extends \Test\TestCase {
 			->setMethods(['updateShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
 			->getMock();
 
-		$folder = $this->createMock(Folder::class);
-		$folder->method('getPath')->willReturn('/path/to/folder');
+		$folder = $this->createFolderMock('/path/to/folder');
 
 		$userA = $this->createMock(IUser::class);
 		$userA->method('getUID')->willReturn('userA');

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -46,6 +46,7 @@ use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareDeletedEvent;
 use OCP\Share\Events\ShareDeletedFromSelfEvent;
 use OCP\Share\Exceptions\AlreadySharedException;
+use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
@@ -227,7 +228,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testDelete($shareType, $sharedWith): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteChildren'])
+			->setMethods(['getShareById', 'deleteChildren', 'deleteReshare'])
 			->getMock();
 
 		$manager->method('deleteChildren')->willReturn([]);
@@ -245,6 +246,7 @@ class ManagerTest extends \Test\TestCase {
 			->setTarget('myTarget');
 
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
+		$manager->expects($this->once())->method('deleteReshare')->with($share);
 
 		$this->defaultProvider
 			->expects($this->once())
@@ -269,7 +271,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDeleteLazyShare(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteChildren'])
+			->setMethods(['getShareById', 'deleteChildren', 'deleteReshare'])
 			->getMock();
 
 		$manager->method('deleteChildren')->willReturn([]);
@@ -288,6 +290,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
+		$manager->expects($this->once())->method('deleteReshare')->with($share);
 
 		$this->defaultProvider
 			->expects($this->once())
@@ -312,7 +315,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDeleteNested(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById'])
+			->setMethods(['getShareById', 'deleteReshare'])
 			->getMock();
 
 		$path = $this->createMock(File::class);
@@ -467,6 +470,115 @@ class ManagerTest extends \Test\TestCase {
 
 		$result = self::invokePrivate($manager, 'deleteChildren', [$share]);
 		$this->assertSame($shares, $result);
+	}
+
+	public function testDeleteReshareWhenUserHasOneShare(): void {
+		$manager = $this->createManagerMock()
+			->setMethods(['deleteShare', 'getSharesInFolder', 'generalCreateChecks'])
+			->getMock();
+
+		$folder = $this->createMock(Folder::class);
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
+		$share->method('getNodeType')->willReturn('folder');
+		$share->method('getSharedWith')->willReturn('UserB');
+		$share->method('getNode')->willReturn($folder);
+
+		$reShare = $this->createMock(IShare::class);
+		$reShare->method('getSharedBy')->willReturn('UserB');
+		$reShare->method('getSharedWith')->willReturn('UserC');
+		$reShare->method('getNode')->willReturn($folder);
+
+		$reShareInSubFolder = $this->createMock(IShare::class);
+		$reShareInSubFolder->method('getSharedBy')->willReturn('UserB');
+
+		$manager->method('getSharesInFolder')->willReturn([$reShareInSubFolder]);
+		$manager->method('generalCreateChecks')->willThrowException(new GenericShareException());
+
+		$this->defaultProvider->method('getSharesBy')
+			->willReturn([$reShare]);
+
+		$manager->expects($this->atLeast(2))->method('deleteShare')->withConsecutive([$reShare], [$reShareInSubFolder]);
+
+		$manager->deleteReshare($share);
+	}
+
+	public function testDeleteReshareWhenUserHasAnotherShare(): void {
+		$manager = $this->createManagerMock()
+			->setMethods(['deleteShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
+			->getMock();
+
+		$folder = $this->createMock(Folder::class);
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
+		$share->method('getNodeType')->willReturn('folder');
+		$share->method('getSharedWith')->willReturn('UserB');
+		$share->method('getNode')->willReturn($folder);
+
+		$reShare = $this->createMock(IShare::class);
+		$reShare->method('getShareType')->willReturn(IShare::TYPE_USER);
+		$reShare->method('getNodeType')->willReturn('folder');
+		$reShare->method('getSharedBy')->willReturn('UserB');
+		$reShare->method('getNode')->willReturn($folder);
+
+		$this->defaultProvider->method('getSharesBy')->willReturn([$reShare]);
+		$manager->method('getSharesInFolder')->willReturn([]);
+		$manager->method('generalCreateChecks')->willReturn(true);
+
+		$manager->expects($this->never())->method('deleteShare');
+
+		$manager->deleteReshare($share);
+	}
+
+	public function testDeleteReshareOfUsersInGroupShare(): void {
+		$manager = $this->createManagerMock()
+			->setMethods(['deleteShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
+			->getMock();
+
+		$folder = $this->createMock(Folder::class);
+
+		$userA = $this->createMock(IUser::class);
+		$userA->method('getUID')->willReturn('userA');
+
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareType')->willReturn(IShare::TYPE_GROUP);
+		$share->method('getNodeType')->willReturn('folder');
+		$share->method('getSharedWith')->willReturn('Group');
+		$share->method('getNode')->willReturn($folder);
+		$share->method('getShareOwner')->willReturn($userA);
+
+		$reShare1 = $this->createMock(IShare::class);
+		$reShare1->method('getShareType')->willReturn(IShare::TYPE_USER);
+		$reShare1->method('getNodeType')->willReturn('folder');
+		$reShare1->method('getSharedBy')->willReturn('UserB');
+		$reShare1->method('getNode')->willReturn($folder);
+
+		$reShare2 = $this->createMock(IShare::class);
+		$reShare2->method('getShareType')->willReturn(IShare::TYPE_USER);
+		$reShare2->method('getNodeType')->willReturn('folder');
+		$reShare2->method('getSharedBy')->willReturn('UserC');
+		$reShare2->method('getNode')->willReturn($folder);
+
+		$userB = $this->createMock(IUser::class);
+		$userB->method('getUID')->willReturn('userB');
+		$userC = $this->createMock(IUser::class);
+		$userC->method('getUID')->willReturn('userC');
+		$group = $this->createMock(IGroup::class);
+		$group->method('getUsers')->willReturn([$userB, $userC]);
+		$this->groupManager->method('get')->with('Group')->willReturn($group);
+
+		$this->defaultProvider->method('getSharesBy')
+			->willReturn([]);
+		$manager->method('generalCreateChecks')->willThrowException(new GenericShareException());
+
+		$manager->method('getSharedWith')->willReturn([]);
+		$manager->expects($this->exactly(2))->method('getSharesInFolder')->willReturnOnConsecutiveCalls([[$reShare1]], [[$reShare2]]);
+
+		$manager->expects($this->exactly(2))->method('deleteShare')->withConsecutive([$reShare1], [$reShare2]);
+
+		$manager->deleteReshare($share);
 	}
 
 	public function testGetShareById(): void {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -228,7 +228,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testDelete($shareType, $sharedWith): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteChildren', 'deleteReshare'])
+			->setMethods(['getShareById', 'deleteChildren', 'deleteReshares'])
 			->getMock();
 
 		$manager->method('deleteChildren')->willReturn([]);
@@ -246,7 +246,7 @@ class ManagerTest extends \Test\TestCase {
 			->setTarget('myTarget');
 
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
-		$manager->expects($this->once())->method('deleteReshare')->with($share);
+		$manager->expects($this->once())->method('deleteReshares')->with($share);
 
 		$this->defaultProvider
 			->expects($this->once())
@@ -271,7 +271,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDeleteLazyShare(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteChildren', 'deleteReshare'])
+			->setMethods(['getShareById', 'deleteChildren', 'deleteReshares'])
 			->getMock();
 
 		$manager->method('deleteChildren')->willReturn([]);
@@ -290,7 +290,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
-		$manager->expects($this->once())->method('deleteReshare')->with($share);
+		$manager->expects($this->once())->method('deleteReshares')->with($share);
 
 		$this->defaultProvider
 			->expects($this->once())
@@ -315,7 +315,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDeleteNested(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteReshare'])
+			->setMethods(['getShareById', 'deleteReshares'])
 			->getMock();
 
 		$path = $this->createMock(File::class);
@@ -501,7 +501,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$manager->expects($this->atLeast(2))->method('deleteShare')->withConsecutive([$reShare], [$reShareInSubFolder]);
 
-		$manager->deleteReshare($share);
+		self::invokePrivate($manager, 'deleteReshares', [$share]);
 	}
 
 	public function testDeleteReshareWhenUserHasAnotherShare(): void {
@@ -529,7 +529,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$manager->expects($this->never())->method('deleteShare');
 
-		$manager->deleteReshare($share);
+		self::invokePrivate($manager, 'deleteReshares', [$share]);
 	}
 
 	public function testDeleteReshareOfUsersInGroupShare(): void {
@@ -578,7 +578,7 @@ class ManagerTest extends \Test\TestCase {
 
 		$manager->expects($this->exactly(2))->method('deleteShare')->withConsecutive([$reShare1], [$reShare2]);
 
-		$manager->deleteReshare($share);
+		self::invokePrivate($manager, 'deleteReshares', [$share]);
 	}
 
 	public function testGetShareById(): void {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -228,7 +228,7 @@ class ManagerTest extends \Test\TestCase {
 	 */
 	public function testDelete($shareType, $sharedWith): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteChildren', 'deleteReshares'])
+			->setMethods(['getShareById', 'deleteChildren', 'promoteReshares'])
 			->getMock();
 
 		$manager->method('deleteChildren')->willReturn([]);
@@ -246,7 +246,7 @@ class ManagerTest extends \Test\TestCase {
 			->setTarget('myTarget');
 
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
-		$manager->expects($this->once())->method('deleteReshares')->with($share);
+		$manager->expects($this->once())->method('promoteReshares')->with($share);
 
 		$this->defaultProvider
 			->expects($this->once())
@@ -271,7 +271,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDeleteLazyShare(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteChildren', 'deleteReshares'])
+			->setMethods(['getShareById', 'deleteChildren', 'promoteReshares'])
 			->getMock();
 
 		$manager->method('deleteChildren')->willReturn([]);
@@ -290,7 +290,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->rootFolder->expects($this->never())->method($this->anything());
 
 		$manager->expects($this->once())->method('deleteChildren')->with($share);
-		$manager->expects($this->once())->method('deleteReshares')->with($share);
+		$manager->expects($this->once())->method('promoteReshares')->with($share);
 
 		$this->defaultProvider
 			->expects($this->once())
@@ -315,7 +315,7 @@ class ManagerTest extends \Test\TestCase {
 
 	public function testDeleteNested(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['getShareById', 'deleteReshares'])
+			->setMethods(['getShareById', 'promoteReshares'])
 			->getMock();
 
 		$path = $this->createMock(File::class);
@@ -472,9 +472,9 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertSame($shares, $result);
 	}
 
-	public function testDeleteReshareWhenUserHasOneShare(): void {
+	public function testPromoteReshareWhenUserHasOneShare(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['deleteShare', 'getSharesInFolder', 'generalCreateChecks'])
+			->setMethods(['updateShare', 'getSharesInFolder', 'generalCreateChecks'])
 			->getMock();
 
 		$folder = $this->createMock(Folder::class);
@@ -499,14 +499,14 @@ class ManagerTest extends \Test\TestCase {
 		$this->defaultProvider->method('getSharesBy')
 			->willReturn([$reShare]);
 
-		$manager->expects($this->atLeast(2))->method('deleteShare')->withConsecutive([$reShare], [$reShareInSubFolder]);
+		$manager->expects($this->atLeast(2))->method('updateShare')->withConsecutive([$reShare], [$reShareInSubFolder]);
 
-		self::invokePrivate($manager, 'deleteReshares', [$share]);
+		self::invokePrivate($manager, 'promoteReshares', [$share]);
 	}
 
-	public function testDeleteReshareWhenUserHasAnotherShare(): void {
+	public function testPromoteReshareWhenUserHasAnotherShare(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['deleteShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
+			->setMethods(['updateShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
 			->getMock();
 
 		$folder = $this->createMock(Folder::class);
@@ -527,14 +527,14 @@ class ManagerTest extends \Test\TestCase {
 		$manager->method('getSharesInFolder')->willReturn([]);
 		$manager->method('generalCreateChecks')->willReturn(true);
 
-		$manager->expects($this->never())->method('deleteShare');
+		$manager->expects($this->never())->method('updateShare');
 
-		self::invokePrivate($manager, 'deleteReshares', [$share]);
+		self::invokePrivate($manager, 'promoteReshares', [$share]);
 	}
 
-	public function testDeleteReshareOfUsersInGroupShare(): void {
+	public function testPromoteReshareOfUsersInGroupShare(): void {
 		$manager = $this->createManagerMock()
-			->setMethods(['deleteShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
+			->setMethods(['updateShare', 'getSharesInFolder', 'getSharedWith', 'generalCreateChecks'])
 			->getMock();
 
 		$folder = $this->createMock(Folder::class);
@@ -576,9 +576,9 @@ class ManagerTest extends \Test\TestCase {
 		$manager->method('getSharedWith')->willReturn([]);
 		$manager->expects($this->exactly(2))->method('getSharesInFolder')->willReturnOnConsecutiveCalls([[$reShare1]], [[$reShare2]]);
 
-		$manager->expects($this->exactly(2))->method('deleteShare')->withConsecutive([$reShare1], [$reShare2]);
+		$manager->expects($this->exactly(2))->method('updateShare')->withConsecutive([$reShare1], [$reShare2]);
 
-		self::invokePrivate($manager, 'deleteReshares', [$share]);
+		self::invokePrivate($manager, 'promoteReshares', [$share]);
 	}
 
 	public function testGetShareById(): void {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Same as #43025 but without the new command.

* ~Catch share exception in transfer ownership and delete invalid shares~
* Promote reshares into direct shares when a user loses access to a file after an unshare

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
