### PR TITLE
feat(settings): Add setup check for apcu cache expunge

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -108,6 +108,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\MysqlUnicodeSupport' => $baseDir . '/../lib/SetupChecks/MysqlUnicodeSupport.php',
     'OCA\\Settings\\SetupChecks\\OcxProviders' => $baseDir . '/../lib/SetupChecks/OcxProviders.php',
     'OCA\\Settings\\SetupChecks\\OverwriteCliUrl' => $baseDir . '/../lib/SetupChecks/OverwriteCliUrl.php',
+    'OCA\\Settings\\SetupChecks\\PhpApcuConfig' => $baseDir . '/../lib/SetupChecks/PhpApcuConfig.php',
     'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => $baseDir . '/../lib/SetupChecks/PhpDefaultCharset.php',
     'OCA\\Settings\\SetupChecks\\PhpDisabledFunctions' => $baseDir . '/../lib/SetupChecks/PhpDisabledFunctions.php',
     'OCA\\Settings\\SetupChecks\\PhpFreetypeSupport' => $baseDir . '/../lib/SetupChecks/PhpFreetypeSupport.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -123,6 +123,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\MysqlUnicodeSupport' => __DIR__ . '/..' . '/../lib/SetupChecks/MysqlUnicodeSupport.php',
         'OCA\\Settings\\SetupChecks\\OcxProviders' => __DIR__ . '/..' . '/../lib/SetupChecks/OcxProviders.php',
         'OCA\\Settings\\SetupChecks\\OverwriteCliUrl' => __DIR__ . '/..' . '/../lib/SetupChecks/OverwriteCliUrl.php',
+        'OCA\\Settings\\SetupChecks\\PhpApcuConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpApcuConfig.php',
         'OCA\\Settings\\SetupChecks\\PhpDefaultCharset' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpDefaultCharset.php',
         'OCA\\Settings\\SetupChecks\\PhpDisabledFunctions' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpDisabledFunctions.php',
         'OCA\\Settings\\SetupChecks\\PhpFreetypeSupport' => __DIR__ . '/..' . '/../lib/SetupChecks/PhpFreetypeSupport.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -50,6 +50,7 @@ use OCA\Settings\SetupChecks\MimeTypeMigrationAvailable;
 use OCA\Settings\SetupChecks\MysqlUnicodeSupport;
 use OCA\Settings\SetupChecks\OcxProviders;
 use OCA\Settings\SetupChecks\OverwriteCliUrl;
+use OCA\Settings\SetupChecks\PhpApcuConfig;
 use OCA\Settings\SetupChecks\PhpDefaultCharset;
 use OCA\Settings\SetupChecks\PhpDisabledFunctions;
 use OCA\Settings\SetupChecks\PhpFreetypeSupport;
@@ -186,6 +187,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(PhpDefaultCharset::class);
 		$context->registerSetupCheck(PhpDisabledFunctions::class);
 		$context->registerSetupCheck(PhpFreetypeSupport::class);
+		$context->registerSetupCheck(PhpApcuConfig::class);
 		$context->registerSetupCheck(PhpGetEnv::class);
 		$context->registerSetupCheck(PhpMemoryLimit::class);
 		$context->registerSetupCheck(PhpModules::class);

--- a/apps/settings/lib/SetupChecks/PhpApcuConfig.php
+++ b/apps/settings/lib/SetupChecks/PhpApcuConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+use OC\Memcache\APCu;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class PhpApcuConfig implements ISetupCheck {
+	public const USAGE_RATE_WARNING = 90;
+	public const AGE_WARNING = 3600 * 8;
+
+	public function __construct(
+		private IL10N $l10n,
+		private IConfig $config,
+	) {
+	}
+
+	public function getCategory(): string {
+		return 'php';
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('PHP APCu configuration');
+	}
+
+	public function run(): SetupResult {
+		$localIsApcu = ltrim($this->config->getSystemValueString('memcache.local'), '\\') === APCu::class;
+		$distributedIsApcu = ltrim($this->config->getSystemValueString('memcache.distributed'), '\\') === APCu::class;
+		if (!$localIsApcu && !$distributedIsApcu) {
+			return SetupResult::success();
+		}
+
+		if (!APCu::isAvailable()) {
+			return SetupResult::success();
+		}
+
+		$cache = apcu_cache_info(true);
+		$mem = apcu_sma_info(true);
+		if ($cache === false || $mem === false) {
+			return SetupResult::success();
+		}
+
+		$expunges = $cache['expunges'];
+		$memSize = $mem['num_seg'] * $mem['seg_size'];
+		$memAvailable = $mem['avail_mem'];
+		$memUsed = $memSize - $memAvailable;
+		$usageRate = round($memUsed / $memSize * 100, 0);
+		$elapsed = max(time() - $cache['start_time'], 1);
+
+		if ($expunges > 0 && $elapsed < self::AGE_WARNING) {
+			return SetupResult::warning($this->l10n->t('Your APCu cache has been running full, consider increasing the apc.shm_size php setting.'));
+		}
+
+		if ($usageRate > self::USAGE_RATE_WARNING) {
+			return SetupResult::warning($this->l10n->t('Your APCu cache is almost full at %s%%, consider increasing the apc.shm_size php setting.', [$usageRate]));
+		}
+
+		return SetupResult::success();
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/46282

## Summary

This adds a basic setup check to warn admins if their APCu cache is close to be full or has been expunged. Ideally we would be able to calculate something like a rate for how long the cache is kept until cleaned up, but i couldn't find a reasonable metric and we cannot get the startup time of the php service itself.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
