### PR TITLE
fix: gracefully handle unexpected exif orientation types

### DIFF
--- a/lib/private/legacy/OC_Image.php
+++ b/lib/private/legacy/OC_Image.php
@@ -390,6 +390,18 @@ class OC_Image implements \OCP\IImage {
 		return min(100, max(10, (int)$quality));
 	}
 
+	private function isValidExifData(array $exif): bool {
+		if (!isset($exif['Orientation'])) {
+			return false;
+		}
+
+		if (!is_numeric($exif['Orientation'])) {
+			return false;
+		}
+
+		return true;
+	}
+
 	/**
 	 * (I'm open for suggestions on better method name ;)
 	 * Get the orientation based on EXIF data.
@@ -418,14 +430,11 @@ class OC_Image implements \OCP\IImage {
 			return -1;
 		}
 		$exif = @exif_read_data($this->filePath, 'IFD0');
-		if (!$exif) {
-			return -1;
-		}
-		if (!isset($exif['Orientation'])) {
+		if (!$exif || !$this->isValidExifData($exif)) {
 			return -1;
 		}
 		$this->exif = $exif;
-		return $exif['Orientation'];
+		return (int)$exif['Orientation'];
 	}
 
 	public function readExif($data): void {
@@ -439,10 +448,7 @@ class OC_Image implements \OCP\IImage {
 		}
 
 		$exif = @exif_read_data('data://image/jpeg;base64,' . base64_encode($data));
-		if (!$exif) {
-			return;
-		}
-		if (!isset($exif['Orientation'])) {
+		if (!$exif || !$this->isValidExifData($exif)) {
 			return;
 		}
 		$this->exif = $exif;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/previewgenerator/issues/506

## Summary

The member `$exif['Orientation']` is a string sometimes which breaks generating previews. I added some code to make it more robust and cast it to an int if the orientation is numeric.

```
2024-08-27T04:50:23+00:00 Scanning folder /laraeva/files/Shared/Photos Ati/2015/2015-10-27
An unhandled exception has been thrown:
TypeError: OC_Image::getOrientation(): Return value must be of type int, string returned in /var/www/html/lib/private/legacy/OC_Image.php:485
Stack trace:
#0 /var/www/html/lib/private/legacy/OC_Image.php(519): OC_Image->getOrientation()
#1 /var/www/html/lib/private/Preview/Image.php(52): OC_Image->fixOrientation()
#2 /var/www/html/lib/private/Preview/GeneratorHelper.php(64): OC\Preview\Image->getThumbnail(Object(OC\Files\Node\File), 2048, 2048)
```

## TODO

- [x] Probably tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
