### PR TITLE
fix(db): Increase log level for very slow transactions

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -28,6 +28,7 @@ use OC\SystemConfig;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Diagnostics\IEventLogger;
 use OCP\IDBConnection;
+use OCP\ILogger;
 use OCP\IRequestId;
 use OCP\PreConditionNotMetException;
 use OCP\Profiler\IProfiler;
@@ -719,7 +720,20 @@ class Connection extends PrimaryReadReplicaConnection {
 			$this->transactionBacktrace = null;
 			$this->transactionActiveSince = null;
 			if ($timeTook > 1) {
-				$this->logger->debug('Transaction took ' . $timeTook . 's', ['exception' => new \Exception('Transaction took ' . $timeTook . 's')]);
+				$logLevel = match (true) {
+					$timeTook > 20 * 60 => ILogger::ERROR,
+					$timeTook > 5 * 60 => ILogger::WARN,
+					$timeTook > 10 => ILogger::INFO,
+					default => ILogger::DEBUG,
+				};
+				$this->logger->log(
+					$logLevel,
+					'Transaction took ' . $timeTook . 's',
+					[
+						'exception' => new \Exception('Transaction took ' . $timeTook . 's'),
+						'timeSpent' => $timeTook,
+					]
+				);
 			}
 		}
 		return $result;
@@ -732,7 +746,20 @@ class Connection extends PrimaryReadReplicaConnection {
 			$this->transactionBacktrace = null;
 			$this->transactionActiveSince = null;
 			if ($timeTook > 1) {
-				$this->logger->debug('Transaction rollback took longer than 1s: ' . $timeTook, ['exception' => new \Exception('Long running transaction rollback')]);
+				$logLevel = match (true) {
+					$timeTook > 20 * 60 => ILogger::ERROR,
+					$timeTook > 5 * 60 => ILogger::WARN,
+					$timeTook > 10 => ILogger::INFO,
+					default => ILogger::DEBUG,
+				};
+				$this->logger->log(
+					$logLevel,
+					'Transaction rollback took longer than 1s: ' . $timeTook,
+					[
+						'exception' => new \Exception('Long running transaction rollback'),
+						'timeSpent' => $timeTook,
+					]
+				);
 			}
 		}
 		return $result;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Transactions that run for more than 20 minutes causes issues very often. This raises the log level to make production troubleshooting hopefully a bit easier.

To quote a db consultant

> transaction should not run more than 20min. if it's longer nextcloud does it wrong.

## TODO

- [x] Adjust log levels

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
