### PR TITLE
fix: remove caching in fetchListOfGroups

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -958,22 +958,6 @@ class Access extends LDAPUtility {
 		}
 		$groupRecords = $this->searchGroups($filter, $attr, $limit, $offset);
 
-		$listOfDNs = array_reduce($groupRecords, function ($listOfDNs, $entry) {
-			$listOfDNs[] = $entry['dn'][0];
-			return $listOfDNs;
-		}, []);
-		$idsByDn = $this->getGroupMapper()->getListOfIdsByDn($listOfDNs);
-
-		array_walk($groupRecords, function (array $record) use ($idsByDn): void {
-			$newlyMapped = false;
-			$gid = $idsByDn[$record['dn'][0]] ?? null;
-			if ($gid === null) {
-				$gid = $this->dn2ocname($record['dn'][0], null, false, $newlyMapped, $record);
-			}
-			if (!$newlyMapped && is_string($gid)) {
-				$this->cacheGroupExists($gid);
-			}
-		});
 		$listOfGroups = $this->fetchList($groupRecords, $this->manyAttributes($attr));
 		$this->connection->writeToCache($cacheKey, $listOfGroups);
 		return $listOfGroups;

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -667,7 +667,7 @@ class AccessTest extends TestCase {
 		$this->groupMapper->expects($this->never())
 			->method('getNameByDN');
 
-		$this->connection->expects($this->exactly(3))
+		$this->connection->expects($this->exactly(1))
 			->method('writeToCache');
 
 		$groups = $this->access->fetchListOfGroups($filter, $attributes);

--- a/build/integration/openldap_features/openldap-uid-username.feature
+++ b/build/integration/openldap_features/openldap-uid-username.feature
@@ -151,6 +151,7 @@ Feature: LDAP
       | ldapAttributesForUserSearch   | employeeNumber                  |
       | useMemberOfToDetectMembership | 1 |
     And parameter "shareapi_only_share_with_group_members" of app "core" is set to "yes"
+    And invoking occ with "ldap:check-group cn=Orcharding,ou=OtherGroups,dc=nextcloud,dc=ci --update"
     And As an "alice"
     When getting sharees for
       # "5" is part of the employee number of some LDAP records
@@ -162,4 +163,3 @@ Feature: LDAP
     And "users" sharees returned are
       | Elisa | 0 | elisa |
     And "exact groups" sharees returned is empty
-


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #42195 

## Summary

When using nested groups without a memberof overlay, then fetchListOfGroups is called from getGroupsByMember without applying the group filter.

In some setups, the "unfiltered" result is then written back to the group mapping table. That might cause random "An administrator removed you from group" activities.

I was unable to replicate it locally, but we got the feedback that the random activities stopped with the patch applied.

Ref: https://github.com/nextcloud/server/issues/42195

## TODO

- [ ] CI & Tests
- [x] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
