### PR TITLE
fix(migration): Correctly sort migrations by version number

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -158,7 +158,7 @@ class MigrationService {
 	/**
 	 * Returns all versions which have already been applied
 	 *
-	 * @return string[]
+	 * @return list<string>
 	 * @codeCoverageIgnore - no need to test this
 	 */
 	public function getMigratedVersions() {
@@ -174,6 +174,8 @@ class MigrationService {
 		$rows = $result->fetchAll(\PDO::FETCH_COLUMN);
 		$result->closeCursor();
 
+		usort($rows, $this->sortMigrations(...));
+
 		return $rows;
 	}
 
@@ -183,7 +185,23 @@ class MigrationService {
 	 */
 	public function getAvailableVersions(): array {
 		$this->ensureMigrationsAreLoaded();
-		return array_map('strval', array_keys($this->migrations));
+		$versions = array_map('strval', array_keys($this->migrations));
+		usort($versions, $this->sortMigrations(...));
+		return $versions;
+	}
+
+	protected function sortMigrations(string $a, string $b): int {
+		preg_match('/(\d+)Date(\d+)/', basename($a), $matchA);
+		preg_match('/(\d+)Date(\d+)/', basename($b), $matchB);
+		if (!empty($matchA) && !empty($matchB)) {
+			$versionA = (int)$matchA[1];
+			$versionB = (int)$matchB[1];
+			if ($versionA !== $versionB) {
+				return ($versionA < $versionB) ? -1 : 1;
+			}
+			return ($matchA[2] < $matchB[2]) ? -1 : 1;
+		}
+		return (basename($a) < basename($b)) ? -1 : 1;
 	}
 
 	/**
@@ -204,17 +222,7 @@ class MigrationService {
 			\RegexIterator::GET_MATCH);
 
 		$files = array_keys(iterator_to_array($iterator));
-		uasort($files, function ($a, $b) {
-			preg_match('/^Version(\d+)Date(\d+)\\.php$/', basename($a), $matchA);
-			preg_match('/^Version(\d+)Date(\d+)\\.php$/', basename($b), $matchB);
-			if (!empty($matchA) && !empty($matchB)) {
-				if ($matchA[1] !== $matchB[1]) {
-					return ($matchA[1] < $matchB[1]) ? -1 : 1;
-				}
-				return ($matchA[2] < $matchB[2]) ? -1 : 1;
-			}
-			return (basename($a) < basename($b)) ? -1 : 1;
-		});
+		usort($files, $this->sortMigrations(...));
 
 		$migrations = [];
 


### PR DESCRIPTION
## Summary

Install Talk

Before:
```
$ occ migration:status spreed
…
    >> Previous Version:                                   8000Date20200407073807
    >> Current Version:                                    8000Date20200407115318
    >> Next Version:                                       10000Date20200819121721
    >> Latest Version:                                     20000Date20240718031959
```

```
$ occ migration:status spreed
…
    >> Previous Version:                                   20000Date20240717180417
    >> Current Version:                                    20000Date20240718031959
    >> Next Version:                                       Already at latest migration step
    >> Latest Version:                                     20000Date20240718031959
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
