### PR TITLE
feat(transfer-ownership): Correctly react to encrypted files

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -245,21 +245,21 @@ class OwnershipTransferService {
 								return false;
 							}
 							if ($fileInfo->isEncrypted()) {
-								/* Encrypted folder means e2ee encrypted */
+								/* Encrypted folder means e2ee encrypted, we cannot transfer it */
 								$encryptedFiles[] = $fileInfo;
 							}
 							return true;
 						}
 						$progress->advance();
 						if ($fileInfo->isEncrypted() && !$masterKeyEnabled) {
-							/* Encrypted file means SSE, we only care if we are using user keys */
+							/* Encrypted file means SSE, we can only transfer it if master key is enabled */
 							$encryptedFiles[] = $fileInfo;
 						}
 						return true;
 					});
 			}
 		} elseif ($sourceFileInfo->isEncrypted() && !$masterKeyEnabled) {
-			/* Encrypted file means SSE, we only care if we are using user keys */
+			/* Encrypted file means SSE, we can only transfer it if master key is enabled */
 			$encryptedFiles[] = $sourceFileInfo;
 		}
 		$progress->finish();

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -204,7 +204,7 @@ class OwnershipTransferService {
 	/**
 	 * @param OutputInterface $output
 	 *
-	 * @throws \Exception
+	 * @throws TransferOwnershipException
 	 */
 	protected function analyse(string $sourceUid,
 		string $destinationUid,
@@ -212,33 +212,56 @@ class OwnershipTransferService {
 		View $view,
 		OutputInterface $output): void {
 		$output->writeln('Validating quota');
-		$size = $view->getFileInfo($sourcePath, false)->getSize(false);
+		$sourceFileInfo = $view->getFileInfo($sourcePath, false);
+		if ($sourceFileInfo === false) {
+			throw new TransferOwnershipException("Unknown path provided: $sourcePath", 1);
+		}
+		$size = $sourceFileInfo->getSize(false);
 		$freeSpace = $view->free_space($destinationUid . '/files/');
 		if ($size > $freeSpace && $freeSpace !== FileInfo::SPACE_UNKNOWN) {
-			$output->writeln('<error>Target user does not have enough free space available.</error>');
-			throw new \Exception('Execution terminated.');
+			throw new TransferOwnershipException('Target user does not have enough free space available.', 1);
 		}
 
 		$output->writeln("Analysing files of $sourceUid ...");
 		$progress = new ProgressBar($output);
 		$progress->start();
 
+		if ($this->encryptionManager->isEnabled()) {
+			$masterKeyEnabled = \OCP\Server::get(\OCA\Encryption\Util::class)->isMasterKeyEnabled();
+		} else {
+			$masterKeyEnabled = false;
+		}
 		$encryptedFiles = [];
-		$this->walkFiles($view, $sourcePath,
-			function (FileInfo $fileInfo) use ($progress, &$encryptedFiles) {
-				if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
-					// only analyze into folders from main storage,
-					if (!$fileInfo->getStorage()->instanceOfStorage(IHomeStorage::class)) {
-						return false;
-					}
-					return true;
-				}
-				$progress->advance();
-				if ($fileInfo->isEncrypted()) {
-					$encryptedFiles[] = $fileInfo;
-				}
-				return true;
-			});
+		if ($sourceFileInfo->getType() === FileInfo::TYPE_FOLDER) {
+			if ($sourceFileInfo->isEncrypted()) {
+				/* Encrypted folder means e2ee encrypted */
+				$encryptedFiles[] = $sourceFileInfo;
+			} else {
+				$this->walkFiles($view, $sourcePath,
+					function (FileInfo $fileInfo) use ($progress, $masterKeyEnabled, &$encryptedFiles) {
+						if ($fileInfo->getType() === FileInfo::TYPE_FOLDER) {
+							// only analyze into folders from main storage,
+							if (!$fileInfo->getStorage()->instanceOfStorage(IHomeStorage::class)) {
+								return false;
+							}
+							if ($fileInfo->isEncrypted()) {
+								/* Encrypted folder means e2ee encrypted */
+								$encryptedFiles[] = $fileInfo;
+							}
+							return true;
+						}
+						$progress->advance();
+						if ($fileInfo->isEncrypted() && !$masterKeyEnabled) {
+							/* Encrypted file means SSE, we only care if we are using user keys */
+							$encryptedFiles[] = $fileInfo;
+						}
+						return true;
+					});
+			}
+		} elseif ($sourceFileInfo->isEncrypted() && !$masterKeyEnabled) {
+			/* Encrypted file means SSE, we only care if we are using user keys */
+			$encryptedFiles[] = $sourceFileInfo;
+		}
 		$progress->finish();
 		$output->writeln('');
 
@@ -249,7 +272,7 @@ class OwnershipTransferService {
 				/** @var FileInfo $encryptedFile */
 				$output->writeln('  ' . $encryptedFile->getPath());
 			}
-			throw new \Exception('Execution terminated.');
+			throw new TransferOwnershipException('Some files are encrypted - please decrypt them first.', 1);
 		}
 	}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

1. For E2EE encrypted files, we abort the transfer.
2. For SSE encrypted files, we abort only if not using master key. 
3. Also fixed the check for when the path to a single file is used.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
