### PR TITLE
fix(logger): ignore session logging during setup

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -387,10 +387,15 @@ class OC {
 		$sessionName = OC_Util::getInstanceId();
 
 		try {
+			$logger = null;
+			if (Server::get(\OC\SystemConfig::class)->getValue('installed', false)) {
+				$logger = logger('core');
+			}
+
 			// set the session name to the instance id - which is unique
 			$session = new \OC\Session\Internal(
 				$sessionName,
-				logger('core'),
+				$logger,
 			);
 
 			$cryptoWrapper = Server::get(\OC\Session\CryptoWrapper::class);

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -29,8 +29,10 @@ class Internal extends Session {
 	 * @param string $name
 	 * @throws \Exception
 	 */
-	public function __construct(string $name,
-		private LoggerInterface $logger) {
+	public function __construct(
+		string $name,
+		private ?LoggerInterface $logger,
+	) {
 		set_error_handler([$this, 'trapError']);
 		$this->invoke('session_name', [$name]);
 		$this->invoke('session_cache_limiter', ['']);
@@ -204,7 +206,7 @@ class Internal extends Session {
 					$timeSpent > 0.5 => ILogger::INFO,
 					default => ILogger::DEBUG,
 				};
-				$this->logger->log(
+				$this->logger?->log(
 					$logLevel,
 					"Slow session operation $functionName detected",
 					[


### PR DESCRIPTION
This fix a regression from #47105 that lock installation process on 29.0.5 (but no 30 😕 ) when using the web interface