### PR TITLE
[TaskProcessing] Add manager::runTask method

### DIFF
--- a/lib/private/TaskProcessing/SynchronousBackgroundJob.php
+++ b/lib/private/TaskProcessing/SynchronousBackgroundJob.php
@@ -57,37 +57,9 @@ class SynchronousBackgroundJob extends QueuedJob {
 				$this->logger->error('Unknown error while retrieving scheduled TaskProcessing tasks', ['exception' => $e]);
 				continue;
 			}
-			try {
-				try {
-					$input = $this->taskProcessingManager->prepareInputData($task);
-				} catch (GenericFileException|NotPermittedException|LockedException|ValidationException|UnauthorizedException $e) {
-					$this->logger->warning('Failed to prepare input data for a TaskProcessing task with synchronous provider ' . $provider->getId(), ['exception' => $e]);
-					$this->taskProcessingManager->setTaskResult($task->getId(), $e->getMessage(), null);
-					// Schedule again
-					$this->jobList->add(self::class, $argument);
-					return;
-				}
-				try {
-					$this->taskProcessingManager->setTaskStatus($task, Task::STATUS_RUNNING);
-					$output = $provider->process($task->getUserId(), $input, fn (float $progress) => $this->taskProcessingManager->setTaskProgress($task->getId(), $progress));
-				} catch (ProcessingException $e) {
-					$this->logger->warning('Failed to process a TaskProcessing task with synchronous provider ' . $provider->getId(), ['exception' => $e]);
-					$this->taskProcessingManager->setTaskResult($task->getId(), $e->getMessage(), null);
-					// Schedule again
-					$this->jobList->add(self::class, $argument);
-					return;
-				} catch (\Throwable $e) {
-					$this->logger->error('Unknown error while processing TaskProcessing task', ['exception' => $e]);
-					$this->taskProcessingManager->setTaskResult($task->getId(), $e->getMessage(), null);
-					// Schedule again
-					$this->jobList->add(self::class, $argument);
-					return;
-				}
-				$this->taskProcessingManager->setTaskResult($task->getId(), null, $output);
-			} catch (NotFoundException $e) {
-				$this->logger->info('Could not find task anymore after execution. Moving on.', ['exception' => $e]);
-			} catch (Exception $e) {
-				$this->logger->error('Failed to report result of TaskProcessing task', ['exception' => $e]);
+			if (!$this->taskProcessingManager->processTask($task, $provider)) {
+				// Schedule again
+				$this->jobList->add(self::class, $argument);
 			}
 		}
 

--- a/lib/public/TaskProcessing/IManager.php
+++ b/lib/public/TaskProcessing/IManager.php
@@ -62,6 +62,33 @@ interface IManager {
 	public function scheduleTask(Task $task): void;
 
 	/**
+	 * Run the task and return the finished task
+	 *
+	 * @param Task $task The task to run
+	 * @return Task The result task
+	 * @throws PreConditionNotMetException If no or not the requested provider was registered but this method was still called
+	 * @throws ValidationException the given task input didn't pass validation against the task type's input shape and/or the providers optional input shape specs
+	 * @throws Exception storing the task in the database failed
+	 * @throws UnauthorizedException the user scheduling the task does not have access to the files used in the input
+	 * @since 30.0.0
+	 */
+	public function runTask(Task $task): Task;
+
+	/**
+	 * Process task with a synchronous provider
+	 *
+	 * Prepare task input data and run the process method of the provider
+	 * This should only be used by OC\TaskProcessing\SynchronousBackgroundJob::run() and OCP\TaskProcessing\IManager::runTask()
+	 *
+	 * @param Task $task
+	 * @param ISynchronousProvider $provider
+	 * @return bool True if the task has run successfully
+	 * @throws Exception
+	 * @since 30.0.0
+	 */
+	public function processTask(Task $task, ISynchronousProvider $provider): bool;
+
+	/**
 	 * Delete a task that has been scheduled before
 	 *
 	 * @param Task $task The task to delete


### PR DESCRIPTION
Add `OCP\TaskProcessing\IManager::runTask` method to run tasks synchronously.
* If the provider is synchronous (Php), the task runs in the same process.
* If not, runTask polls the task that should be picked by an external provider ASAP.

The changeset looks big but it's just moving stuff from the background job to the manager and refactoring the manager a bit to factorize stuff between `scheduleTask` and `runTask`.

Additional change: Fix the condition to reschedule the background job. As discussed with @kyteinsky, knowing that some synchronous providers can handle currently scheduled tasks is not enough. They have to be a preferred provider (selected in the AI admin settings).

This should be backported to stable30.