### PR TITLE
fix(files_external): Handling in FTP UI for custom ports

### DIFF
--- a/apps/files_external/lib/Lib/Backend/FTP.php
+++ b/apps/files_external/lib/Lib/Backend/FTP.php
@@ -23,6 +23,8 @@ class FTP extends Backend {
 			->setText($l->t('FTP'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),
+				(new DefinitionParameter('port', $l->t('Port')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('root', $l->t('Remote subfolder')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('secure', $l->t('Secure ftps://')))


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #32773 
* Resolves: nextcloud/documentation#941

## Summary

Docs say we support this, but it is broken in the Web UI. We already handle the `port` parameter so let's use it properly.

https://github.com/nextcloud/server/blob/11822def85f80fb4ec98d174bf7c4acf9dae6efd/apps/files_external/lib/Lib/Storage/FTP.php#L47


## TODO

- [x] Follow-up PR(s) pending any other backends with similar situations (i.e. SFTP)
- [x] Update doc sections for each backend

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
