### PR TITLE
feat(webhook_listeners): Enable the app by default

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -91,7 +91,8 @@
     "updatenotification",
     "user_status",
     "viewer",
-    "weather_status"
+    "weather_status",
+    "webhook_listeners"
   ],
   "alwaysEnabled": [
     "files",


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Enable the app webhook_listeners by default.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
