### PR TITLE
fix(files_sharing): Make share labels nullable

### DIFF
--- a/apps/files_sharing/lib/ResponseDefinitions.php
+++ b/apps/files_sharing/lib/ResponseDefinitions.php
@@ -28,7 +28,7 @@ namespace OCA\Files_Sharing;
  *     item_size: float|int,
  *     item_source: int,
  *     item_type: 'file'|'folder',
- *     label: string,
+ *     label: ?string,
  *     mail_send: 0|1,
  *     mimetype: string,
  *     note: string,

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -578,7 +578,8 @@
                         ]
                     },
                     "label": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "mail_send": {
                         "type": "integer",


### PR DESCRIPTION
## Summary

To my understand the label should rather be an empty string and not null since the default value for the label is an empty string.
This problem is easily reproducible though, so I'm just adjusting the spec instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
