### PR TITLE
fix(config): Avoid error messages for restricted opcache API

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -184,7 +184,7 @@ class Config {
 
 			// Invalidate opcache (only if the timestamp changed)
 			if (function_exists('opcache_invalidate')) {
-				opcache_invalidate($file, false);
+				@opcache_invalidate($file, false);
 			}
 
 			$filePointer = @fopen($file, 'r');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #47562 <!-- related github issue -->

## Summary

Make changes recently added via #44230 match #8188 to avoid failures in restricted hosting environments.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
