### PR TITLE
fix: Do not fail to get internal path on NonExistingFile

### DIFF
--- a/lib/private/Files/Node/NonExistingFile.php
+++ b/lib/private/Files/Node/NonExistingFile.php
@@ -38,6 +38,14 @@ class NonExistingFile extends File {
 		}
 	}
 
+	public function getInternalPath() {
+		if ($this->fileInfo) {
+			return parent::getInternalPath();
+		} else {
+			return $this->getParent()->getMountPoint()->getInternalPath($this->getPath());
+		}
+	}
+
 	public function stat() {
 		throw new NotFoundException();
 	}

--- a/lib/private/Files/Node/NonExistingFolder.php
+++ b/lib/private/Files/Node/NonExistingFolder.php
@@ -38,6 +38,14 @@ class NonExistingFolder extends Folder {
 		}
 	}
 
+	public function getInternalPath() {
+		if ($this->fileInfo) {
+			return parent::getInternalPath();
+		} else {
+			return $this->getParent()->getMountPoint()->getInternalPath($this->getPath());
+		}
+	}
+
 	public function stat() {
 		throw new NotFoundException();
 	}


### PR DESCRIPTION
Follow up to:
- https://github.com/nextcloud/server/pull/47252
- https://github.com/nextcloud/server/pull/44871

## Summary

If we cannot get the internal path from the file info (e.g. when creating a new file), but we can obtain it from the parent node through the mountpoint.

Fixes errors log spam when creating a new file and having admin_audit enabled when being called in https://github.com/nextcloud/server/blob/af6de04e9e141466dc229e444ff3f146f4a34765/apps/admin_audit/lib/Actions/Files.php#L166
