### PR TITLE
Move preferred install method to top spot

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -70,6 +70,7 @@ body:
         Select installation method you've used.
         _Describe the method in the "Additional info" section if you chose "Other"._
       options:
+        - "Official All-in-One appliance"
         - "Community Web installer on a VPS or web space"
         - "Community Manual installation with Archive"
         - "Community Docker image"
@@ -77,7 +78,6 @@ body:
         - "Community SNAP package"
         - "Community VM appliance"
         - "Other Community project"
-        - "Official All-in-One appliance"
   - type: dropdown
     id: nextcloud-version
     attributes:
@@ -110,10 +110,10 @@ body:
         Select PHP engine version serving Nextcloud Server.
         _Describe in the "Additional info" section if you chose "Other"._
       options:
-        - "PHP 8.0"
-        - "PHP 8.1"
-        - "PHP 8.2"
         - "PHP 8.3"
+        - "PHP 8.2"
+        - "PHP 8.1"
+        - "PHP 8.0"
         - "Other"
   - type: dropdown
     id: webserver

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -63,22 +63,6 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: install-method
-    attributes:
-      label: Installation method
-      description: |
-        Select installation method you've used.
-        _Describe the method in the "Additional info" section if you chose "Other"._
-      options:
-        - "Official All-in-One appliance"
-        - "Community Web installer on a VPS or web space"
-        - "Community Manual installation with Archive"
-        - "Community Docker image"
-        - "Community NextcloudPi appliance"
-        - "Community SNAP package"
-        - "Community VM appliance"
-        - "Other Community project"
-  - type: dropdown
     id: nextcloud-version
     attributes:
       label: Nextcloud Server version


### PR DESCRIPTION
## Summary

Move the preferred installation method (All-In-One) to the top position when reporting bugs.

Likewise for the latest supported PHP version.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
