### PR TITLE
fix(test): Fix provisioning enabled apps

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -41,6 +41,7 @@ jobs:
               - '.php-cs-fixer.dist.php'
               - 'composer.json'
               - 'composer.lock'
+              - 'core/shipped.json'
 
   integration-sqlite:
     runs-on: ubuntu-latest

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -607,6 +607,7 @@ Feature: provisioning
 			| user_status |
 			| viewer |
 			| workflowengine |
+			| webhook_listeners |
 			| weather_status |
 			| files_external |
 			| oauth2 |


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/pull/47532 added the app, but didn't adjust the tests. They didn't even run, because the files were not changed.
Example failure: https://github.com/nextcloud/server/actions/runs/10610490820/job/29408077638

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
