### PR TITLE
fix: re-enable content-length header via htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -106,5 +106,13 @@
   SetEnvIf Transfer-Encoding "chunked" proxy-sendcl=1
 </IfModule>
 
+# Apache disabled the sending of the server-side content-length header 
+# in their 2.4.59 patch updated which breaks some use-cases in Nextcloud.
+# Setting ap_trust_cgilike_cl allows to bring back the usual behaviour.
+# See https://bz.apache.org/bugzilla/show_bug.cgi?id=68973
+<IfModule mod_env.c>
+  SetEnv ap_trust_cgilike_cl
+</IfModule>
+
 AddDefaultCharset utf-8
 Options -Indexes


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/47017
Close https://github.com/nextcloud/all-in-one/pull/5119

```
# Apache disabled the sending of the server-side content-length header 
# in their 2.4.59 patch updated which breaks some use-cases in Nextcloud.
# Setting ap_trust_cgilike_cl allows to bring back the usual behaviour.
# See https://bz.apache.org/bugzilla/show_bug.cgi?id=68973
```