### PR TITLE
fix(DB): set sharding parameters only when intended

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -225,11 +225,16 @@ class ConnectionFactory {
 		}
 
 		$connectionParams['sharding'] = $this->config->getValue('dbsharding', []);
-		$connectionParams['shard_connection_manager'] = $this->shardConnectionManager;
-		$connectionParams['auto_increment_handler'] = new AutoIncrementHandler(
-			$this->cacheFactory,
-			$this->shardConnectionManager,
-		);
+		if (!empty($connectionParams['sharding'])) {
+			$connectionParams['shard_connection_manager'] = $this->shardConnectionManager;
+			$connectionParams['auto_increment_handler'] = new AutoIncrementHandler(
+				$this->cacheFactory,
+				$this->shardConnectionManager,
+			);
+		} else {
+			// just in case only the presence could lead to funny behaviour
+			unset($connectionParams['sharding']);
+		}
 
 		$connectionParams = array_merge($connectionParams, $additionalConnectionParams);
 

--- a/tests/lib/DB/QueryBuilder/Partitioned/PartitionedQueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/Partitioned/PartitionedQueryBuilderTest.php
@@ -26,6 +26,9 @@ class PartitionedQueryBuilderTest extends TestCase {
 	private AutoIncrementHandler $autoIncrementHandler;
 
 	protected function setUp(): void {
+		if (PHP_INT_SIZE < 8) {
+			$this->markTestSkipped('Test requires 64bit');
+		}
 		$this->connection = Server::get(IDBConnection::class);
 		$this->shardConnectionManager = Server::get(ShardConnectionManager::class);
 		$this->autoIncrementHandler = Server::get(AutoIncrementHandler::class);

--- a/tests/lib/DB/QueryBuilder/Sharded/SharedQueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/Sharded/SharedQueryBuilderTest.php
@@ -27,6 +27,9 @@ class SharedQueryBuilderTest extends TestCase {
 	private AutoIncrementHandler $autoIncrementHandler;
 
 	protected function setUp(): void {
+		if (PHP_INT_SIZE < 8) {
+			$this->markTestSkipped('Test requires 64bit');
+		}
 		$this->connection = Server::get(IDBConnection::class);
 		$this->autoIncrementHandler = Server::get(AutoIncrementHandler::class);
 	}

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [31, 0, 0, 1];
+$OC_Version = [31, 0, 0, 2];
 
 // The human-readable string
 $OC_VersionString = '31.0.0 dev';


### PR DESCRIPTION
## Summary

32bit setup fails to due to AutoIncrementHandler

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
