### PR TITLE
Use app path dir instead of hardcoded path for theme

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -42,6 +42,7 @@ class JSResourceLocator extends ResourceLocator {
 				// Handle symlinks
 				$appRoot = realpath($appRoot);
 			}
+			$appDirName = basename($appRoot);
 			// Get the app webroot
 			$appWebRoot = dirname($this->appManager->getAppWebPath($app));
 		} catch (AppPathNotFoundException $e) {
@@ -57,7 +58,7 @@ class JSResourceLocator extends ResourceLocator {
 			$found += $this->appendScriptIfExist($this->serverroot, $script);
 			$found += $this->appendScriptIfExist($this->serverroot, $theme_dir.$script);
 			$found += $this->appendScriptIfExist($appRoot, $script, $appWebRoot);
-			$found += $this->appendScriptIfExist($this->serverroot, $theme_dir.'apps/'.$script);
+			$found += $this->appendScriptIfExist($this->serverroot, $theme_dir.$appDirName.'/'.$script);
 
 			if ($found) {
 				return;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->



## Summary

- https://github.com/nextcloud/server/commit/d0d9b398432d74145c0df686aed434450255b6b9 rolled  back https://github.com/nextcloud/server/commit/5e20c3e7b97598a8e632d9c5ccdef7de7813a4e8
  - This was a fix for https://github.com/nextcloud/server/issues/40897

-  So now the issue closed above is no longer working
- My fix is just to use the generic app path name instead of a hardcoded `/apps`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
