### PR TITLE
fix: Run migration sql as statement so that the primary db node is used

### DIFF
--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -139,7 +139,7 @@ class Migrator {
 		$step = 0;
 		foreach ($sqls as $sql) {
 			$this->emit($sql, $step++, count($sqls));
-			$connection->executeQuery($sql);
+			$connection->executeStatement($sql);
 		}
 		if (!$connection->getDatabasePlatform() instanceof MySQLPlatform) {
 			$connection->commit();


### PR DESCRIPTION
Otherwise database migrations could fail when Nextcloud is setup with read replicas.