### PR TITLE
chore: Cleanup app framework middleware

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -242,7 +242,6 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 				new OC\AppFramework\Middleware\Security\CSPMiddleware(
 					$server->query(OC\Security\CSP\ContentSecurityPolicyManager::class),
 					$server->query(OC\Security\CSP\ContentSecurityPolicyNonceManager::class),
-					$server->query(OC\Security\CSRF\CsrfTokenManager::class)
 				)
 			);
 			$dispatcher->registerMiddleware(

--- a/lib/private/AppFramework/Middleware/Security/CSPMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/CSPMiddleware.php
@@ -10,7 +10,6 @@ namespace OC\AppFramework\Middleware\Security;
 
 use OC\Security\CSP\ContentSecurityPolicyManager;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
-use OC\Security\CSRF\CsrfTokenManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
@@ -18,19 +17,11 @@ use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
 
 class CSPMiddleware extends Middleware {
-	/** @var ContentSecurityPolicyManager */
-	private $contentSecurityPolicyManager;
-	/** @var ContentSecurityPolicyNonceManager */
-	private $cspNonceManager;
-	/** @var CsrfTokenManager */
-	private $csrfTokenManager;
 
-	public function __construct(ContentSecurityPolicyManager $policyManager,
-		ContentSecurityPolicyNonceManager $cspNonceManager,
-		CsrfTokenManager $csrfTokenManager) {
-		$this->contentSecurityPolicyManager = $policyManager;
-		$this->cspNonceManager = $cspNonceManager;
-		$this->csrfTokenManager = $csrfTokenManager;
+	public function __construct(
+		private ContentSecurityPolicyManager $policyManager,
+		private ContentSecurityPolicyNonceManager $cspNonceManager,
+	) {
 	}
 
 	/**
@@ -49,8 +40,8 @@ class CSPMiddleware extends Middleware {
 			return $response;
 		}
 
-		$defaultPolicy = $this->contentSecurityPolicyManager->getDefaultPolicy();
-		$defaultPolicy = $this->contentSecurityPolicyManager->mergePolicies($defaultPolicy, $policy);
+		$defaultPolicy = $this->policyManager->getDefaultPolicy();
+		$defaultPolicy = $this->policyManager->mergePolicies($defaultPolicy, $policy);
 
 		if ($this->cspNonceManager->browserSupportsCspV3()) {
 			$defaultPolicy->useJsNonce($this->cspNonceManager->getNonce());

--- a/lib/private/AppFramework/Middleware/Security/SameSiteCookieMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SameSiteCookieMiddleware.php
@@ -46,13 +46,13 @@ class SameSiteCookieMiddleware extends Middleware {
 
 	public function afterException($controller, $methodName, \Exception $exception) {
 		if ($exception instanceof LaxSameSiteCookieFailedException) {
-			$respone = new Response();
-			$respone->setStatus(Http::STATUS_FOUND);
-			$respone->addHeader('Location', $this->request->getRequestUri());
+			$response = new Response();
+			$response->setStatus(Http::STATUS_FOUND);
+			$response->addHeader('Location', $this->request->getRequestUri());
 
 			$this->setSameSiteCookie();
 
-			return $respone;
+			return $response;
 		}
 
 		throw $exception;

--- a/tests/lib/AppFramework/Middleware/Security/CSPMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CSPMiddlewareTest.php
@@ -12,7 +12,6 @@ use OC\AppFramework\Middleware\Security\CSPMiddleware;
 use OC\Security\CSP\ContentSecurityPolicy;
 use OC\Security\CSP\ContentSecurityPolicyManager;
 use OC\Security\CSP\ContentSecurityPolicyNonceManager;
-use OC\Security\CSRF\CsrfTokenManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\EmptyContentSecurityPolicy;
 use OCP\AppFramework\Http\Response;
@@ -25,8 +24,6 @@ class CSPMiddlewareTest extends \Test\TestCase {
 	private $controller;
 	/** @var ContentSecurityPolicyManager&MockObject */
 	private $contentSecurityPolicyManager;
-	/** @var CsrfTokenManager&MockObject */
-	private $csrfTokenManager;
 	/** @var ContentSecurityPolicyNonceManager&MockObject */
 	private $cspNonceManager;
 
@@ -35,12 +32,10 @@ class CSPMiddlewareTest extends \Test\TestCase {
 
 		$this->controller = $this->createMock(Controller::class);
 		$this->contentSecurityPolicyManager = $this->createMock(ContentSecurityPolicyManager::class);
-		$this->csrfTokenManager = $this->createMock(CsrfTokenManager::class);
 		$this->cspNonceManager = $this->createMock(ContentSecurityPolicyNonceManager::class);
 		$this->middleware = new CSPMiddleware(
 			$this->contentSecurityPolicyManager,
 			$this->cspNonceManager,
-			$this->csrfTokenManager
 		);
 	}
 


### PR DESCRIPTION
## Summary

Remove unused `CSRFTokenManager` from `CSPMiddleware` and fix a typo in `SameSiteCookieMiddleware`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
