### PR TITLE
fix: logging done at the beginning and end of getUsersDetails, getUserData and fillStorageInfo

### DIFF
--- a/apps/provisioning_api/lib/Controller/AUserData.php
+++ b/apps/provisioning_api/lib/Controller/AUserData.php
@@ -110,6 +110,13 @@ abstract class AUserData extends OCSController {
 	 * @throws OCSNotFoundException
 	 */
 	protected function getUserData(string $userId, bool $includeScopes = false): ?array {
+		\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+			'Start of getUserData for {user}',
+			[
+				'user' => $userId,
+				'ticket' => '66440',
+			]
+		);
 		$currentLoggedInUser = $this->userSession->getUser();
 		assert($currentLoggedInUser !== null, 'No user logged in');
 
@@ -222,6 +229,13 @@ abstract class AUserData extends OCSController {
 			'setDisplayName' => $backend instanceof ISetDisplayNameBackend || $backend->implementsActions(Backend::SET_DISPLAYNAME),
 			'setPassword' => $backend instanceof ISetPasswordBackend || $backend->implementsActions(Backend::SET_PASSWORD),
 		];
+		\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+			'End of getUserData for {user}',
+			[
+				'user' => $userId,
+				'ticket' => '66440',
+			]
+		);
 
 		return $data;
 	}
@@ -256,6 +270,14 @@ abstract class AUserData extends OCSController {
 	 * @throws OCSException
 	 */
 	protected function fillStorageInfo(string $userId): array {
+		\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+			'Start of fillStorageInfo for {user}',
+			[
+				'user' => $userId,
+				'ticket' => '66440',
+			]
+		);
+
 		try {
 			\OC_Util::tearDownFS();
 			\OC_Util::setupFS($userId);
@@ -294,6 +316,14 @@ abstract class AUserData extends OCSController {
 			\OC_Util::tearDownFS();
 			return [];
 		}
+		\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+			'End of fillStorageInfo for {user}',
+			[
+				'user' => $userId,
+				'ticket' => '66440',
+			]
+		);
+
 		return $data;
 	}
 }

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -215,6 +215,13 @@ class UsersController extends AUserData {
 		$usersDetails = [];
 		foreach ($users as $userId) {
 			$userId = (string) $userId;
+			\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+				'Start of getUsersDetails for {user}',
+				[
+					'user' => $userId,
+					'ticket' => '66440',
+				]
+			);
 			try {
 				$userData = $this->getUserData($userId);
 			} catch (OCSNotFoundException $e) {
@@ -231,6 +238,13 @@ class UsersController extends AUserData {
 				// only showing its id
 				$usersDetails[$userId] = ['id' => $userId];
 			}
+			\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+				'End of getUsersDetails for {user}',
+				[
+					'user' => $userId,
+					'ticket' => '66440',
+				]
+			);
 		}
 
 		return new DataResponse([

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -190,6 +190,12 @@ class UsersController extends AUserData {
 	 * 200: Users details returned
 	 */
 	public function getUsersDetails(string $search = '', int $limit = null, int $offset = 0): DataResponse {
+		\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+			'Start of getUsersDetails',
+			[
+				'ticket' => '66440',
+			]
+		);
 		$currentUser = $this->userSession->getUser();
 		$users = [];
 
@@ -246,7 +252,12 @@ class UsersController extends AUserData {
 				]
 			);
 		}
-
+		\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+			'End of getUsersDetails',
+			[
+				'ticket' => '66440',
+			]
+		);
 		return new DataResponse([
 			'users' => $usersDetails
 		]);


### PR DESCRIPTION
fix: logging done at the beginning and end of getUsersDetails, getUserData and fillStorageInfo

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
