### PR TITLE
fix(RichObjectStrings/Validator): Validate key value types of rich object parameters

### DIFF
--- a/apps/files_sharing/lib/Notification/Notifier.php
+++ b/apps/files_sharing/lib/Notification/Notifier.php
@@ -126,9 +126,9 @@ class Notifier implements INotifier {
 				[
 					'node' => [
 						'type' => 'file',
-						'id' => $node->getId(),
+						'id' => (string)$node->getId(),
 						'name' => $node->getName(),
-						'path' => $path,
+						'path' => (string)$path,
 					],
 				]
 			);

--- a/lib/private/Activity/Event.php
+++ b/lib/private/Activity/Event.php
@@ -259,7 +259,7 @@ class Event implements IEvent {
 	}
 
 	/**
-	 * @return array[]
+	 * @return array<string, array<string, string>>
 	 * @since 11.0.0
 	 */
 	public function getRichSubjectParameters(): array {
@@ -335,7 +335,7 @@ class Event implements IEvent {
 	}
 
 	/**
-	 * @return array[]
+	 * @return array<string, array<string, string>>
 	 * @since 11.0.0
 	 */
 	public function getRichMessageParameters(): array {

--- a/lib/private/RichObjectStrings/Validator.php
+++ b/lib/private/RichObjectStrings/Validator.php
@@ -78,6 +78,15 @@ class Validator implements IValidator {
 		if (!empty($missingKeys)) {
 			throw new InvalidObjectExeption('Object is invalid, missing keys:'.json_encode($missingKeys));
 		}
+
+		foreach ($parameter as $key => $value) {
+			if (!is_string($key)) {
+				throw new InvalidObjectExeption('Object is invalid, key ' . $key . ' is not a string');
+			}
+			if (!is_string($value)) {
+				throw new InvalidObjectExeption('Object is invalid, value ' . $value . ' is not a string');
+			}
+		}
 	}
 
 	/**

--- a/lib/public/Activity/IEvent.php
+++ b/lib/public/Activity/IEvent.php
@@ -121,7 +121,7 @@ interface IEvent {
 	 * See https://github.com/nextcloud/server/issues/1706 for more information.
 	 *
 	 * @param string $subject
-	 * @param array $parameters
+	 * @param array<string, array<string, string>> $parameters
 	 * @return $this
 	 * @throws InvalidValueException if the subject or parameters are invalid
 	 * @since 11.0.0
@@ -136,7 +136,7 @@ interface IEvent {
 	public function getRichSubject(): string;
 
 	/**
-	 * @return array[]
+	 * @return array<string, array<string, string>>
 	 * @since 11.0.0
 	 */
 	public function getRichSubjectParameters(): array;
@@ -187,7 +187,7 @@ interface IEvent {
 	 * See https://github.com/nextcloud/server/issues/1706 for more information.
 	 *
 	 * @param string $message
-	 * @param array $parameters
+	 * @param array<string, array<string, string>> $parameters
 	 * @return $this
 	 * @throws \InvalidArgumentException if the message or parameters are invalid
 	 * @since 11.0.0
@@ -202,7 +202,7 @@ interface IEvent {
 	public function getRichMessage(): string;
 
 	/**
-	 * @return array[]
+	 * @return array<string, array<string, string>>
 	 * @since 11.0.0
 	 */
 	public function getRichMessageParameters(): array;

--- a/lib/public/Notification/INotification.php
+++ b/lib/public/Notification/INotification.php
@@ -137,7 +137,7 @@ interface INotification {
 	 * See https://github.com/nextcloud/server/issues/1706 for more information.
 	 *
 	 * @param string $subject
-	 * @param array $parameters
+	 * @param array<string, array<string, string>> $parameters
 	 * @return $this
 	 * @throws InvalidValueException if the subject or parameters are invalid
 	 * @since 11.0.0
@@ -213,7 +213,7 @@ interface INotification {
 	 * See https://github.com/nextcloud/server/issues/1706 for more information.
 	 *
 	 * @param string $message
-	 * @param array $parameters
+	 * @param array<string, array<string, string>> $parameters
 	 * @return $this
 	 * @throws InvalidValueException if the message or parameters are invalid
 	 * @since 11.0.0

--- a/lib/public/SetupCheck/SetupResult.php
+++ b/lib/public/SetupCheck/SetupResult.php
@@ -45,6 +45,7 @@ class SetupResult implements \JsonSerializable {
 	/**
 	 * @brief Private constructor, use success()/info()/warning()/error() instead
 	 * @param self::SUCCESS|self::INFO|self::WARNING|self::ERROR $severity
+	 * @param array<string, array<string, string>> $descriptionParameters
 	 * @throws \OCP\RichObjectStrings\InvalidObjectExeption
 	 * @since 28.0.0
 	 * @since 28.0.2 Optional parameter ?array $descriptionParameters

--- a/tests/lib/RichObjectStrings/ValidatorTest.php
+++ b/tests/lib/RichObjectStrings/ValidatorTest.php
@@ -8,6 +8,7 @@ namespace Test\RichObjectStrings;
 
 use OC\RichObjectStrings\Validator;
 use OCP\RichObjectStrings\Definitions;
+use OCP\RichObjectStrings\InvalidObjectExeption;
 use Test\TestCase;
 
 class ValidatorTest extends TestCase {
@@ -33,5 +34,27 @@ class ValidatorTest extends TestCase {
 			],
 		]);
 		$this->addToAssertionCount(2);
+
+		$this->expectException(InvalidObjectExeption::class);
+
+		$this->expectExceptionMessage('Object is invalid, value 123 is not a string');
+		$v->validate('test {string1} test.', [
+			'string1' => [
+				'type' => 'user',
+				'id' => 'johndoe',
+				'name' => 'John Doe',
+				'key' => 123,
+			],
+		]);
+
+		$this->expectExceptionMessage('Object is invalid, key 456 is not a string');
+		$v->validate('test {string1} test.', [
+			'string1' => [
+				'type' => 'user',
+				'id' => 'johndoe',
+				'name' => 'John Doe',
+				456 => 'value',
+			],
+		]);
 	}
 }


### PR DESCRIPTION
## Summary

A lot of apps set invalid rich object parameters for notifications. Most common are integer ids were the casting was forgotten.

Technically this is not a breaking change since the apps triggering this behavior are just broken, but we are way to late into the cycle to backport this to 30 and have everyone fix their apps, so I'm not doing that (let alone backport it to older versions).

Not sure if this needs to have some upgrade docs, please let me know.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
