### PR TITLE
fix: Properly calculate intermediate icon for touch icon generation

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -124,9 +124,10 @@ class IconBuilder {
 		$color = $this->themingDefaults->getColorPrimary();
 
 		// generate background image with rounded corners
+		$cornerRadius = 0.2 * $size;
 		$background = '<?xml version="1.0" encoding="UTF-8"?>' .
-			'<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:cc="http://creativecommons.org/ns#" width="512" height="512" xmlns:xlink="http://www.w3.org/1999/xlink">' .
-			'<rect x="0" y="0" rx="100" ry="100" width="512" height="512" style="fill:' . $color . ';" />' .
+			'<svg xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:cc="http://creativecommons.org/ns#" width="' . $size . '" height="' . $size . '" xmlns:xlink="http://www.w3.org/1999/xlink">' .
+			'<rect x="0" y="0" rx="' . $cornerRadius . '" ry="' . $cornerRadius . '" width="' . $size. '" height="' . $size . '" style="fill:' . $color . ';" />' .
 			'</svg>';
 		// resize svg magic as this seems broken in Imagemagick
 		if ($mime === 'image/svg+xml' || substr($appIconContent, 0, 4) === '<svg') {
@@ -136,22 +137,17 @@ class IconBuilder {
 				$svg = $appIconContent;
 			}
 			$tmp = new Imagick();
+			$tmp->setBackgroundColor(new ImagickPixel('transparent'));
+			$tmp->setResolution(72, 72);
 			$tmp->readImageBlob($svg);
 			$x = $tmp->getImageWidth();
 			$y = $tmp->getImageHeight();
-			$res = $tmp->getImageResolution();
 			$tmp->destroy();
-
-			if ($x > $y) {
-				$max = $x;
-			} else {
-				$max = $y;
-			}
 
 			// convert svg to resized image
 			$appIconFile = new Imagick();
-			$resX = (int)(512 * $res['x'] / $max * 2.53);
-			$resY = (int)(512 * $res['y'] / $max * 2.53);
+			$resX = (int)(72 * $size / $x);
+			$resY = (int)(72 * $size / $y);
 			$appIconFile->setResolution($resX, $resY);
 			$appIconFile->setBackgroundColor(new ImagickPixel('transparent'));
 			$appIconFile->readImageBlob($svg);
@@ -166,22 +162,21 @@ class IconBuilder {
 			) {
 				$appIconFile->negateImage(false);
 			}
-			$appIconFile->scaleImage(512, 512, true);
 		} else {
 			$appIconFile = new Imagick();
 			$appIconFile->setBackgroundColor(new ImagickPixel('transparent'));
 			$appIconFile->readImageBlob($appIconContent);
-			$appIconFile->scaleImage(512, 512, true);
 		}
 		// offset for icon positioning
-		$border_w = (int)($appIconFile->getImageWidth() * 0.05);
-		$border_h = (int)($appIconFile->getImageHeight() * 0.05);
+		$padding = 0.15;
+		$border_w = (int)($appIconFile->getImageWidth() * $padding);
+		$border_h = (int)($appIconFile->getImageHeight() * $padding);
 		$innerWidth = ($appIconFile->getImageWidth() - $border_w * 2);
 		$innerHeight = ($appIconFile->getImageHeight() - $border_h * 2);
 		$appIconFile->adaptiveResizeImage($innerWidth, $innerHeight);
 		// center icon
-		$offset_w = (int)(512 / 2 - $innerWidth / 2);
-		$offset_h = (int)(512 / 2 - $innerHeight / 2);
+		$offset_w = (int)($size / 2 - $innerWidth / 2);
+		$offset_h = (int)($size / 2 - $innerHeight / 2);
 
 		$finalIconFile = new Imagick();
 		$finalIconFile->setBackgroundColor(new ImagickPixel('transparent'));


### PR DESCRIPTION
Fix touch icon rendering that is used by iOS devices if you add a webpage to the home screen. While the previous logic used to work it seems these days imagick does not have a resolution set for svg files, so we need to change calculation slightly so that our intermediate image has the right sizing for the final icon.

(The resolution naming seems confusing here, it is rather the density https://www.php.net/manual/en/imagick.setimageresolution.php#96182)

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/efdc1539-7679-404c-abbc-2605ebb90247) | ![image](https://github.com/user-attachments/assets/a53595d7-477d-4eec-97bf-1e42160282b2) |
