### PR TITLE
test(cypress): Await promise in response to prevent timeout

### DIFF
--- a/cypress/e2e/files/files-renaming.cy.ts
+++ b/cypress/e2e/files/files-renaming.cy.ts
@@ -78,7 +78,10 @@ describe('files: Rename nodes', { testIsolation: true }, () => {
 		cy.intercept(
 			'MOVE',
 			/\/remote.php\/dav\/files\//,
-			async () => { await promise },
+			(request) => {
+				// we need to wait in the onResponse handler as the intercept handler times out otherwise
+				request.on('response', async () => { await promise })
+			},
 		).as('moveFile')
 
 		// Start the renaming


### PR DESCRIPTION
## Summary

The idea is to:
1. intercept the request
2. then test the loading state,
3. and after the tests continue the request

Problem here: `cy.intercept` has a timeout on the request-handler which uses the same timeout as DOM assertions (4s) we could increase it, but this also will increase DOM assertion timeout.

So instead we do not await in the request handler, but in the response handler. This should use the response timeout which is much higher (30s).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
