### PR TITLE
fix(OCP): Fix Image interface

### DIFF
--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -779,9 +779,7 @@ class Image implements IImage {
 	}
 
 	/**
-	 * Loads an image from a string of data.
-	 *
-	 * @param string $str A string of image data as read from a file.
+	 * @inheritDoc
 	 */
 	public function loadFromData(string $str): GdImage|false {
 		if (!$this->checkImageDataSize($str)) {

--- a/lib/private/StreamImage.php
+++ b/lib/private/StreamImage.php
@@ -133,4 +133,12 @@ class StreamImage implements IStreamImage {
 	public function resizeCopy(int $maxSize): IImage {
 		throw new \BadMethodCallException('Not implemented');
 	}
+
+	public function loadFromData(string $str): \GdImage|false {
+		throw new \BadMethodCallException('Not implemented');
+	}
+
+	public function readExif(string $data): void {
+		throw new \BadMethodCallException('Not implemented');
+	}
 }

--- a/lib/public/IImage.php
+++ b/lib/public/IImage.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  */
 namespace OCP;
 
+use GdImage;
+
 /**
  * Class for basic image manipulation
  * @since 8.1.0
@@ -202,4 +204,22 @@ interface IImage {
 	 * @since 19.0.0
 	 */
 	public function resizeCopy(int $maxSize): IImage;
+
+	/**
+	 * Loads an image from a string of data.
+	 *
+	 * @param string $str A string of image data as read from a file.
+	 *
+	 * @since 31.0.0
+	 */
+	public function loadFromData(string $str): GdImage|false;
+
+	/**
+	 * Reads the EXIF data for an image.
+	 *
+	 * @param string $data EXIF data
+	 *
+	 * @since 31.0.0
+	 */
+	public function readExif(string $data): void;
 }

--- a/lib/public/Image.php
+++ b/lib/public/Image.php
@@ -14,5 +14,11 @@ namespace OCP;
  * This class provides functions to handle images
  * @since 6.0.0
  */
-class Image extends \OC\Image {
+class Image extends \OC\Image implements \OCP\IImage {
+	/**
+	 * @since 31.0.0
+	 */
+	public function __construct() {
+		parent::__construct();
+	}
 }


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/pull/47535#issuecomment-2324017343

## Summary

Using a private class in the public interface leads to no methods being resolved. Thus it needs to implement \OCP\IImage.
\OCP\IImage is also missing some methods that were relied on in OC_Image by other apps (e.g. Talk https://github.com/nextcloud/spreed/pull/13197) and needed to be added.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
