### PR TITLE
chore(IConfig): Adjust type of `getUsersForUserValue`

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -462,7 +462,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @return list<string> of user IDs
 	 */
 	public function getUsersForUserValue($appName, $key, $value) {
 		// TODO - FIXME
@@ -496,7 +496,7 @@ class AllConfig implements IConfig {
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @return list<string> of user IDs
 	 */
 	public function getUsersForUserValueCaseInsensitive($appName, $key, $value) {
 		// TODO - FIXME

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -245,7 +245,8 @@ interface IConfig {
 	 * @param string $appName the app to get the user for
 	 * @param string $key the key to get the user for
 	 * @param string $value the value to get the user for
-	 * @return array of user IDs
+	 * @return list<string> of user IDs
+	 * @since 31.0.0 return type of `list<string>`
 	 * @since 8.0.0
 	 */
 	public function getUsersForUserValue($appName, $key, $value);


### PR DESCRIPTION
## Summary

It is returning a list of strings so adjust the return typing to reflect this (`list<string>` instead of `array`).
This makes working with the result a bit easier.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
