### PR TITLE
chore(IGetRealUIDBackend): Fix typo in doc block

### DIFF
--- a/lib/public/User/Backend/IGetRealUIDBackend.php
+++ b/lib/public/User/Backend/IGetRealUIDBackend.php
@@ -17,7 +17,7 @@ interface IGetRealUIDBackend {
 	 * For example the database backend accepts different cased UIDs in all the functions
 	 * but the internal UID that is to be used should be correctly cased.
 	 *
-	 * This little function makes sure that the used UID will be correct hen using the user object
+	 * This little function makes sure that the used UID will be correct when using the user object
 	 *
 	 * @since 17.0.0
 	 * @param string $uid


### PR DESCRIPTION
## Summary

Just fixing this typo (`when` instead of `hen`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
