### PR TITLE
attempt to add a meaningful user name to the from field of a calendar…

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -194,6 +194,15 @@ class IMipPlugin extends SabreIMipPlugin {
 
 		$sender = substr($iTipMessage->sender, 7);
 
+		/* if $senderName still NULL, see if userManager has a match
+		 * for the sender email now it's been extracted ... */
+		if ($senderName === null) {
+			$iumatches = $this->userManager->getByEmail($sender);
+			if ($iumatches) {
+				$senderName = $iumatches[0]->getDisplayName();
+			}
+		}
+
 		$replyingAttendee = null;
 		switch (strtolower($iTipMessage->method)) {
 			case self::METHOD_REPLY:


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #45081 <!-- related github issue -->

## Summary
When generating a calendar event invite email from an event generated within thu
nderbird or similar application, nextcloud generates a From line that does not i
dentify the person generating the invite. This patch makes a further attempt to 
extract a real name and add it to the From line. I've been running this patch in
formally against most nextcloud versions from v25.0.4 onwards, and it has fixed 
the issue, and not caused any observed problems.

@GalacticWave @SebastianKrupinski

[ apologies, 2nd attempt at a PR, based on master this time ]


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
