### PR TITLE
fix(appstore): Cache apps.json also on dev instances

### DIFF
--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
 
 abstract class Fetcher {
 	public const INVALIDATE_AFTER_SECONDS = 3600;
+	public const INVALIDATE_AFTER_SECONDS_UNSTABLE = 900;
 	public const RETRY_AFTER_FAILURE_SECONDS = 300;
 	public const APP_STORE_URL = 'https://apps.nextcloud.com/api/v1';
 
@@ -133,12 +134,17 @@ abstract class Fetcher {
 			$file = $rootFolder->getFile($this->fileName);
 			$jsonBlob = json_decode($file->getContent(), true);
 
-			// Always get latests apps info if $allowUnstable
-			if (!$allowUnstable && is_array($jsonBlob)) {
+			if (is_array($jsonBlob)) {
 				// No caching when the version has been updated
 				if (isset($jsonBlob['ncversion']) && $jsonBlob['ncversion'] === $this->getVersion()) {
 					// If the timestamp is older than 3600 seconds request the files new
-					if ((int)$jsonBlob['timestamp'] > ($this->timeFactory->getTime() - self::INVALIDATE_AFTER_SECONDS)) {
+					$invalidateAfterSeconds = self::INVALIDATE_AFTER_SECONDS;
+
+					if ($allowUnstable) {
+						$invalidateAfterSeconds = self::INVALIDATE_AFTER_SECONDS_UNSTABLE;
+					}
+
+					if ((int)$jsonBlob['timestamp'] > ($this->timeFactory->getTime() - $invalidateAfterSeconds)) {
 						return $jsonBlob['data'];
 					}
 
@@ -159,11 +165,6 @@ abstract class Fetcher {
 
 			if (empty($responseJson) || empty($responseJson['data'])) {
 				return [];
-			}
-
-			// Don't store the apps request file
-			if ($allowUnstable) {
-				return $responseJson['data'];
 			}
 
 			$file->putContent(json_encode($responseJson));


### PR DESCRIPTION
## Summary

Currently caching of appstore files is disabled as soon as we are running `beta`, `daily` or `git` channel. When we run the current master and open `index.php/settings/apps/discover` we hit https://github.com/nextcloud/server/blob/09fef8f0ec279929c01a9a65a53a5c65da4ca52b/lib/private/App/AppStore/Fetcher/Fetcher.php#L111-L117 already 5 times, resulting in 5 requests to `apps.json` from the app store.

While it makes sense to have a shorter cache time for dev instances, we shouldn't omit all caching. This PR adds a 15 min caching (instead of 60 min on production) to dev instances.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
