### PR TITLE
fix: Fix missing footer on public pages

### DIFF
--- a/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
+++ b/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
@@ -159,4 +159,16 @@ class PublicTemplateResponse extends TemplateResponse {
 	public function getFooterVisible(): bool {
 		return $this->footerVisible;
 	}
+
+	/**
+	 * @return string
+	 * @since 14.0.0
+	 */
+	public function render(): string {
+		$params = array_merge($this->getParams(), [
+			'template' => $this,
+		]);
+		$this->setParams($params);
+		return parent::render();
+	}
 }


### PR DESCRIPTION
## Resolves

- The footer was missing from public pages
- Regression from https://github.com/nextcloud/server/pull/47568

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/a25448d4-50e0-49d8-9506-af954b941835) | ![image](https://github.com/user-attachments/assets/e692f57f-94c8-43cb-91ac-36ed28e1b7f9)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)