### PR TITLE
fix: Use sha256 to hash arguments of background jobs

### DIFF
--- a/core/Migrations/Version28000Date20240828142927.php
+++ b/core/Migrations/Version28000Date20240828142927.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\Attributes\ColumnType;
+use OCP\Migration\Attributes\ModifyColumn;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Migrate the argument_hash column of oc_jobs to use sha256 instead of md5.
+ */
+#[ModifyColumn(table: 'jobs', name: 'argument_hash', type: ColumnType::STRING, description: 'Increase the column size from 32 to 64')]
+#[ModifyColumn(table: 'jobs', name: 'argument_hash', type: ColumnType::STRING, description: 'Rehash the argument_hash column using sha256')]
+class Version28000Date20240828142927 extends SimpleMigrationStep {
+	public function __construct(
+		protected IDBConnection $connection,
+	) {
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		// Increase the column size from 32 to 64
+		$table = $schema->getTable('jobs');
+		$table->modifyColumn('argument_hash', [
+			'notnull' => false,
+			'length' => 64,
+		]);
+
+		return $schema;
+	}
+
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		$chunkSize = 1000;
+		$offset = 0;
+		$nullHash = hash('sha256', 'null');
+
+		$selectQuery = $this->connection->getQueryBuilder()
+			->select('*')
+			->from('jobs')
+			->setMaxResults($chunkSize);
+
+		$insertQuery = $this->connection->getQueryBuilder();
+		$insertQuery->update('jobs')
+			->set('argument_hash', $insertQuery->createParameter('argument_hash'))
+			->where($insertQuery->expr()->eq('id', $insertQuery->createParameter('id')));
+
+		do {
+			$result = $selectQuery
+				->setFirstResult($offset)
+				->executeQuery();
+
+			$jobs = $result->fetchAll();
+			$count = count($jobs);
+
+			foreach ($jobs as $jobRow) {
+				if ($jobRow['argument'] === 'null') {
+					$hash = $nullHash;
+				} else {
+					$hash = hash('sha256', $jobRow['argument']);
+				}
+				$insertQuery->setParameter('id', (string)$jobRow['id'], IQueryBuilder::PARAM_INT);
+				$insertQuery->setParameter('argument_hash', $hash);
+				$insertQuery->executeStatement();
+			}
+
+			$offset += $chunkSize;
+		} while ($count === $chunkSize);
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1364,6 +1364,7 @@ return array(
     'OC\\Core\\Migrations\\Version28000Date20231004103301' => $baseDir . '/core/Migrations/Version28000Date20231004103301.php',
     'OC\\Core\\Migrations\\Version28000Date20231103104802' => $baseDir . '/core/Migrations/Version28000Date20231103104802.php',
     'OC\\Core\\Migrations\\Version28000Date20231126110901' => $baseDir . '/core/Migrations/Version28000Date20231126110901.php',
+    'OC\\Core\\Migrations\\Version28000Date20240828142927' => $baseDir . '/core/Migrations/Version28000Date20240828142927.php',
     'OC\\Core\\Migrations\\Version29000Date20231126110901' => $baseDir . '/core/Migrations/Version29000Date20231126110901.php',
     'OC\\Core\\Migrations\\Version29000Date20231213104850' => $baseDir . '/core/Migrations/Version29000Date20231213104850.php',
     'OC\\Core\\Migrations\\Version29000Date20240124132201' => $baseDir . '/core/Migrations/Version29000Date20240124132201.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1397,6 +1397,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version28000Date20231004103301' => __DIR__ . '/../../..' . '/core/Migrations/Version28000Date20231004103301.php',
         'OC\\Core\\Migrations\\Version28000Date20231103104802' => __DIR__ . '/../../..' . '/core/Migrations/Version28000Date20231103104802.php',
         'OC\\Core\\Migrations\\Version28000Date20231126110901' => __DIR__ . '/../../..' . '/core/Migrations/Version28000Date20231126110901.php',
+        'OC\\Core\\Migrations\\Version28000Date20240828142927' => __DIR__ . '/../../..' . '/core/Migrations/Version28000Date20240828142927.php',
         'OC\\Core\\Migrations\\Version29000Date20231126110901' => __DIR__ . '/../../..' . '/core/Migrations/Version29000Date20231126110901.php',
         'OC\\Core\\Migrations\\Version29000Date20231213104850' => __DIR__ . '/../../..' . '/core/Migrations/Version29000Date20231213104850.php',
         'OC\\Core\\Migrations\\Version29000Date20240124132201' => __DIR__ . '/../../..' . '/core/Migrations/Version29000Date20240124132201.php',

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -20,7 +20,6 @@ use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 use function get_class;
 use function json_encode;
-use function md5;
 use function strlen;
 
 class JobList implements IJobList {
@@ -50,7 +49,7 @@ class JobList implements IJobList {
 				->values([
 					'class' => $query->createNamedParameter($class),
 					'argument' => $query->createNamedParameter($argumentJson),
-					'argument_hash' => $query->createNamedParameter(md5($argumentJson)),
+					'argument_hash' => $query->createNamedParameter(hash('sha256', $argumentJson)),
 					'last_run' => $query->createNamedParameter(0, IQueryBuilder::PARAM_INT),
 					'last_checked' => $query->createNamedParameter($firstCheck, IQueryBuilder::PARAM_INT),
 				]);
@@ -60,7 +59,7 @@ class JobList implements IJobList {
 				->set('last_checked', $query->createNamedParameter($firstCheck, IQueryBuilder::PARAM_INT))
 				->set('last_run', $query->createNamedParameter(0, IQueryBuilder::PARAM_INT))
 				->where($query->expr()->eq('class', $query->createNamedParameter($class)))
-				->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(md5($argumentJson))));
+				->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(hash('sha256', $argumentJson))));
 		}
 		$query->executeStatement();
 	}
@@ -81,7 +80,7 @@ class JobList implements IJobList {
 			->where($query->expr()->eq('class', $query->createNamedParameter($class)));
 		if (!is_null($argument)) {
 			$argumentJson = json_encode($argument);
-			$query->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(md5($argumentJson))));
+			$query->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(hash('sha256', $argumentJson))));
 		}
 
 		// Add galera safe delete chunking if using mysql
@@ -122,7 +121,7 @@ class JobList implements IJobList {
 		$query->select('id')
 			->from('jobs')
 			->where($query->expr()->eq('class', $query->createNamedParameter($class)))
-			->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(md5($argument))))
+			->andWhere($query->expr()->eq('argument_hash', $query->createNamedParameter(hash('sha256', $argument))))
 			->setMaxResults(1);
 
 		$result = $query->executeQuery();


### PR DESCRIPTION
As we are using this hash as ID, it makes it more reliable than the current md5 hash we are using.