### PR TITLE
fix(FileInfo): correctly implement `\ArrayAccess::offsetGet`

### DIFF
--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -95,11 +95,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		unset($this->data[$offset]);
 	}
 
-	/**
-	 * @return mixed
-	 */
-	#[\ReturnTypeWillChange]
-	public function offsetGet($offset) {
+	public function offsetGet(mixed $offset): mixed {
 		return match ($offset) {
 			'type' => $this->getType(),
 			'etag' => $this->getEtag(),
@@ -164,7 +160,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return string
 	 */
 	public function getEtag() {
-		$this->updateEntryfromSubMounts();
+		$this->updateEntryFromSubMounts();
 		if (count($this->childEtags) > 0) {
 			$combinedEtag = $this->data['etag'] . '::' . implode('::', $this->childEtags);
 			return md5($combinedEtag);
@@ -179,7 +175,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 */
 	public function getSize($includeMounts = true) {
 		if ($includeMounts) {
-			$this->updateEntryfromSubMounts();
+			$this->updateEntryFromSubMounts();
 
 			if ($this->isEncrypted() && isset($this->data['unencrypted_size']) && $this->data['unencrypted_size'] > 0) {
 				return $this->data['unencrypted_size'];
@@ -195,7 +191,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	 * @return int
 	 */
 	public function getMTime() {
-		$this->updateEntryfromSubMounts();
+		$this->updateEntryFromSubMounts();
 		return (int)$this->data['mtime'];
 	}
 
@@ -318,7 +314,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 		$this->subMounts = $mounts;
 	}
 
-	private function updateEntryfromSubMounts(): void {
+	private function updateEntryFromSubMounts(): void {
 		if ($this->subMountsUsed) {
 			return;
 		}


### PR DESCRIPTION
## Summary

We are targeting PHP 8.1+, since PHP 8.0 `offsetGet` has the `mixed` types for `offset` and return value. So this adds the types to correctly implement the interface.
Also fix a minor capitalization issue in a private function.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
