### PR TITLE
feat(carddav): add command to list address books

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -53,6 +53,7 @@
 
 	<commands>
 		<command>OCA\DAV\Command\CreateAddressBook</command>
+		<command>OCA\DAV\Command\ListAddressbooks</command>
 		<command>OCA\DAV\Command\CreateCalendar</command>
 		<command>OCA\DAV\Command\CreateSubscription</command>
 		<command>OCA\DAV\Command\DeleteCalendar</command>

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -156,6 +156,7 @@ return array(
     'OCA\\DAV\\Command\\CreateSubscription' => $baseDir . '/../lib/Command/CreateSubscription.php',
     'OCA\\DAV\\Command\\DeleteCalendar' => $baseDir . '/../lib/Command/DeleteCalendar.php',
     'OCA\\DAV\\Command\\FixCalendarSyncCommand' => $baseDir . '/../lib/Command/FixCalendarSyncCommand.php',
+    'OCA\\DAV\\Command\\ListAddressbooks' => $baseDir . '/../lib/Command/ListAddressbooks.php',
     'OCA\\DAV\\Command\\ListCalendars' => $baseDir . '/../lib/Command/ListCalendars.php',
     'OCA\\DAV\\Command\\MoveCalendar' => $baseDir . '/../lib/Command/MoveCalendar.php',
     'OCA\\DAV\\Command\\RemoveInvalidShares' => $baseDir . '/../lib/Command/RemoveInvalidShares.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -171,6 +171,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Command\\CreateSubscription' => __DIR__ . '/..' . '/../lib/Command/CreateSubscription.php',
         'OCA\\DAV\\Command\\DeleteCalendar' => __DIR__ . '/..' . '/../lib/Command/DeleteCalendar.php',
         'OCA\\DAV\\Command\\FixCalendarSyncCommand' => __DIR__ . '/..' . '/../lib/Command/FixCalendarSyncCommand.php',
+        'OCA\\DAV\\Command\\ListAddressbooks' => __DIR__ . '/..' . '/../lib/Command/ListAddressbooks.php',
         'OCA\\DAV\\Command\\ListCalendars' => __DIR__ . '/..' . '/../lib/Command/ListCalendars.php',
         'OCA\\DAV\\Command\\MoveCalendar' => __DIR__ . '/..' . '/../lib/Command/MoveCalendar.php',
         'OCA\\DAV\\Command\\RemoveInvalidShares' => __DIR__ . '/..' . '/../lib/Command/RemoveInvalidShares.php',

--- a/apps/dav/lib/Command/ListAddressbooks.php
+++ b/apps/dav/lib/Command/ListAddressbooks.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Command;
+
+use OCA\DAV\CardDAV\CardDavBackend;
+use OCA\DAV\CardDAV\SystemAddressbook;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListAddressbooks extends Command {
+	public function __construct(
+		protected IUserManager $userManager,
+		private CardDavBackend $cardDavBackend,
+	) {
+		parent::__construct('dav:list-addressbooks');
+	}
+
+	protected function configure(): void {
+		$this
+			->setDescription('List all addressbooks of a user')
+			->addArgument('uid',
+				InputArgument::REQUIRED,
+				'User for whom all addressbooks will be listed');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$user = $input->getArgument('uid');
+		if (!$this->userManager->userExists($user)) {
+			throw new \InvalidArgumentException("User <$user> is unknown.");
+		}
+
+		$addressBooks = $this->cardDavBackend->getAddressBooksForUser("principals/users/$user");
+
+		$addressBookTableData = [];
+		foreach ($addressBooks as $book) {
+			// skip system / contacts integration address book
+			if ($book['uri'] === SystemAddressbook::URI_SHARED) {
+				continue;
+			}
+
+			$readOnly = false;
+			$readOnlyIndex = '{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only';
+			if (isset($book[$readOnlyIndex])) {
+				$readOnly = $book[$readOnlyIndex];
+			}
+
+			$addressBookTableData[] = [
+				$book['uri'],
+				$book['{DAV:}displayname'],
+				$book['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal'] ?? $book['principaluri'],
+				$book['{' . \OCA\DAV\DAV\Sharing\Plugin::NS_NEXTCLOUD . '}owner-displayname'],
+				$readOnly ? ' x ' : ' ✓ ',
+			];
+		}
+
+		if (count($addressBookTableData) > 0) {
+			$table = new Table($output);
+			$table->setHeaders(['Database ID', 'URI', 'Displayname', 'Owner principal', 'Owner displayname', 'Writable'])
+				->setRows($addressBookTableData);
+
+			$table->render();
+		} else {
+			$output->writeln("<info>User <$user> has no addressbooks</info>");
+		}
+		return self::SUCCESS;
+	}
+}

--- a/apps/dav/lib/Command/ListCalendars.php
+++ b/apps/dav/lib/Command/ListCalendars.php
@@ -63,7 +63,7 @@ class ListCalendars extends Command {
 
 		if (count($calendarTableData) > 0) {
 			$table = new Table($output);
-			$table->setHeaders(['uri', 'displayname', 'owner\'s userid', 'owner\'s displayname', 'writable'])
+			$table->setHeaders(['URI', 'Displayname', 'Owner principal', 'Owner displayname', 'Writable'])
 				->setRows($calendarTableData);
 
 			$table->render();

--- a/apps/dav/tests/unit/Command/ListAddressbooksTest.php
+++ b/apps/dav/tests/unit/Command/ListAddressbooksTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Tests\Command;
+
+use OCA\DAV\CardDAV\CardDavBackend;
+use OCA\DAV\Command\ListAddressbooks;
+use OCP\IUserManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Tester\CommandTester;
+use Test\TestCase;
+
+/**
+ * Class ListCalendarsTest
+ *
+ * @package OCA\DAV\Tests\Command
+ */
+class ListAddressbooksTest extends TestCase {
+
+	private \OCP\IUserManager|MockObject $userManager;
+	private CardDavBackend|MockObject $cardDavBackend;
+	private ListAddressbooks $command;
+
+	public const USERNAME = 'username';
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->cardDavBackend = $this->createMock(CardDavBackend::class);
+
+		$this->command = new ListAddressbooks(
+			$this->userManager,
+			$this->cardDavBackend
+		);
+	}
+
+	public function testWithBadUser(): void {
+		$this->expectException(\InvalidArgumentException::class);
+
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with(self::USERNAME)
+			->willReturn(false);
+
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'uid' => self::USERNAME,
+		]);
+		$this->assertStringContainsString('User <' . self::USERNAME . '> in unknown', $commandTester->getDisplay());
+	}
+
+	public function testWithCorrectUserWithNoCalendars(): void {
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with(self::USERNAME)
+			->willReturn(true);
+
+		$this->cardDavBackend->expects($this->once())
+			->method('getAddressBooksForUser')
+			->with('principals/users/' . self::USERNAME)
+			->willReturn([]);
+
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'uid' => self::USERNAME,
+		]);
+		$this->assertStringContainsString('User <' . self::USERNAME . "> has no addressbooks\n", $commandTester->getDisplay());
+	}
+
+	public function dataExecute() {
+		return [
+			[false, '✓'],
+			[true, 'x']
+		];
+	}
+
+	/**
+	 * @dataProvider dataExecute
+	 */
+	public function testWithCorrectUser(bool $readOnly, string $output): void {
+		$this->userManager->expects($this->once())
+			->method('userExists')
+			->with(self::USERNAME)
+			->willReturn(true);
+
+		$this->cardDavBackend->expects($this->once())
+			->method('getAddressBooksForUser')
+			->with('principals/users/' . self::USERNAME)
+			->willReturn([
+				[
+					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}read-only' => $readOnly,
+					'uri' => 'test',
+					'{DAV:}displayname' => 'dp',
+					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_OWNCLOUD . '}owner-principal' => 'owner-principal',
+					'{' . \OCA\DAV\DAV\Sharing\Plugin::NS_NEXTCLOUD . '}owner-displayname' => 'owner-dp',
+				]
+			]);
+
+		$commandTester = new CommandTester($this->command);
+		$commandTester->execute([
+			'uid' => self::USERNAME,
+		]);
+		$this->assertStringContainsString($output, $commandTester->getDisplay());
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
FOr https://github.com/nextcloud/server/issues/23509 to make sense, we need a way to list address books as well if we want an admin to have the full information for sharing / unsharing

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] ~~Screenshots before/after for front-end changes~~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] ~~[Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)~~
