### PR TITLE
chore(files): Use public API where possible

### DIFF
--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -119,16 +119,18 @@ class Helper {
 	public static function formatFileInfo(FileInfo $i) {
 		$entry = [];
 
-		$entry['id'] = $i['fileid'];
-		$entry['parentId'] = $i['parent'];
-		$entry['mtime'] = $i['mtime'] * 1000;
+		$entry['id'] = $i->getId();
+		$entry['parentId'] = $i->getParentId();
+		$entry['mtime'] = $i->getMtime() * 1000;
 		// only pick out the needed attributes
 		$entry['name'] = $i->getName();
-		$entry['permissions'] = $i['permissions'];
-		$entry['mimetype'] = $i['mimetype'];
-		$entry['size'] = $i['size'];
-		$entry['type'] = $i['type'];
-		$entry['etag'] = $i['etag'];
+		$entry['permissions'] = $i->getPermissions();
+		$entry['mimetype'] = $i->getMimetype();
+		$entry['size'] = $i->getSize();
+		$entry['type'] = $i->getType();
+		$entry['etag'] = $i->getEtag();
+		// TODO: this is using the private implementation of FileInfo
+		// the array access is not part of the public interface
 		if (isset($i['tags'])) {
 			$entry['tags'] = $i['tags'];
 		}
@@ -138,6 +140,10 @@ class Helper {
 		if (isset($i['is_share_mount_point'])) {
 			$entry['isShareMountPoint'] = $i['is_share_mount_point'];
 		}
+		if (isset($i['extraData'])) {
+			$entry['extraData'] = $i['extraData'];
+		}
+
 		$mountType = null;
 		$mount = $i->getMountPoint();
 		$mountType = $mount->getMountType();
@@ -146,9 +152,6 @@ class Helper {
 				$mountType .= '-root';
 			}
 			$entry['mountType'] = $mountType;
-		}
-		if (isset($i['extraData'])) {
-			$entry['extraData'] = $i['extraData'];
 		}
 		return $entry;
 	}

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -802,14 +802,6 @@
       <code><![CDATA[$i]]></code>
       <code><![CDATA[$i]]></code>
       <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
-      <code><![CDATA[$i]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="apps/files/lib/Service/OwnershipTransferService.php">


### PR DESCRIPTION
## Summary

This is not fixing all issues in the helper, but at least where possible use the public methods.
For the rest I am not sure what the best solution would be, just ignore? Make the data access public (probably not)...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
