### PR TITLE
fix: Replace conflicting tags in `xml_exception` template

### DIFF
--- a/core/templates/xml_exception.php
+++ b/core/templates/xml_exception.php
@@ -15,8 +15,8 @@ function print_exception(Throwable $e, \OCP\IL10N $l): void {
 	}
 }
 
+print_unescaped('<?xml version="1.0" encoding="utf-8"?>' . "\n");
 ?>
-<?xml version="1.0" encoding="utf-8"?>
 <d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
 	<s:exception><?php p($l->t('Internal Server Error')) ?></s:exception>
 	<s:message>


### PR DESCRIPTION
* Regression of https://github.com/nextcloud/server/pull/47770

## Summary

The `<?xml` tag is interpreted as PHP short tags, so this causes errors. Instead just print that part of the template.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
