### PR TITLE
fix(appstore): return if appstore is manually disabled

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -148,9 +148,16 @@ class AppFetcher extends Fetcher {
 		$this->ignoreMaxVersion = $ignoreMaxVersion;
 	}
 
-
-	public function get($allowUnstable = false) {
+	public function get($allowUnstable = false): array {
 		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
+
+		$appStoreEnabled = $this->config->getSystemValueBool('appstoreenabled', true);
+		$internetAvailable = $this->config->getSystemValueBool('has_internet_connection', true);
+
+		if (!$appStoreEnabled || !$internetAvailable) {
+			$this->logger->debug('AppStore is disabled or this instance has no Internet connection', ['app' => 'appstoreFetcher']);
+			return [];
+		}
 
 		$apps = parent::get($allowPreReleases);
 		if (empty($apps)) {

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -155,7 +155,7 @@ class AppFetcher extends Fetcher {
 		$internetAvailable = $this->config->getSystemValueBool('has_internet_connection', true);
 
 		if (!$appStoreEnabled || !$internetAvailable) {
-			$this->logger->debug('AppStore is disabled or this instance has no Internet connection', ['app' => 'appstoreFetcher']);
+			$this->logger->info('AppStore is disabled or this instance has no Internet connection', ['app' => 'appstoreFetcher']);
 			return [];
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/47833

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
