### PR TITLE
fix(files): Never return a null ETag in DAV

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -391,7 +391,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 	 * get the ETag for a file or folder
 	 *
 	 * @param string $path
-	 * @return string
+	 * @return string|false
 	 */
 	public function getETag($path) {
 		return uniqid();

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -721,10 +721,9 @@ class DAV extends Common {
 		return $stat ? $stat['permissions'] : 0;
 	}
 
-	/** {@inheritdoc} */
 	public function getETag($path) {
 		$meta = $this->getMetaData($path);
-		return $meta ? $meta['etag'] : null;
+		return $meta ? $meta['etag'] : false;
 	}
 
 	/**

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -513,17 +513,11 @@ class Local extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	/**
-	 * get the ETag for a file or folder
-	 *
-	 * @param string $path
-	 * @return string
-	 */
 	public function getETag($path) {
 		return $this->calculateEtag($path, $this->stat($path));
 	}
 
-	private function calculateEtag(string $path, array $stat): string {
+	private function calculateEtag(string $path, array $stat): string|false {
 		if ($stat['mode'] & 0x4000 && !($stat['mode'] & 0x8000)) { // is_dir & not socket
 			return parent::getETag($path);
 		} else {


### PR DESCRIPTION
## Summary

Introduced by https://github.com/nextcloud/server/pull/47731. Psalm should have already complained before, but never did. There was also no baseline update so idk why we only see it now.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
