### PR TITLE
Add an endpoint to remove all webhook registrations from an app

### DIFF
--- a/apps/webhook_listeners/lib/Controller/WebhooksController.php
+++ b/apps/webhook_listeners/lib/Controller/WebhooksController.php
@@ -247,7 +247,7 @@ class WebhooksController extends OCSController {
 	 *
 	 * @return DataResponse<Http::STATUS_OK, bool, array{}>
 	 *
-	 * 200: Boolean returned whether something was deleted FIXME
+	 * 200: Boolean returned whether something was deleted
 	 *
 	 * @throws OCSBadRequestException Bad request
 	 * @throws OCSForbiddenException Insufficient permissions
@@ -266,6 +266,36 @@ class WebhooksController extends OCSController {
 			throw new OCSForbiddenException($e->getMessage(), $e);
 		} catch (\Exception $e) {
 			$this->logger->error('Error when deleting flow with id ' . $id, ['exception' => $e]);
+			throw new OCSException('An internal error occurred', Http::STATUS_INTERNAL_SERVER_ERROR, $e);
+		}
+	}
+
+	/**
+	 * Remove all existing webhook registration mapped to an AppAPI app id
+	 *
+	 * @param string $appid id of the app, as in the EX-APP-ID for creation
+	 *
+	 * @return DataResponse<Http::STATUS_OK, int, array{}>
+	 *
+	 * 200: Integer number of registrations deleted
+	 *
+	 * @throws OCSBadRequestException Bad request
+	 * @throws OCSForbiddenException Insufficient permissions
+	 * @throws OCSException Other error
+	 */
+	#[ApiRoute(verb: 'DELETE', url: '/api/v1/webhooks/byappid/{appid}')]
+	#[AuthorizedAdminSetting(settings:Admin::class)]
+	#[AppApiAdminAccessWithoutUser]
+	public function deleteByAppId(string $appid): DataResponse {
+		try {
+			$deletedCount = $this->mapper->deleteByAppId($appid);
+			return new DataResponse($deletedCount);
+		} catch (\UnexpectedValueException $e) {
+			throw new OCSBadRequestException($e->getMessage(), $e);
+		} catch (\DomainException $e) {
+			throw new OCSForbiddenException($e->getMessage(), $e);
+		} catch (\Exception $e) {
+			$this->logger->error('Error when deleting flows for app id ' . $appid, ['exception' => $e]);
 			throw new OCSException('An internal error occurred', Http::STATUS_INTERNAL_SERVER_ERROR, $e);
 		}
 	}

--- a/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListenerMapper.php
@@ -160,6 +160,21 @@ class WebhookListenerMapper extends QBMapper {
 	}
 
 	/**
+	 * Delete all registrations made by the given appId
+	 *
+	 * @throws Exception
+	 * @return int number of registration deleted
+	 */
+	public function deleteByAppId(string $appId): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('app_id', $qb->createNamedParameter($appId, IQueryBuilder::PARAM_STR)));
+
+		return $qb->executeStatement();
+	}
+
+	/**
 	 * @throws Exception
 	 * @return list<string>
 	 */

--- a/apps/webhook_listeners/openapi.json
+++ b/apps/webhook_listeners/openapi.json
@@ -686,7 +686,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Boolean returned whether something was deleted FIXME",
+                        "description": "Boolean returned whether something was deleted",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -707,6 +707,134 @@
                                                 },
                                                 "data": {
                                                     "type": "boolean"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Insufficient permissions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/ocs/v2.php/apps/webhook_listeners/api/v1/webhooks/byappid/{appid}": {
+            "delete": {
+                "operationId": "webhooks-delete-by-app-id",
+                "summary": "Remove all existing webhook registration mapped to an AppAPI app id",
+                "description": "This endpoint requires admin access",
+                "tags": [
+                    "webhooks"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "appid",
+                        "in": "path",
+                        "description": "id of the app, as in the EX-APP-ID for creation",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Integer number of registrations deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "integer",
+                                                    "format": "int64"
                                                 }
                                             }
                                         }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Add a mapper method and an endpoint to clear all webhook registrations related to a given AppAPI id.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
