### PR TITLE
fix: provision api's status codes

### DIFF
--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -488,7 +488,7 @@ class UsersController extends AUserData {
 				$group = $this->groupManager->get($groupid);
 				// Check if group exists
 				if ($group === null) {
-					throw new OCSException($this->l10n->t('Sub-admin group does not exist'), 102);
+					throw new OCSException($this->l10n->t('Sub-admin group does not exist'), 109);
 				}
 				// Check if trying to make subadmin of admin group
 				if ($group->getGID() === 'admin') {
@@ -508,7 +508,7 @@ class UsersController extends AUserData {
 		}
 		if ($password === '') {
 			if ($email === '') {
-				throw new OCSException($this->l10n->t('To send a password link to the user an email address is required.'), 108);
+				throw new OCSException($this->l10n->t('An email address is required, to send a password link to the user.'), 108);
 			}
 
 			$passwordEvent = new GenerateSecurePasswordEvent();
@@ -1011,7 +1011,7 @@ class UsersController extends AUserData {
 		}
 		// Check if permitted to edit this field
 		if (!in_array($key, $permittedFields)) {
-			throw new OCSException('', 103);
+			throw new OCSException('', 113);
 		}
 		// Process the edit
 		switch ($key) {
@@ -1032,14 +1032,14 @@ class UsersController extends AUserData {
 						$quota = \OCP\Util::computerFileSize($quota);
 					}
 					if ($quota === false) {
-						throw new OCSException($this->l10n->t('Invalid quota value: %1$s', [$value]), 102);
+						throw new OCSException($this->l10n->t('Invalid quota value: %1$s', [$value]), 101);
 					}
 					if ($quota === -1) {
 						$quota = 'none';
 					} else {
 						$maxQuota = (int)$this->config->getAppValue('files', 'max_quota', '-1');
 						if ($maxQuota !== -1 && $quota > $maxQuota) {
-							throw new OCSException($this->l10n->t('Invalid quota value. %1$s is exceeding the maximum quota', [$value]), 102);
+							throw new OCSException($this->l10n->t('Invalid quota value. %1$s is exceeding the maximum quota', [$value]), 101);
 						}
 						$quota = \OCP\Util::humanFileSize($quota);
 					}
@@ -1048,7 +1048,7 @@ class UsersController extends AUserData {
 				if ($quota === 'none') {
 					$allowUnlimitedQuota = $this->config->getAppValue('files', 'allow_unlimited_quota', '1') === '1';
 					if (!$allowUnlimitedQuota) {
-						throw new OCSException($this->l10n->t('Unlimited quota is forbidden on this instance'), 102);
+						throw new OCSException($this->l10n->t('Unlimited quota is forbidden on this instance'), 101);
 					}
 				}
 				$targetUser->setQuota($quota);
@@ -1059,33 +1059,33 @@ class UsersController extends AUserData {
 			case self::USER_FIELD_PASSWORD:
 				try {
 					if (strlen($value) > IUserManager::MAX_PASSWORD_LENGTH) {
-						throw new OCSException($this->l10n->t('Invalid password value'), 102);
+						throw new OCSException($this->l10n->t('Invalid password value'), 101);
 					}
 					if (!$targetUser->canChangePassword()) {
-						throw new OCSException($this->l10n->t('Setting the password is not supported by the users backend'), 103);
+						throw new OCSException($this->l10n->t('Setting the password is not supported by the users backend'), 112);
 					}
 					$targetUser->setPassword($value);
 				} catch (HintException $e) { // password policy error
-					throw new OCSException($e->getMessage(), 103);
+					throw new OCSException($e->getMessage(), 107);
 				}
 				break;
 			case self::USER_FIELD_LANGUAGE:
 				$languagesCodes = $this->l10nFactory->findAvailableLanguages();
 				if (!in_array($value, $languagesCodes, true) && $value !== 'en') {
-					throw new OCSException($this->l10n->t('Invalid language'), 102);
+					throw new OCSException($this->l10n->t('Invalid language'), 101);
 				}
 				$this->config->setUserValue($targetUser->getUID(), 'core', 'lang', $value);
 				break;
 			case self::USER_FIELD_LOCALE:
 				if (!$this->l10nFactory->localeExists($value)) {
-					throw new OCSException($this->l10n->t('Invalid locale'), 102);
+					throw new OCSException($this->l10n->t('Invalid locale'), 101);
 				}
 				$this->config->setUserValue($targetUser->getUID(), 'core', 'locale', $value);
 				break;
 			case self::USER_FIELD_FIRST_DAY_OF_WEEK:
 				$intValue = (int)$value;
 				if ($intValue < -1 || $intValue > 6) {
-					throw new OCSException($this->l10n->t('Invalid first day of week'), 102);
+					throw new OCSException($this->l10n->t('Invalid first day of week'), 101);
 				}
 				if ($intValue === -1) {
 					$this->config->deleteUserValue($targetUser->getUID(), 'core', AUserData::USER_FIELD_FIRST_DAY_OF_WEEK);
@@ -1110,14 +1110,14 @@ class UsersController extends AUserData {
 					}
 				}
 				if (!$success) {
-					throw new OCSException('', 102);
+					throw new OCSException('', 101);
 				}
 				break;
 			case IAccountManager::PROPERTY_EMAIL:
 				if (filter_var($value, FILTER_VALIDATE_EMAIL) || $value === '') {
 					$targetUser->setEMailAddress($value);
 				} else {
-					throw new OCSException('', 102);
+					throw new OCSException('', 101);
 				}
 				break;
 			case IAccountManager::COLLECTION_EMAIL:
@@ -1126,13 +1126,13 @@ class UsersController extends AUserData {
 					$mailCollection = $userAccount->getPropertyCollection(IAccountManager::COLLECTION_EMAIL);
 
 					if ($mailCollection->getPropertyByValue($value)) {
-						throw new OCSException('', 102);
+						throw new OCSException('', 101);
 					}
 
 					$mailCollection->addPropertyWithDefaults($value);
 					$this->accountManager->updateAccount($userAccount);
 				} else {
-					throw new OCSException('', 102);
+					throw new OCSException('', 101);
 				}
 				break;
 			case IAccountManager::PROPERTY_PHONE:
@@ -1156,7 +1156,7 @@ class UsersController extends AUserData {
 								$this->knownUserService->deleteByContactUserId($targetUser->getUID());
 							}
 						} catch (InvalidArgumentException $e) {
-							throw new OCSException('Invalid ' . $e->getMessage(), 102);
+							throw new OCSException('Invalid ' . $e->getMessage(), 101);
 						}
 					}
 				} catch (PropertyDoesNotExistException $e) {
@@ -1165,7 +1165,7 @@ class UsersController extends AUserData {
 				try {
 					$this->accountManager->updateAccount($userAccount);
 				} catch (InvalidArgumentException $e) {
-					throw new OCSException('Invalid ' . $e->getMessage(), 102);
+					throw new OCSException('Invalid ' . $e->getMessage(), 101);
 				}
 				break;
 			case IAccountManager::PROPERTY_PROFILE_ENABLED:
@@ -1203,12 +1203,12 @@ class UsersController extends AUserData {
 						$userProperty->setScope($value);
 						$this->accountManager->updateAccount($userAccount);
 					} catch (InvalidArgumentException $e) {
-						throw new OCSException('Invalid ' . $e->getMessage(), 102);
+						throw new OCSException('Invalid ' . $e->getMessage(), 101);
 					}
 				}
 				break;
 			default:
-				throw new OCSException('', 103);
+				throw new OCSException('', 113);
 		}
 		return new DataResponse();
 	}

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -1623,7 +1623,7 @@ class UsersControllerTest extends TestCase {
 			->with($userAccount);
 
 		$this->expectException(OCSException::class);
-		$this->expectExceptionCode(102);
+		$this->expectExceptionCode(101);
 		$this->api->editUser('UserToEdit', 'additional_mail', 'demo@nextcloud.com')->getData();
 	}
 
@@ -1682,13 +1682,13 @@ class UsersControllerTest extends TestCase {
 			->with($userAccount);
 
 		$this->expectException(OCSException::class);
-		$this->expectExceptionCode(102);
+		$this->expectExceptionCode(101);
 		$this->api->editUser('UserToEdit', 'additional_mail', 'demo1@nextcloud.com')->getData();
 	}
 
 	public function testEditUserRegularUserSelfEditChangeEmailInvalid(): void {
 		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
-		$this->expectExceptionCode(102);
+		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
@@ -1922,7 +1922,7 @@ class UsersControllerTest extends TestCase {
 
 	public function testEditUserRegularUserSelfEditChangeQuota(): void {
 		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
-		$this->expectExceptionCode(103);
+		$this->expectExceptionCode(113);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
@@ -2009,7 +2009,7 @@ class UsersControllerTest extends TestCase {
 	public function testEditUserAdminUserSelfEditChangeInvalidQuota(): void {
 		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
 		$this->expectExceptionMessage('Invalid quota value: ABC');
-		$this->expectExceptionCode(102);
+		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
 		$loggedInUser

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -214,7 +214,7 @@ Feature: provisioning
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
       | value | no-reply@nextcloud.com |
-    And the OCS status code should be "102"
+    And the OCS status code should be "101"
     And the HTTP status code should be "200"
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
@@ -225,7 +225,7 @@ Feature: provisioning
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | additional_mail |
       | value | no.reply2@nextcloud.com |
-    And the OCS status code should be "102"
+    And the OCS status code should be "101"
     And the HTTP status code should be "200"
     Then user "brand-new-user" has
       | id | brand-new-user |
@@ -270,17 +270,17 @@ Feature: provisioning
     When sending "PUT" to "/cloud/users/brand-new-user" with
       | key | phoneScope |
       | value | invalid |
-    Then the OCS status code should be "102"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     When sending "PUT" to "/cloud/users/brand-new-user" with
       | key | displaynameScope |
       | value | v2-private |
-    Then the OCS status code should be "102"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
     When sending "PUT" to "/cloud/users/brand-new-user" with
       | key | emailScope |
       | value | v2-private |
-    Then the OCS status code should be "102"
+    Then the OCS status code should be "101"
     And the HTTP status code should be "200"
 
   Scenario: Edit a user account multi-value property scopes with invalid or unsupported value
@@ -326,7 +326,7 @@ Feature: provisioning
     When sending "PUT" to "/cloud/users/brand-new-user" with
       | key | phoneScope |
       | value | v2-private |
-    Then the OCS status code should be "103"
+    Then the OCS status code should be "113"
     And the HTTP status code should be "200"
 
   Scenario: Search by phone number


### PR DESCRIPTION
## Summary
`addUser`calls `editUser` which creates inconsistencies in status codes 

## TODO
- [x] Get this approved 
- [x] Backport 
- [x] Update documentation https://github.com/nextcloud/documentation/pull/12249

## More info 
# OLD

## CODE:

# New user ( affected by  Edit user exceptions )

101: Invalid password value/argument 

102: User already exists | Sub-admin group does not exist 

103: Cannot create sub-admins for admin group 

104: Group does not exist 

105: Insufficient privileges for group

106: No group specified (required for sub-admins) 

107: Hint exceptions 

108: An email address is required, to send a password link to the user. 

110: Required email address was not provided

111: Could not create non-existing user ID

# Edit user:

101: Invalid argument 

102: Invalid Quota /password / language / locale / first day of the week 

103: No permission to edit a field / (password policy / Setting the password is not supported by the users backend) 

998: user Not found

## Documentation

# New user:

- 100 - successful
- 101 - invalid input data
- 102 - username already exists
- 103 - unknown error occurred whilst adding the user
- 104 - group does not exist
- 105 - insufficient privileges for group
- 106 - no group specified (required for subadmins)
- 107 - all errors that contain a hint - for example “Password is among the 1,000,000 most common ones. Please make it unique.” (this code was added in 12.0.6 & 13.0.1)
- 108 - password and email empty. Must set password or an email
- 109 - invitation email cannot be send

# Edit user:

- 100 - successful
- 101 - user not found
- 102 - invalid input data

# NEW

# New user ( affected by  Edit user exceptions )

101: Invalid password value/argument 

102: User already exists 

103: Cannot create sub-admins for admin group 

104: Group does not exist 

105: Insufficient privileges for group

106: No group specified (required for sub-admins) 

107: Hint exceptions 

108: An email address is required, to send a password link to the user. 

109: Sub-admin group does not exist 

110: Required email address was not provided

111: Could not create non-existing user ID

# Edit user:

101: Invalid argument /Invalid Quota /password / language / locale / first day of the week 

107: password policy (hint exception)

112:  Setting the password is not supported by the users backend

113: editing field not allowed/ field doesn’t exist

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
