### PR TITLE
Fix copying or moving from shared groupfolders

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -538,11 +538,13 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool {
 		if ($this->canDoCrossStorageMove($sourceStorage)) {
-			if ($sourceStorage->instanceOfStorage(Jail::class)) {
+			// resolve any jailed paths
+			while ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**
 				 * @var \OC\Files\Storage\Wrapper\Jail $sourceStorage
 				 */
 				$sourceInternalPath = $sourceStorage->getUnjailedPath($sourceInternalPath);
+				$sourceStorage = $sourceStorage->getUnjailedStorage();
 			}
 			/**
 			 * @var \OC\Files\Storage\Local $sourceStorage
@@ -556,11 +558,13 @@ class Local extends \OC\Files\Storage\Common {
 
 	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($this->canDoCrossStorageMove($sourceStorage)) {
-			if ($sourceStorage->instanceOfStorage(Jail::class)) {
+			// resolve any jailed paths
+			while ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**
 				 * @var \OC\Files\Storage\Wrapper\Jail $sourceStorage
 				 */
 				$sourceInternalPath = $sourceStorage->getUnjailedPath($sourceInternalPath);
+				$sourceStorage = $sourceStorage->getUnjailedStorage();
 			}
 			/**
 			 * @var \OC\Files\Storage\Local $sourceStorage

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -7,6 +7,8 @@
 
 namespace Test\Files\Storage;
 
+use OC\Files\Storage\Wrapper\Jail;
+
 /**
  * Class LocalTest
  *
@@ -134,5 +136,26 @@ class LocalTest extends Storage {
 		$this->instance = new \OC\Files\Storage\Local(['datadir' => $this->tmpDir . '/unexist']);
 		// no exception thrown
 		$this->assertNotNull($this->instance);
+	}
+
+	public function testMoveNestedJail(): void {
+		$this->instance->mkdir('foo');
+		$this->instance->mkdir('foo/bar');
+		$this->instance->mkdir('target');
+		$this->instance->file_put_contents('foo/bar/file.txt', 'foo');
+		$jail1 = new Jail([
+			'storage' => $this->instance,
+			'root' => 'foo'
+		]);
+		$jail2 = new Jail([
+			'storage' => $jail1,
+			'root' => 'bar'
+		]);
+		$jail3 = new Jail([
+			'storage' => $this->instance,
+			'root' => 'target'
+		]);
+		$jail3->moveFromStorage($jail2, 'file.txt', 'file.txt');
+		$this->assertTrue($this->instance->file_exists('target/file.txt'));
 	}
 }


### PR DESCRIPTION
When copying a shared groupfolder into another local folder the whole data directory ends being (recursively) copied to the other folder. There are other scenarios that fail, but that one is probably the most severe one.

The problem is that shared groupfolders have two jails, [one for the shared storage](https://github.com/nextcloud/server/blob/af6de04e9e141466dc229e444ff3f146f4a34765/apps/files_sharing/lib/SharedStorage.php#L39) and [another one for the groupfolder storage](https://github.com/nextcloud/groupfolders/blob/bd1947df4909ae906f58ce9590e425d6e5dde66b/lib/Mount/MountProvider.php#L234-L237) wrapped by the shared storage, and when a file or folder is copied between two local storages the source path (on disk) to copy or move from is got from the unjailed path of the source storage. However, if the source storage has more than one jail getting the unjailed path resolves the most external jail, but the source path needs to be got from the most internal jail instead (the one closer to the local storage).

In the case of a shared groupfolder the external unjailed path of the shared groupfolder itself is `""`, and when getting the source path of `""` in the local storage [the full path ends being the data directory](https://github.com/nextcloud/server/blob/181aecad4c4c1ab62a5e3e5476cb8cdbe530bbee/lib/private/Files/Storage/Local.php#L482), so [the whole data directory ends being copied to the target](https://github.com/nextcloud/server/blob/181aecad4c4c1ab62a5e3e5476cb8cdbe530bbee/lib/private/Files/Storage/Local.php#L372).

[The fix is based on the code from `Common::moveFromStorage`](https://github.com/nextcloud/server/blob/70fa51f042014cfaf80d489a838eafc4b08192b3/lib/private/Files/Storage/Common.php#L614-L621), which already uses the most internal unjailed path.

E2E tests (as integration tests are not setup yet in the groupfolders app) were added in nextcloud/groupfolders#3185

Note that the issue can not be reproduced when trying to move the shared groupfolder into another folder (not shared and in the same parent mount) because, in that case, [the shared mount is moved](https://github.com/nextcloud/server/blob/0308001118462f5a6369fed313b844f631a43bcb/lib/private/Files/View.php#L767-L769). On the other hand, it can be reproduced when trying to move a file from the shared groupfolder into another folder, as in that case [`moveFromStorage` is used](https://github.com/nextcloud/server/blob/0308001118462f5a6369fed313b844f631a43bcb/lib/private/Files/View.php#L785). Thus the slightly different scenarios below, one copying the whole shared groupfolder, and one moving a file from the shared groupfolder.

Beware when testing the scenario 1 below, as it will mess with the Nextcloud data directory and can potentially take a lot of disk space.

## How to test (scenario 1)

- Create two users
- Create a group and add user A to the group
- Enable groupfolders app
- Create a groupfolder for the group of user A
- Log in as user A
- Share the groupfolder with user B
- Log in as user B
- Create a folder
- Copy the shared groupfolder into the folder

### Result with this pull request

The copy succeeds; opening the target directory shows the copied groupfolder

### Result without this pull request

The copy eventually fails; although the WebUI might not show any file inside the target directory, if the filesystem is checked it can be seen that it tried to recursively copy the Nextcloud data directory into the target



## How to test (scenario 2)

- Create two users
- Create a group and add user A to the group
- Enable groupfolders app
- Create a groupfolder for the group of user A
- Log in as user A
- Open groupfolder
- Upload a file
- Share the groupfolder with user B
- Log in as user B
- Create a folder
- Open shared groupfolder
- Move the file into the folder

### Result with this pull request

The move succeeds; opening the target directory shows the moved file

### Result without this pull request

The move fails; the Nextcloud logs contain an error about not being able to move `{NEXTCLOUD_DATA_DIRECTORY}/{NAME_OF_THE_FILE_TO_MOVE}`
