### PR TITLE
fix(preview): gracefully handle file not being opened in ProviderV2

### DIFF
--- a/lib/private/Preview/ProviderV2.php
+++ b/lib/private/Preview/ProviderV2.php
@@ -71,6 +71,9 @@ abstract class ProviderV2 implements IProviderV2 {
 			$absPath = \OC::$server->getTempManager()->getTemporaryFile();
 
 			$content = $file->fopen('r');
+			if ($content === false) {
+				return false;
+			}
 
 			if ($maxSize) {
 				$content = stream_get_contents($content, $maxSize);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/previewgenerator/issues/510

## Summary

Sometimes, the call to `fopen` fails, e.g. if the file resides on an external storage which is not available. We should handle this case gracefully and just return `false` which is also compliant with the method's return type `@return string|false`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
