### PR TITLE
fix: Only write once to template instead of create/copy

### DIFF
--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -144,11 +144,9 @@ class TemplateManager implements ITemplateManager {
 				throw new GenericFileException($this->l10n->t('Invalid path'));
 			}
 			$folder = $userFolder->get(dirname($filePath));
-			$targetFile = $folder->newFile(basename($filePath));
 			$template = null;
 			if ($templateType === 'user' && $templateId !== '') {
 				$template = $userFolder->get($templateId);
-				$template->copy($targetFile->getPath());
 			} else {
 				$matchingProvider = array_filter($this->getRegisteredProviders(), function (ICustomTemplateProvider $provider) use ($templateType) {
 					return $templateType === get_class($provider);
@@ -156,9 +154,11 @@ class TemplateManager implements ITemplateManager {
 				$provider = array_shift($matchingProvider);
 				if ($provider) {
 					$template = $provider->getCustomTemplate($templateId);
-					$template->copy($targetFile->getPath());
 				}
 			}
+
+			$targetFile = $folder->newFile(basename($filePath), ($template instanceof File ? $template->fopen('rb') : null));
+
 			$this->eventDispatcher->dispatchTyped(new FileCreatedFromTemplateEvent($template, $targetFile, $templateFields));
 			return $this->formatFile($userFolder->get($filePath));
 		} catch (\Exception $e) {


### PR DESCRIPTION
Avoid triggering two file operations (create/copy) and write the template content on creation directly to also trigger a NodeWrittenEvent