### PR TITLE
fix: `user:settings` command when user is not available

### DIFF
--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -219,7 +219,7 @@ class Setting extends Base {
 		}
 	}
 
-	protected function getUserSettings($uid, $app) {
+	protected function getUserSettings(string $uid, string $app): array {
 		$settings = $this->config->getAllUserValues($uid);
 		if ($app !== '') {
 			if (isset($settings[$app])) {
@@ -230,7 +230,10 @@ class Setting extends Base {
 		}
 
 		$user = $this->userManager->get($uid);
-		$settings['settings']['display_name'] = $user->getDisplayName();
+		if ($user !== null) {
+			// Only add the display name if the user exists
+			$settings['settings']['display_name'] = $user->getDisplayName();
+		}
 
 		return $settings;
 	}


### PR DESCRIPTION
## Summary

If `ignore-missing-user` all sub commands work, except listing all settings for a user like `occ user:settings --ignore-missing-user user core`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
