### PR TITLE
fix: allow deletion of user without LDAP connection

### DIFF
--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -206,7 +206,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 			try {
 				$existsOnLDAP = $this->userExistsOnLDAP($uid);
 			} catch(ServerNotAvailableException $e) {
-				$this->logger->info('Could not establish connection to LDAP server, deleting user locally' . $uid, ['exception' => $e]);
+				$this->logger->info('Could not establish connection to LDAP server, found user locally ' . $uid, ['exception' => $e]);
 			}
 		}
 		if ($existsLocally && !$existsOnLDAP) {

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\User_LDAP;
 
+use OC\ServerNotAvailableException;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
@@ -202,7 +203,11 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 		$existsOnLDAP = false;
 		$existsLocally = $this->handleRequest($uid, 'userExists', [$uid]);
 		if ($existsLocally) {
-			$existsOnLDAP = $this->userExistsOnLDAP($uid);
+			try {
+				$existsOnLDAP = $this->userExistsOnLDAP($uid);
+			} catch(ServerNotAvailableException $e) {
+				$this->logger->info('Could not establish connection to LDAP server, deleting user locally' . $uid, ['exception' => $e]);
+			}
 		}
 		if ($existsLocally && !$existsOnLDAP) {
 			try {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/44161

## Summary

This seems deceptively simple, and I'm not sure this is the correct way to do this.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
