### PR TITLE
fix: Add whiteboard to education and public sector bundle

### DIFF
--- a/lib/private/App/AppStore/Bundles/EducationBundle.php
+++ b/lib/private/App/AppStore/Bundles/EducationBundle.php
@@ -24,6 +24,7 @@ class EducationBundle extends Bundle {
 			'announcementcenter',
 			'quota_warning',
 			'user_saml',
+			'whiteboard',
 		];
 	}
 }

--- a/lib/private/App/AppStore/Bundles/PublicSectorBundle.php
+++ b/lib/private/App/AppStore/Bundles/PublicSectorBundle.php
@@ -28,6 +28,7 @@ class PublicSectorBundle extends Bundle {
 			'richdocuments',
 			'admin_audit',
 			'files_retention',
+			'whiteboard',
 		];
 	}
 

--- a/tests/lib/App/AppStore/Bundles/EducationBundleTest.php
+++ b/tests/lib/App/AppStore/Bundles/EducationBundleTest.php
@@ -21,6 +21,7 @@ class EducationBundleTest extends BundleBase {
 			'announcementcenter',
 			'quota_warning',
 			'user_saml',
+			'whiteboard',
 		];
 	}
 }


### PR DESCRIPTION
Adding the whiteboard to relevant app bundles

Contributes to https://github.com/nextcloud/whiteboard/issues/99