### PR TITLE
feat: Make `CheckServerResponseTrait` public and provide as `OCP\SetupCheck\CheckServerResponseTrait`

### DIFF
--- a/apps/dav/lib/SetupChecks/WebdavEndpoint.php
+++ b/apps/dav/lib/SetupChecks/WebdavEndpoint.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace OCA\DAV\SetupChecks;
 
-use OCA\Settings\SetupChecks\CheckServerResponseTrait;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -82,7 +82,6 @@ return array(
     'OCA\\Settings\\SetupChecks\\AllowedAdminRanges' => $baseDir . '/../lib/SetupChecks/AllowedAdminRanges.php',
     'OCA\\Settings\\SetupChecks\\AppDirsWithDifferentOwner' => $baseDir . '/../lib/SetupChecks/AppDirsWithDifferentOwner.php',
     'OCA\\Settings\\SetupChecks\\BruteForceThrottler' => $baseDir . '/../lib/SetupChecks/BruteForceThrottler.php',
-    'OCA\\Settings\\SetupChecks\\CheckServerResponseTrait' => $baseDir . '/../lib/SetupChecks/CheckServerResponseTrait.php',
     'OCA\\Settings\\SetupChecks\\CheckUserCertificates' => $baseDir . '/../lib/SetupChecks/CheckUserCertificates.php',
     'OCA\\Settings\\SetupChecks\\CodeIntegrity' => $baseDir . '/../lib/SetupChecks/CodeIntegrity.php',
     'OCA\\Settings\\SetupChecks\\CronErrors' => $baseDir . '/../lib/SetupChecks/CronErrors.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -97,7 +97,6 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\AllowedAdminRanges' => __DIR__ . '/..' . '/../lib/SetupChecks/AllowedAdminRanges.php',
         'OCA\\Settings\\SetupChecks\\AppDirsWithDifferentOwner' => __DIR__ . '/..' . '/../lib/SetupChecks/AppDirsWithDifferentOwner.php',
         'OCA\\Settings\\SetupChecks\\BruteForceThrottler' => __DIR__ . '/..' . '/../lib/SetupChecks/BruteForceThrottler.php',
-        'OCA\\Settings\\SetupChecks\\CheckServerResponseTrait' => __DIR__ . '/..' . '/../lib/SetupChecks/CheckServerResponseTrait.php',
         'OCA\\Settings\\SetupChecks\\CheckUserCertificates' => __DIR__ . '/..' . '/../lib/SetupChecks/CheckUserCertificates.php',
         'OCA\\Settings\\SetupChecks\\CodeIntegrity' => __DIR__ . '/..' . '/../lib/SetupChecks/CodeIntegrity.php',
         'OCA\\Settings\\SetupChecks\\CronErrors' => __DIR__ . '/..' . '/../lib/SetupChecks/CronErrors.php',

--- a/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
+++ b/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
@@ -12,6 +12,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;

--- a/apps/settings/lib/SetupChecks/JavaScriptModules.php
+++ b/apps/settings/lib/SetupChecks/JavaScriptModules.php
@@ -12,6 +12,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;
@@ -43,7 +44,7 @@ class JavaScriptModules implements ISetupCheck {
 		$testFile = $this->urlGenerator->linkTo('settings', 'js/esm-test.mjs');
 
 		$noResponse = true;
-		foreach ($this->runHEAD($testFile) as $response) {
+		foreach ($this->runRequest('HEAD', $testFile) as $response) {
 			$noResponse = false;
 			if (preg_match('/(text|application)\/javascript/i', $response->getHeader('Content-Type'))) {
 				return SetupResult::success();

--- a/apps/settings/lib/SetupChecks/JavaScriptSourceMaps.php
+++ b/apps/settings/lib/SetupChecks/JavaScriptSourceMaps.php
@@ -12,6 +12,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;
@@ -42,7 +43,7 @@ class JavaScriptSourceMaps implements ISetupCheck {
 	public function run(): SetupResult {
 		$testFile = $this->urlGenerator->linkTo('settings', 'js/map-test.js.map');
 
-		foreach ($this->runHEAD($testFile) as $response) {
+		foreach ($this->runRequest('HEAD', $testFile) as $response) {
 			return SetupResult::success();
 		}
 

--- a/apps/settings/lib/SetupChecks/OcxProviders.php
+++ b/apps/settings/lib/SetupChecks/OcxProviders.php
@@ -12,6 +12,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;

--- a/apps/settings/lib/SetupChecks/SecurityHeaders.php
+++ b/apps/settings/lib/SetupChecks/SecurityHeaders.php
@@ -13,6 +13,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;
@@ -71,8 +72,8 @@ class SecurityHeaders implements ISetupCheck {
 					}
 				}
 
-				$xssfields = array_map('trim', explode(';', $response->getHeader('X-XSS-Protection')));
-				if (!in_array('1', $xssfields) || !in_array('mode=block', $xssfields)) {
+				$xssFields = array_map('trim', explode(';', $response->getHeader('X-XSS-Protection')));
+				if (!in_array('1', $xssFields) || !in_array('mode=block', $xssFields)) {
 					$msg .= $this->l10n->t('- The `%1$s` HTTP header does not contain `%2$s`. This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.', ['X-XSS-Protection', '1; mode=block'])."\n";
 				}
 

--- a/apps/settings/lib/SetupChecks/WellKnownUrls.php
+++ b/apps/settings/lib/SetupChecks/WellKnownUrls.php
@@ -13,6 +13,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;

--- a/apps/settings/lib/SetupChecks/Woff2Loading.php
+++ b/apps/settings/lib/SetupChecks/Woff2Loading.php
@@ -12,6 +12,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 use Psr\Log\LoggerInterface;
@@ -49,7 +50,7 @@ class Woff2Loading implements ISetupCheck {
 
 	protected function checkFont(string $fileExtension, string $url): SetupResult {
 		$noResponse = true;
-		$responses = $this->runHEAD($url);
+		$responses = $this->runRequest('HEAD', $url);
 		foreach ($responses as $response) {
 			$noResponse = false;
 			if ($response->getStatusCode() === 200) {

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -700,6 +700,7 @@ return array(
     'OCP\\Settings\\IManager' => $baseDir . '/lib/public/Settings/IManager.php',
     'OCP\\Settings\\ISettings' => $baseDir . '/lib/public/Settings/ISettings.php',
     'OCP\\Settings\\ISubAdminSettings' => $baseDir . '/lib/public/Settings/ISubAdminSettings.php',
+    'OCP\\SetupCheck\\CheckServerResponseTrait' => $baseDir . '/lib/public/SetupCheck/CheckServerResponseTrait.php',
     'OCP\\SetupCheck\\ISetupCheck' => $baseDir . '/lib/public/SetupCheck/ISetupCheck.php',
     'OCP\\SetupCheck\\ISetupCheckManager' => $baseDir . '/lib/public/SetupCheck/ISetupCheckManager.php',
     'OCP\\SetupCheck\\SetupResult' => $baseDir . '/lib/public/SetupCheck/SetupResult.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -733,6 +733,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Settings\\IManager' => __DIR__ . '/../../..' . '/lib/public/Settings/IManager.php',
         'OCP\\Settings\\ISettings' => __DIR__ . '/../../..' . '/lib/public/Settings/ISettings.php',
         'OCP\\Settings\\ISubAdminSettings' => __DIR__ . '/../../..' . '/lib/public/Settings/ISubAdminSettings.php',
+        'OCP\\SetupCheck\\CheckServerResponseTrait' => __DIR__ . '/../../..' . '/lib/public/SetupCheck/CheckServerResponseTrait.php',
         'OCP\\SetupCheck\\ISetupCheck' => __DIR__ . '/../../..' . '/lib/public/SetupCheck/ISetupCheck.php',
         'OCP\\SetupCheck\\ISetupCheckManager' => __DIR__ . '/../../..' . '/lib/public/SetupCheck/ISetupCheckManager.php',
         'OCP\\SetupCheck\\SetupResult' => __DIR__ . '/../../..' . '/lib/public/SetupCheck/SetupResult.php',

--- a/tests/lib/SetupCheck/CheckServerResponseTraitImplementation.php
+++ b/tests/lib/SetupCheck/CheckServerResponseTraitImplementation.php
@@ -6,13 +6,13 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests\SetupChecks;
+namespace Test\SetupCheck;
 
-use OCA\Settings\SetupChecks\CheckServerResponseTrait;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -22,7 +22,6 @@ class CheckServerResponseTraitImplementation {
 
 	use CheckServerResponseTrait {
 		CheckServerResponseTrait::getRequestOptions as public;
-		CheckServerResponseTrait::runHEAD as public;
 		CheckServerResponseTrait::runRequest as public;
 		CheckServerResponseTrait::normalizeUrl as public;
 		CheckServerResponseTrait::getTestUrls as public;

--- a/tests/lib/SetupCheck/CheckServerResponseTraitTest.php
+++ b/tests/lib/SetupCheck/CheckServerResponseTraitTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests\SetupChecks;
+namespace Test\SetupCheck;
 
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;


### PR DESCRIPTION
## Summary

This trait is used by other apps for creating setup checks, so we should provide it instead apps using private API.
Note that I removed the `runHead` as this is just sugar but having it in OCP could make things in the future harder...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
