### PR TITLE
fix(collaboration): Reduce timeouts to 3s for link reference connects

### DIFF
--- a/lib/public/Collaboration/Reference/LinkReferenceProvider.php
+++ b/lib/public/Collaboration/Reference/LinkReferenceProvider.php
@@ -114,7 +114,7 @@ class LinkReferenceProvider implements IReferenceProvider, IPublicReferenceProvi
 
 		$client = $this->clientService->newClient();
 		try {
-			$headResponse = $client->head($reference->getId(), [ 'timeout' => 10 ]);
+			$headResponse = $client->head($reference->getId(), [ 'timeout' => 3 ]);
 		} catch (\Exception $e) {
 			$this->logger->debug('Failed to perform HEAD request to get target metadata', ['exception' => $e]);
 			return;
@@ -136,7 +136,7 @@ class LinkReferenceProvider implements IReferenceProvider, IPublicReferenceProvi
 		}
 
 		try {
-			$response = $client->get($reference->getId(), [ 'timeout' => 10, 'stream' => true ]);
+			$response = $client->get($reference->getId(), [ 'timeout' => 3, 'stream' => true ]);
 		} catch (\Exception $e) {
 			$this->logger->debug('Failed to fetch link for obtaining open graph data', ['exception' => $e]);
 			return;
@@ -184,7 +184,7 @@ class LinkReferenceProvider implements IReferenceProvider, IPublicReferenceProvi
 					$folder = $appData->newFolder('opengraph');
 				}
 
-				$response = $client->get($object->images[0]->url, ['timeout' => 10]);
+				$response = $client->get($object->images[0]->url, ['timeout' => 3]);
 				$contentType = $response->getHeader('Content-Type');
 				$contentLength = $response->getHeader('Content-Length');
 


### PR DESCRIPTION

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #34720 <!-- related github issue -->

## Summary

Fixes rest of #34720 

See https://github.com/nextcloud/server/issues/34720#issuecomment-1286609205

Any timeout value is somewhat arbitrary. We're currently using 10s. Lowered to 3s for now.

Might be worth backporting to 30 just to more feedback from real world usage sooner, but otherwise probably doesn't matter at the moment.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
