### PR TITLE
fix(settings): SetupChecks were broken for subdirectory installations

### DIFF
--- a/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
+++ b/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
@@ -139,8 +139,8 @@ trait CheckServerResponseTrait {
 	 * @param bool $httpErrors Ignore requests with HTTP errors (will not yield if request has a 4xx or 5xx response)
 	 * @return Generator<int, IResponse>
 	 */
-	protected function runHEAD(string $url, bool $ignoreSSL = true, bool $httpErrors = true): Generator {
-		return $this->runRequest('HEAD', $url, ['ignoreSSL' => $ignoreSSL, 'httpErrors' => $httpErrors]);
+	protected function runHEAD(string $url, bool $ignoreSSL = true, bool $httpErrors = true, bool $removeWebroot = false): Generator {
+		return $this->runRequest('HEAD', $url, ['ignoreSSL' => $ignoreSSL, 'httpErrors' => $httpErrors], $removeWebroot);
 	}
 
 	protected function getRequestOptions(bool $ignoreSSL, bool $httpErrors): array {

--- a/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
+++ b/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
@@ -44,7 +44,7 @@ class DataDirectoryProtected implements ISetupCheck {
 		$dataUrl = $this->urlGenerator->linkTo('', $dataDir . '/.ncdata');
 
 		$noResponse = true;
-		foreach ($this->runRequest('GET', $dataUrl, [ 'httpErrors' => false ]) as $response) {
+		foreach ($this->runRequest('GET', $dataUrl, [ 'httpErrors' => false ], removeWebroot: true) as $response) {
 			$noResponse = false;
 			if ($response->getStatusCode() < 400) {
 				// Read the response body
@@ -65,6 +65,6 @@ class DataDirectoryProtected implements ISetupCheck {
 			return SetupResult::warning($this->l10n->t('Could not check that the data directory is protected. Please check manually that your server does not allow access to the data directory.') . "\n" . $this->serverConfigHelp());
 		}
 		return SetupResult::success();
-		
+
 	}
 }

--- a/apps/settings/lib/SetupChecks/JavaScriptModules.php
+++ b/apps/settings/lib/SetupChecks/JavaScriptModules.php
@@ -43,7 +43,7 @@ class JavaScriptModules implements ISetupCheck {
 		$testFile = $this->urlGenerator->linkTo('settings', 'js/esm-test.mjs');
 
 		$noResponse = true;
-		foreach ($this->runHEAD($testFile) as $response) {
+		foreach ($this->runHEAD($testFile, removeWebroot: true) as $response) {
 			$noResponse = false;
 			if (preg_match('/(text|application)\/javascript/i', $response->getHeader('Content-Type'))) {
 				return SetupResult::success();
@@ -54,6 +54,6 @@ class JavaScriptModules implements ISetupCheck {
 			return SetupResult::warning($this->l10n->t('Unable to run check for JavaScript support. Please remedy or confirm manually if your webserver serves `.mjs` files using the JavaScript MIME type.') . "\n" . $this->serverConfigHelp());
 		}
 		return SetupResult::error($this->l10n->t('Your webserver does not serve `.mjs` files using the JavaScript MIME type. This will break some apps by preventing browsers from executing the JavaScript files. You should configure your webserver to serve `.mjs` files with either the `text/javascript` or `application/javascript` MIME type.'));
-		
+
 	}
 }

--- a/apps/settings/lib/SetupChecks/JavaScriptSourceMaps.php
+++ b/apps/settings/lib/SetupChecks/JavaScriptSourceMaps.php
@@ -42,7 +42,7 @@ class JavaScriptSourceMaps implements ISetupCheck {
 	public function run(): SetupResult {
 		$testFile = $this->urlGenerator->linkTo('settings', 'js/map-test.js.map');
 
-		foreach ($this->runHEAD($testFile) as $response) {
+		foreach ($this->runHEAD($testFile, removeWebroot: true) as $response) {
 			return SetupResult::success();
 		}
 

--- a/apps/settings/lib/SetupChecks/SecurityHeaders.php
+++ b/apps/settings/lib/SetupChecks/SecurityHeaders.php
@@ -51,7 +51,7 @@ class SecurityHeaders implements ISetupCheck {
 
 		foreach ($urls as [$verb,$url,$validStatuses]) {
 			$works = null;
-			foreach ($this->runRequest($verb, $url, ['httpErrors' => false]) as $response) {
+			foreach ($this->runRequest($verb, $url, ['httpErrors' => false], removeWebroot: true) as $response) {
 				// Check that the response status matches
 				if (!in_array($response->getStatusCode(), $validStatuses)) {
 					$works = false;

--- a/apps/settings/lib/SetupChecks/Woff2Loading.php
+++ b/apps/settings/lib/SetupChecks/Woff2Loading.php
@@ -42,7 +42,7 @@ class Woff2Loading implements ISetupCheck {
 	public function run(): SetupResult {
 		$url = $this->urlGenerator->linkTo('', 'core/fonts/NotoSans-Regular-latin.woff2');
 		$noResponse = true;
-		$responses = $this->runHEAD($url);
+		$responses = $this->runHEAD($url, removeWebroot: true);
 		foreach ($responses as $response) {
 			$noResponse = false;
 			if ($response->getStatusCode() === 200) {
@@ -60,6 +60,6 @@ class Woff2Loading implements ISetupCheck {
 			$this->l10n->t('Your web server is not properly set up to deliver .woff2 files. This is typically an issue with the Nginx configuration. For Nextcloud 15 it needs an adjustement to also deliver .woff2 files. Compare your Nginx configuration to the recommended configuration in our documentation.'),
 			$this->urlGenerator->linkToDocs('admin-nginx'),
 		);
-		
+
 	}
 }


### PR DESCRIPTION
## Summary

The URL generator adds the subdir, but the getTestUrls method adds it as well, so we need to remove it once.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
