### PR TITLE
chore(files): Provide old node on moved

### DIFF
--- a/apps/files/src/components/FileEntry/FileEntryName.vue
+++ b/apps/files/src/components/FileEntry/FileEntryName.vue
@@ -46,7 +46,6 @@ import { showError, showSuccess } from '@nextcloud/dialogs'
 import { emit } from '@nextcloud/event-bus'
 import { FileType, NodeStatus } from '@nextcloud/files'
 import { translate as t } from '@nextcloud/l10n'
-import { dirname } from '@nextcloud/paths'
 import { defineComponent, inject } from 'vue'
 
 import NcTextField from '@nextcloud/vue/dist/Components/NcTextField.js'
@@ -244,6 +243,7 @@ export default defineComponent({
 				return
 			}
 
+			const oldNode = this.source.clone()
 			const oldName = this.source.basename
 			const oldEncodedSource = this.source.encodedSource
 			if (oldName === newName) {
@@ -272,8 +272,8 @@ export default defineComponent({
 				emit('files:node:updated', this.source)
 				emit('files:node:renamed', this.source)
 				emit('files:node:moved', {
-					node: this.source,
-					oldSource: `${dirname(this.source.source)}/${oldName}`,
+					newNode: this.source,
+					oldNode,
 				})
 				showSuccess(t('files', 'Renamed "{oldName}" to "{newName}"', { oldName, newName }))
 

--- a/apps/files/src/eventbus.d.ts
+++ b/apps/files/src/eventbus.d.ts
@@ -16,7 +16,7 @@ declare module '@nextcloud/event-bus' {
 		'files:node:deleted': Node
 		'files:node:updated': Node
 		'files:node:renamed': Node
-		'files:node:moved': { node: Node, oldSource: string }
+		'files:node:moved': { newNode: Node, oldNode: Node }
 
 		'files:filter:added': IFileListFilter
 		'files:filter:removed': string


### PR DESCRIPTION
## Summary

Provides the old node in the event payload instead of just the source

## Requires

- https://github.com/nextcloud-libraries/nextcloud-files/pull/1077

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)