### PR TITLE
fix: Do not try to set HTTP response code on already closed connection

### DIFF
--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -198,7 +198,8 @@ class OC_Files {
 		} catch (\OCP\Files\ConnectionLostException $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex, ['level' => \OCP\ILogger::DEBUG]);
-			\OC_Template::printErrorPage('Connection lost', $ex->getMessage(), 200);
+			/* We do not print anything here, the connection is already closed */
+			die();
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
 			OC::$server->getLogger()->logException($ex);


### PR DESCRIPTION
* Resolves: #45835 
 
## Summary

This avoids a PHP warning in the logs about trying to set the response
 code while the output already started. It’s useless to try to print an
 error page anyway in this situation because the connection was closed
 already.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
