### PR TITLE
fix(ci): Use latest buildjet version

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -80,7 +80,7 @@ jobs:
         run: npm run cypress:version
 
       - name: Save context
-        uses: buildjet/cache/save@v3
+        uses: buildjet/cache/save@v4
         with:
           key: cypress-context-${{ github.run_id }}
           path: ./
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Restore context
-        uses: buildjet/cache/restore@v3
+        uses: buildjet/cache/restore@v4
         with:
           fail-on-cache-miss: true
           key: cypress-context-${{ github.run_id }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -80,7 +80,7 @@ jobs:
         run: npm run cypress:version
 
       - name: Save context
-        uses: buildjet/cache/save@e376f15c6ec6dc595375c78633174c7e5f92dc0e # v3
+        uses: buildjet/cache/save@v3
         with:
           key: cypress-context-${{ github.run_id }}
           path: ./
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Restore context
-        uses: buildjet/cache/restore@e376f15c6ec6dc595375c78633174c7e5f92dc0e # v3
+        uses: buildjet/cache/restore@v3
         with:
           fail-on-cache-miss: true
           key: cypress-context-${{ github.run_id }}


### PR DESCRIPTION
## Summary

@susnux @skjnldsv We need to update the buildjet action, 25s now on restore, see https://github.com/nextcloud/server/actions/runs/10869657438/job/30161269276#step:2:12

We are suffering from a bug in node that keeps node running when there are unfullfilled promises, ref
* https://github.com/actions/cache/issues/1442
* https://github.com/actions/cache/blob/704facf57e6136b1bc63b828d79edcd491f0ee84/src/restoreImpl.ts#L102-L109

Seems that version we are using does not include the upstream fix. We can fix it to the latest hash or just use v3, as you like.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
