### PR TITLE
fix(Entity): Fix magic setter call for custom strong typed setters

### DIFF
--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -52,9 +52,8 @@ abstract class Entity {
 		$instance = new static();
 
 		foreach ($row as $key => $value) {
-			$prop = ucfirst($instance->columnToProperty($key));
-			$setter = 'set' . $prop;
-			$instance->$setter($value);
+			$prop = $instance->columnToProperty($key);
+			$instance->setter($prop, [$value]);
 		}
 
 		$instance->resetUpdatedFields();

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -27,7 +27,6 @@ use PHPUnit\Framework\Constraint\IsType;
  * @method void setTrueOrFalse(bool $trueOrFalse)
  * @method bool getAnotherBool()
  * @method bool isAnotherBool()
- * @method void setAnotherBool(bool $anotherBool)
  * @method string getLongText()
  * @method void setLongText(string $longText)
  */
@@ -46,6 +45,10 @@ class TestEntity extends Entity {
 		$this->addType('anotherBool', 'boolean');
 		$this->addType('longText', 'blob');
 		$this->name = $name;
+	}
+
+	public function setAnotherBool(bool $anotherBool): void {
+		parent::setAnotherBool($anotherBool);
 	}
 }
 
@@ -71,12 +74,14 @@ class EntityTest extends \Test\TestCase {
 	public function testFromRow() {
 		$row = [
 			'pre_name' => 'john',
-			'email' => 'john@something.com'
+			'email' => 'john@something.com',
+			'another_bool' => 1,
 		];
 		$this->entity = TestEntity::fromRow($row);
 
 		$this->assertEquals($row['pre_name'], $this->entity->getPreName());
 		$this->assertEquals($row['email'], $this->entity->getEmail());
+		$this->assertEquals($row['another_bool'], $this->entity->getAnotherBool());
 	}
 
 


### PR DESCRIPTION
For reference: https://github.com/nextcloud/server/pull/47984

## Summary

When enforcing strict types in Entity.php the fromRow method can fail if the the type to used to store the data in the db is different from the target php type (e.g. bool in sqlite is integer 0/1).
Usually magic methods are used and those don't have strict types, but if you have a custom setter it will trigger an error because the argument type does not match.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
