### PR TITLE
feat(db): switch from settype to casts

### DIFF
--- a/lib/private/Tagging/Tag.php
+++ b/lib/private/Tagging/Tag.php
@@ -45,14 +45,16 @@ class Tag extends Entity {
 	 * @todo migrate existing database columns to the correct names
 	 * to be able to drop this direct mapping
 	 */
-	public function columnToProperty($columnName) {
+	public function columnToProperty(string $columnName): string {
 		if ($columnName === 'category') {
 			return 'name';
-		} elseif ($columnName === 'uid') {
-			return 'owner';
-		} else {
-			return parent::columnToProperty($columnName);
 		}
+
+		if ($columnName === 'uid') {
+			return 'owner';
+		}
+
+		return parent::columnToProperty($columnName);
 	}
 
 	/**
@@ -61,13 +63,15 @@ class Tag extends Entity {
 	 * @param string $property the name of the property
 	 * @return string the column name
 	 */
-	public function propertyToColumn($property) {
+	public function propertyToColumn(string $property): string {
 		if ($property === 'name') {
 			return 'category';
-		} elseif ($property === 'owner') {
-			return 'uid';
-		} else {
-			return parent::propertyToColumn($property);
 		}
+
+		if ($property === 'owner') {
+			return 'uid';
+		}
+
+		return parent::propertyToColumn($property);
 	}
 }

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -460,9 +460,9 @@ class AppTest extends \Test\TestCase {
 	public function testEnabledApps($user, $expectedApps, $forceAll) {
 		$userManager = \OC::$server->getUserManager();
 		$groupManager = \OC::$server->getGroupManager();
-		$user1 = $userManager->createUser(self::TEST_USER1, self::TEST_USER1);
-		$user2 = $userManager->createUser(self::TEST_USER2, self::TEST_USER2);
-		$user3 = $userManager->createUser(self::TEST_USER3, self::TEST_USER3);
+		$user1 = $userManager->createUser(self::TEST_USER1, 'NotAnEasyPassword123456+');
+		$user2 = $userManager->createUser(self::TEST_USER2, 'NotAnEasyPassword123456_');
+		$user3 = $userManager->createUser(self::TEST_USER3, 'NotAnEasyPassword123456?');
 
 		$group1 = $groupManager->createGroup(self::TEST_GROUP1);
 		$group1->addUser($user1);
@@ -508,7 +508,7 @@ class AppTest extends \Test\TestCase {
 	 */
 	public function testEnabledAppsCache() {
 		$userManager = \OC::$server->getUserManager();
-		$user1 = $userManager->createUser(self::TEST_USER1, self::TEST_USER1);
+		$user1 = $userManager->createUser(self::TEST_USER1, 'NotAnEasyPassword123456+');
 
 		\OC_User::setUserId(self::TEST_USER1);
 

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -671,7 +671,7 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testDeleteReferencesOfActorWithUserManagement() {
-		$user = \OC::$server->getUserManager()->createUser('xenia', '123456');
+		$user = \OC::$server->getUserManager()->createUser('xenia', 'NotAnEasyPassword123456+');
 		$this->assertTrue($user instanceof IUser);
 
 		$manager = \OC::$server->get(ICommentsManager::class);

--- a/tests/lib/Files/Cache/UpdaterLegacyTest.php
+++ b/tests/lib/Files/Cache/UpdaterLegacyTest.php
@@ -56,7 +56,7 @@ class UpdaterLegacyTest extends \Test\TestCase {
 			self::$user = $this->getUniqueID();
 		}
 
-		\OC::$server->getUserManager()->createUser(self::$user, 'password');
+		\OC::$server->getUserManager()->createUser(self::$user, 'NotAnEasyPassword123456+');
 		$this->loginAsUser(self::$user);
 
 		Filesystem::init(self::$user, '/' . self::$user . '/files');


### PR DESCRIPTION
Signed-off-by: Anna Larch <anna@nextcloud.com>

## Summary
casting directly to the proper type is up to 6 times faster than using `settype`

Also added the types for the methods, let's see if things go boom (although they might not without strict types)

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
