### PR TITLE
fix(BaseResponse): Cast XML element values to string

### DIFF
--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -143,8 +143,10 @@ abstract class BaseResponse extends Response {
 				$writer->startElement($k);
 				$this->toXML($v->jsonSerialize(), $writer);
 				$writer->endElement();
+			} elseif ($v === null) {
+				$writer->writeElement($k);
 			} else {
-				$writer->writeElement($k, $v);
+				$writer->writeElement($k, (string)$v);
 			}
 		}
 	}


### PR DESCRIPTION
For reference: https://github.com/nextcloud/server/pull/47984

## Summary

writeElement() only accepts ?string, so we need to cast it explicitly as it will fail with strict types enforced.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
