### PR TITLE
fix(S3ConfigTrait): Allow proxy field to take false

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConfigTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConfigTrait.php
@@ -20,7 +20,7 @@ trait S3ConfigTrait {
 
 	protected int $timeout;
 
-	protected string $proxy;
+	protected string|false $proxy;
 
 	protected string $storageClass;
 


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/47984

## Summary

Can be false: https://github.com/nextcloud/server/blob/01478f1c406cdbed7e5f6a52c0ebed040405ff29/lib/private/Files/ObjectStore/S3ConnectionTrait.php#L40

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
