### PR TITLE
fix(Comment): Initialize childrenCount as integer

### DIFF
--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -16,7 +16,7 @@ class Comment implements IComment {
 		'id' => '',
 		'parentId' => '0',
 		'topmostParentId' => '0',
-		'childrenCount' => '0',
+		'childrenCount' => 0,
 		'message' => '',
 		'verb' => '',
 		'actorType' => '',


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/47984

## Summary

Expected to be an integer: https://github.com/nextcloud/server/blob/01478f1c406cdbed7e5f6a52c0ebed040405ff29/lib/private/Comments/Comment.php#L138-L140

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
