### PR TITLE
fix(user_ldap): Use %n in plural translation to avoid a crash in L10N

### DIFF
--- a/apps/user_ldap/lib/SetupChecks/LdapConnection.php
+++ b/apps/user_ldap/lib/SetupChecks/LdapConnection.php
@@ -58,7 +58,7 @@ class LdapConnection implements ISetupCheck {
 		if (!empty($bindFailedConfigurations)) {
 			$output .= $this->l10n->n(
 				'Binding failed for this LDAP configuration: %s',
-				'Binding failed for these LDAP configurations: %s',
+				'Binding failed for %n LDAP configurations: %s',
 				count($bindFailedConfigurations),
 				[implode(',', $bindFailedConfigurations)]
 			)."\n";
@@ -66,7 +66,7 @@ class LdapConnection implements ISetupCheck {
 		if (!empty($searchFailedConfigurations)) {
 			$output .= $this->l10n->n(
 				'Searching failed for this LDAP configuration: %s',
-				'Searching failed for these LDAP configurations: %s',
+				'Searching failed for %n LDAP configurations: %s',
 				count($searchFailedConfigurations),
 				[implode(',', $searchFailedConfigurations)]
 			)."\n";
@@ -74,7 +74,7 @@ class LdapConnection implements ISetupCheck {
 		if (!empty($inactiveConfigurations)) {
 			$output .= $this->l10n->n(
 				'There is an inactive LDAP configuration: %s',
-				'There are inactive LDAP configurations: %s',
+				'There are %n inactive LDAP configurations: %s',
 				count($inactiveConfigurations),
 				[implode(',', $inactiveConfigurations)]
 			)."\n";
@@ -86,7 +86,7 @@ class LdapConnection implements ISetupCheck {
 		}
 		return SetupResult::success($this->l10n->n(
 			'Binding and searching works on the configured LDAP connection (%s)',
-			'Binding and searching works on all of the configured LDAP connections (%s)',
+			'Binding and searching works on all of the %n configured LDAP connections (%s)',
 			count($availableConfigs),
 			[implode(',', $availableConfigs)]
 		));


### PR DESCRIPTION
* Resolves: #47997

## Summary

Tested and works.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
