### PR TITLE
fix: correct link to trademark

### DIFF
--- a/LICENSES/LicenseRef-NextcloudTrademarks.txt
+++ b/LICENSES/LicenseRef-NextcloudTrademarks.txt
@@ -6,4 +6,4 @@ and our products: “Nextcloud Files”; “Nextcloud Groupware” and “Nextcl
 This set of marks is collectively referred to as the “Nextcloud marks.”
 
 Use of Nextcloud logos and other marks is only permitted under the guidelines provided by the Nextcloud GmbH.
-A copy can be found at https://discord.com/branding
+A copy can be found at https://nextcloud.com/trademarks/


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
