### PR TITLE
fix(dav): imip service test expects integers for last occurence

### DIFF
--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -202,7 +202,7 @@ class IMipPluginTest extends TestCase {
 		$this->plugin->setVCalendar($oldVCalendar);
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('frodo@hobb.it')
@@ -248,7 +248,7 @@ class IMipPluginTest extends TestCase {
 			->willReturn('yes');
 		$this->service->expects(self::once())
 			->method('createInvitationToken')
-			->with($message, $newVevent, '1496912700')
+			->with($message, $newVevent, 1496912700)
 			->willReturn('token');
 		$this->service->expects(self::once())
 			->method('addResponseButtons')
@@ -305,7 +305,7 @@ class IMipPluginTest extends TestCase {
 		$this->plugin->setVCalendar($oldVCalendar);
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('the-shire@hobb.it')
@@ -406,7 +406,7 @@ class IMipPluginTest extends TestCase {
 		$this->plugin->setVCalendar($oldVCalendar);
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('frodo@hobb.it')
@@ -452,7 +452,7 @@ class IMipPluginTest extends TestCase {
 			->willReturn('yes');
 		$this->service->expects(self::once())
 			->method('createInvitationToken')
-			->with($message, $newVevent, '1496912700')
+			->with($message, $newVevent, 1496912700)
 			->willReturn('token');
 		$this->service->expects(self::once())
 			->method('addResponseButtons')
@@ -485,7 +485,7 @@ class IMipPluginTest extends TestCase {
 
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('frodo@hobb.it')
@@ -537,7 +537,7 @@ class IMipPluginTest extends TestCase {
 		$this->plugin->setVCalendar($oldVcalendar);
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('frodo@hobb.it')
@@ -583,7 +583,7 @@ class IMipPluginTest extends TestCase {
 			->willReturn('yes');
 		$this->service->expects(self::once())
 			->method('createInvitationToken')
-			->with($message, $newVevent, '1496912700')
+			->with($message, $newVevent, 1496912700)
 			->willReturn('token');
 		$this->service->expects(self::once())
 			->method('addResponseButtons')
@@ -650,7 +650,7 @@ class IMipPluginTest extends TestCase {
 		// construct service mock returns
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->service->expects(self::once())
 			->method('getCurrentAttendee')
 			->with($message)
@@ -676,7 +676,7 @@ class IMipPluginTest extends TestCase {
 			->willReturn(true);
 		$this->service->expects(self::once())
 			->method('createInvitationToken')
-			->with($message, $event, '1496912700')
+			->with($message, $event, 1496912700)
 			->willReturn('token');
 		$this->service->expects(self::once())
 			->method('addResponseButtons')
@@ -703,7 +703,7 @@ class IMipPluginTest extends TestCase {
 			->method('findServiceByAddress')
 			->with('user1', 'gandalf@wiz.ard')
 			->willReturn($this->mailService);
-		
+
 		$this->plugin->schedule($message);
 		$this->assertEquals('1.1', $message->getScheduleStatus());
 	}
@@ -737,7 +737,7 @@ class IMipPluginTest extends TestCase {
 		}
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('frodo@hobb.it')
@@ -784,7 +784,7 @@ class IMipPluginTest extends TestCase {
 			->willReturn('yes');
 		$this->service->expects(self::once())
 			->method('createInvitationToken')
-			->with($message, $newVevent, '1496912700')
+			->with($message, $newVevent, 1496912700)
 			->willReturn('token');
 		$this->service->expects(self::once())
 			->method('addResponseButtons')
@@ -830,7 +830,7 @@ class IMipPluginTest extends TestCase {
 		}
 		$this->service->expects(self::once())
 			->method('getLastOccurrence')
-			->willReturn('1496912700');
+			->willReturn(1496912700);
 		$this->mailer->expects(self::once())
 			->method('validateMailAddress')
 			->with('frodo@hobb.it')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
