### PR TITLE
fix(a11y): Add OTF font loading check

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -49,8 +49,8 @@
     </Else>
   </FilesMatch>
 
-  # Let browsers cache WOFF files for a week
-  <FilesMatch "\.woff2?$">
+  # Let browsers cache OTF and WOFF files for a week
+  <FilesMatch "\.(otf|woff2?)$">
     Header set Cache-Control "max-age=604800"
   </FilesMatch>
 </IfModule>
@@ -106,7 +106,7 @@
   SetEnvIf Transfer-Encoding "chunked" proxy-sendcl=1
 </IfModule>
 
-# Apache disabled the sending of the server-side content-length header 
+# Apache disabled the sending of the server-side content-length header
 # in their 2.4.59 patch updated which breaks some use-cases in Nextcloud.
 # Setting ap_trust_cgilike_cl allows to bring back the usual behaviour.
 # See https://bz.apache.org/bugzilla/show_bug.cgi?id=68973

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -484,7 +484,7 @@ class Setup {
 			$content .= "\n  Options -MultiViews";
 			$content .= "\n  RewriteRule ^core/js/oc.js$ index.php [PT,E=PATH_INFO:$1]";
 			$content .= "\n  RewriteRule ^core/preview.png$ index.php [PT,E=PATH_INFO:$1]";
-			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|mjs|svg|gif|ico|jpg|jpeg|png|webp|html|ttf|woff2?|map|webm|mp4|mp3|ogg|wav|flac|wasm|tflite)$";
+			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !\\.(css|js|mjs|svg|gif|ico|jpg|jpeg|png|webp|html|otf|ttf|woff2?|map|webm|mp4|mp3|ogg|wav|flac|wasm|tflite)$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/core/ajax/update\\.php";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/core/img/(favicon\\.ico|manifest\\.json)$";
 			$content .= "\n  RewriteCond %{REQUEST_FILENAME} !/(cron|public|remote|status)\\.php";


### PR DESCRIPTION
## Summary

I applied https://github.com/nextcloud/server/pull/47995 on production and the font didn't work anymore. Turns out OTF file loading is not checked and not allowed by .htaccess in default.

Since the check only exists since [Nextcloud 29](https://github.com/nextcloud/server/pull/43588) I will cancel the backport of the dyslexia for 28 as we can not easily adjust the check there.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
