### PR TITLE
fix(Storage): Document getOwner() can return false

### DIFF
--- a/apps/dav/lib/Storage/PublicOwnerWrapper.php
+++ b/apps/dav/lib/Storage/PublicOwnerWrapper.php
@@ -26,7 +26,7 @@ class PublicOwnerWrapper extends Wrapper {
 		$this->owner = $arguments['owner'];
 	}
 
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		$owner = parent::getOwner($path);
 
 		if ($owner === null || $owner === false) {

--- a/apps/dav/lib/Storage/PublicOwnerWrapper.php
+++ b/apps/dav/lib/Storage/PublicOwnerWrapper.php
@@ -12,8 +12,7 @@ use OC\Files\Storage\Wrapper\Wrapper;
 
 class PublicOwnerWrapper extends Wrapper {
 
-	/** @var string */
-	private $owner;
+	private string $owner;
 
 	/**
 	 * @param array $arguments ['storage' => $storage, 'owner' => $owner]
@@ -28,11 +27,10 @@ class PublicOwnerWrapper extends Wrapper {
 
 	public function getOwner($path): string|false {
 		$owner = parent::getOwner($path);
-
-		if ($owner === null || $owner === false) {
-			return $this->owner;
+		if ($owner !== false) {
+			return $owner;
 		}
 
-		return $owner;
+		return $this->owner;
 	}
 }

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -345,7 +345,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return json_decode($response->getBody(), true);
 	}
 
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		return $this->cloudId->getDisplayId();
 	}
 

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -446,7 +446,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return new \OCA\Files_Sharing\Scanner($storage);
 	}
 
-	public function getOwner($path): string {
+	public function getOwner($path): string|false {
 		return $this->superShare->getShareOwner();
 	}
 

--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -49,6 +49,10 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 
 		if ($storage->instanceOfStorage(ISharedStorage::class)) {
 			$owner = $storage->getOwner('');
+			if ($owner === false) {
+				throw new NotFoundException('No owner for ' . $file->getPath());
+			}
+
 			$user = $this->userManager->get($owner);
 
 			$fileId = $file->getId();

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -253,7 +253,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 
 		$owner = null;
 		$ownerId = $storage->getOwner($cacheEntry['internalPath']);
-		if (!empty($ownerId)) {
+		if ($ownerId !== false) {
 			// Cache the user manager (for performance)
 			if ($this->userManager === null) {
 				$this->userManager = \OCP\Server::get(IUserManager::class);

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -28,6 +28,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -477,9 +478,23 @@ class Root extends Folder implements IRootFolder {
 			$pathRelativeToMount = substr($internalPath, strlen($rootInternalPath));
 			$pathRelativeToMount = ltrim($pathRelativeToMount, '/');
 			$absolutePath = rtrim($mount->getMountPoint() . $pathRelativeToMount, '/');
+			$storage = $mount->getStorage();
+			if ($storage === null) {
+				return null;
+			}
+			$ownerId = $storage->getOwner($pathRelativeToMount);
+			if ($ownerId !== false) {
+				$owner = Server::get(IUserManager::class)->get($ownerId);
+			} else {
+				$owner = null;
+			}
 			return $this->createNode($absolutePath, new FileInfo(
-				$absolutePath, $mount->getStorage(), $cacheEntry->getPath(), $cacheEntry, $mount,
-				\OC::$server->getUserManager()->get($mount->getStorage()->getOwner($pathRelativeToMount))
+				$absolutePath,
+				$storage,
+				$cacheEntry->getPath(),
+				$cacheEntry,
+				$mount,
+				$owner,
 			));
 		}, $mountsContainingFile);
 

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -32,13 +32,7 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements IHomeStorage 
 		return 'object::user:' . $this->user->getUID();
 	}
 
-	/**
-	 * get the owner of a path
-	 *
-	 * @param string $path The path to get the owner
-	 * @return string uid
-	 */
-	public function getOwner($path): string {
+	public function getOwner($path): string|false {
 		return $this->user->getUID();
 	}
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -390,13 +390,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage {
 		return $this->getCache($storage)->getStorageCache();
 	}
 
-	/**
-	 * get the owner of a path
-	 *
-	 * @param string $path The path to get the owner
-	 * @return string|false uid or false
-	 */
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		if ($this->owner === null) {
 			$this->owner = \OC_User::getUser();
 		}

--- a/lib/private/Files/Storage/Home.php
+++ b/lib/private/Files/Storage/Home.php
@@ -83,13 +83,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 		return $this->user;
 	}
 
-	/**
-	 * get the owner of a path
-	 *
-	 * @param string $path The path to get the owner
-	 * @return string uid or false
-	 */
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		return $this->user->getUID();
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/Availability.php
+++ b/lib/private/Files/Storage/Wrapper/Availability.php
@@ -373,12 +373,12 @@ class Availability extends Wrapper {
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		try {
 			return parent::getOwner($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -370,13 +370,7 @@ class Jail extends Wrapper {
 		return new CacheJail($sourceCache, $this->rootPath);
 	}
 
-	/**
-	 * get the user id of the owner of a file or folder
-	 *
-	 * @param string $path
-	 * @return string
-	 */
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		return $this->getWrapperStorage()->getOwner($this->getUnjailedPath($path));
 	}
 

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -381,14 +381,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->getScanner($path, $storage);
 	}
 
-
-	/**
-	 * get the user id of the owner of a file or folder
-	 *
-	 * @param string $path
-	 * @return string
-	 */
-	public function getOwner($path) {
+	public function getOwner($path): string|false {
 		return $this->getWrapperStorage()->getOwner($path);
 	}
 

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -28,6 +28,7 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\ReservedWordException;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Server;
@@ -1364,7 +1365,7 @@ class View {
 
 			$ownerId = $storage->getOwner($internalPath);
 			$owner = null;
-			if ($ownerId !== null && $ownerId !== false) {
+			if ($ownerId !== false) {
 				// ownerId might be null if files are accessed with an access token without file system access
 				$owner = $this->getUserObjectForOwner($ownerId);
 			}
@@ -1450,7 +1451,12 @@ class View {
 			if ($sharingDisabled) {
 				$content['permissions'] = $content['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
 			}
-			$owner = $this->getUserObjectForOwner($storage->getOwner($content['path']));
+			$ownerId = $storage->getOwner($content['path']);
+			if ($ownerId !== false) {
+				$owner = $this->getUserObjectForOwner($ownerId);
+			} else {
+				$owner = null;
+			}
 			return new FileInfo($path . '/' . $content['name'], $storage, $content['path'], $content, $mount, $owner);
 		}, $contents);
 		$files = array_combine($fileNames, $fileInfos);
@@ -1527,7 +1533,12 @@ class View {
 							$rootEntry['permissions'] = $rootEntry['permissions'] & ~\OCP\Constants::PERMISSION_SHARE;
 						}
 
-						$owner = $this->getUserObjectForOwner($subStorage->getOwner(''));
+						$ownerId = $subStorage->getOwner('');
+						if ($ownerId !== false) {
+							$owner = $this->getUserObjectForOwner($ownerId);
+						} else {
+							$owner = null;
+						}
 						$files[$rootEntry->getName()] = new FileInfo($path . '/' . $rootEntry['name'], $subStorage, '', $rootEntry, $mount, $owner);
 					}
 				}
@@ -1644,7 +1655,12 @@ class View {
 					$internalPath = $result['path'];
 					$path = $mountPoint . $result['path'];
 					$result['path'] = substr($mountPoint . $result['path'], $rootLength);
-					$owner = $userManager->get($storage->getOwner($internalPath));
+					$ownerId = $storage->getOwner($internalPath);
+					if ($ownerId !== false) {
+						$owner = $userManager->get($ownerId);
+					} else {
+						$owner = null;
+					}
 					$files[] = new FileInfo($path, $storage, $internalPath, $result, $mount, $owner);
 				}
 			}
@@ -1663,7 +1679,12 @@ class View {
 							$internalPath = $result['path'];
 							$result['path'] = rtrim($relativeMountPoint . $result['path'], '/');
 							$path = rtrim($mountPoint . $internalPath, '/');
-							$owner = $userManager->get($storage->getOwner($internalPath));
+							$ownerId = $storage->getOwner($internalPath);
+							if ($ownerId !== false) {
+								$owner = $userManager->get($ownerId);
+							} else {
+								$owner = null;
+							}
 							$files[] = new FileInfo($path, $storage, $internalPath, $result, $mount, $owner);
 						}
 					}
@@ -1811,7 +1832,12 @@ class View {
 		$mount = $this->getMount($path);
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($this->getAbsolutePath($path));
-		$owner = \OC::$server->getUserManager()->get($storage->getOwner($internalPath));
+		$ownerId = $storage->getOwner($internalPath);
+		if ($ownerId !== false) {
+			$owner = Server::get(IUserManager::class)->get($ownerId);
+		} else {
+			$owner = null;
+		}
 		return new FileInfo(
 			$this->getAbsolutePath($path),
 			$storage,
@@ -1846,7 +1872,7 @@ class View {
 
 		// Short cut for read-only validation
 		if ($readonly) {
-			$validator = \OCP\Server::get(FilenameValidator::class);
+			$validator = Server::get(FilenameValidator::class);
 			if ($validator->isForbidden($fileName)) {
 				$l = \OCP\Util::getL10N('lib');
 				throw new InvalidPathException($l->t('Filename is a reserved word'));

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1676,11 +1676,9 @@ class View {
 	/**
 	 * Get the owner for a file or folder
 	 *
-	 * @param string $path
-	 * @return string the user id of the owner
 	 * @throws NotFoundException
 	 */
-	public function getOwner($path) {
+	public function getOwner(string $path): string {
 		$info = $this->getFileInfo($path);
 		if (!$info) {
 			throw new NotFoundException($path . ' not found while trying to get owner');

--- a/lib/private/Lockdown/Filesystem/NullStorage.php
+++ b/lib/private/Lockdown/Filesystem/NullStorage.php
@@ -155,8 +155,8 @@ class NullStorage extends Common {
 		return true;
 	}
 
-	public function getOwner($path) {
-		return null;
+	public function getOwner($path): string|false {
+		return false;
 	}
 
 	public function getCache($path = '', $storage = null) {

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -541,10 +541,9 @@ class OC_Helper {
 			$relative = 0;
 		}
 
-		/** @var string $ownerId */
 		$ownerId = $storage->getOwner($path);
 		$ownerDisplayName = '';
-		if ($ownerId) {
+		if ($ownerId !== false) {
 			$ownerDisplayName = \OC::$server->getUserManager()->getDisplayName($ownerId) ?? '';
 		}
 

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -414,7 +414,7 @@ interface IStorage {
 
 	/**
 	 * @param string $path path for which to retrieve the owner
-	 * @return string
+	 * @return string|false
 	 * @since 9.0.0
 	 */
 	public function getOwner($path);

--- a/tests/lib/Lockdown/Filesystem/NullStorageTest.php
+++ b/tests/lib/Lockdown/Filesystem/NullStorageTest.php
@@ -219,7 +219,7 @@ class NullStorageTest extends TestCase {
 	}
 
 	public function testGetOwner(): void {
-		$this->assertNull($this->storage->getOwner('foo'));
+		$this->assertFalse($this->storage->getOwner('foo'));
 	}
 
 	public function testGetCache(): void {


### PR DESCRIPTION
## Summary

The return type of getOwner() was never specified, but all implementations already treat it as `string|false`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
