### PR TITLE
fix(appstoreFetcher): get list from a custom store and remove unnecessary warning

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -152,14 +152,6 @@ class AppFetcher extends Fetcher {
 	public function get($allowUnstable = false): array {
 		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
 
-		$appStoreEnabled = $this->config->getSystemValueBool('appstoreenabled', true);
-		$internetAvailable = $this->config->getSystemValueBool('has_internet_connection', true);
-
-		if (!$appStoreEnabled || !$internetAvailable) {
-			$this->logger->info('AppStore is disabled or this instance has no Internet connection', ['app' => 'appstoreFetcher']);
-			return [];
-		}
-
 		$apps = parent::get($allowPreReleases);
 		if (empty($apps)) {
 			return [];

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -162,7 +162,6 @@ class AppFetcher extends Fetcher {
 
 		$apps = parent::get($allowPreReleases);
 		if (empty($apps)) {
-			$this->logger->warning('Could not get apps from the appstore', ['app' => 'appstoreFetcher']);
 			return [];
 		}
 		$allowList = $this->config->getSystemValue('appsallowlist');

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -121,6 +121,7 @@ abstract class Fetcher {
 		$isDefaultAppStore = $this->config->getSystemValueString('appstoreurl', self::APP_STORE_URL) === self::APP_STORE_URL;
 
 		if (!$appstoreenabled || (!$internetavailable && $isDefaultAppStore)) {
+			$this->logger->info('AppStore is disabled or this instance has no Internet connection to access the default app store', ['app' => 'appstoreFetcher']);
 			return [];
 		}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/47833
* Resolves: apps list is not loaded from a custom URL

I might miss something or misunderstand what's happening here. 

## Summary

### fix(appstoreFetcher): remove unneeded warning

- Fixes the root cause of https://github.com/nextcloud/server/issues/47833
- The root cause - warning in AppFetcher added in https://github.com/nextcloud/server/pull/46555

Base `get` in `Fetcher` returns `[]` in 2 cases:
1. Something went wrong, and the request failed — unexpected
   - In this case `warning` in `AppFetcher` is unnecessary, because it is already covered by base `Fetcher`:
https://github.com/nextcloud/server/blob/b9fb1db0f807fbbbfdbbf544a24d7cc3b396ec14/lib/private/App/AppStore/Fetcher/Fetcher.php#L172-L174
1. No app list should have been fetched (e.g. disabled)
   - In this case there should be no warning => removed to fix the linked issue

### fix(appstoreFetcher): get app list from custom app store

- Fixes regression from https://github.com/nextcloud/server/pull/47834/
- New check misses one case: appstore enabled, no internet, but it is OK because a custom local app store is set up. As a result - it doesn't try to load the list from custom local URL.
- This new check in `AppFetcher` is unnecessary as already correctly covered by the base method:
https://github.com/nextcloud/server/blob/b9fb1db0f807fbbbfdbbf544a24d7cc3b396ec14/lib/private/App/AppStore/Fetcher/Fetcher.php#L123-L125
- Because the new `info` log may be useful - added it to the base method

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
