### PR TITLE
fix: Remove legacy settings forms

### DIFF
--- a/apps/settings/lib/Controller/CommonSettingsTrait.php
+++ b/apps/settings/lib/Controller/CommonSettingsTrait.php
@@ -75,7 +75,7 @@ trait CommonSettingsTrait {
 				/** @psalm-suppress PossiblyNullArgument */
 				$declarativeFormIDs = $this->declarativeSettingsManager->getFormIDs($this->userSession->getUser(), $type, $section->getID());
 
-				if (empty($settings) && empty($declarativeFormIDs) && !($section->getID() === 'additional' && count(\OC_App::getForms('admin')) > 0)) {
+				if (empty($settings) && empty($declarativeFormIDs)) {
 					continue;
 				}
 

--- a/apps/settings/lib/Controller/PersonalSettingsController.php
+++ b/apps/settings/lib/Controller/PersonalSettingsController.php
@@ -18,7 +18,6 @@ use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Settings\IDeclarativeManager;
 use OCP\Settings\IManager as ISettingsManager;
-use OCP\Template;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class PersonalSettingsController extends Controller {
@@ -61,39 +60,6 @@ class PersonalSettingsController extends Controller {
 	protected function getSettings($section) {
 		$settings = $this->settingsManager->getPersonalSettings($section);
 		$formatted = $this->formatSettings($settings);
-		if ($section === 'additional') {
-			$formatted['content'] .= $this->getLegacyForms();
-		}
 		return $formatted;
-	}
-
-	/**
-	 * @return bool|string
-	 */
-	private function getLegacyForms() {
-		$forms = \OC_App::getForms('personal');
-
-		$forms = array_map(function ($form) {
-			if (preg_match('%(<h2(?P<class>[^>]*)>.*?</h2>)%i', $form, $regs)) {
-				$sectionName = str_replace('<h2' . $regs['class'] . '>', '', $regs[0]);
-				$sectionName = str_replace('</h2>', '', $sectionName);
-				$anchor = strtolower($sectionName);
-				$anchor = str_replace(' ', '-', $anchor);
-
-				return [
-					'anchor' => $anchor,
-					'section-name' => $sectionName,
-					'form' => $form
-				];
-			}
-			return [
-				'form' => $form
-			];
-		}, $forms);
-
-		$out = new Template('settings', 'settings/additional');
-		$out->assign('forms', $forms);
-
-		return $out->fetchPage();
 	}
 }

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -260,9 +260,7 @@ class Manager implements IManager {
 
 		$sections = [];
 
-		$legacyForms = \OC_App::getForms('personal');
-		if ((!empty($legacyForms) && $this->hasLegacyPersonalSettingsToRender($legacyForms))
-			|| count($this->getPersonalSettings('additional')) > 1) {
+		if (count($this->getPersonalSettings('additional')) > 1) {
 			$sections[98] = [new Section('additional', $this->l->t('Additional settings'), 0, $this->url->imagePath('core', 'actions/settings-dark.svg'))];
 		}
 
@@ -280,20 +278,6 @@ class Manager implements IManager {
 		ksort($sections);
 
 		return $sections;
-	}
-
-	/**
-	 * @param string[] $forms
-	 *
-	 * @return bool
-	 */
-	private function hasLegacyPersonalSettingsToRender(array $forms): bool {
-		foreach ($forms as $form) {
-			if (trim($form) !== '') {
-				return true;
-			}
-		}
-		return false;
 	}
 
 	/**

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -26,12 +26,10 @@ use function OCP\Log\logger;
 
 /**
  * This class manages the apps. It allows them to register and integrate in the
- * ownCloud ecosystem. Furthermore, this class is responsible for installing,
+ * Nextcloud ecosystem. Furthermore, this class is responsible for installing,
  * upgrading and removing apps.
  */
 class OC_App {
-	private static $adminForms = [];
-	private static $personalForms = [];
 	private static $altLogin = [];
 	private static $alreadyRegistered = [];
 	public const supportedApp = 300;
@@ -68,7 +66,7 @@ class OC_App {
 	 * @param string[] $types
 	 * @return bool
 	 *
-	 * This function walks through the ownCloud directory and loads all apps
+	 * This function walks through the Nextcloud directory and loads all apps
 	 * it can find. A directory contains an app if the file /appinfo/info.xml
 	 * exists.
 	 *
@@ -386,28 +384,6 @@ class OC_App {
 	}
 
 	/**
-	 * @param string $type
-	 * @return array
-	 */
-	public static function getForms(string $type): array {
-		$forms = [];
-		switch ($type) {
-			case 'admin':
-				$source = self::$adminForms;
-				break;
-			case 'personal':
-				$source = self::$personalForms;
-				break;
-			default:
-				return [];
-		}
-		foreach ($source as $form) {
-			$forms[] = include $form;
-		}
-		return $forms;
-	}
-
-	/**
 	 * @param array $entry
 	 * @deprecated 20.0.0 Please register your alternative login option using the registerAlternativeLogin() on the RegistrationContext in your Application class implementing the OCP\Authentication\IAlternativeLogin interface
 	 */
@@ -611,7 +587,7 @@ class OC_App {
 	}
 
 	/**
-	 * Check whether the current ownCloud version matches the given
+	 * Check whether the current Nextcloud version matches the given
 	 * application's version requirements.
 	 *
 	 * The comparison is made based on the number of parts that the
@@ -621,7 +597,7 @@ class OC_App {
 	 * This means that it's possible to specify "requiremin" => 6
 	 * and "requiremax" => 6 and it will still match ownCloud 6.0.3.
 	 *
-	 * @param string $ocVersion ownCloud version to check against
+	 * @param string $ocVersion Nextcloud version to check against
 	 * @param array $appInfo app info (from xml)
 	 *
 	 * @return boolean true if compatible, otherwise false


### PR DESCRIPTION
## Summary

`OC_App::getForms` was always returning an empty array, because there were no setter for `adminForms` or `personalForms` anymore. So removed all that legacy settings forms logic.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
