### PR TITLE
fix: Remove deprecated aliases from test

### DIFF
--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -71,9 +71,6 @@ class ServerTest extends \Test\TestCase {
 			['EncryptionManager', '\OCP\Encryption\IManager'],
 			['EventLogger', '\OCP\Diagnostics\IEventLogger'],
 
-			['GroupManager', '\OC\Group\Manager'],
-			['GroupManager', '\OCP\IGroupManager'],
-
 			['Hasher', '\OC\Security\Hasher'],
 			['Hasher', '\OCP\Security\IHasher'],
 			['HttpClientService', '\OC\Http\Client\ClientService'],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
