### PR TITLE
[stable30] feat(share): ensure unique share tokens

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -665,13 +665,25 @@ class Manager implements IManager {
 				$this->linkCreateChecks($share);
 				$this->setLinkParent($share);
 
-				// For now ignore a set token.
-				$share->setToken(
-					$this->secureRandom->generate(
+				for ($i = 0; $i <= 3; $i++) {
+					$token = $this->secureRandom->generate(
 						\OC\Share\Constants::TOKEN_LENGTH,
 						\OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE
-					)
-				);
+					);
+
+					try {
+						$this->getShareByToken($token);
+					} catch (\OCP\Share\Exceptions\ShareNotFound $e) {
+						// Set the unique token
+						$share->setToken($token);
+						break;
+					}
+
+					// Abort after 3 failed attempts
+					if ($i >= 3) {
+						throw new \Exception('Unable to generate a unique share token after 3 attempts.');
+					}
+				}
 
 				// Verify the expiration date
 				$share = $this->validateExpirationDateLink($share);


### PR DESCRIPTION
- check for token collisions and retry up to three times.
- abort with an error if maximum token length is reached without finding a unique token.

Backport of #47265 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
