### PR TITLE
feat(app_api): make app_api shipped and default enabled

### DIFF
--- a/core/shipped.json
+++ b/core/shipped.json
@@ -2,6 +2,7 @@
   "shippedApps": [
     "activity",
     "admin_audit",
+    "app_api",
     "bruteforcesettings",
     "circles",
     "cloud_federation_api",
@@ -54,6 +55,7 @@
   ],
   "defaultEnabled": [
     "activity",
+    "app_api",
     "bruteforcesettings",
     "circles",
     "comments",


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Make [app_api](https://github.com/nextcloud/app_api) shipped and default enabled (since NC 30.0.1).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
