### PR TITLE
Object store move fixes and more

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
+use OC\AllConfig;
 use OCP\IConfig;
 
 /**
@@ -31,7 +32,7 @@ class PartFileInRootUploadTest extends UploadTest {
 					return $config->getSystemValue($key, $default);
 				}
 			});
-		$this->overwriteService('AllConfig', $mockConfig);
+		$this->overwriteService(AllConfig::class, $mockConfig);
 		parent::setUp();
 	}
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -534,6 +534,8 @@ class ShareAPIControllerTest extends TestCase {
 
 		$parentFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$parentFolder->method('getId')->willReturn(3);
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->method('getMountType')->willReturn('');
 
 		$file = $this->getMockBuilder('OCP\Files\File')->getMock();
 		$file->method('getId')->willReturn(1);
@@ -543,6 +545,7 @@ class ShareAPIControllerTest extends TestCase {
 		$file->method('getSize')->willReturn(123465);
 		$file->method('getMTime')->willReturn(1234567890);
 		$file->method('getMimeType')->willReturn('myMimeType');
+		$file->method('getMountPoint')->willReturn($mountPoint);
 
 		$folder = $this->getMockBuilder(Folder::class)->getMock();
 		$folder->method('getId')->willReturn(2);
@@ -552,6 +555,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getSize')->willReturn(123465);
 		$folder->method('getMTime')->willReturn(1234567890);
 		$folder->method('getMimeType')->willReturn('myFolderMimeType');
+		$folder->method('getMountPoint')->willReturn($mountPoint);
 
 		[$shareAttributes, $shareAttributesReturnJson] = $this->mockShareAttributes();
 
@@ -607,6 +611,9 @@ class ShareAPIControllerTest extends TestCase {
 			'item_size' => 123465,
 			'item_mtime' => 1234567890,
 			'attributes' => null,
+			'item_permissions' => 4,
+			'is-mount-root' => false,
+			'mount-type' => '',
 		];
 		$data[] = [$share, $expected];
 
@@ -661,6 +668,9 @@ class ShareAPIControllerTest extends TestCase {
 			'item_size' => 123465,
 			'item_mtime' => 1234567890,
 			'attributes' => null,
+			'item_permissions' => 4,
+			'is-mount-root' => false,
+			'mount-type' => '',
 		];
 		$data[] = [$share, $expected];
 
@@ -721,6 +731,9 @@ class ShareAPIControllerTest extends TestCase {
 			'item_size' => 123465,
 			'item_mtime' => 1234567890,
 			'attributes' => null,
+			'item_permissions' => 4,
+			'is-mount-root' => false,
+			'mount-type' => '',
 		];
 		$data[] = [$share, $expected];
 
@@ -3740,6 +3753,12 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getMimeType')->willReturn('myFolderMimeType');
 		$fileWithPreview->method('getMimeType')->willReturn('mimeWithPreview');
 
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->method('getMountType')->willReturn('');
+		$file->method('getMountPoint')->willReturn($mountPoint);
+		$folder->method('getMountPoint')->willReturn($mountPoint);
+		$fileWithPreview->method('getMountPoint')->willReturn($mountPoint);
+
 		$file->method('getPath')->willReturn('file');
 		$folder->method('getPath')->willReturn('folder');
 		$fileWithPreview->method('getPath')->willReturn('fileWithPreview');
@@ -3839,6 +3858,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => '[{"scope":"permissions","key":"download","value":true}]',
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 		// User backend up
@@ -3880,6 +3900,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => '[{"scope":"permissions","key":"download","value":true}]',
+				'item_permissions' => 1,
 			], $share, [
 				['owner', $owner],
 				['initiator', $initiator],
@@ -3937,6 +3958,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -3990,6 +4012,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 11,
 			], $share, [], false
 		];
 
@@ -4044,6 +4067,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4095,6 +4119,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4153,6 +4178,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4211,6 +4237,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4263,6 +4290,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4315,6 +4343,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4370,6 +4399,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4422,6 +4452,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4474,6 +4505,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4543,6 +4575,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4598,6 +4631,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, [], false
 		];
 
@@ -4651,6 +4685,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 11,
 			], $share, [], false
 		];
 
@@ -4815,6 +4850,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 1,
 			], $share, false, []
 		];
 
@@ -4866,6 +4902,7 @@ class ShareAPIControllerTest extends TestCase {
 				'is-mount-root' => false,
 				'mount-type' => '',
 				'attributes' => null,
+				'item_permissions' => 9,
 			], $share, true, [
 				'share_with_displayname' => 'recipientRoomName'
 			]
@@ -4905,11 +4942,14 @@ class ShareAPIControllerTest extends TestCase {
 				->willReturn(true);
 
 			$helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
-				->setMethods(['formatShare'])
+				->setMethods(['formatShare', 'canAccessShare'])
 				->getMock();
 			$helper->method('formatShare')
 				->with($share)
 				->willReturn($formatShareByHelper);
+			$helper->method('canAccessShare')
+				->with($share)
+				->willReturn(true);
 
 			$this->serverContainer->method('get')
 				->with('\OCA\Talk\Share\Helper\ShareAPIController')

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -326,6 +326,7 @@ class ShareControllerTest extends \Test\TestCase {
 			'sharePermissions' => (Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE),
 			'filename' => $filename,
 			'view' => $view,
+			'fileId' => 111,
 		];
 
 		$response = $this->shareController->showShare();

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -11,6 +11,7 @@ use OCA\Files_Sharing\Tests\TestCase;
 use OCP\Contacts\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudIdManager;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\ICacheFactory;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -74,6 +75,7 @@ class CacheTest extends TestCase {
 			$this->storage,
 			$this->cloudIdManager->getCloudId($this->remoteUser, 'http://example.com/owncloud')
 		);
+		$this->cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$this->cache->put(
 			'test.txt',
 			[

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -591,6 +591,7 @@ class StorageTest extends \Test\TestCase {
 		$event->expects($this->any())->method('shouldMoveToTrashBin')->willReturn(!$appDisablesTrash);
 
 		$userFolder->expects($this->any())->method('getById')->with($fileID)->willReturn([$node]);
+		$rootFolder->expects($this->any())->method('getById')->with($fileID)->willReturn([$node]);
 		$rootFolder->expects($this->any())->method('getUserFolder')->willReturn($userFolder);
 
 		$storage = $this->getMockBuilder(Storage::class)

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -265,6 +265,9 @@ class Cache implements ICache {
 		if (!isset($data['parent'])) {
 			$data['parent'] = $this->getParentId($file);
 		}
+		if ($data['parent'] === -1 && $file !== '') {
+			throw new \Exception('Parent folder not in filecache for ' . $file);
+		}
 		$data['name'] = basename($file);
 
 		[$values, $extensionValues] = $this->normalizeData($data);

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -607,10 +607,14 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			}
 			$sourceStorage->rmdir($sourceInternalPath);
 		} else {
+			$sourceStream = $sourceStorage->fopen($sourceInternalPath, 'r');
+			if (!$sourceStream) {
+				return false;
+			}
 			// move the cache entry before the contents so that we have the correct fileid/urn for the target
 			$this->getCache()->moveFromCache($sourceCache, $sourceInternalPath, $targetInternalPath);
 			try {
-				$this->writeStream($targetInternalPath, $sourceStorage->fopen($sourceInternalPath, 'r'), $sourceCacheEntry->getSize());
+				$this->writeStream($targetInternalPath, $sourceStream, $sourceCacheEntry->getSize());
 			} catch (\Exception $e) {
 				// restore the cache entry
 				$sourceCache->moveFromCache($this->getCache(), $targetInternalPath, $sourceInternalPath);

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -602,6 +602,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			$sourceCacheEntry = $sourceCache->get($sourceInternalPath);
 		}
 		if ($sourceCacheEntry->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
+			$this->mkdir($targetInternalPath);
 			foreach ($sourceCache->getFolderContents($sourceInternalPath) as $child) {
 				$this->moveFromStorage($sourceStorage, $child->getPath(), $targetInternalPath . '/' . $child->getName());
 			}

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -492,6 +492,10 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		if ($exists) {
 			$fileId = $stat['fileid'];
 		} else {
+			$parent = $this->normalizePath(dirname($path));
+			if (!$this->is_dir($parent)) {
+				throw new \InvalidArgumentException("trying to upload a file ($path) inside a non-directory ($parent)");
+			}
 			$fileId = $this->getCache()->put($uploadPath, $stat);
 		}
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -459,13 +459,10 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	}
 
 	public function file_put_contents($path, $data) {
-		$handle = $this->fopen($path, 'w+');
-		if (!$handle) {
-			return false;
-		}
-		$result = fwrite($handle, $data);
-		fclose($handle);
-		return $result;
+		$fh = fopen('php://temp', 'w+');
+		fwrite($fh, $data);
+		rewind($fh);
+		return $this->writeStream($path, $fh, strlen($data));
 	}
 
 	public function writeStream(string $path, $stream, ?int $size = null): int {

--- a/lib/private/Files/ObjectStore/StorageObjectStore.php
+++ b/lib/private/Files/ObjectStore/StorageObjectStore.php
@@ -27,8 +27,8 @@ class StorageObjectStore implements IObjectStore {
 	 * @return string the container or bucket name where objects are stored
 	 * @since 7.0.0
 	 */
-	public function getStorageId() {
-		$this->storage->getId();
+	public function getStorageId(): string {
+		return $this->storage->getId();
 	}
 
 	/**

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -11,6 +11,7 @@ use OC\Files\Cache\Cache;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchComparison;
 use OCP\IDBConnection;
 use OCP\IUser;
@@ -148,7 +149,7 @@ class CacheTest extends \Test\TestCase {
 		}
 		$file2 = $folder . '/bar';
 		$file3 = $folder . '/foo';
-		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 		$fileData = [];
 		$fileData['bar'] = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'foo/file'];
 		$fileData['foo'] = ['size' => 20, 'mtime' => 25, 'mimetype' => 'foo/file'];
@@ -188,7 +189,7 @@ class CacheTest extends \Test\TestCase {
 	}
 
 	public function testRemoveRecursive(): void {
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 		$fileData = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'text/plain'];
 		$folders = ['folder', 'folder/subfolder', 'folder/sub2', 'folder/sub2/sub3'];
 		$files = ['folder/foo.txt', 'folder/bar.txt', 'folder/subfolder/asd.txt', 'folder/sub2/qwerty.txt', 'folder/sub2/sub3/foo.txt'];
@@ -224,7 +225,7 @@ class CacheTest extends \Test\TestCase {
 		$file1 = 'folder';
 		$file2 = 'folder/bar';
 		$file3 = 'folder/foo';
-		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 		$fileData = [];
 		$fileData['bar'] = ['size' => 1000, 'encrypted' => 1, 'mtime' => 20, 'mimetype' => 'foo/file'];
 		$fileData['foo'] = ['size' => 20, 'encrypted' => 1, 'mtime' => 25, 'mimetype' => 'foo/file'];
@@ -267,11 +268,10 @@ class CacheTest extends \Test\TestCase {
 		$dir1 = 'knownsize';
 		$dir2 = 'unknownsize';
 		$fileData = [];
-		$fileData[''] = ['size' => -1, 'mtime' => 20, 'mimetype' => 'httpd/unix-directory'];
-		$fileData[$dir1] = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'httpd/unix-directory'];
-		$fileData[$dir2] = ['size' => -1, 'mtime' => 25, 'mimetype' => 'httpd/unix-directory'];
+		$fileData[''] = ['size' => -1, 'mtime' => 20, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
+		$fileData[$dir1] = ['size' => 1000, 'mtime' => 20, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
+		$fileData[$dir2] = ['size' => -1, 'mtime' => 25, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
-		$this->cache->put('', $fileData['']);
 		$this->cache->put($dir1, $fileData[$dir1]);
 		$this->cache->put($dir2, $fileData[$dir2]);
 
@@ -338,7 +338,6 @@ class CacheTest extends \Test\TestCase {
 		$this->assertEquals(1, count($this->cache->search('foo')));
 		$this->assertEquals(1, count($this->cache->search('%folder%')));
 		$this->assertEquals(1, count($this->cache->search('folder%')));
-		$this->assertEquals(3, count($this->cache->search('%')));
 
 		// case insensitive search should match the same files
 		$this->assertEquals(2, count($this->cache->search('%Foo%')));
@@ -450,7 +449,7 @@ class CacheTest extends \Test\TestCase {
 	 */
 	public function testMove($sourceFolder, $targetFolder, $children): void {
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/bar'];
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		// create folders
 		foreach ([$sourceFolder, $targetFolder] as $current) {
@@ -485,7 +484,7 @@ class CacheTest extends \Test\TestCase {
 
 	public function testMoveFromCache(): void {
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/bar'];
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		$this->cache2->put('folder', $folderData);
 		$this->cache2->put('folder/sub', $data);
@@ -554,6 +553,7 @@ class CacheTest extends \Test\TestCase {
 	public function testLongId(): void {
 		$storage = new LongId([]);
 		$cache = $storage->getCache();
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$storageId = $storage->getId();
 		$data = ['size' => 1000, 'mtime' => 20, 'mimetype' => 'foo/file'];
 		$id = $cache->put('foo', $data);
@@ -582,7 +582,7 @@ class CacheTest extends \Test\TestCase {
 			->method('normalize')
 			->willReturnArgument(0);
 
-		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		// put root folder
 		$this->assertFalse($cacheMock->get('folder'));
@@ -621,7 +621,7 @@ class CacheTest extends \Test\TestCase {
 		// folder name "Schön" with U+0308 (un-normalized)
 		$folderWith0308 = "\x53\x63\x68\x6f\xcc\x88\x6e";
 
-		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		// put root folder
 		$this->assertFalse($this->cache->get('folder'));
@@ -660,12 +660,8 @@ class CacheTest extends \Test\TestCase {
 	 * @dataProvider bogusPathNamesProvider
 	 */
 	public function testBogusPaths($bogusPath, $fixedBogusPath): void {
-		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
-
-		// put root folder
-		$this->assertFalse($this->cache->get(''));
-		$parentId = $this->cache->put('', $data);
-		$this->assertGreaterThan(0, $parentId);
+		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
+		$parentId = $this->cache->getId('');
 
 		$this->assertGreaterThan(0, $this->cache->put($bogusPath, $data));
 
@@ -719,7 +715,7 @@ class CacheTest extends \Test\TestCase {
 		$this->assertTrue($this->cache->inCache($name . 'asd'));
 		$this->cache->remove($name . 'asd');
 		$this->assertFalse($this->cache->inCache($name . 'asd'));
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 		$this->cache->put($name, $folderData);
 		$this->cache->put('other', $folderData);
 		$childs = ['asd', 'bar', 'foo', 'sub/folder'];
@@ -743,8 +739,7 @@ class CacheTest extends \Test\TestCase {
 	}
 
 	public function testExtended(): void {
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
-		$this->cache->put('', $folderData);
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain', 'creation_time' => 20];
 		$id1 = $this->cache->put('foo1', $data);
@@ -827,5 +822,7 @@ class CacheTest extends \Test\TestCase {
 		$this->storage2 = new \OC\Files\Storage\Temporary([]);
 		$this->cache = new \OC\Files\Cache\Cache($this->storage);
 		$this->cache2 = new \OC\Files\Cache\Cache($this->storage2);
+		$this->cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$this->cache2->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 	}
 }

--- a/tests/lib/Files/Cache/MoveFromCacheTraitTest.php
+++ b/tests/lib/Files/Cache/MoveFromCacheTraitTest.php
@@ -8,6 +8,7 @@
 namespace Test\Files\Cache;
 
 use OC\Files\Cache\MoveFromCacheTrait;
+use OCP\Files\Cache\ICacheEntry;
 
 class FallBackCrossCacheMoveCache extends \OC\Files\Cache\Cache {
 	use MoveFromCacheTrait;
@@ -26,5 +27,8 @@ class MoveFromCacheTraitTest extends CacheTest {
 		$this->storage2 = new \OC\Files\Storage\Temporary([]);
 		$this->cache = new FallBackCrossCacheMoveCache($this->storage);
 		$this->cache2 = new FallBackCrossCacheMoveCache($this->storage2);
+
+		$this->cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$this->cache2->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 	}
 }

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -13,6 +13,7 @@ use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Jail;
 use OC\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Search\ISearchComparison;
 use Test\Files\Cache\CacheTest;
 
@@ -31,17 +32,19 @@ class CacheJailTest extends CacheTest {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->storage->mkdir('foo');
+		$this->storage->mkdir('jail');
 		$this->sourceCache = $this->cache;
-		$this->cache = new \OC\Files\Cache\Wrapper\CacheJail($this->sourceCache, 'foo');
+		$this->cache = new \OC\Files\Cache\Wrapper\CacheJail($this->sourceCache, 'jail');
+		$this->cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 	}
 
 	public function testSearchOutsideJail(): void {
 		$this->storage->getScanner()->scan('');
-		$file1 = 'foo/foobar';
+		$file1 = 'jail/foobar';
 		$file2 = 'folder/foobar';
 		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/folder'];
 
+		$this->sourceCache->insert('folder', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$this->sourceCache->put($file1, $data1);
 		$this->sourceCache->put($file2, $data1);
 
@@ -52,20 +55,20 @@ class CacheJailTest extends CacheTest {
 		$this->assertEquals('foobar', $result[0]['path']);
 
 		$result = $this->cache->search('%foo%');
-		$this->assertCount(2, $result);
+		$this->assertCount(1, $result);
 		usort($result, function ($a, $b) {
 			return $a['path'] <=> $b['path'];
 		});
-		$this->assertEquals('', $result[0]['path']);
-		$this->assertEquals('foobar', $result[1]['path']);
+		$this->assertEquals('foobar', $result[0]['path']);
 	}
 
 	public function testSearchMimeOutsideJail(): void {
 		$this->storage->getScanner()->scan('');
-		$file1 = 'foo/foobar';
+		$file1 = 'jail/foobar';
 		$file2 = 'folder/foobar';
 		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/folder'];
 
+		$this->sourceCache->insert('folder', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$this->sourceCache->put($file1, $data1);
 		$this->sourceCache->put($file2, $data1);
 
@@ -78,10 +81,12 @@ class CacheJailTest extends CacheTest {
 
 	public function testSearchQueryOutsideJail(): void {
 		$this->storage->getScanner()->scan('');
-		$file1 = 'foo/foobar';
+		$file1 = 'jail/foobar';
 		$file2 = 'folder/foobar';
 		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/folder'];
 
+
+		$this->sourceCache->insert('folder', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$this->sourceCache->put($file1, $data1);
 		$this->sourceCache->put($file2, $data1);
 
@@ -92,19 +97,19 @@ class CacheJailTest extends CacheTest {
 		$this->assertCount(1, $result);
 		$this->assertEquals('foobar', $result[0]['path']);
 
-		$query = new SearchQuery(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'name', 'foo'), 10, 0, [], $user);
+		$query = new SearchQuery(new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'name', 'jail'), 10, 0, [], $user);
 		$result = $this->cache->searchQuery($query);
 		$this->assertCount(1, $result);
 		$this->assertEquals('', $result[0]['path']);
 	}
 
 	public function testClearKeepEntriesOutsideJail(): void {
-		$file1 = 'foo/foobar';
-		$file2 = 'foo/foobar/asd';
+		$file1 = 'jail/foobar';
+		$file2 = 'jail/foobar/asd';
 		$file3 = 'folder/foobar';
-		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
-		$this->sourceCache->put('foo', $data1);
+		$this->sourceCache->put('folder', $data1);
 		$this->sourceCache->put($file1, $data1);
 		$this->sourceCache->put($file2, $data1);
 		$this->sourceCache->put($file3, $data1);
@@ -116,8 +121,8 @@ class CacheJailTest extends CacheTest {
 	}
 
 	public function testGetById(): void {
-		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
-		$id = $this->sourceCache->put('foo/bar', $data1);
+		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
+		$id = $this->sourceCache->put('jail/bar', $data1);
 
 		// path from jailed foo of foo/bar is bar
 		$path = $this->cache->getPathById($id);
@@ -126,7 +131,7 @@ class CacheJailTest extends CacheTest {
 		// path from jailed '' of foo/bar is foo/bar
 		$this->cache = new \OC\Files\Cache\Wrapper\CacheJail($this->sourceCache, '');
 		$path = $this->cache->getPathById($id);
-		$this->assertEquals('foo/bar', $path);
+		$this->assertEquals('jail/bar', $path);
 	}
 
 	public function testGetIncomplete(): void {
@@ -135,7 +140,7 @@ class CacheJailTest extends CacheTest {
 	}
 
 	public function testMoveFromJail(): void {
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		$this->sourceCache->put('source', $folderData);
 		$this->sourceCache->put('source/foo', $folderData);
@@ -151,7 +156,7 @@ class CacheJailTest extends CacheTest {
 	}
 
 	public function testMoveToJail(): void {
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		$this->sourceCache->put('source', $folderData);
 		$this->sourceCache->put('source/foo', $folderData);
@@ -167,7 +172,7 @@ class CacheJailTest extends CacheTest {
 	}
 
 	public function testMoveBetweenJail(): void {
-		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 
 		$this->sourceCache->put('source', $folderData);
 		$this->sourceCache->put('source/foo', $folderData);
@@ -185,9 +190,9 @@ class CacheJailTest extends CacheTest {
 
 	public function testSearchNested(): void {
 		$this->storage->getScanner()->scan('');
-		$file1 = 'foo';
-		$file2 = 'foo/bar';
-		$file3 = 'foo/bar/asd';
+		$file1 = 'jail';
+		$file2 = 'jail/bar';
+		$file3 = 'jail/bar/asd';
 		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/folder'];
 
 		$this->sourceCache->put($file1, $data1);
@@ -203,9 +208,9 @@ class CacheJailTest extends CacheTest {
 
 	public function testRootJail(): void {
 		$this->storage->getScanner()->scan('');
-		$file1 = 'foo';
-		$file2 = 'foo/bar';
-		$file3 = 'foo/bar/asd';
+		$file1 = 'jail';
+		$file2 = 'jail/bar';
+		$file3 = 'jail/bar/asd';
 		$data1 = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/folder'];
 
 		$this->sourceCache->put($file1, $data1);
@@ -216,13 +221,13 @@ class CacheJailTest extends CacheTest {
 
 		$result = $nested->search('%asd%');
 		$this->assertCount(1, $result);
-		$this->assertEquals('foo/bar/asd', $result[0]['path']);
+		$this->assertEquals('jail/bar/asd', $result[0]['path']);
 	}
 
 	public function testWatcher(): void {
 		$storage = new Jail([
 			'storage' => $this->storage,
-			'root' => 'foo'
+			'root' => 'jail'
 		]);
 		$storage->getScanner()->scan('');
 		$storage->file_put_contents('bar', 'asd');
@@ -235,7 +240,7 @@ class CacheJailTest extends CacheTest {
 	public function testWatcherAfterInnerWatcher(): void {
 		$storage = new Jail([
 			'storage' => $this->storage,
-			'root' => 'foo'
+			'root' => 'jail'
 		]);
 		$storage->getScanner()->scan('');
 		$storage->file_put_contents('bar', 'asd');

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -17,6 +17,7 @@ use OC\Files\Node\File;
 use OC\Files\Node\Folder;
 use OC\Files\Node\Node;
 use OC\Files\Node\Root;
+use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchOrder;
 use OC\Files\Search\SearchQuery;
@@ -26,6 +27,7 @@ use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
+use OCP\Files\Search\ISearchBinaryOperator;
 use OCP\Files\Search\ISearchComparison;
 use OCP\Files\Search\ISearchOrder;
 use OCP\Files\Storage\IStorage;
@@ -312,6 +314,7 @@ class FolderTest extends NodeTest {
 			->method('getInternalPath')
 			->willReturn('foo');
 
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('foo', ['size' => 200, 'mtime' => 55, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('foo/qwerty', ['size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']);
 
@@ -356,6 +359,7 @@ class FolderTest extends NodeTest {
 		$storage->method('getOwner')
 			->willReturn('owner');
 
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('files', ['size' => 200, 'mtime' => 55, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('files/foo', ['size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']);
 
@@ -396,6 +400,7 @@ class FolderTest extends NodeTest {
 		$storage->method('getOwner')
 			->willReturn('owner');
 
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('foo', ['size' => 200, 'mtime' => 55, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('foo/qwerty', ['size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']);
 
@@ -454,9 +459,11 @@ class FolderTest extends NodeTest {
 		$subStorage->method('getOwner')
 			->willReturn('owner');
 
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('foo', ['size' => 200, 'mtime' => 55, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('foo/qwerty', ['size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']);
 
+		$subCache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$subCache->insert('asd', ['size' => 200, 'mtime' => 55, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$subCache->insert('asd/qwerty', ['size' => 200, 'mtime' => 55, 'mimetype' => 'text/plain']);
 
@@ -737,6 +744,10 @@ class FolderTest extends NodeTest {
 
 		$cache = $storage->getCache();
 
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$cache->insert('bar', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$cache->insert('bar/foo', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$cache->insert('bar/asd', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$id1 = $cache->put('bar/foo/inside.txt', [
 			'storage_mtime' => $baseTime,
 			'mtime' => $baseTime,
@@ -803,6 +814,9 @@ class FolderTest extends NodeTest {
 
 		$cache = $storage->getCache();
 
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$cache->insert('bar', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$cache->insert('bar/foo', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$id1 = $cache->put('bar/foo/folder', [
 			'storage_mtime' => $baseTime,
 			'mtime' => $baseTime,
@@ -870,6 +884,8 @@ class FolderTest extends NodeTest {
 
 		$cache = $storage->getCache();
 
+		$cache->insert('', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$cache->insert('folder', ['size' => 0, 'mtime' => 0, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$id1 = $cache->put('folder/inside.txt', [
 			'storage_mtime' => $baseTime,
 			'mtime' => $baseTime,
@@ -877,6 +893,7 @@ class FolderTest extends NodeTest {
 			'size' => 3,
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
 		]);
+
 		$cache->put('outside.txt', [
 			'storage_mtime' => $baseTime - 100,
 			'mtime' => $baseTime - 100,
@@ -980,14 +997,19 @@ class FolderTest extends NodeTest {
 		$subStorage2->method('getOwner')
 			->willReturn('owner');
 
+
+		$cache->insert('', ['size' => 0, 'mtime' => 10, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
+		$cache->insert('foo', ['size' => 0, 'mtime' => 10, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$cache->insert('foo/foo1', ['size' => 200, 'mtime' => 10, 'mimetype' => 'text/plain']);
 		$cache->insert('foo/foo2', ['size' => 200, 'mtime' => 20, 'mimetype' => 'text/plain']);
 		$cache->insert('foo/foo3', ['size' => 200, 'mtime' => 30, 'mimetype' => 'text/plain']);
 		$cache->insert('foo/foo4', ['size' => 200, 'mtime' => 40, 'mimetype' => 'text/plain']);
 
+		$subCache1->insert('', ['size' => 0, 'mtime' => 10, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$subCache1->insert('foo5', ['size' => 300, 'mtime' => 15, 'mimetype' => 'text/plain']);
 		$subCache1->insert('foo6', ['size' => 300, 'mtime' => 50, 'mimetype' => 'text/plain']);
 
+		$subCache2->insert('', ['size' => 0, 'mtime' => 10, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE]);
 		$subCache2->insert('foo7', ['size' => 200, 'mtime' => 5, 'mimetype' => 'text/plain']);
 		$subCache2->insert('foo8', ['size' => 200, 'mtime' => 60, 'mimetype' => 'text/plain']);
 
@@ -1001,7 +1023,11 @@ class FolderTest extends NodeTest {
 
 		$node = new Folder($root, $view, '/bar/foo');
 		$comparison = new SearchComparison(ISearchComparison::COMPARE_LIKE, 'name', '%foo%');
-		$query = new SearchQuery($comparison, $limit, $offset, $ordering);
+		$operator = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_AND, [
+			$comparison,
+			new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_NOT, [new SearchComparison(ISearchComparison::COMPARE_EQUAL, 'mimetype', ICacheEntry::DIRECTORY_MIMETYPE)]),
+		]);
+		$query = new SearchQuery($operator, $limit, $offset, $ordering);
 		$result = $node->search($query);
 		$cache->clear();
 		$subCache1->clear();

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -76,7 +76,7 @@ class ObjectStoreStorageTest extends Storage {
 	 */
 	public function testMove($source, $target): void {
 		$this->initSourceAndTarget($source);
-		$sourceId = $this->instance->getCache()->getId(ltrim('/', $source));
+		$sourceId = $this->instance->getCache()->getId(ltrim($source, '/'));
 		$this->assertNotEquals(-1, $sourceId);
 
 		$this->instance->rename($source, $target);
@@ -85,7 +85,7 @@ class ObjectStoreStorageTest extends Storage {
 		$this->assertFalse($this->instance->file_exists($source), $source.' still exists');
 		$this->assertSameAsLorem($target);
 
-		$targetId = $this->instance->getCache()->getId(ltrim('/', $target));
+		$targetId = $this->instance->getCache()->getId(ltrim($target, '/'));
 		$this->assertSame($sourceId, $targetId, 'fileid must be stable on move or shares will break');
 	}
 

--- a/tests/lib/Repair/RepairMimeTypesTest.php
+++ b/tests/lib/Repair/RepairMimeTypesTest.php
@@ -54,6 +54,7 @@ class RepairMimeTypesTest extends \Test\TestCase {
 			->willReturn('11.0.0.0');
 
 		$this->storage = new Temporary([]);
+		$this->storage->getScanner()->scan('');
 
 		$this->repair = new RepairMimeTypes(
 			$config,


### PR DESCRIPTION
Fixes some issues in cross-storage moves with object storage found by the tests added in https://github.com/nextcloud/server/pull/47986

I'm not sure how much of these issues would occur in the real world or only in the artificial test situations.

Comes with a bonus lower overhead `file_put_contents` implementation.

Fixes https://github.com/nextcloud/server/issues/48169