### PR TITLE
fix(autocomplete): Move known array keys to psalm docs

### DIFF
--- a/apps/files_sharing/tests/Collaboration/ShareRecipientSorterTest.php
+++ b/apps/files_sharing/tests/Collaboration/ShareRecipientSorterTest.php
@@ -109,7 +109,7 @@ class ShareRecipientSorterTest extends TestCase {
 			]
 		];
 		$workArray = $originalArray;
-		$this->sorter->sort($workArray, ['itemType' => 'files', 'itemId' => 404]);
+		$this->sorter->sort($workArray, ['itemType' => 'files', 'itemId' => '404']);
 
 		$this->assertEquals($originalArray, $workArray);
 	}
@@ -118,7 +118,7 @@ class ShareRecipientSorterTest extends TestCase {
 		return [[
 			[
 				#0 – sort properly and otherwise keep existing order
-				'context' => ['itemType' => 'files', 'itemId' => 42],
+				'context' => ['itemType' => 'files', 'itemId' => '42'],
 				'accessList' => ['users' => ['celia', 'darius', 'faruk', 'gail'], 'bots' => ['r2-d2']],
 				'input' => [
 					'users' =>
@@ -155,7 +155,7 @@ class ShareRecipientSorterTest extends TestCase {
 			],
 			[
 				#1 – no recipients
-				'context' => ['itemType' => 'files', 'itemId' => 42],
+				'context' => ['itemType' => 'files', 'itemId' => '42'],
 				'accessList' => ['users' => false],
 				'input' => [
 					'users' =>
@@ -192,7 +192,7 @@ class ShareRecipientSorterTest extends TestCase {
 			],
 			[
 				#2 – unsupported item  type
-				'context' => ['itemType' => 'announcements', 'itemId' => 42],
+				'context' => ['itemType' => 'announcements', 'itemId' => '42'],
 				'accessList' => null, // not needed
 				'input' => [
 					'users' =>
@@ -229,7 +229,7 @@ class ShareRecipientSorterTest extends TestCase {
 			],
 			[
 				#3 – no nothing
-				'context' => ['itemType' => 'files', 'itemId' => 42],
+				'context' => ['itemType' => 'files', 'itemId' => '42'],
 				'accessList' => [],
 				'input' => [],
 				'expected' => [],

--- a/lib/public/Collaboration/AutoComplete/IManager.php
+++ b/lib/public/Collaboration/AutoComplete/IManager.php
@@ -20,7 +20,7 @@ interface IManager {
 	/**
 	 * @param array $sorters list of sorter IDs, separated by "|"
 	 * @param array $sortArray array representation of OCP\Collaboration\Collaborators\ISearchResult
-	 * @param array $context context info of the search, keys: itemType, itemId
+	 * @param array{itemType: string, itemId: string, search?: string} $context context info of the search
 	 * @since 13.0.0
 	 */
 	public function runSorters(array $sorters, array &$sortArray, array $context);

--- a/lib/public/Collaboration/AutoComplete/ISorter.php
+++ b/lib/public/Collaboration/AutoComplete/ISorter.php
@@ -23,7 +23,7 @@ interface ISorter {
 	 * executes the sort action
 	 *
 	 * @param array $sortArray the array to be sorted, provided as reference
-	 * @param array $context carries key 'itemType' and 'itemId' of the source object (e.g. a file)
+	 * @param array{itemType: string, itemId: string, search?: string} $context carries key 'itemType' and 'itemId' of the source object (e.g. a file)
 	 * @since 13.0.0
 	 */
 	public function sort(array &$sortArray, array $context);


### PR DESCRIPTION
Found by using rector in Talk

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
