### PR TITLE
[stable29] fix(appstoreFetcher): get list from a custom store and remove unnecessary warning

### DIFF
--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -186,7 +186,6 @@ class AppFetcher extends Fetcher {
 
 		$apps = parent::get($allowPreReleases);
 		if (empty($apps)) {
-			$this->logger->warning('Could not get apps from the appstore', ['app' => 'appstoreFetcher']);
 			return [];
 		}
 		$allowList = $this->config->getSystemValue('appsallowlist');

--- a/lib/private/App/AppStore/Fetcher/AppFetcher.php
+++ b/lib/private/App/AppStore/Fetcher/AppFetcher.php
@@ -176,14 +176,6 @@ class AppFetcher extends Fetcher {
 	public function get($allowUnstable = false): array {
 		$allowPreReleases = $allowUnstable || $this->getChannel() === 'beta' || $this->getChannel() === 'daily' || $this->getChannel() === 'git';
 
-		$appStoreEnabled = $this->config->getSystemValueBool('appstoreenabled', true);
-		$internetAvailable = $this->config->getSystemValueBool('has_internet_connection', true);
-
-		if (!$appStoreEnabled || !$internetAvailable) {
-			$this->logger->info('AppStore is disabled or this instance has no Internet connection', ['app' => 'appstoreFetcher']);
-			return [];
-		}
-
 		$apps = parent::get($allowPreReleases);
 		if (empty($apps)) {
 			return [];

--- a/lib/private/App/AppStore/Fetcher/Fetcher.php
+++ b/lib/private/App/AppStore/Fetcher/Fetcher.php
@@ -145,6 +145,7 @@ abstract class Fetcher {
 		$isDefaultAppStore = $this->config->getSystemValueString('appstoreurl', self::APP_STORE_URL) === self::APP_STORE_URL;
 
 		if (!$appstoreenabled || (!$internetavailable && $isDefaultAppStore)) {
+			$this->logger->info('AppStore is disabled or this instance has no Internet connection to access the default app store', ['app' => 'appstoreFetcher']);
 			return [];
 		}
 


### PR DESCRIPTION
- Manual backport of: https://github.com/nextcloud/server/pull/48114