### PR TITLE
fix(StorageObjectStore): Add missing return statement to getStorageId()

### DIFF
--- a/lib/private/Files/ObjectStore/StorageObjectStore.php
+++ b/lib/private/Files/ObjectStore/StorageObjectStore.php
@@ -28,7 +28,7 @@ class StorageObjectStore implements IObjectStore {
 	 * @since 7.0.0
 	 */
 	public function getStorageId() {
-		$this->storage->getId();
+		return $this->storage->getId();
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #48169

## Summary
Missing return statement to getStorageId() added.