### PR TITLE
fix(activity): Update more activity providers to use new exceptions

### DIFF
--- a/apps/comments/lib/Activity/Provider.php
+++ b/apps/comments/lib/Activity/Provider.php
@@ -54,7 +54,7 @@ class Provider implements IProvider {
 			if ($this->activityManager->isFormattingFilteredObject()) {
 				try {
 					return $this->parseShortVersion($event);
-				} catch (\InvalidArgumentException $e) {
+				} catch (UnknownActivityException) {
 					// Ignore and simply use the long version...
 				}
 			}
@@ -66,7 +66,7 @@ class Provider implements IProvider {
 	}
 
 	/**
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 */
 	protected function parseShortVersion(IEvent $event): IEvent {
 		$subjectParameters = $this->getSubjectParameters($event);
@@ -81,14 +81,14 @@ class Provider implements IProvider {
 				]);
 			}
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		return $event;
 	}
 
 	/**
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 */
 	protected function parseLongVersion(IEvent $event): IEvent {
 		$subjectParameters = $this->getSubjectParameters($event);
@@ -113,7 +113,7 @@ class Provider implements IProvider {
 					]);
 			}
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		return $event;

--- a/apps/files/lib/Activity/FavoriteProvider.php
+++ b/apps/files/lib/Activity/FavoriteProvider.php
@@ -64,7 +64,7 @@ class FavoriteProvider implements IProvider {
 		if ($this->activityManager->isFormattingFilteredObject()) {
 			try {
 				return $this->parseShortVersion($event);
-			} catch (\InvalidArgumentException $e) {
+			} catch (UnknownActivityException) {
 				// Ignore and simply use the long version...
 			}
 		}
@@ -75,10 +75,10 @@ class FavoriteProvider implements IProvider {
 	/**
 	 * @param IEvent $event
 	 * @return IEvent
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 * @since 11.0.0
 	 */
-	public function parseShortVersion(IEvent $event) {
+	public function parseShortVersion(IEvent $event): IEvent {
 		if ($event->getSubject() === self::SUBJECT_ADDED) {
 			$event->setParsedSubject($this->l->t('Added to favorites'));
 			if ($this->activityManager->getRequirePNG()) {
@@ -95,7 +95,7 @@ class FavoriteProvider implements IProvider {
 				$event->setIcon($this->url->getAbsoluteURL($this->url->imagePath('core', 'actions/star.svg')));
 			}
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		return $event;
@@ -105,10 +105,10 @@ class FavoriteProvider implements IProvider {
 	 * @param IEvent $event
 	 * @param IEvent|null $previousEvent
 	 * @return IEvent
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 * @since 11.0.0
 	 */
-	public function parseLongVersion(IEvent $event, ?IEvent $previousEvent = null) {
+	public function parseLongVersion(IEvent $event, ?IEvent $previousEvent = null): IEvent {
 		if ($event->getSubject() === self::SUBJECT_ADDED) {
 			$subject = $this->l->t('You added {file} to your favorites');
 			if ($this->activityManager->getRequirePNG()) {
@@ -125,7 +125,7 @@ class FavoriteProvider implements IProvider {
 				$event->setIcon($this->url->getAbsoluteURL($this->url->imagePath('core', 'actions/star.svg')));
 			}
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		$this->setSubjects($event, $subject);

--- a/apps/files/lib/Activity/Provider.php
+++ b/apps/files/lib/Activity/Provider.php
@@ -94,7 +94,7 @@ class Provider implements IProvider {
 		if ($this->activityManager->isFormattingFilteredObject()) {
 			try {
 				return $this->parseShortVersion($event, $previousEvent);
-			} catch (\InvalidArgumentException $e) {
+			} catch (UnknownActivityException) {
 				// Ignore and simply use the long version...
 			}
 		}
@@ -114,10 +114,10 @@ class Provider implements IProvider {
 	 * @param IEvent $event
 	 * @param IEvent|null $previousEvent
 	 * @return IEvent
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 * @since 11.0.0
 	 */
-	public function parseShortVersion(IEvent $event, ?IEvent $previousEvent = null) {
+	public function parseShortVersion(IEvent $event, ?IEvent $previousEvent = null): IEvent {
 		$parsedParameters = $this->getParameters($event);
 
 		if ($event->getSubject() === 'created_by') {
@@ -139,7 +139,7 @@ class Provider implements IProvider {
 			$subject = $this->l->t('Moved by {user}');
 			$this->setIcon($event, 'change');
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		if (!isset($parsedParameters['user'])) {
@@ -156,10 +156,10 @@ class Provider implements IProvider {
 	 * @param IEvent $event
 	 * @param IEvent|null $previousEvent
 	 * @return IEvent
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 * @since 11.0.0
 	 */
-	public function parseLongVersion(IEvent $event, ?IEvent $previousEvent = null) {
+	public function parseLongVersion(IEvent $event, ?IEvent $previousEvent = null): IEvent {
 		$this->fileIsEncrypted = false;
 		$parsedParameters = $this->getParameters($event);
 
@@ -253,7 +253,7 @@ class Provider implements IProvider {
 			$subject = $this->l->t('{user} moved {oldfile} to {newfile}');
 			$this->setIcon($event, 'change');
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		if ($this->fileIsEncrypted) {
@@ -292,9 +292,9 @@ class Provider implements IProvider {
 	/**
 	 * @param IEvent $event
 	 * @return array
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 */
-	protected function getParameters(IEvent $event) {
+	protected function getParameters(IEvent $event): array {
 		$parameters = $event->getSubjectParameters();
 		switch ($event->getSubject()) {
 			case 'created_self':
@@ -347,9 +347,9 @@ class Provider implements IProvider {
 	 * @param array|string $parameter
 	 * @param IEvent|null $event
 	 * @return array
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 */
-	protected function getFile($parameter, ?IEvent $event = null) {
+	protected function getFile($parameter, ?IEvent $event = null): array {
 		if (is_array($parameter)) {
 			$path = reset($parameter);
 			$id = (string)key($parameter);
@@ -358,7 +358,7 @@ class Provider implements IProvider {
 			$path = $parameter;
 			$id = $event->getObjectId();
 		} else {
-			throw new \InvalidArgumentException('Could not generate file parameter');
+			throw new UnknownActivityException('Could not generate file parameter');
 		}
 
 		$encryptionContainer = $this->getEndToEndEncryptionContainer($id, $path);

--- a/apps/files/tests/Activity/ProviderTest.php
+++ b/apps/files/tests/Activity/ProviderTest.php
@@ -6,6 +6,7 @@
 namespace OCA\Files\Tests\Activity;
 
 use OCA\Files\Activity\Provider;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IEventMerger;
 use OCP\Activity\IManager;
@@ -132,7 +133,7 @@ class ProviderTest extends TestCase {
 
 
 	public function testGetFileThrows(): void {
-		$this->expectException(\InvalidArgumentException::class);
+		$this->expectException(UnknownActivityException::class);
 
 		$provider = $this->getProvider();
 		self::invokePrivate($provider, 'getFile', ['/Foo/Bar.txt', null]);

--- a/apps/settings/lib/Activity/GroupProvider.php
+++ b/apps/settings/lib/Activity/GroupProvider.php
@@ -103,9 +103,6 @@ class GroupProvider implements IProvider {
 		return $event;
 	}
 
-	/**
-	 * @throws \InvalidArgumentException
-	 */
 	protected function setSubjects(IEvent $event, string $subject, array $parameters): void {
 		$event->setRichSubject($subject, $parameters);
 	}

--- a/apps/settings/lib/Activity/Provider.php
+++ b/apps/settings/lib/Activity/Provider.php
@@ -118,7 +118,7 @@ class Provider implements IProvider {
 	/**
 	 * @param IEvent $event
 	 * @return array
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 */
 	protected function getParameters(IEvent $event): array {
 		$subject = $event->getSubject();
@@ -162,12 +162,9 @@ class Provider implements IProvider {
 				];
 		}
 
-		throw new \InvalidArgumentException('Unknown subject');
+		throw new UnknownActivityException('Unknown subject');
 	}
 
-	/**
-	 * @throws \InvalidArgumentException
-	 */
 	protected function setSubjects(IEvent $event, string $subject, array $parameters): void {
 		$event->setRichSubject($subject, $parameters);
 	}

--- a/apps/settings/tests/Activity/SecurityProviderTest.php
+++ b/apps/settings/tests/Activity/SecurityProviderTest.php
@@ -5,8 +5,8 @@
  */
 namespace OCA\Settings\Tests;
 
-use InvalidArgumentException;
 use OCA\Settings\Activity\SecurityProvider;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\IL10N;
@@ -45,7 +45,7 @@ class SecurityProviderTest extends TestCase {
 		$event->expects($this->once())
 			->method('getType')
 			->willReturn('comments');
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(UnknownActivityException::class);
 
 		$this->provider->parse($lang, $event);
 	}
@@ -112,7 +112,7 @@ class SecurityProviderTest extends TestCase {
 			->method('getSubject')
 			->willReturn('unrelated');
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(UnknownActivityException::class);
 		$this->provider->parse($lang, $event);
 	}
 }

--- a/apps/systemtags/lib/Activity/Provider.php
+++ b/apps/systemtags/lib/Activity/Provider.php
@@ -68,7 +68,7 @@ class Provider implements IProvider {
 		if ($this->activityManager->isFormattingFilteredObject()) {
 			try {
 				return $this->parseShortVersion($event);
-			} catch (\InvalidArgumentException $e) {
+			} catch (UnknownActivityException) {
 				// Ignore and simply use the long version...
 			}
 		}
@@ -79,10 +79,10 @@ class Provider implements IProvider {
 	/**
 	 * @param IEvent $event
 	 * @return IEvent
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 * @since 11.0.0
 	 */
-	public function parseShortVersion(IEvent $event) {
+	public function parseShortVersion(IEvent $event): IEvent {
 		$parsedParameters = $this->getParameters($event);
 
 		if ($this->activityManager->getRequirePNG()) {
@@ -142,7 +142,7 @@ class Provider implements IProvider {
 					]);
 			}
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		return $event;
@@ -151,10 +151,10 @@ class Provider implements IProvider {
 	/**
 	 * @param IEvent $event
 	 * @return IEvent
-	 * @throws \InvalidArgumentException
+	 * @throws UnknownActivityException
 	 * @since 11.0.0
 	 */
-	public function parseLongVersion(IEvent $event) {
+	public function parseLongVersion(IEvent $event): IEvent {
 		$parsedParameters = $this->getParameters($event);
 
 		if ($this->activityManager->getRequirePNG()) {
@@ -249,7 +249,7 @@ class Provider implements IProvider {
 					->setRichSubject($this->l->t('{actor} removed system tag {systemtag} from {file}'), $parsedParameters);
 			}
 		} else {
-			throw new \InvalidArgumentException();
+			throw new UnknownActivityException();
 		}
 
 		return $event;

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
  */
 namespace OCA\TwoFactorBackupCodes\Test\Unit\Activity;
 
-use InvalidArgumentException;
 use OCA\TwoFactorBackupCodes\Activity\Provider;
+use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
 use OCP\IL10N;
@@ -47,7 +47,7 @@ class ProviderTest extends TestCase {
 		$event->expects($this->once())
 			->method('getApp')
 			->willReturn('comments');
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(UnknownActivityException::class);
 
 		$this->provider->parse($lang, $event);
 	}
@@ -109,7 +109,7 @@ class ProviderTest extends TestCase {
 			->method('getSubject')
 			->willReturn('unrelated');
 
-		$this->expectException(InvalidArgumentException::class);
+		$this->expectException(UnknownActivityException::class);
 		$this->provider->parse($lang, $event);
 	}
 }


### PR DESCRIPTION
- Follow up to #48086 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
