### PR TITLE
feat(deps): Upgrade phpseclib to v3

### DIFF
--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -16,7 +16,7 @@ use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUserSession;
-use phpseclib\Crypt\RC4;
+use phpseclib3\Crypt\RC4;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -724,7 +724,6 @@ class Crypt {
 	 */
 	private function rc4Decrypt(string $data, string $secret): string {
 		$rc4 = new RC4();
-		/** @psalm-suppress InternalMethod */
 		$rc4->setKey($secret);
 
 		return $rc4->decrypt($data);
@@ -735,7 +734,6 @@ class Crypt {
 	 */
 	private function rc4Encrypt(string $data, string $secret): string {
 		$rc4 = new RC4();
-		/** @psalm-suppress InternalMethod */
 		$rc4->setKey($secret);
 
 		return $rc4->encrypt($data);

--- a/apps/encryption/lib/Crypto/Crypt.php
+++ b/apps/encryption/lib/Crypto/Crypt.php
@@ -17,7 +17,7 @@ use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUserSession;
-use phpseclib\Crypt\RC4;
+use phpseclib3\Crypt\RC4;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -722,7 +722,6 @@ class Crypt {
 	 */
 	private function rc4Decrypt(string $data, string $secret): string {
 		$rc4 = new RC4();
-		/** @psalm-suppress InternalMethod */
 		$rc4->setKey($secret);
 
 		return $rc4->decrypt($data);
@@ -733,7 +732,6 @@ class Crypt {
 	 */
 	private function rc4Encrypt(string $data, string $secret): string {
 		$rc4 = new RC4();
-		/** @psalm-suppress InternalMethod */
 		$rc4->setKey($secret);
 
 		return $rc4->encrypt($data);

--- a/apps/files_external/composer/composer/autoload_classmap.php
+++ b/apps/files_external/composer/composer/autoload_classmap.php
@@ -96,6 +96,7 @@ return array(
     'OCA\\Files_External\\Lib\\Storage\\OwnCloud' => $baseDir . '/../lib/Lib/Storage/OwnCloud.php',
     'OCA\\Files_External\\Lib\\Storage\\SFTP' => $baseDir . '/../lib/Lib/Storage/SFTP.php',
     'OCA\\Files_External\\Lib\\Storage\\SFTPReadStream' => $baseDir . '/../lib/Lib/Storage/SFTPReadStream.php',
+    'OCA\\Files_External\\Lib\\Storage\\SFTPReflection' => $baseDir . '/../lib/Lib/Storage/SFTPReflection.php',
     'OCA\\Files_External\\Lib\\Storage\\SFTPWriteStream' => $baseDir . '/../lib/Lib/Storage/SFTPWriteStream.php',
     'OCA\\Files_External\\Lib\\Storage\\SMB' => $baseDir . '/../lib/Lib/Storage/SMB.php',
     'OCA\\Files_External\\Lib\\Storage\\StreamWrapper' => $baseDir . '/../lib/Lib/Storage/StreamWrapper.php',

--- a/apps/files_external/composer/composer/autoload_static.php
+++ b/apps/files_external/composer/composer/autoload_static.php
@@ -111,6 +111,7 @@ class ComposerStaticInitFiles_External
         'OCA\\Files_External\\Lib\\Storage\\OwnCloud' => __DIR__ . '/..' . '/../lib/Lib/Storage/OwnCloud.php',
         'OCA\\Files_External\\Lib\\Storage\\SFTP' => __DIR__ . '/..' . '/../lib/Lib/Storage/SFTP.php',
         'OCA\\Files_External\\Lib\\Storage\\SFTPReadStream' => __DIR__ . '/..' . '/../lib/Lib/Storage/SFTPReadStream.php',
+        'OCA\\Files_External\\Lib\\Storage\\SFTPReflection' => __DIR__ . '/..' . '/../lib/Lib/Storage/SFTPReflection.php',
         'OCA\\Files_External\\Lib\\Storage\\SFTPWriteStream' => __DIR__ . '/..' . '/../lib/Lib/Storage/SFTPWriteStream.php',
         'OCA\\Files_External\\Lib\\Storage\\SMB' => __DIR__ . '/..' . '/../lib/Lib/Storage/SMB.php',
         'OCA\\Files_External\\Lib\\Storage\\StreamWrapper' => __DIR__ . '/..' . '/../lib/Lib/Storage/StreamWrapper.php',

--- a/apps/files_external/lib/Controller/AjaxController.php
+++ b/apps/files_external/lib/Controller/AjaxController.php
@@ -42,10 +42,15 @@ class AjaxController extends Controller {
 	 */
 	private function generateSshKeys($keyLength) {
 		$key = $this->rsaMechanism->createKey($keyLength);
-		// Replace the placeholder label with a more meaningful one
-		$key['publickey'] = str_replace('phpseclib-generated-key', gethostname(), $key['publickey']);
-
-		return $key;
+		return [
+			'private_key' => $key->toString('PKCS1'),
+			// Replace the placeholder label with a more meaningful one
+			'public_key' => str_replace(
+				'phpseclib-generated-key',
+				gethostname(),
+				$key->getPublicKey()->toString('OpenSSH'),
+			),
+		];
 	}
 
 	/**
@@ -57,10 +62,7 @@ class AjaxController extends Controller {
 	public function getSshKeys($keyLength = 1024) {
 		$key = $this->generateSshKeys($keyLength);
 		return new JSONResponse(
-			['data' => [
-				'private_key' => $key['privatekey'],
-				'public_key' => $key['publickey']
-			],
+			['data' => $key,
 				'status' => 'success'
 			]);
 	}

--- a/apps/files_external/lib/Controller/AjaxController.php
+++ b/apps/files_external/lib/Controller/AjaxController.php
@@ -78,10 +78,15 @@ class AjaxController extends Controller {
 	 */
 	private function generateSshKeys($keyLength) {
 		$key = $this->rsaMechanism->createKey($keyLength);
-		// Replace the placeholder label with a more meaningful one
-		$key['publickey'] = str_replace('phpseclib-generated-key', gethostname(), $key['publickey']);
-
-		return $key;
+		return [
+			'private_key' => $key->toString('PKCS1'),
+			// Replace the placeholder label with a more meaningful one
+			'public_key' => str_replace(
+				'phpseclib-generated-key',
+				gethostname(),
+				$key->getPublicKey()->toString('OpenSSH'),
+			),
+		];
 	}
 
 	/**
@@ -93,10 +98,7 @@ class AjaxController extends Controller {
 	public function getSshKeys($keyLength = 1024) {
 		$key = $this->generateSshKeys($keyLength);
 		return new JSONResponse([
-			'data' => [
-				'private_key' => $key['privatekey'],
-				'public_key' => $key['publickey']
-			],
+			'data' => $key,
 			'status' => 'success',
 		]);
 	}

--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
@@ -66,7 +66,8 @@ class RSA extends AuthMechanism {
 			$keyLength = 1024;
 		}
 
+		$secret = $this->config->getSystemValue('secret', '');
 		return $rsa->createKey($keyLength)
-			->withPassword($this->config->getSystemValue('secret', ''));
+			->withPassword($secret);
 	}
 }

--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSA.php
@@ -14,7 +14,7 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
-use phpseclib\Crypt\RSA as RSACrypt;
+use phpseclib3\Crypt\RSA as RSACrypt;
 
 /**
  * RSA public key authentication
@@ -45,15 +45,16 @@ class RSA extends AuthMechanism {
 	 */
 	#[\Override]
 	public function manipulateStorageConfig(StorageConfig &$storage, ?IUser $user = null) {
-		$auth = new RSACrypt();
-		$auth->setPassword($this->config->getSystemValue('secret', ''));
-		if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
+		try {
+			$auth = RSACrypt::loadPrivateKey(
+				$storage->getBackendOption('private_key'),
+				$this->config->getSystemValue('secret', '')
+			);
+		} catch (\Throwable) {
 			// Add fallback routine for a time where secret was not enforced to be exists
-			$auth->setPassword('');
-			if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
-				throw new \RuntimeException('unable to load private key');
-			}
+			$auth = RSACrypt::loadPrivateKey($storage->getBackendOption('private_key'));
 		}
+
 		$storage->setBackendOption('public_key_auth', $auth);
 	}
 
@@ -61,17 +62,14 @@ class RSA extends AuthMechanism {
 	 * Generate a keypair
 	 *
 	 * @param int $keyLenth
-	 * @return array ['privatekey' => $privateKey, 'publickey' => $publicKey]
 	 */
-	public function createKey($keyLength) {
-		$rsa = new RSACrypt();
-		$rsa->setPublicKeyFormat(RSACrypt::PUBLIC_FORMAT_OPENSSH);
-		$rsa->setPassword($this->config->getSystemValue('secret', ''));
-
+	public function createKey($keyLength): RSACrypt\PrivateKey {
 		if ($keyLength !== 1024 && $keyLength !== 2048 && $keyLength !== 4096) {
 			$keyLength = 1024;
 		}
 
-		return $rsa->createKey($keyLength);
+		$secret = $this->config->getSystemValue('secret', '');
+		$rsa = RSACrypt::createKey($keyLength);
+		return $rsa->withPassword($secret);
 	}
 }

--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
@@ -11,7 +11,7 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
-use phpseclib\Crypt\RSA as RSACrypt;
+use phpseclib3\Crypt\RSA;
 
 /**
  * RSA public key authentication
@@ -39,12 +39,12 @@ class RSAPrivateKey extends AuthMechanism {
 	 * @return void
 	 */
 	public function manipulateStorageConfig(StorageConfig &$storage, ?IUser $user = null) {
-		$auth = new RSACrypt();
-		$auth->setPassword($this->config->getSystemValue('secret', ''));
-		if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
+		$auth = new RSA\PrivateKey();
+		$auth->withPassword($this->config->getSystemValue('secret', ''));
+		if (!$auth->loadPrivateKey($storage->getBackendOption('private_key'))) {
 			// Add fallback routine for a time where secret was not enforced to be exists
-			$auth->setPassword('');
-			if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
+			$auth->withPassword('');
+			if (!$auth->loadPrivateKey($storage->getBackendOption('private_key'))) {
 				throw new \RuntimeException('unable to load private key');
 			}
 		}

--- a/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
+++ b/apps/files_external/lib/Lib/Auth/PublicKey/RSAPrivateKey.php
@@ -13,7 +13,8 @@ use OCA\Files_External\Lib\StorageConfig;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
-use phpseclib\Crypt\RSA as RSACrypt;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\Exception\NoKeyLoadedException;
 
 /**
  * RSA public key authentication
@@ -42,14 +43,18 @@ class RSAPrivateKey extends AuthMechanism {
 	 */
 	#[\Override]
 	public function manipulateStorageConfig(StorageConfig &$storage, ?IUser $user = null) {
-		$auth = new RSACrypt();
-		$auth->setPassword($this->config->getSystemValue('secret', ''));
-		if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
+
+		try {
+			$auth = RSA\PrivateKey::loadPrivateKey(
+				$storage->getBackendOption('private_key'),
+				$this->config->getSystemValue('secret', ''),
+			);
+		} catch (NoKeyLoadedException) {
 			// Add fallback routine for a time where secret was not enforced to be exists
-			$auth->setPassword('');
-			if (!$auth->loadKey($storage->getBackendOption('private_key'))) {
-				throw new \RuntimeException('unable to load private key');
-			}
+			$auth = RSA\PrivateKey::loadPrivateKey(
+				$storage->getBackendOption('private_key'),
+				'',
+			);
 		}
 		$storage->setBackendOption('public_key_auth', $auth);
 	}

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -14,7 +14,7 @@ use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
-use phpseclib\Net\SFTP\Stream;
+use phpseclib3\Net\SFTP\Stream;
 
 /**
  * Uses phpseclib's Net\SFTP class and the Net\SFTP\Stream stream wrapper to
@@ -29,7 +29,7 @@ class SFTP extends Common {
 	private $auth = [];
 
 	/**
-	 * @var \phpseclib\Net\SFTP
+	 * @var \phpseclib3\Net\SFTP
 	 */
 	protected $client;
 	private IMimeTypeDetector $mimeTypeDetector;
@@ -93,16 +93,16 @@ class SFTP extends Common {
 	/**
 	 * Returns the connection.
 	 *
-	 * @return \phpseclib\Net\SFTP connected client instance
+	 * @return \phpseclib3\Net\SFTP connected client instance
 	 * @throws \Exception when the connection failed
 	 */
-	public function getConnection(): \phpseclib\Net\SFTP {
+	public function getConnection(): \phpseclib3\Net\SFTP {
 		if (!is_null($this->client)) {
 			return $this->client;
 		}
 
 		$hostKeys = $this->readHostKeys();
-		$this->client = new \phpseclib\Net\SFTP($this->host, $this->port);
+		$this->client = new \phpseclib3\Net\SFTP($this->host, $this->port);
 
 		// The SSH Host Key MUST be verified before login().
 		$currentHostKey = $this->client->getServerPublicHostKey();
@@ -453,7 +453,7 @@ class SFTP extends Common {
 					return false;
 				}
 				/** @psalm-suppress InternalMethod */
-				if (!$connection->put($absTarget, $chunk, \phpseclib\Net\SFTP::SOURCE_STRING, $i)) {
+				if (!$connection->put($absTarget, $chunk, \phpseclib3\Net\SFTP::SOURCE_STRING, $i)) {
 					return false;
 				}
 			}

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -19,7 +19,7 @@ use OCP\Constants;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Server;
-use phpseclib\Net\SFTP\Stream;
+use phpseclib3\Net\SFTP\Stream;
 
 /**
  * Uses phpseclib's Net\SFTP class and the Net\SFTP\Stream stream wrapper to
@@ -34,7 +34,7 @@ class SFTP extends Common {
 	private $auth = [];
 
 	/**
-	 * @var \phpseclib\Net\SFTP
+	 * @var \phpseclib3\Net\SFTP
 	 */
 	protected $client;
 	private CappedMemoryCache $knownMTimes;
@@ -106,16 +106,16 @@ class SFTP extends Common {
 	/**
 	 * Returns the connection.
 	 *
-	 * @return \phpseclib\Net\SFTP connected client instance
+	 * @return \phpseclib3\Net\SFTP connected client instance
 	 * @throws \Exception when the connection failed
 	 */
-	public function getConnection(): \phpseclib\Net\SFTP {
+	public function getConnection(): \phpseclib3\Net\SFTP {
 		if (!is_null($this->client)) {
 			return $this->client;
 		}
 
 		$hostKeys = $this->readHostKeys();
-		$this->client = new \phpseclib\Net\SFTP($this->host, $this->port);
+		$this->client = new \phpseclib3\Net\SFTP($this->host, $this->port);
 
 		// The SSH Host Key MUST be verified before login().
 		$currentHostKey = $this->client->getServerPublicHostKey();
@@ -130,7 +130,6 @@ class SFTP extends Common {
 
 		$login = false;
 		foreach ($this->auth as $auth) {
-			/** @psalm-suppress TooManyArguments */
 			$login = $this->client->login($this->user, $auth);
 			if ($login === true) {
 				break;
@@ -338,7 +337,7 @@ class SFTP extends Common {
 				case 'wb':
 					SFTPWriteStream::register();
 					// the SFTPWriteStream doesn't go through the "normal" methods so it doesn't clear the stat cache.
-					$connection->_remove_from_stat_cache($absPath);
+					$connection->clearStatCache();
 					$context = stream_context_create(['sftp' => ['session' => $connection]]);
 					$fh = fopen('sftpwrite://' . trim($absPath, '/'), 'w', false, $context);
 					if ($fh) {
@@ -487,7 +486,7 @@ class SFTP extends Common {
 			$absTarget = $this->absPath($target);
 
 			$connection = $this->getConnection();
-			$size = $connection->size($absSource);
+			$size = $connection->filesize($absSource);
 			if ($size === false) {
 				return false;
 			}
@@ -498,7 +497,7 @@ class SFTP extends Common {
 					return false;
 				}
 				/** @psalm-suppress InternalMethod */
-				if (!$connection->put($absTarget, $chunk, \phpseclib\Net\SFTP::SOURCE_STRING, $i)) {
+				if (!$connection->put($absTarget, $chunk, \phpseclib3\Net\SFTP::SOURCE_STRING, $i)) {
 					return false;
 				}
 			}

--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCA\Files_External\Lib\Storage;
 
 use Icewind\Streams\File;
-use phpseclib\Net\SSH2;
+use phpseclib3\Net\SSH2;
 
 class SFTPReadStream implements File {
 	/** @var resource */
 	public $context;
 
-	/** @var \phpseclib\Net\SFTP */
+	/** @var \phpseclib3\Net\SFTP */
 	private $sftp;
 
 	/** @var string */
@@ -53,7 +53,7 @@ class SFTPReadStream implements File {
 		} else {
 			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
 		}
-		if (isset($context['session']) and $context['session'] instanceof \phpseclib\Net\SFTP) {
+		if (isset($context['session']) and $context['session'] instanceof \phpseclib3\Net\SFTP) {
 			$this->sftp = $context['session'];
 		} else {
 			throw new \BadMethodCallException('Invalid context, session not set');

--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -13,6 +13,8 @@ use Icewind\Streams\File;
 use phpseclib3\Net\SSH2;
 
 class SFTPReadStream implements File {
+	use SFTPReflection;
+
 	/** @var resource */
 	public $context;
 
@@ -73,27 +75,25 @@ class SFTPReadStream implements File {
 
 		$this->loadContext('sftp');
 
-		if (!($this->sftp->bitmap & SSH2::MASK_LOGIN)) {
+		if (!($this->getSftpProperty($this->sftp, 'bitmap') & SSH2::MASK_LOGIN)) {
 			return false;
 		}
 
-		$remote_file = $this->sftp->_realpath($path);
+		$remote_file = $this->sftp->realpath($path);
 		if ($remote_file === false) {
 			return false;
 		}
 
 		$packet = pack('Na*N2', strlen($remote_file), $remote_file, NET_SFTP_OPEN_READ, 0);
-		if (!$this->sftp->_send_sftp_packet(NET_SFTP_OPEN, $packet)) {
-			return false;
-		}
+		$this->invokeSftp($this->sftp, 'send_sftp_packet', [NET_SFTP_OPEN, $packet]);
 
-		$response = $this->sftp->_get_sftp_packet();
-		switch ($this->sftp->packet_type) {
+		$response = $this->invokeSftp($this->sftp, 'get_sftp_packet');
+		switch ($this->getSftpProperty($this->sftp, 'packet_type')) {
 			case NET_SFTP_HANDLE:
 				$this->handle = substr($response, 4);
 				break;
 			case NET_SFTP_STATUS: // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
-				$this->sftp->_logError($response);
+				$this->invokeSftp($this->sftp, 'logError', [$response]);
 				return false;
 			default:
 				user_error('Expected SSH_FXP_HANDLE or SSH_FXP_STATUS');
@@ -152,19 +152,24 @@ class SFTPReadStream implements File {
 
 	private function request_chunk(int $size) {
 		if ($this->pendingRead) {
-			$this->sftp->_get_sftp_packet();
+			$this->invokeSftp($this->sftp, 'get_sftp_packet');
 		}
 
 		$packet = pack('Na*N3', strlen($this->handle), $this->handle, $this->internalPosition / 4294967296, $this->internalPosition, $size);
 		$this->pendingRead = true;
-		return $this->sftp->_send_sftp_packet(NET_SFTP_READ, $packet);
+		try {
+			$this->invokeSftp($this->sftp, 'send_sftp_packet', [NET_SFTP_READ, $packet]);
+			return true;
+		} catch (\Throwable) {
+			return false;
+		}
 	}
 
 	private function read_chunk() {
 		$this->pendingRead = false;
-		$response = $this->sftp->_get_sftp_packet();
+		$response = $this->invokeSftp($this->sftp, 'get_sftp_packet');
 
-		switch ($this->sftp->packet_type) {
+		switch ($this->getSftpProperty($this->sftp, 'packet_type')) {
 			case NET_SFTP_DATA:
 				$temp = substr($response, 4);
 				$len = strlen($temp);
@@ -220,9 +225,9 @@ class SFTPReadStream implements File {
 	public function stream_close() {
 		// we still have a read request incoming that needs to be handled before we can close
 		if ($this->pendingRead) {
-			$this->sftp->_get_sftp_packet();
+			$this->invokeSftp($this->sftp, 'get_sftp_packet');
 		}
-		if (!$this->sftp->_close_handle($this->handle)) {
+		if (!$this->invokeSftp($this->sftp, 'close_handle', [$this->handle])) {
 			return false;
 		}
 		return true;

--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 namespace OCA\Files_External\Lib\Storage;
 
 use Icewind\Streams\File;
-use phpseclib\Net\SSH2;
+use phpseclib3\Net\SSH2;
 
 class SFTPReadStream implements File {
 	/** @var resource */
 	public $context;
 
-	/** @var \phpseclib\Net\SFTP */
+	/** @var \phpseclib3\Net\SFTP */
 	private $sftp;
 
 	/** @var string */
@@ -54,7 +54,7 @@ class SFTPReadStream implements File {
 		} else {
 			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
 		}
-		if (isset($context['session']) && $context['session'] instanceof \phpseclib\Net\SFTP) {
+		if (isset($context['session']) && $context['session'] instanceof \phpseclib3\Net\SFTP) {
 			$this->sftp = $context['session'];
 		} else {
 			throw new \BadMethodCallException('Invalid context, session not set');

--- a/apps/files_external/lib/Lib/Storage/SFTPReflection.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReflection.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_External\Lib\Storage;
+
+use phpseclib3\Net\SFTP;
+
+/**
+ * The SFTP read/write stream wrappers implement pipelined reads and buffered
+ * writes directly on the SFTP protocol to get better throughput than the public
+ * SFTP::get()/put() API can offer (a single kept-open remote handle, read-ahead,
+ * chunked writes).
+ *
+ * phpseclib v3 made the required low-level packet methods and a couple of
+ * properties private/protected. To keep the performance-oriented implementation
+ * working without vendoring or forking phpseclib, we reach into those internals
+ * through reflection. The reflection objects are cached because they are used
+ * once per protocol packet.
+ */
+trait SFTPReflection {
+	/** @var array<string, \ReflectionMethod> */
+	private static array $sftpReflectionMethods = [];
+	/** @var array<string, \ReflectionProperty> */
+	private static array $sftpReflectionProperties = [];
+
+	/**
+	 * Invoke a method that is private in phpseclib v3.
+	 */
+	private function invokeSftp(SFTP $sftp, string $method, array $arguments = []): mixed {
+		self::$sftpReflectionMethods[$method] ??= new \ReflectionMethod(SFTP::class, $method);
+		return self::$sftpReflectionMethods[$method]->invokeArgs($sftp, $arguments);
+	}
+
+	/**
+	 * Read a property that is private/protected in phpseclib v3.
+	 */
+	private function getSftpProperty(SFTP $sftp, string $property): mixed {
+		self::$sftpReflectionProperties[$property] ??= new \ReflectionProperty(SFTP::class, $property);
+		return self::$sftpReflectionProperties[$property]->getValue($sftp);
+	}
+}

--- a/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCA\Files_External\Lib\Storage;
 
 use Icewind\Streams\File;
-use phpseclib\Net\SSH2;
+use phpseclib3\Net\SSH2;
 
 class SFTPWriteStream implements File {
 	/** @var resource */
 	public $context;
 
-	/** @var \phpseclib\Net\SFTP */
+	/** @var \phpseclib3\Net\SFTP */
 	private $sftp;
 
 	/** @var string */
@@ -51,7 +51,7 @@ class SFTPWriteStream implements File {
 		} else {
 			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
 		}
-		if (isset($context['session']) and $context['session'] instanceof \phpseclib\Net\SFTP) {
+		if (isset($context['session']) and $context['session'] instanceof \phpseclib3\Net\SFTP) {
 			$this->sftp = $context['session'];
 		} else {
 			throw new \BadMethodCallException('Invalid context, session not set');

--- a/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
@@ -13,6 +13,8 @@ use Icewind\Streams\File;
 use phpseclib3\Net\SSH2;
 
 class SFTPWriteStream implements File {
+	use SFTPReflection;
+
 	/** @var resource */
 	public $context;
 
@@ -70,7 +72,7 @@ class SFTPWriteStream implements File {
 
 		$this->loadContext('sftp');
 
-		if (!($this->sftp->bitmap & SSH2::MASK_LOGIN)) {
+		if (!($this->getSftpProperty($this->sftp, 'bitmap') & SSH2::MASK_LOGIN)) {
 			return false;
 		}
 
@@ -82,17 +84,19 @@ class SFTPWriteStream implements File {
 		}
 
 		$packet = pack('Na*N2', strlen($remote_file), $remote_file, NET_SFTP_OPEN_WRITE | NET_SFTP_OPEN_CREATE | NET_SFTP_OPEN_TRUNCATE, 0);
-		if (!$this->sftp->_send_sftp_packet(NET_SFTP_OPEN, $packet)) {
+		try {
+			$this->invokeSftp($this->sftp, 'send_sftp_packet', [NET_SFTP_OPEN, $packet]);
+		} catch (\Throwable) {
 			return false;
 		}
 
-		$response = $this->sftp->_get_sftp_packet();
-		switch ($this->sftp->packet_type) {
+		$response = $this->invokeSftp($this->sftp, 'get_sftp_packet');
+		switch ($this->getSftpProperty($this->sftp, 'packet_type')) {
 			case NET_SFTP_HANDLE:
 				$this->handle = substr($response, 4);
 				break;
 			case NET_SFTP_STATUS: // presumably SSH_FX_NO_SUCH_FILE or SSH_FX_PERMISSION_DENIED
-				$this->sftp->_logError($response);
+				$this->invokeSftp($this->sftp, 'logError', [$response]);
 				return false;
 			default:
 				user_error('Expected SSH_FXP_HANDLE or SSH_FXP_STATUS');
@@ -157,13 +161,15 @@ class SFTPWriteStream implements File {
 	public function stream_flush() {
 		$size = strlen($this->buffer);
 		$packet = pack('Na*N3a*', strlen($this->handle), $this->handle, $this->internalPosition / 4294967296, $this->internalPosition, $size, $this->buffer);
-		if (!$this->sftp->_send_sftp_packet(NET_SFTP_WRITE, $packet)) {
+		try {
+			$this->invokeSftp($this->sftp, 'send_sftp_packet', [NET_SFTP_WRITE, $packet]);
+		} catch (\Throwable) {
 			return false;
 		}
 		$this->internalPosition += $size;
 		$this->buffer = '';
 
-		return $this->sftp->_read_put_responses(1);
+		return $this->invokeSftp($this->sftp, 'read_put_responses', [1]);
 	}
 
 	#[\Override]
@@ -174,7 +180,7 @@ class SFTPWriteStream implements File {
 	#[\Override]
 	public function stream_close() {
 		$this->stream_flush();
-		if (!$this->sftp->_close_handle($this->handle)) {
+		if (!$this->invokeSftp($this->sftp, 'close_handle', [$this->handle])) {
 			return false;
 		}
 		$this->sftp->touch($this->path, time(), time());

--- a/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
@@ -10,13 +10,13 @@ declare(strict_types=1);
 namespace OCA\Files_External\Lib\Storage;
 
 use Icewind\Streams\File;
-use phpseclib\Net\SSH2;
+use phpseclib3\Net\SSH2;
 
 class SFTPWriteStream implements File {
 	/** @var resource */
 	public $context;
 
-	/** @var \phpseclib\Net\SFTP */
+	/** @var \phpseclib3\Net\SFTP */
 	private $sftp;
 
 	/** @var string */
@@ -54,7 +54,7 @@ class SFTPWriteStream implements File {
 		} else {
 			throw new \BadMethodCallException('Invalid context, "' . $name . '" options not set');
 		}
-		if (isset($context['session']) && $context['session'] instanceof \phpseclib\Net\SFTP) {
+		if (isset($context['session']) && $context['session'] instanceof \phpseclib3\Net\SFTP) {
 			$this->sftp = $context['session'];
 		} else {
 			throw new \BadMethodCallException('Invalid context, session not set');
@@ -74,7 +74,7 @@ class SFTPWriteStream implements File {
 			return false;
 		}
 
-		$remote_file = $this->sftp->_realpath($path);
+		$remote_file = $this->sftp->realpath($path);
 
 		$this->path = $remote_file;
 		if ($remote_file === false) {

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -18,7 +18,7 @@ use OCP\AppFramework\QueryException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IL10N;
 use OCP\Util;
-use phpseclib\Crypt\AES;
+use phpseclib3\Crypt\AES;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/apps/files_external/lib/Service/EncryptionService.php
+++ b/apps/files_external/lib/Service/EncryptionService.php
@@ -12,7 +12,7 @@ namespace OCA\Files_External\Service;
 
 use OCP\IConfig;
 use OCP\Security\ISecureRandom;
-use phpseclib\Crypt\AES;
+use phpseclib3\Crypt\AES;
 
 class EncryptionService {
 	public function __construct(
@@ -78,8 +78,28 @@ class EncryptionService {
 	 * Returns the encryption cipher
 	 */
 	private function getCipher(): AES {
-		$cipher = new AES(AES::MODE_CBC);
-		$cipher->setKey($this->config->getSystemValue('passwordsalt', null));
+		$cipher = new AES('cbc');
+		$cipher->setKey($this->normalizeKey((string)$this->config->getSystemValue('passwordsalt', '')));
 		return $cipher;
+	}
+
+	/**
+	 * Normalize the configured `passwordsalt` into a valid AES key.
+	 *
+	 * Note: phpseclib v2 accepted keys of any length and silently normalized them:
+	 * the key length was rounded up to the next valid AES size (16, 24 or 32
+	 * bytes), the key was read in whole 4-byte words (trailing bytes that did
+	 * not form a full word were dropped) and any missing high words were
+	 * treated as zero. phpseclib v3 rejects keys that are not exactly 16, 24 or
+	 * 32 bytes, so we reproduce the v2 behaviour here to keep previously stored
+	 * passwords decryptable.
+	 */
+	private function normalizeKey(string $key): string {
+		$length = strlen($key);
+		$keyLength = $length <= 16 ? 16 : ($length <= 24 ? 24 : 32);
+		// Drop trailing bytes that do not form a full 4-byte word (phpseclib v2 used unpack('N*'))
+		$key = substr($key, 0, intdiv($length, 4) * 4);
+		// Zero-pad missing high words and truncate to the target key length
+		return substr(str_pad($key, $keyLength, "\0"), 0, $keyLength);
 	}
 }

--- a/apps/files_external/tests/Controller/AjaxControllerTest.php
+++ b/apps/files_external/tests/Controller/AjaxControllerTest.php
@@ -21,6 +21,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use phpseclib3\Crypt\RSA as CryptRSA;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -37,8 +38,12 @@ class AjaxControllerTest extends TestCase {
 
 	protected function setUp(): void {
 		$this->request = $this->createMock(IRequest::class);
-		$this->rsa = $this->createMock(RSA::class);
-		$this->globalAuth = $this->createMock(GlobalAuth::class);
+		$this->rsa = $this->getMockBuilder(RSA::class)
+			->disableOriginalConstructor()
+			->getMock();
+		$this->globalAuth = $this->getMockBuilder(GlobalAuth::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->userManager = $this->createMock(IUserManager::class);
@@ -114,24 +119,32 @@ class AjaxControllerTest extends TestCase {
 	}
 
 	public function testGetSshKeys(): void {
+		// phpseclib3's PrivateKey/PublicKey are final and cannot be mocked, so
+		// generate a real key pair and assert the controller serialises it.
+		$privateKey = CryptRSA::createKey(1024);
+
 		$this->rsa
 			->expects($this->once())
 			->method('createKey')
-			->willReturn([
-				'privatekey' => 'MyPrivateKey',
-				'publickey' => 'MyPublicKey',
-			]);
+			->willReturn($privateKey);
 
-		$expected = new JSONResponse(
-			[
-				'data' => [
-					'private_key' => 'MyPrivateKey',
-					'public_key' => 'MyPublicKey',
-				],
-				'status' => 'success',
-			]
+		$response = $this->ajaxController->getSshKeys();
+
+		$this->assertInstanceOf(JSONResponse::class, $response);
+		$data = $response->getData();
+		$this->assertSame('success', $data['status']);
+		$this->assertSame(
+			$privateKey->toString('PKCS1'),
+			$data['data']['private_key'],
 		);
-		$this->assertEquals($expected, $this->ajaxController->getSshKeys());
+		$this->assertSame(
+			str_replace(
+				'phpseclib-generated-key',
+				gethostname(),
+				$privateKey->getPublicKey()->toString('OpenSSH'),
+			),
+			$data['data']['public_key'],
+		);
 	}
 
 	public function testSaveGlobalCredentialsAsAdminForAnotherUser(): void {

--- a/apps/files_external/tests/Service/EncryptionServiceTest.php
+++ b/apps/files_external/tests/Service/EncryptionServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_External\Tests\Service;
+
+use OCA\Files_External\Service\EncryptionService;
+use OCP\IConfig;
+use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class EncryptionServiceTest extends \Test\TestCase {
+	private IConfig&MockObject $config;
+	private ISecureRandom&MockObject $secureRandom;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
+	}
+
+	private function service(string $passwordSalt): EncryptionService {
+		$this->config->method('getSystemValue')
+			->with('passwordsalt', '')
+			->willReturn($passwordSalt);
+		return new EncryptionService($this->config, $this->secureRandom);
+	}
+
+	public static function saltProvider(): array {
+		return [
+			'typical 30-char salt' => [str_repeat('a', 30)],
+			'16-char salt' => [str_repeat('b', 16)],
+			'24-char salt' => [str_repeat('c', 24)],
+			'32-char salt' => [str_repeat('d', 32)],
+			'long 40-char salt' => [str_repeat('e', 40)],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('saltProvider')]
+	public function testEncryptDecryptRoundTrip(string $passwordSalt): void {
+		$this->secureRandom->method('generate')->willReturn(str_repeat("\x11", 16));
+		$service = $this->service($passwordSalt);
+
+		$options = $service->encryptPasswords(['password' => 'my-secret-password']);
+		$this->assertArrayHasKey('password_encrypted', $options);
+		$this->assertSame('', $options['password']);
+
+		$decrypted = $service->decryptPasswords(['password_encrypted' => $options['password_encrypted']]);
+		$this->assertSame('my-secret-password', $decrypted['password']);
+		$this->assertArrayNotHasKey('password_encrypted', $decrypted);
+	}
+
+	/**
+	 * Ciphertexts written with phpseclib v2 must remain decryptable after the
+	 * upgrade to phpseclib v3. v2 accepted arbitrary-length keys and normalized
+	 * them (round up to 16/24/32 bytes, read whole 4-byte words only, zero-pad
+	 * missing high words). Here we recreate such a ciphertext with OpenSSL — an
+	 * independent AES implementation — using that exact effective key.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('saltProvider')]
+	public function testDecryptsLegacyPhpseclibV2Ciphertext(string $passwordSalt): void {
+		$plaintext = 'legacy-external-storage-password';
+
+		// Reproduce the phpseclib v2 effective AES key
+		$length = strlen($passwordSalt);
+		$keyLength = $length <= 16 ? 16 : ($length <= 24 ? 24 : 32);
+		$effectiveKey = substr(str_pad(substr($passwordSalt, 0, intdiv($length, 4) * 4), $keyLength, "\0"), 0, $keyLength);
+
+		$iv = str_repeat("\x22", 16);
+		$rawCiphertext = openssl_encrypt($plaintext, 'aes-' . ($keyLength * 8) . '-cbc', $effectiveKey, OPENSSL_RAW_DATA, $iv);
+		$stored = base64_encode($iv . $rawCiphertext);
+
+		$service = $this->service($passwordSalt);
+		$decrypted = $service->decryptPasswords(['password_encrypted' => $stored]);
+		$this->assertSame($plaintext, $decrypted['password']);
+	}
+}

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1603,12 +1603,6 @@
     <DeprecatedMethod>
       <code><![CDATA[generate]]></code>
     </DeprecatedMethod>
-    <InternalMethod>
-      <code><![CDATA[decrypt]]></code>
-      <code><![CDATA[encrypt]]></code>
-      <code><![CDATA[setIV]]></code>
-      <code><![CDATA[setIV]]></code>
-    </InternalMethod>
   </file>
   <file src="apps/files_external/lib/Service/StoragesService.php">
     <DeprecatedMethod>
@@ -3939,11 +3933,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/IntegrityCheck/Checker.php">
-    <InvalidArrayAccess>
-      <code><![CDATA[$x509->getDN(X509::DN_OPENSSL)['CN']]]></code>
-      <code><![CDATA[$x509->getDN(X509::DN_OPENSSL)['CN']]]></code>
-      <code><![CDATA[$x509->getDN(true)['CN']]]></code>
-    </InvalidArrayAccess>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getOnlyDefaultAliases]]></code>
     </UndefinedInterfaceMethod>
@@ -4086,16 +4075,6 @@
     <FalsableReturnStatement>
       <code><![CDATA[filemtime($this->getDefaultCertificatesBundlePath())]]></code>
     </FalsableReturnStatement>
-  </file>
-  <file src="lib/private/Security/Crypto.php">
-    <InternalMethod>
-      <code><![CDATA[decrypt]]></code>
-      <code><![CDATA[encrypt]]></code>
-      <code><![CDATA[setIV]]></code>
-      <code><![CDATA[setIV]]></code>
-      <code><![CDATA[setPassword]]></code>
-      <code><![CDATA[setPassword]]></code>
-    </InternalMethod>
   </file>
   <file src="lib/private/Security/Normalizer/IpAddress.php">
     <FalsableReturnStatement>

--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -10,8 +10,8 @@ namespace OC\Core\Command\Integrity;
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use OCP\IURLGenerator;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -68,8 +68,7 @@ class SignApp extends Command {
 			return 1;
 		}
 
-		$rsa = new RSA();
-		$rsa->loadKey($privateKey);
+		$rsa = RSA::loadPrivateKey($privateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$x509->setPrivateKey($rsa);

--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -11,8 +11,8 @@ namespace OC\Core\Command\Integrity;
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use OCP\IURLGenerator;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -71,8 +71,7 @@ class SignApp extends Command {
 			return 1;
 		}
 
-		$rsa = new RSA();
-		$rsa->loadKey($privateKey);
+		$rsa = RSA::loadPrivateKey($privateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$x509->setPrivateKey($rsa);

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -9,8 +9,8 @@ namespace OC\Core\Command\Integrity;
 
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -63,8 +63,7 @@ class SignCore extends Command {
 			return 1;
 		}
 
-		$rsa = new RSA();
-		$rsa->loadKey($privateKey);
+		$rsa = RSA::loadPrivateKey($privateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$x509->setPrivateKey($rsa);

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -10,8 +10,8 @@ namespace OC\Core\Command\Integrity;
 
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -66,8 +66,7 @@ class SignCore extends Command {
 			return 1;
 		}
 
-		$rsa = new RSA();
-		$rsa->loadKey($privateKey);
+		$rsa = RSA::loadPrivateKey($privateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$x509->setPrivateKey($rsa);

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -24,7 +24,7 @@ use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\ITempManager;
 use OCP\Migration\IOutput;
-use phpseclib\File\X509;
+use phpseclib3\File\X509;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -31,7 +31,7 @@ use OCP\L10N\IFactory;
 use OCP\Migration\IOutput;
 use OCP\Server;
 use OCP\Util;
-use phpseclib\File\X509;
+use phpseclib3\File\X509;
 use Psr\Log\LoggerInterface;
 
 /**

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -213,7 +213,7 @@ class Checker {
 				json_encode($signature, JSON_PRETTY_PRINT)
 			);
 		} catch (\Exception $e) {
-			if (!$this->fileAccessHelper->is_writable($appInfoDir)) {
+			if ($this->fileAccessHelper->is_writable($appInfoDir) === false) {
 				throw new \Exception($appInfoDir . ' is not writable');
 			}
 			throw $e;

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -179,6 +179,7 @@ class Checker {
 
 		$signature = $privateKey
 			->withPadding(RSA::SIGNATURE_PSS)
+			->withHash('sha1')
 			->withMGFHash('sha512')
 			->withSaltLength(0)
 			->sign(json_encode($hashes));
@@ -319,6 +320,7 @@ class Checker {
 
 		$rsa = $rsa
 			->withPadding(RSA::SIGNATURE_PSS)
+			->withHash('sha1')
 			->withMGFHash('sha512')
 			->withSaltLength(0);
 

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -178,6 +178,7 @@ class Checker {
 
 		$signature = $privateKey
 			->withPadding(RSA::SIGNATURE_PSS)
+			->withHash('sha1')
 			->withMGFHash('sha512')
 			->withSaltLength(0)
 			->sign(json_encode($hashes));
@@ -318,6 +319,7 @@ class Checker {
 
 		$rsa = $rsa
 			->withPadding(RSA::SIGNATURE_PSS)
+			->withHash('sha1')
 			->withMGFHash('sha512')
 			->withSaltLength(0);
 

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -22,8 +22,8 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\ServerVersion;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 
 /**
  * Class Checker handles the code signing using X.509 and RSA. ownCloud ships with
@@ -166,24 +166,26 @@ class Checker {
 	 *
 	 * @param array $hashes
 	 * @param X509 $certificate
-	 * @param RSA $privateKey
+	 * @param RSA\PrivateKey $privateKey
 	 * @return array
 	 */
-	private function createSignatureData(array $hashes,
+	private function createSignatureData(
+		array $hashes,
 		X509 $certificate,
-		RSA $privateKey): array {
+		RSA\PrivateKey $privateKey,
+	): array {
 		ksort($hashes);
 
-		$privateKey->setSignatureMode(RSA::SIGNATURE_PSS);
-		$privateKey->setMGFHash('sha512');
-		// See https://tools.ietf.org/html/rfc3447#page-38
-		$privateKey->setSaltLength(0);
-		$signature = $privateKey->sign(json_encode($hashes));
+		$signature = $privateKey
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0)
+			->sign(json_encode($hashes));
 
 		return [
 			'hashes' => $hashes,
 			'signature' => base64_encode($signature),
-			'certificate' => $certificate->saveX509($certificate->currentCert),
+			'certificate' => $certificate->saveX509($certificate->getCurrentCert()),
 		];
 	}
 
@@ -192,12 +194,12 @@ class Checker {
 	 *
 	 * @param string $path
 	 * @param X509 $certificate
-	 * @param RSA $privateKey
+	 * @param RSA\PrivateKey $privateKey
 	 * @throws \Exception
 	 */
 	public function writeAppSignature($path,
 		X509 $certificate,
-		RSA $privateKey) {
+		RSA\PrivateKey $privateKey) {
 		$appInfoDir = $path . '/appinfo';
 		try {
 			$this->fileAccessHelper->assertDirectoryExists($appInfoDir);
@@ -210,7 +212,7 @@ class Checker {
 				json_encode($signature, JSON_PRETTY_PRINT)
 			);
 		} catch (\Exception $e) {
-			if (!$this->fileAccessHelper->is_writable($appInfoDir)) {
+			if ($this->fileAccessHelper->is_writable($appInfoDir) === false) {
 				throw new \Exception($appInfoDir . ' is not writable');
 			}
 			throw $e;
@@ -221,12 +223,12 @@ class Checker {
 	 * Write the signature of core
 	 *
 	 * @param X509 $certificate
-	 * @param RSA $rsa
+	 * @param RSA\PrivateKey $rsa
 	 * @param string $path
 	 * @throws \Exception
 	 */
 	public function writeCoreSignature(X509 $certificate,
-		RSA $rsa,
+		RSA\PrivateKey $rsa,
 		$path) {
 		$coreDir = $path . '/core';
 		try {
@@ -290,15 +292,14 @@ class Checker {
 		$certificate = $signatureData['certificate'];
 
 		// Check if certificate is signed by Nextcloud Root Authority
-		$x509 = new \phpseclib\File\X509();
+		$x509 = new X509();
 		$rootCertificatePublicKey = $this->fileAccessHelper->file_get_contents($this->environmentHelper->getServerRoot() . '/resources/codesigning/root.crt');
 
 		$rootCerts = $this->splitCerts($rootCertificatePublicKey);
 		foreach ($rootCerts as $rootCert) {
 			$x509->loadCA($rootCert);
 		}
-		$x509->loadX509($certificate);
-		if (!$x509->validateSignature()) {
+		if ($x509->loadX509($certificate) === false || !$x509->validateSignature()) {
 			throw new InvalidSignatureException('Certificate is not valid.');
 		}
 		// Verify if certificate has proper CN. "core" CN is always trusted.
@@ -309,13 +310,18 @@ class Checker {
 		}
 
 		// Check if the signature of the files is valid
-		$rsa = new \phpseclib\Crypt\RSA();
-		$rsa->loadKey($x509->currentCert['tbsCertificate']['subjectPublicKeyInfo']['subjectPublicKey']);
-		$rsa->setSignatureMode(RSA::SIGNATURE_PSS);
-		$rsa->setMGFHash('sha512');
-		// See https://tools.ietf.org/html/rfc3447#page-38
-		$rsa->setSaltLength(0);
-		if (!$rsa->verify(json_encode($expectedHashes), $signature)) {
+		/** @var RSA\PublicKey|false */
+		$rsa = $x509->getPublicKey();
+		if ($rsa === false) {
+			throw new InvalidSignatureException('Certificate does not provide valid public RSA key.');
+		}
+
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
+
+		if (!$rsa->verify(json_encode($expectedHashes), (string)$signature)) {
 			throw new InvalidSignatureException('Signature could not get verified.');
 		}
 

--- a/lib/private/Repair/NC25/AddMissingSecretJob.php
+++ b/lib/private/Repair/NC25/AddMissingSecretJob.php
@@ -32,7 +32,7 @@ class AddMissingSecretJob implements IRepairStep {
 		$passwordSalt = $this->config->getSystemValueString('passwordsalt', '');
 		if ($passwordSalt === '') {
 			try {
-				$this->config->setSystemValue('passwordsalt', $this->random->generate(30));
+				$this->config->setSystemValue('passwordsalt', $this->random->generate(32));
 			} catch (HintException $e) {
 				$output->warning('passwordsalt is missing from your config.php and your config.php is read only. Please fix it manually.');
 			}

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -11,8 +11,8 @@ namespace OC\Security;
 use Exception;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Hash;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\Hash;
 
 /**
  * Class Crypto provides a high-level encryption layer using AES-CBC. If no key has been provided
@@ -31,7 +31,7 @@ class Crypto implements ICrypto {
 	public function __construct(
 		private IConfig $config,
 	) {
-		$this->cipher = new AES();
+		$this->cipher = new AES('cbc');
 	}
 
 	/**

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -12,8 +12,8 @@ namespace OC\Security;
 use Exception;
 use OCP\IConfig;
 use OCP\Security\ICrypto;
-use phpseclib\Crypt\AES;
-use phpseclib\Crypt\Hash;
+use phpseclib3\Crypt\AES;
+use phpseclib3\Crypt\Hash;
 use SensitiveParameter;
 
 /**
@@ -33,7 +33,7 @@ class Crypto implements ICrypto {
 	public function __construct(
 		private IConfig $config,
 	) {
-		$this->cipher = new AES();
+		$this->cipher = new AES('cbc');
 	}
 
 	/**
@@ -77,7 +77,11 @@ class Crypto implements ICrypto {
 			$password = $this->config->getSystemValueString('secret');
 		}
 		$keyMaterial = hash_hkdf('sha512', $password);
-		$this->cipher->setPassword(substr($keyMaterial, 0, 32));
+		// Pin the PBKDF2 parameters to phpseclib v2 defaults ('sha1' hash, 'phpseclib' salt).
+		// phpseclib v3 changed the default salt to 'phpseclib/salt', which would derive a
+		// different AES key and break decryption of previously stored ciphertexts.
+		// TODO: We should put our own salt into the HKDF derivation to avoid this dependency on phpseclib's defaults!
+		$this->cipher->setPassword(substr($keyMaterial, 0, 32), 'pbkdf2', 'sha1', 'phpseclib');
 
 		$iv = \random_bytes($this->ivLength);
 		$this->cipher->setIV($iv);
@@ -172,7 +176,9 @@ class Crypto implements ICrypto {
 				$hmacKey = substr($keyMaterial, 32);
 			}
 		}
-		$this->cipher->setPassword($encryptionKey);
+		// Match the v2-compatible PBKDF2 parameters used in encrypt(), see the note there.
+		// TODO: We should put our own salt into the HKDF derivation to avoid this dependency on phpseclib's defaults!
+		$this->cipher->setPassword($encryptionKey, 'pbkdf2', 'sha1', 'phpseclib');
 		$this->cipher->setIV($iv);
 
 		if ($isOwnCloudV2Migration) {

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -57,7 +57,7 @@ use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class Setup {
-	public const MIN_PASSWORD_SALT_LENGTH = 30;
+	public const MIN_PASSWORD_SALT_LENGTH = 32;
 	public const MIN_SECRET_LENGTH = 48;
 
 	protected IL10N $l10n;

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -18,8 +18,8 @@ use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\ServerVersion;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
 use Test\TestCase;
 
 class CheckerTest extends TestCase {
@@ -29,7 +29,7 @@ class CheckerTest extends TestCase {
 	private $environmentHelper;
 	/** @var AppLocator|\PHPUnit\Framework\MockObject\MockObject */
 	private $appLocator;
-	/** @var Checker */
+	/** @var Checker|\PHPUnit\Framework\MockObject\MockObject */
 	private $checker;
 	/** @var FileAccessHelper|\PHPUnit\Framework\MockObject\MockObject */
 	private $fileAccessHelper;
@@ -96,8 +96,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature('NotExistingApp', $x509, $rsa);
@@ -115,8 +114,8 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsaPrivateKey = file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.key');
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -146,8 +145,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -477,8 +475,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -501,8 +498,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -536,8 +532,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/app/');
@@ -571,8 +566,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessUnmodified/');
@@ -601,8 +595,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithInvalidModifiedContent/');
@@ -636,8 +629,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithValidModifiedContent');

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -131,6 +131,14 @@ class CheckerTest extends TestCase {
     "certificate": "-----BEGIN CERTIFICATE-----\r\nMIIEwTCCAqmgAwIBAgIUWv0iujufs5lUr0svCf\/qTQvoyKAwDQYJKoZIhvcNAQEF\r\nBQAwIzEhMB8GA1UECgwYb3duQ2xvdWQgQ29kZSBTaWduaW5nIENBMB4XDTE1MTEw\r\nMzIyNDk1M1oXDTE2MTEwMzIyNDk1M1owEjEQMA4GA1UEAwwHU29tZUFwcDCCAiIw\r\nDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK8q0x62agGSRBqeWsaeEwFfepMk\r\nF8cAobMMi50qHCv9IrOn\/ZH9l52xBrbIkErVmRjmly0d4JhD8Ymhidsh9ONKYl\/j\r\n+ishsZDM8eNNdp3Ew+fEYVvY1W7mR1qU24NWj0bzVsClI7hvPVIuw7AjfBDq1C5+\r\nA+ZSLSXYvOK2cEWjdxQfuNZwEZSjmA63DUllBIrm35IaTvfuyhU6BW9yHZxmb8+M\r\nw0xDv30D5UkE\/2N7Pa\/HQJLxCR+3zKibRK3nUyRDLSXxMkU9PnFNaPNX59VPgyj4\r\nGB1CFSToldJVPF4pzh7p36uGXZVxs8m3LFD4Ol8mhi7jkxDZjqFN46gzR0r23Py6\r\ndol9vfawGIoUwp9LvL0S7MvdRY0oazLXwClLP4OQ17zpSMAiCj7fgNT661JamPGj\r\nt5O7Zn2wA7I4ddDS\/HDTWCu98Zwc9fHIpsJPgCZ9awoqxi4Mnf7Pk9g5nnXhszGC\r\ncxxIASQKM+GhdzoRxKknax2RzUCwCzcPRtCj8AQT\/x\/mqN3PfRmlnFBNACUw9bpZ\r\nSOoNq2pCF9igftDWpSIXQ38pVpKLWowjjg3DVRmVKBgivHnUnVLyzYBahHPj0vaz\r\ntFtUFRaqXDnt+4qyUGyrT5h5pjZaTcHIcSB4PiarYwdVvgslgwnQzOUcGAzRWBD4\r\n6jV2brP5vFY3g6iPAgMBAAEwDQYJKoZIhvcNAQEFBQADggIBACTY3CCHC+Z28gCf\r\nFWGKQ3wAKs+k4+0yoti0qm2EKX7rSGQ0PHSas6uW79WstC4Rj+DYkDtIhGMSg8FS\r\nHVGZHGBCc0HwdX+BOAt3zi4p7Sf3oQef70\/4imPoKxbAVCpd\/cveVcFyDC19j1yB\r\nBapwu87oh+muoeaZxOlqQI4UxjBlR\/uRSMhOn2UGauIr3dWJgAF4pGt7TtIzt+1v\r\n0uA6FtN1Y4R5O8AaJPh1bIG0CVvFBE58esGzjEYLhOydgKFnEP94kVPgJD5ds9C3\r\npPhEpo1dRpiXaF7WGIV1X6DI\/ipWvfrF7CEy6I\/kP1InY\/vMDjQjeDnJ\/VrXIWXO\r\nyZvHXVaN\/m+1RlETsH7YO\/QmxRue9ZHN3gvvWtmpCeA95sfpepOk7UcHxHZYyQbF\r\n49\/au8j+5tsr4A83xzsT1JbcKRxkAaQ7WDJpOnE5O1+H0fB+BaLakTg6XX9d4Fo7\r\n7Gin7hVWX7pL+JIyxMzME3LhfI61+CRcqZQIrpyaafUziPQbWIPfEs7h8tCOWyvW\r\nUO8ZLervYCB3j44ivkrxPlcBklDCqqKKBzDP9dYOtS\/P4RB1NkHA9+NTvmBpTonS\r\nSFXdg9fFMD7VfjDE3Vnk+8DWkVH5wBYowTAD7w9Wuzr7DumiAULexnP\/Y7xwxLv7\r\n4B+pXTAcRK0zECDEaX3npS8xWzrB\r\n-----END CERTIFICATE-----"
 }';
 		$this->fileAccessHelper
+			->expects(self::any())
+			->method('is_writable')
+			->with(
+				$this->equalTo(\OC::$SERVERROOT . '/tests/data/integritycheck/app//appinfo'),
+			)
+			->willReturn(true);
+
+		$this->fileAccessHelper
 			->expects($this->once())
 			->method('file_put_contents')
 			->with(
@@ -145,7 +153,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		$rsa = RSA::load($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -97,6 +97,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature('NotExistingApp', $x509, $rsa);
@@ -116,6 +121,11 @@ class CheckerTest extends TestCase {
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsaPrivateKey = file_get_contents(__DIR__ .'/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -153,7 +163,12 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = RSA::load($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -484,6 +499,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -507,6 +527,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -541,6 +566,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/app/');
@@ -575,6 +605,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessUnmodified/');
@@ -604,6 +639,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithInvalidModifiedContent/');
@@ -638,6 +678,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithValidModifiedContent');

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -95,6 +95,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature('NotExistingApp', $x509, $rsa);
@@ -113,6 +118,11 @@ class CheckerTest extends TestCase {
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -150,7 +160,12 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = RSA::load($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -454,6 +469,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -476,6 +496,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -510,6 +535,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/app/');
@@ -544,6 +574,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessUnmodified/');
@@ -573,6 +608,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithInvalidModifiedContent/');
@@ -608,6 +648,11 @@ class CheckerTest extends TestCase {
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
 		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
+		// After loading the key, always set the PSS padding and options:
+		$rsa = $rsa
+			->withPadding(RSA::SIGNATURE_PSS)
+			->withMGFHash('sha512')
+			->withSaltLength(0);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithValidModifiedContent');

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -19,26 +19,27 @@ use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\ServerVersion;
-use phpseclib\Crypt\RSA;
-use phpseclib\File\X509;
+use phpseclib3\Crypt\RSA;
+use phpseclib3\File\X509;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class CheckerTest extends TestCase {
-	/** @var ServerVersion|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ServerVersion&MockObject */
 	private $serverVersion;
-	/** @var EnvironmentHelper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var EnvironmentHelper&MockObject */
 	private $environmentHelper;
-	/** @var FileAccessHelper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var FileAccessHelper&MockObject */
 	private $fileAccessHelper;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig&MockObject */
 	private $config;
-	/** @var IAppConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IAppConfig&MockObject */
 	private $appConfig;
-	/** @var ICacheFactory|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ICacheFactory&MockObject */
 	private $cacheFactory;
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IAppManager&MockObject */
 	private $appManager;
-	/** @var Detection|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Detection&MockObject */
 	private $mimeTypeDetector;
 
 	private Checker $checker;
@@ -93,8 +94,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature('NotExistingApp', $x509, $rsa);
@@ -111,8 +111,8 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -128,6 +128,14 @@ class CheckerTest extends TestCase {
     "certificate": "-----BEGIN CERTIFICATE-----\r\nMIIEwTCCAqmgAwIBAgIUWv0iujufs5lUr0svCf\/qTQvoyKAwDQYJKoZIhvcNAQEF\r\nBQAwIzEhMB8GA1UECgwYb3duQ2xvdWQgQ29kZSBTaWduaW5nIENBMB4XDTE1MTEw\r\nMzIyNDk1M1oXDTE2MTEwMzIyNDk1M1owEjEQMA4GA1UEAwwHU29tZUFwcDCCAiIw\r\nDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK8q0x62agGSRBqeWsaeEwFfepMk\r\nF8cAobMMi50qHCv9IrOn\/ZH9l52xBrbIkErVmRjmly0d4JhD8Ymhidsh9ONKYl\/j\r\n+ishsZDM8eNNdp3Ew+fEYVvY1W7mR1qU24NWj0bzVsClI7hvPVIuw7AjfBDq1C5+\r\nA+ZSLSXYvOK2cEWjdxQfuNZwEZSjmA63DUllBIrm35IaTvfuyhU6BW9yHZxmb8+M\r\nw0xDv30D5UkE\/2N7Pa\/HQJLxCR+3zKibRK3nUyRDLSXxMkU9PnFNaPNX59VPgyj4\r\nGB1CFSToldJVPF4pzh7p36uGXZVxs8m3LFD4Ol8mhi7jkxDZjqFN46gzR0r23Py6\r\ndol9vfawGIoUwp9LvL0S7MvdRY0oazLXwClLP4OQ17zpSMAiCj7fgNT661JamPGj\r\nt5O7Zn2wA7I4ddDS\/HDTWCu98Zwc9fHIpsJPgCZ9awoqxi4Mnf7Pk9g5nnXhszGC\r\ncxxIASQKM+GhdzoRxKknax2RzUCwCzcPRtCj8AQT\/x\/mqN3PfRmlnFBNACUw9bpZ\r\nSOoNq2pCF9igftDWpSIXQ38pVpKLWowjjg3DVRmVKBgivHnUnVLyzYBahHPj0vaz\r\ntFtUFRaqXDnt+4qyUGyrT5h5pjZaTcHIcSB4PiarYwdVvgslgwnQzOUcGAzRWBD4\r\n6jV2brP5vFY3g6iPAgMBAAEwDQYJKoZIhvcNAQEFBQADggIBACTY3CCHC+Z28gCf\r\nFWGKQ3wAKs+k4+0yoti0qm2EKX7rSGQ0PHSas6uW79WstC4Rj+DYkDtIhGMSg8FS\r\nHVGZHGBCc0HwdX+BOAt3zi4p7Sf3oQef70\/4imPoKxbAVCpd\/cveVcFyDC19j1yB\r\nBapwu87oh+muoeaZxOlqQI4UxjBlR\/uRSMhOn2UGauIr3dWJgAF4pGt7TtIzt+1v\r\n0uA6FtN1Y4R5O8AaJPh1bIG0CVvFBE58esGzjEYLhOydgKFnEP94kVPgJD5ds9C3\r\npPhEpo1dRpiXaF7WGIV1X6DI\/ipWvfrF7CEy6I\/kP1InY\/vMDjQjeDnJ\/VrXIWXO\r\nyZvHXVaN\/m+1RlETsH7YO\/QmxRue9ZHN3gvvWtmpCeA95sfpepOk7UcHxHZYyQbF\r\n49\/au8j+5tsr4A83xzsT1JbcKRxkAaQ7WDJpOnE5O1+H0fB+BaLakTg6XX9d4Fo7\r\n7Gin7hVWX7pL+JIyxMzME3LhfI61+CRcqZQIrpyaafUziPQbWIPfEs7h8tCOWyvW\r\nUO8ZLervYCB3j44ivkrxPlcBklDCqqKKBzDP9dYOtS\/P4RB1NkHA9+NTvmBpTonS\r\nSFXdg9fFMD7VfjDE3Vnk+8DWkVH5wBYowTAD7w9Wuzr7DumiAULexnP\/Y7xwxLv7\r\n4B+pXTAcRK0zECDEaX3npS8xWzrB\r\n-----END CERTIFICATE-----"
 }';
 		$this->fileAccessHelper
+			->expects(self::any())
+			->method('is_writable')
+			->with(
+				$this->equalTo(\OC::$SERVERROOT . '/tests/data/integritycheck/app//appinfo'),
+			)
+			->willReturn(true);
+
+		$this->fileAccessHelper
 			->expects($this->once())
 			->method('file_put_contents')
 			->with(
@@ -142,8 +150,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::load($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeAppSignature(\OC::$SERVERROOT . '/tests/data/integritycheck/app/', $x509, $rsa);
@@ -446,8 +453,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -469,8 +475,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/SomeApp.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, __DIR__);
@@ -504,8 +509,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/app/');
@@ -539,8 +543,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessUnmodified/');
@@ -569,8 +572,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithInvalidModifiedContent/');
@@ -605,8 +607,7 @@ class CheckerTest extends TestCase {
 
 		$keyBundle = file_get_contents(__DIR__ . '/../../data/integritycheck/core.crt');
 		$rsaPrivateKey = file_get_contents(__DIR__ . '/../../data/integritycheck/core.key');
-		$rsa = new RSA();
-		$rsa->loadKey($rsaPrivateKey);
+		$rsa = RSA::loadPrivateKey($rsaPrivateKey);
 		$x509 = new X509();
 		$x509->loadX509($keyBundle);
 		$this->checker->writeCoreSignature($x509, $rsa, \OC::$SERVERROOT . '/tests/data/integritycheck/htaccessWithValidModifiedContent');
@@ -976,7 +977,8 @@ class CheckerTest extends TestCase {
 	}
 
 	public function testRunInstanceVerification(): void {
-		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
+		/** @var Checker&MockObject */
+		$checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
 			->setConstructorArgs([
 				$this->serverVersion,
 				$this->environmentHelper,
@@ -993,7 +995,7 @@ class CheckerTest extends TestCase {
 			])
 			->getMock();
 
-		$this->checker
+		$checker
 			->expects($this->once())
 			->method('verifyCoreSignature');
 		$this->appManager
@@ -1020,7 +1022,7 @@ class CheckerTest extends TestCase {
 			'calendar',
 			'dav',
 		];
-		$this->checker
+		$checker
 			->expects($this->exactly(3))
 			->method('verifyAppSignature')
 			->willReturnCallback(function ($app) use (&$calls) {
@@ -1047,7 +1049,7 @@ class CheckerTest extends TestCase {
 			->method('deleteKey')
 			->with('core', 'oc.integritycheck.checker');
 
-		$this->checker->runInstanceVerification();
+		$checker->runInstanceVerification();
 	}
 
 	public function testVerifyAppSignatureWithoutSignatureDataAndCodeCheckerDisabled(): void {


### PR DESCRIPTION
* For https://github.com/nextcloud/3rdparty/pull/1972

## Summary

Updated to v3 - needed to adjust quiet some places.
AI was just used for https://github.com/nextcloud/server/pull/48183/changes/3983f8a2b80df3f16e549d375d6b49177382833c to help finding a working alternative because the old implementation was using v2 private functions which were not PHP private but just prefixed with `_`.
In v3 they made them really private so we have two options:
- drop our custom streams and use the streams provided by the library
- the solution implemented here using reflection to hack around the private fields...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
