### PR TITLE
chore: Remove deprecated `IJob::execute` method

### DIFF
--- a/core/Command/Background/Job.php
+++ b/core/Command/Background/Job.php
@@ -69,8 +69,7 @@ class Job extends Command {
 			$output->writeln('<error>Something went wrong when trying to retrieve Job with ID ' . $jobId . ' from database</error>');
 			return 1;
 		}
-		/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
-		$job->execute($this->jobList);
+		$job->start($this->jobList);
 		$job = $this->jobList->getById($jobId);
 
 		if (($job === null) || ($lastRun !== $job->getLastRun())) {

--- a/core/Command/Background/JobWorker.php
+++ b/core/Command/Background/JobWorker.php
@@ -125,9 +125,7 @@ class JobWorker extends JobBase {
 				$this->printJobInfo($job->getId(), $job, $output);
 			}
 
-			/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
-			$job->execute($this->jobList);
-
+			$job->start($this->jobList);
 			$output->writeln('Job ' . $job->getId() . ' has finished', OutputInterface::VERBOSITY_VERBOSE);
 
 			// clean up after unclean jobs

--- a/cron.php
+++ b/cron.php
@@ -171,8 +171,7 @@ Options:
 				echo 'Starting job ' . $jobDetails . PHP_EOL;
 			}
 
-			/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
-			$job->execute($jobList);
+			$job->start($jobList);
 
 			$timeAfter = time();
 			$memoryAfter = memory_get_usage();
@@ -237,8 +236,7 @@ Options:
 			$job = $jobList->getNext();
 			if ($job != null) {
 				$logger->debug('WebCron call has selected job with ID ' . strval($job->getId()), ['app' => 'cron']);
-				/** @psalm-suppress DeprecatedMethod Calling execute until it is removed, then will switch to start */
-				$job->execute($jobList);
+				$job->start($jobList);
 				$jobList->setLastJob($job);
 			}
 			OC_JSON::success();

--- a/lib/public/BackgroundJob/IJob.php
+++ b/lib/public/BackgroundJob/IJob.php
@@ -7,8 +7,6 @@
  */
 namespace OCP\BackgroundJob;
 
-use OCP\ILogger;
-
 /**
  * This interface represents a background job run with cron
  *
@@ -16,6 +14,8 @@ use OCP\ILogger;
  * \OCP\BackgroundJob\TimedJob or \OCP\BackgroundJob\QueuedJob
  *
  * @since 7.0.0
+ * @since 25.0.0 deprecated `execute()` method in favor of `start()`
+ * @since 33.0.0 removed deprecated `execute()` method
  */
 interface IJob {
 	/**
@@ -28,24 +28,13 @@ interface IJob {
 	public const TIME_SENSITIVE = 1;
 
 	/**
-	 * Run the background job with the registered argument
-	 *
-	 * @param IJobList $jobList The job list that manages the state of this job
-	 * @param ILogger|null $logger
-	 * @since 7.0.0
-	 * @deprecated 25.0.0 Use start() instead. This method will be removed
-	 * with the ILogger interface
-	 */
-	public function execute(IJobList $jobList, ?ILogger $logger = null);
-
-	/**
 	 * Start the background job with the registered argument
 	 *
 	 * This methods will take care of running the background job, of initializing
 	 * the state and cleaning up the job list after running the job.
 	 *
 	 * For common background job scenario, you will want to use TimedJob or QueuedJob
-	 * instead of overwritting this method.
+	 * instead of overwriting this method.
 	 *
 	 * @param IJobList $jobList The job list that manages the state of this job
 	 * @since 25.0.0

--- a/lib/public/BackgroundJob/Job.php
+++ b/lib/public/BackgroundJob/Job.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace OCP\BackgroundJob;
 
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\ILogger;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -18,32 +17,21 @@ use Psr\Log\LoggerInterface;
  * For the most common use cases have a look at QueuedJob and TimedJob
  *
  * @since 15.0.0
+ * @since 25.0.0 deprecated `execute()` method in favor of `start()`
+ * @since 33.0.0 removed deprecated `execute()` method
  */
 abstract class Job implements IJob, IParallelAwareJob {
 	protected int $id = 0;
 	protected int $lastRun = 0;
-	protected $argument;
-	protected ITimeFactory $time;
+	protected mixed $argument = null;
 	protected bool $allowParallelRuns = true;
 
 	/**
 	 * @since 15.0.0
 	 */
-	public function __construct(ITimeFactory $time) {
-		$this->time = $time;
-	}
-
-	/**
-	 * The function to prepare the execution of the job.
-	 *
-	 * @return void
-	 *
-	 * @since 15.0.0
-	 * @deprecated 25.0.0 Use start() instead. This method will be removed
-	 * with the ILogger interface
-	 */
-	public function execute(IJobList $jobList, ?ILogger $logger = null) {
-		$this->start($jobList);
+	public function __construct(
+		protected ITimeFactory $time,
+	) {
 	}
 
 	/**

--- a/lib/public/BackgroundJob/QueuedJob.php
+++ b/lib/public/BackgroundJob/QueuedJob.php
@@ -7,27 +7,14 @@ declare(strict_types=1);
  */
 namespace OCP\BackgroundJob;
 
-use OCP\ILogger;
-
 /**
  * Simple base class for a one time background job
  *
  * @since 15.0.0
+ * @since 25.0.0 deprecated `execute()` method in favor of `start()`
+ * @since 33.0.0 removed deprecated `execute()` method
  */
 abstract class QueuedJob extends Job {
-	/**
-	 * Run the job, then remove it from the joblist
-	 *
-	 * @param IJobList $jobList
-	 * @param ILogger|null $logger
-	 *
-	 * @since 15.0.0
-	 * @deprecated 25.0.0 Use start() instead. This method will be removed
-	 * with the ILogger interface
-	 */
-	final public function execute($jobList, ?ILogger $logger = null) {
-		$this->start($jobList);
-	}
 
 	/**
 	 * Run the job, then remove it from the joblist

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
  */
 namespace OCP\BackgroundJob;
 
-use OCP\ILogger;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 
@@ -16,6 +15,8 @@ use Psr\Log\LoggerInterface;
  * Call setInterval with your desired interval in seconds from the constructor.
  *
  * @since 15.0.0
+ * @since 25.0.0 deprecated `execute()` method in favor of `start()`
+ * @since 33.0.0 removed deprecated `execute()` method
  */
 abstract class TimedJob extends Job {
 	protected int $interval = 0;
@@ -28,7 +29,7 @@ abstract class TimedJob extends Job {
 	 *
 	 * @since 15.0.0
 	 */
-	public function setInterval(int $seconds) {
+	public function setInterval(int $seconds): void {
 		$this->interval = $seconds;
 	}
 
@@ -69,19 +70,6 @@ abstract class TimedJob extends Job {
 		}
 
 		$this->timeSensitivity = $sensitivity;
-	}
-
-	/**
-	 * Run the job if the last run is more than the interval ago
-	 *
-	 * @param IJobList $jobList
-	 * @param ILogger|null $logger
-	 *
-	 * @since 15.0.0
-	 * @deprecated 25.0.0 Use start() instead
-	 */
-	final public function execute(IJobList $jobList, ?ILogger $logger = null) {
-		$this->start($jobList);
 	}
 
 	/**


### PR DESCRIPTION
* resolves https://github.com/nextcloud/server/issues/32127

## Summary

`IJob::execute` is deprecated for quite some time and `ILogger` does not provide any logging functions anymore.
Now after 3 years we can remove it with Nextcloud 33.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
