### PR TITLE
fix(psalm): Update psalm baseline

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1482,11 +1482,6 @@
       <code><![CDATA[\Sabre\HTTP\decodePath($pathInfo)]]></code>
     </UndefinedFunction>
   </file>
-  <file src="lib/private/AppFramework/Logger.php">
-    <InvalidReturnType>
-      <code><![CDATA[log]]></code>
-    </InvalidReturnType>
-  </file>
   <file src="lib/private/AppFramework/Middleware/OCSMiddleware.php">
     <InternalMethod>
       <code><![CDATA[setOCSVersion]]></code>
@@ -2388,7 +2383,6 @@
     </InvalidReturnType>
     <NullableReturnStatement>
       <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
     </NullableReturnStatement>
     <TooManyArguments>
       <code><![CDATA[new IteratorDirectory([])]]></code>
@@ -2414,8 +2408,8 @@
   </file>
   <file src="lib/private/Log/Systemdlog.php">
     <UndefinedFunction>
-      <code><![CDATA[sd_journal_send('PRIORITY='.$journal_level,
-			'SYSLOG_IDENTIFIER='.$this->syslogId,
+      <code><![CDATA[sd_journal_send('PRIORITY=' . $journal_level,
+			'SYSLOG_IDENTIFIER=' . $this->syslogId,
 			'MESSAGE=' . $this->logDetailsAsJSON($app, $message, $level))]]></code>
     </UndefinedFunction>
   </file>


### PR DESCRIPTION
## Summary

Makes psalm green again. Somehow wasn't caught in https://github.com/nextcloud/server/pull/48181 (this update is only necessary because of formatting changes).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
