### PR TITLE
chore: Cleanup and prepare `\OC\Repair\RepairMimeTypes` tests for PHPUnit 10

### DIFF
--- a/tests/lib/Repair/CleanTagsTest.php
+++ b/tests/lib/Repair/CleanTagsTest.php
@@ -8,8 +8,10 @@
 namespace Test\Repair;
 
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Tests for the cleaning the tags tables
@@ -19,25 +21,18 @@ use OCP\Migration\IOutput;
  * @see \OC\Repair\CleanTags
  */
 class CleanTagsTest extends \Test\TestCase {
-	/** @var \OC\Repair\CleanTags */
-	protected $repair;
 
-	/** @var \OCP\IDBConnection */
-	protected $connection;
+	private ?int $createdFile = null;
+	private \OC\Repair\CleanTags $repair;
+	private IDBConnection $connection;
 
-	/** @var \OCP\IUserManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $userManager;
-
-	/** @var int */
-	protected $createdFile;
-
-	/** @var IOutput */
-	private $outputMock;
+	private IUserManager&MockObject $userManager;
+	private IOutput&MockObject $outputMock;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
+		$this->outputMock = $this->getMockBuilder(IOutput::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -45,7 +40,7 @@ class CleanTagsTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = \OCP\Server::get(IDBConnection::class);
 		$this->repair = new \OC\Repair\CleanTags($this->connection, $this->userManager);
 		$this->cleanUpTables();
 	}
@@ -59,14 +54,14 @@ class CleanTagsTest extends \Test\TestCase {
 	protected function cleanUpTables() {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->delete('vcategory')
-			->execute();
+			->executeStatement();
 
 		$qb->delete('vcategory_to_object')
-			->execute();
+			->executeStatement();
 
 		$qb->delete('filecache')
 			->runAcrossAllShards()
-			->execute();
+			->executeStatement();
 	}
 
 	public function testRun(): void {
@@ -119,7 +114,7 @@ class CleanTagsTest extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$result = $qb->select($qb->func()->count('*'))
 			->from($tableName)
-			->execute();
+			->executeQuery();
 
 		$this->assertEquals($expected, $result->fetchOne(), $message);
 	}
@@ -140,7 +135,7 @@ class CleanTagsTest extends \Test\TestCase {
 				'category' => $qb->createNamedParameter($category),
 				'type' => $qb->createNamedParameter($type),
 			])
-			->execute();
+			->executeStatement();
 
 		return $qb->getLastInsertId();
 	}
@@ -159,7 +154,7 @@ class CleanTagsTest extends \Test\TestCase {
 				'categoryid' => $qb->createNamedParameter($category, IQueryBuilder::PARAM_INT),
 				'type' => $qb->createNamedParameter($type),
 			])
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -167,7 +162,7 @@ class CleanTagsTest extends \Test\TestCase {
 	 * @return int
 	 */
 	protected function getFileID() {
-		if ($this->createdFile) {
+		if ($this->createdFile !== null) {
 			return $this->createdFile;
 		}
 
@@ -181,7 +176,7 @@ class CleanTagsTest extends \Test\TestCase {
 				'path' => $qb->createNamedParameter($fileName),
 				'path_hash' => $qb->createNamedParameter(md5($fileName)),
 			])
-			->execute();
+			->executeStatement();
 		$fileName = $this->getUniqueID('TestRepairCleanTags', 12);
 		$qb->insert('filecache')
 			->values([
@@ -189,7 +184,7 @@ class CleanTagsTest extends \Test\TestCase {
 				'path' => $qb->createNamedParameter($fileName),
 				'path_hash' => $qb->createNamedParameter(md5($fileName)),
 			])
-			->execute();
+			->executeStatement();
 
 		$this->createdFile = $qb->getLastInsertId();
 		return $this->createdFile;

--- a/tests/lib/Repair/ClearFrontendCachesTest.php
+++ b/tests/lib/Repair/ClearFrontendCachesTest.php
@@ -10,19 +10,15 @@ use OC\Template\JSCombiner;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ClearFrontendCachesTest extends \Test\TestCase {
-	/** @var ICacheFactory */
-	private $cacheFactory;
 
-	/** @var JSCombiner */
-	private $jsCombiner;
+	private ICacheFactory&MockObject $cacheFactory;
+	private JSCombiner&MockObject $jsCombiner;
+	private IOutput&MockObject $outputMock;
 
-	/** @var \OC\Repair\ClearFrontendCaches */
-	protected $repair;
-
-	/** @var IOutput */
-	private $outputMock;
+	protected \OC\Repair\ClearFrontendCaches $repair;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/tests/lib/Repair/ClearGeneratedAvatarCacheTest.php
+++ b/tests/lib/Repair/ClearGeneratedAvatarCacheTest.php
@@ -10,27 +10,19 @@ use OC\Avatar\AvatarManager;
 use OC\Repair\ClearGeneratedAvatarCache;
 use OCP\BackgroundJob\IJobList;
 use OCP\IConfig;
-use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ClearGeneratedAvatarCacheTest extends \Test\TestCase {
-	/** @var AvatarManager */
-	private $avatarManager;
 
-	/** @var IOutput */
-	private $outputMock;
-
-	/** @var IConfig */
-	private $config;
-
-	/** @var IJobList */
-	private $jobList;
+	private AvatarManager&MockObject $avatarManager;
+	private IConfig&MockObject $config;
+	private IJobList&MockObject $jobList;
 
 	protected ClearGeneratedAvatarCache $repair;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->outputMock = $this->createMock(IOutput::class);
 		$this->avatarManager = $this->createMock(AvatarManager::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->jobList = $this->createMock(IJobList::class);

--- a/tests/lib/Repair/OldGroupMembershipSharesTest.php
+++ b/tests/lib/Repair/OldGroupMembershipSharesTest.php
@@ -8,8 +8,11 @@
 namespace Test\Repair;
 
 use OC\Repair\OldGroupMembershipShares;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\Migration\IOutput;
 use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class OldGroupMembershipSharesTest
@@ -19,23 +22,17 @@ use OCP\Share\IShare;
  * @package Test\Repair
  */
 class OldGroupMembershipSharesTest extends \Test\TestCase {
-	/** @var OldGroupMembershipShares */
-	protected $repair;
 
-	/** @var \OCP\IDBConnection */
-	protected $connection;
-
-	/** @var \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $groupManager;
+	private IDBConnection $connection;
+	private IGroupManager&MockObject $groupManager;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		/** \OCP\IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
-		$this->groupManager = $this->getMockBuilder('OCP\IGroupManager')
+		$this->groupManager = $this->getMockBuilder(IGroupManager::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = \OCP\Server::get(IDBConnection::class);
 
 		$this->deleteAllShares();
 	}
@@ -48,7 +45,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 
 	protected function deleteAllShares() {
 		$qb = $this->connection->getQueryBuilder();
-		$qb->delete('share')->execute();
+		$qb->delete('share')->executeStatement();
 	}
 
 	public function testRun(): void {
@@ -76,7 +73,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member], ['id' => $notAMember]], $rows);
 		$result->closeCursor();
@@ -92,7 +89,7 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $group2], ['id' => $user1], ['id' => $member]], $rows);
 		$result->closeCursor();
@@ -127,8 +124,8 @@ class OldGroupMembershipSharesTest extends \Test\TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values($shareValues)
-			->execute();
+			->executeStatement();
 
-		return $this->connection->lastInsertId('*PREFIX*share');
+		return $qb->getLastInsertId();
 	}
 }

--- a/tests/lib/Repair/RepairDavSharesTest.php
+++ b/tests/lib/Repair/RepairDavSharesTest.php
@@ -16,23 +16,19 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 use function in_array;
 
 class RepairDavSharesTest extends TestCase {
-	/** @var IOutput|\PHPUnit\Framework\MockObject\MockObject */
-	protected $output;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $config;
-	/** @var IDBConnection|\PHPUnit\Framework\MockObject\MockObject */
-	protected $dbc;
-	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $groupManager;
-	/** @var \PHPUnit\Framework\MockObject\MockObject|LoggerInterface */
-	protected $logger;
-	/** @var RepairDavSharesTest */
-	protected $repair;
+
+	private IOutput&MockObject $output;
+	private IConfig&MockObject $config;
+	private IDBConnection&MockObject $dbc;
+	private LoggerInterface&MockObject $logger;
+	private IGroupManager&MockObject $groupManager;
+	private RepairDavShares $repair;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -138,6 +134,7 @@ class RepairDavSharesTest extends TestCase {
 			->method('execute')
 			->willReturn($shareResults);
 
+		$updateCalls = [];
 		$updateMock = $this->createMock(IQueryBuilder::class);
 		$updateMock->expects($this->any())
 			->method('expr')
@@ -153,13 +150,10 @@ class RepairDavSharesTest extends TestCase {
 			->willReturnSelf();
 		$updateMock->expects($this->exactly(4))
 			->method('setParameter')
-			->withConsecutive(
-				['updatedPrincipalUri', 'principals/groups/' . urlencode('family friends')],
-				['shareId', 7],
-				['updatedPrincipalUri', 'principals/groups/' . urlencode('Wants Repair')],
-				['shareId', 1],
-			)
-			->willReturnSelf();
+			->willReturnCallback(function () use (&$updateCalls, &$updateMock) {
+				$updateCalls[] = func_get_args();
+				return $updateMock;
+			});
 		$updateMock->expects($this->exactly(2))
 			->method('execute');
 
@@ -174,5 +168,11 @@ class RepairDavSharesTest extends TestCase {
 			});
 
 		$this->repair->run($this->output);
+		self::assertEquals([
+			['updatedPrincipalUri', 'principals/groups/' . urlencode('family friends'), null],
+			['shareId', 7, null],
+			['updatedPrincipalUri', 'principals/groups/' . urlencode('Wants Repair'), null],
+			['shareId', 1, null]
+		], $updateCalls);
 	}
 }

--- a/tests/lib/Repair/RepairInvalidSharesTest.php
+++ b/tests/lib/Repair/RepairInvalidSharesTest.php
@@ -9,8 +9,8 @@ namespace Test\Repair;
 
 use OC\Repair\RepairInvalidShares;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\Migration\IOutput;
-use OCP\Migration\IRepairStep;
 use OCP\Share\IShare;
 use Test\TestCase;
 
@@ -22,11 +22,9 @@ use Test\TestCase;
  * @see \OC\Repair\RepairInvalidShares
  */
 class RepairInvalidSharesTest extends TestCase {
-	/** @var IRepairStep */
-	private $repair;
 
-	/** @var \OCP\IDBConnection */
-	private $connection;
+	private RepairInvalidShares $repair;
+	private IDBConnection $connection;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -39,10 +37,9 @@ class RepairInvalidSharesTest extends TestCase {
 			->with('version')
 			->willReturn('12.0.0.0');
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = \OCP\Server::get(IDBConnection::class);
 		$this->deleteAllShares();
 
-		/** @var \OCP\IConfig $config */
 		$this->repair = new RepairInvalidShares($config, $this->connection);
 	}
 
@@ -54,7 +51,7 @@ class RepairInvalidSharesTest extends TestCase {
 
 	protected function deleteAllShares() {
 		$qb = $this->connection->getQueryBuilder();
-		$qb->delete('share')->execute();
+		$qb->delete('share')->executeStatement();
 	}
 
 	/**
@@ -80,30 +77,30 @@ class RepairInvalidSharesTest extends TestCase {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values($shareValues)
-			->execute();
-		$parent = $this->getLastShareId();
+			->executeStatement();
+		$parent = $qb->getLastInsertId();
 
 		// share with existing parent
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values(array_merge($shareValues, [
 				'parent' => $qb->expr()->literal($parent),
-			]))->execute();
-		$validChild = $this->getLastShareId();
+			]))->executeStatement();
+		$validChild = $qb->getLastInsertId();
 
 		// share with non-existing parent
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
 			->values(array_merge($shareValues, [
 				'parent' => $qb->expr()->literal($parent + 100),
-			]))->execute();
-		$invalidChild = $this->getLastShareId();
+			]))->executeStatement();
+		$invalidChild = $qb->getLastInsertId();
 
 		$query = $this->connection->getQueryBuilder();
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $validChild], ['id' => $invalidChild]], $rows);
 		$result->closeCursor();
@@ -119,7 +116,7 @@ class RepairInvalidSharesTest extends TestCase {
 		$result = $query->select('id')
 			->from('share')
 			->orderBy('id', 'ASC')
-			->execute();
+			->executeQuery();
 		$rows = $result->fetchAll();
 		$this->assertEquals([['id' => $parent], ['id' => $validChild]], $rows);
 		$result->closeCursor();
@@ -167,9 +164,7 @@ class RepairInvalidSharesTest extends TestCase {
 				'permissions' => $qb->expr()->literal($testPerms),
 				'stime' => $qb->expr()->literal(time()),
 			])
-			->execute();
-
-		$shareId = $this->getLastShareId();
+			->executeStatement();
 
 		/** @var IOutput | \PHPUnit\Framework\MockObject\MockObject $outputMock */
 		$outputMock = $this->getMockBuilder('\OCP\Migration\IOutput')
@@ -182,7 +177,7 @@ class RepairInvalidSharesTest extends TestCase {
 			->select('*')
 			->from('share')
 			->orderBy('permissions', 'ASC')
-			->execute()
+			->executeQuery()
 			->fetchAll();
 
 		$this->assertCount(1, $results);
@@ -190,12 +185,5 @@ class RepairInvalidSharesTest extends TestCase {
 		$updatedShare = $results[0];
 
 		$this->assertEquals($expectedPerms, $updatedShare['permissions']);
-	}
-
-	/**
-	 * @return int
-	 */
-	protected function getLastShareId() {
-		return $this->connection->lastInsertId('*PREFIX*share');
 	}
 }

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -16,7 +16,6 @@
 	<testsuite name="Nextcloud Server">
 		<directory suffix=".php">lib/</directory>
 		<directory suffix=".php">Core/</directory>
-		<directory suffix=".php">Test/</directory>
 		<file>apps.php</file>
 	</testsuite>
 	<coverage>


### PR DESCRIPTION
## Summary

Cleanup tests, remove and replaced deprecated stuff (esp. `withConsecutive`)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
