### PR TITLE
fix(IStorage): Use false instead of bool intersection type to match implementations

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -283,8 +283,8 @@ class DirectoryTest extends \Test\TestCase {
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
 			->willReturnMap([
-				'\OCA\Files_Sharing\SharedStorage' => false,
-				'\OC\Files\Storage\Wrapper\Quota' => false,
+				['\OCA\Files_Sharing\SharedStorage', false],
+				['\OC\Files\Storage\Wrapper\Quota', false],
 			]);
 
 		$storage->expects($this->once())

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -28,7 +28,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 
 	private LoggerInterface $logger;
 
-	public function needsPartFile() {
+	public function needsPartFile(): bool {
 		return false;
 	}
 
@@ -63,7 +63,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return string correctly encoded path
 	 */
-	private function normalizePath($path) {
+	private function normalizePath($path): string {
 		$path = trim($path, '/');
 
 		if (!$path) {
@@ -73,24 +73,24 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return $path;
 	}
 
-	private function isRoot($path) {
+	private function isRoot($path): bool {
 		return $path === '.';
 	}
 
-	private function cleanKey($path) {
+	private function cleanKey($path): string {
 		if ($this->isRoot($path)) {
 			return '/';
 		}
 		return $path;
 	}
 
-	private function clearCache() {
+	private function clearCache(): void {
 		$this->objectCache = new CappedMemoryCache();
 		$this->directoryCache = new CappedMemoryCache();
 		$this->filesCache = new CappedMemoryCache();
 	}
 
-	private function invalidateCache($key) {
+	private function invalidateCache($key): void {
 		unset($this->objectCache[$key]);
 		$keys = array_keys($this->objectCache->getData());
 		$keyLength = strlen($key);
@@ -110,10 +110,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		unset($this->directoryCache[$key]);
 	}
 
-	/**
-	 * @return array|false
-	 */
-	private function headObject(string $key) {
+	private function headObject(string $key): array|false {
 		if (!isset($this->objectCache[$key])) {
 			try {
 				$this->objectCache[$key] = $this->getConnection()->headObject([
@@ -144,11 +141,9 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	 * Implementation from flysystem-aws-s3-v3:
 	 * https://github.com/thephpleague/flysystem-aws-s3-v3/blob/8241e9cc5b28f981e0d24cdaf9867f14c7498ae4/src/AwsS3Adapter.php#L670-L694
 	 *
-	 * @param $path
-	 * @return bool
 	 * @throws \Exception
 	 */
-	private function doesDirectoryExist($path) {
+	private function doesDirectoryExist($path): bool {
 		if ($path === '.' || $path === '') {
 			return true;
 		}
@@ -190,13 +185,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	/**
-	 * Remove a file or folder
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	protected function remove($path) {
+	protected function remove($path): bool {
 		// remember fileType to reduce http calls
 		$fileType = $this->filetype($path);
 		if ($fileType === 'dir') {
@@ -208,7 +197,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -236,12 +225,12 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		return $this->filetype($path) !== false;
 	}
 
 
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->isRoot($path)) {
@@ -256,12 +245,12 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return $this->batchDelete($path);
 	}
 
-	protected function clearBucket() {
+	protected function clearBucket(): bool {
 		$this->clearCache();
 		return $this->batchDelete();
 	}
 
-	private function batchDelete($path = null) {
+	private function batchDelete($path = null): bool {
 		// TODO explore using https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.S3.BatchDelete.html
 		$params = [
 			'Bucket' => $this->bucket
@@ -312,7 +301,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function stat($path) {
+	public function stat($path): array|false {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -334,11 +323,8 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	 *
 	 * When the information is already present (e.g. opendir has been called before)
 	 * this value is return. Otherwise a headObject is emitted.
-	 *
-	 * @param $path
-	 * @return int|mixed
 	 */
-	private function getContentLength($path) {
+	private function getContentLength($path): int {
 		if (isset($this->filesCache[$path])) {
 			return (int)$this->filesCache[$path]['ContentLength'];
 		}
@@ -356,11 +342,8 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	 *
 	 * When the information is already present (e.g. opendir has been called before)
 	 * this value is return. Otherwise a headObject is emitted.
-	 *
-	 * @param $path
-	 * @return mixed|string
 	 */
-	private function getLastModified($path) {
+	private function getLastModified($path): string {
 		if (isset($this->filesCache[$path])) {
 			return $this->filesCache[$path]['LastModified'];
 		}
@@ -373,7 +356,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return 'now';
 	}
 
-	public function is_dir($path) {
+	public function is_dir($path): bool {
 		$path = $this->normalizePath($path);
 
 		if (isset($this->filesCache[$path])) {
@@ -391,7 +374,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		$path = $this->normalizePath($path);
 
 		if ($this->isRoot($path)) {
@@ -419,7 +402,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function getPermissions($path) {
+	public function getPermissions($path): int {
 		$type = $this->filetype($path);
 		if (!$type) {
 			return 0;
@@ -427,7 +410,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return $type === 'dir' ? Constants::PERMISSION_ALL : Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE;
 	}
 
-	public function unlink($path) {
+	public function unlink($path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -506,7 +489,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		if (is_null($mtime)) {
 			$mtime = time();
 		}
@@ -541,7 +524,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function copy($source, $target, $isFile = null) {
+	public function copy($source, $target, $isFile = null): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -584,7 +567,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -611,18 +594,18 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function test() {
+	public function test(): bool {
 		$this->getConnection()->headBucket([
 			'Bucket' => $this->bucket
 		]);
 		return true;
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return $this->id;
 	}
 
-	public function writeBack($tmpFile, $path) {
+	public function writeBack($tmpFile, $path): bool {
 		try {
 			$source = fopen($tmpFile, 'r');
 			$this->writeObject($path, $source, $this->mimeDetector->detectPath($path));
@@ -642,7 +625,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	/**
 	 * check if curl is installed
 	 */
-	public static function checkDependencies() {
+	public static function checkDependencies(): bool {
 		return true;
 	}
 
@@ -743,7 +726,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		// for files we can get the proper mtime
 		if ($path !== '' && $object = $this->headObject($path)) {
 			$stat = $this->objectToMetaData($object);

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -78,15 +78,15 @@ class FTP extends Common {
 		return $this->connection;
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return 'ftp::' . $this->username . '@' . $this->host . '/' . $this->root;
 	}
 
-	protected function buildPath($path) {
+	protected function buildPath($path): string {
 		return rtrim($this->root . '/' . $path, '/');
 	}
 
-	public static function checkDependencies() {
+	public static function checkDependencies(): array|bool {
 		if (function_exists('ftp_login')) {
 			return true;
 		} else {
@@ -94,7 +94,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function filemtime($path) {
+	public function filemtime($path): int|false {
 		$result = $this->getConnection()->mdtm($this->buildPath($path));
 
 		if ($result === -1) {
@@ -135,7 +135,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		if ($this->is_dir($path)) {
 			$result = $this->getConnection()->rmdir($this->buildPath($path));
 			// recursive rmdir support depends on the ftp server
@@ -153,7 +153,6 @@ class FTP extends Common {
 
 	/**
 	 * @param string $path
-	 * @return bool
 	 */
 	private function recursiveRmDir($path): bool {
 		$contents = $this->getDirectoryContent($path);
@@ -170,7 +169,7 @@ class FTP extends Common {
 		return $result;
 	}
 
-	public function test() {
+	public function test(): bool {
 		try {
 			return $this->getConnection()->systype() !== false;
 		} catch (\Exception $e) {
@@ -178,7 +177,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function stat($path) {
+	public function stat($path): array|false {
 		if (!$this->file_exists($path)) {
 			return false;
 		}
@@ -188,14 +187,14 @@ class FTP extends Common {
 		];
 	}
 
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		if ($path === '' || $path === '.' || $path === '/') {
 			return true;
 		}
 		return $this->filetype($path) !== false;
 	}
 
-	public function unlink($path) {
+	public function unlink($path): bool {
 		switch ($this->filetype($path)) {
 			case 'dir':
 				return $this->rmdir($path);
@@ -211,14 +210,14 @@ class FTP extends Common {
 		return IteratorDirectory::wrap($files);
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		if ($this->is_dir($path)) {
 			return false;
 		}
 		return $this->getConnection()->mkdir($this->buildPath($path)) !== false;
 	}
 
-	public function is_dir($path) {
+	public function is_dir($path): bool {
 		if ($path === '') {
 			return true;
 		}
@@ -230,11 +229,11 @@ class FTP extends Common {
 		}
 	}
 
-	public function is_file($path) {
+	public function is_file($path): bool {
 		return $this->filesize($path) !== false;
 	}
 
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		if ($this->is_dir($path)) {
 			return 'dir';
 		} elseif ($this->is_file($path)) {
@@ -310,7 +309,7 @@ class FTP extends Common {
 		return $stream;
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		if ($this->file_exists($path)) {
 			return false;
 		} else {
@@ -319,7 +318,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		$this->unlink($target);
 		return $this->getConnection()->rename($this->buildPath($source), $this->buildPath($target));
 	}

--- a/apps/files_external/lib/Lib/Storage/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Storage/OwnCloud.php
@@ -55,7 +55,7 @@ class OwnCloud extends \OC\Files\Storage\DAV implements IDisableEncryptionStorag
 		parent::__construct($params);
 	}
 
-	public function needsPartFile() {
+	public function needsPartFile(): bool {
 		return false;
 	}
 }

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -39,7 +39,7 @@ class SFTP extends Common {
 	 * @param string $host protocol://server:port
 	 * @return array [$server, $port]
 	 */
-	private function splitHost($host) {
+	private function splitHost($host): array {
 		$input = $host;
 		if (!str_contains($host, '://')) {
 			// add a protocol to fix parse_url behavior with ipv6
@@ -56,9 +56,6 @@ class SFTP extends Common {
 		}
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
 	public function __construct($params) {
 		// Register sftp://
 		Stream::register();
@@ -98,7 +95,7 @@ class SFTP extends Common {
 	 * @return \phpseclib\Net\SFTP connected client instance
 	 * @throws \Exception when the connection failed
 	 */
-	public function getConnection() {
+	public function getConnection(): \phpseclib\Net\SFTP {
 		if (!is_null($this->client)) {
 			return $this->client;
 		}
@@ -132,10 +129,7 @@ class SFTP extends Common {
 		return $this->client;
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function test() {
+	public function test(): bool {
 		if (
 			!isset($this->host)
 			|| !isset($this->user)
@@ -145,10 +139,7 @@ class SFTP extends Common {
 		return $this->getConnection()->nlist() !== false;
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getId() {
+	public function getId(): string {
 		$id = 'sftp::' . $this->user . '@' . $this->host;
 		if ($this->port !== 22) {
 			$id .= ':' . $this->port;
@@ -160,39 +151,26 @@ class SFTP extends Common {
 		return $id;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getHost() {
+	public function getHost(): string {
 		return $this->host;
 	}
 
-	/**
-	 * @return string
-	 */
-	public function getRoot() {
+	public function getRoot(): string {
 		return $this->root;
 	}
 
-	/**
-	 * @return mixed
-	 */
-	public function getUser() {
+	public function getUser(): string {
 		return $this->user;
 	}
 
 	/**
 	 * @param string $path
-	 * @return string
 	 */
-	private function absPath($path) {
+	private function absPath($path): string {
 		return $this->root . $this->cleanPath($path);
 	}
 
-	/**
-	 * @return string|false
-	 */
-	private function hostKeysPath() {
+	private function hostKeysPath(): string|false {
 		try {
 			$userId = \OC_User::getUser();
 			if ($userId === false) {
@@ -207,11 +185,7 @@ class SFTP extends Common {
 		return false;
 	}
 
-	/**
-	 * @param $keys
-	 * @return bool
-	 */
-	protected function writeHostKeys($keys) {
+	protected function writeHostKeys($keys): bool {
 		try {
 			$keyPath = $this->hostKeysPath();
 			if ($keyPath && file_exists($keyPath)) {
@@ -227,10 +201,7 @@ class SFTP extends Common {
 		return false;
 	}
 
-	/**
-	 * @return array
-	 */
-	protected function readHostKeys() {
+	protected function readHostKeys(): array {
 		try {
 			$keyPath = $this->hostKeysPath();
 			if (file_exists($keyPath)) {
@@ -253,10 +224,7 @@ class SFTP extends Common {
 		return [];
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		try {
 			return $this->getConnection()->mkdir($this->absPath($path));
 		} catch (\Exception $e) {
@@ -264,10 +232,7 @@ class SFTP extends Common {
 		}
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		try {
 			$result = $this->getConnection()->delete($this->absPath($path), true);
 			// workaround: stray stat cache entry when deleting empty folders
@@ -279,9 +244,6 @@ class SFTP extends Common {
 		}
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
 	public function opendir($path) {
 		try {
 			$list = $this->getConnection()->nlist($this->absPath($path));
@@ -302,10 +264,7 @@ class SFTP extends Common {
 		}
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		try {
 			$stat = $this->getConnection()->stat($this->absPath($path));
 			if (!is_array($stat) || !array_key_exists('type', $stat)) {
@@ -323,10 +282,7 @@ class SFTP extends Common {
 		return false;
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		try {
 			return $this->getConnection()->stat($this->absPath($path)) !== false;
 		} catch (\Exception $e) {
@@ -334,10 +290,7 @@ class SFTP extends Common {
 		}
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function unlink($path) {
+	public function unlink($path): bool {
 		try {
 			return $this->getConnection()->delete($this->absPath($path), true);
 		} catch (\Exception $e) {
@@ -345,9 +298,6 @@ class SFTP extends Common {
 		}
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
 	public function fopen($path, $mode) {
 		try {
 			$absPath = $this->absPath($path);
@@ -389,10 +339,7 @@ class SFTP extends Common {
 		return false;
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		try {
 			if (!is_null($mtime)) {
 				return false;
@@ -413,14 +360,11 @@ class SFTP extends Common {
 	 * @param string $target
 	 * @throws \Exception
 	 */
-	public function getFile($path, $target) {
+	public function getFile($path, $target): void {
 		$this->getConnection()->get($path, $target);
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		try {
 			if ($this->file_exists($target)) {
 				$this->unlink($target);
@@ -437,7 +381,7 @@ class SFTP extends Common {
 	/**
 	 * @return array{mtime: int, size: int, ctime: int}|false
 	 */
-	public function stat($path) {
+	public function stat($path): array|false {
 		try {
 			$stat = $this->getConnection()->stat($this->absPath($path));
 
@@ -456,9 +400,8 @@ class SFTP extends Common {
 
 	/**
 	 * @param string $path
-	 * @return string
 	 */
-	public function constructUrl($path) {
+	public function constructUrl($path): string {
 		// Do not pass the password here. We want to use the Net_SFTP object
 		// supplied via stream context or fail. We only supply username and
 		// hostname because this might show up in logs (they are not used).
@@ -466,7 +409,7 @@ class SFTP extends Common {
 		return $url;
 	}
 
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		/** @psalm-suppress InternalMethod */
 		$result = $this->getConnection()->put($this->absPath($path), $data);
 		if ($result) {
@@ -498,7 +441,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		if ($this->is_dir($source) || $this->is_dir($target)) {
 			return parent::copy($source, $target);
 		} else {
@@ -525,7 +468,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function getPermissions($path) {
+	public function getPermissions($path): int {
 		$stat = $this->getConnection()->stat($this->absPath($path));
 		if (!$stat) {
 			return 0;
@@ -537,7 +480,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		$stat = $this->getConnection()->stat($this->absPath($path));
 		if (!$stat) {
 			return null;

--- a/apps/files_external/lib/Lib/Storage/StreamWrapper.php
+++ b/apps/files_external/lib/Lib/Storage/StreamWrapper.php
@@ -12,13 +12,13 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @return string|null
 	 */
-	abstract public function constructUrl($path);
+	abstract public function constructUrl($path): ?string;
 
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		return mkdir($this->constructUrl($path));
 	}
 
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		if ($this->is_dir($path) && $this->isDeletable($path)) {
 			$dh = $this->opendir($path);
 			if (!is_resource($dh)) {
@@ -44,15 +44,15 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common {
 		return opendir($this->constructUrl($path));
 	}
 
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		return @filetype($this->constructUrl($path));
 	}
 
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		return file_exists($this->constructUrl($path));
 	}
 
-	public function unlink($path) {
+	public function unlink($path): bool {
 		$url = $this->constructUrl($path);
 		$success = unlink($url);
 		// normally unlink() is supposed to do this implicitly,
@@ -65,7 +65,7 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common {
 		return fopen($this->constructUrl($path), $mode);
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		if ($this->file_exists($path)) {
 			if (is_null($mtime)) {
 				$fh = $this->fopen($path, 'a');
@@ -86,22 +86,22 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common {
 	 * @param string $path
 	 * @param string $target
 	 */
-	public function getFile($path, $target) {
+	public function getFile($path, $target): bool {
 		return copy($this->constructUrl($path), $target);
 	}
 
 	/**
 	 * @param string $target
 	 */
-	public function uploadFile($path, $target) {
+	public function uploadFile($path, $target): bool {
 		return copy($path, $this->constructUrl($target));
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		return rename($this->constructUrl($source), $this->constructUrl($target));
 	}
 
-	public function stat($path) {
+	public function stat($path): array|false {
 		return stat($this->constructUrl($path));
 	}
 }

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -18,6 +18,9 @@ use OCA\Files_Sharing\ISharedStorage;
 use OCP\AppFramework\Http;
 use OCP\Constants;
 use OCP\Federation\ICloudId;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\IScanner;
+use OCP\Files\Cache\IWatcher;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\Files\Storage\IReliableEtagStorage;
@@ -91,7 +94,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		);
 	}
 
-	public function getWatcher($path = '', $storage = null) {
+	public function getWatcher($path = '', $storage = null): IWatcher {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -122,22 +125,18 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return $this->password;
 	}
 
-	/**
-	 * Get id of the mount point.
-	 * @return string
-	 */
-	public function getId() {
+	public function getId(): string {
 		return 'shared::' . md5($this->token . '@' . $this->getRemote());
 	}
 
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): ICache {
 		if (is_null($this->cache)) {
 			$this->cache = new Cache($this, $this->cloudId);
 		}
 		return $this->cache;
 	}
 
-	public function getScanner($path = '', $storage = null) {
+	public function getScanner($path = '', $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -148,16 +147,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return $this->scanner;
 	}
 
-	/**
-	 * Check if a file or folder has been updated since $time
-	 *
-	 * @param string $path
-	 * @param int $time
-	 * @throws \OCP\Files\StorageNotAvailableException
-	 * @throws \OCP\Files\StorageInvalidException
-	 * @return bool
-	 */
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		// since for owncloud webdav servers we can rely on etag propagation we only need to check the root of the storage
 		// because of that we only do one check for the entire storage per request
 		if ($this->updateChecked) {
@@ -177,7 +167,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		}
 	}
 
-	public function test() {
+	public function test(): bool {
 		try {
 			return parent::test();
 		} catch (StorageInvalidException $e) {
@@ -227,7 +217,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		}
 	}
 
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		if ($path === '') {
 			return true;
 		} else {
@@ -368,7 +358,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return $permissions;
 	}
 
-	public function needsPartFile() {
+	public function needsPartFile(): bool {
 		return false;
 	}
 
@@ -418,7 +408,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return $permissions;
 	}
 
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		return parent::free_space('');
 	}
 

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -95,7 +95,8 @@ class ExternalStorageTest extends \Test\TestCase {
 	}
 
 	public function testIfTestReturnsTheValue(): void {
-		$result = $this->getTestStorage('https://remoteserver')->test();
+		$storage = $this->getTestStorage('https://remoteserver');
+		$result = $storage->test();
 		$this->assertSame(true, $result);
 	}
 }
@@ -108,9 +109,9 @@ class TestSharingExternalStorage extends \OCA\Files_Sharing\External\Storage {
 		return $this->createBaseUri();
 	}
 
-	public function stat($path) {
+	public function stat($path): array|false {
 		if ($path === '') {
-			return true;
+			return ['key' => 'value'];
 		}
 		return parent::stat($path);
 	}

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -48,14 +48,7 @@ class Storage extends Wrapper {
 		parent::__construct($parameters);
 	}
 
-	/**
-	 * Deletes the given file by moving it into the trashbin.
-	 *
-	 * @param string $path path of file or folder to delete
-	 *
-	 * @return bool true if the operation succeeded, false otherwise
-	 */
-	public function unlink($path) {
+	public function unlink($path): bool {
 		if ($this->trashEnabled) {
 			try {
 				return $this->doDelete($path, 'unlink');
@@ -72,14 +65,7 @@ class Storage extends Wrapper {
 		}
 	}
 
-	/**
-	 * Deletes the given folder by moving it into the trashbin.
-	 *
-	 * @param string $path path of folder to delete
-	 *
-	 * @return bool true if the operation succeeded, false otherwise
-	 */
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		if ($this->trashEnabled) {
 			return $this->doDelete($path, 'rmdir');
 		} else {
@@ -94,7 +80,7 @@ class Storage extends Wrapper {
 	 * @param $path
 	 * @return bool
 	 */
-	protected function shouldMoveToTrash($path) {
+	protected function shouldMoveToTrash($path): bool {
 		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$parts = explode('/', $normalized);
 		if (count($parts) < 4 || strpos($normalized, '/appdata_') === 0) {
@@ -132,7 +118,7 @@ class Storage extends Wrapper {
 	 * @param Node $node
 	 * @return MoveToTrashEvent
 	 */
-	protected function createMoveToTrashEvent(Node $node) {
+	protected function createMoveToTrashEvent(Node $node): MoveToTrashEvent {
 		return new MoveToTrashEvent($node);
 	}
 
@@ -144,7 +130,7 @@ class Storage extends Wrapper {
 	 *
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
-	private function doDelete($path, $method) {
+	private function doDelete($path, $method): bool {
 		if (
 			!\OC::$server->getAppManager()->isEnabledForUser('files_trashbin')
 			|| (pathinfo($path, PATHINFO_EXTENSION) === 'part')
@@ -170,7 +156,7 @@ class Storage extends Wrapper {
 	/**
 	 * Setup the storage wrapper callback
 	 */
-	public static function setupStorage() {
+	public static function setupStorage(): void {
 		$trashManager = \OC::$server->get(ITrashManager::class);
 		$userManager = \OC::$server->get(IUserManager::class);
 		$logger = \OC::$server->get(LoggerInterface::class);
@@ -195,7 +181,7 @@ class Storage extends Wrapper {
 		return $this->mountPoint;
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		$sourceIsTrashbin = $sourceStorage->instanceOfStorage(Storage::class);
 		try {
 			// the fallback for moving between storage involves a copy+delete
@@ -219,11 +205,11 @@ class Storage extends Wrapper {
 		}
 	}
 
-	protected function disableTrash() {
+	protected function disableTrash(): void {
 		$this->trashEnabled = false;
 	}
 
-	protected function enableTrash() {
+	protected function enableTrash(): void {
 		$this->trashEnabled = true;
 	}
 }

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -29,11 +29,11 @@ use Psr\Log\LoggerInterface;
 use Test\Traits\MountProviderTrait;
 
 class TemporaryNoCross extends Temporary {
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null): bool {
 		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		return Common::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 }

--- a/apps/workflowengine/tests/Check/FileMimeTypeTest.php
+++ b/apps/workflowengine/tests/Check/FileMimeTypeTest.php
@@ -16,7 +16,7 @@ use OCP\IRequest;
 use Test\TestCase;
 
 class TemporaryNoLocal extends Temporary {
-	public function instanceOfStorage($className) {
+	public function instanceOfStorage($className): bool {
 		if ($className === '\OC\Files\Storage\Local') {
 			return false;
 		} else {

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2066,11 +2066,6 @@
       <code><![CDATA[remove]]></code>
     </UndefinedMethod>
   </file>
-  <file src="lib/private/Files/ObjectStore/ObjectStoreStorage.php">
-    <InvalidScalarArgument>
-      <code><![CDATA[$source]]></code>
-    </InvalidScalarArgument>
-  </file>
   <file src="lib/private/Files/ObjectStore/S3ConnectionTrait.php">
     <InternalClass>
       <code><![CDATA[ClientResolver::_default_signature_provider()]]></code>
@@ -2164,16 +2159,6 @@
       <code><![CDATA[$lastChunkPos]]></code>
       <code><![CDATA[$size]]></code>
     </InvalidScalarArgument>
-  </file>
-  <file src="lib/private/Files/Storage/Wrapper/Jail.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->getWrapperStorage()->filetype($this->getUnjailedPath($path))]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType/>
-  </file>
-  <file src="lib/private/Files/Storage/Wrapper/Wrapper.php">
-    <InvalidReturnStatement/>
-    <InvalidReturnType/>
   </file>
   <file src="lib/private/Files/Stream/SeekableHttpStream.php">
     <InvalidReturnType>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -935,9 +935,6 @@
     <InvalidNullableReturnType>
       <code><![CDATA[ICacheEntry]]></code>
     </InvalidNullableReturnType>
-    <InvalidReturnStatement>
-      <code><![CDATA[new FailedCache()]]></code>
-    </InvalidReturnStatement>
     <NullableReturnStatement>
       <code><![CDATA[$this->sourceRootInfo]]></code>
     </NullableReturnStatement>
@@ -2099,10 +2096,6 @@
       <code><![CDATA[!$permissions]]></code>
       <code><![CDATA[$this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file)]]></code>
     </InvalidOperand>
-    <NoInterfaceProperties>
-      <code><![CDATA[$storage->scanner]]></code>
-      <code><![CDATA[$storage->scanner]]></code>
-    </NoInterfaceProperties>
   </file>
   <file src="lib/private/Files/Storage/DAV.php">
     <InvalidClass>
@@ -2114,16 +2107,6 @@
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[fopen]]></code>
-    </InvalidReturnType>
-  </file>
-  <file src="lib/private/Files/Storage/FailedStorage.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[new FailedCache()]]></code>
-      <code><![CDATA[true]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[getCache]]></code>
-      <code><![CDATA[verifyPath]]></code>
     </InvalidReturnType>
   </file>
   <file src="lib/private/Files/Storage/Local.php">
@@ -2169,16 +2152,12 @@
   </file>
   <file src="lib/private/Files/Storage/Wrapper/Encryption.php">
     <InvalidOperand>
-      <code><![CDATA[$result]]></code>
-      <code><![CDATA[$result]]></code>
       <code><![CDATA[$this->copyFromStorage($sourceStorage, $sourceInternalPath . '/' . $file, $targetInternalPath . '/' . $file, false, $isRename)]]></code>
     </InvalidOperand>
     <InvalidReturnStatement>
-      <code><![CDATA[$newUnencryptedSize]]></code>
       <code><![CDATA[$result]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
-      <code><![CDATA[bool]]></code>
       <code><![CDATA[int]]></code>
     </InvalidReturnType>
     <InvalidScalarArgument>
@@ -2190,17 +2169,11 @@
     <InvalidReturnStatement>
       <code><![CDATA[$this->getWrapperStorage()->filetype($this->getUnjailedPath($path))]]></code>
     </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[bool]]></code>
-    </InvalidReturnType>
+    <InvalidReturnType/>
   </file>
   <file src="lib/private/Files/Storage/Wrapper/Wrapper.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$this->getWrapperStorage()->test()]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[true]]></code>
-    </InvalidReturnType>
+    <InvalidReturnStatement/>
+    <InvalidReturnType/>
   </file>
   <file src="lib/private/Files/Stream/SeekableHttpStream.php">
     <InvalidReturnType>
@@ -2370,20 +2343,6 @@
     </NullableReturnStatement>
   </file>
   <file src="lib/private/Lockdown/Filesystem/NullStorage.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[getPermissions]]></code>
-    </InvalidNullableReturnType>
-    <InvalidReturnStatement>
-      <code><![CDATA[new IteratorDirectory([])]]></code>
-      <code><![CDATA[new NullCache()]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[getCache]]></code>
-      <code><![CDATA[opendir]]></code>
-    </InvalidReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[null]]></code>
-    </NullableReturnStatement>
     <TooManyArguments>
       <code><![CDATA[new IteratorDirectory([])]]></code>
     </TooManyArguments>

--- a/lib/private/Files/Storage/CommonTest.php
+++ b/lib/private/Files/Storage/CommonTest.php
@@ -18,43 +18,43 @@ class CommonTest extends \OC\Files\Storage\Common {
 		$this->storage = new \OC\Files\Storage\Local($params);
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return 'test::' . $this->storage->getId();
 	}
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		return $this->storage->mkdir($path);
 	}
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		return $this->storage->rmdir($path);
 	}
 	public function opendir($path) {
 		return $this->storage->opendir($path);
 	}
-	public function stat($path) {
+	public function stat($path): array|false {
 		return $this->storage->stat($path);
 	}
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		return @$this->storage->filetype($path);
 	}
-	public function isReadable($path) {
+	public function isReadable($path): bool {
 		return $this->storage->isReadable($path);
 	}
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		return $this->storage->isUpdatable($path);
 	}
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		return $this->storage->file_exists($path);
 	}
-	public function unlink($path) {
+	public function unlink($path): bool {
 		return $this->storage->unlink($path);
 	}
 	public function fopen($path, $mode) {
 		return $this->storage->fopen($path, $mode);
 	}
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		return $this->storage->free_space($path);
 	}
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		return $this->storage->touch($path, $mtime);
 	}
 }

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -128,7 +128,7 @@ class DAV extends Common {
 		$this->mimeTypeDetector = \OC::$server->getMimeTypeDetector();
 	}
 
-	protected function init() {
+	protected function init(): void {
 		if ($this->ready) {
 			return;
 		}
@@ -177,17 +177,15 @@ class DAV extends Common {
 	/**
 	 * Clear the stat cache
 	 */
-	public function clearStatCache() {
+	public function clearStatCache(): void {
 		$this->statCache->clear();
 	}
 
-	/** {@inheritdoc} */
-	public function getId() {
+	public function getId(): string {
 		return 'webdav::' . $this->user . '@' . $this->host . '/' . $this->root;
 	}
 
-	/** {@inheritdoc} */
-	public function createBaseUri() {
+	public function createBaseUri(): string {
 		$baseUri = 'http';
 		if ($this->secure) {
 			$baseUri .= 's';
@@ -196,8 +194,7 @@ class DAV extends Common {
 		return $baseUri;
 	}
 
-	/** {@inheritdoc} */
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		$result = $this->simpleResponse('MKCOL', $path, null, 201);
@@ -207,8 +204,7 @@ class DAV extends Common {
 		return $result;
 	}
 
-	/** {@inheritdoc} */
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		// FIXME: some WebDAV impl return 403 when trying to DELETE
@@ -219,7 +215,6 @@ class DAV extends Common {
 		return $result;
 	}
 
-	/** {@inheritdoc} */
 	public function opendir($path) {
 		$this->init();
 		$path = $this->cleanPath($path);
@@ -244,11 +239,11 @@ class DAV extends Common {
 	 *
 	 * @param string $path path to propfind
 	 *
-	 * @return array|boolean propfind response or false if the entry was not found
+	 * @return array|false propfind response or false if the entry was not found
 	 *
 	 * @throws ClientHttpException
 	 */
-	protected function propfind($path) {
+	protected function propfind($path): array|false {
 		$path = $this->cleanPath($path);
 		$cachedResponse = $this->statCache->get($path);
 		// we either don't know it, or we know it exists but need more details
@@ -276,8 +271,7 @@ class DAV extends Common {
 		return $response;
 	}
 
-	/** {@inheritdoc} */
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		try {
 			$response = $this->propfind($path);
 			if ($response === false) {
@@ -295,8 +289,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	/** {@inheritdoc} */
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		try {
 			$path = $this->cleanPath($path);
 			$cachedState = $this->statCache->get($path);
@@ -314,8 +307,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	/** {@inheritdoc} */
-	public function unlink($path) {
+	public function unlink($path): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		$result = $this->simpleResponse('DELETE', $path, null, 204);
@@ -324,7 +316,6 @@ class DAV extends Common {
 		return $result;
 	}
 
-	/** {@inheritdoc} */
 	public function fopen($path, $mode) {
 		$this->init();
 		$path = $this->cleanPath($path);
@@ -402,13 +393,12 @@ class DAV extends Common {
 	/**
 	 * @param string $tmpFile
 	 */
-	public function writeBack($tmpFile, $path) {
+	public function writeBack($tmpFile, $path): void {
 		$this->uploadFile($tmpFile, $path);
 		unlink($tmpFile);
 	}
 
-	/** {@inheritdoc} */
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		$this->init();
 		$path = $this->cleanPath($path);
 		try {
@@ -426,8 +416,7 @@ class DAV extends Common {
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		$this->init();
 		if (is_null($mtime)) {
 			$mtime = time();
@@ -469,7 +458,7 @@ class DAV extends Common {
 	 * @param mixed $data
 	 * @return int|float|false
 	 */
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		$path = $this->cleanPath($path);
 		$result = parent::file_put_contents($path, $data);
 		$this->statCache->remove($path);
@@ -480,7 +469,7 @@ class DAV extends Common {
 	 * @param string $path
 	 * @param string $target
 	 */
-	protected function uploadFile($path, $target) {
+	protected function uploadFile($path, $target): void {
 		$this->init();
 
 		// invalidate
@@ -500,8 +489,7 @@ class DAV extends Common {
 		$this->removeCachedFile($target);
 	}
 
-	/** {@inheritdoc} */
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		$this->init();
 		$source = $this->cleanPath($source);
 		$target = $this->cleanPath($target);
@@ -532,8 +520,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	/** {@inheritdoc} */
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		$this->init();
 		$source = $this->cleanPath($source);
 		$target = $this->cleanPath($target);
@@ -561,7 +548,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		if (Filesystem::isFileBlacklisted($path)) {
 			throw new ForbiddenException('Invalid path: ' . $path, false);
 		}
@@ -623,24 +610,18 @@ class DAV extends Common {
 		];
 	}
 
-	/** {@inheritdoc} */
-	public function stat($path) {
+	public function stat($path): array|false {
 		$meta = $this->getMetaData($path);
 		return $meta ?: false;
 
 	}
 
-	/** {@inheritdoc} */
-	public function getMimeType($path) {
+	public function getMimeType($path): string|false {
 		$meta = $this->getMetaData($path);
 		return $meta ? $meta['mimetype'] : false;
 	}
 
-	/**
-	 * @param string $path
-	 * @return string
-	 */
-	public function cleanPath($path) {
+	public function cleanPath($path): string {
 		if ($path === '') {
 			return $path;
 		}
@@ -655,7 +636,7 @@ class DAV extends Common {
 	 * @param string $path to encode
 	 * @return string encoded path
 	 */
-	protected function encodePath($path) {
+	protected function encodePath($path): string {
 		// slashes need to stay
 		return str_replace('%2F', '/', rawurlencode($path));
 	}
@@ -669,7 +650,7 @@ class DAV extends Common {
 	 * @throws StorageInvalidException
 	 * @throws StorageNotAvailableException
 	 */
-	protected function simpleResponse($method, $path, $body, $expected) {
+	protected function simpleResponse($method, $path, $body, $expected): bool {
 		$path = $this->cleanPath($path);
 		try {
 			$response = $this->client->request($method, $this->encodePath($path), $body);
@@ -691,46 +672,37 @@ class DAV extends Common {
 	/**
 	 * check if curl is installed
 	 */
-	public static function checkDependencies() {
+	public static function checkDependencies(): bool {
 		return true;
 	}
 
-	/** {@inheritdoc} */
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_UPDATE);
 	}
 
-	/** {@inheritdoc} */
-	public function isCreatable($path) {
+	public function isCreatable($path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_CREATE);
 	}
 
-	/** {@inheritdoc} */
-	public function isSharable($path) {
+	public function isSharable($path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_SHARE);
 	}
 
-	/** {@inheritdoc} */
-	public function isDeletable($path) {
+	public function isDeletable($path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_DELETE);
 	}
 
-	/** {@inheritdoc} */
-	public function getPermissions($path) {
+	public function getPermissions($path): int {
 		$stat = $this->getMetaData($path);
 		return $stat ? $stat['permissions'] : 0;
 	}
 
-	public function getETag($path) {
+	public function getETag($path): string|false {
 		$meta = $this->getMetaData($path);
 		return $meta ? $meta['etag'] : false;
 	}
 
-	/**
-	 * @param string $permissionsString
-	 * @return int
-	 */
-	protected function parsePermissions($permissionsString) {
+	protected function parsePermissions($permissionsString): int {
 		$permissions = Constants::PERMISSION_READ;
 		if (str_contains($permissionsString, 'R')) {
 			$permissions |= Constants::PERMISSION_SHARE;
@@ -748,15 +720,7 @@ class DAV extends Common {
 		return $permissions;
 	}
 
-	/**
-	 * check if a file or folder has been updated since $time
-	 *
-	 * @param string $path
-	 * @param int $time
-	 * @throws \OCP\Files\StorageNotAvailableException
-	 * @return bool
-	 */
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		try {
@@ -822,7 +786,7 @@ class DAV extends Common {
 	 *                                      which might be temporary
 	 * @throws ForbiddenException if the action is not allowed
 	 */
-	protected function convertException(Exception $e, $path = '') {
+	protected function convertException(Exception $e, $path = ''): void {
 		Server::get(LoggerInterface::class)->debug($e->getMessage(), ['app' => 'files_external', 'exception' => $e]);
 		if ($e instanceof ClientHttpException) {
 			if ($e->getHttpStatus() === Http::STATUS_LOCKED) {

--- a/lib/private/Files/Storage/FailedStorage.php
+++ b/lib/private/Files/Storage/FailedStorage.php
@@ -29,168 +29,163 @@ class FailedStorage extends Common {
 		}
 	}
 
-	public function getId() {
+	public function getId(): string {
 		// we can't return anything sane here
 		return 'failedstorage';
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function rmdir($path) {
+	public function rmdir($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function opendir($path) {
+	public function opendir($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function is_dir($path) {
+	public function is_dir($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function is_file($path) {
+	public function is_file($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function stat($path) {
+	public function stat($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function filetype($path) {
+	public function filetype($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function filesize($path): false|int|float {
+	public function filesize($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isCreatable($path) {
+	public function isCreatable($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isReadable($path) {
+	public function isReadable($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isUpdatable($path) {
+	public function isUpdatable($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isDeletable($path) {
+	public function isDeletable($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isSharable($path) {
+	public function isSharable($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getPermissions($path) {
+	public function getPermissions($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function file_exists($path) {
+	public function file_exists($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function filemtime($path) {
+	public function filemtime($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function file_get_contents($path) {
+	public function file_get_contents($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function unlink($path) {
+	public function unlink($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen($path, $mode): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getMimeType($path) {
+	public function getMimeType($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function hash($type, $path, $raw = false) {
+	public function hash($type, $path, $raw = false): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function free_space($path) {
+	public function free_space($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function search($query) {
+	public function touch($path, $mtime = null): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function touch($path, $mtime = null) {
+	public function getLocalFile($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getLocalFile($path) {
+	public function hasUpdated($path, $time): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function hasUpdated($path, $time) {
+	public function getETag($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getETag($path) {
+	public function getDirectDownload($path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getDirectDownload($path) {
+	public function verifyPath($path, $fileName): void {
+	}
+
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function verifyPath($path, $fileName) {
-		return true;
-	}
-
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function acquireLock($path, $type, ILockingProvider $provider): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider) {
+	public function releaseLock($path, $type, ILockingProvider $provider): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider) {
+	public function changeLock($path, $type, ILockingProvider $provider): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider) {
+	public function getAvailability(): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getAvailability() {
+	public function setAvailability($isAvailable): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function setAvailability($isAvailable) {
-		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
-	}
-
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): FailedCache {
 		return new FailedCache();
 	}
 }

--- a/lib/private/Files/Storage/Home.php
+++ b/lib/private/Files/Storage/Home.php
@@ -8,6 +8,8 @@
 namespace OC\Files\Storage;
 
 use OC\Files\Cache\HomePropagator;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\IPropagator;
 use OCP\IUser;
 
 /**
@@ -38,41 +40,31 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 		parent::__construct(['datadir' => $datadir]);
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return $this->id;
 	}
 
-	/**
-	 * @return \OC\Files\Cache\HomeCache
-	 */
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): ICache {
 		if (!$storage) {
 			$storage = $this;
 		}
 		if (!isset($this->cache)) {
 			$this->cache = new \OC\Files\Cache\HomeCache($storage, $this->getCacheDependencies());
 		}
-		/** @var \OC\Files\Cache\HomeCache */
 		return $this->cache;
 	}
 
-	public function getPropagator($storage = null) {
+	public function getPropagator($storage = null): IPropagator {
 		if (!$storage) {
 			$storage = $this;
 		}
 		if (!isset($this->propagator)) {
 			$this->propagator = new HomePropagator($storage, \OC::$server->getDatabaseConnection());
 		}
-		/** @var \OC\Files\Cache\Propagator */
 		return $this->propagator;
 	}
 
 
-	/**
-	 * Returns the owner of this home storage
-	 *
-	 * @return \OC\User\User owner of this home storage
-	 */
 	public function getUser(): IUser {
 		return $this->user;
 	}

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -74,11 +74,11 @@ class Local extends \OC\Files\Storage\Common {
 	public function __destruct() {
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return 'local::' . $this->datadir;
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		$sourcePath = $this->getSourcePath($path);
 		$oldMask = umask($this->defUMask);
 		$result = @mkdir($sourcePath, 0777, true);
@@ -86,7 +86,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $result;
 	}
 
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		if (!$this->isDeletable($path)) {
 			return false;
 		}
@@ -129,7 +129,7 @@ class Local extends \OC\Files\Storage\Common {
 		return opendir($this->getSourcePath($path));
 	}
 
-	public function is_dir($path) {
+	public function is_dir($path): bool {
 		if ($this->caseInsensitive && !$this->file_exists($path)) {
 			return false;
 		}
@@ -139,14 +139,14 @@ class Local extends \OC\Files\Storage\Common {
 		return is_dir($this->getSourcePath($path));
 	}
 
-	public function is_file($path) {
+	public function is_file($path): bool {
 		if ($this->caseInsensitive && !$this->file_exists($path)) {
 			return false;
 		}
 		return is_file($this->getSourcePath($path));
 	}
 
-	public function stat($path) {
+	public function stat($path): array|false {
 		$fullPath = $this->getSourcePath($path);
 		clearstatcache(true, $fullPath);
 		if (!file_exists($fullPath)) {
@@ -164,7 +164,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $statResult;
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		try {
 			$stat = $this->stat($path);
 		} catch (ForbiddenException $e) {
@@ -213,7 +213,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $data;
 	}
 
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		$filetype = filetype($this->getSourcePath($path));
 		if ($filetype == 'link') {
 			$filetype = filetype(realpath($this->getSourcePath($path)));
@@ -221,7 +221,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $filetype;
 	}
 
-	public function filesize($path): false|int|float {
+	public function filesize($path): int|float|false {
 		if (!$this->is_file($path)) {
 			return 0;
 		}
@@ -233,15 +233,15 @@ class Local extends \OC\Files\Storage\Common {
 		return filesize($fullPath);
 	}
 
-	public function isReadable($path) {
+	public function isReadable($path): bool {
 		return is_readable($this->getSourcePath($path));
 	}
 
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		return is_writable($this->getSourcePath($path));
 	}
 
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		if ($this->caseInsensitive) {
 			$fullPath = $this->getSourcePath($path);
 			$parentPath = dirname($fullPath);
@@ -255,7 +255,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function filemtime($path) {
+	public function filemtime($path): int|false {
 		$fullPath = $this->getSourcePath($path);
 		clearstatcache(true, $fullPath);
 		if (!$this->file_exists($path)) {
@@ -268,7 +268,7 @@ class Local extends \OC\Files\Storage\Common {
 		return filemtime($fullPath);
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		// sets the modification time of the file to the given value.
 		// If mtime is nil the current time is set.
 		// note that the access time of the file always changes to the current time.
@@ -289,11 +289,11 @@ class Local extends \OC\Files\Storage\Common {
 		return $result;
 	}
 
-	public function file_get_contents($path) {
+	public function file_get_contents($path): string|false {
 		return file_get_contents($this->getSourcePath($path));
 	}
 
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		$oldMask = umask($this->defUMask);
 		if ($this->unlinkOnTruncate) {
 			$this->unlink($path);
@@ -303,7 +303,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $result;
 	}
 
-	public function unlink($path) {
+	public function unlink($path): bool {
 		if ($this->is_dir($path)) {
 			return $this->rmdir($path);
 		} elseif ($this->is_file($path)) {
@@ -313,7 +313,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	private function checkTreeForForbiddenItems(string $path) {
+	private function checkTreeForForbiddenItems(string $path): void {
 		$iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path));
 		foreach ($iterator as $file) {
 			/** @var \SplFileInfo $file */
@@ -364,7 +364,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $this->copy($source, $target) && $this->unlink($source);
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		if ($this->is_dir($source)) {
 			return parent::copy($source, $target);
 		} else {
@@ -401,7 +401,7 @@ class Local extends \OC\Files\Storage\Common {
 		return hash_file($type, $this->getSourcePath($path), $raw);
 	}
 
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		$sourcePath = $this->getSourcePath($path);
 		// using !is_dir because $sourcePath might be a part file or
 		// non-existing file, so we'd still want to use the parent dir
@@ -417,20 +417,19 @@ class Local extends \OC\Files\Storage\Common {
 		return Util::numericToNumber($space);
 	}
 
-	public function search($query) {
+	public function search($query): array {
 		return $this->searchInDir($query);
 	}
 
-	public function getLocalFile($path) {
+	public function getLocalFile($path): string|false {
 		return $this->getSourcePath($path);
 	}
 
 	/**
 	 * @param string $query
 	 * @param string $dir
-	 * @return array
 	 */
-	protected function searchInDir($query, $dir = '') {
+	protected function searchInDir($query, $dir = ''): array {
 		$files = [];
 		$physicalDir = $this->getSourcePath($dir);
 		foreach (scandir($physicalDir) as $item) {
@@ -449,14 +448,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $files;
 	}
 
-	/**
-	 * check if a file or folder has been updated since $time
-	 *
-	 * @param string $path
-	 * @param int $time
-	 * @return bool
-	 */
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		if ($this->file_exists($path)) {
 			return $this->filemtime($path) > $time;
 		} else {
@@ -468,10 +460,9 @@ class Local extends \OC\Files\Storage\Common {
 	 * Get the source path (on disk) of a given path
 	 *
 	 * @param string $path
-	 * @return string
 	 * @throws ForbiddenException
 	 */
-	public function getSourcePath($path) {
+	public function getSourcePath($path): string {
 		if (Filesystem::isFileBlacklisted($path)) {
 			throw new ForbiddenException('Invalid path: ' . $path, false);
 		}
@@ -503,14 +494,11 @@ class Local extends \OC\Files\Storage\Common {
 		throw new ForbiddenException('Following symlinks is not allowed', false);
 	}
 
-	/**
-	 * {@inheritdoc}
-	 */
-	public function isLocal() {
+	public function isLocal(): bool {
 		return true;
 	}
 
-	public function getETag($path) {
+	public function getETag($path): string|false {
 		return $this->calculateEtag($path, $this->stat($path));
 	}
 
@@ -540,7 +528,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	private function canDoCrossStorageMove(IStorage $sourceStorage) {
+	private function canDoCrossStorageMove(IStorage $sourceStorage): bool {
 		/** @psalm-suppress UndefinedClass */
 		return $sourceStorage->instanceOfStorage(Local::class)
 			// Don't treat ACLStorageWrapper like local storage where copy can be done directly.
@@ -553,14 +541,7 @@ class Local extends \OC\Files\Storage\Common {
 			&& !$sourceStorage->instanceOfStorage(Encryption::class);
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @param bool $preserveMtime
-	 * @return bool
-	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false): bool {
 		if ($this->canDoCrossStorageMove($sourceStorage)) {
 			if ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**
@@ -584,7 +565,7 @@ class Local extends \OC\Files\Storage\Common {
 	 * @param string $targetInternalPath
 	 * @return bool
 	 */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		if ($this->canDoCrossStorageMove($sourceStorage)) {
 			if ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**

--- a/lib/private/Files/Storage/LocalRootStorage.php
+++ b/lib/private/Files/Storage/LocalRootStorage.php
@@ -9,15 +9,13 @@ declare(strict_types=1);
 namespace OC\Files\Storage;
 
 use OC\Files\Cache\LocalRootScanner;
+use OCP\Files\Cache\IScanner;
 
 class LocalRootStorage extends Local {
-	public function getScanner($path = '', $storage = null) {
+	public function getScanner($path = '', $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
-		if (!isset($storage->scanner)) {
-			$storage->scanner = new LocalRootScanner($storage);
-		}
-		return $storage->scanner;
+		return $storage->scanner ?? ($storage->scanner = new LocalRootScanner($storage));
 	}
 }

--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -32,7 +32,7 @@ trait LocalTempFileTrait {
 	/**
 	 * @param string $path
 	 */
-	protected function removeCachedFile($path) {
+	protected function removeCachedFile($path): void {
 		unset($this->cachedFiles[$path]);
 	}
 

--- a/lib/private/Files/Storage/PolyFill/CopyDirectory.php
+++ b/lib/private/Files/Storage/PolyFill/CopyDirectory.php
@@ -12,31 +12,28 @@ trait CopyDirectory {
 	 * Check if a path is a directory
 	 *
 	 * @param string $path
-	 * @return bool
 	 */
-	abstract public function is_dir($path);
+	abstract public function is_dir($path): bool;
 
 	/**
 	 * Check if a file or folder exists
 	 *
 	 * @param string $path
-	 * @return bool
 	 */
-	abstract public function file_exists($path);
+	abstract public function file_exists($path): bool;
 
 	/**
 	 * Delete a file or folder
 	 *
 	 * @param string $path
-	 * @return bool
 	 */
-	abstract public function unlink($path);
+	abstract public function unlink($path): bool;
 
 	/**
 	 * Open a directory handle for a folder
 	 *
 	 * @param string $path
-	 * @return resource | bool
+	 * @return resource|false
 	 */
 	abstract public function opendir($path);
 
@@ -44,11 +41,10 @@ trait CopyDirectory {
 	 * Create a new folder
 	 *
 	 * @param string $path
-	 * @return bool
 	 */
-	abstract public function mkdir($path);
+	abstract public function mkdir($path): bool;
 
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		if ($this->is_dir($source)) {
 			if ($this->file_exists($target)) {
 				$this->unlink($target);
@@ -62,12 +58,8 @@ trait CopyDirectory {
 
 	/**
 	 * For adapters that don't support copying folders natively
-	 *
-	 * @param $source
-	 * @param $target
-	 * @return bool
 	 */
-	protected function copyRecursive($source, $target) {
+	protected function copyRecursive($source, $target): bool {
 		$dh = $this->opendir($source);
 		$result = true;
 		while (($file = readdir($dh)) !== false) {

--- a/lib/private/Files/Storage/Storage.php
+++ b/lib/private/Files/Storage/Storage.php
@@ -8,11 +8,11 @@
 
 namespace OC\Files\Storage;
 
-use OC\Files\Cache\Cache;
-use OC\Files\Cache\Propagator;
-use OC\Files\Cache\Scanner;
-use OC\Files\Cache\Updater;
-use OC\Files\Cache\Watcher;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\IPropagator;
+use OCP\Files\Cache\IScanner;
+use OCP\Files\Cache\IUpdater;
+use OCP\Files\Cache\IWatcher;
 use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\IStorage;
 
@@ -23,51 +23,44 @@ use OCP\Files\Storage\IStorage;
  */
 interface Storage extends IStorage, ILockingStorage {
 	/**
-	 * @inheritDoc
-	 * @return Cache
+	 * @param string $path
+	 * @param ?IStorage $storage
 	 */
-	public function getCache($path = '', $storage = null);
-
-	/**
-	 * @inheritDoc
-	 * @return Scanner
-	 */
-	public function getScanner($path = '', $storage = null);
-
-	/**
-	 * @inheritDoc
-	 * @return Watcher
-	 */
-	public function getWatcher($path = '', $storage = null);
-
-	/**
-	 * @inheritDoc
-	 * @return Propagator
-	 */
-	public function getPropagator($storage = null);
-
-	/**
-	 * @inheritDoc
-	 * @return Updater
-	 */
-	public function getUpdater($storage = null);
-
-	/**
-	 * @return \OC\Files\Cache\Storage
-	 */
-	public function getStorageCache();
+	public function getCache($path = '', $storage = null): ICache;
 
 	/**
 	 * @param string $path
-	 * @return array|null
+	 * @param ?IStorage $storage
 	 */
-	public function getMetaData($path);
+	public function getScanner($path = '', $storage = null): IScanner;
+
+	/**
+	 * @param string $path
+	 * @param ?IStorage $storage
+	 */
+	public function getWatcher($path = '', $storage = null): IWatcher;
+
+	/**
+	 * @param ?IStorage $storage
+	 */
+	public function getPropagator($storage = null): IPropagator;
+
+	/**
+	 * @param ?IStorage $storage
+	 */
+	public function getUpdater($storage = null): IUpdater;
+
+	public function getStorageCache(): \OC\Files\Cache\Storage;
+
+	/**
+	 * @param string $path
+	 */
+	public function getMetaData($path): ?array;
 
 	/**
 	 * Get the contents of a directory with metadata
 	 *
 	 * @param string $directory
-	 * @return \Traversable an iterator, containing file metadata
 	 *
 	 * The metadata array will contain the following fields
 	 *
@@ -79,5 +72,5 @@ interface Storage extends IStorage, ILockingStorage {
 	 * - storage_mtime
 	 * - permissions
 	 */
-	public function getDirectoryContent($directory): \Traversable;
+	public function getDirectoryContent($directory): \Traversable|false;
 }

--- a/lib/private/Files/Storage/StorageFactory.php
+++ b/lib/private/Files/Storage/StorageFactory.php
@@ -19,19 +19,7 @@ class StorageFactory implements IStorageFactory {
 	 */
 	private $storageWrappers = [];
 
-	/**
-	 * allow modifier storage behaviour by adding wrappers around storages
-	 *
-	 * $callback should be a function of type (string $mountPoint, Storage $storage) => Storage
-	 *
-	 * @param string $wrapperName name of the wrapper
-	 * @param callable $callback callback
-	 * @param int $priority wrappers with the lower priority are applied last (meaning they get called first)
-	 * @param \OCP\Files\Mount\IMountPoint[] $existingMounts existing mount points to apply the wrapper to
-	 * @return bool true if the wrapper was added, false if there was already a wrapper with this
-	 *              name registered
-	 */
-	public function addStorageWrapper($wrapperName, $callback, $priority = 50, $existingMounts = []) {
+	public function addStorageWrapper($wrapperName, $callback, $priority = 50, $existingMounts = []): bool {
 		if (isset($this->storageWrappers[$wrapperName])) {
 			return false;
 		}
@@ -52,7 +40,7 @@ class StorageFactory implements IStorageFactory {
 	 * @param string $wrapperName name of the wrapper
 	 * @internal
 	 */
-	public function removeStorageWrapper($wrapperName) {
+	public function removeStorageWrapper($wrapperName): void {
 		unset($this->storageWrappers[$wrapperName]);
 	}
 
@@ -63,7 +51,7 @@ class StorageFactory implements IStorageFactory {
 	 * @param array $arguments
 	 * @return IStorage
 	 */
-	public function getInstance(IMountPoint $mountPoint, $class, $arguments) {
+	public function getInstance(IMountPoint $mountPoint, $class, $arguments): IStorage {
 		if (!($class instanceof IConstructableStorage)) {
 			\OCP\Server::get(LoggerInterface::class)->warning('Building a storage not implementing IConstructableStorage is deprecated since 31.0.0', ['class' => $class]);
 		}
@@ -72,9 +60,8 @@ class StorageFactory implements IStorageFactory {
 
 	/**
 	 * @param IStorage $storage
-	 * @return IStorage
 	 */
-	public function wrap(IMountPoint $mountPoint, $storage) {
+	public function wrap(IMountPoint $mountPoint, $storage): IStorage {
 		$wrappers = array_values($this->storageWrappers);
 		usort($wrappers, function ($a, $b) {
 			return $b['priority'] - $a['priority'];

--- a/lib/private/Files/Storage/Temporary.php
+++ b/lib/private/Files/Storage/Temporary.php
@@ -15,7 +15,7 @@ class Temporary extends Local {
 		parent::__construct(['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]);
 	}
 
-	public function cleanUp() {
+	public function cleanUp(): void {
 		\OC_Helper::rmdirr($this->datadir);
 	}
 
@@ -24,7 +24,7 @@ class Temporary extends Local {
 		$this->cleanUp();
 	}
 
-	public function getDataDir() {
+	public function getDataDir(): array|string {
 		return $this->datadir;
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/Availability.php
+++ b/lib/private/Files/Storage/Wrapper/Availability.php
@@ -28,7 +28,7 @@ class Availability extends Wrapper {
 		parent::__construct($parameters);
 	}
 
-	public static function shouldRecheck($availability) {
+	public static function shouldRecheck($availability): bool {
 		if (!$availability['available']) {
 			// trigger a recheck if TTL reached
 			if ((time() - $availability['last_checked']) > self::RECHECK_TTL_SEC) {
@@ -40,10 +40,8 @@ class Availability extends Wrapper {
 
 	/**
 	 * Only called if availability === false
-	 *
-	 * @return bool
 	 */
-	private function updateAvailability() {
+	private function updateAvailability(): bool {
 		// reset availability to false so that multiple requests don't recheck concurrently
 		$this->setAvailability(false);
 		try {
@@ -55,10 +53,7 @@ class Availability extends Wrapper {
 		return $result;
 	}
 
-	/**
-	 * @return bool
-	 */
-	private function isAvailable() {
+	private function isAvailable(): bool {
 		$availability = $this->getAvailability();
 		if (self::shouldRecheck($availability)) {
 			return $this->updateAvailability();
@@ -69,154 +64,153 @@ class Availability extends Wrapper {
 	/**
 	 * @throws StorageNotAvailableException
 	 */
-	private function checkAvailability() {
+	private function checkAvailability(): void {
 		if (!$this->isAvailable()) {
 			throw new StorageNotAvailableException();
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::mkdir($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::rmdir($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
 	public function opendir($path) {
 		$this->checkAvailability();
 		try {
 			return parent::opendir($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function is_dir($path) {
+	public function is_dir($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::is_dir($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function is_file($path) {
+	public function is_file($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::is_file($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function stat($path) {
+	public function stat($path): array|false {
 		$this->checkAvailability();
 		try {
 			return parent::stat($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::filetype($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function filesize($path): false|int|float {
+	public function filesize($path): int|float|false {
 		$this->checkAvailability();
 		try {
 			return parent::filesize($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function isCreatable($path) {
+	public function isCreatable($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isCreatable($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function isReadable($path) {
+	public function isReadable($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isReadable($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isUpdatable($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function isDeletable($path) {
+	public function isDeletable($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isDeletable($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function isSharable($path) {
+	public function isSharable($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isSharable($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function getPermissions($path) {
+	public function getPermissions($path): int {
 		$this->checkAvailability();
 		try {
 			return parent::getPermissions($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return 0;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		if ($path === '') {
 			return true;
 		}
@@ -225,91 +219,91 @@ class Availability extends Wrapper {
 			return parent::file_exists($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function filemtime($path) {
+	public function filemtime($path): int|false {
 		$this->checkAvailability();
 		try {
 			return parent::filemtime($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function file_get_contents($path) {
+	public function file_get_contents($path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::file_get_contents($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		$this->checkAvailability();
 		try {
 			return parent::file_put_contents($path, $data);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function unlink($path) {
+	public function unlink($path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::unlink($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		$this->checkAvailability();
 		try {
 			return parent::rename($source, $target);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		$this->checkAvailability();
 		try {
 			return parent::copy($source, $target);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
 	public function fopen($path, $mode) {
 		$this->checkAvailability();
 		try {
 			return parent::fopen($path, $mode);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function getMimeType($path) {
+	public function getMimeType($path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::getMimeType($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function hash($type, $path, $raw = false) {
+	public function hash($type, $path, $raw = false): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::hash($type, $path, $raw);
@@ -319,48 +313,37 @@ class Availability extends Wrapper {
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		$this->checkAvailability();
 		try {
 			return parent::free_space($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function search($query) {
-		$this->checkAvailability();
-		try {
-			return parent::search($query);
-		} catch (StorageNotAvailableException $e) {
-			$this->setUnavailable($e);
-		}
-	}
-
-	/** {@inheritdoc} */
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		$this->checkAvailability();
 		try {
 			return parent::touch($path, $mtime);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function getLocalFile($path) {
+	public function getLocalFile($path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::getLocalFile($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		if (!$this->isAvailable()) {
 			return false;
 		}
@@ -382,52 +365,53 @@ class Availability extends Wrapper {
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function getETag($path) {
+	public function getETag($path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::getETag($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function getDirectDownload($path) {
+	public function getDirectDownload($path): array|false {
 		$this->checkAvailability();
 		try {
 			return parent::getDirectDownload($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		$this->checkAvailability();
 		try {
 			return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	/** {@inheritdoc} */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		$this->checkAvailability();
 		try {
 			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		$this->checkAvailability();
 		try {
 			return parent::getMetaData($path);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return null;
 		}
 	}
 
@@ -454,12 +438,13 @@ class Availability extends Wrapper {
 
 
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent($directory): \Traversable|false {
 		$this->checkAvailability();
 		try {
 			return parent::getDirectoryContent($directory);
 		} catch (StorageNotAvailableException $e) {
 			$this->setUnavailable($e);
+			return false;
 		}
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/EncodingDirectoryWrapper.php
+++ b/lib/private/Files/Storage/Wrapper/EncodingDirectoryWrapper.php
@@ -13,11 +13,7 @@ use OC\Files\Filesystem;
  * Normalize file names while reading directory entries
  */
 class EncodingDirectoryWrapper extends DirectoryWrapper {
-	/**
-	 * @psalm-suppress ImplementedReturnTypeMismatch Until return type is fixed upstream
-	 * @return string|false
-	 */
-	public function dir_readdir() {
+	public function dir_readdir(): string|false {
 		$file = readdir($this->source);
 		if ($file !== false && $file !== '.' && $file !== '..') {
 			$file = trim(Filesystem::normalizePath($file), '/');
@@ -28,7 +24,6 @@ class EncodingDirectoryWrapper extends DirectoryWrapper {
 
 	/**
 	 * @param resource $source
-	 * @param callable $filter
 	 * @return resource|false
 	 */
 	public static function wrap($source) {

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -18,7 +18,6 @@ use OC\Files\Storage\Common;
 use OC\Files\Storage\LocalTempFileTrait;
 use OC\Memcache\ArrayCache;
 use OCP\Cache\CappedMemoryCache;
-use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Encryption\IFile;
 use OCP\Encryption\IManager;
 use OCP\Encryption\Keys\IStorage;
@@ -104,11 +103,7 @@ class Encryption extends Wrapper {
 		parent::__construct($parameters);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.filesize.php
-	 * The result for filesize when called on a folder is required to be 0
-	 */
-	public function filesize($path): false|int|float {
+	public function filesize($path): int|float|false {
 		$fullPath = $this->getFullPath($path);
 
 		$info = $this->getCache()->get($path);
@@ -179,7 +174,7 @@ class Encryption extends Wrapper {
 		return $data;
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		$data = $this->storage->getMetaData($path);
 		if (is_null($data)) {
 			return null;
@@ -194,13 +189,7 @@ class Encryption extends Wrapper {
 		}
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_get_contents.php
-	 *
-	 * @param string $path
-	 * @return string|false
-	 */
-	public function file_get_contents($path) {
+	public function file_get_contents($path): string|false {
 		$encryptionModule = $this->getEncryptionModule($path);
 
 		if ($encryptionModule) {
@@ -215,14 +204,7 @@ class Encryption extends Wrapper {
 		return $this->storage->file_get_contents($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_put_contents.php
-	 *
-	 * @param string $path
-	 * @param mixed $data
-	 * @return int|false
-	 */
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		// file put content will always be translated to a stream write
 		$handle = $this->fopen($path, 'w');
 		if (is_resource($handle)) {
@@ -234,13 +216,7 @@ class Encryption extends Wrapper {
 		return false;
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.unlink.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function unlink($path) {
+	public function unlink($path): bool {
 		$fullPath = $this->getFullPath($path);
 		if ($this->util->isExcluded($fullPath)) {
 			return $this->storage->unlink($path);
@@ -254,14 +230,7 @@ class Encryption extends Wrapper {
 		return $this->storage->unlink($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.rename.php
-	 *
-	 * @param string $source
-	 * @param string $target
-	 * @return bool
-	 */
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		$result = $this->storage->rename($source, $target);
 
 		if ($result &&
@@ -286,13 +255,7 @@ class Encryption extends Wrapper {
 		return $result;
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.rmdir.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		$result = $this->storage->rmdir($path);
 		$fullPath = $this->getFullPath($path);
 		if ($result &&
@@ -305,13 +268,7 @@ class Encryption extends Wrapper {
 		return $result;
 	}
 
-	/**
-	 * check if a file can be read
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isReadable($path) {
+	public function isReadable($path): bool {
 		$isReadable = true;
 
 		$metaData = $this->getMetaData($path);
@@ -328,12 +285,6 @@ class Encryption extends Wrapper {
 		return $this->storage->isReadable($path) && $isReadable;
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.copy.php
-	 *
-	 * @param string $source
-	 * @param string $target
-	 */
 	public function copy($source, $target): bool {
 		$sourcePath = $this->getFullPath($source);
 
@@ -347,15 +298,6 @@ class Encryption extends Wrapper {
 		return $this->copyFromStorage($this, $source, $target);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.fopen.php
-	 *
-	 * @param string $path
-	 * @param string $mode
-	 * @return resource|bool
-	 * @throws GenericEncryptionException
-	 * @throws ModuleDoesNotExistsException
-	 */
 	public function fopen($path, $mode) {
 		// check if the file is stored in the array cache, this means that we
 		// copy a file over to the versions folder, in this case we don't want to
@@ -409,10 +351,8 @@ class Encryption extends Wrapper {
 					// if we update a encrypted file with a un-encrypted one we change the db flag
 					if ($targetIsEncrypted && $encryptionEnabled === false) {
 						$cache = $this->storage->getCache();
-						if ($cache) {
-							$entry = $cache->get($path);
-							$cache->update($entry->getId(), ['encrypted' => 0]);
-						}
+						$entry = $cache->get($path);
+						$cache->update($entry->getId(), ['encrypted' => 0]);
 					}
 					if ($encryptionEnabled) {
 						// if $encryptionModuleId is empty, the default module will be used
@@ -508,10 +448,8 @@ class Encryption extends Wrapper {
 	 * @param string $path internal path relative to the storage root
 	 * @param int $size size of the physical file
 	 * @param int $unencryptedSize size of the unencrypted file
-	 *
-	 * @return int calculated unencrypted size
 	 */
-	protected function fixUnencryptedSize(string $path, int $size, int $unencryptedSize): int {
+	protected function fixUnencryptedSize(string $path, int $size, int $unencryptedSize): int|float {
 		$headerSize = $this->getHeaderSize($path);
 		$header = $this->getHeader($path);
 		$encryptionModule = $this->getEncryptionModule($path);
@@ -580,12 +518,10 @@ class Encryption extends Wrapper {
 
 		// write to cache if applicable
 		$cache = $this->storage->getCache();
-		if ($cache) {
-			$entry = $cache->get($path);
-			$cache->update($entry['fileid'], [
-				'unencrypted_size' => $newUnencryptedSize
-			]);
-		}
+		$entry = $cache->get($path);
+		$cache->update($entry['fileid'], [
+			'unencrypted_size' => $newUnencryptedSize
+		]);
 
 		return $newUnencryptedSize;
 	}
@@ -617,19 +553,12 @@ class Encryption extends Wrapper {
 		return $data;
 	}
 
-	/**
-	 * @param Storage\IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @param bool $preserveMtime
-	 * @return bool
-	 */
 	public function moveFromStorage(
 		Storage\IStorage $sourceStorage,
 		$sourceInternalPath,
 		$targetInternalPath,
 		$preserveMtime = true,
-	) {
+	): bool {
 		if ($sourceStorage === $this) {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
@@ -647,30 +576,21 @@ class Encryption extends Wrapper {
 		$result = $this->copyBetweenStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime, true);
 		if ($result) {
 			if ($sourceStorage->is_dir($sourceInternalPath)) {
-				$result &= $sourceStorage->rmdir($sourceInternalPath);
+				$result = $sourceStorage->rmdir($sourceInternalPath);
 			} else {
-				$result &= $sourceStorage->unlink($sourceInternalPath);
+				$result = $sourceStorage->unlink($sourceInternalPath);
 			}
 		}
 		return $result;
 	}
 
-
-	/**
-	 * @param Storage\IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @param bool $preserveMtime
-	 * @param bool $isRename
-	 * @return bool
-	 */
 	public function copyFromStorage(
 		Storage\IStorage $sourceStorage,
 		$sourceInternalPath,
 		$targetInternalPath,
 		$preserveMtime = false,
 		$isRename = false,
-	) {
+	): bool {
 		// TODO clean this up once the underlying moveFromStorage in OC\Files\Storage\Wrapper\Common is fixed:
 		// - call $this->storage->copyFromStorage() instead of $this->copyBetweenStorage
 		// - copy the file cache update from  $this->copyBetweenStorage to this method
@@ -695,7 +615,7 @@ class Encryption extends Wrapper {
 		$targetInternalPath,
 		$isRename,
 		$keepEncryptionVersion,
-	) {
+	): void {
 		$isEncrypted = $this->encryptionManager->isEnabled() && $this->shouldEncrypt($targetInternalPath);
 		$cacheInformation = [
 			'encrypted' => $isEncrypted,
@@ -750,7 +670,7 @@ class Encryption extends Wrapper {
 		$targetInternalPath,
 		$preserveMtime,
 		$isRename,
-	) {
+	): bool {
 		// for versions we have nothing to do, because versions should always use the
 		// key from the original file. Just create a 1:1 copy and done
 		if ($this->isVersion($targetInternalPath) ||
@@ -828,7 +748,7 @@ class Encryption extends Wrapper {
 		return (bool)$result;
 	}
 
-	public function getLocalFile($path) {
+	public function getLocalFile($path): string|false {
 		if ($this->encryptionManager->isEnabled()) {
 			$cachedFile = $this->getCachedFile($path);
 			if (is_string($cachedFile)) {
@@ -838,14 +758,14 @@ class Encryption extends Wrapper {
 		return $this->storage->getLocalFile($path);
 	}
 
-	public function isLocal() {
+	public function isLocal(): bool {
 		if ($this->encryptionManager->isEnabled()) {
 			return false;
 		}
 		return $this->storage->isLocal();
 	}
 
-	public function stat($path) {
+	public function stat($path): array|false {
 		$stat = $this->storage->stat($path);
 		if (!$stat) {
 			return false;
@@ -857,7 +777,7 @@ class Encryption extends Wrapper {
 		return $stat;
 	}
 
-	public function hash($type, $path, $raw = false) {
+	public function hash($type, $path, $raw = false): string|false {
 		$fh = $this->fopen($path, 'rb');
 		$ctx = hash_init($type);
 		hash_update_stream($ctx, $fh);
@@ -871,7 +791,7 @@ class Encryption extends Wrapper {
 	 * @param string $path relative to mount point
 	 * @return string full path including mount point
 	 */
-	protected function getFullPath($path) {
+	protected function getFullPath($path): string {
 		return Filesystem::normalizePath($this->mountPoint . '/' . $path);
 	}
 
@@ -882,7 +802,7 @@ class Encryption extends Wrapper {
 	 * @param string $path
 	 * @return string
 	 */
-	protected function readFirstBlock($path) {
+	protected function readFirstBlock($path): string {
 		$firstBlock = '';
 		if ($this->storage->is_file($path)) {
 			$handle = $this->storage->fopen($path, 'r');
@@ -898,7 +818,7 @@ class Encryption extends Wrapper {
 	 * @param string $path
 	 * @return int
 	 */
-	protected function getHeaderSize($path) {
+	protected function getHeaderSize($path): int {
 		$headerSize = 0;
 		$realFile = $this->util->stripPartialFileExtension($path);
 		if ($this->storage->is_file($realFile)) {
@@ -919,7 +839,7 @@ class Encryption extends Wrapper {
 	 * @param string $path
 	 * @return array
 	 */
-	protected function getHeader($path) {
+	protected function getHeader($path): array {
 		$realFile = $this->util->stripPartialFileExtension($path);
 		$exists = $this->storage->is_file($realFile);
 		if ($exists) {
@@ -956,7 +876,7 @@ class Encryption extends Wrapper {
 	 * @throws ModuleDoesNotExistsException
 	 * @throws \Exception
 	 */
-	protected function getEncryptionModule($path) {
+	protected function getEncryptionModule($path): ?\OCP\Encryption\IEncryptionModule {
 		$encryptionModule = null;
 		$header = $this->getHeader($path);
 		$encryptionModuleId = $this->util->getEncryptionModuleId($header);
@@ -976,7 +896,7 @@ class Encryption extends Wrapper {
 	 * @param string $path
 	 * @param int $unencryptedSize
 	 */
-	public function updateUnencryptedSize($path, $unencryptedSize) {
+	public function updateUnencryptedSize($path, $unencryptedSize): void {
 		$this->unencryptedSize[$path] = $unencryptedSize;
 	}
 
@@ -987,7 +907,7 @@ class Encryption extends Wrapper {
 	 * @param string $target path relative to data/
 	 * @return bool
 	 */
-	protected function copyKeys($source, $target) {
+	protected function copyKeys($source, $target): bool {
 		if (!$this->util->isExcluded($source)) {
 			return $this->keyStorage->copyKeys($source, $target);
 		}
@@ -1001,7 +921,7 @@ class Encryption extends Wrapper {
 	 * @param $path
 	 * @return bool
 	 */
-	protected function isVersion($path) {
+	protected function isVersion($path): bool {
 		$normalized = Filesystem::normalizePath($path);
 		return substr($normalized, 0, strlen('/files_versions/')) === '/files_versions/';
 	}
@@ -1012,7 +932,7 @@ class Encryption extends Wrapper {
 	 * @param $path
 	 * @return bool
 	 */
-	protected function shouldEncrypt($path) {
+	protected function shouldEncrypt($path): bool {
 		$fullPath = $this->getFullPath($path);
 		$mountPointConfig = $this->mount->getOption('encrypt', true);
 		if ($mountPointConfig === false) {

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -11,6 +11,9 @@ use OC\Files\Cache\Wrapper\CacheJail;
 use OC\Files\Cache\Wrapper\JailPropagator;
 use OC\Files\Cache\Wrapper\JailWatcher;
 use OC\Files\Filesystem;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\IPropagator;
+use OCP\Files\Cache\IWatcher;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IWriteStreamStorage;
 use OCP\Lock\ILockingProvider;
@@ -37,19 +40,19 @@ class Jail extends Wrapper {
 		$this->rootPath = $arguments['root'];
 	}
 
-	public function getUnjailedPath($path) {
+	public function getUnjailedPath($path): string {
 		return trim(Filesystem::normalizePath($this->rootPath . '/' . $path), '/');
 	}
 
 	/**
 	 * This is separate from Wrapper::getWrapperStorage so we can get the jailed storage consistently even if the jail is inside another wrapper
 	 */
-	public function getUnjailedStorage() {
+	public function getUnjailedStorage(): IStorage {
 		return $this->storage;
 	}
 
 
-	public function getJailedPath($path) {
+	public function getJailedPath($path): ?string {
 		$root = rtrim($this->rootPath, '/') . '/';
 
 		if ($path !== $this->rootPath && !str_starts_with($path, $root)) {
@@ -60,305 +63,123 @@ class Jail extends Wrapper {
 		}
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return parent::getId();
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.mkdir.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		return $this->getWrapperStorage()->mkdir($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.rmdir.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		return $this->getWrapperStorage()->rmdir($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.opendir.php
-	 *
-	 * @param string $path
-	 * @return resource|false
-	 */
 	public function opendir($path) {
 		return $this->getWrapperStorage()->opendir($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.is_dir.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function is_dir($path) {
+	public function is_dir($path): bool {
 		return $this->getWrapperStorage()->is_dir($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.is_file.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function is_file($path) {
+	public function is_file($path): bool {
 		return $this->getWrapperStorage()->is_file($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.stat.php
-	 * only the following keys are required in the result: size and mtime
-	 *
-	 * @param string $path
-	 * @return array|bool
-	 */
-	public function stat($path) {
+	public function stat($path): array|false {
 		return $this->getWrapperStorage()->stat($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.filetype.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		return $this->getWrapperStorage()->filetype($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.filesize.php
-	 * The result for filesize when called on a folder is required to be 0
-	 */
-	public function filesize($path): false|int|float {
+	public function filesize($path): int|float|false {
 		return $this->getWrapperStorage()->filesize($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * check if a file can be created in $path
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isCreatable($path) {
+	public function isCreatable($path): bool {
 		return $this->getWrapperStorage()->isCreatable($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * check if a file can be read
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isReadable($path) {
+	public function isReadable($path): bool {
 		return $this->getWrapperStorage()->isReadable($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * check if a file can be written to
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		return $this->getWrapperStorage()->isUpdatable($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * check if a file can be deleted
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isDeletable($path) {
+	public function isDeletable($path): bool {
 		return $this->getWrapperStorage()->isDeletable($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * check if a file can be shared
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isSharable($path) {
+	public function isSharable($path): bool {
 		return $this->getWrapperStorage()->isSharable($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * get the full permissions of a path.
-	 * Should return a combination of the PERMISSION_ constants defined in lib/public/constants.php
-	 *
-	 * @param string $path
-	 * @return int
-	 */
-	public function getPermissions($path) {
+	public function getPermissions($path): int {
 		return $this->getWrapperStorage()->getPermissions($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_exists.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		return $this->getWrapperStorage()->file_exists($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.filemtime.php
-	 *
-	 * @param string $path
-	 * @return int|bool
-	 */
-	public function filemtime($path) {
+	public function filemtime($path): int|false {
 		return $this->getWrapperStorage()->filemtime($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_get_contents.php
-	 *
-	 * @param string $path
-	 * @return string|false
-	 */
-	public function file_get_contents($path) {
+	public function file_get_contents($path): string|false {
 		return $this->getWrapperStorage()->file_get_contents($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_put_contents.php
-	 *
-	 * @param string $path
-	 * @param mixed $data
-	 * @return int|float|false
-	 */
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		return $this->getWrapperStorage()->file_put_contents($this->getUnjailedPath($path), $data);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.unlink.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function unlink($path) {
+	public function unlink($path): bool {
 		return $this->getWrapperStorage()->unlink($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.rename.php
-	 *
-	 * @param string $source
-	 * @param string $target
-	 * @return bool
-	 */
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		return $this->getWrapperStorage()->rename($this->getUnjailedPath($source), $this->getUnjailedPath($target));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.copy.php
-	 *
-	 * @param string $source
-	 * @param string $target
-	 * @return bool
-	 */
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		return $this->getWrapperStorage()->copy($this->getUnjailedPath($source), $this->getUnjailedPath($target));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.fopen.php
-	 *
-	 * @param string $path
-	 * @param string $mode
-	 * @return resource|bool
-	 */
 	public function fopen($path, $mode) {
 		return $this->getWrapperStorage()->fopen($this->getUnjailedPath($path), $mode);
 	}
 
-	/**
-	 * get the mimetype for a file or folder
-	 * The mimetype for a folder is required to be "httpd/unix-directory"
-	 *
-	 * @param string $path
-	 * @return string|bool
-	 */
-	public function getMimeType($path) {
+	public function getMimeType($path): string|false {
 		return $this->getWrapperStorage()->getMimeType($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.hash.php
-	 *
-	 * @param string $type
-	 * @param string $path
-	 * @param bool $raw
-	 * @return string|bool
-	 */
-	public function hash($type, $path, $raw = false) {
+	public function hash($type, $path, $raw = false): string|false {
 		return $this->getWrapperStorage()->hash($type, $this->getUnjailedPath($path), $raw);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.free_space.php
-	 *
-	 * @param string $path
-	 * @return int|float|bool
-	 */
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		return $this->getWrapperStorage()->free_space($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.touch.php
-	 * If the backend does not support the operation, false should be returned
-	 *
-	 * @param string $path
-	 * @param int $mtime
-	 * @return bool
-	 */
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		return $this->getWrapperStorage()->touch($this->getUnjailedPath($path), $mtime);
 	}
 
-	/**
-	 * get the path to a local version of the file.
-	 * The local version of the file can be temporary and doesn't have to be persistent across requests
-	 *
-	 * @param string $path
-	 * @return string|false
-	 */
-	public function getLocalFile($path) {
+	public function getLocalFile($path): string|false {
 		return $this->getWrapperStorage()->getLocalFile($this->getUnjailedPath($path));
 	}
 
-	/**
-	 * check if a file or folder has been updated since $time
-	 *
-	 * @param string $path
-	 * @param int $time
-	 * @return bool
-	 *
-	 * hasUpdated for folders should return at least true if a file inside the folder is add, removed or renamed.
-	 * returning true for other changes in the folder is optional
-	 */
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		return $this->getWrapperStorage()->hasUpdated($this->getUnjailedPath($path), $time);
 	}
 
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): ICache {
 		$sourceCache = $this->getWrapperStorage()->getCache($this->getUnjailedPath($path));
 		return new CacheJail($sourceCache, $this->rootPath);
 	}
@@ -367,34 +188,28 @@ class Jail extends Wrapper {
 		return $this->getWrapperStorage()->getOwner($this->getUnjailedPath($path));
 	}
 
-	public function getWatcher($path = '', $storage = null) {
+	public function getWatcher($path = '', $storage = null): IWatcher {
 		$sourceWatcher = $this->getWrapperStorage()->getWatcher($this->getUnjailedPath($path), $this->getWrapperStorage());
 		return new JailWatcher($sourceWatcher, $this->rootPath);
 	}
 
-	/**
-	 * get the ETag for a file or folder
-	 *
-	 * @param string $path
-	 * @return string|false
-	 */
-	public function getETag($path) {
+	public function getETag($path): string|false {
 		return $this->getWrapperStorage()->getETag($this->getUnjailedPath($path));
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		return $this->getWrapperStorage()->getMetaData($this->getUnjailedPath($path));
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider) {
+	public function acquireLock($path, $type, ILockingProvider $provider): void {
 		$this->getWrapperStorage()->acquireLock($this->getUnjailedPath($path), $type, $provider);
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider) {
+	public function releaseLock($path, $type, ILockingProvider $provider): void {
 		$this->getWrapperStorage()->releaseLock($this->getUnjailedPath($path), $type, $provider);
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider) {
+	public function changeLock($path, $type, ILockingProvider $provider): void {
 		$this->getWrapperStorage()->changeLock($this->getUnjailedPath($path), $type, $provider);
 	}
 
@@ -402,39 +217,26 @@ class Jail extends Wrapper {
 	 * Resolve the path for the source of the share
 	 *
 	 * @param string $path
-	 * @return array
 	 */
-	public function resolvePath($path) {
+	public function resolvePath($path): array {
 		return [$this->getWrapperStorage(), $this->getUnjailedPath($path)];
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
 		return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $this->getUnjailedPath($targetInternalPath));
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
 		return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $this->getUnjailedPath($targetInternalPath));
 	}
 
-	public function getPropagator($storage = null) {
+	public function getPropagator($storage = null): IPropagator {
 		if (isset($this->propagator)) {
 			return $this->propagator;
 		}
@@ -460,7 +262,7 @@ class Jail extends Wrapper {
 		}
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent($directory): \Traversable|false {
 		return $this->getWrapperStorage()->getDirectoryContent($this->getUnjailedPath($directory));
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/KnownMtime.php
+++ b/lib/private/Files/Storage/Wrapper/KnownMtime.php
@@ -26,7 +26,7 @@ class KnownMtime extends Wrapper {
 		$this->clock = $arguments['clock'];
 	}
 
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		$result = parent::file_put_contents($path, $data);
 		if ($result) {
 			$now = $this->clock->now()->getTimestamp();
@@ -35,7 +35,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function stat($path) {
+	public function stat($path): array|false {
 		$stat = parent::stat($path);
 		if ($stat) {
 			$this->applyKnownMtime($path, $stat);
@@ -43,7 +43,7 @@ class KnownMtime extends Wrapper {
 		return $stat;
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		$stat = parent::getMetaData($path);
 		if ($stat) {
 			$this->applyKnownMtime($path, $stat);
@@ -51,19 +51,19 @@ class KnownMtime extends Wrapper {
 		return $stat;
 	}
 
-	private function applyKnownMtime(string $path, array &$stat) {
+	private function applyKnownMtime(string $path, array &$stat): void {
 		if (isset($stat['mtime'])) {
 			$knownMtime = $this->knowMtimes->get($path) ?? 0;
 			$stat['mtime'] = max($stat['mtime'], $knownMtime);
 		}
 	}
 
-	public function filemtime($path) {
+	public function filemtime($path): int|false {
 		$knownMtime = $this->knowMtimes->get($path) ?? 0;
 		return max(parent::filemtime($path), $knownMtime);
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		$result = parent::mkdir($path);
 		if ($result) {
 			$this->knowMtimes->set($path, $this->clock->now()->getTimestamp());
@@ -71,7 +71,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		$result = parent::rmdir($path);
 		if ($result) {
 			$this->knowMtimes->set($path, $this->clock->now()->getTimestamp());
@@ -79,7 +79,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function unlink($path) {
+	public function unlink($path): bool {
 		$result = parent::unlink($path);
 		if ($result) {
 			$this->knowMtimes->set($path, $this->clock->now()->getTimestamp());
@@ -87,7 +87,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		$result = parent::rename($source, $target);
 		if ($result) {
 			$this->knowMtimes->set($target, $this->clock->now()->getTimestamp());
@@ -96,7 +96,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		$result = parent::copy($source, $target);
 		if ($result) {
 			$this->knowMtimes->set($target, $this->clock->now()->getTimestamp());
@@ -112,7 +112,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		$result = parent::touch($path, $mtime);
 		if ($result) {
 			$this->knowMtimes->set($path, $mtime ?? $this->clock->now()->getTimestamp());
@@ -120,7 +120,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		$result = parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		if ($result) {
 			$this->knowMtimes->set($targetInternalPath, $this->clock->now()->getTimestamp());
@@ -128,7 +128,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		$result = parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		if ($result) {
 			$this->knowMtimes->set($targetInternalPath, $this->clock->now()->getTimestamp());

--- a/lib/private/Files/Storage/Wrapper/PermissionsMask.php
+++ b/lib/private/Files/Storage/Wrapper/PermissionsMask.php
@@ -34,31 +34,31 @@ class PermissionsMask extends Wrapper {
 		$this->mask = $arguments['mask'];
 	}
 
-	private function checkMask($permissions) {
+	private function checkMask($permissions): bool {
 		return ($this->mask & $permissions) === $permissions;
 	}
 
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		return $this->checkMask(Constants::PERMISSION_UPDATE) and parent::isUpdatable($path);
 	}
 
-	public function isCreatable($path) {
+	public function isCreatable($path): bool {
 		return $this->checkMask(Constants::PERMISSION_CREATE) and parent::isCreatable($path);
 	}
 
-	public function isDeletable($path) {
+	public function isDeletable($path): bool {
 		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::isDeletable($path);
 	}
 
-	public function isSharable($path) {
+	public function isSharable($path): bool {
 		return $this->checkMask(Constants::PERMISSION_SHARE) and parent::isSharable($path);
 	}
 
-	public function getPermissions($path) {
+	public function getPermissions($path): int {
 		return $this->storage->getPermissions($path) & $this->mask;
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		//This is a rename of the transfer file to the original file
 		if (dirname($source) === dirname($target) && strpos($source, '.ocTransferId') > 0) {
 			return $this->checkMask(Constants::PERMISSION_CREATE) and parent::rename($source, $target);
@@ -66,28 +66,28 @@ class PermissionsMask extends Wrapper {
 		return $this->checkMask(Constants::PERMISSION_UPDATE) and parent::rename($source, $target);
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		return $this->checkMask(Constants::PERMISSION_CREATE) and parent::copy($source, $target);
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
 		return $this->checkMask($permissions) and parent::touch($path, $mtime);
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		return $this->checkMask(Constants::PERMISSION_CREATE) and parent::mkdir($path);
 	}
 
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::rmdir($path);
 	}
 
-	public function unlink($path) {
+	public function unlink($path): bool {
 		return $this->checkMask(Constants::PERMISSION_DELETE) and parent::unlink($path);
 	}
 
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		$permissions = $this->file_exists($path) ? Constants::PERMISSION_UPDATE : Constants::PERMISSION_CREATE;
 		return $this->checkMask($permissions) ? parent::file_put_contents($path, $data) : false;
 	}
@@ -101,7 +101,7 @@ class PermissionsMask extends Wrapper {
 		}
 	}
 
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): \OCP\Files\Cache\ICache {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -109,7 +109,7 @@ class PermissionsMask extends Wrapper {
 		return new CachePermissionsMask($sourceCache, $this->mask);
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		$data = parent::getMetaData($path);
 
 		if ($data && isset($data['permissions'])) {
@@ -119,7 +119,7 @@ class PermissionsMask extends Wrapper {
 		return $data;
 	}
 
-	public function getScanner($path = '', $storage = null) {
+	public function getScanner($path = '', $storage = null): \OCP\Files\Cache\IScanner {
 		if (!$storage) {
 			$storage = $this->storage;
 		}

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -33,9 +33,6 @@ class Quota extends Wrapper {
 		$this->quotaIncludeExternalStorage = $parameters['include_external_storage'] ?? false;
 	}
 
-	/**
-	 * @return int|float quota value
-	 */
 	public function getQuota(): int|float {
 		if ($this->quota === null) {
 			$quotaCallback = $this->quotaCallback;
@@ -55,9 +52,8 @@ class Quota extends Wrapper {
 	/**
 	 * @param string $path
 	 * @param IStorage $storage
-	 * @return int|float
 	 */
-	protected function getSize($path, $storage = null) {
+	protected function getSize($path, $storage = null): int|float {
 		if ($this->quotaIncludeExternalStorage) {
 			$rootInfo = Filesystem::getFileInfo('', 'ext');
 			if ($rootInfo) {
@@ -75,13 +71,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	/**
-	 * Get free space as limited by the quota
-	 *
-	 * @param string $path
-	 * @return int|float|bool
-	 */
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		if (!$this->hasQuota()) {
 			return $this->storage->free_space($path);
 		}
@@ -101,14 +91,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_put_contents.php
-	 *
-	 * @param string $path
-	 * @param mixed $data
-	 * @return int|float|false
-	 */
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		if (!$this->hasQuota()) {
 			return $this->storage->file_put_contents($path, $data);
 		}
@@ -120,14 +103,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.copy.php
-	 *
-	 * @param string $source
-	 * @param string $target
-	 * @return bool
-	 */
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->copy($source, $target);
 		}
@@ -139,13 +115,6 @@ class Quota extends Wrapper {
 		}
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.fopen.php
-	 *
-	 * @param string $path
-	 * @param string $mode
-	 * @return resource|bool
-	 */
 	public function fopen($path, $mode) {
 		if (!$this->hasQuota()) {
 			return $this->storage->fopen($path, $mode);
@@ -170,10 +139,9 @@ class Quota extends Wrapper {
 	 * Checks whether the given path is a part file
 	 *
 	 * @param string $path Path that may identify a .part file
-	 * @return bool
 	 * @note this is needed for reusing keys
 	 */
-	private function isPartFile($path) {
+	private function isPartFile($path): bool {
 		$extension = pathinfo($path, PATHINFO_EXTENSION);
 
 		return ($extension === 'part');
@@ -186,13 +154,7 @@ class Quota extends Wrapper {
 		return str_starts_with(ltrim($path, '/'), 'files/');
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
@@ -204,13 +166,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
@@ -222,7 +178,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->mkdir($path);
 		}
@@ -234,7 +190,7 @@ class Quota extends Wrapper {
 		return parent::mkdir($path);
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->touch($path, $mtime);
 		}

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -8,7 +8,12 @@
 namespace OC\Files\Storage\Wrapper;
 
 use OC\Files\Storage\FailedStorage;
-use OCP\Files\InvalidPathException;
+use OC\Files\Storage\Storage;
+use OCP\Files\Cache\ICache;
+use OCP\Files\Cache\IPropagator;
+use OCP\Files\Cache\IScanner;
+use OCP\Files\Cache\IUpdater;
+use OCP\Files\Cache\IWatcher;
 use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IWriteStreamStorage;
@@ -35,10 +40,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		$this->storage = $parameters['storage'];
 	}
 
-	/**
-	 * @return \OC\Files\Storage\Storage
-	 */
-	public function getWrapperStorage() {
+	public function getWrapperStorage(): Storage {
 		if (!$this->storage) {
 			$message = 'storage wrapper ' . get_class($this) . " doesn't have a wrapped storage set";
 			$logger = Server::get(LoggerInterface::class);
@@ -48,319 +50,130 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->storage;
 	}
 
-	/**
-	 * Get the identifier for the storage,
-	 * the returned id should be the same for every storage object that is created with the same parameters
-	 * and two storage objects with the same id should refer to two storages that display the same files.
-	 *
-	 * @return string
-	 */
-	public function getId() {
+	public function getId(): string {
 		return $this->getWrapperStorage()->getId();
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.mkdir.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function mkdir($path) {
+	public function mkdir($path): bool {
 		return $this->getWrapperStorage()->mkdir($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.rmdir.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function rmdir($path) {
+	public function rmdir($path): bool {
 		return $this->getWrapperStorage()->rmdir($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.opendir.php
-	 *
-	 * @param string $path
-	 * @return resource|false
-	 */
 	public function opendir($path) {
 		return $this->getWrapperStorage()->opendir($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.is_dir.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function is_dir($path) {
+	public function is_dir($path): bool {
 		return $this->getWrapperStorage()->is_dir($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.is_file.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function is_file($path) {
+	public function is_file($path): bool {
 		return $this->getWrapperStorage()->is_file($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.stat.php
-	 * only the following keys are required in the result: size and mtime
-	 *
-	 * @param string $path
-	 * @return array|bool
-	 */
-	public function stat($path) {
+	public function stat($path): array|false {
 		return $this->getWrapperStorage()->stat($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.filetype.php
-	 *
-	 * @param string $path
-	 * @return string|bool
-	 */
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		return $this->getWrapperStorage()->filetype($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.filesize.php
-	 * The result for filesize when called on a folder is required to be 0
-	 */
-	public function filesize($path): false|int|float {
+	public function filesize($path): int|float|false {
 		return $this->getWrapperStorage()->filesize($path);
 	}
 
-	/**
-	 * check if a file can be created in $path
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isCreatable($path) {
+	public function isCreatable($path): bool {
 		return $this->getWrapperStorage()->isCreatable($path);
 	}
 
-	/**
-	 * check if a file can be read
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isReadable($path) {
+	public function isReadable($path): bool {
 		return $this->getWrapperStorage()->isReadable($path);
 	}
 
-	/**
-	 * check if a file can be written to
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		return $this->getWrapperStorage()->isUpdatable($path);
 	}
 
-	/**
-	 * check if a file can be deleted
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isDeletable($path) {
+	public function isDeletable($path): bool {
 		return $this->getWrapperStorage()->isDeletable($path);
 	}
 
-	/**
-	 * check if a file can be shared
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function isSharable($path) {
+	public function isSharable($path): bool {
 		return $this->getWrapperStorage()->isSharable($path);
 	}
 
-	/**
-	 * get the full permissions of a path.
-	 * Should return a combination of the PERMISSION_ constants defined in lib/public/constants.php
-	 *
-	 * @param string $path
-	 * @return int
-	 */
-	public function getPermissions($path) {
+	public function getPermissions($path): int {
 		return $this->getWrapperStorage()->getPermissions($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_exists.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		return $this->getWrapperStorage()->file_exists($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.filemtime.php
-	 *
-	 * @param string $path
-	 * @return int|bool
-	 */
-	public function filemtime($path) {
+	public function filemtime($path): int|false {
 		return $this->getWrapperStorage()->filemtime($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_get_contents.php
-	 *
-	 * @param string $path
-	 * @return string|false
-	 */
-	public function file_get_contents($path) {
+	public function file_get_contents($path): string|false {
 		return $this->getWrapperStorage()->file_get_contents($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.file_put_contents.php
-	 *
-	 * @param string $path
-	 * @param mixed $data
-	 * @return int|float|false
-	 */
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): int|float|false {
 		return $this->getWrapperStorage()->file_put_contents($path, $data);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.unlink.php
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	public function unlink($path) {
+	public function unlink($path): bool {
 		return $this->getWrapperStorage()->unlink($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.rename.php
-	 *
-	 * @param string $source
-	 * @param string $target
-	 * @return bool
-	 */
-	public function rename($source, $target) {
+	public function rename($source, $target): bool {
 		return $this->getWrapperStorage()->rename($source, $target);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.copy.php
-	 *
-	 * @param string $source
-	 * @param string $target
-	 * @return bool
-	 */
-	public function copy($source, $target) {
+	public function copy($source, $target): bool {
 		return $this->getWrapperStorage()->copy($source, $target);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.fopen.php
-	 *
-	 * @param string $path
-	 * @param string $mode
-	 * @return resource|bool
-	 */
 	public function fopen($path, $mode) {
 		return $this->getWrapperStorage()->fopen($path, $mode);
 	}
 
-	/**
-	 * get the mimetype for a file or folder
-	 * The mimetype for a folder is required to be "httpd/unix-directory"
-	 *
-	 * @param string $path
-	 * @return string|bool
-	 */
-	public function getMimeType($path) {
+	public function getMimeType($path): string|false {
 		return $this->getWrapperStorage()->getMimeType($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.hash.php
-	 *
-	 * @param string $type
-	 * @param string $path
-	 * @param bool $raw
-	 * @return string|bool
-	 */
-	public function hash($type, $path, $raw = false) {
+	public function hash($type, $path, $raw = false): string|false {
 		return $this->getWrapperStorage()->hash($type, $path, $raw);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.free_space.php
-	 *
-	 * @param string $path
-	 * @return int|float|bool
-	 */
-	public function free_space($path) {
+	public function free_space($path): int|float|false {
 		return $this->getWrapperStorage()->free_space($path);
 	}
 
-	/**
-	 * see https://www.php.net/manual/en/function.touch.php
-	 * If the backend does not support the operation, false should be returned
-	 *
-	 * @param string $path
-	 * @param int $mtime
-	 * @return bool
-	 */
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		return $this->getWrapperStorage()->touch($path, $mtime);
 	}
 
-	/**
-	 * get the path to a local version of the file.
-	 * The local version of the file can be temporary and doesn't have to be persistent across requests
-	 *
-	 * @param string $path
-	 * @return string|false
-	 */
-	public function getLocalFile($path) {
+	public function getLocalFile($path): string|false {
 		return $this->getWrapperStorage()->getLocalFile($path);
 	}
 
-	/**
-	 * check if a file or folder has been updated since $time
-	 *
-	 * @param string $path
-	 * @param int $time
-	 * @return bool
-	 *
-	 * hasUpdated for folders should return at least true if a file inside the folder is add, removed or renamed.
-	 * returning true for other changes in the folder is optional
-	 */
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		return $this->getWrapperStorage()->hasUpdated($path, $time);
 	}
 
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): ICache {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getCache($path, $storage);
 	}
 
-	public function getScanner($path = '', $storage = null) {
+	public function getScanner($path = '', $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -371,66 +184,44 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->getOwner($path);
 	}
 
-	public function getWatcher($path = '', $storage = null) {
+	public function getWatcher($path = '', $storage = null): IWatcher {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getWatcher($path, $storage);
 	}
 
-	public function getPropagator($storage = null) {
+	public function getPropagator($storage = null): IPropagator {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getPropagator($storage);
 	}
 
-	public function getUpdater($storage = null) {
+	public function getUpdater($storage = null): IUpdater {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getUpdater($storage);
 	}
 
-	public function getStorageCache() {
+	public function getStorageCache(): \OC\Files\Cache\Storage {
 		return $this->getWrapperStorage()->getStorageCache();
 	}
 
-	/**
-	 * get the ETag for a file or folder
-	 *
-	 * @param string $path
-	 * @return string|false
-	 */
-	public function getETag($path) {
+	public function getETag($path): string|false {
 		return $this->getWrapperStorage()->getETag($path);
 	}
 
-	/**
-	 * Returns true
-	 *
-	 * @return true
-	 */
-	public function test() {
+	public function test(): bool {
 		return $this->getWrapperStorage()->test();
 	}
 
-	/**
-	 * Returns the wrapped storage's value for isLocal()
-	 *
-	 * @return bool wrapped storage's isLocal() value
-	 */
-	public function isLocal() {
+	public function isLocal(): bool {
 		return $this->getWrapperStorage()->isLocal();
 	}
 
-	/**
-	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
-	 *
-	 * @param class-string<IStorage> $class
-	 * @return bool
-	 */
-	public function instanceOfStorage($class) {
+	public function instanceOfStorage($class): bool {
 		if (ltrim($class, '\\') === 'OC\Files\Storage\Shared') {
 			// FIXME Temporary fix to keep existing checks working
 			$class = '\OCA\Files_Sharing\SharedStorage';
@@ -443,7 +234,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 	 * @psalm-param class-string<T> $class
 	 * @psalm-return T|null
 	 */
-	public function getInstanceOfStorage(string $class) {
+	public function getInstanceOfStorage(string $class): ?IStorage {
 		$storage = $this;
 		while ($storage instanceof Wrapper) {
 			if ($storage instanceof $class) {
@@ -468,53 +259,23 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return call_user_func_array([$this->getWrapperStorage(), $method], $args);
 	}
 
-	/**
-	 * A custom storage implementation can return an url for direct download of a give file.
-	 *
-	 * For now the returned array can hold the parameter url - in future more attributes might follow.
-	 *
-	 * @param string $path
-	 * @return array|bool
-	 */
-	public function getDirectDownload($path) {
+	public function getDirectDownload($path): array|false {
 		return $this->getWrapperStorage()->getDirectDownload($path);
 	}
 
-	/**
-	 * Get availability of the storage
-	 *
-	 * @return array [ available, last_checked ]
-	 */
-	public function getAvailability() {
+	public function getAvailability(): array {
 		return $this->getWrapperStorage()->getAvailability();
 	}
 
-	/**
-	 * Set availability of the storage
-	 *
-	 * @param bool $isAvailable
-	 */
-	public function setAvailability($isAvailable) {
+	public function setAvailability($isAvailable): void {
 		$this->getWrapperStorage()->setAvailability($isAvailable);
 	}
 
-	/**
-	 * @param string $path the path of the target folder
-	 * @param string $fileName the name of the file itself
-	 * @return void
-	 * @throws InvalidPathException
-	 */
-	public function verifyPath($path, $fileName) {
+	public function verifyPath($path, $fileName): void {
 		$this->getWrapperStorage()->verifyPath($path, $fileName);
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
@@ -522,13 +283,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
@@ -536,32 +291,29 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
-	public function getMetaData($path) {
+	public function getMetaData($path): ?array {
 		return $this->getWrapperStorage()->getMetaData($path);
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider) {
+	public function acquireLock($path, $type, ILockingProvider $provider): void {
 		if ($this->getWrapperStorage()->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 			$this->getWrapperStorage()->acquireLock($path, $type, $provider);
 		}
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider) {
+	public function releaseLock($path, $type, ILockingProvider $provider): void {
 		if ($this->getWrapperStorage()->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 			$this->getWrapperStorage()->releaseLock($path, $type, $provider);
 		}
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider) {
+	public function changeLock($path, $type, ILockingProvider $provider): void {
 		if ($this->getWrapperStorage()->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 			$this->getWrapperStorage()->changeLock($path, $type, $provider);
 		}
 	}
 
-	/**
-	 * @return bool
-	 */
-	public function needsPartFile() {
+	public function needsPartFile(): bool {
 		return $this->getWrapperStorage()->needsPartFile();
 	}
 
@@ -579,11 +331,11 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		}
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent($directory): \Traversable|false {
 		return $this->getWrapperStorage()->getDirectoryContent($directory);
 	}
 
-	public function isWrapperOf(IStorage $storage) {
+	public function isWrapperOf(IStorage $storage): bool {
 		$wrapped = $this->getWrapperStorage();
 		if ($wrapped === $storage) {
 			return true;

--- a/lib/private/Files/Stream/Quota.php
+++ b/lib/private/Files/Stream/Quota.php
@@ -23,7 +23,7 @@ class Quota extends Wrapper {
 	/**
 	 * @param resource $stream
 	 * @param int $limit
-	 * @return bool|resource
+	 * @return resource|false
 	 */
 	public static function wrap($stream, $limit) {
 		$context = stream_context_create([

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -106,6 +106,7 @@ class Scanner extends PublicEmitter {
 	 * @param \OC\Files\Mount\MountPoint $mount
 	 */
 	protected function attachListener($mount) {
+		/** @var \OC\Files\Cache\Scanner $scanner */
 		$scanner = $mount->getStorage()->getScanner();
 		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function ($path) use ($mount) {
 			$this->emit('\OC\Files\Utils\Scanner', 'scanFile', [$mount->getMountPoint() . $path]);
@@ -145,6 +146,7 @@ class Scanner extends PublicEmitter {
 					continue;
 				}
 
+				/** @var \OC\Files\Cache\Scanner $scanner */
 				$scanner = $storage->getScanner();
 				$this->attachListener($mount);
 
@@ -221,6 +223,7 @@ class Scanner extends PublicEmitter {
 				continue;
 			}
 			$relativePath = $mount->getInternalPath($dir);
+			/** @var \OC\Files\Cache\Scanner $scanner */
 			$scanner = $storage->getScanner();
 			$scanner->setUseTransactions(false);
 			$this->attachListener($mount);

--- a/lib/private/Lockdown/Filesystem/NullStorage.php
+++ b/lib/private/Lockdown/Filesystem/NullStorage.php
@@ -8,6 +8,7 @@ namespace OC\Lockdown\Filesystem;
 use Icewind\Streams\IteratorDirectory;
 use OC\Files\FileInfo;
 use OC\Files\Storage\Common;
+use OCP\Files\Cache\ICache;
 use OCP\Files\Storage\IStorage;
 
 class NullStorage extends Common {
@@ -15,143 +16,143 @@ class NullStorage extends Common {
 		parent::__construct($parameters);
 	}
 
-	public function getId() {
+	public function getId(): string {
 		return 'null';
 	}
 
-	public function mkdir($path) {
+	public function mkdir($path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function rmdir($path) {
+	public function rmdir($path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function opendir($path) {
+	public function opendir($path): IteratorDirectory {
 		return new IteratorDirectory([]);
 	}
 
-	public function is_dir($path) {
+	public function is_dir($path): bool {
 		return $path === '';
 	}
 
-	public function is_file($path) {
+	public function is_file($path): bool {
 		return false;
 	}
 
-	public function stat($path) {
+	public function stat($path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function filetype($path) {
+	public function filetype($path): string|false {
 		return ($path === '') ? 'dir' : false;
 	}
 
-	public function filesize($path): false|int|float {
+	public function filesize($path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function isCreatable($path) {
+	public function isCreatable($path): bool {
 		return false;
 	}
 
-	public function isReadable($path) {
+	public function isReadable($path): bool {
 		return $path === '';
 	}
 
-	public function isUpdatable($path) {
+	public function isUpdatable($path): bool {
 		return false;
 	}
 
-	public function isDeletable($path) {
+	public function isDeletable($path): bool {
 		return false;
 	}
 
-	public function isSharable($path) {
+	public function isSharable($path): bool {
 		return false;
 	}
 
-	public function getPermissions($path) {
-		return null;
+	public function getPermissions($path): int {
+		return 0;
 	}
 
-	public function file_exists($path) {
+	public function file_exists($path): bool {
 		return $path === '';
 	}
 
-	public function filemtime($path) {
+	public function filemtime($path): int|false {
 		return ($path === '') ? time() : false;
 	}
 
-	public function file_get_contents($path) {
+	public function file_get_contents($path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function file_put_contents($path, $data) {
+	public function file_put_contents($path, $data): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function unlink($path) {
+	public function unlink($path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function rename($source, $target) {
+	public function rename($source, $target): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function copy($source, $target) {
+	public function copy($source, $target): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen($path, $mode): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function getMimeType($path) {
+	public function getMimeType($path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function hash($type, $path, $raw = false) {
+	public function hash($type, $path, $raw = false): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function free_space($path) {
+	public function free_space($path): int {
 		return FileInfo::SPACE_UNKNOWN;
 	}
 
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function getLocalFile($path) {
+	public function getLocalFile($path): string|false {
 		return false;
 	}
 
-	public function hasUpdated($path, $time) {
+	public function hasUpdated($path, $time): bool {
 		return false;
 	}
 
-	public function getETag($path) {
+	public function getETag($path): string {
 		return '';
 	}
 
-	public function isLocal() {
+	public function isLocal(): bool {
 		return false;
 	}
 
-	public function getDirectDownload($path) {
+	public function getDirectDownload($path): array|false {
 		return false;
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function test() {
+	public function test(): bool {
 		return true;
 	}
 
@@ -159,7 +160,7 @@ class NullStorage extends Common {
 		return false;
 	}
 
-	public function getCache($path = '', $storage = null) {
+	public function getCache($path = '', $storage = null): ICache {
 		return new NullCache();
 	}
 }

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -87,7 +87,7 @@ interface IStorage {
 	 * only the following keys are required in the result: size and mtime
 	 *
 	 * @param string $path
-	 * @return array|bool
+	 * @return array|false
 	 * @since 9.0.0
 	 */
 	public function stat($path);
@@ -96,7 +96,7 @@ interface IStorage {
 	 * see https://www.php.net/manual/en/function.filetype.php
 	 *
 	 * @param string $path
-	 * @return string|bool
+	 * @return string|false
 	 * @since 9.0.0
 	 */
 	public function filetype($path);
@@ -106,7 +106,7 @@ interface IStorage {
 	 * The result for filesize when called on a folder is required to be 0
 	 *
 	 * @param string $path
-	 * @return false|int|float
+	 * @return int|float|false
 	 * @since 9.0.0
 	 */
 	public function filesize($path);
@@ -179,7 +179,7 @@ interface IStorage {
 	 * see https://www.php.net/manual/en/function.filemtime.php
 	 *
 	 * @param string $path
-	 * @return int|bool
+	 * @return int|false
 	 * @since 9.0.0
 	 */
 	public function filemtime($path);
@@ -237,7 +237,7 @@ interface IStorage {
 	 *
 	 * @param string $path
 	 * @param string $mode
-	 * @return resource|bool
+	 * @return resource|false
 	 * @since 9.0.0
 	 */
 	public function fopen($path, $mode);
@@ -247,7 +247,7 @@ interface IStorage {
 	 * The mimetype for a folder is required to be "httpd/unix-directory"
 	 *
 	 * @param string $path
-	 * @return string|bool
+	 * @return string|false
 	 * @since 9.0.0
 	 */
 	public function getMimeType($path);
@@ -258,16 +258,16 @@ interface IStorage {
 	 * @param string $type
 	 * @param string $path
 	 * @param bool $raw
-	 * @return string|bool
+	 * @return string|false
 	 * @since 9.0.0
 	 */
 	public function hash($type, $path, $raw = false);
 
 	/**
-	 * see https://www.php.net/manual/en/function.free_space.php
+	 * see https://www.php.net/manual/en/function.disk-free-space.php
 	 *
 	 * @param string $path
-	 * @return int|float|bool
+	 * @return int|float|false
 	 * @since 9.0.0
 	 */
 	public function free_space($path);
@@ -345,7 +345,7 @@ interface IStorage {
 	 * For now the returned array can hold the parameter url - in future more attributes might follow.
 	 *
 	 * @param string $path
-	 * @return array|bool
+	 * @return array|false
 	 * @since 9.0.0
 	 */
 	public function getDirectDownload($path);

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -17,7 +17,7 @@ use OCP\IDBConnection;
 use OCP\IUser;
 
 class LongId extends \OC\Files\Storage\Temporary {
-	public function getId() {
+	public function getId(): string {
 		return 'long:' . str_repeat('foo', 50) . parent::getId();
 	}
 }

--- a/tests/lib/Files/Mount/ManagerTest.php
+++ b/tests/lib/Files/Mount/ManagerTest.php
@@ -11,7 +11,7 @@ use OC\Files\SetupManagerFactory;
 use OC\Files\Storage\Temporary;
 
 class LongId extends Temporary {
-	public function getId() {
+	public function getId(): string {
 		return 'long:' . str_repeat('foo', 50) . parent::getId();
 	}
 }

--- a/tests/lib/Files/Storage/CopyDirectoryTest.php
+++ b/tests/lib/Files/Storage/CopyDirectoryTest.php
@@ -10,7 +10,7 @@ namespace Test\Files\Storage;
 use OC\Files\Storage\Temporary;
 
 class StorageNoRecursiveCopy extends Temporary {
-	public function copy($path1, $path2) {
+	public function copy($path1, $path2): bool {
 		if ($this->is_dir($path1)) {
 			return false;
 		}

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -37,23 +37,23 @@ use Test\TestMoveableMountPoint;
 use Test\Traits\UserTrait;
 
 class TemporaryNoTouch extends Temporary {
-	public function touch($path, $mtime = null) {
+	public function touch($path, $mtime = null): bool {
 		return false;
 	}
 }
 
 class TemporaryNoCross extends Temporary {
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null) {
+	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null): bool {
 		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath) {
+	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
 		return Common::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 }
 
 class TemporaryNoLocal extends Temporary {
-	public function instanceOfStorage($className) {
+	public function instanceOfStorage($className): bool {
 		if ($className === '\OC\Files\Storage\Local') {
 			return false;
 		} else {
@@ -1752,6 +1752,8 @@ class ViewTest extends \Test\TestCase {
 				ILockingProvider::LOCK_SHARED,
 				ILockingProvider::LOCK_EXCLUSIVE,
 				ILockingProvider::LOCK_SHARED,
+				null,
+				0,
 			],
 
 			// ---- delete hook ----
@@ -1783,6 +1785,8 @@ class ViewTest extends \Test\TestCase {
 				ILockingProvider::LOCK_SHARED,
 				ILockingProvider::LOCK_SHARED,
 				null,
+				null,
+				false,
 			],
 			[
 				'fopen',
@@ -1809,8 +1813,28 @@ class ViewTest extends \Test\TestCase {
 			// ---- no hooks, no locks ---
 			['is_dir', ['dir'], 'dir', null],
 			['is_file', ['dir'], 'dir', null],
-			['stat', ['dir'], 'dir', null],
-			['filetype', ['dir'], 'dir', null],
+			[
+				'stat',
+				['dir'],
+				'dir',
+				null,
+				ILockingProvider::LOCK_SHARED,
+				ILockingProvider::LOCK_SHARED,
+				ILockingProvider::LOCK_SHARED,
+				null,
+				false,
+			],
+			[
+				'filetype',
+				['dir'],
+				'dir',
+				null,
+				ILockingProvider::LOCK_SHARED,
+				ILockingProvider::LOCK_SHARED,
+				ILockingProvider::LOCK_SHARED,
+				null,
+				false,
+			],
 			[
 				'filesize',
 				['dir'],
@@ -1829,7 +1853,17 @@ class ViewTest extends \Test\TestCase {
 			['isDeletable', ['dir'], 'dir', null],
 			['isSharable', ['dir'], 'dir', null],
 			['file_exists', ['dir'], 'dir', null],
-			['filemtime', ['dir'], 'dir', null],
+			[
+				'filemtime',
+				['dir'],
+				'dir',
+				null,
+				ILockingProvider::LOCK_SHARED,
+				ILockingProvider::LOCK_SHARED,
+				ILockingProvider::LOCK_SHARED,
+				null,
+				false,
+			],
 		];
 	}
 

--- a/tests/lib/Lockdown/Filesystem/NullStorageTest.php
+++ b/tests/lib/Lockdown/Filesystem/NullStorageTest.php
@@ -96,7 +96,7 @@ class NullStorageTest extends TestCase {
 	}
 
 	public function testGetPermissions(): void {
-		$this->assertNull($this->storage->getPermissions('foo'));
+		$this->assertEquals(0, $this->storage->getPermissions('foo'));
 	}
 
 	public function testFile_exists(): void {


### PR DESCRIPTION
## Summary

This adds strong return types to all implementations to match the interface.
The changes escalated a bit, but everything should be fixed at once.
It also fixes some bugs in poorly implemented storages.

Technically this is a breaking change due to changing the signature, but I only did that for private classes and the fix is completely backwards compatible.
The temporary pain of adding the return types to all implementations is justified by fixing all these type mismatches for once.
This change should also allow us to actually add the strong return types to IStorage since all implementations should also be extending Common which already has them.
Please don't hate me for this change :see_no_evil:

I was not able to test files_external due to the terrible test setup which I can not get working locally, so let's see what CI has to say.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
