### PR TITLE
Add rector config

### DIFF
--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -157,7 +157,7 @@ class Application extends App implements IBootstrap {
 
 	private function tagHooks(IAuditLogger $logger,
 		IEventDispatcher $eventDispatcher): void {
-		$eventDispatcher->addListener(\OCP\SystemTag\ManagerEvent::EVENT_CREATE, function (\OCP\SystemTag\ManagerEvent $event) use ($logger) {
+		$eventDispatcher->addListener(\OCP\SystemTag\ManagerEvent::EVENT_CREATE, function (\OCP\SystemTag\ManagerEvent $event) use ($logger): void {
 			$tagActions = new TagManagement($logger);
 			$tagActions->createTag($event->getTag());
 		});
@@ -168,56 +168,56 @@ class Application extends App implements IBootstrap {
 
 		$eventDispatcher->addListener(
 			BeforeNodeRenamedEvent::class,
-			function (BeforeNodeRenamedEvent $event) use ($fileActions) {
+			function (BeforeNodeRenamedEvent $event) use ($fileActions): void {
 				$fileActions->beforeRename($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
 			NodeRenamedEvent::class,
-			function (NodeRenamedEvent $event) use ($fileActions) {
+			function (NodeRenamedEvent $event) use ($fileActions): void {
 				$fileActions->afterRename($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
 			NodeCreatedEvent::class,
-			function (NodeCreatedEvent $event) use ($fileActions) {
+			function (NodeCreatedEvent $event) use ($fileActions): void {
 				$fileActions->create($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
 			NodeCopiedEvent::class,
-			function (NodeCopiedEvent $event) use ($fileActions) {
+			function (NodeCopiedEvent $event) use ($fileActions): void {
 				$fileActions->copy($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
 			BeforeNodeWrittenEvent::class,
-			function (BeforeNodeWrittenEvent $event) use ($fileActions) {
+			function (BeforeNodeWrittenEvent $event) use ($fileActions): void {
 				$fileActions->write($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
 			NodeWrittenEvent::class,
-			function (NodeWrittenEvent $event) use ($fileActions) {
+			function (NodeWrittenEvent $event) use ($fileActions): void {
 				$fileActions->update($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
 			BeforeNodeReadEvent::class,
-			function (BeforeNodeReadEvent $event) use ($fileActions) {
+			function (BeforeNodeReadEvent $event) use ($fileActions): void {
 				$fileActions->read($event);
 			}
 		);
 
 		$eventDispatcher->addListener(
 			NodeDeletedEvent::class,
-			function (NodeDeletedEvent $event) use ($fileActions) {
+			function (NodeDeletedEvent $event) use ($fileActions): void {
 				$fileActions->delete($event);
 			}
 		);

--- a/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
+++ b/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
@@ -54,7 +54,7 @@ class ContactInteractionListener implements IEventListener {
 			return;
 		}
 
-		$this->atomic(function () use ($event) {
+		$this->atomic(function () use ($event): void {
 			$uid = $event->getUid();
 			$email = $event->getEmail();
 			$federatedCloudId = $event->getFederatedCloudId();

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -214,20 +214,20 @@ class Application extends App implements IBootstrap {
 		$hm->setup();
 
 		// first time login event setup
-		$dispatcher->addListener(IUser::class . '::firstLogin', function ($event) use ($hm) {
+		$dispatcher->addListener(IUser::class . '::firstLogin', function ($event) use ($hm): void {
 			if ($event instanceof GenericEvent) {
 				$hm->firstLogin($event->getSubject());
 			}
 		});
 
-		$dispatcher->addListener(UserUpdatedEvent::class, function (UserUpdatedEvent $event) use ($container) {
+		$dispatcher->addListener(UserUpdatedEvent::class, function (UserUpdatedEvent $event) use ($container): void {
 			/** @var SyncService $syncService */
 			$syncService = \OCP\Server::get(SyncService::class);
 			$syncService->updateUser($event->getUser());
 		});
 
 
-		$dispatcher->addListener(CalendarShareUpdatedEvent::class, function (CalendarShareUpdatedEvent $event) use ($container) {
+		$dispatcher->addListener(CalendarShareUpdatedEvent::class, function (CalendarShareUpdatedEvent $event) use ($container): void {
 			/** @var Backend $backend */
 			$backend = $container->query(Backend::class);
 			$backend->onCalendarUpdateShares(
@@ -272,7 +272,7 @@ class Application extends App implements IBootstrap {
 
 	public function registerCalendarManager(ICalendarManager $calendarManager,
 		IAppContainer $container): void {
-		$calendarManager->register(function () use ($container, $calendarManager) {
+		$calendarManager->register(function () use ($container, $calendarManager): void {
 			$user = \OC::$server->getUserSession()->getUser();
 			if ($user !== null) {
 				$this->setupCalendarProvider($calendarManager, $container, $user->getUID());

--- a/apps/dav/lib/BackgroundJob/RegisterRegenerateBirthdayCalendars.php
+++ b/apps/dav/lib/BackgroundJob/RegisterRegenerateBirthdayCalendars.php
@@ -41,7 +41,7 @@ class RegisterRegenerateBirthdayCalendars extends QueuedJob {
 	 * @inheritDoc
 	 */
 	public function run($argument) {
-		$this->userManager->callForSeenUsers(function (IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user): void {
 			$this->jobList->add(GenerateBirthdayCalendarBackgroundJob::class, [
 				'userId' => $user->getUID(),
 				'purgeBeforeGenerating' => true

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -865,7 +865,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @return void
 	 */
 	public function deleteCalendar($calendarId, bool $forceDeletePermanently = false) {
-		$this->atomic(function () use ($calendarId, $forceDeletePermanently) {
+		$this->atomic(function () use ($calendarId, $forceDeletePermanently): void {
 			// The calendar is deleted right away if this is either enforced by the caller
 			// or the special contacts birthday calendar or when the preference of an empty
 			// retention (0 seconds) is set, which signals a disabled trashbin.
@@ -926,7 +926,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	public function restoreCalendar(int $id): void {
-		$this->atomic(function () use ($id) {
+		$this->atomic(function () use ($id): void {
 			$qb = $this->db->getQueryBuilder();
 			$update = $qb->update('calendars')
 				->set('deleted_at', $qb->createNamedParameter(null))
@@ -1471,7 +1471,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 */
 	public function deleteCalendarObject($calendarId, $objectUri, $calendarType = self::CALENDAR_TYPE_CALENDAR, bool $forceDeletePermanently = false) {
 		$this->cachedObjects = [];
-		$this->atomic(function () use ($calendarId, $objectUri, $calendarType, $forceDeletePermanently) {
+		$this->atomic(function () use ($calendarId, $objectUri, $calendarType, $forceDeletePermanently): void {
 			$data = $this->getCalendarObject($calendarId, $objectUri, $calendarType);
 
 			if ($data === null) {
@@ -1553,7 +1553,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 */
 	public function restoreCalendarObject(array $objectData): void {
 		$this->cachedObjects = [];
-		$this->atomic(function () use ($objectData) {
+		$this->atomic(function () use ($objectData): void {
 			$id = (int)$objectData['id'];
 			$restoreUri = str_replace('-deleted.ics', '.ics', $objectData['uri']);
 			$targetObject = $this->getCalendarObject(
@@ -2697,7 +2697,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @return void
 	 */
 	public function deleteSubscription($subscriptionId) {
-		$this->atomic(function () use ($subscriptionId) {
+		$this->atomic(function () use ($subscriptionId): void {
 			$subscriptionRow = $this->getSubscriptionById($subscriptionId);
 
 			$query = $this->db->getQueryBuilder();
@@ -2889,7 +2889,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$this->cachedObjects = [];
 		$table = $calendarType === self::CALENDAR_TYPE_CALENDAR ? 'calendars': 'calendarsubscriptions';
 
-		$this->atomic(function () use ($calendarId, $objectUris, $operation, $calendarType, $table) {
+		$this->atomic(function () use ($calendarId, $objectUris, $operation, $calendarType, $table): void {
 			$query = $this->db->getQueryBuilder();
 			$query->select('synctoken')
 				->from($table)
@@ -2924,7 +2924,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	public function restoreChanges(int $calendarId, int $calendarType = self::CALENDAR_TYPE_CALENDAR): void {
 		$this->cachedObjects = [];
 
-		$this->atomic(function () use ($calendarId, $calendarType) {
+		$this->atomic(function () use ($calendarId, $calendarType): void {
 			$qbAdded = $this->db->getQueryBuilder();
 			$qbAdded->select('uri')
 				->from('calendarobjects')
@@ -3090,7 +3090,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @param list<string> $remove
 	 */
 	public function updateShares(IShareable $shareable, array $add, array $remove): void {
-		$this->atomic(function () use ($shareable, $add, $remove) {
+		$this->atomic(function () use ($shareable, $add, $remove): void {
 			$calendarId = $shareable->getResourceId();
 			$calendarRow = $this->getCalendarById($calendarId);
 			if ($calendarRow === null) {
@@ -3188,7 +3188,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 */
 	public function updateProperties($calendarId, $objectUri, $calendarData, $calendarType = self::CALENDAR_TYPE_CALENDAR) {
 		$this->cachedObjects = [];
-		$this->atomic(function () use ($calendarId, $objectUri, $calendarData, $calendarType) {
+		$this->atomic(function () use ($calendarId, $objectUri, $calendarData, $calendarType): void {
 			$objectId = $this->getCalendarObjectId($calendarId, $objectUri, $calendarType);
 
 			try {
@@ -3260,7 +3260,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * deletes all birthday calendars
 	 */
 	public function deleteAllBirthdayCalendars() {
-		$this->atomic(function () {
+		$this->atomic(function (): void {
 			$query = $this->db->getQueryBuilder();
 			$result = $query->select(['id'])->from('calendars')
 				->where($query->expr()->eq('uri', $query->createNamedParameter(BirthdayService::BIRTHDAY_CALENDAR_URI)))
@@ -3280,7 +3280,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	 * @param $subscriptionId
 	 */
 	public function purgeAllCachedEventsForSubscription($subscriptionId) {
-		$this->atomic(function () use ($subscriptionId) {
+		$this->atomic(function () use ($subscriptionId): void {
 			$query = $this->db->getQueryBuilder();
 			$query->select('uri')
 				->from('calendarobjects')
@@ -3326,7 +3326,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 			return;
 		}
 
-		$this->atomic(function () use ($subscriptionId, $calendarObjectIds, $calendarObjectUris) {
+		$this->atomic(function () use ($subscriptionId, $calendarObjectIds, $calendarObjectUris): void {
 			foreach (array_chunk($calendarObjectIds, 1000) as $chunk) {
 				$query = $this->db->getQueryBuilder();
 				$query->delete($this->dbObjectPropertiesTable)

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -416,7 +416,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @return void
 	 */
 	public function deleteAddressBook($addressBookId) {
-		$this->atomic(function () use ($addressBookId) {
+		$this->atomic(function () use ($addressBookId): void {
 			$addressBookId = (int)$addressBookId;
 			$addressBookData = $this->getAddressBookById($addressBookId);
 			$shares = $this->getShares($addressBookId);
@@ -939,7 +939,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @return void
 	 */
 	protected function addChange(int $addressBookId, string $objectUri, int $operation): void {
-		$this->atomic(function () use ($addressBookId, $objectUri, $operation) {
+		$this->atomic(function () use ($addressBookId, $objectUri, $operation): void {
 			$query = $this->db->getQueryBuilder();
 			$query->select('synctoken')
 				->from('addressbooks')
@@ -1014,7 +1014,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @param list<string> $remove
 	 */
 	public function updateShares(IShareable $shareable, array $add, array $remove): void {
-		$this->atomic(function () use ($shareable, $add, $remove) {
+		$this->atomic(function () use ($shareable, $add, $remove): void {
 			$addressBookId = $shareable->getResourceId();
 			$addressBookData = $this->getAddressBookById($addressBookId);
 			$oldShares = $this->getShares($addressBookId);
@@ -1292,7 +1292,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	 * @param string $vCardSerialized
 	 */
 	protected function updateProperties($addressBookId, $cardUri, $vCardSerialized) {
-		$this->atomic(function () use ($addressBookId, $cardUri, $vCardSerialized) {
+		$this->atomic(function () use ($addressBookId, $cardUri, $vCardSerialized): void {
 			$cardId = $this->getCardId($addressBookId, $cardUri);
 			$vCard = $this->readCard($vCardSerialized);
 

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -77,7 +77,7 @@ class SyncService {
 			$cardUri = basename($resource);
 			if (isset($status[200])) {
 				$vCard = $this->download($url, $userName, $sharedSecret, $resource);
-				$this->atomic(function () use ($addressBookId, $cardUri, $vCard) {
+				$this->atomic(function () use ($addressBookId, $cardUri, $vCard): void {
 					$existingCard = $this->backend->getCard($addressBookId, $cardUri);
 					if ($existingCard === false) {
 						$this->backend->createCard($addressBookId, $cardUri, $vCard);
@@ -200,7 +200,7 @@ class SyncService {
 
 		$cardId = self::getCardUri($user);
 		if ($user->isEnabled()) {
-			$this->atomic(function () use ($addressBookId, $cardId, $user) {
+			$this->atomic(function () use ($addressBookId, $cardId, $user): void {
 				$card = $this->backend->getCard($addressBookId, $cardId);
 				if ($card === false) {
 					$vCard = $this->converter->createCardFromUser($user);
@@ -251,7 +251,7 @@ class SyncService {
 	 */
 	public function syncInstance(?\Closure $progressCallback = null) {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
-		$this->userManager->callForAllUsers(function ($user) use ($systemAddressBook, $progressCallback) {
+		$this->userManager->callForAllUsers(function ($user) use ($systemAddressBook, $progressCallback): void {
 			$this->updateUser($user);
 			if (!is_null($progressCallback)) {
 				$progressCallback();

--- a/apps/dav/lib/Command/FixCalendarSyncCommand.php
+++ b/apps/dav/lib/Command/FixCalendarSyncCommand.php
@@ -49,7 +49,7 @@ class FixCalendarSyncCommand extends Command {
 			$this->fixUserCalendars($user);
 		} else {
 			$progress = new ProgressBar($output);
-			$this->userManager->callForSeenUsers(function (IUser $user) use ($progress) {
+			$this->userManager->callForSeenUsers(function (IUser $user) use ($progress): void {
 				$this->fixUserCalendars($user, $progress);
 			});
 			$progress->finish();

--- a/apps/dav/lib/Command/SyncBirthdayCalendar.php
+++ b/apps/dav/lib/Command/SyncBirthdayCalendar.php
@@ -58,7 +58,7 @@ class SyncBirthdayCalendar extends Command {
 		$output->writeln('Start birthday calendar sync for all users ...');
 		$p = new ProgressBar($output);
 		$p->start();
-		$this->userManager->callForSeenUsers(function ($user) use ($p) {
+		$this->userManager->callForSeenUsers(function ($user) use ($p): void {
 			$p->advance();
 
 			$userId = $user->getUID();

--- a/apps/dav/lib/Command/SyncSystemAddressBook.php
+++ b/apps/dav/lib/Command/SyncSystemAddressBook.php
@@ -32,7 +32,7 @@ class SyncSystemAddressBook extends Command {
 		$output->writeln('Syncing users ...');
 		$progress = new ProgressBar($output);
 		$progress->start();
-		$this->syncService->syncInstance(function () use ($progress) {
+		$this->syncService->syncInstance(function () use ($progress): void {
 			$progress->advance();
 		});
 

--- a/apps/dav/lib/Comments/CommentsPlugin.php
+++ b/apps/dav/lib/Comments/CommentsPlugin.php
@@ -73,7 +73,7 @@ class CommentsPlugin extends ServerPlugin {
 
 		$this->server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
 
-		$this->server->xml->classMap['DateTime'] = function (Writer $writer, \DateTime $value) {
+		$this->server->xml->classMap['DateTime'] = function (Writer $writer, \DateTime $value): void {
 			$writer->write(\Sabre\HTTP\toDate($value));
 		};
 

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -181,19 +181,19 @@ class File extends Node implements IFile {
 			if ($this->request->getHeader('X-HASH') !== '') {
 				$hash = $this->request->getHeader('X-HASH');
 				if ($hash === 'all' || $hash === 'md5') {
-					$data = HashWrapper::wrap($data, 'md5', function ($hash) {
+					$data = HashWrapper::wrap($data, 'md5', function ($hash): void {
 						$this->header('X-Hash-MD5: ' . $hash);
 					});
 				}
 
 				if ($hash === 'all' || $hash === 'sha1') {
-					$data = HashWrapper::wrap($data, 'sha1', function ($hash) {
+					$data = HashWrapper::wrap($data, 'sha1', function ($hash): void {
 						$this->header('X-Hash-SHA1: ' . $hash);
 					});
 				}
 
 				if ($hash === 'all' || $hash === 'sha256') {
-					$data = HashWrapper::wrap($data, 'sha256', function ($hash) {
+					$data = HashWrapper::wrap($data, 'sha256', function ($hash): void {
 						$this->header('X-Hash-SHA256: ' . $hash);
 					});
 				}
@@ -201,7 +201,7 @@ class File extends Node implements IFile {
 
 			if ($partStorage->instanceOfStorage(IWriteStreamStorage::class)) {
 				$isEOF = false;
-				$wrappedData = CallbackWrapper::wrap($data, null, null, null, null, function ($stream) use (&$isEOF) {
+				$wrappedData = CallbackWrapper::wrap($data, null, null, null, null, function ($stream) use (&$isEOF): void {
 					$isEOF = feof($stream);
 				});
 

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -131,7 +131,7 @@ class FilesPlugin extends ServerPlugin {
 		$this->server->on('afterWriteContent', [$this, 'sendFileIdHeader']);
 		$this->server->on('afterMethod:GET', [$this,'httpGet']);
 		$this->server->on('afterMethod:GET', [$this, 'handleDownloadToken']);
-		$this->server->on('afterResponse', function ($request, ResponseInterface $response) {
+		$this->server->on('afterResponse', function ($request, ResponseInterface $response): void {
 			$body = $response->getBody();
 			if (is_resource($body)) {
 				fclose($body);

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -105,7 +105,7 @@ class ServerFactory {
 		$server->addPlugin(new ErrorPagePlugin($this->request, $this->config));
 
 		// wait with registering these until auth is handled and the filesystem is setup
-		$server->on('beforeMethod:*', function () use ($server, $objectTree, $viewCallBack) {
+		$server->on('beforeMethod:*', function () use ($server, $objectTree, $viewCallBack): void {
 			// ensure the skeleton is copied
 			$userFolder = \OC::$server->getUserFolder();
 

--- a/apps/dav/lib/Controller/BirthdayCalendarController.php
+++ b/apps/dav/lib/Controller/BirthdayCalendarController.php
@@ -78,7 +78,7 @@ class BirthdayCalendarController extends Controller {
 		$this->config->setAppValue($this->appName, 'generateBirthdayCalendar', 'yes');
 
 		// add background job for each user
-		$this->userManager->callForSeenUsers(function (IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user): void {
 			$this->jobList->add(GenerateBirthdayCalendarBackgroundJob::class, [
 				'userId' => $user->getUID(),
 			]);

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -62,7 +62,7 @@ class HookManager {
 			'post_createUser',
 			$this,
 			'postCreateUser');
-		\OC::$server->getUserManager()->listen('\OC\User', 'assignedUserId', function ($uid) {
+		\OC::$server->getUserManager()->listen('\OC\User', 'assignedUserId', function ($uid): void {
 			$this->postCreateUser(['uid' => $uid]);
 		});
 		Util::connectHook('OC_User',
@@ -74,7 +74,7 @@ class HookManager {
 			'post_deleteUser',
 			$this,
 			'postDeleteUser');
-		\OC::$server->getUserManager()->listen('\OC\User', 'postUnassignedUserId', function ($uid) {
+		\OC::$server->getUserManager()->listen('\OC\User', 'postUnassignedUserId', function ($uid): void {
 			$this->postDeleteUser(['uid' => $uid]);
 		});
 		\OC::$server->getUserManager()->listen('\OC\User', 'postUnassignedUserId', [$this, 'postUnassignedUserId']);

--- a/apps/dav/lib/Migration/ChunkCleanup.php
+++ b/apps/dav/lib/Migration/ChunkCleanup.php
@@ -52,7 +52,7 @@ class ChunkCleanup implements IRepairStep {
 
 		$output->startProgress();
 		// Loop over all seen users
-		$this->userManager->callForSeenUsers(function (IUser $user) use ($output) {
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($output): void {
 			try {
 				$userFolder = $this->rootFolder->getUserFolder($user->getUID());
 				$userRoot = $userFolder->getParent();

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -231,7 +231,7 @@ class Server {
 		$this->server->addPlugin(new SearchPlugin($lazySearchBackend));
 
 		// wait with registering these until auth is handled and the filesystem is setup
-		$this->server->on('beforeMethod:*', function () use ($root, $lazySearchBackend, $logger) {
+		$this->server->on('beforeMethod:*', function () use ($root, $lazySearchBackend, $logger): void {
 			// Allow view-only plugin for webdav requests
 			$this->server->addPlugin(new ViewOnlyPlugin(
 				\OC::$server->getUserFolder(),

--- a/apps/dav/tests/unit/Listener/OutOfOfficeListenerTest.php
+++ b/apps/dav/tests/unit/Listener/OutOfOfficeListenerTest.php
@@ -202,7 +202,7 @@ class OutOfOfficeListenerTest extends TestCase {
 			->willReturn($calendar);
 		$calendar->expects(self::once())
 			->method('createFile')
-			->willReturnCallback(function ($name, $data) {
+			->willReturnCallback(function ($name, $data): void {
 				$vcalendar = Reader::read($data);
 				if (!($vcalendar instanceof VCalendar)) {
 					throw new InvalidArgumentException('Calendar data should be a VCALENDAR');
@@ -352,7 +352,7 @@ class OutOfOfficeListenerTest extends TestCase {
 			->willThrowException(new NotFound());
 		$calendar->expects(self::once())
 			->method('createFile')
-			->willReturnCallback(function ($name, $data) {
+			->willReturnCallback(function ($name, $data): void {
 				$vcalendar = Reader::read($data);
 				if (!($vcalendar instanceof VCalendar)) {
 					throw new InvalidArgumentException('Calendar data should be a VCALENDAR');
@@ -419,7 +419,7 @@ class OutOfOfficeListenerTest extends TestCase {
 			->willReturn($eventNode);
 		$eventNode->expects(self::once())
 			->method('put')
-			->willReturnCallback(function ($data) {
+			->willReturnCallback(function ($data): void {
 				$vcalendar = Reader::read($data);
 				if (!($vcalendar instanceof VCalendar)) {
 					throw new InvalidArgumentException('Calendar data should be a VCALENDAR');

--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -39,7 +39,7 @@ class Application extends App implements IBootstrap {
 	public function boot(IBootContext $context): void {
 		\OCP\Util::addScript(self::APP_ID, 'encryption');
 
-		$context->injectFn(function (IManager $encryptionManager) use ($context) {
+		$context->injectFn(function (IManager $encryptionManager) use ($context): void {
 			if (!($encryptionManager instanceof \OC\Encryption\Manager)) {
 				return;
 			}

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -317,7 +317,7 @@ class EncryptionTest extends TestCase {
 		$this->keyManagerMock->expects($this->never())->method('getPublicKey');
 		$this->keyManagerMock->expects($this->never())->method('addSystemKeys');
 		$this->keyManagerMock->expects($this->once())->method('setVersion')
-			->willReturnCallback(function ($path, $version, $view) {
+			->willReturnCallback(function ($path, $version, $view): void {
 				$this->assertSame('path', $path);
 				$this->assertSame(2, $version);
 				$this->assertTrue($view instanceof \OC\Files\View);
@@ -335,7 +335,7 @@ class EncryptionTest extends TestCase {
 
 		$this->keyManagerMock->expects($this->any())
 			->method('getPublicKey')->willReturnCallback(
-				function ($user) {
+				function ($user): void {
 					throw new PublicKeyMissingException($user);
 				}
 			);

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -204,7 +204,7 @@ class UserHooksTest extends TestCase {
 
 		$this->keyManagerMock->expects($this->exactly(4))
 			->method('setPrivateKey')
-			->willReturnCallback(function ($user, $key) {
+			->willReturnCallback(function ($user, $key): void {
 				$header = substr($key, 0, strlen(Crypt::HEADER_START));
 				$this->assertSame(
 					Crypt::HEADER_START,

--- a/apps/federation/lib/Command/SyncFederationAddressBooks.php
+++ b/apps/federation/lib/Command/SyncFederationAddressBooks.php
@@ -31,7 +31,7 @@ class SyncFederationAddressBooks extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$progress = new ProgressBar($output);
 		$progress->start();
-		$this->syncService->syncThemAll(function ($url, $ex) use ($progress, $output) {
+		$this->syncService->syncThemAll(function ($url, $ex) use ($progress, $output): void {
 			if ($ex instanceof \Exception) {
 				$output->writeln("Error while syncing $url : " . $ex->getMessage());
 			} else {

--- a/apps/federation/lib/SyncJob.php
+++ b/apps/federation/lib/SyncJob.php
@@ -24,7 +24,7 @@ class SyncJob extends TimedJob {
 	}
 
 	protected function run($argument) {
-		$this->syncService->syncThemAll(function ($url, $ex) {
+		$this->syncService->syncThemAll(function ($url, $ex): void {
 			if ($ex instanceof \Exception) {
 				$this->logger->error("Error while syncing $url.", [
 					'app' => 'fed-sync',

--- a/apps/federation/tests/SyncFederationAddressbooksTest.php
+++ b/apps/federation/tests/SyncFederationAddressbooksTest.php
@@ -57,7 +57,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
-		$s->syncThemAll(function ($url, $ex) {
+		$s->syncThemAll(function ($url, $ex): void {
 			$this->callBacks[] = [$url, $ex];
 		});
 		$this->assertEquals('1', count($this->callBacks));
@@ -85,7 +85,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
-		$s->syncThemAll(function ($url, $ex) {
+		$s->syncThemAll(function ($url, $ex): void {
 			$this->callBacks[] = [$url, $ex];
 		});
 		$this->assertEquals(2, count($this->callBacks));
@@ -116,7 +116,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
-		$s->syncThemAll(function ($url, $ex) {
+		$s->syncThemAll(function ($url, $ex): void {
 			$this->callBacks[] = [$url, $ex];
 		});
 		$this->assertEquals('1', count($this->callBacks));

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -144,7 +144,7 @@ class TrustedServersTest extends TestCase {
 			->willReturn($server);
 		$this->dispatcher->expects($this->once())->method('dispatchTyped')
 			->willReturnCallback(
-				function ($event) {
+				function ($event): void {
 					$this->assertSame(get_class($event), \OCP\Federation\Events\TrustedServerRemovedEvent::class);
 					/** @var \OCP\Federated\Events\TrustedServerRemovedEvent $event */
 					$this->assertSame('url_hash', $event->getUrlHash());
@@ -252,7 +252,7 @@ class TrustedServersTest extends TestCase {
 			->willReturn($this->httpClient);
 
 		$this->httpClient->expects($this->once())->method('get')->with($server . '/status.php')
-			->willReturnCallback(function () {
+			->willReturnCallback(function (): void {
 				throw new \Exception('simulated exception');
 			});
 

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -106,7 +106,7 @@ class Scan extends Base {
 		);
 
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function (string $path) use ($output, $scanMetadata) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function (string $path) use ($output, $scanMetadata): void {
 			$output->writeln("\tFile\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->filesCounter;
 			$this->abortIfInterrupted();
@@ -120,29 +120,29 @@ class Scan extends Base {
 			}
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output): void {
 			$output->writeln("\tFolder\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->foldersCounter;
 			$this->abortIfInterrupted();
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output): void {
 			$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')', OutputInterface::VERBOSITY_VERBOSE);
 			++$this->errorsCounter;
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output): void {
 			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
 			++$this->errorsCounter;
 		});
 
-		$this->eventDispatcher->addListener(NodeAddedToCache::class, function () {
+		$this->eventDispatcher->addListener(NodeAddedToCache::class, function (): void {
 			++$this->newCounter;
 		});
-		$this->eventDispatcher->addListener(FileCacheUpdated::class, function () {
+		$this->eventDispatcher->addListener(FileCacheUpdated::class, function (): void {
 			++$this->updatedCounter;
 		});
-		$this->eventDispatcher->addListener(NodeRemovedFromCache::class, function () {
+		$this->eventDispatcher->addListener(NodeRemovedFromCache::class, function (): void {
 			++$this->removedCounter;
 		});
 

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -73,23 +73,23 @@ class ScanAppData extends Base {
 		);
 
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function ($path) use ($output): void {
 			$output->writeln("\tFile   <info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->filesCounter;
 			$this->abortIfInterrupted();
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'scanFolder', function ($path) use ($output): void {
 			$output->writeln("\tFolder <info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->foldersCounter;
 			$this->abortIfInterrupted();
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output): void {
 			$output->writeln('Error while scanning, storage not available (' . $e->getMessage() . ')', OutputInterface::VERBOSITY_VERBOSE);
 		});
 
-		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output) {
+		$scanner->listen('\OC\Files\Utils\Scanner', 'normalizedNameMismatch', function ($fullPath) use ($output): void {
 			$output->writeln("\t<error>Entry \"" . $fullPath . '" will not be accessible due to incompatible encoding</error>');
 		});
 

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -75,10 +75,10 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (IMountProviderCollection $mountProviderCollection, ConfigAdapter $configAdapter) {
+		$context->injectFn(function (IMountProviderCollection $mountProviderCollection, ConfigAdapter $configAdapter): void {
 			$mountProviderCollection->registerProvider($configAdapter);
 		});
-		$context->injectFn(function (BackendService $backendService, UserPlaceholderHandler $userConfigHandler) {
+		$context->injectFn(function (BackendService $backendService, UserPlaceholderHandler $userConfigHandler): void {
 			$backendService->registerBackendProvider($this);
 			$backendService->registerAuthMechanismProvider($this);
 			$backendService->registerConfigHandler('user', function () use ($userConfigHandler) {

--- a/apps/files_external/lib/BackgroundJob/CredentialsCleanup.php
+++ b/apps/files_external/lib/BackgroundJob/CredentialsCleanup.php
@@ -41,7 +41,7 @@ class CredentialsCleanup extends TimedJob {
 	}
 
 	protected function run($argument) {
-		$this->userManager->callForSeenUsers(function (IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user): void {
 			$storages = $this->userGlobalStoragesService->getAllStoragesForUser($user);
 
 			$usesLoginCredentials = array_reduce($storages, function (bool $uses, StorageConfig $storage) {

--- a/apps/files_external/lib/Command/Notify.php
+++ b/apps/files_external/lib/Command/Notify.php
@@ -95,7 +95,7 @@ class Notify extends StorageAuthBase {
 			$this->selfTest($storage, $notifyHandler, $output);
 		}
 
-		$notifyHandler->listen(function (IChange $change) use ($mount, $output, $dryRun) {
+		$notifyHandler->listen(function (IChange $change) use ($mount, $output, $dryRun): void {
 			$this->logUpdate($change, $output);
 			if ($change instanceof IRenameChange) {
 				$this->markParentAsOutdated($mount->getId(), $change->getTargetPath(), $output, $dryRun);

--- a/apps/files_external/lib/Command/Scan.php
+++ b/apps/files_external/lib/Command/Scan.php
@@ -70,13 +70,13 @@ class Scan extends StorageAuthBase {
 		/** @var Scanner $scanner */
 		$scanner = $storage->getScanner();
 
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function (string $path) use ($output) {
+		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function (string $path) use ($output): void {
 			$output->writeln("\tFile\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->filesCounter;
 			$this->abortIfInterrupted();
 		});
 
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function (string $path) use ($output) {
+		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function (string $path) use ($output): void {
 			$output->writeln("\tFolder\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->foldersCounter;
 			$this->abortIfInterrupted();

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -474,7 +474,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 
 				$handle = fopen($tmpFile, 'w');
-				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {
+				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile): void {
 					$this->writeBack($tmpFile, $path);
 				});
 			case 'a':
@@ -499,7 +499,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 				}
 
 				$handle = fopen($tmpFile, $mode);
-				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {
+				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile): void {
 					$this->writeBack($tmpFile, $path);
 				});
 		}
@@ -760,7 +760,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		if ($size === null) {
 			$size = 0;
 			// track the number of bytes read from the input stream to return as the number of written bytes.
-			$stream = CountWrapper::wrap($stream, function (int $writtenSize) use (&$size) {
+			$stream = CountWrapper::wrap($stream, function (int $writtenSize) use (&$size): void {
 				$size = $writtenSize;
 			});
 		}

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -277,7 +277,7 @@ class FTP extends Common {
 					$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 				}
 				$source = fopen($tmpFile, $mode);
-				return CallbackWrapper::wrap($source, null, null, function () use ($tmpFile, $path) {
+				return CallbackWrapper::wrap($source, null, null, function () use ($tmpFile, $path): void {
 					$this->writeStream($path, fopen($tmpFile, 'r'));
 					unlink($tmpFile);
 				});
@@ -287,7 +287,7 @@ class FTP extends Common {
 
 	public function writeStream(string $path, $stream, ?int $size = null): int {
 		if ($size === null) {
-			$stream = CountWrapper::wrap($stream, function ($writtenSize) use (&$size) {
+			$stream = CountWrapper::wrap($stream, function ($writtenSize) use (&$size): void {
 				$size = $writtenSize;
 			});
 		}

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -478,7 +478,7 @@ class SFTP extends Common {
 
 	public function writeStream(string $path, $stream, ?int $size = null): int {
 		if ($size === null) {
-			$stream = CountWrapper::wrap($stream, function (int $writtenSize) use (&$size) {
+			$stream = CountWrapper::wrap($stream, function (int $writtenSize) use (&$size): void {
 				$size = $writtenSize;
 			});
 			if (!$stream) {

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -458,7 +458,7 @@ class SMB extends Common implements INotifyStorage {
 				case 'w':
 				case 'wb':
 					$source = $this->share->write($fullPath);
-					return CallBackWrapper::wrap($source, null, null, function () use ($fullPath) {
+					return CallBackWrapper::wrap($source, null, null, function () use ($fullPath): void {
 						unset($this->statCache[$fullPath]);
 					});
 				case 'a':
@@ -490,7 +490,7 @@ class SMB extends Common implements INotifyStorage {
 					}
 					$source = fopen($tmpFile, $mode);
 					$share = $this->share;
-					return CallbackWrapper::wrap($source, null, null, function () use ($tmpFile, $fullPath, $share) {
+					return CallbackWrapper::wrap($source, null, null, function () use ($tmpFile, $fullPath, $share): void {
 						unset($this->statCache[$fullPath]);
 						$share->put($tmpFile, $fullPath);
 						unlink($tmpFile);

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -414,7 +414,7 @@ class Swift extends \OC\Files\Storage\Common {
 					file_put_contents($tmpFile, $source);
 				}
 				$handle = fopen($tmpFile, $mode);
-				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile) {
+				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile): void {
 					$this->writeBack($tmpFile, $path);
 				});
 		}

--- a/apps/files_external/tests/Auth/Password/GlobalAuth.php
+++ b/apps/files_external/tests/Auth/Password/GlobalAuth.php
@@ -53,7 +53,7 @@ class GlobalAuthTest extends TestCase {
 			});
 		$storageConfig->expects($this->any())
 			->method('setBackendOption')
-			->willReturnCallback(function ($key, $value) use (&$config) {
+			->willReturnCallback(function ($key, $value) use (&$config): void {
 				$config[$key] = $value;
 			});
 

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -119,10 +119,10 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function registerEventsScripts(IEventDispatcher $dispatcher): void {
-		$dispatcher->addListener(ResourcesLoadAdditionalScriptsEvent::class, function () {
+		$dispatcher->addListener(ResourcesLoadAdditionalScriptsEvent::class, function (): void {
 			\OCP\Util::addScript('files_sharing', 'collaboration');
 		});
-		$dispatcher->addListener(\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class, function () {
+		$dispatcher->addListener(\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class, function (): void {
 			/**
 			 * Always add main sharing script
 			 */
@@ -130,12 +130,12 @@ class Application extends App implements IBootstrap {
 		});
 
 		// notifications api to accept incoming user shares
-		$dispatcher->addListener(ShareCreatedEvent::class, function (ShareCreatedEvent $event) {
+		$dispatcher->addListener(ShareCreatedEvent::class, function (ShareCreatedEvent $event): void {
 			/** @var Listener $listener */
 			$listener = $this->getContainer()->query(Listener::class);
 			$listener->shareNotification($event);
 		});
-		$dispatcher->addListener(IGroup::class . '::postAddUser', function ($event) {
+		$dispatcher->addListener(IGroup::class . '::postAddUser', function ($event): void {
 			if (!$event instanceof OldGenericEvent) {
 				return;
 			}

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -181,7 +181,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->shareManager
 			->expects($this->exactly(7))
 			->method('getShareById')
-			->willReturnCallback(function ($id) {
+			->willReturnCallback(function ($id): void {
 				if ($id === 'ocinternal:42' || $id === 'ocRoomShare:42' || $id === 'ocFederatedSharing:42' || $id === 'ocCircleShare:42' || $id === 'ocMailShare:42' || $id === 'deck:42' || $id === 'sciencemesh:42') {
 					throw new \OCP\Share\Exceptions\ShareNotFound();
 				} else {
@@ -2416,7 +2416,7 @@ class ShareAPIControllerTest extends TestCase {
 				~\OCP\Constants::PERMISSION_CREATE,
 				''
 			)->willReturnCallback(
-				function ($share) {
+				function ($share): void {
 					$share->setSharedWith('recipientRoom');
 					$share->setPermissions(
 						\OCP\Constants::PERMISSION_ALL &
@@ -2532,7 +2532,7 @@ class ShareAPIControllerTest extends TestCase {
 				~\OCP\Constants::PERMISSION_CREATE,
 				''
 			)->willReturnCallback(
-				function ($share) {
+				function ($share): void {
 					throw new OCSNotFoundException('Exception thrown by the helper');
 				}
 			);

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -317,7 +317,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$initialState = [];
 		$this->initialState->expects(self::any())
 			->method('provideInitialState')
-			->willReturnCallback(function ($key, $value) use (&$initialState) {
+			->willReturnCallback(function ($key, $value) use (&$initialState): void {
 				$initialState[$key] = $value;
 			});
 		$expectedInitialState = [
@@ -456,7 +456,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$initialState = [];
 		$this->initialState->expects(self::any())
 			->method('provideInitialState')
-			->willReturnCallback(function ($key, $value) use (&$initialState) {
+			->willReturnCallback(function ($key, $value) use (&$initialState): void {
 				$initialState[$key] = $value;
 			});
 		$expectedInitialState = [

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -50,7 +50,7 @@ class ExpireTrash extends TimedJob {
 			return;
 		}
 
-		$this->userManager->callForSeenUsers(function (IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user): void {
 			$uid = $user->getUID();
 			if (!$this->setupFS($uid)) {
 				return;

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -74,7 +74,7 @@ class ExpireTrash extends Command {
 		} else {
 			$p = new ProgressBar($output);
 			$p->start();
-			$this->userManager->callForSeenUsers(function (IUser $user) use ($p) {
+			$this->userManager->callForSeenUsers(function (IUser $user) use ($p): void {
 				$p->advance();
 				$this->expireTrashForUser($user);
 			});

--- a/apps/files_trashbin/lib/Command/Size.php
+++ b/apps/files_trashbin/lib/Command/Size.php
@@ -103,7 +103,7 @@ class Size extends Base {
 			}
 		} else {
 			$users = [];
-			$this->userManager->callForSeenUsers(function (IUser $user) use (&$users) {
+			$this->userManager->callForSeenUsers(function (IUser $user) use (&$users): void {
 				$users[] = $user->getUID();
 			});
 			$userValues = $this->config->getUserValueForUsers('files_trashbin', 'trashbin_size', $users);

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -145,7 +145,7 @@ class CleanUpTest extends TestCase {
 			->getMock();
 		$instance->expects($this->exactly(count($userIds)))
 			->method('removeDeletedFiles')
-			->willReturnCallback(function ($user) use ($userIds) {
+			->willReturnCallback(function ($user) use ($userIds): void {
 				$this->assertTrue(in_array($user, $userIds));
 			});
 		$this->userManager->expects($this->exactly(count($userIds)))
@@ -181,7 +181,7 @@ class CleanUpTest extends TestCase {
 			->willReturn($backendUsers);
 		$instance->expects($this->exactly(count($backendUsers)))
 			->method('removeDeletedFiles')
-			->willReturnCallback(function ($user) use ($backendUsers) {
+			->willReturnCallback(function ($user) use ($backendUsers): void {
 				$this->assertTrue(in_array($user, $backendUsers));
 			});
 		$inputInterface = $this->createMock(InputInterface::class);

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -42,7 +42,7 @@ class ExpireVersions extends TimedJob {
 			return;
 		}
 
-		$this->userManager->callForSeenUsers(function (IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user): void {
 			$uid = $user->getUID();
 			if (!$this->setupFS($uid)) {
 				return;

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -59,7 +59,7 @@ class ExpireVersions extends Command {
 
 		$p = new ProgressBar($output);
 		$p->start();
-		$this->userManager->callForSeenUsers(function (IUser $user) use ($p) {
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($p): void {
 			$p->advance();
 			$this->expireVersionsForUser($user);
 		});

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -180,7 +180,7 @@ class VersionManager implements IVersionManager, IDeletableVersionBackend, INeed
 			$lockContext = new LockContext($root, ILock::TYPE_APP, $owner);
 			$lockManager = \OC::$server->get(ILockManager::class);
 			$result = null;
-			$lockManager->runInScope($lockContext, function () use ($callback, &$result) {
+			$lockManager->runInScope($lockContext, function () use ($callback, &$result): void {
 				$result = $callback();
 			});
 			return $result;

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -111,7 +111,7 @@ class CleanupTest extends TestCase {
 			->getMock();
 		$instance->expects($this->exactly(count($userIds)))
 			->method('deleteVersions')
-			->willReturnCallback(function ($user) use ($userIds) {
+			->willReturnCallback(function ($user) use ($userIds): void {
 				$this->assertTrue(in_array($user, $userIds));
 			});
 
@@ -150,7 +150,7 @@ class CleanupTest extends TestCase {
 
 		$instance->expects($this->exactly(count($backendUsers)))
 			->method('deleteVersions')
-			->willReturnCallback(function ($user) use ($backendUsers) {
+			->willReturnCallback(function ($user) use ($backendUsers): void {
 				$this->assertTrue(in_array($user, $backendUsers));
 			});
 

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -732,7 +732,7 @@ class VersioningTest extends \Test\TestCase {
 		$eventHandler->expects($this->any())
 			->method('callback')
 			->willReturnCallback(
-				function ($p) use (&$params) {
+				function ($p) use (&$params): void {
 					$params = $p;
 				}
 			);

--- a/apps/lookup_server_connector/lib/AppInfo/Application.php
+++ b/apps/lookup_server_connector/lib/AppInfo/Application.php
@@ -37,7 +37,7 @@ class Application extends App implements IBootstrap {
 	 */
 	private function registerEventListeners(IEventDispatcher $dispatcher,
 		ContainerInterface $appContainer): void {
-		$dispatcher->addListener(UserUpdatedEvent::class, function (UserUpdatedEvent $event) use ($appContainer) {
+		$dispatcher->addListener(UserUpdatedEvent::class, function (UserUpdatedEvent $event) use ($appContainer): void {
 			/** @var UpdateLookupServer $updateLookupServer */
 			$updateLookupServer = $appContainer->get(UpdateLookupServer::class);
 			$updateLookupServer->userUpdated($event->getUser());

--- a/apps/oauth2/lib/Controller/SettingsController.php
+++ b/apps/oauth2/lib/Controller/SettingsController.php
@@ -69,7 +69,7 @@ class SettingsController extends Controller {
 	public function deleteClient(int $id): JSONResponse {
 		$client = $this->clientMapper->getByUid($id);
 
-		$this->userManager->callForSeenUsers(function (IUser $user) use ($client) {
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($client): void {
 			$this->tokenProvider->invalidateTokensOfUser($user->getUID(), $client->getName());
 		});
 

--- a/apps/oauth2/tests/Controller/SettingsControllerTest.php
+++ b/apps/oauth2/tests/Controller/SettingsControllerTest.php
@@ -122,7 +122,7 @@ class SettingsControllerTest extends TestCase {
 		$userManager = \OC::$server->getUserManager();
 		// count other users in the db before adding our own
 		$count = 0;
-		$function = function (IUser $user) use (&$count) {
+		$function = function (IUser $user) use (&$count): void {
 			if ($user->getLastLogin() > 0) {
 				$count++;
 			}

--- a/apps/systemtags/lib/AppInfo/Application.php
+++ b/apps/systemtags/lib/AppInfo/Application.php
@@ -33,19 +33,19 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		$context->injectFn(function (IEventDispatcher $dispatcher) use ($context) {
+		$context->injectFn(function (IEventDispatcher $dispatcher) use ($context): void {
 			/*
 			 * @todo move the OCP events and then move the registration to `register`
 			 */
 			$dispatcher->addListener(
 				LoadAdditionalScriptsEvent::class,
-				function () {
+				function (): void {
 					\OCP\Util::addScript('core', 'systemtags');
 					\OCP\Util::addInitScript(self::APP_ID, 'init');
 				}
 			);
 
-			$managerListener = function (ManagerEvent $event) use ($context) {
+			$managerListener = function (ManagerEvent $event) use ($context): void {
 				/** @var \OCA\SystemTags\Activity\Listener $listener */
 				$listener = $context->getServerContainer()->query(Listener::class);
 				$listener->event($event);
@@ -54,7 +54,7 @@ class Application extends App implements IBootstrap {
 			$dispatcher->addListener(ManagerEvent::EVENT_DELETE, $managerListener);
 			$dispatcher->addListener(ManagerEvent::EVENT_UPDATE, $managerListener);
 
-			$mapperListener = function (MapperEvent $event) use ($context) {
+			$mapperListener = function (MapperEvent $event) use ($context): void {
 				/** @var \OCA\SystemTags\Activity\Listener $listener */
 				$listener = $context->getServerContainer()->query(Listener::class);
 				$listener->mapperEvent($event);

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -508,7 +508,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->config
 			->expects($this->exactly(2))
 			->method('setAppValue')
-			->willReturnCallback(function () use ($expectedCalls, &$i) {
+			->willReturnCallback(function () use ($expectedCalls, &$i): void {
 				$this->assertEquals($expectedCalls[$i], func_get_args());
 				$i++;
 			});

--- a/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/CheckBackupCodes.php
@@ -39,7 +39,7 @@ class CheckBackupCodes extends QueuedJob {
 	}
 
 	protected function run($argument) {
-		$this->userManager->callForSeenUsers(function (IUser $user) {
+		$this->userManager->callForSeenUsers(function (IUser $user): void {
 			if (!$user->isEnabled()) {
 				return;
 			}

--- a/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
+++ b/apps/twofactor_backupcodes/lib/Service/BackupCodeStorage.php
@@ -87,7 +87,7 @@ class BackupCodeStorage {
 		$codes = $this->mapper->getBackupCodes($user);
 		$total = count($codes);
 		$used = 0;
-		array_walk($codes, function (BackupCode $code) use (&$used) {
+		array_walk($codes, function (BackupCode $code) use (&$used): void {
 			if ((int)$code->getUsed() === 1) {
 				$used++;
 			}

--- a/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/BackgroundJob/CheckBackupCodeTest.php
@@ -50,7 +50,7 @@ class CheckBackupCodeTest extends TestCase {
 		$this->user = $this->createMock(IUser::class);
 
 		$this->userManager->method('callForSeenUsers')
-			->willReturnCallback(function (\Closure $e) {
+			->willReturnCallback(function (\Closure $e): void {
 				$e($this->user);
 			});
 

--- a/apps/updatenotification/lib/AppInfo/Application.php
+++ b/apps/updatenotification/lib/AppInfo/Application.php
@@ -50,7 +50,7 @@ class Application extends App implements IBootstrap {
 			IAppManager $appManager,
 			IGroupManager $groupManager,
 			ContainerInterface $container,
-			LoggerInterface $logger) {
+			LoggerInterface $logger): void {
 			if ($config->getSystemValue('updatechecker', true) !== true) {
 				// Updater check is disabled
 				return;

--- a/apps/updatenotification/lib/BackgroundJob/AppUpdatedNotifications.php
+++ b/apps/updatenotification/lib/BackgroundJob/AppUpdatedNotifications.php
@@ -88,7 +88,7 @@ class AppUpdatedNotifications extends QueuedJob {
 		$isDefer = $this->notificationManager->defer();
 
 		// Notify all seen users about the app update
-		$this->userManager->callForSeenUsers(function (IUser $user) use ($guestsEnabled, $appId, $notification) {
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($guestsEnabled, $appId, $notification): void {
 			if (!$guestsEnabled && ($user->getBackendClassName() === '\OCA\Guests\UserBackend')) {
 				return;
 			}

--- a/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
@@ -250,7 +250,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		$i = 0;
 		$job->expects($this->exactly(\count($notifications)))
 			->method('createNotifications')
-			->willReturnCallback(function () use ($notifications, &$i) {
+			->willReturnCallback(function () use ($notifications, &$i): void {
 				$this->assertEquals($notifications[$i], func_get_args());
 				$i++;
 			});

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -954,7 +954,7 @@ class Access extends LDAPUtility {
 		}, []);
 		$idsByDn = $this->getGroupMapper()->getListOfIdsByDn($listOfDNs);
 
-		array_walk($groupRecords, function (array $record) use ($idsByDn) {
+		array_walk($groupRecords, function (array $record) use ($idsByDn): void {
 			$newlyMapped = false;
 			$gid = $idsByDn[$record['dn'][0]] ?? null;
 			if ($gid === null) {

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -110,7 +110,7 @@ class Application extends App implements IBootstrap {
 			User_Proxy $userBackend,
 			Group_Proxy $groupBackend,
 			Helper $helper,
-		) {
+		): void {
 			$configPrefixes = $helper->getServerConfigurationPrefixes(true);
 			if (count($configPrefixes) > 0) {
 				$userPluginManager = $appContainer->get(UserPluginManager::class);
@@ -140,7 +140,7 @@ class Application extends App implements IBootstrap {
 	private function registerBackendDependents(IAppContainer $appContainer, IEventDispatcher $dispatcher): void {
 		$dispatcher->addListener(
 			'OCA\\Files_External::loadAdditionalBackends',
-			function () use ($appContainer) {
+			function () use ($appContainer): void {
 				$storagesBackendService = $appContainer->get(BackendService::class);
 				$storagesBackendService->registerConfigHandler('home', function () use ($appContainer) {
 					return $appContainer->get(ExtStorageConfigHandler::class);

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -612,7 +612,7 @@ class AccessTest extends TestCase {
 		];
 		$expected = $fakeLdapEntries;
 		unset($expected['count']);
-		array_walk($expected, function (&$v) {
+		array_walk($expected, function (&$v): void {
 			$v['dn'] = [$v['dn']];	// dn is translated into an array internally for consistency
 		});
 

--- a/apps/user_ldap/tests/LDAPTest.php
+++ b/apps/user_ldap/tests/LDAPTest.php
@@ -38,7 +38,7 @@ class LDAPTest extends TestCase {
 	 */
 	public function testSearchWithErrorHandler(string $errorMessage, bool $passThrough): void {
 		$wasErrorHandlerCalled = false;
-		$errorHandler = function ($number, $message, $file, $line) use (&$wasErrorHandlerCalled) {
+		$errorHandler = function ($number, $message, $file, $line) use (&$wasErrorHandlerCalled): void {
 			$wasErrorHandlerCalled = true;
 		};
 
@@ -48,7 +48,7 @@ class LDAPTest extends TestCase {
 			->expects($this->once())
 			->method('invokeLDAPMethod')
 			->with('search', $this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->anything())
-			->willReturnCallback(function () use ($errorMessage) {
+			->willReturnCallback(function () use ($errorMessage): void {
 				trigger_error($errorMessage);
 			});
 

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
@@ -227,7 +227,7 @@ abstract class AbstractMappingTest extends \Test\TestCase {
 		$callbackCalls = 0;
 		$test = $this;
 
-		$callback = function (string $id) use ($test, &$callbackCalls) {
+		$callback = function (string $id) use ($test, &$callbackCalls): void {
 			$test->assertTrue(trim($id) !== '');
 			$callbackCalls++;
 		};

--- a/apps/user_ldap/tests/Service/UpdateGroupsServiceTest.php
+++ b/apps/user_ldap/tests/Service/UpdateGroupsServiceTest.php
@@ -137,7 +137,7 @@ class UpdateGroupsServiceTest extends TestCase {
 		$removedEvents = 0;
 		$this->dispatcher->expects($this->exactly(4))
 			->method('dispatchTyped')
-			->willReturnCallback(function ($event) use (&$addedEvents, &$removedEvents) {
+			->willReturnCallback(function ($event) use (&$addedEvents, &$removedEvents): void {
 				if ($event instanceof UserRemovedEvent) {
 					$removedEvents++;
 				} elseif ($event instanceof UserAddedEvent) {

--- a/apps/workflowengine/lib/AppInfo/Application.php
+++ b/apps/workflowengine/lib/AppInfo/Application.php
@@ -51,10 +51,10 @@ class Application extends App implements IBootstrap {
 
 		foreach ($configuredEvents as $operationClass => $events) {
 			foreach ($events as $entityClass => $eventNames) {
-				array_map(function (string $eventName) use ($manager, $container, $dispatcher, $logger, $operationClass, $entityClass) {
+				array_map(function (string $eventName) use ($manager, $container, $dispatcher, $logger, $operationClass, $entityClass): void {
 					$dispatcher->addListener(
 						$eventName,
-						function ($event) use ($manager, $container, $eventName, $logger, $operationClass, $entityClass) {
+						function ($event) use ($manager, $container, $eventName, $logger, $operationClass, $entityClass): void {
 							$ruleMatcher = $manager->getRuleMatcher();
 							try {
 								/** @var IEntity $entity */

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -309,12 +309,12 @@ class ManagerTest extends TestCase {
 		$userOps = $this->manager->getOperations('OCA\WFE\TestOp', $userScope);
 
 		$this->assertSame(1, count($adminOps));
-		array_walk($adminOps, function ($op) {
+		array_walk($adminOps, function ($op): void {
 			$this->assertTrue($op['class'] === 'OCA\WFE\TestOp');
 		});
 
 		$this->assertSame(2, count($userOps));
-		array_walk($userOps, function ($op) {
+		array_walk($userOps, function ($op): void {
 			$this->assertTrue($op['class'] === 'OCA\WFE\TestOp');
 		});
 	}
@@ -517,7 +517,7 @@ class ManagerTest extends TestCase {
 
 		$this->dispatcher->expects($this->once())
 			->method('dispatchTyped')
-			->willReturnCallback(function (RegisterEntitiesEvent $e) use ($extraEntity) {
+			->willReturnCallback(function (RegisterEntitiesEvent $e) use ($extraEntity): void {
 				$this->manager->registerEntity($extraEntity);
 			});
 

--- a/build/rector.php
+++ b/build/rector.php
@@ -9,29 +9,31 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
+$nextcloudDir = dirname(__DIR__);
+
 $config = RectorConfig::configure()
 	->withPaths([
-		__DIR__ . '/apps',
-		// __DIR__ . '/config',
-		// __DIR__ . '/core',
-		// __DIR__ . '/lib',
-		// __DIR__ . '/ocs',
-		// __DIR__ . '/ocs-provider',
-		// __DIR__ . '/tests',
-		// __DIR__ . '/themes',
+		$nextcloudDir . '/apps',
+		// $nextcloudDir . '/config',
+		// $nextcloudDir . '/core',
+		// $nextcloudDir . '/lib',
+		// $nextcloudDir . '/ocs',
+		// $nextcloudDir . '/ocs-provider',
+		// $nextcloudDir . '/tests',
+		// $nextcloudDir . '/themes',
 	])
 	->withSkip([
-		__DIR__ . '/apps/*/3rdparty/*',
-		__DIR__ . '/apps/*/build/stubs/*',
-		__DIR__ . '/apps/*/composer/*',
-		__DIR__ . '/apps/*/config/*',
+		$nextcloudDir . '/apps/*/3rdparty/*',
+		$nextcloudDir . '/apps/*/build/stubs/*',
+		$nextcloudDir . '/apps/*/composer/*',
+		$nextcloudDir . '/apps/*/config/*',
 	])
 	// uncomment to reach your current PHP version
 	// ->withPhpSets()
 	->withTypeCoverageLevel(0);
 
 
-$ignoredEntries = shell_exec('git status --porcelain --ignored ' . escapeshellarg(__DIR__));
+$ignoredEntries = shell_exec('git status --porcelain --ignored ' . escapeshellarg($nextcloudDir));
 $ignoredEntries = explode("\n", $ignoredEntries);
 $ignoredEntries = array_filter($ignoredEntries, static fn (string $line) => str_starts_with($line, '!! '));
 $ignoredEntries = array_map(static fn (string $line) => substr($line, 3), $ignoredEntries);

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
 		"test": "phpunit --configuration tests/phpunit-autotest.xml",
 		"test:db": "@composer run test -- --group DB,SLOWDB",
 		"test:files_external": "phpunit --configuration tests/phpunit-autotest-external.xml",
-		"rector": "rector && composer cs:fix"
+		"rector": "rector --config=build/rector.php && composer cs:fix"
 	},
 	"extra": {
 		"bamarni-bin": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
 		],
 		"test": "phpunit --configuration tests/phpunit-autotest.xml",
 		"test:db": "@composer run test -- --group DB,SLOWDB",
-		"test:files_external": "phpunit --configuration tests/phpunit-autotest-external.xml"
+		"test:files_external": "phpunit --configuration tests/phpunit-autotest-external.xml",
+		"rector": "rector && composer cs:fix"
 	},
 	"extra": {
 		"bamarni-bin": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+use Rector\Config\RectorConfig;
+
+$config = RectorConfig::configure()
+	->withPaths([
+		__DIR__ . '/apps',
+		// __DIR__ . '/config',
+		// __DIR__ . '/core',
+		// __DIR__ . '/lib',
+		// __DIR__ . '/ocs',
+		// __DIR__ . '/ocs-provider',
+		// __DIR__ . '/tests',
+		// __DIR__ . '/themes',
+	])
+	->withSkip([
+		__DIR__ . '/apps/*/3rdparty/*',
+		__DIR__ . '/apps/*/build/stubs/*',
+		__DIR__ . '/apps/*/composer/*',
+		__DIR__ . '/apps/*/config/*',
+	])
+	// uncomment to reach your current PHP version
+	// ->withPhpSets()
+	->withTypeCoverageLevel(0);
+
+
+$ignoredEntries = shell_exec('git status --porcelain --ignored ' . escapeshellarg(__DIR__));
+$ignoredEntries = explode("\n", $ignoredEntries);
+$ignoredEntries = array_filter($ignoredEntries, static fn (string $line) => str_starts_with($line, '!! '));
+$ignoredEntries = array_map(static fn (string $line) => substr($line, 3), $ignoredEntries);
+$ignoredEntries = array_values($ignoredEntries);
+
+foreach ($ignoredEntries as $ignoredEntry) {
+	if (str_ends_with($ignoredEntry, '/')) {
+		$config->withSkip([$ignoredEntry . '*']);
+	} else {
+		$config->withSkip([$ignoredEntry . '/*']);
+	}
+}
+
+return $config;

--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -1,0 +1,6 @@
+{
+    "require-dev": {
+        "rector/rector": "^1.2",
+        "nextcloud/rector": "^0.2.0"
+    }
+}

--- a/vendor-bin/rector/composer.lock
+++ b/vendor-bin/rector/composer.lock
@@ -1,0 +1,198 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "10939f70efcd3b6d290ecf8f7e9d9da0",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "nextcloud/rector",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nextcloud-libraries/rector.git",
+                "reference": "c5cceb7faf2d4df61fe1fd8f82e19c7b106dbe00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nextcloud-libraries/rector/zipball/c5cceb7faf2d4df61fe1fd8f82e19c7b106dbe00",
+                "reference": "c5cceb7faf2d4df61fe1fd8f82e19c7b106dbe00",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5",
+                "ramsey/devtools": "^2.0",
+                "rector/rector": "^1.2"
+            },
+            "type": "library",
+            "extra": {
+                "captainhook": {
+                    "force-install": true
+                },
+                "ramsey/conventional-commits": {
+                    "configFile": "conventional-commits.json"
+                },
+                "ramsey/devtools": {
+                    "command-prefix": "dev",
+                    "memory-limit": "-1"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nextcloud\\Rector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Christoph Wurst",
+                    "email": "christoph@winzerhof-wurst.at",
+                    "homepage": "https://wuc.me"
+                }
+            ],
+            "description": "Rector upgrade rules for Nextcloud",
+            "keywords": [
+                "nextcloud",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/nextcloud-libraries/rector/issues",
+                "source": "https://github.com/nextcloud-libraries/rector/tree/v0.2.0"
+            },
+            "time": "2024-09-19T09:54:28+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-19T07:58:01+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "1.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "e98aa793ca3fcd17e893cfaf9103ac049775d339"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e98aa793ca3fcd17e893cfaf9103ac049775d339",
+                "reference": "e98aa793ca3fcd17e893cfaf9103ac049775d339",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "phpstan/phpstan": "^1.12.2"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/1.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-08T17:43:24+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
## Summary

And so it begins…

1. Added rector in a vendor-bin
2. Added a mostly-empty configuration
3. Applied to apps folder

Long term goal is to apply rectors from https://github.com/nextcloud-libraries/rector to core code. We’ll need to be extra careful with folders like lib/public because they use some deprecated stuff on purpose I think.
So not sure if the best way forward is to add more rules or more folders.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
