### PR TITLE
fix: improve moving object store items to trashbin

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -15,7 +15,6 @@ use OC\Files\Node\File;
 use OC\Files\Node\Folder;
 use OC\Files\Node\NonExistingFile;
 use OC\Files\Node\NonExistingFolder;
-use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\View;
 use OC_User;
 use OCA\Files_Trashbin\AppInfo\Application;
@@ -30,6 +29,7 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\ILockingStorage;
+use OCP\Files\Storage\IStorage;
 use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -256,11 +256,10 @@ class Trashbin {
 		$trashPath = '/files_trashbin/files/' . static::getTrashFilename($filename, $timestamp);
 		$gotLock = false;
 
-		while (!$gotLock) {
+		do {
+			/** @var ILockingStorage & IStorage $trashStorage */
+			[$trashStorage, $trashInternalPath] = $ownerView->resolvePath($trashPath);
 			try {
-				/** @var ILockingStorage $trashStorage */
-				[$trashStorage, $trashInternalPath] = $ownerView->resolvePath($trashPath);
-
 				$trashStorage->acquireLock($trashInternalPath, ILockingProvider::LOCK_EXCLUSIVE, $lockingProvider);
 				$gotLock = true;
 			} catch (LockedException $e) {
@@ -271,7 +270,7 @@ class Trashbin {
 
 				$trashPath = '/files_trashbin/files/' . static::getTrashFilename($filename, $timestamp);
 			}
-		}
+		} while (!$gotLock);
 
 		$sourceStorage = $sourceInfo->getStorage();
 		$sourceInternalPath = $sourceInfo->getInternalPath();
@@ -285,14 +284,12 @@ class Trashbin {
 			return false;
 		}
 
-		$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
-
 		try {
 			$moveSuccessful = true;
 
-			// when moving within the same object store, the cache update done above is enough to move the file
-			if (!($trashStorage->instanceOfStorage(ObjectStoreStorage::class) && $trashStorage->getId() === $sourceStorage->getId())) {
-				$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
+			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
+			if ($sourceStorage->getCache()->inCache($sourceInternalPath)) {
+				$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 			}
 		} catch (\OCA\Files_Trashbin\Exceptions\CopyRecursiveException $e) {
 			$moveSuccessful = false;


### PR DESCRIPTION
With various changes to how objectstore `moveFromStorage` works since this code was last touched. The following version should be "more correct".