### PR TITLE
fix(profiler): clear command does not work

### DIFF
--- a/lib/private/Profiler/FileProfilerStorage.php
+++ b/lib/private/Profiler/FileProfilerStorage.php
@@ -81,11 +81,11 @@ class FileProfilerStorage {
 		$iterator = new \RecursiveIteratorIterator($iterator, \RecursiveIteratorIterator::CHILD_FIRST);
 
 		foreach ($iterator as $file) {
-			$file = (string)$file->getPathInfo();
-			if (is_file($file)) {
-				unlink($file);
+			$path = $file->getPathname();
+			if (is_file($path)) {
+				unlink($path);
 			} else {
-				rmdir($file);
+				rmdir($path);
 			}
 		}
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: occ profiler:clear not working

## Summary

- The loop is supposed to delete the files first and then the directories.
- getPathInfo returns a SplFileInfo object for the parent (the folder in our case).
- A non-empty directory cannot be deleted.


![Screenshot from 2024-09-20 18-13-09](https://github.com/user-attachments/assets/2387bfd1-6785-4973-9809-014255f1960c)



## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
