### PR TITLE
feat: Add check for enterprise

### DIFF
--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -159,6 +159,7 @@ class JSConfigHelper {
 			'version' => implode('.', $this->serverVersion->getVersion()),
 			'versionstring' => $this->serverVersion->getVersionString(),
 			'enable_non-accessible_features' => $this->config->getSystemValueBool('enable_non-accessible_features', true),
+			'is_enterprise' => Util::isEnterprise(),
 		];
 
 		$array = [

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -74,6 +74,14 @@ class Util {
 	}
 
 	/**
+	 * @since 31.0.0
+	 */
+	public static function isEnterprise() {
+		$versionString = Server::get(ServerVersion::class)->getVersionString();
+		return str_contains($versionString, 'Enterprise');
+	}
+
+	/**
 	 * check if sharing is disabled for the current user
 	 *
 	 * @return boolean


### PR DESCRIPTION
## Summary

Part of https://github.com/nextcloud/server/issues/45440

Add a simple check to check if the current instance is on the enterprise edition

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)