### PR TITLE
feat(prioritynotifications): Allow some apps to mark notifications as priority

### DIFF
--- a/lib/private/Notification/Notification.php
+++ b/lib/private/Notification/Notification.php
@@ -16,6 +16,14 @@ use OCP\RichObjectStrings\IRichTextFormatter;
 use OCP\RichObjectStrings\IValidator;
 
 class Notification implements INotification {
+	/**
+	 * A very small and privileged list of apps that are allowed to push during DND.
+	 */
+	public const PRIORITY_NOTIFICATION_APPS = [
+		'spreed',
+		'twofactor_nextcloud_notification',
+	];
+
 	protected string $app = '';
 	protected string $user = '';
 	protected \DateTime $dateTime;
@@ -33,6 +41,7 @@ class Notification implements INotification {
 	protected array $messageRichParameters = [];
 	protected string $link = '';
 	protected string $icon = '';
+	protected bool $priorityNotification = false;
 	protected array $actions = [];
 	protected array $actionsParsed = [];
 	protected bool $hasPrimaryAction = false;
@@ -333,6 +342,25 @@ class Notification implements INotification {
 	/**
 	 * {@inheritDoc}
 	 */
+	public function setPriorityNotification(bool $priorityNotification): INotification {
+		if ($priorityNotification && !in_array($this->getApp(), self::PRIORITY_NOTIFICATION_APPS, true)) {
+			throw new InvalidValueException('priorityNotification');
+		}
+
+		$this->priorityNotification = $priorityNotification;
+		return $this;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isPriorityNotification(): bool {
+		return $this->priorityNotification;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function createAction(): IAction {
 		return new Action();
 	}
@@ -434,6 +462,10 @@ class Notification implements INotification {
 	}
 
 	protected function isValidCommon(): bool {
+		if ($this->isPriorityNotification() && !in_array($this->getApp(), self::PRIORITY_NOTIFICATION_APPS, true)) {
+			return false;
+		}
+
 		return
 			$this->getApp() !== ''
 			&&

--- a/lib/public/Notification/INotification.php
+++ b/lib/public/Notification/INotification.php
@@ -264,6 +264,18 @@ interface INotification {
 	public function getIcon(): string;
 
 	/**
+	 * @return $this
+	 * @throws InvalidValueException if the app is not allowed to send priority notifications
+	 * @since 31.0.0
+	 */
+	public function setPriorityNotification(bool $priorityNotification): INotification;
+
+	/**
+	 * @since 31.0.0
+	 */
+	public function isPriorityNotification(): bool;
+
+	/**
 	 * @return IAction
 	 * @since 9.0.0
 	 */


### PR DESCRIPTION
They will be still send as push during DND.
Apps are currently limited to:
- twofactor_nextcloud_notification to help with login (currently already hard coded in notifications https://github.com/nextcloud/notifications/issues/1353)
- spreed which will only set it for pushes in manually picked conversations

## Siblings
- https://github.com/nextcloud/notifications/pull/2059
- https://github.com/nextcloud/twofactor_nextcloud_notification/pull/893

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
