### PR TITLE
Correctly look up filename when logged in but inaccessible

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -361,9 +361,10 @@ class FileEventsListener implements IEventListener {
 
 		$owner = $node->getOwner()?->getUid();
 
-		// If no owner, extract it from the path.
-		// e.g. /user/files/foobar.txt
-		if (!$owner) {
+		// If no owner, extract it from the path, e.g. /user/files/foobar.txt
+		// Also try this if they are the same, because it might be a group folder that the user does not have access to
+		// E.g. where filling in a form with a spreadsheet attached
+		if (!$owner || $owner == $user) {
 			$parts = explode('/', $node->getPath(), 4);
 			if (count($parts) === 4) {
 				$owner = $parts[1];


### PR DESCRIPTION
Fixes a forms bug by changing how files_versions gets the path for a Node to tolerate the forms app writing files that are not even visible to the logged-in user.

In FileEventsListener::getPathForNode(), if the user is not logged in, and we can't find the file owner, we guess the file owner from the path. Most likely the username in the path has some access to the file, so we can find the filename. This allows writing files when the user is not logged in, for instance where we are filling in a form from a public link.

However, in the case where there is a logged-in user, and the file is on a group share, both the username and the owner will be the same UID. Which is fine as long as we have access to the file.

But in the case where we are actually writing a spreadsheet update for a form submission, the logged in user may not have access to the file. However, it is still a legitimate write by the forms app, so it is safe to use the owner in the path, just as if we were logged out.

I'm not 100% sure about the security implications here and request review. However it provides a simple workaround for our use case:
- Form with an attached spreadsheet
- User is logged in
- User has access to the form but not the spreadsheet
- The spreadsheet is in a group folder
- The versioning app is enabled

The result is an error every time, see the forms bug https://github.com/nextcloud/forms/issues/2067 (note that the actual error has changed since the initial report!)

The alternative is to fix the underlying problem in the forms app, which would be a much bigger diff, see the above.

However, if I am right about the security model here, this is a safe workaround, and may actually be correct.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: [forms bug #2067](https://github.com/nextcloud/forms/issues/2067)

## Summary

Fixes a reproducible form submission error due to a conflict between how forms and versioning see permissions.

At this stage I'm asking for review that this is basically the right solution and there are no security implications. I believe it is safe but request review on that assumption!

An alternative fix in forms would be much more work, see their bug.

## TODO

- [ ] Confirm that the fix is safe before proceeding with the rest

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
