### PR TITLE
fix(files_external): Catch correct exception

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -160,6 +160,8 @@ class SMB extends Common implements INotifyStorage {
 	 * @param string $path
 	 * @return IFileInfo
 	 * @throws StorageAuthException
+	 * @throws \OCP\Files\NotFoundException
+	 * @throws \OCP\Files\ForbiddenException
 	 */
 	protected function getFileInfo($path) {
 		try {
@@ -336,7 +338,7 @@ class SMB extends Common implements INotifyStorage {
 	public function stat($path, $retry = true) {
 		try {
 			$result = $this->formatInfo($this->getFileInfo($path));
-		} catch (ForbiddenException $e) {
+		} catch (\OCP\Files\ForbiddenException $e) {
 			return false;
 		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
@@ -557,7 +559,7 @@ class SMB extends Common implements INotifyStorage {
 			$fileInfo = $this->getFileInfo($path);
 		} catch (\OCP\Files\NotFoundException $e) {
 			return null;
-		} catch (ForbiddenException $e) {
+		} catch (\OCP\Files\ForbiddenException $e) {
 			return null;
 		}
 		if (!$fileInfo) {
@@ -633,7 +635,7 @@ class SMB extends Common implements INotifyStorage {
 			return $this->getFileInfo($path)->isDirectory() ? 'dir' : 'file';
 		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
-		} catch (ForbiddenException $e) {
+		} catch (\OCP\Files\ForbiddenException $e) {
 			return false;
 		}
 	}
@@ -668,7 +670,7 @@ class SMB extends Common implements INotifyStorage {
 			return true;
 		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
-		} catch (ForbiddenException $e) {
+		} catch (\OCP\Files\ForbiddenException $e) {
 			return false;
 		} catch (ConnectException $e) {
 			throw new StorageNotAvailableException($e->getMessage(), (int)$e->getCode(), $e);
@@ -681,7 +683,7 @@ class SMB extends Common implements INotifyStorage {
 			return $this->showHidden || !$info->isHidden();
 		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
-		} catch (ForbiddenException $e) {
+		} catch (\OCP\Files\ForbiddenException $e) {
 			return false;
 		}
 	}
@@ -694,7 +696,7 @@ class SMB extends Common implements INotifyStorage {
 			return ($this->showHidden || !$info->isHidden()) && (!$info->isReadOnly() || $info->isDirectory());
 		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
-		} catch (ForbiddenException $e) {
+		} catch (\OCP\Files\ForbiddenException $e) {
 			return false;
 		}
 	}
@@ -705,7 +707,7 @@ class SMB extends Common implements INotifyStorage {
 			return ($this->showHidden || !$info->isHidden()) && !$info->isReadOnly();
 		} catch (\OCP\Files\NotFoundException $e) {
 			return false;
-		} catch (ForbiddenException $e) {
+		} catch (\OCP\Files\ForbiddenException $e) {
 			return false;
 		}
 	}


### PR DESCRIPTION
SMB#getFileInfo used to throw an icewind/smb exception, but nowadays throws \OCP\Files\ForbiddenException. This fixes downstream methods to catch the new exception.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
