### PR TITLE
[stable28] chore(deps): Bump aws/aws-sdk-php from 3.240.8 to 3.322.4

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -156,6 +156,7 @@ trait S3ConnectionTrait {
 				'connect_timeout' => 5
 			],
 			'use_aws_shared_config_files' => false,
+			'suppress_php_deprecation_warning' => true,
 		];
 
 		if ($this->params['s3-accelerate']) {


### PR DESCRIPTION
- [x] https://github.com/nextcloud/3rdparty/pull/1947

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
