### PR TITLE
fix(dav): don't crash subscription on invalid calendar object

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/RefreshWebcalService.php
@@ -12,6 +12,7 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use OCP\AppFramework\Utility\ITimeFactory;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Exception\BadRequest;
+use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\PropPatch;
 use Sabre\VObject\Component;
 use Sabre\VObject\DateTimeParser;
@@ -101,7 +102,13 @@ class RefreshWebcalService {
 					continue;
 				}
 
-				$denormalized = $this->calDavBackend->getDenormalizedData($vObject->serialize());
+				try {
+					$denormalized = $this->calDavBackend->getDenormalizedData($vObject->serialize());
+				} catch (InvalidDataException|Forbidden $ex) {
+					$this->logger->warning('Unable to denormalize calendar object from subscription {subscriptionId}', ['exception' => $ex, 'subscriptionId' => $subscription['id'], 'source' => $subscription['source']]);
+					continue;
+				}
+
 				// Find all identical sets and remove them from the update
 				if (isset($localData[$uid]) && $denormalized['etag'] === $localData[$uid]['etag']) {
 					unset($localData[$uid]);
@@ -127,7 +134,7 @@ class RefreshWebcalService {
 					$objectUri = $this->getRandomCalendarObjectUri();
 					$this->calDavBackend->createCalendarObject($subscription['id'], $objectUri, $vObject->serialize(), CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION);
 				} catch (NoInstancesException|BadRequest $ex) {
-					$this->logger->error('Unable to create calendar object from subscription {subscriptionId}', ['exception' => $ex, 'subscriptionId' => $subscription['id'], 'source' => $subscription['source']]);
+					$this->logger->warning('Unable to create calendar object from subscription {subscriptionId}', ['exception' => $ex, 'subscriptionId' => $subscription['id'], 'source' => $subscription['source']]);
 				}
 			}
 

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
@@ -302,7 +302,7 @@ class RefreshWebcalServiceTest extends TestCase {
 			->willThrowException($badRequestException);
 
 		$this->logger->expects(self::once())
-			->method('error')
+			->method('warning')
 			->with('Unable to create calendar object from subscription {subscriptionId}', ['exception' => $badRequestException, 'subscriptionId' => '42', 'source' => 'webcal://foo.bar/bla2']);
 
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/48518

## Summary

I had two different problems here when subscribing to an external calendar. 
When importing the same calendar these wrong objects get skipped.
But subscribing crashes at this point completely causing a partially imported calendar.

Nextcloud 29.0.7 is not affected.

```json
{
  "reqId": "3KSLP9rLSEFtuslDIPBy",
  "level": 3,
  "time": "2024-09-25T10:04:22+00:00",
  "remoteAddr": "...",
  "user": "...",
  "app": "webdav",
  "method": "MKCOL",
  "url": "/remote.php/dav/calendars/...",
  "message": "The supplied iCalendar datetime value is incorrect: 20181202 00:00:00",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0",
  "version": "30.0.0.14",
  "exception": {
    "Exception": "Sabre\\VObject\\InvalidDataException",
    "Message": "The supplied iCalendar datetime value is incorrect: 20181202 00:00:00",
    "Code": 0,
    "Trace": /*...*/,
    "File": "/var/www/html/3rdparty/sabre/vobject/lib/DateTimeParser.php",
    "Line": 40,
    "message": "The supplied iCalendar datetime value is incorrect: 20181202 00:00:00",
    "exception": {},
    "CustomMessage": "The supplied iCalendar datetime value is incorrect: 20181202 00:00:00"
  }
}
```

and

```json
{
  "reqId": "s9qaIfKbFDRspoMdIoXP",
  "level": 0,
  "time": "2024-09-25T09:56:50+00:00",
  "remoteAddr": "...",
  "user": "...",
  "app": "webdav",
  "method": "MKCOL",
  "url": "/remote.php/dav/calendars/...",
  "message": "This recurrence rule does not generate any valid instances",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0",
  "version": "30.0.0.14",
  "exception": {
    "Exception": "Sabre\\DAV\\Exception\\Forbidden",
    "Message": "This recurrence rule does not generate any valid instances",
    "Code": 0,
    "Trace": /*...*/,
    "File": "/var/www/html/apps/dav/lib/CalDAV/CalDavBackend.php",
    "Line": 3022,
    "message": "This recurrence rule does not generate any valid instances",
    "exception": {},
    "CustomMessage": "This recurrence rule does not generate any valid instances"
  }
}
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
