### PR TITLE
refactor(rector): Extend scope to all PHP files

### DIFF
--- a/build/rector.php
+++ b/build/rector.php
@@ -14,15 +14,19 @@ $nextcloudDir = dirname(__DIR__);
 $config = RectorConfig::configure()
 	->withPaths([
 		$nextcloudDir . '/apps',
-		// $nextcloudDir . '/config',
-		// $nextcloudDir . '/core',
-		// $nextcloudDir . '/lib',
-		// $nextcloudDir . '/ocs',
-		// $nextcloudDir . '/ocs-provider',
-		// $nextcloudDir . '/tests',
-		// $nextcloudDir . '/themes',
+		$nextcloudDir . '/build',
+		$nextcloudDir . '/config',
+		$nextcloudDir . '/core',
+		$nextcloudDir . '/lib',
+		$nextcloudDir . '/ocs',
+		$nextcloudDir . '/ocs-provider',
+		$nextcloudDir . '/tests',
+		$nextcloudDir . '/themes',
+		$nextcloudDir . '/*.php',
 	])
 	->withSkip([
+		$nextcloudDir . '/build/stubs/*',
+		$nextcloudDir . '/lib/composer/*',
 		$nextcloudDir . '/apps/*/3rdparty/*',
 		$nextcloudDir . '/apps/*/build/stubs/*',
 		$nextcloudDir . '/apps/*/composer/*',


### PR DESCRIPTION
## Summary

Currently fails due to a bug in rector: https://github.com/rectorphp/rector/issues/8841

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
