### PR TITLE
fix(QueryBuilder): Restrict identifier length to 30 characters due to Oracle limitations

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -206,6 +206,23 @@ class QueryBuilder implements IQueryBuilder {
 		// }
 		// }
 
+		$tooLongOutputColumns = [];
+		foreach ($this->getOutputColumns() as $column) {
+			if (strlen($column) > 30) {
+				$tooLongOutputColumns[] = $column;
+			}
+		}
+
+		if (!empty($tooLongOutputColumns)) {
+			$exception = new QueryException('More than 30 characters for an output column name are not allowed on Oracle.');
+			$this->logger->error($exception->getMessage(), [
+				'query' => $this->getSQL(),
+				'columns' => $tooLongOutputColumns,
+				'app' => 'core',
+				'exception' => $exception,
+			]);
+		}
+
 		$numberOfParameters = 0;
 		$hasTooLargeArrayParameter = false;
 		foreach ($this->getParameters() as $parameter) {


### PR DESCRIPTION
## Summary

According to https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html we still support Oracle versions <12.2.
https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Database-Object-Names-and-Qualifiers.html says:
`If COMPATIBLE is set to a value of 12.2 or higher, then names must be from 1 to 128 bytes long` and `If COMPATIBLE is set to a value lower than 12.2, then names must be from 1 to 30 bytes long`.
This means we must prevent any identifier with more than 30 characters as long as we support Oracle <12.2.

This check should also be extended to table names and schema names, but I'm not sure how to do that best.
I found this due to https://github.com/nextcloud/groupfolders/actions/runs/10960223441/job/30434816204 (which tests against Oracle 11) which triggers this query:
```sql
 SELECT `g`.`folder_id`,
       `g`.`group_id`,
       `g`.`circle_id`,
       `g`.`permissions`,
       `hp_cc`.`unique_id`                 AS `hp_cc_unique_id`,
       `hp_cc`.`name`                      AS `hp_cc_name`,
       `hp_cc`.`display_name`              AS `hp_cc_display_name`,
       `hp_cc`.`sanitized_name`            AS `hp_cc_sanitized_name`,
       `hp_cc`.`source`                    AS `hp_cc_source`,
       `hp_cc`.`description`               AS `hp_cc_description`,
       `hp_cc`.`settings`                  AS `hp_cc_settings`,
       `hp_cc`.`config`                    AS `hp_cc_config`,
       `hp_cc`.`contact_addressbook`       AS `hp_cc_contact_addressbook`,
       `hp_cc`.`contact_groupname`         AS `hp_cc_contact_groupname`,
       `hp_cc`.`creation`                  AS `hp_cc_creation`,
       `hp_cc_wn`.`circle_id`              AS `hp_cc_wn_circle_id`,
       `hp_cc_wn`.`member_id`              AS `hp_cc_wn_member_id`,
       `hp_cc_wn`.`single_id`              AS `hp_cc_wn_single_id`,
       `hp_cc_wn`.`user_id`                AS `hp_cc_wn_user_id`,
       `hp_cc_wn`.`instance`               AS `hp_cc_wn_instance`,
       `hp_cc_wn`.`user_type`              AS `hp_cc_wn_user_type`,
       `hp_cc_wn`.`level`                  AS `hp_cc_wn_level`,
       `hp_cc_wn`.`status`                 AS `hp_cc_wn_status`,
       `hp_cc_wn`.`note`                   AS `hp_cc_wn_note`,
       `hp_cc_wn`.`contact_id`             AS `hp_cc_wn_contact_id`,
       `hp_cc_wn`.`cached_name`            AS `hp_cc_wn_cached_name`,
       `hp_cc_wn`.`cached_update`          AS `hp_cc_wn_cached_update`,
       `hp_cc_wn`.`contact_meta`           AS `hp_cc_wn_contact_meta`,
       `hp_cc_wn`.`joined`                 AS `hp_cc_wn_joined`,
       `hp_cc_wn_on`.`unique_id`           AS `hp_cc_wn_on_unique_id`,
       `hp_cc_wn_on`.`name`                AS `hp_cc_wn_on_name`,
       `hp_cc_wn_on`.`display_name`        AS `hp_cc_wn_on_display_name`,
       `hp_cc_wn_on`.`sanitized_name`      AS `hp_cc_wn_on_sanitized_name`,
       `hp_cc_wn_on`.`source`              AS `hp_cc_wn_on_source`,
       `hp_cc_wn_on`.`description`         AS `hp_cc_wn_on_description`,
       `hp_cc_wn_on`.`settings`            AS `hp_cc_wn_on_settings`,
       `hp_cc_wn_on`.`config`              AS `hp_cc_wn_on_config`,
       `hp_cc_wn_on`.`contact_addressbook` AS `hp_cc_wn_on_contact_addressbook`,
       `hp_cc_wn_on`.`contact_groupname`   AS `hp_cc_wn_on_contact_groupname`,
       `hp_cc_wn_on`.`creation`            AS `hp_cc_wn_on_creation`
FROM   `*prefix*group_folders_groups` `g`
       LEFT JOIN `*prefix*circles_circle` `hp_cc`
              ON `hp_cc`.`unique_id` = `g`.`circle_id`
       LEFT JOIN `*prefix*circles_member` `hp_cc_wn`
              ON ( `hp_cc_wn`.`circle_id` = `hp_cc`.`unique_id` )
                 AND ( `hp_cc_wn`.`level` = :dcValue1 )
       LEFT JOIN `*prefix*circles_circle` `hp_cc_wn_on`
              ON `hp_cc_wn_on`.`unique_id` = `hp_cc_wn`.`single_id`
```
where `hp_cc_wn_on_contact_addressbook` is 31 characters.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
