### PR TITLE
refactor(apps): Use PHP 5.5 features

### DIFF
--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -232,6 +232,6 @@ class Application extends App implements IBootstrap {
 	private function trashbinHooks(IAuditLogger $logger): void {
 		$trashActions = new Trashbin($logger);
 		Util::connectHook('\OCP\Trashbin', 'preDelete', $trashActions, 'delete');
-		Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', $trashActions, 'restore');
+		Util::connectHook(\OCA\Files_Trashbin\Trashbin::class, 'post_restore', $trashActions, 'restore');
 	}
 }

--- a/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
+++ b/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
@@ -35,12 +35,12 @@ class ApplicationTest extends TestCase {
 		$c = $app->getContainer();
 
 		$services = [
-			'OCA\Comments\Controller\NotificationsController',
-			'OCA\Comments\Activity\Filter',
-			'OCA\Comments\Activity\Listener',
-			'OCA\Comments\Activity\Provider',
-			'OCA\Comments\Activity\Setting',
-			'OCA\Comments\Notification\Listener',
+			\OCA\Comments\Controller\NotificationsController::class,
+			\OCA\Comments\Activity\Filter::class,
+			\OCA\Comments\Activity\Listener::class,
+			\OCA\Comments\Activity\Provider::class,
+			\OCA\Comments\Activity\Setting::class,
+			\OCA\Comments\Notification\Listener::class,
 			Notifier::class,
 		];
 

--- a/apps/comments/tests/Unit/Notification/ListenerTest.php
+++ b/apps/comments/tests/Unit/Notification/ListenerTest.php
@@ -102,7 +102,7 @@ class ListenerTest extends TestCase {
 			->willReturn($notification);
 		$this->notificationManager->expects($this->exactly(6))
 			->method($notificationMethod)
-			->with($this->isInstanceOf('\OCP\Notification\INotification'));
+			->with($this->isInstanceOf(\OCP\Notification\INotification::class));
 
 		$this->userManager->expects($this->exactly(6))
 			->method('userExists')

--- a/apps/dav/lib/CalDAV/Search/Xml/Request/CalendarSearchReport.php
+++ b/apps/dav/lib/CalDAV/Search/Xml/Request/CalendarSearchReport.php
@@ -67,13 +67,13 @@ class CalendarSearchReport implements XmlDeserializable {
 	 */
 	public static function xmlDeserialize(Reader $reader) {
 		$elems = $reader->parseInnerTree([
-			'{http://nextcloud.com/ns}comp-filter' => 'OCA\\DAV\\CalDAV\\Search\\Xml\\Filter\\CompFilter',
-			'{http://nextcloud.com/ns}prop-filter' => 'OCA\\DAV\\CalDAV\\Search\\Xml\\Filter\\PropFilter',
-			'{http://nextcloud.com/ns}param-filter' => 'OCA\\DAV\\CalDAV\\Search\\Xml\\Filter\\ParamFilter',
-			'{http://nextcloud.com/ns}search-term' => 'OCA\\DAV\\CalDAV\\Search\\Xml\\Filter\\SearchTermFilter',
-			'{http://nextcloud.com/ns}limit' => 'OCA\\DAV\\CalDAV\\Search\\Xml\\Filter\\LimitFilter',
-			'{http://nextcloud.com/ns}offset' => 'OCA\\DAV\\CalDAV\\Search\\Xml\\Filter\\OffsetFilter',
-			'{DAV:}prop' => 'Sabre\\Xml\\Element\\KeyValue',
+			'{http://nextcloud.com/ns}comp-filter' => \OCA\DAV\CalDAV\Search\Xml\Filter\CompFilter::class,
+			'{http://nextcloud.com/ns}prop-filter' => \OCA\DAV\CalDAV\Search\Xml\Filter\PropFilter::class,
+			'{http://nextcloud.com/ns}param-filter' => \OCA\DAV\CalDAV\Search\Xml\Filter\ParamFilter::class,
+			'{http://nextcloud.com/ns}search-term' => \OCA\DAV\CalDAV\Search\Xml\Filter\SearchTermFilter::class,
+			'{http://nextcloud.com/ns}limit' => \OCA\DAV\CalDAV\Search\Xml\Filter\LimitFilter::class,
+			'{http://nextcloud.com/ns}offset' => \OCA\DAV\CalDAV\Search\Xml\Filter\OffsetFilter::class,
+			'{DAV:}prop' => \Sabre\Xml\Element\KeyValue::class,
 		]);
 
 		$newProps = [

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -352,7 +352,7 @@ class FilesReportPlugin extends ServerPlugin {
 	 * @return array
 	 */
 	private function getCirclesFileIds(array $circlesIds) {
-		if (!$this->appManager->isEnabledForUser('circles') || !class_exists('\OCA\Circles\Api\v1\Circles')) {
+		if (!$this->appManager->isEnabledForUser('circles') || !class_exists(\OCA\Circles\Api\v1\Circles::class)) {
 			return [];
 		}
 		return \OCA\Circles\Api\v1\Circles::getFilesForCircles($circlesIds);

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -525,7 +525,7 @@ class Principal implements BackendInterface {
 	 * @return array|null
 	 */
 	protected function circleToPrincipal($circleUniqueId) {
-		if (!$this->appManager->isEnabledForUser('circles') || !class_exists('\OCA\Circles\Api\v1\Circles')) {
+		if (!$this->appManager->isEnabledForUser('circles') || !class_exists(\OCA\Circles\Api\v1\Circles::class)) {
 			return null;
 		}
 
@@ -559,7 +559,7 @@ class Principal implements BackendInterface {
 	 * @suppress PhanUndeclaredClassMethod
 	 */
 	public function getCircleMembership($principal):array {
-		if (!$this->appManager->isEnabledForUser('circles') || !class_exists('\OCA\Circles\Api\v1\Circles')) {
+		if (!$this->appManager->isEnabledForUser('circles') || !class_exists(\OCA\Circles\Api\v1\Circles::class)) {
 			return [];
 		}
 

--- a/apps/dav/lib/DAV/Sharing/Xml/ShareRequest.php
+++ b/apps/dav/lib/DAV/Sharing/Xml/ShareRequest.php
@@ -29,8 +29,8 @@ class ShareRequest implements XmlDeserializable {
 
 	public static function xmlDeserialize(Reader $reader) {
 		$elements = $reader->parseInnerTree([
-			'{' . Plugin::NS_OWNCLOUD . '}set' => 'Sabre\\Xml\\Element\\KeyValue',
-			'{' . Plugin::NS_OWNCLOUD . '}remove' => 'Sabre\\Xml\\Element\\KeyValue',
+			'{' . Plugin::NS_OWNCLOUD . '}set' => \Sabre\Xml\Element\KeyValue::class,
+			'{' . Plugin::NS_OWNCLOUD . '}remove' => \Sabre\Xml\Element\KeyValue::class,
 		]);
 
 		$set = [];

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -52,7 +52,7 @@ class PublicCalendarRootTest extends TestCase {
 		parent::setUp();
 
 		$db = \OC::$server->getDatabaseConnection();
-		$this->principal = $this->createMock('OCA\DAV\Connector\Sabre\Principal');
+		$this->principal = $this->createMock(\OCA\DAV\Connector\Sabre\Principal::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->random = \OC::$server->getSecureRandom();

--- a/apps/dav/tests/unit/CalDAV/Search/Request/CalendarSearchReportTest.php
+++ b/apps/dav/tests/unit/CalDAV/Search/Request/CalendarSearchReportTest.php
@@ -12,7 +12,7 @@ use Test\TestCase;
 class CalendarSearchReportTest extends TestCase {
 	private $elementMap = [
 		'{http://nextcloud.com/ns}calendar-search' =>
-			'OCA\\DAV\\CalDAV\\Search\\Xml\\Request\\CalendarSearchReport',
+			\OCA\DAV\CalDAV\Search\Xml\Request\CalendarSearchReport::class,
 	];
 
 	public function testFoo(): void {

--- a/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
@@ -51,7 +51,7 @@ class SearchPluginTest extends TestCase {
 
 		$this->assertEquals(
 			$server->xml->elementMap['{http://nextcloud.com/ns}calendar-search'],
-			'OCA\\DAV\\CalDAV\\Search\\Xml\\Request\\CalendarSearchReport'
+			\OCA\DAV\CalDAV\Search\Xml\Request\CalendarSearchReport::class
 		);
 	}
 

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -73,7 +73,7 @@ class BirthdayServiceTest extends TestCase {
 		if ($expectedSummary === null) {
 			$this->assertNull($cal);
 		} else {
-			$this->assertInstanceOf('Sabre\VObject\Component\VCalendar', $cal);
+			$this->assertInstanceOf(\Sabre\VObject\Component\VCalendar::class, $cal);
 			$this->assertEquals('-//IDN nextcloud.com//Birthday calendar//EN', $cal->PRODID->getValue());
 			$this->assertTrue(isset($cal->VEVENT));
 			$this->assertEquals($expectedRrule, $cal->VEVENT->RRULE->getValue());

--- a/apps/dav/tests/unit/CardDAV/ConverterTest.php
+++ b/apps/dav/tests/unit/CardDAV/ConverterTest.php
@@ -95,7 +95,7 @@ class ConverterTest extends TestCase {
 		$converter = new Converter($accountManager, $this->userManager, $this->urlGenerator, $this->logger);
 		$vCard = $converter->createCardFromUser($user);
 		if ($expectedVCard !== null) {
-			$this->assertInstanceOf('Sabre\VObject\Component\VCard', $vCard);
+			$this->assertInstanceOf(\Sabre\VObject\Component\VCard::class, $vCard);
 			$cardData = $vCard->jsonSerialize();
 			$this->compareData($expectedVCard, $cardData);
 		} else {

--- a/apps/dav/tests/unit/Comments/CommentsPluginTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsPluginTest.php
@@ -41,7 +41,7 @@ class CommentsPluginTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$this->server = $this->getMockBuilder(\Sabre\DAV\Server::class)
 			->setConstructorArgs([$this->tree])
 			->setMethods(['getRequestUri'])
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -65,7 +65,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		$this->expectExceptionMessage('This version of the client is unsupported. Upgrade to <a href="https://nextcloud.com/install/#install-clients">version 1.7.0 or later</a>.');
 
 		/** @var RequestInterface|MockObject $request */
-		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
+		$request = $this->createMock(\Sabre\HTTP\RequestInterface::class);
 		$request
 			->expects($this->once())
 			->method('getHeader')
@@ -97,7 +97,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		$this->expectExceptionMessage('This version of the client is unsupported. Upgrade to <a href="https://example.com&quot;&gt;&lt;script&gt;alter(&quot;hacked&quot;);&lt;/script&gt;">version 1.7.0 &lt;script&gt;alert(&quot;unsafe&quot;)&lt;/script&gt; or later</a>.');
 
 		/** @var RequestInterface|MockObject $request */
-		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
+		$request = $this->createMock(\Sabre\HTTP\RequestInterface::class);
 		$request
 			->expects($this->once())
 			->method('getHeader')

--- a/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
@@ -32,7 +32,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$this->server = $this->getMockBuilder(\Sabre\DAV\Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -42,7 +42,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 
 	public function nodeProvider() {
 		$mocks = [];
-		foreach (['\OCA\DAV\Connector\Sabre\File', '\OCA\DAV\Connector\Sabre\Directory', '\Sabre\DAV\INode'] as $class) {
+		foreach ([\OCA\DAV\Connector\Sabre\File::class, \OCA\DAV\Connector\Sabre\Directory::class, \Sabre\DAV\INode::class] as $class) {
 			$mocks[] = $this->getMockBuilder($class)
 				->disableOriginalConstructor()
 				->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -65,7 +65,7 @@ class DirectoryTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->view = $this->createMock('OC\Files\View');
+		$this->view = $this->createMock(\OC\Files\View::class);
 		$this->info = $this->createMock('OC\Files\FileInfo');
 		$this->info->method('isReadable')
 			->willReturn(true);
@@ -283,8 +283,8 @@ class DirectoryTest extends \Test\TestCase {
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
 			->willReturnMap([
-				'\OCA\Files_Sharing\SharedStorage' => false,
-				'\OC\Files\Storage\Wrapper\Quota' => false,
+				\OCA\Files_Sharing\SharedStorage::class => false,
+				\OC\Files\Storage\Wrapper\Quota::class => false,
 			]);
 
 		$storage->expects($this->once())
@@ -334,8 +334,8 @@ class DirectoryTest extends \Test\TestCase {
 		$storage->expects($this->any())
 			->method('instanceOfStorage')
 			->willReturnMap([
-				['\OCA\Files_Sharing\SharedStorage', false],
-				['\OC\Files\Storage\Wrapper\Quota', true],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
+				[\OC\Files\Storage\Wrapper\Quota::class, true],
 			]);
 
 		$storage->expects($this->once())

--- a/apps/dav/tests/unit/Connector/Sabre/Exception/ForbiddenTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/Exception/ForbiddenTest.php
@@ -32,7 +32,7 @@ class ForbiddenTest extends \Test\TestCase {
 EOD;
 
 		$ex = new Forbidden($message, $retry);
-		$server = $this->getMockBuilder('Sabre\DAV\Server')
+		$server = $this->getMockBuilder(\Sabre\DAV\Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$ex->serialize($server, $error);

--- a/apps/dav/tests/unit/Connector/Sabre/Exception/InvalidPathTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/Exception/InvalidPathTest.php
@@ -32,7 +32,7 @@ class InvalidPathTest extends \Test\TestCase {
 EOD;
 
 		$ex = new InvalidPath($message, $retry);
-		$server = $this->getMockBuilder('Sabre\DAV\Server')
+		$server = $this->getMockBuilder(\Sabre\DAV\Server::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$ex->serialize($server, $error);

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -94,53 +94,53 @@ class FileTest extends TestCase {
 			[
 				// return false
 				null,
-				'\Sabre\Dav\Exception',
+				\Sabre\Dav\Exception::class,
 				false
 			],
 			[
 				new \OCP\Files\NotPermittedException(),
-				'Sabre\DAV\Exception\Forbidden'
+				\Sabre\DAV\Exception\Forbidden::class
 			],
 			[
 				new \OCP\Files\EntityTooLargeException(),
-				'OCA\DAV\Connector\Sabre\Exception\EntityTooLarge'
+				\OCA\DAV\Connector\Sabre\Exception\EntityTooLarge::class
 			],
 			[
 				new \OCP\Files\InvalidContentException(),
-				'OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType'
+				\OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType::class
 			],
 			[
 				new \OCP\Files\InvalidPathException(),
-				'Sabre\DAV\Exception\Forbidden'
+				\Sabre\DAV\Exception\Forbidden::class
 			],
 			[
 				new \OCP\Files\ForbiddenException('', true),
-				'OCA\DAV\Connector\Sabre\Exception\Forbidden'
+				\OCA\DAV\Connector\Sabre\Exception\Forbidden::class
 			],
 			[
 				new \OCP\Files\LockNotAcquiredException('/test.txt', 1),
-				'OCA\DAV\Connector\Sabre\Exception\FileLocked'
+				\OCA\DAV\Connector\Sabre\Exception\FileLocked::class
 			],
 			[
 				new \OCP\Lock\LockedException('/test.txt'),
-				'OCA\DAV\Connector\Sabre\Exception\FileLocked'
+				\OCA\DAV\Connector\Sabre\Exception\FileLocked::class
 			],
 			[
 				new \OCP\Encryption\Exceptions\GenericEncryptionException(),
-				'Sabre\DAV\Exception\ServiceUnavailable'
+				\Sabre\DAV\Exception\ServiceUnavailable::class
 			],
 			[
 				new \OCP\Files\StorageNotAvailableException(),
-				'Sabre\DAV\Exception\ServiceUnavailable'
+				\Sabre\DAV\Exception\ServiceUnavailable::class
 			],
 			[
 				new \Sabre\DAV\Exception('Generic sabre exception'),
-				'Sabre\DAV\Exception',
+				\Sabre\DAV\Exception::class,
 				false
 			],
 			[
 				new \Exception('Generic exception'),
-				'Sabre\DAV\Exception'
+				\Sabre\DAV\Exception::class
 			],
 		];
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -124,7 +124,7 @@ class FilesPluginTest extends TestCase {
 
 	public function testGetPropertiesForFile(): void {
 		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		$node = $this->createTestNode(\OCA\DAV\Connector\Sabre\File::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',
@@ -181,7 +181,7 @@ class FilesPluginTest extends TestCase {
 
 	public function testGetPropertiesStorageNotAvailable(): void {
 		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		$node = $this->createTestNode(\OCA\DAV\Connector\Sabre\File::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',
@@ -228,7 +228,7 @@ class FilesPluginTest extends TestCase {
 		);
 
 		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		$node = $this->createTestNode(\OCA\DAV\Connector\Sabre\File::class);
 		$node->expects($this->any())
 			->method('getDavPermissions')
 			->willReturn('DWCKMSR');
@@ -243,7 +243,7 @@ class FilesPluginTest extends TestCase {
 
 	public function testGetPropertiesForDirectory(): void {
 		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
+		$node = $this->createTestNode(\OCA\DAV\Connector\Sabre\Directory::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',
@@ -345,7 +345,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testUpdateProps(): void {
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		$node = $this->createTestNode(\OCA\DAV\Connector\Sabre\File::class);
 
 		$testDate = 'Fri, 13 Feb 2015 00:01:02 GMT';
 		$testCreationDate = '2007-08-31T16:47+00:00';
@@ -615,7 +615,7 @@ class FilesPluginTest extends TestCase {
 
 	public function testHasPreview(): void {
 		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
+		$node = $this->createTestNode(\OCA\DAV\Connector\Sabre\Directory::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -58,7 +58,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$this->server = $this->getMockBuilder(\Sabre\DAV\Server::class)
 			->setConstructorArgs([$this->tree])
 			->onlyMethods(['getRequestUri', 'getBaseUri'])
 			->getMock();
@@ -293,9 +293,9 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);
-		$this->assertInstanceOf('\OCA\DAV\Connector\Sabre\Directory', $result[0]);
+		$this->assertInstanceOf(\OCA\DAV\Connector\Sabre\Directory::class, $result[0]);
 		$this->assertEquals('first node', $result[0]->getName());
-		$this->assertInstanceOf('\OCA\DAV\Connector\Sabre\File', $result[1]);
+		$this->assertInstanceOf(\OCA\DAV\Connector\Sabre\File::class, $result[1]);
 		$this->assertEquals('second node', $result[1]->getName());
 	}
 
@@ -346,9 +346,9 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);
-		$this->assertInstanceOf('\OCA\DAV\Connector\Sabre\Directory', $result[0]);
+		$this->assertInstanceOf(\OCA\DAV\Connector\Sabre\Directory::class, $result[0]);
 		$this->assertEquals('first node', $result[0]->getName());
-		$this->assertInstanceOf('\OCA\DAV\Connector\Sabre\File', $result[1]);
+		$this->assertInstanceOf(\OCA\DAV\Connector\Sabre\File::class, $result[1]);
 		$this->assertEquals('second node', $result[1]->getName());
 	}
 
@@ -410,14 +410,14 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$props1 = $responses[0]->getResponseProperties();
 		$this->assertEquals('111', $props1[200]['{http://owncloud.org/ns}fileid']);
 		$this->assertNull($props1[404]['{DAV:}getcontentlength']);
-		$this->assertInstanceOf('\Sabre\DAV\Xml\Property\ResourceType', $props1[200]['{DAV:}resourcetype']);
+		$this->assertInstanceOf(\Sabre\DAV\Xml\Property\ResourceType::class, $props1[200]['{DAV:}resourcetype']);
 		$resourceType1 = $props1[200]['{DAV:}resourcetype']->getValue();
 		$this->assertEquals('{DAV:}collection', $resourceType1[0]);
 
 		$props2 = $responses[1]->getResponseProperties();
 		$this->assertEquals('1024', $props2[200]['{DAV:}getcontentlength']);
 		$this->assertEquals('222', $props2[200]['{http://owncloud.org/ns}fileid']);
-		$this->assertInstanceOf('\Sabre\DAV\Xml\Property\ResourceType', $props2[200]['{DAV:}resourcetype']);
+		$this->assertInstanceOf(\Sabre\DAV\Xml\Property\ResourceType::class, $props2[200]['{DAV:}resourcetype']);
 		$this->assertCount(0, $props2[200]['{DAV:}resourcetype']->getValue());
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -252,6 +252,6 @@ class ObjectTreeTest extends \Test\TestCase {
 		$tree = new \OCA\DAV\Connector\Sabre\ObjectTree();
 		$tree->init($rootNode, $view, $mountManager);
 
-		$this->assertInstanceOf('\Sabre\DAV\INode', $tree->getNodeForPath($path));
+		$this->assertInstanceOf(\Sabre\DAV\INode::class, $tree->getNodeForPath($path));
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
@@ -29,7 +29,7 @@ class DeleteTest extends RequestTestCase {
 		$mount->getStorage()->unlink($mount->getInternalPath($internalPath));
 
 		// cache entry still exists
-		$this->assertInstanceOf('\OCP\Files\FileInfo', $view->getFileInfo('foo.txt'));
+		$this->assertInstanceOf(\OCP\Files\FileInfo::class, $view->getFileInfo('foo.txt'));
 
 		$response = $this->request($view, $user, 'pass', 'DELETE', '/foo.txt');
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
@@ -23,7 +23,7 @@ class EncryptionMasterKeyUploadTest extends UploadTest {
 	protected function setupUser($name, $password) {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->registerMount($name, \OC\Files\Storage\Local::class, '/' . $name, ['datadir' => $tmpFolder]);
 		// we use the master key
 		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '1');
 		$this->setupForUser($name, $password);

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
@@ -23,7 +23,7 @@ class EncryptionUploadTest extends UploadTest {
 	protected function setupUser($name, $password) {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->registerMount($name, \OC\Files\Storage\Local::class, '/' . $name, ['datadir' => $tmpFolder]);
 		// we use per-user keys
 		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '0');
 		$this->setupForUser($name, $password);

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -58,7 +58,7 @@ abstract class RequestTestCase extends TestCase {
 	protected function setupUser($name, $password) {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->registerMount($name, \OC\Files\Storage\Local::class, '/' . $name, ['datadir' => $tmpFolder]);
 		$this->loginAsUser($name);
 		return new View('/' . $name . '/files');
 	}

--- a/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
+++ b/apps/dav/tests/unit/Controller/BirthdayCalendarControllerTest.php
@@ -83,7 +83,7 @@ class BirthdayCalendarControllerTest extends TestCase {
 			);
 
 		$response = $this->controller->enable();
-		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
+		$this->assertInstanceOf(\OCP\AppFramework\Http\JSONResponse::class, $response);
 	}
 
 	public function testDisable(): void {
@@ -97,6 +97,6 @@ class BirthdayCalendarControllerTest extends TestCase {
 			->method('deleteAllBirthdayCalendars');
 
 		$response = $this->controller->disable();
-		$this->assertInstanceOf('OCP\AppFramework\Http\JSONResponse', $response);
+		$this->assertInstanceOf(\OCP\AppFramework\Http\JSONResponse::class, $response);
 	}
 }

--- a/apps/dav/tests/unit/DAV/ErrorPagePluginTest.php
+++ b/apps/dav/tests/unit/DAV/ErrorPagePluginTest.php
@@ -24,7 +24,7 @@ class ErrorPagePluginTest extends \Test\TestCase {
 		$plugin->expects($this->once())->method('generateBody')->willReturn(':boom:');
 		$plugin->expects($this->once())->method('sendResponse');
 		/** @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject $server */
-		$server = $this->getMockBuilder('Sabre\DAV\Server')->disableOriginalConstructor()->getMock();
+		$server = $this->getMockBuilder(\Sabre\DAV\Server::class)->disableOriginalConstructor()->getMock();
 		$server->expects($this->once())->method('on');
 		$httpResponse = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->getMock();
 		$httpResponse->expects($this->once())->method('addHeaders');

--- a/apps/dav/tests/unit/Files/MultipartRequestParserTest.php
+++ b/apps/dav/tests/unit/Files/MultipartRequestParserTest.php
@@ -32,7 +32,7 @@ class MultipartRequestParserTest extends TestCase {
 	}
 
 	private function getMultipartParser(array $parts, array $headers = [], string $boundary = 'boundary_azertyuiop'): MultipartRequestParser {
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(\Sabre\HTTP\RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -74,7 +74,7 @@ class MultipartRequestParserTest extends TestCase {
 	 */
 	public function testBodyTypeValidation(): void {
 		$bodyStream = 'I am not a stream, but pretend to be';
-		$request = $this->getMockBuilder('Sabre\HTTP\RequestInterface')
+		$request = $this->getMockBuilder(\Sabre\HTTP\RequestInterface::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$request->expects($this->any())

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -97,12 +97,12 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 			[
 				// cannot unassign invisible tag
 				new SystemTag(1, 'Original', false, true),
-				'Sabre\DAV\Exception\NotFound',
+				\Sabre\DAV\Exception\NotFound::class,
 			],
 			[
 				// cannot unassign non-assignable tag
 				new SystemTag(1, 'Original', true, false),
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 		];
 	}

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -117,37 +117,37 @@ class SystemTagNodeTest extends \Test\TestCase {
 				// changing permissions not allowed
 				new SystemTag(1, 'Original', true, true),
 				['Original', false, true],
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 			[
 				// changing permissions not allowed
 				new SystemTag(1, 'Original', true, true),
 				['Original', true, false],
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 			[
 				// changing permissions not allowed
 				new SystemTag(1, 'Original', true, true),
 				['Original', false, false],
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 			[
 				// changing non-assignable not allowed
 				new SystemTag(1, 'Original', true, false),
 				['Rename', true, false],
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 			[
 				// changing non-assignable not allowed
 				new SystemTag(1, 'Original', true, false),
 				['Original', true, true],
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 			[
 				// invisible tag does not exist
 				new SystemTag(1, 'Original', false, false),
 				['Rename', false, false],
-				'Sabre\DAV\Exception\NotFound',
+				\Sabre\DAV\Exception\NotFound::class,
 			],
 		];
 	}
@@ -242,12 +242,12 @@ class SystemTagNodeTest extends \Test\TestCase {
 			[
 				// cannot delete invisible tag
 				new SystemTag(1, 'Original', false, true),
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 			[
 				// cannot delete non-assignable tag
 				new SystemTag(1, 'Original', true, false),
-				'Sabre\DAV\Exception\Forbidden',
+				\Sabre\DAV\Exception\Forbidden::class,
 			],
 		];
 	}

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -575,8 +575,8 @@ class SystemTagPluginTest extends \Test\TestCase {
 
 	public function nodeClassProvider() {
 		return [
-			['\OCA\DAV\SystemTag\SystemTagsByIdCollection'],
-			['\OCA\DAV\SystemTag\SystemTagsObjectMappingCollection'],
+			[\OCA\DAV\SystemTag\SystemTagsByIdCollection::class],
+			[\OCA\DAV\SystemTag\SystemTagsObjectMappingCollection::class],
 		];
 	}
 

--- a/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
@@ -89,7 +89,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 
 		$childNode = $this->getNode()->getChild('123');
 
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagNode', $childNode);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagNode::class, $childNode);
 		$this->assertEquals('123', $childNode->getName());
 		$this->assertEquals($tag, $childNode->getSystemTag());
 	}
@@ -145,8 +145,8 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 
 		$this->assertCount(2, $children);
 
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagNode', $children[0]);
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagNode', $children[1]);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagNode::class, $children[0]);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagNode::class, $children[1]);
 		$this->assertEquals($tag1, $children[0]->getSystemTag());
 		$this->assertEquals($tag2, $children[1]->getSystemTag());
 	}
@@ -164,8 +164,8 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 
 		$this->assertCount(2, $children);
 
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagNode', $children[0]);
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagNode', $children[1]);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagNode::class, $children[0]);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagNode::class, $children[1]);
 		$this->assertEquals($tag1, $children[0]->getSystemTag());
 		$this->assertEquals($tag2, $children[1]->getSystemTag());
 	}

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -88,9 +88,9 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	public function permissionsProvider() {
 		return [
 			// invisible, tag does not exist for user
-			[false, true, '\Sabre\DAV\Exception\PreconditionFailed'],
+			[false, true, \Sabre\DAV\Exception\PreconditionFailed::class],
 			// visible but static, cannot assign tag
-			[true, false, '\Sabre\DAV\Exception\Forbidden'],
+			[true, false, \Sabre\DAV\Exception\Forbidden::class],
 		];
 	}
 
@@ -163,7 +163,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 
 		$childNode = $this->getNode()->getChild('555');
 
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagMappingNode', $childNode);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagMappingNode::class, $childNode);
 		$this->assertEquals('555', $childNode->getName());
 	}
 
@@ -251,8 +251,8 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 
 		$this->assertCount(2, $children);
 
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagMappingNode', $children[0]);
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagMappingNode', $children[1]);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagMappingNode::class, $children[0]);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagMappingNode::class, $children[1]);
 
 		$this->assertEquals(111, $children[0]->getObjectId());
 		$this->assertEquals('files', $children[0]->getObjectType());

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
@@ -111,7 +111,7 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 			->willReturn($this->createMock(\OCP\Files\Node::class));
 		$childNode = $this->node->getChild('555');
 
-		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagsObjectMappingCollection', $childNode);
+		$this->assertInstanceOf(\OCA\DAV\SystemTag\SystemTagsObjectMappingCollection::class, $childNode);
 		$this->assertEquals('555', $childNode->getName());
 	}
 

--- a/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
+++ b/apps/dav/tests/unit/Upload/ChunkingPluginTest.php
@@ -38,10 +38,10 @@ class ChunkingPluginTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->server = $this->getMockBuilder('\Sabre\DAV\Server')
+		$this->server = $this->getMockBuilder(\Sabre\DAV\Server::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->tree = $this->getMockBuilder('\Sabre\DAV\Tree')
+		$this->tree = $this->getMockBuilder(\Sabre\DAV\Tree::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -242,7 +242,7 @@ class FixEncryptedVersion extends Command {
 			return true;
 		}
 
-		if ($storage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage')) {
+		if ($storage->instanceOfStorage(\OCA\Files_Sharing\ISharedStorage::class)) {
 			$output->writeln("<info>The file: \"$path\" is a share. Please also run the script for the owner of the share</info>");
 			return true;
 		}

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -378,7 +378,7 @@ class Encryption implements IEncryptionModule {
 	public function shouldEncrypt($path) {
 		if ($this->util->shouldEncryptHomeStorage() === false) {
 			$storage = $this->util->getStorage($path);
-			if ($storage && $storage->instanceOfStorage('\OCP\Files\IHomeStorage')) {
+			if ($storage && $storage->instanceOfStorage(\OCP\Files\IHomeStorage::class)) {
 				return false;
 			}
 		}

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -52,7 +52,7 @@ class FixEncryptedVersionTest extends TestCase {
 
 		$this->createUser($this->userId, 'foo12345678');
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->registerMount($this->userId, '\OC\Files\Storage\Local', '/' . $this->userId, ['datadir' => $tmpFolder]);
+		$this->registerMount($this->userId, \OC\Files\Storage\Local::class, '/' . $this->userId, ['datadir' => $tmpFolder]);
 		$this->setupForUser($this->userId, 'foo12345678');
 		$this->loginWithEncryption($this->userId);
 

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -375,7 +375,7 @@ class EncryptionTest extends TestCase {
 
 		if ($shouldEncryptHomeStorage === false) {
 			$this->storageMock->expects($this->once())->method('instanceOfStorage')
-				->with('\OCP\Files\IHomeStorage')->willReturn($isHomeStorage);
+				->with(\OCP\Files\IHomeStorage::class)->willReturn($isHomeStorage);
 			$this->utilMock->expects($this->once())->method('getStorage')->with($path)
 				->willReturn($this->storageMock);
 		}

--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -249,7 +249,7 @@ class Notifications {
 			return true;
 		} elseif ($try === 0) {
 			// only add new job on first try
-			$this->jobList->add('OCA\FederatedFileSharing\BackgroundJob\RetryJob',
+			$this->jobList->add(\OCA\FederatedFileSharing\BackgroundJob\RetryJob::class,
 				[
 					'remote' => $remote,
 					'remoteId' => $remoteId,

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -76,18 +76,18 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->request = $this->getMockBuilder(IRequest::class)->disableOriginalConstructor()->getMock();
-		$this->federatedShareProvider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
+		$this->federatedShareProvider = $this->getMockBuilder(\OCA\FederatedFileSharing\FederatedShareProvider::class)
 			->disableOriginalConstructor()->getMock();
 		$this->shareManager = $this->getMockBuilder(IManager::class)->disableOriginalConstructor()->getMock();
-		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
+		$this->addressHandler = $this->getMockBuilder(\OCA\FederatedFileSharing\AddressHandler::class)
 			->disableOriginalConstructor()->getMock();
-		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->disableOriginalConstructor()->getMock();
+		$this->rootFolder = $this->getMockBuilder(\OCP\Files\IRootFolder::class)->disableOriginalConstructor()->getMock();
 		$this->userManager = $this->getMockBuilder(IUserManager::class)->disableOriginalConstructor()->getMock();
 		$this->share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
 		$this->session = $this->getMockBuilder(ISession::class)->disableOriginalConstructor()->getMock();
 		$this->l10n = $this->getMockBuilder(IL10N::class)->disableOriginalConstructor()->getMock();
 		$this->userSession = $this->getMockBuilder(IUserSession::class)->disableOriginalConstructor()->getMock();
-		$this->clientService = $this->getMockBuilder('OCP\Http\Client\IClientService')->disableOriginalConstructor()->getMock();
+		$this->clientService = $this->getMockBuilder(\OCP\Http\Client\IClientService::class)->disableOriginalConstructor()->getMock();
 		$this->contactsManager = $this->createMock(IContactsManager::class);
 		$this->cloudIdManager = new CloudIdManager(
 			$this->contactsManager,

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -86,7 +86,7 @@ class RequestHandlerControllerTest extends \Test\TestCase {
 
 	protected function setUp(): void {
 		$this->share = $this->getMockBuilder(IShare::class)->getMock();
-		$this->federatedShareProvider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
+		$this->federatedShareProvider = $this->getMockBuilder(\OCA\FederatedFileSharing\FederatedShareProvider::class)
 			->disableOriginalConstructor()->getMock();
 		$this->federatedShareProvider->expects($this->any())
 			->method('isOutgoingServer2serverShareEnabled')->willReturn(true);
@@ -95,9 +95,9 @@ class RequestHandlerControllerTest extends \Test\TestCase {
 		$this->federatedShareProvider->expects($this->any())->method('getShareById')
 			->willReturn($this->share);
 
-		$this->notifications = $this->getMockBuilder('OCA\FederatedFileSharing\Notifications')
+		$this->notifications = $this->getMockBuilder(\OCA\FederatedFileSharing\Notifications::class)
 			->disableOriginalConstructor()->getMock();
-		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
+		$this->addressHandler = $this->getMockBuilder(\OCA\FederatedFileSharing\AddressHandler::class)
 			->disableOriginalConstructor()->getMock();
 		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
 		$this->cloudIdManager = $this->createMock(ICloudIdManager::class);

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -74,10 +74,10 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->notifications = $this->getMockBuilder('OCA\FederatedFileSharing\Notifications')
+		$this->notifications = $this->getMockBuilder(\OCA\FederatedFileSharing\Notifications::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->tokenHandler = $this->getMockBuilder('OCA\FederatedFileSharing\TokenHandler')
+		$this->tokenHandler = $this->getMockBuilder(\OCA\FederatedFileSharing\TokenHandler::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
@@ -86,11 +86,11 @@ class FederatedShareProviderTest extends \Test\TestCase {
 				return vsprintf($text, $parameters);
 			});
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
+		$this->rootFolder = $this->getMockBuilder(\OCP\Files\IRootFolder::class)->getMock();
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
 		//$this->addressHandler = new AddressHandler(\OC::$server->getURLGenerator(), $this->l);
-		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')->disableOriginalConstructor()->getMock();
+		$this->addressHandler = $this->getMockBuilder(\OCA\FederatedFileSharing\AddressHandler::class)->disableOriginalConstructor()->getMock();
 		$this->contactsManager = $this->createMock(IContactsManager::class);
 		$this->cloudIdManager = new CloudIdManager(
 			$this->contactsManager,
@@ -442,7 +442,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	 * @dataProvider dataTestUpdate
 	 */
 	public function testUpdate($owner, $sharedBy, $expirationDate): void {
-		$this->provider = $this->getMockBuilder('OCA\FederatedFileSharing\FederatedShareProvider')
+		$this->provider = $this->getMockBuilder(\OCA\FederatedFileSharing\FederatedShareProvider::class)
 			->setConstructorArgs(
 				[
 					$this->connection,

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -46,10 +46,10 @@ class NotificationsTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->jobList = $this->getMockBuilder('OCP\BackgroundJob\IJobList')->getMock();
+		$this->jobList = $this->getMockBuilder(\OCP\BackgroundJob\IJobList::class)->getMock();
 		$this->discoveryService = $this->getMockBuilder(IDiscoveryService::class)->getMock();
-		$this->httpClientService = $this->getMockBuilder('OCP\Http\Client\IClientService')->getMock();
-		$this->addressHandler = $this->getMockBuilder('OCA\FederatedFileSharing\AddressHandler')
+		$this->httpClientService = $this->getMockBuilder(\OCP\Http\Client\IClientService::class)->getMock();
+		$this->addressHandler = $this->getMockBuilder(\OCA\FederatedFileSharing\AddressHandler::class)
 			->disableOriginalConstructor()->getMock();
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->cloudFederationProviderManager = $this->createMock(ICloudFederationProviderManager::class);
@@ -76,7 +76,7 @@ class NotificationsTest extends \Test\TestCase {
 				$this->logger,
 			);
 		} else {
-			$instance = $this->getMockBuilder('OCA\FederatedFileSharing\Notifications')
+			$instance = $this->getMockBuilder(\OCA\FederatedFileSharing\Notifications::class)
 				->setConstructorArgs(
 					[
 						$this->addressHandler,
@@ -120,7 +120,7 @@ class NotificationsTest extends \Test\TestCase {
 		if ($try === 0 && $expected === false) {
 			$this->jobList->expects($this->once())->method('add')
 				->with(
-					'OCA\FederatedFileSharing\BackgroundJob\RetryJob',
+					\OCA\FederatedFileSharing\BackgroundJob\RetryJob::class,
 					[
 						'remote' => $remote,
 						'remoteId' => $id,

--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -130,7 +130,7 @@ class OCSAuthAPIController extends OCSController {
 		}
 
 		$this->jobList->add(
-			'OCA\Federation\BackgroundJob\GetSharedSecret',
+			\OCA\Federation\BackgroundJob\GetSharedSecret::class,
 			[
 				'url' => $url,
 				'token' => $token,

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -89,7 +89,7 @@ class RequestSharedSecretTest extends TestCase {
 	 */
 	public function testStart($isTrustedServer, $retainBackgroundJob): void {
 		/** @var RequestSharedSecret |MockObject $requestSharedSecret */
-		$requestSharedSecret = $this->getMockBuilder('OCA\Federation\BackgroundJob\RequestSharedSecret')
+		$requestSharedSecret = $this->getMockBuilder(\OCA\Federation\BackgroundJob\RequestSharedSecret::class)
 			->setConstructorArgs(
 				[
 					$this->httpClientService,

--- a/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
+++ b/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
@@ -91,7 +91,7 @@ class OCSAuthAPIControllerTest extends TestCase {
 
 		if ($ok) {
 			$this->jobList->expects($this->once())->method('add')
-				->with('OCA\Federation\BackgroundJob\GetSharedSecret', ['url' => $url, 'token' => $token, 'created' => $this->currentTime]);
+				->with(\OCA\Federation\BackgroundJob\GetSharedSecret::class, ['url' => $url, 'token' => $token, 'created' => $this->currentTime]);
 		} else {
 			$this->jobList->expects($this->never())->method('add');
 			$this->jobList->expects($this->never())->method('remove');
@@ -127,7 +127,7 @@ class OCSAuthAPIControllerTest extends TestCase {
 		$token = 'token';
 
 		/** @var OCSAuthAPIController | \PHPUnit\Framework\MockObject\MockObject $ocsAuthApi */
-		$ocsAuthApi = $this->getMockBuilder('OCA\Federation\Controller\OCSAuthAPIController')
+		$ocsAuthApi = $this->getMockBuilder(\OCA\Federation\Controller\OCSAuthAPIController::class)
 			->setConstructorArgs(
 				[
 					'federation',

--- a/apps/federation/tests/DAV/FedAuthTest.php
+++ b/apps/federation/tests/DAV/FedAuthTest.php
@@ -22,7 +22,7 @@ class FedAuthTest extends TestCase {
 	 */
 	public function testFedAuth($expected, $user, $password): void {
 		/** @var DbHandler | \PHPUnit\Framework\MockObject\MockObject $db */
-		$db = $this->getMockBuilder('OCA\Federation\DbHandler')->disableOriginalConstructor()->getMock();
+		$db = $this->getMockBuilder(\OCA\Federation\DbHandler::class)->disableOriginalConstructor()->getMock();
 		$db->method('auth')->willReturn(true);
 		$auth = new FedAuth($db);
 		$result = $this->invokePrivate($auth, 'validateUserPass', [$user, $password]);

--- a/apps/federation/tests/Settings/AdminTest.php
+++ b/apps/federation/tests/Settings/AdminTest.php
@@ -19,7 +19,7 @@ class AdminTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->trustedServers = $this->getMockBuilder('\OCA\Federation\TrustedServers')->disableOriginalConstructor()->getMock();
+		$this->trustedServers = $this->getMockBuilder(\OCA\Federation\TrustedServers::class)->disableOriginalConstructor()->getMock();
 		$this->admin = new Admin(
 			$this->trustedServers,
 			$this->createMock(IL10N::class)

--- a/apps/federation/tests/SyncFederationAddressbooksTest.php
+++ b/apps/federation/tests/SyncFederationAddressbooksTest.php
@@ -35,7 +35,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 	public function testSync(): void {
 		/** @var DbHandler | MockObject $dbHandler */
-		$dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+		$dbHandler = $this->getMockBuilder(\OCA\Federation\DbHandler::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$dbHandler->method('getAllServer')
@@ -49,7 +49,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 			]);
 		$dbHandler->expects($this->once())->method('setServerStatus')->
 			with('https://cloud.drop.box', 1, '1');
-		$syncService = $this->getMockBuilder('OCA\DAV\CardDAV\SyncService')
+		$syncService = $this->getMockBuilder(\OCA\DAV\CardDAV\SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$syncService->expects($this->once())->method('syncRemoteAddressBook')
@@ -65,7 +65,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 	public function testException(): void {
 		/** @var DbHandler | MockObject $dbHandler */
-		$dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')->
+		$dbHandler = $this->getMockBuilder(\OCA\Federation\DbHandler::class)->
 		disableOriginalConstructor()->
 		getMock();
 		$dbHandler->method('getAllServer')->
@@ -77,7 +77,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 				'sync_token' => '0'
 			]
 		]);
-		$syncService = $this->getMockBuilder('OCA\DAV\CardDAV\SyncService')
+		$syncService = $this->getMockBuilder(\OCA\DAV\CardDAV\SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$syncService->expects($this->once())->method('syncRemoteAddressBook')
@@ -93,7 +93,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 
 	public function testSuccessfulSyncWithoutChangesAfterFailure(): void {
 		/** @var DbHandler | MockObject $dbHandler */
-		$dbHandler = $this->getMockBuilder('OCA\Federation\DbHandler')
+		$dbHandler = $this->getMockBuilder(\OCA\Federation\DbHandler::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$dbHandler->method('getAllServer')
@@ -108,7 +108,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 		$dbHandler->method('getServerStatus')->willReturn(\OCA\Federation\TrustedServers::STATUS_FAILURE);
 		$dbHandler->expects($this->once())->method('setServerStatus')->
 			with('https://cloud.drop.box', 1);
-		$syncService = $this->getMockBuilder('OCA\DAV\CardDAV\SyncService')
+		$syncService = $this->getMockBuilder(\OCA\DAV\CardDAV\SyncService::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$syncService->expects($this->once())->method('syncRemoteAddressBook')

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -84,7 +84,7 @@ class TrustedServersTest extends TestCase {
 
 	public function testAddServer(): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject|TrustedServers $trustedServers */
-		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+		$trustedServers = $this->getMockBuilder(\OCA\Federation\TrustedServers::class)
 			->setConstructorArgs(
 				[
 					$this->dbHandler,
@@ -110,7 +110,7 @@ class TrustedServersTest extends TestCase {
 			->willReturn('token');
 		$this->dbHandler->expects($this->once())->method('addToken')->with('https://url', 'token');
 		$this->jobList->expects($this->once())->method('add')
-			->with('OCA\Federation\BackgroundJob\RequestSharedSecret',
+			->with(\OCA\Federation\BackgroundJob\RequestSharedSecret::class,
 				['url' => 'https://url', 'token' => 'token', 'created' => 1234567]);
 
 		$this->assertSame(
@@ -195,7 +195,7 @@ class TrustedServersTest extends TestCase {
 		$server = 'server1';
 
 		/** @var \PHPUnit\Framework\MockObject\MockObject | TrustedServers $trustedServers */
-		$trustedServers = $this->getMockBuilder('OCA\Federation\TrustedServers')
+		$trustedServers = $this->getMockBuilder(\OCA\Federation\TrustedServers::class)
 			->setConstructorArgs(
 				[
 					$this->dbHandler,

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -147,6 +147,6 @@ class Application extends App implements IBootstrap {
 	}
 
 	private function registerHooks(): void {
-		Util::connectHook('\OCP\Config', 'js', '\OCA\Files\App', 'extendJsConfig');
+		Util::connectHook('\OCP\Config', 'js', \OCA\Files\App::class, 'extendJsConfig');
 	}
 }

--- a/apps/files/tests/BackgroundJob/ScanFilesTest.php
+++ b/apps/files/tests/BackgroundJob/ScanFilesTest.php
@@ -43,7 +43,7 @@ class ScanFilesTest extends TestCase {
 		$connection = \OC::$server->getDatabaseConnection();
 		$this->mountCache = \OC::$server->getUserMountCache();
 
-		$this->scanFiles = $this->getMockBuilder('\OCA\Files\BackgroundJob\ScanFiles')
+		$this->scanFiles = $this->getMockBuilder(\OCA\Files\BackgroundJob\ScanFiles::class)
 			->setConstructorArgs([
 				$config,
 				$dispatcher,

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -58,7 +58,7 @@ class ViewControllerTest extends TestCase {
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->userSession = $this->getMockBuilder(IUserSession::class)->getMock();
-		$this->appManager = $this->getMockBuilder('\OCP\App\IAppManager')->getMock();
+		$this->appManager = $this->getMockBuilder(\OCP\App\IAppManager::class)->getMock();
 		$this->user = $this->getMockBuilder(IUser::class)->getMock();
 		$this->user->expects($this->any())
 			->method('getUID')
@@ -66,7 +66,7 @@ class ViewControllerTest extends TestCase {
 		$this->userSession->expects($this->any())
 			->method('getUser')
 			->willReturn($this->user);
-		$this->rootFolder = $this->getMockBuilder('\OCP\Files\IRootFolder')->getMock();
+		$this->rootFolder = $this->getMockBuilder(\OCP\Files\IRootFolder::class)->getMock();
 		$this->initialState = $this->createMock(IInitialState::class);
 		$this->templateManager = $this->createMock(ITemplateManager::class);
 		$this->userConfig = $this->createMock(UserConfig::class);

--- a/apps/files_external/lib/Command/Scan.php
+++ b/apps/files_external/lib/Command/Scan.php
@@ -70,13 +70,13 @@ class Scan extends StorageAuthBase {
 		/** @var Scanner $scanner */
 		$scanner = $storage->getScanner();
 
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFile', function (string $path) use ($output): void {
+		$scanner->listen(\OC\Files\Cache\Scanner::class, 'scanFile', function (string $path) use ($output): void {
 			$output->writeln("\tFile\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->filesCounter;
 			$this->abortIfInterrupted();
 		});
 
-		$scanner->listen('\OC\Files\Cache\Scanner', 'scanFolder', function (string $path) use ($output): void {
+		$scanner->listen(\OC\Files\Cache\Scanner::class, 'scanFolder', function (string $path) use ($output): void {
 			$output->writeln("\tFolder\t<info>$path</info>", OutputInterface::VERBOSITY_VERBOSE);
 			++$this->foldersCounter;
 			$this->abortIfInterrupted();

--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -19,7 +19,7 @@ class AmazonS3 extends Backend {
 		$this
 			->setIdentifier('amazons3')
 			->addIdentifierAlias('\OC\Files\Storage\AmazonS3') // legacy compat
-			->setStorageClass('\OCA\Files_External\Lib\Storage\AmazonS3')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\AmazonS3::class)
 			->setText($l->t('Amazon S3'))
 			->addParameters([
 				new DefinitionParameter('bucket', $l->t('Bucket')),

--- a/apps/files_external/lib/Lib/Backend/FTP.php
+++ b/apps/files_external/lib/Lib/Backend/FTP.php
@@ -19,7 +19,7 @@ class FTP extends Backend {
 		$this
 			->setIdentifier('ftp')
 			->addIdentifierAlias('\OC\Files\Storage\FTP') // legacy compat
-			->setStorageClass('\OCA\Files_External\Lib\Storage\FTP')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\FTP::class)
 			->setText($l->t('FTP'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),

--- a/apps/files_external/lib/Lib/Backend/Local.php
+++ b/apps/files_external/lib/Lib/Backend/Local.php
@@ -18,8 +18,8 @@ class Local extends Backend {
 	public function __construct(IL10N $l, NullMechanism $legacyAuth) {
 		$this
 			->setIdentifier('local')
-			->addIdentifierAlias('\OC\Files\Storage\Local') // legacy compat
-			->setStorageClass('\OC\Files\Storage\Local')
+			->addIdentifierAlias(\OC\Files\Storage\Local::class) // legacy compat
+			->setStorageClass(\OC\Files\Storage\Local::class)
 			->setText($l->t('Local'))
 			->addParameters([
 				new DefinitionParameter('datadir', $l->t('Location')),

--- a/apps/files_external/lib/Lib/Backend/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Backend/OwnCloud.php
@@ -16,7 +16,7 @@ class OwnCloud extends Backend {
 		$this
 			->setIdentifier('owncloud')
 			->addIdentifierAlias('\OC\Files\Storage\OwnCloud') // legacy compat
-			->setStorageClass('\OCA\Files_External\Lib\Storage\OwnCloud')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\OwnCloud::class)
 			->setText($l->t('Nextcloud'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('URL')),

--- a/apps/files_external/lib/Lib/Backend/SFTP.php
+++ b/apps/files_external/lib/Lib/Backend/SFTP.php
@@ -16,7 +16,7 @@ class SFTP extends Backend {
 		$this
 			->setIdentifier('sftp')
 			->addIdentifierAlias('\OC\Files\Storage\SFTP') // legacy compat
-			->setStorageClass('\OCA\Files_External\Lib\Storage\SFTP')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\SFTP::class)
 			->setText($l->t('SFTP'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),

--- a/apps/files_external/lib/Lib/Backend/SFTP_Key.php
+++ b/apps/files_external/lib/Lib/Backend/SFTP_Key.php
@@ -15,7 +15,7 @@ class SFTP_Key extends Backend {
 	public function __construct(IL10N $l, RSA $legacyAuth, SFTP $sftpBackend) {
 		$this
 			->setIdentifier('\OC\Files\Storage\SFTP_Key')
-			->setStorageClass('\OCA\Files_External\Lib\Storage\SFTP')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\SFTP::class)
 			->setText($l->t('SFTP with secret key login'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -27,7 +27,7 @@ class SMB extends Backend {
 		$this
 			->setIdentifier('smb')
 			->addIdentifierAlias('\OC\Files\Storage\SMB')// legacy compat
-			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\SMB::class)
 			->setText($l->t('SMB/CIFS'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),

--- a/apps/files_external/lib/Lib/Backend/SMB_OC.php
+++ b/apps/files_external/lib/Lib/Backend/SMB_OC.php
@@ -24,7 +24,7 @@ class SMB_OC extends Backend {
 	public function __construct(IL10N $l, SessionCredentials $legacyAuth, SMB $smbBackend) {
 		$this
 			->setIdentifier('\OC\Files\Storage\SMB_OC')
-			->setStorageClass('\OCA\Files_External\Lib\Storage\SMB')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\SMB::class)
 			->setText($l->t('SMB/CIFS using OC login'))
 			->addParameters([
 				new DefinitionParameter('host', $l->t('Host')),

--- a/apps/files_external/lib/Lib/Backend/Swift.php
+++ b/apps/files_external/lib/Lib/Backend/Swift.php
@@ -20,7 +20,7 @@ class Swift extends Backend {
 		$this
 			->setIdentifier('swift')
 			->addIdentifierAlias('\OC\Files\Storage\Swift') // legacy compat
-			->setStorageClass('\OCA\Files_External\Lib\Storage\Swift')
+			->setStorageClass(\OCA\Files_External\Lib\Storage\Swift::class)
 			->setText($l->t('OpenStack Object Storage'))
 			->addParameters([
 				(new DefinitionParameter('service_name', $l->t('Service name')))

--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -38,7 +38,7 @@ class SFTPReadStream implements File {
 		if (in_array($protocol, stream_get_wrappers(), true)) {
 			return false;
 		}
-		return stream_wrapper_register($protocol, get_called_class());
+		return stream_wrapper_register($protocol, static::class);
 	}
 
 	/**

--- a/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
@@ -36,7 +36,7 @@ class SFTPWriteStream implements File {
 		if (in_array($protocol, stream_get_wrappers(), true)) {
 			return false;
 		}
-		return stream_wrapper_register($protocol, get_called_class());
+		return stream_wrapper_register($protocol, static::class);
 	}
 
 	/**

--- a/apps/files_external/tests/Backend/LegacyBackendTest.php
+++ b/apps/files_external/tests/Backend/LegacyBackendTest.php
@@ -22,11 +22,11 @@ class LegacyBackendTest extends \Test\TestCase {
 	}
 
 	public function testConstructor(): void {
-		$auth = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\Builtin')
+		$auth = $this->getMockBuilder(\OCA\Files_External\Lib\Auth\Builtin::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$class = '\OCA\Files_External\Tests\Backend\LegacyBackendTest';
+		$class = \OCA\Files_External\Tests\Backend\LegacyBackendTest::class;
 		$definition = [
 			'configuration' => [
 				'textfield' => 'Text field',
@@ -44,7 +44,7 @@ class LegacyBackendTest extends \Test\TestCase {
 
 		$backend = new LegacyBackend($class, $definition, $auth);
 
-		$this->assertEquals('\OCA\Files_External\Tests\Backend\LegacyBackendTest', $backend->getStorageClass());
+		$this->assertEquals(\OCA\Files_External\Tests\Backend\LegacyBackendTest::class, $backend->getStorageClass());
 		$this->assertEquals('Backend text', $backend->getText());
 		$this->assertEquals(123, $backend->getPriority());
 		$this->assertContains('foo/bar.js', $backend->getCustomJs());
@@ -78,11 +78,11 @@ class LegacyBackendTest extends \Test\TestCase {
 	}
 
 	public function testNoDependencies(): void {
-		$auth = $this->getMockBuilder('\OCA\Files_External\Lib\Auth\Builtin')
+		$auth = $this->getMockBuilder(\OCA\Files_External\Lib\Auth\Builtin::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$class = '\OCA\Files_External\Tests\Backend\LegacyBackendTest';
+		$class = \OCA\Files_External\Tests\Backend\LegacyBackendTest::class;
 		$definition = [
 			'configuration' => [
 			],

--- a/apps/files_external/tests/Command/CommandTest.php
+++ b/apps/files_external/tests/Command/CommandTest.php
@@ -20,7 +20,7 @@ abstract class CommandTest extends TestCase {
 	 * @return \OCA\Files_External\Service\GlobalStoragesService|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getGlobalStorageService(array $mounts = []) {
-		$mock = $this->getMockBuilder('OCA\Files_External\Service\GlobalStoragesService')
+		$mock = $this->getMockBuilder(\OCA\Files_External\Service\GlobalStoragesService::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/files_external/tests/Controller/AjaxControllerTest.php
+++ b/apps/files_external/tests/Controller/AjaxControllerTest.php
@@ -31,10 +31,10 @@ class AjaxControllerTest extends TestCase {
 
 	protected function setUp(): void {
 		$this->request = $this->createMock(IRequest::class);
-		$this->rsa = $this->getMockBuilder('\\OCA\\Files_External\\Lib\\Auth\\PublicKey\\RSA')
+		$this->rsa = $this->getMockBuilder(\OCA\Files_External\Lib\Auth\PublicKey\RSA::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->globalAuth = $this->getMockBuilder('\\OCA\\Files_External\\Lib\\Auth\\Password\GlobalAuth')
+		$this->globalAuth = $this->getMockBuilder(\OCA\Files_External\Lib\Auth\Password\GlobalAuth::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->userSession = $this->createMock(IUserSession::class);

--- a/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/GlobalStoragesControllerTest.php
@@ -21,7 +21,7 @@ class GlobalStoragesControllerTest extends StoragesControllerTest {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->service = $this->getMockBuilder('\OCA\Files_External\Service\GlobalStoragesService')
+		$this->service = $this->getMockBuilder(\OCA\Files_External\Service\GlobalStoragesService::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/files_external/tests/Controller/StoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/StoragesControllerTest.php
@@ -40,7 +40,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	/**
 	 * @return \OCA\Files_External\Lib\Backend\Backend|MockObject
 	 */
-	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OCA\Files_External\Lib\Storage\SMB') {
+	protected function getBackendMock($class = \OCA\Files_External\Lib\Backend\SMB::class, $storageClass = \OCA\Files_External\Lib\Storage\SMB::class) {
 		$backend = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -56,7 +56,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	/**
 	 * @return \OCA\Files_External\Lib\Auth\AuthMechanism|MockObject
 	 */
-	protected function getAuthMechMock($scheme = 'null', $class = '\OCA\Files_External\Lib\Auth\NullMechanism') {
+	protected function getAuthMechMock($scheme = 'null', $class = \OCA\Files_External\Lib\Auth\NullMechanism::class) {
 		$authMech = $this->getMockBuilder(AuthMechanism::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -97,8 +97,8 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 
 		$response = $this->controller->create(
 			'mount',
-			'\OCA\Files_External\Lib\Storage\SMB',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Storage\SMB::class,
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -129,7 +129,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->create(
 			'mount',
 			'local',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -169,8 +169,8 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->update(
 			1,
 			'mount',
-			'\OCA\Files_External\Lib\Storage\SMB',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Storage\SMB::class,
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -211,8 +211,8 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 
 		$response = $this->controller->create(
 			$mountPoint,
-			'\OCA\Files_External\Lib\Storage\SMB',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Storage\SMB::class,
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -225,8 +225,8 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->update(
 			1,
 			$mountPoint,
-			'\OCA\Files_External\Lib\Storage\SMB',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Storage\SMB::class,
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -249,7 +249,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->create(
 			'mount',
 			'\OC\Files\Storage\InvalidStorage',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -263,7 +263,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 			1,
 			'mount',
 			'\OC\Files\Storage\InvalidStorage',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -302,8 +302,8 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 		$response = $this->controller->update(
 			255,
 			'mount',
-			'\OCA\Files_External\Lib\Storage\SMB',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Storage\SMB::class,
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],
@@ -400,8 +400,8 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 
 		$response = $this->controller->create(
 			'mount',
-			'\OCA\Files_External\Lib\Storage\SMB',
-			'\OCA\Files_External\Lib\Auth\NullMechanism',
+			\OCA\Files_External\Lib\Storage\SMB::class,
+			\OCA\Files_External\Lib\Auth\NullMechanism::class,
 			[],
 			[],
 			[],

--- a/apps/files_external/tests/Controller/UserStoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/UserStoragesControllerTest.php
@@ -28,7 +28,7 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->service = $this->getMockBuilder('\OCA\Files_External\Service\UserStoragesService')
+		$this->service = $this->getMockBuilder(\OCA\Files_External\Service\UserStoragesService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -88,7 +88,7 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 
 		$response = $this->controller->create(
 			'mount',
-			'\OCA\Files_External\Lib\Storage\SMB',
+			\OCA\Files_External\Lib\Storage\SMB::class,
 			'\Auth\Mechanism',
 			[],
 			[],
@@ -102,7 +102,7 @@ class UserStoragesControllerTest extends StoragesControllerTest {
 		$response = $this->controller->update(
 			1,
 			'mount',
-			'\OCA\Files_External\Lib\Storage\SMB',
+			\OCA\Files_External\Lib\Storage\SMB::class,
 			'\Auth\Mechanism',
 			[],
 			[],

--- a/apps/files_external/tests/FrontendDefinitionTraitTest.php
+++ b/apps/files_external/tests/FrontendDefinitionTraitTest.php
@@ -16,7 +16,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->getMock();
 		$param->method('getName')->willReturn('foo');
 
-		$trait = $this->getMockForTrait('\OCA\Files_External\Lib\FrontendDefinitionTrait');
+		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\FrontendDefinitionTrait::class);
 		$trait->setText('test');
 		$trait->addParameters([$param]);
 		$trait->addCustomJs('foo/bar.js');
@@ -67,7 +67,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 		$storageConfig->expects($this->any())
 			->method('setBackendOption');
 
-		$trait = $this->getMockForTrait('\OCA\Files_External\Lib\FrontendDefinitionTrait');
+		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\FrontendDefinitionTrait::class);
 		$trait->setText('test');
 		$trait->addParameters($backendParams);
 
@@ -98,7 +98,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->method('setBackendOption')
 			->with('param', 'foobar');
 
-		$trait = $this->getMockForTrait('\OCA\Files_External\Lib\FrontendDefinitionTrait');
+		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\FrontendDefinitionTrait::class);
 		$trait->setText('test');
 		$trait->addParameter($param);
 

--- a/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
+++ b/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
@@ -21,10 +21,10 @@ class LegacyDependencyCheckPolyfillTest extends \Test\TestCase {
 	}
 
 	public function testCheckDependencies(): void {
-		$trait = $this->getMockForTrait('\OCA\Files_External\Lib\LegacyDependencyCheckPolyfill');
+		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\LegacyDependencyCheckPolyfill::class);
 		$trait->expects($this->once())
 			->method('getStorageClass')
-			->willReturn('\OCA\Files_External\Tests\LegacyDependencyCheckPolyfillTest');
+			->willReturn(\OCA\Files_External\Tests\LegacyDependencyCheckPolyfillTest::class);
 
 		$dependencies = $trait->checkDependencies();
 		$this->assertCount(2, $dependencies);

--- a/apps/files_external/tests/PersonalMountTest.php
+++ b/apps/files_external/tests/PersonalMountTest.php
@@ -16,11 +16,11 @@ class PersonalMountTest extends TestCase {
 	public function testFindByStorageId(): void {
 		$storageConfig = $this->createMock(StorageConfig::class);
 		/** @var \OCA\Files_External\Service\UserStoragesService $storageService */
-		$storageService = $this->getMockBuilder('\OCA\Files_External\Service\UserStoragesService')
+		$storageService = $this->getMockBuilder(\OCA\Files_External\Service\UserStoragesService::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
+		$storage = $this->getMockBuilder(\OC\Files\Storage\Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -187,7 +187,7 @@ class BackendServiceTest extends \Test\TestCase {
 		$backendNotAvailable->expects($this->once())
 			->method('checkDependencies')
 			->willReturn([
-				$this->getMockBuilder('\OCA\Files_External\Lib\MissingDependency')
+				$this->getMockBuilder(\OCA\Files_External\Lib\MissingDependency::class)
 					->disableOriginalConstructor()
 					->getMock()
 			]);

--- a/apps/files_external/tests/Service/StoragesServiceTest.php
+++ b/apps/files_external/tests/Service/StoragesServiceTest.php
@@ -98,7 +98,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 
 		// prepare BackendService mock
 		$this->backendService =
-			$this->getMockBuilder('\OCA\Files_External\Service\BackendService')
+			$this->getMockBuilder(\OCA\Files_External\Service\BackendService::class)
 				->disableOriginalConstructor()
 				->getMock();
 
@@ -123,10 +123,10 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 		$this->backendService->method('getAuthMechanisms')
 			->willReturn($authMechanisms);
 
-		$sftpBackend = $this->getBackendMock('\OCA\Files_External\Lib\Backend\SFTP', '\OCA\Files_External\Lib\Storage\SFTP');
+		$sftpBackend = $this->getBackendMock(\OCA\Files_External\Lib\Backend\SFTP::class, \OCA\Files_External\Lib\Storage\SFTP::class);
 		$backends = [
-			'identifier:\OCA\Files_External\Lib\Backend\DAV' => $this->getBackendMock('\OCA\Files_External\Lib\Backend\DAV', '\OC\Files\Storage\DAV'),
-			'identifier:\OCA\Files_External\Lib\Backend\SMB' => $this->getBackendMock('\OCA\Files_External\Lib\Backend\SMB', '\OCA\Files_External\Lib\Storage\SMB'),
+			'identifier:\OCA\Files_External\Lib\Backend\DAV' => $this->getBackendMock(\OCA\Files_External\Lib\Backend\DAV::class, '\OC\Files\Storage\DAV'),
+			'identifier:\OCA\Files_External\Lib\Backend\SMB' => $this->getBackendMock(\OCA\Files_External\Lib\Backend\SMB::class, \OCA\Files_External\Lib\Storage\SMB::class),
 			'identifier:\OCA\Files_External\Lib\Backend\SFTP' => $sftpBackend,
 			'identifier:sftp_alias' => $sftpBackend,
 		];
@@ -155,7 +155,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 		$containerMock = $this->createMock(IAppContainer::class);
 		$containerMock->method('query')
 			->willReturnCallback(function ($name) {
-				if ($name === 'OCA\Files_External\Service\BackendService') {
+				if ($name === \OCA\Files_External\Service\BackendService::class) {
 					return $this->backendService;
 				}
 			});
@@ -169,7 +169,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 		}
 	}
 
-	protected function getBackendMock($class = '\OCA\Files_External\Lib\Backend\SMB', $storageClass = '\OCA\Files_External\Lib\Storage\SMB') {
+	protected function getBackendMock($class = \OCA\Files_External\Lib\Backend\SMB::class, $storageClass = \OCA\Files_External\Lib\Storage\SMB::class) {
 		$backend = $this->getMockBuilder(Backend::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -180,7 +180,7 @@ abstract class StoragesServiceTest extends \Test\TestCase {
 		return $backend;
 	}
 
-	protected function getAuthMechMock($scheme = 'null', $class = '\OCA\Files_External\Lib\Auth\NullMechanism') {
+	protected function getAuthMechMock($scheme = 'null', $class = \OCA\Files_External\Lib\Auth\NullMechanism::class) {
 		$authMech = $this->getMockBuilder(AuthMechanism::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/files_external/tests/Service/UserStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserStoragesServiceTest.php
@@ -185,7 +185,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 
 		$newStorage = $this->globalStoragesService->addStorage($storage);
 
-		$this->assertInstanceOf('\OCA\Files_External\Lib\StorageConfig', $this->globalStoragesService->getStorage($newStorage->getId()));
+		$this->assertInstanceOf(\OCA\Files_External\Lib\StorageConfig::class, $this->globalStoragesService->getStorage($newStorage->getId()));
 
 		$this->service->getStorage($newStorage->getId());
 	}

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -226,7 +226,7 @@ class DeletedShareAPIController extends OCSController {
 			throw new QueryException();
 		}
 
-		return $this->serverContainer->get('\OCA\Talk\Share\Helper\DeletedShareAPIController');
+		return $this->serverContainer->get(\OCA\Talk\Share\Helper\DeletedShareAPIController::class);
 	}
 
 	/**

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -762,7 +762,7 @@ class ShareAPIController extends OCSController {
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
 		} elseif ($shareType === IShare::TYPE_CIRCLE) {
-			if (!\OC::$server->getAppManager()->isEnabledForUser('circles') || !class_exists('\OCA\Circles\ShareByCircleProvider')) {
+			if (!\OC::$server->getAppManager()->isEnabledForUser('circles') || !class_exists(\OCA\Circles\ShareByCircleProvider::class)) {
 				throw new OCSNotFoundException($this->l->t('You cannot share to a Team if the app is not enabled'));
 			}
 
@@ -1775,7 +1775,7 @@ class ShareAPIController extends OCSController {
 			throw new QueryException();
 		}
 
-		return $this->serverContainer->get('\OCA\Talk\Share\Helper\ShareAPIController');
+		return $this->serverContainer->get(\OCA\Talk\Share\Helper\ShareAPIController::class);
 	}
 
 	/**
@@ -1936,7 +1936,7 @@ class ShareAPIController extends OCSController {
 		}
 
 		if ($share->getShareType() === IShare::TYPE_CIRCLE && \OC::$server->getAppManager()->isEnabledForUser('circles')
-			&& class_exists('\OCA\Circles\Api\v1\Circles')) {
+			&& class_exists(\OCA\Circles\Api\v1\Circles::class)) {
 			$hasCircleId = (str_ends_with($share->getSharedWith(), ']'));
 			$shareWithStart = ($hasCircleId ? strrpos($share->getSharedWith(), '[') + 1 : 0);
 			$shareWithLength = ($hasCircleId ? -1 : strpos($share->getSharedWith(), ' '));

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -163,7 +163,7 @@ class ShareesAPIController extends OCSController {
 		}
 
 		// FIXME: DI
-		if (\OC::$server->getAppManager()->isEnabledForUser('circles') && class_exists('\OCA\Circles\ShareByCircleProvider')) {
+		if (\OC::$server->getAppManager()->isEnabledForUser('circles') && class_exists(\OCA\Circles\ShareByCircleProvider::class)) {
 			$shareTypes[] = IShare::TYPE_CIRCLE;
 		}
 
@@ -336,7 +336,7 @@ class ShareesAPIController extends OCSController {
 		}
 
 		// FIXME: DI
-		if (\OC::$server->getAppManager()->isEnabledForUser('circles') && class_exists('\OCA\Circles\ShareByCircleProvider')) {
+		if (\OC::$server->getAppManager()->isEnabledForUser('circles') && class_exists(\OCA\Circles\ShareByCircleProvider::class)) {
 			$shareTypes[] = IShare::TYPE_CIRCLE;
 		}
 

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -12,10 +12,10 @@ use OCA\Files_Sharing\AppInfo\Application;
 
 class Helper {
 	public static function registerHooks() {
-		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook');
-		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
+		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', \OCA\Files_Sharing\Updater::class, 'renameHook');
+		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', \OCA\Files_Sharing\Hooks::class, 'unshareChildren');
 
-		\OCP\Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');
+		\OCP\Util::connectHook('OC_User', 'post_deleteUser', \OCA\Files_Sharing\Hooks::class, 'deleteUser');
 	}
 
 	/**

--- a/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
@@ -27,7 +27,7 @@ class LoadAdditionalListener implements IEventListener {
 		Util::addStyle(Application::APP_ID, 'icons');
 
 		$shareManager = \OC::$server->get(IManager::class);
-		if ($shareManager->shareApiEnabled() && class_exists('\OCA\Files\App')) {
+		if ($shareManager->shareApiEnabled() && class_exists(\OCA\Files\App::class)) {
 			Util::addInitScript(Application::APP_ID, 'init');
 		}
 	}

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -80,7 +80,7 @@ class MountProvider implements IMountProvider {
 					$ownerViews[$owner] = new View('/' . $parentShare->getShareOwner() . '/files');
 				}
 				$mount = new SharedMount(
-					'\OCA\Files_Sharing\SharedStorage',
+					\OCA\Files_Sharing\SharedStorage::class,
 					$mounts,
 					[
 						'user' => $user->getUID(),

--- a/apps/files_sharing/lib/Scanner.php
+++ b/apps/files_sharing/lib/Scanner.php
@@ -42,7 +42,7 @@ class Scanner extends \OC\Files\Cache\Scanner {
 		if ($this->sourceScanner) {
 			return $this->sourceScanner;
 		}
-		if ($this->storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage')) {
+		if ($this->storage->instanceOfStorage(\OCA\Files_Sharing\SharedStorage::class)) {
 			/** @var \OC\Files\Storage\Storage $storage */
 			[$storage] = $this->storage->resolvePath('');
 			$this->sourceScanner = $storage->getScanner();

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -203,13 +203,13 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 	 * @inheritdoc
 	 */
 	public function instanceOfStorage($class): bool {
-		if ($class === '\OC\Files\Storage\Common' || $class == Common::class) {
+		if ($class === \OC\Files\Storage\Common::class || $class == Common::class) {
 			return true;
 		}
 		if (in_array($class, [
 			'\OC\Files\Storage\Home',
 			'\OC\Files\ObjectStore\HomeObjectStoreStorage',
-			'\OCP\Files\IHomeStorage',
+			\OCP\Files\IHomeStorage::class,
 			Home::class,
 			HomeObjectStoreStorage::class,
 			IHomeStorage::class

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1264,7 +1264,7 @@ class ApiTest extends TestCase {
 		$this->shareManager->deleteShare($share);
 
 		\OC_Hook::clear('OC_Filesystem', 'post_initMountPoints');
-		\OC_Hook::clear('\OCA\Files_Sharing\Tests\ApiTest', 'initTestMountPointsHook');
+		\OC_Hook::clear(\OCA\Files_Sharing\Tests\ApiTest::class, 'initTestMountPointsHook');
 	}
 
 	public function datesProvider() {

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -521,7 +521,7 @@ class ShareAPIControllerTest extends TestCase {
 	public function dataGetShare() {
 		$data = [];
 
-		$cache = $this->getMockBuilder('OC\Files\Cache\Cache')
+		$cache = $this->getMockBuilder(\OC\Files\Cache\Cache::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$cache->method('getNumericStorageId')->willReturn(101);
@@ -537,7 +537,7 @@ class ShareAPIControllerTest extends TestCase {
 		$mountPoint = $this->createMock(IMountPoint::class);
 		$mountPoint->method('getMountType')->willReturn('');
 
-		$file = $this->getMockBuilder('OCP\Files\File')->getMock();
+		$file = $this->getMockBuilder(\OCP\Files\File::class)->getMock();
 		$file->method('getId')->willReturn(1);
 		$file->method('getPath')->willReturn('file');
 		$file->method('getStorage')->willReturn($storage);
@@ -1588,7 +1588,7 @@ class ShareAPIControllerTest extends TestCase {
 				->with('spreed')
 				->willReturn(true);
 
-			$helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
+			$helper = $this->getMockBuilder(\OCA\Talk\Share\Helper\ShareAPIController::class)
 				->setMethods(['canAccessShare'])
 				->getMock();
 			$helper->method('canAccessShare')
@@ -1596,7 +1596,7 @@ class ShareAPIControllerTest extends TestCase {
 				->willReturn($canAccessShareByHelper);
 
 			$this->serverContainer->method('get')
-				->with('\OCA\Talk\Share\Helper\ShareAPIController')
+				->with(\OCA\Talk\Share\Helper\ShareAPIController::class)
 				->willReturn($helper);
 		}
 
@@ -1939,8 +1939,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -1963,8 +1963,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -1988,8 +1988,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -2012,8 +2012,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -2051,8 +2051,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -2090,8 +2090,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -2136,8 +2136,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$path->method('getPath')->willReturn('valid-path');
@@ -2175,8 +2175,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -2221,8 +2221,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$path->method('getStorage')->willReturn($storage);
 		$this->rootFolder->method('getUserFolder')->with($this->currentUser)->willReturnSelf();
@@ -2404,7 +2404,7 @@ class ShareAPIControllerTest extends TestCase {
 			->with('spreed')
 			->willReturn(true);
 
-		$helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
+		$helper = $this->getMockBuilder(\OCA\Talk\Share\Helper\ShareAPIController::class)
 			->setMethods(['createShare'])
 			->getMock();
 		$helper->method('createShare')
@@ -2427,7 +2427,7 @@ class ShareAPIControllerTest extends TestCase {
 			);
 
 		$this->serverContainer->method('get')
-			->with('\OCA\Talk\Share\Helper\ShareAPIController')
+			->with(\OCA\Talk\Share\Helper\ShareAPIController::class)
 			->willReturn($helper);
 
 		$this->shareManager->method('createShare')
@@ -2520,7 +2520,7 @@ class ShareAPIControllerTest extends TestCase {
 			->with('spreed')
 			->willReturn(true);
 
-		$helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
+		$helper = $this->getMockBuilder(\OCA\Talk\Share\Helper\ShareAPIController::class)
 			->setMethods(['createShare'])
 			->getMock();
 		$helper->method('createShare')
@@ -2538,7 +2538,7 @@ class ShareAPIControllerTest extends TestCase {
 			);
 
 		$this->serverContainer->method('get')
-			->with('\OCA\Talk\Share\Helper\ShareAPIController')
+			->with(\OCA\Talk\Share\Helper\ShareAPIController::class)
 			->willReturn($helper);
 
 		$this->shareManager->expects($this->never())->method('createShare');
@@ -2590,8 +2590,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', true],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, true],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$userFolder->method('getStorage')->willReturn($storage);
 		$path->method('getStorage')->willReturn($storage);
@@ -3779,7 +3779,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getMTime')->willReturn(1234567890);
 		$fileWithPreview->method('getMTime')->willReturn(1234567890);
 
-		$cache = $this->getMockBuilder('OCP\Files\Cache\ICache')->getMock();
+		$cache = $this->getMockBuilder(\OCP\Files\Cache\ICache::class)->getMock();
 		$cache->method('getNumericStorageId')->willReturn(100);
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('getId')->willReturn('storageId');
@@ -4792,7 +4792,7 @@ class ShareAPIControllerTest extends TestCase {
 		$mountPoint->method('getMountType')->willReturn('');
 		$file->method('getMountPoint')->willReturn($mountPoint);
 
-		$cache = $this->getMockBuilder('OCP\Files\Cache\ICache')->getMock();
+		$cache = $this->getMockBuilder(\OCP\Files\Cache\ICache::class)->getMock();
 		$cache->method('getNumericStorageId')->willReturn(100);
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('getId')->willReturn('storageId');
@@ -4941,7 +4941,7 @@ class ShareAPIControllerTest extends TestCase {
 				->with('spreed')
 				->willReturn(true);
 
-			$helper = $this->getMockBuilder('\OCA\Talk\Share\Helper\ShareAPIController')
+			$helper = $this->getMockBuilder(\OCA\Talk\Share\Helper\ShareAPIController::class)
 				->setMethods(['formatShare', 'canAccessShare'])
 				->getMock();
 			$helper->method('formatShare')
@@ -4952,7 +4952,7 @@ class ShareAPIControllerTest extends TestCase {
 				->willReturn(true);
 
 			$this->serverContainer->method('get')
-				->with('\OCA\Talk\Share\Helper\ShareAPIController')
+				->with(\OCA\Talk\Share\Helper\ShareAPIController::class)
 				->willReturn($helper);
 		}
 
@@ -4966,8 +4966,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$userFolder->method('getStorage')->willReturn($storage);
 		$node->method('getStorage')->willReturn($storage);
@@ -4981,8 +4981,8 @@ class ShareAPIControllerTest extends TestCase {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('instanceOfStorage')
 			->willReturnMap([
-				['OCA\Files_Sharing\External\Storage', false],
-				['OCA\Files_Sharing\SharedStorage', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
+				[\OCA\Files_Sharing\SharedStorage::class, false],
 			]);
 		$userFolder->method('getStorage')->willReturn($storage);
 		$node->method('getStorage')->willReturn($storage);

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -625,7 +625,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$owner->method('getDisplayName')->willReturn('ownerDisplay');
 		$owner->method('getUID')->willReturn('ownerUID');
 
-		$file = $this->getMockBuilder('OCP\Files\File')->getMock();
+		$file = $this->getMockBuilder(\OCP\Files\File::class)->getMock();
 		$file->method('getName')->willReturn($filename);
 		$file->method('getMimetype')->willReturn('text/plain');
 		$file->method('getSize')->willReturn(33);

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -350,7 +350,7 @@ class ShareesAPIControllerTest extends TestCase {
 		$urlGenerator = $this->createMock(IURLGenerator::class);
 
 		/** @var MockObject|ShareesAPIController $sharees */
-		$sharees = $this->getMockBuilder('\OCA\Files_Sharing\Controller\ShareesAPIController')
+		$sharees = $this->getMockBuilder(\OCA\Files_Sharing\Controller\ShareesAPIController::class)
 			->setConstructorArgs([
 				'files_sharing',
 				$request,

--- a/apps/files_sharing/tests/EncryptedSizePropagationTest.php
+++ b/apps/files_sharing/tests/EncryptedSizePropagationTest.php
@@ -18,7 +18,7 @@ class EncryptedSizePropagationTest extends SizePropagationTest {
 	protected function setupUser($name, $password = '') {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->registerMount($name, \OC\Files\Storage\Local::class, '/' . $name, ['datadir' => $tmpFolder]);
 		$this->config->setAppValue('encryption', 'useMasterKey', '0');
 		$this->setupForUser($name, $password);
 		$this->loginWithEncryption($name);

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -59,7 +59,7 @@ class CacheTest extends TestCase {
 		);
 		$this->remoteUser = $this->getUniqueID('remoteuser');
 
-		$this->storage = $this->getMockBuilder('\OCA\Files_Sharing\External\Storage')
+		$this->storage = $this->getMockBuilder(\OCA\Files_Sharing\External\Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->storage

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -252,7 +252,7 @@ class ManagerTest extends TestCase {
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
 
 		if (!$isGroup) {
-			$client = $this->getMockBuilder('OCP\Http\Client\IClient')
+			$client = $this->getMockBuilder(\OCP\Http\Client\IClient::class)
 				->disableOriginalConstructor()->getMock();
 			$this->clientService->expects($this->at(0))
 				->method('newClient')
@@ -308,7 +308,7 @@ class ManagerTest extends TestCase {
 		$this->assertNotMount('{{TemporaryMountPointName#' . $shareData1['name'] . '}}-1');
 
 		if (!$isGroup) {
-			$client = $this->getMockBuilder('OCP\Http\Client\IClient')
+			$client = $this->getMockBuilder(\OCP\Http\Client\IClient::class)
 				->disableOriginalConstructor()->getMock();
 			$this->clientService->expects($this->at(0))
 				->method('newClient')
@@ -364,9 +364,9 @@ class ManagerTest extends TestCase {
 			// no http requests here
 			$this->manager->removeGroupShares('group1');
 		} else {
-			$client1 = $this->getMockBuilder('OCP\Http\Client\IClient')
+			$client1 = $this->getMockBuilder(\OCP\Http\Client\IClient::class)
 				->disableOriginalConstructor()->getMock();
-			$client2 = $this->getMockBuilder('OCP\Http\Client\IClient')
+			$client2 = $this->getMockBuilder(\OCP\Http\Client\IClient::class)
 				->disableOriginalConstructor()->getMock();
 			$this->clientService->expects($this->exactly(2))
 				->method('newClient')
@@ -728,18 +728,18 @@ class ManagerTest extends TestCase {
 	private function assertMount($mountPoint) {
 		$mountPoint = rtrim($mountPoint, '/');
 		$mount = $this->mountManager->find($this->getFullPath($mountPoint));
-		$this->assertInstanceOf('\OCA\Files_Sharing\External\Mount', $mount);
-		$this->assertInstanceOf('\OCP\Files\Mount\IMountPoint', $mount);
+		$this->assertInstanceOf(\OCA\Files_Sharing\External\Mount::class, $mount);
+		$this->assertInstanceOf(\OCP\Files\Mount\IMountPoint::class, $mount);
 		$this->assertEquals($this->getFullPath($mountPoint), rtrim($mount->getMountPoint(), '/'));
 		$storage = $mount->getStorage();
-		$this->assertInstanceOf('\OCA\Files_Sharing\External\Storage', $storage);
+		$this->assertInstanceOf(\OCA\Files_Sharing\External\Storage::class, $storage);
 	}
 
 	private function assertNotMount($mountPoint) {
 		$mountPoint = rtrim($mountPoint, '/');
 		try {
 			$mount = $this->mountManager->find($this->getFullPath($mountPoint));
-			$this->assertInstanceOf('\OCP\Files\Mount\IMountPoint', $mount);
+			$this->assertInstanceOf(\OCP\Files\Mount\IMountPoint::class, $mount);
 			$this->assertNotEquals($this->getFullPath($mountPoint), rtrim($mount->getMountPoint(), '/'));
 		} catch (NotFoundException $e) {
 

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -22,10 +22,10 @@ class ScannerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->storage = $this->getMockBuilder('\OCA\Files_Sharing\External\Storage')
+		$this->storage = $this->getMockBuilder(\OCA\Files_Sharing\External\Storage::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->cache = $this->getMockBuilder('\OC\Files\Cache\Cache')
+		$this->cache = $this->getMockBuilder(\OC\Files\Cache\Cache::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->storage->expects($this->any())

--- a/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
@@ -114,7 +114,7 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 			$controller->expects($this->once())->method('cleanup');
 		}
 
-		$response = $this->getMockBuilder('OCP\AppFramework\Http\Response')
+		$response = $this->getMockBuilder(\OCP\AppFramework\Http\Response::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$this->middleware->afterController($controller, 'foo', $response);

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -47,7 +47,7 @@ class MountProviderTest extends \Test\TestCase {
 
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->user = $this->getMockBuilder(IUser::class)->getMock();
-		$this->loader = $this->getMockBuilder('OCP\Files\Storage\IStorageFactory')->getMock();
+		$this->loader = $this->getMockBuilder(\OCP\Files\Storage\IStorageFactory::class)->getMock();
 		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$eventDispatcher = $this->createMock(IEventDispatcher::class);
@@ -169,10 +169,10 @@ class MountProviderTest extends \Test\TestCase {
 			});
 		$mounts = $this->provider->getMountsForUser($this->user, $this->loader);
 		$this->assertCount(4, $mounts);
-		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[0]);
-		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[1]);
-		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[2]);
-		$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mounts[3]);
+		$this->assertInstanceOf(\OCA\Files_Sharing\SharedMount::class, $mounts[0]);
+		$this->assertInstanceOf(\OCA\Files_Sharing\SharedMount::class, $mounts[1]);
+		$this->assertInstanceOf(\OCA\Files_Sharing\SharedMount::class, $mounts[2]);
+		$this->assertInstanceOf(\OCA\Files_Sharing\SharedMount::class, $mounts[3]);
 		$mountedShare1 = $mounts[0]->getShare();
 		$this->assertEquals('2', $mountedShare1->getId());
 		$this->assertEquals('user2', $mountedShare1->getShareOwner());
@@ -401,7 +401,7 @@ class MountProviderTest extends \Test\TestCase {
 
 		foreach ($mounts as $index => $mount) {
 			$expectedShare = $expectedShares[$index];
-			$this->assertInstanceOf('OCA\Files_Sharing\SharedMount', $mount);
+			$this->assertInstanceOf(\OCA\Files_Sharing\SharedMount::class, $mount);
 
 			// supershare
 			$share = $mount->getShare();

--- a/apps/files_sharing/tests/PropagationTestCase.php
+++ b/apps/files_sharing/tests/PropagationTestCase.php
@@ -28,7 +28,7 @@ abstract class PropagationTestCase extends TestCase {
 		\OC_Hook::clear('OC_Filesystem', 'post_write');
 		\OC_Hook::clear('OC_Filesystem', 'post_delete');
 		\OC_Hook::clear('OC_Filesystem', 'post_rename');
-		\OC_Hook::clear('OCP\Share', 'post_update_permissions');
+		\OC_Hook::clear(\OCP\Share::class, 'post_update_permissions');
 		parent::tearDown();
 	}
 

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -417,7 +417,7 @@ class SharedStorageTest extends TestCase {
 		$this->assertTrue($view->file_exists($this->folder));
 
 		[$sharedStorage,] = $view->resolvePath($this->folder);
-		$this->assertTrue($sharedStorage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage'));
+		$this->assertTrue($sharedStorage->instanceOfStorage(\OCA\Files_Sharing\ISharedStorage::class));
 
 		$sourceStorage = new \OC\Files\Storage\Temporary([]);
 		$sourceStorage->file_put_contents('foo.txt', 'asd');
@@ -447,7 +447,7 @@ class SharedStorageTest extends TestCase {
 		$this->assertTrue($view->file_exists($this->folder));
 
 		[$sharedStorage,] = $view->resolvePath($this->folder);
-		$this->assertTrue($sharedStorage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage'));
+		$this->assertTrue($sharedStorage->instanceOfStorage(\OCA\Files_Sharing\ISharedStorage::class));
 
 		$sourceStorage = new \OC\Files\Storage\Temporary([]);
 		$sourceStorage->file_put_contents('foo.txt', 'asd');
@@ -502,7 +502,7 @@ class SharedStorageTest extends TestCase {
 		$this->assertTrue($view2->file_exists('/foo (2)'));
 
 		$mount = $view2->getMount('/foo');
-		$this->assertInstanceOf('\OCA\Files_Sharing\SharedMount', $mount);
+		$this->assertInstanceOf(\OCA\Files_Sharing\SharedMount::class, $mount);
 		/** @var \OCA\Files_Sharing\SharedStorage $storage */
 		$storage = $mount->getStorage();
 

--- a/apps/files_sharing/tests/SizePropagationTest.php
+++ b/apps/files_sharing/tests/SizePropagationTest.php
@@ -23,7 +23,7 @@ class SizePropagationTest extends TestCase {
 	protected function setupUser($name, $password = '') {
 		$this->createUser($name, $password);
 		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->registerMount($name, \OC\Files\Storage\Local::class, '/' . $name, ['datadir' => $tmpFolder]);
 		$this->loginAsUser($name);
 		return new View('/' . $name . '/files');
 	}

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -65,7 +65,7 @@ abstract class TestCase extends \Test\TestCase {
 		\OC::$server->getGroupManager()->clearBackends();
 
 		// clear share hooks
-		\OC_Hook::clear('OCP\\Share');
+		\OC_Hook::clear(\OCP\Share::class);
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
 
 		// create users

--- a/apps/files_sharing/tests/UnshareChildrenTest.php
+++ b/apps/files_sharing/tests/UnshareChildrenTest.php
@@ -25,7 +25,7 @@ class UnshareChildrenTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
+		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', \OCA\Files_Sharing\Hooks::class, 'unshareChildren');
 
 		$this->folder = self::TEST_FOLDER_NAME;
 		$this->subfolder = '/subfolder_share_api_test';

--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -256,7 +256,7 @@ class RestoreAllFiles extends Base {
 			 * That's why PSALM doesn't know the class GroupTrashItem.
 			 * @psalm-suppress RedundantCondition
 			 */
-			if ($scope === self::SCOPE_GROUPFOLDERS && $trashItemClass !== 'OCA\GroupFolders\Trash\GroupTrashItem') {
+			if ($scope === self::SCOPE_GROUPFOLDERS && $trashItemClass !== \OCA\GroupFolders\Trash\GroupTrashItem::class) {
 				$output->writeln('Skipping <info>' . $trashItem->getName() . '</info> because it is not a groupfolders trash item', OutputInterface::VERBOSITY_VERBOSE);
 				continue;
 			}

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -329,7 +329,7 @@ class Trashbin implements IEventListener {
 			if (!$result) {
 				\OC::$server->get(LoggerInterface::class)->error('trash bin database couldn\'t be updated', ['app' => 'files_trashbin']);
 			}
-			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
+			\OCP\Util::emitHook(\OCA\Files_Trashbin\Trashbin::class, 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
 				'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))]);
 
 			self::retainVersions($filename, $owner, $ownerPath, $timestamp);
@@ -505,7 +505,7 @@ class Trashbin implements IEventListener {
 			$view->chroot('/' . $user . '/files');
 			$view->touch('/' . $location . '/' . $uniqueFilename, $mtime);
 			$view->chroot($fakeRoot);
-			\OCP\Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', ['filePath' => $targetPath, 'trashPath' => $sourcePath]);
+			\OCP\Util::emitHook(\OCA\Files_Trashbin\Trashbin::class, 'post_restore', ['filePath' => $targetPath, 'trashPath' => $sourcePath]);
 
 			$sourceNode = self::getNodeForPath($sourcePath);
 			$targetNode = self::getNodeForPath($targetPath);

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -45,7 +45,7 @@ class CleanUpTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')
+		$this->rootFolder = $this->getMockBuilder(\OCP\Files\IRootFolder::class)
 			->disableOriginalConstructor()->getMock();
 		$this->userManager = $this->getMockBuilder('OC\User\Manager')
 			->disableOriginalConstructor()->getMock();
@@ -139,7 +139,7 @@ class CleanUpTest extends TestCase {
 	 */
 	public function testExecuteDeleteListOfUsers(): void {
 		$userIds = ['user1', 'user2', 'user3'];
-		$instance = $this->getMockBuilder('OCA\Files_Trashbin\Command\CleanUp')
+		$instance = $this->getMockBuilder(\OCA\Files_Trashbin\Command\CleanUp::class)
 			->setMethods(['removeDeletedFiles'])
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->dbConnection])
 			->getMock();
@@ -150,7 +150,7 @@ class CleanUpTest extends TestCase {
 			});
 		$this->userManager->expects($this->exactly(count($userIds)))
 			->method('userExists')->willReturn(true);
-		$inputInterface = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+		$inputInterface = $this->getMockBuilder(\Symfony\Component\Console\Input\InputInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$inputInterface->method('getArgument')
 			->with('user_id')
@@ -160,7 +160,7 @@ class CleanUpTest extends TestCase {
 				['all-users', false],
 				['verbose', false],
 			]);
-		$outputInterface = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+		$outputInterface = $this->getMockBuilder(\Symfony\Component\Console\Output\OutputInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$this->invokePrivate($instance, 'execute', [$inputInterface, $outputInterface]);
 	}
@@ -171,7 +171,7 @@ class CleanUpTest extends TestCase {
 	public function testExecuteAllUsers(): void {
 		$userIds = [];
 		$backendUsers = ['user1', 'user2'];
-		$instance = $this->getMockBuilder('OCA\Files_Trashbin\Command\CleanUp')
+		$instance = $this->getMockBuilder(\OCA\Files_Trashbin\Command\CleanUp::class)
 			->setMethods(['removeDeletedFiles'])
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->dbConnection])
 			->getMock();

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -503,7 +503,7 @@ class StorageTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\Storage\Temporary | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		$storage = $this->getMockBuilder(\OC\Files\Storage\Temporary::class)
 			->setConstructorArgs([[]])
 			->setMethods(['rename', 'unlink', 'moveFromStorage'])
 			->getMock();
@@ -540,7 +540,7 @@ class StorageTest extends \Test\TestCase {
 		/**
 		 * @var \OC\Files\Storage\Temporary | \PHPUnit\Framework\MockObject\MockObject $storage
 		 */
-		$storage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		$storage = $this->getMockBuilder(\OC\Files\Storage\Temporary::class)
 			->setConstructorArgs([[]])
 			->setMethods(['rename', 'unlink', 'rmdir'])
 			->getMock();
@@ -574,7 +574,7 @@ class StorageTest extends \Test\TestCase {
 		$fileID = 1;
 		$cache = $this->createMock(ICache::class);
 		$cache->expects($this->any())->method('getId')->willReturn($fileID);
-		$tmpStorage = $this->getMockBuilder('\OC\Files\Storage\Temporary')
+		$tmpStorage = $this->getMockBuilder(\OC\Files\Storage\Temporary::class)
 			->disableOriginalConstructor()->getMock($cache);
 		$tmpStorage->expects($this->any())->method('getCache')->willReturn($cache);
 		$userManager = $this->getMockBuilder(IUserManager::class)

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -45,7 +45,7 @@ class TrashbinTest extends \Test\TestCase {
 		\OC_User::useBackend('database');
 
 		// clear share hooks
-		\OC_Hook::clear('OCP\\Share');
+		\OC_Hook::clear(\OCP\Share::class);
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
 
 		// init files sharing

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -414,7 +414,7 @@ class Storage {
 
 		try {
 			// TODO add a proper way of overwriting a file while maintaining file ids
-			if ($storage1->instanceOfStorage('\OC\Files\ObjectStore\ObjectStoreStorage') || $storage2->instanceOfStorage('\OC\Files\ObjectStore\ObjectStoreStorage')) {
+			if ($storage1->instanceOfStorage(\OC\Files\ObjectStore\ObjectStoreStorage::class) || $storage2->instanceOfStorage(\OC\Files\ObjectStore\ObjectStoreStorage::class)) {
 				$source = $storage1->fopen($internalPath1, 'r');
 				$target = $storage2->fopen($internalPath2, 'w');
 				[, $result] = \OC_Helper::streamCopy($source, $target);

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -38,11 +38,11 @@ class CleanupTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')
+		$this->rootFolder = $this->getMockBuilder(\OCP\Files\IRootFolder::class)
 			->disableOriginalConstructor()->getMock();
 		$this->userManager = $this->getMockBuilder('OC\User\Manager')
 			->disableOriginalConstructor()->getMock();
-		$this->versionMapper = $this->getMockBuilder('OCA\Files_Versions\Db\VersionsMapper')
+		$this->versionMapper = $this->getMockBuilder(\OCA\Files_Versions\Db\VersionsMapper::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->cleanup = new CleanUp($this->rootFolder, $this->userManager, $this->versionMapper);
@@ -105,7 +105,7 @@ class CleanupTest extends TestCase {
 	public function testExecuteDeleteListOfUsers(): void {
 		$userIds = ['user1', 'user2', 'user3'];
 
-		$instance = $this->getMockBuilder('OCA\Files_Versions\Command\CleanUp')
+		$instance = $this->getMockBuilder(\OCA\Files_Versions\Command\CleanUp::class)
 			->setMethods(['deleteVersions'])
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->versionMapper])
 			->getMock();
@@ -118,13 +118,13 @@ class CleanupTest extends TestCase {
 		$this->userManager->expects($this->exactly(count($userIds)))
 			->method('userExists')->willReturn(true);
 
-		$inputInterface = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+		$inputInterface = $this->getMockBuilder(\Symfony\Component\Console\Input\InputInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$inputInterface->expects($this->once())->method('getArgument')
 			->with('user_id')
 			->willReturn($userIds);
 
-		$outputInterface = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+		$outputInterface = $this->getMockBuilder(\Symfony\Component\Console\Output\OutputInterface::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->invokePrivate($instance, 'execute', [$inputInterface, $outputInterface]);
@@ -137,7 +137,7 @@ class CleanupTest extends TestCase {
 		$userIds = [];
 		$backendUsers = ['user1', 'user2'];
 
-		$instance = $this->getMockBuilder('OCA\Files_Versions\Command\CleanUp')
+		$instance = $this->getMockBuilder(\OCA\Files_Versions\Command\CleanUp::class)
 			->setMethods(['deleteVersions'])
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->versionMapper])
 			->getMock();
@@ -154,13 +154,13 @@ class CleanupTest extends TestCase {
 				$this->assertTrue(in_array($user, $backendUsers));
 			});
 
-		$inputInterface = $this->getMockBuilder('\Symfony\Component\Console\Input\InputInterface')
+		$inputInterface = $this->getMockBuilder(\Symfony\Component\Console\Input\InputInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$inputInterface->expects($this->once())->method('getArgument')
 			->with('user_id')
 			->willReturn($userIds);
 
-		$outputInterface = $this->getMockBuilder('\Symfony\Component\Console\Output\OutputInterface')
+		$outputInterface = $this->getMockBuilder(\Symfony\Component\Console\Output\OutputInterface::class)
 			->disableOriginalConstructor()->getMock();
 
 		$this->userManager->expects($this->once())

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -84,7 +84,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	 * @return \OCP\IGroup|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function createGroup($gid) {
-		$group = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$group = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$group
 			->method('getGID')
 			->willReturn($gid);

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -170,14 +170,14 @@ class UsersControllerTest extends TestCase {
 			->expects($this->once())
 			->method('isAdmin')
 			->willReturn(false);
-		$firstGroup = $this->getMockBuilder('OCP\IGroup')
+		$firstGroup = $this->getMockBuilder(\OCP\IGroup::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$firstGroup
 			->expects($this->once())
 			->method('getGID')
 			->willReturn('FirstGroup');
-		$secondGroup = $this->getMockBuilder('OCP\IGroup')
+		$secondGroup = $this->getMockBuilder(\OCP\IGroup::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$secondGroup
@@ -649,7 +649,7 @@ class UsersControllerTest extends TestCase {
 			->method('createUser')
 			->with('NewUser', 'PasswordOfTheNewUser')
 			->willReturn($user);
-		$group = $this->getMockBuilder('OCP\IGroup')
+		$group = $this->getMockBuilder(\OCP\IGroup::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$group
@@ -777,7 +777,7 @@ class UsersControllerTest extends TestCase {
 			->method('isAdmin')
 			->with('regularUser')
 			->willReturn(false);
-		$existingGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$existingGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->groupManager
 			->expects($this->once())
 			->method('get')
@@ -842,10 +842,10 @@ class UsersControllerTest extends TestCase {
 			->method('createUser')
 			->with('NewUser', 'PasswordOfTheNewUser')
 			->willReturn($user);
-		$existingGroup1 = $this->getMockBuilder('OCP\IGroup')
+		$existingGroup1 = $this->getMockBuilder(\OCP\IGroup::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$existingGroup2 = $this->getMockBuilder('OCP\IGroup')
+		$existingGroup2 = $this->getMockBuilder(\OCP\IGroup::class)
 			->disableOriginalConstructor()
 			->getMock();
 		$existingGroup1
@@ -2766,12 +2766,12 @@ class UsersControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getSubAdmin')
 			->willReturn($subAdminManager);
-		$group1 = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$group1 = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$group1
 			->expects($this->any())
 			->method('getGID')
 			->willReturn('Group1');
-		$group2 = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$group2 = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$group2
 			->expects($this->any())
 			->method('getGID')
@@ -3061,7 +3061,7 @@ class UsersControllerTest extends TestCase {
 		$this->expectExceptionCode(103);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -3091,7 +3091,7 @@ class UsersControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('unauthorizedUser');
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -3137,7 +3137,7 @@ class UsersControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUID')
 			->willReturn('admin');
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->once())
 			->method('getGID')
@@ -3187,7 +3187,7 @@ class UsersControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getUID')
 			->willReturn('subadmin');
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->any())
 			->method('getGID')
@@ -3238,7 +3238,7 @@ class UsersControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('subadmin');
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->any())
 			->method('getGID')
@@ -3295,7 +3295,7 @@ class UsersControllerTest extends TestCase {
 			->method('getUID')
 			->willReturn('admin');
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->userSession
 			->expects($this->once())
 			->method('getUser')
@@ -3373,7 +3373,7 @@ class UsersControllerTest extends TestCase {
 		$this->expectExceptionCode(103);
 
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->once())
 			->method('getGID')
@@ -3394,7 +3394,7 @@ class UsersControllerTest extends TestCase {
 
 	public function testAddSubAdminTwice(): void {
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -3422,7 +3422,7 @@ class UsersControllerTest extends TestCase {
 
 	public function testAddSubAdminSuccessful(): void {
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -3496,7 +3496,7 @@ class UsersControllerTest extends TestCase {
 		$this->expectExceptionCode(102);
 
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -3524,7 +3524,7 @@ class UsersControllerTest extends TestCase {
 
 	public function testRemoveSubAdminSuccessful(): void {
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$this->userManager
 			->expects($this->once())
 			->method('get')
@@ -3571,7 +3571,7 @@ class UsersControllerTest extends TestCase {
 
 	public function testGetUserSubAdminGroupsWithGroups(): void {
 		$targetUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
-		$targetGroup = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+		$targetGroup = $this->getMockBuilder(\OCP\IGroup::class)->disableOriginalConstructor()->getMock();
 		$targetGroup
 			->expects($this->once())
 			->method('getGID')

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -108,7 +108,7 @@ class UsersController extends Controller {
 		} else {
 			if ($this->appManager->isEnabledForUser('user_ldap')) {
 				$isLDAPUsed =
-					$this->groupManager->isBackendUsed('\OCA\User_LDAP\Group_Proxy');
+					$this->groupManager->isBackendUsed(\OCA\User_LDAP\Group_Proxy::class);
 				if ($isLDAPUsed) {
 					// LDAP user count can be slow, so we sort by group name here
 					$sortGroupsBy = \OC\Group\MetaData::SORT_GROUPNAME;

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -918,7 +918,7 @@ class UsersControllerTest extends \Test\TestCase {
 		if ($onlyVerificationCode === false) {
 			$this->accountManager->expects($this->once())->method('updateAccount')->with($userAccount)->willReturnArgument(1);
 			$this->jobList->expects($this->once())->method('add')
-				->with('OCA\Settings\BackgroundJobs\VerifyUserData',
+				->with(\OCA\Settings\BackgroundJobs\VerifyUserData::class,
 					[
 						'verificationCode' => $code,
 						'data' => $dataBefore[$type]['value'],

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -73,13 +73,13 @@ class ShareByMailProviderTest extends TestCase {
 			});
 		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
 		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
-		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->getMock();
+		$this->rootFolder = $this->getMockBuilder(\OCP\Files\IRootFolder::class)->getMock();
 		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
-		$this->secureRandom = $this->getMockBuilder('\OCP\Security\ISecureRandom')->getMock();
-		$this->mailer = $this->getMockBuilder('\OCP\Mail\IMailer')->getMock();
+		$this->secureRandom = $this->getMockBuilder(\OCP\Security\ISecureRandom::class)->getMock();
+		$this->mailer = $this->getMockBuilder(\OCP\Mail\IMailer::class)->getMock();
 		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
 		$this->share = $this->getMockBuilder(IShare::class)->getMock();
-		$this->activityManager = $this->getMockBuilder('OCP\Activity\IManager')->getMock();
+		$this->activityManager = $this->getMockBuilder(\OCP\Activity\IManager::class)->getMock();
 		$this->settingsManager = $this->getMockBuilder(SettingsManager::class)->disableOriginalConstructor()->getMock();
 		$this->defaults = $this->createMock(Defaults::class);
 		$this->hasher = $this->getMockBuilder(IHasher::class)->getMock();
@@ -98,7 +98,7 @@ class ShareByMailProviderTest extends TestCase {
 	 */
 	private function getInstance(array $mockedMethods = []) {
 		if (!empty($mockedMethods)) {
-			return $this->getMockBuilder('OCA\ShareByMail\ShareByMailProvider')
+			return $this->getMockBuilder(\OCA\ShareByMail\ShareByMailProvider::class)
 				->setConstructorArgs([
 					$this->config,
 					$this->connection,
@@ -621,7 +621,7 @@ class ShareByMailProviderTest extends TestCase {
 		$this->expectException(\Exception::class);
 
 		$this->share->expects($this->once())->method('getSharedWith')->willReturn('user1');
-		$node = $this->getMockBuilder('OCP\Files\Node')->getMock();
+		$node = $this->getMockBuilder(\OCP\Files\Node::class)->getMock();
 		$node->expects($this->any())->method('getName')->willReturn('fileName');
 		$this->share->expects($this->any())->method('getNode')->willReturn($node);
 
@@ -645,7 +645,7 @@ class ShareByMailProviderTest extends TestCase {
 		$this->share->expects($this->any())->method('getNote')->willReturn('Check this!');
 		$this->share->expects($this->any())->method('getMailSend')->willReturn(true);
 
-		$node = $this->getMockBuilder('OCP\Files\Node')->getMock();
+		$node = $this->getMockBuilder(\OCP\Files\Node::class)->getMock();
 		$node->expects($this->any())->method('getName')->willReturn('fileName');
 		$this->share->expects($this->any())->method('getNode')->willReturn($node);
 
@@ -878,7 +878,7 @@ class ShareByMailProviderTest extends TestCase {
 
 		$result = $instance->getShareById($id2);
 
-		$this->assertInstanceOf('OCP\Share\IShare', $result);
+		$this->assertInstanceOf(\OCP\Share\IShare::class, $result);
 	}
 
 
@@ -932,7 +932,7 @@ class ShareByMailProviderTest extends TestCase {
 
 		$this->assertTrue(is_array($result));
 		$this->assertSame(1, count($result));
-		$this->assertInstanceOf('OCP\Share\IShare', $result[0]);
+		$this->assertInstanceOf(\OCP\Share\IShare::class, $result[0]);
 	}
 
 	public function testGetShareByToken(): void {
@@ -961,7 +961,7 @@ class ShareByMailProviderTest extends TestCase {
 
 		$result = $instance->getShareByToken('token');
 
-		$this->assertInstanceOf('OCP\Share\IShare', $result);
+		$this->assertInstanceOf(\OCP\Share\IShare::class, $result);
 	}
 
 
@@ -984,7 +984,7 @@ class ShareByMailProviderTest extends TestCase {
 
 		$this->assertTrue($idMail !== $idPublic);
 
-		$this->assertInstanceOf('OCP\Share\IShare',
+		$this->assertInstanceOf(\OCP\Share\IShare::class,
 			$instance->getShareByToken('token2')
 		);
 	}

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -70,7 +70,7 @@ class IconControllerTest extends TestCase {
 	}
 
 	private function iconFileMock($filename, $data) {
-		$icon = $this->getMockBuilder('OCP\Files\File')->getMock();
+		$icon = $this->getMockBuilder(\OCP\Files\File::class)->getMock();
 		$icon->expects($this->any())->method('getContent')->willReturn($data);
 		$icon->expects($this->any())->method('getMimeType')->willReturn('image type');
 		$icon->expects($this->any())->method('getEtag')->willReturn('my etag');

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -132,7 +132,7 @@ class Application extends App implements IBootstrap {
 		\OCP\Util::connectHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',
-			'\OCA\User_LDAP\Helper',
+			\OCA\User_LDAP\Helper::class,
 			'loginName2UserName'
 		);
 	}

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -29,7 +29,7 @@ class ConnectionTest extends \Test\TestCase {
 
 		$this->ldap = $this->createMock(ILDAPWrapper::class);
 		// we use a mock here to replace the cache mechanism, due to missing DI in LDAP backend.
-		$this->connection = $this->getMockBuilder('OCA\User_LDAP\Connection')
+		$this->connection = $this->getMockBuilder(\OCA\User_LDAP\Connection::class)
 			->setMethods(['getFromCache', 'writeToCache'])
 			->setConstructorArgs([$this->ldap, '', null])
 			->getMock();

--- a/apps/user_ldap/tests/GroupLDAPPluginTest.php
+++ b/apps/user_ldap/tests/GroupLDAPPluginTest.php
@@ -20,7 +20,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 	public function testImplementsActions(): void {
 		$pluginManager = $this->getGroupPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions'])
 			->getMock();
 
@@ -28,7 +28,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 			->method('respondToActions')
 			->willReturn(GroupInterface::CREATE_GROUP);
 
-		$plugin2 = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin2 = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions'])
 			->getMock();
 
@@ -47,7 +47,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 	public function testCreateGroup(): void {
 		$pluginManager = $this->getGroupPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions', 'createGroup'])
 			->getMock();
 
@@ -77,7 +77,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 	public function testDeleteGroup(): void {
 		$pluginManager = $this->getGroupPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions', 'deleteGroup'])
 			->getMock();
 
@@ -107,7 +107,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 	public function testAddToGroup(): void {
 		$pluginManager = $this->getGroupPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions', 'addToGroup'])
 			->getMock();
 
@@ -138,7 +138,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 	public function testRemoveFromGroup(): void {
 		$pluginManager = $this->getGroupPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions', 'removeFromGroup'])
 			->getMock();
 
@@ -169,7 +169,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 	public function testCountUsersInGroup(): void {
 		$pluginManager = $this->getGroupPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions', 'countUsersInGroup'])
 			->getMock();
 
@@ -200,7 +200,7 @@ class GroupLDAPPluginTest extends \Test\TestCase {
 	public function testgetGroupDetails(): void {
 		$pluginManager = $this->getGroupPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPGroupPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPGroupPluginDummy::class)
 			->setMethods(['respondToActions', 'getGroupDetails'])
 			->getMock();
 

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -31,7 +31,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	private function getServerMock(IUserLDAP $userBackend, IGroupLDAP $groupBackend) {
-		$server = $this->getMockBuilder('OC\Server')
+		$server = $this->getMockBuilder(\OC\Server::class)
 			->setMethods(['getUserManager', 'getBackends', 'getGroupManager'])
 			->setConstructorArgs(['', new \OC\Config(\OC::$configDir)])
 			->getMock();
@@ -65,7 +65,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	private function getGroupManagerMock(IGroupLDAP $groupBackend) {
-		$groupManager = $this->getMockBuilder('OC\Group\Manager')
+		$groupManager = $this->getMockBuilder(\OC\Group\Manager::class)
 			->setMethods(['getBackends'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -76,7 +76,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	private function getDefaultGroupBackendMock() {
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -93,7 +93,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('User id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -106,7 +106,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetUserDN(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getLDAPAccess', 'username2dn'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -132,11 +132,11 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Group id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -150,12 +150,12 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetGroupDN(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getLDAPAccess', 'username2dn'])
 			->disableOriginalConstructor()
 			->getMock();
 
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists', 'getLDAPAccess', 'groupname2dn'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -178,7 +178,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetUserName(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['dn2UserName'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -194,7 +194,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testDNasBaseParameter(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods([])
 			->disableOriginalConstructor()
 			->getMock();
@@ -210,7 +210,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testSanitizeDN(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods([])
 			->disableOriginalConstructor()
 			->getMock();
@@ -230,7 +230,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('User id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -243,7 +243,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetLDAPConnection(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getNewLDAPConnection'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -266,11 +266,11 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Group id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -284,11 +284,11 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetGroupLDAPConnection(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists','getNewLDAPConnection'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -313,7 +313,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('User id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -354,7 +354,7 @@ class LDAPProviderTest extends \Test\TestCase {
 			->method('username2dn')
 			->willReturn($dn);
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getLDAPAccess', 'getConnection', 'getConfiguration'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -376,7 +376,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('User id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -410,7 +410,7 @@ class LDAPProviderTest extends \Test\TestCase {
 			->method('getConnection')
 			->willReturn($connection);
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getLDAPAccess', 'getConnection', 'getConfiguration'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -432,7 +432,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('User id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -445,7 +445,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testClearCache(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getLDAPAccess', 'getConnection', 'clearCache'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -471,10 +471,10 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Group id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -487,10 +487,10 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testClearGroupCache(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists', 'getLDAPAccess', 'getConnection', 'clearCache'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -512,7 +512,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testDnExists(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['dn2UserName'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -527,7 +527,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testFlagRecord(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods([])
 			->disableOriginalConstructor()
 			->getMock();
@@ -540,7 +540,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testUnflagRecord(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods([])
 			->disableOriginalConstructor()
 			->getMock();
@@ -557,7 +557,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('User id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -570,7 +570,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetLDAPDisplayNameField(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getLDAPAccess', 'getConnection', 'getConfiguration'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -595,7 +595,7 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('User id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -608,7 +608,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetLDAPEmailField(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->setMethods(['userExists', 'getLDAPAccess', 'getConnection', 'getConfiguration'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -633,11 +633,11 @@ class LDAPProviderTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Group id not found in LDAP');
 
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists'])
 			->disableOriginalConstructor()
 			->getMock();
@@ -651,11 +651,11 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	public function testgetLDAPGroupMemberAssoc(): void {
-		$userBackend = $this->getMockBuilder('OCA\User_LDAP\User_LDAP')
+		$userBackend = $this->getMockBuilder(\OCA\User_LDAP\User_LDAP::class)
 			->disableOriginalConstructor()
 			->getMock();
 
-		$groupBackend = $this->getMockBuilder('OCA\User_LDAP\Group_LDAP')
+		$groupBackend = $this->getMockBuilder(\OCA\User_LDAP\Group_LDAP::class)
 			->setMethods(['groupExists', 'getLDAPAccess', 'getConnection', 'getConfiguration'])
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/user_ldap/tests/UserLDAPPluginTest.php
+++ b/apps/user_ldap/tests/UserLDAPPluginTest.php
@@ -20,7 +20,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testImplementsActions(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions'])
 			->getMock();
 
@@ -28,7 +28,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 			->method('respondToActions')
 			->willReturn(Backend::CREATE_USER);
 
-		$plugin2 = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin2 = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions'])
 			->getMock();
 
@@ -47,7 +47,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testCreateUser(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'createUser'])
 			->getMock();
 
@@ -78,7 +78,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testSetPassword(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'setPassword'])
 			->getMock();
 
@@ -109,7 +109,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testGetHome(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'getHome'])
 			->getMock();
 
@@ -139,7 +139,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testGetDisplayName(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'getDisplayName'])
 			->getMock();
 
@@ -169,7 +169,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testSetDisplayName(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'setDisplayName'])
 			->getMock();
 
@@ -200,7 +200,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testCanChangeAvatar(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'canChangeAvatar'])
 			->getMock();
 
@@ -230,7 +230,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testCountUsers(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'countUsers'])
 			->getMock();
 
@@ -257,7 +257,7 @@ class UserLDAPPluginTest extends \Test\TestCase {
 	public function testDeleteUser(): void {
 		$pluginManager = $this->getUserPluginManager();
 
-		$plugin = $this->getMockBuilder('OCA\User_LDAP\Tests\LDAPUserPluginDummy')
+		$plugin = $this->getMockBuilder(\OCA\User_LDAP\Tests\LDAPUserPluginDummy::class)
 			->setMethods(['respondToActions', 'canDeleteUser','deleteUser'])
 			->getMock();
 

--- a/apps/user_ldap/tests/WizardTest.php
+++ b/apps/user_ldap/tests/WizardTest.php
@@ -41,9 +41,9 @@ class WizardTest extends TestCase {
 		static $accMethods;
 
 		if (is_null($confMethods)) {
-			$confMethods = get_class_methods('\OCA\User_LDAP\Configuration');
-			$connMethods = get_class_methods('\OCA\User_LDAP\Connection');
-			$accMethods = get_class_methods('\OCA\User_LDAP\Access');
+			$confMethods = get_class_methods(\OCA\User_LDAP\Configuration::class);
+			$connMethods = get_class_methods(\OCA\User_LDAP\Connection::class);
+			$accMethods = get_class_methods(\OCA\User_LDAP\Access::class);
 		}
 		/** @var ILDAPWrapper|\PHPUnit\Framework\MockObject\MockObject $lw */
 		$lw = $this->createMock(ILDAPWrapper::class);

--- a/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
+++ b/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
@@ -18,7 +18,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 				return sprintf($string, $args);
 			});
 
-		$check = $this->getMockBuilder('OCA\WorkflowEngine\Check\AbstractStringCheck')
+		$check = $this->getMockBuilder(\OCA\WorkflowEngine\Check\AbstractStringCheck::class)
 			->setConstructorArgs([
 				$l,
 			])

--- a/apps/workflowengine/tests/Check/FileMimeTypeTest.php
+++ b/apps/workflowengine/tests/Check/FileMimeTypeTest.php
@@ -17,7 +17,7 @@ use Test\TestCase;
 
 class TemporaryNoLocal extends Temporary {
 	public function instanceOfStorage($className) {
-		if ($className === '\OC\Files\Storage\Local') {
+		if ($className === \OC\Files\Storage\Local::class) {
 			return false;
 		} else {
 			return parent::instanceOfStorage($className);

--- a/apps/workflowengine/tests/Check/RequestTimeTest.php
+++ b/apps/workflowengine/tests/Check/RequestTimeTest.php
@@ -30,7 +30,7 @@ class RequestTimeTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->timeFactory = $this->getMockBuilder('OCP\AppFramework\Utility\ITimeFactory')
+		$this->timeFactory = $this->getMockBuilder(\OCP\AppFramework\Utility\ITimeFactory::class)
 			->getMock();
 	}
 

--- a/build/rector.php
+++ b/build/rector.php
@@ -28,8 +28,7 @@ $config = RectorConfig::configure()
 		$nextcloudDir . '/apps/*/composer/*',
 		$nextcloudDir . '/apps/*/config/*',
 	])
-	// uncomment to reach your current PHP version
-	// ->withPhpSets()
+	->withPhpSets(php55: true)
 	->withTypeCoverageLevel(0);
 
 


### PR DESCRIPTION
## Summary

Setting rector PHP level to 5.3 and 5.4 did not lead to any changes so we can start at 5.5 right away.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
