### PR TITLE
fix(files_sharing): Parse OCM share permissions from OCM and not OCS prop

### DIFF
--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -345,6 +345,10 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 
 	public function getPermissions($path): int {
 		$response = $this->propfind($path);
+		if ($response === false) {
+			return 0;
+		}
+
 		$ocsPermissions = $response['{http://open-collaboration-services.org/ns}share-permissions'] ?? null;
 		$ocmPermissions = $response['{http://open-cloud-mesh.org/ns}share-permissions'] ?? null;
 		$ocPermissions = $response['{http://owncloud.org/ns}permissions'] ?? null;

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -350,7 +350,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 			$permissions = (int)$response['{http://open-collaboration-services.org/ns}share-permissions'];
 		} elseif (isset($response['{http://open-cloud-mesh.org/ns}share-permissions'])) {
 			// permissions provided by the OCM API
-			$permissions = $this->ocmPermissions2ncPermissions($response['{http://open-collaboration-services.org/ns}share-permissions'], $path);
+			$permissions = $this->ocmPermissions2ncPermissions($response['{http://open-cloud-mesh.org/ns}share-permissions'], $path);
 		} elseif (isset($response['{http://owncloud.org/ns}permissions'])) {
 			return $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);
 		} else {

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -345,14 +345,17 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 
 	public function getPermissions($path): int {
 		$response = $this->propfind($path);
+		$ocsPermissions = $response['{http://open-collaboration-services.org/ns}share-permissions'] ?? null;
+		$ocmPermissions = $response['{http://open-cloud-mesh.org/ns}share-permissions'] ?? null;
+		$ocPermissions = $response['{http://owncloud.org/ns}permissions'] ?? null;
 		// old federated sharing permissions
-		if (isset($response['{http://open-collaboration-services.org/ns}share-permissions'])) {
-			$permissions = (int)$response['{http://open-collaboration-services.org/ns}share-permissions'];
-		} elseif (isset($response['{http://open-cloud-mesh.org/ns}share-permissions'])) {
+		if ($ocsPermissions !== null) {
+			$permissions = (int)$ocsPermissions;
+		} elseif ($ocmPermissions !== null) {
 			// permissions provided by the OCM API
-			$permissions = $this->ocmPermissions2ncPermissions($response['{http://open-cloud-mesh.org/ns}share-permissions'], $path);
-		} elseif (isset($response['{http://owncloud.org/ns}permissions'])) {
-			return $this->parsePermissions($response['{http://owncloud.org/ns}permissions']);
+			$permissions = $this->ocmPermissions2ncPermissions($ocmPermissions, $path);
+		} elseif ($ocPermissions !== null) {
+			return $this->parsePermissions($ocPermissions);
 		} else {
 			// use default permission if remote server doesn't provide the share permissions
 			$permissions = $this->getDefaultPermissions($path);


### PR DESCRIPTION
## Summary

Checks for OCM permissions prop, but parses them from the OCS permissions prop.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
