### PR TITLE
Auto import Nextcloud classes in rector runs

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -17,6 +17,7 @@ use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -39,7 +40,7 @@ class Files extends Action {
 				'path' => mb_substr($node->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file read: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;
@@ -59,7 +60,7 @@ class Files extends Action {
 			$source = $event->getSource();
 			$this->renamedNodes[$source->getId()] = $source;
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file rename: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;
@@ -79,7 +80,7 @@ class Files extends Action {
 				'newpath' => mb_substr($target->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file rename: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;
@@ -103,7 +104,7 @@ class Files extends Action {
 				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file create: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;
@@ -130,7 +131,7 @@ class Files extends Action {
 				'newpath' => mb_substr($event->getTarget()->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file copy: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;
@@ -153,7 +154,7 @@ class Files extends Action {
 				'path' => mb_substr($node->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file write: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;
@@ -179,7 +180,7 @@ class Files extends Action {
 				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file delete: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;

--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -56,6 +56,7 @@ use OCP\Preview\BeforePreviewFetchedEvent;
 use OCP\Share;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareDeletedEvent;
+use OCP\SystemTag\ManagerEvent;
 use OCP\User\Events\BeforeUserLoggedInEvent;
 use OCP\User\Events\BeforeUserLoggedOutEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
@@ -156,7 +157,7 @@ class Application extends App implements IBootstrap {
 
 	private function tagHooks(IAuditLogger $logger,
 		IEventDispatcher $eventDispatcher): void {
-		$eventDispatcher->addListener(\OCP\SystemTag\ManagerEvent::EVENT_CREATE, function (\OCP\SystemTag\ManagerEvent $event) use ($logger): void {
+		$eventDispatcher->addListener(ManagerEvent::EVENT_CREATE, function (ManagerEvent $event) use ($logger): void {
 			$tagActions = new TagManagement($logger);
 			$tagActions->createTag($event->getTag());
 		});

--- a/apps/admin_audit/lib/Listener/FileEventListener.php
+++ b/apps/admin_audit/lib/Listener/FileEventListener.php
@@ -15,6 +15,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotFoundException;
 use OCP\Preview\BeforePreviewFetchedEvent;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -47,7 +48,7 @@ class FileEventListener extends Action implements IEventListener {
 				array_keys($params)
 			);
 		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Exception thrown in file preview: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
 			);
 			return;

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -27,6 +27,7 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Share\Exceptions\ShareNotFound;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -276,7 +277,7 @@ class RequestHandlerController extends Controller {
 	private function mapUid($uid) {
 		// FIXME this should be a method in the user management instead
 		$this->logger->debug('shareWith before, ' . $uid, ['app' => $this->appName]);
-		\OCP\Util::emitHook(
+		Util::emitHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',
 			['uid' => &$uid]

--- a/apps/comments/tests/Unit/Notification/ListenerTest.php
+++ b/apps/comments/tests/Unit/Notification/ListenerTest.php
@@ -33,7 +33,7 @@ class ListenerTest extends TestCase {
 		parent::setUp();
 
 		$this->notificationManager = $this->createMock(\OCP\Notification\IManager::class);
-		$this->userManager = $this->createMock(\OCP\IUserManager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 
 		$this->listener = new Listener(
 			$this->notificationManager,

--- a/apps/dashboard/lib/Controller/DashboardController.php
+++ b/apps/dashboard/lib/Controller/DashboardController.php
@@ -10,11 +10,11 @@ namespace OCA\Dashboard\Controller;
 
 use OCA\Dashboard\Service\DashboardService;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\FrontpageRoute;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\FeaturePolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Dashboard\IIconWidget;
@@ -24,6 +24,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
+use OCP\Util;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class DashboardController extends Controller {
@@ -49,8 +50,8 @@ class DashboardController extends Controller {
 	#[NoAdminRequired]
 	#[FrontpageRoute(verb: 'GET', url: '/')]
 	public function index(): TemplateResponse {
-		\OCP\Util::addStyle('dashboard', 'dashboard');
-		\OCP\Util::addScript('dashboard', 'main', 'theming');
+		Util::addStyle('dashboard', 'dashboard');
+		Util::addScript('dashboard', 'main', 'theming');
 
 		$widgets = array_map(function (IWidget $widget) {
 			return [
@@ -76,7 +77,7 @@ class DashboardController extends Controller {
 		]);
 
 		// For the weather widget we should allow the geolocation
-		$featurePolicy = new Http\FeaturePolicy();
+		$featurePolicy = new FeaturePolicy();
 		$featurePolicy->addAllowedGeoLocationDomain('\'self\'');
 		$response->setFeaturePolicy($featurePolicy);
 

--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -10,6 +10,8 @@ use OC\KnownUser\KnownUserService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\CalendarRoot;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
+use OCA\DAV\CalDAV\Proxy\ProxyMapper;
+use OCA\DAV\CalDAV\Schedule\IMipPlugin;
 use OCA\DAV\CalDAV\Security\RateLimitingPlugin;
 use OCA\DAV\CalDAV\Validation\CalDavValidatePlugin;
 use OCA\DAV\Connector\LegacyDAVACL;
@@ -18,6 +20,9 @@ use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 $authBackend = new Auth(
@@ -35,7 +40,7 @@ $principalBackend = new Principal(
 	\OC::$server->getShareManager(),
 	\OC::$server->getUserSession(),
 	\OC::$server->getAppManager(),
-	\OC::$server->query(\OCA\DAV\CalDAV\Proxy\ProxyMapper::class),
+	\OC::$server->query(ProxyMapper::class),
 	\OC::$server->get(KnownUserService::class),
 	\OC::$server->getConfig(),
 	\OC::$server->getL10NFactory(),
@@ -45,8 +50,8 @@ $db = \OC::$server->getDatabaseConnection();
 $userManager = \OC::$server->getUserManager();
 $random = \OC::$server->getSecureRandom();
 $logger = \OC::$server->get(LoggerInterface::class);
-$dispatcher = \OC::$server->get(\OCP\EventDispatcher\IEventDispatcher::class);
-$config = \OC::$server->get(\OCP\IConfig::class);
+$dispatcher = \OC::$server->get(IEventDispatcher::class);
+$config = \OC::$server->get(IConfig::class);
 
 $calDavBackend = new CalDavBackend(
 	$db,
@@ -96,11 +101,11 @@ $server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
 $server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DefaultCalendarValidator::class)));
 
 if ($sendInvitations) {
-	$server->addPlugin(\OC::$server->query(\OCA\DAV\CalDAV\Schedule\IMipPlugin::class));
+	$server->addPlugin(\OC::$server->query(IMipPlugin::class));
 }
 $server->addPlugin(new ExceptionLoggerPlugin('caldav', $logger));
-$server->addPlugin(\OCP\Server::get(RateLimitingPlugin::class));
-$server->addPlugin(\OCP\Server::get(CalDavValidatePlugin::class));
+$server->addPlugin(Server::get(RateLimitingPlugin::class));
+$server->addPlugin(Server::get(CalDavValidatePlugin::class));
 
 // And off we go!
 $server->exec();

--- a/apps/dav/appinfo/v2/direct.php
+++ b/apps/dav/appinfo/v2/direct.php
@@ -6,7 +6,9 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+use OCA\DAV\Db\DirectMapper;
 use OCA\DAV\Direct\ServerFactory;
+use OCP\AppFramework\Utility\ITimeFactory;
 
 // no php execution timeout for webdav
 if (!str_contains(@ini_get('disable_functions'), 'set_time_limit')) {
@@ -25,8 +27,8 @@ $server = $serverFactory->createServer(
 	$baseuri,
 	$requestUri,
 	\OC::$server->getRootFolder(),
-	\OC::$server->query(\OCA\DAV\Db\DirectMapper::class),
-	\OC::$server->query(\OCP\AppFramework\Utility\ITimeFactory::class),
+	\OC::$server->query(DirectMapper::class),
+	\OC::$server->query(ITimeFactory::class),
 	\OC::$server->getBruteForceThrottler(),
 	\OC::$server->getRequest()
 );

--- a/apps/dav/appinfo/v2/remote.php
+++ b/apps/dav/appinfo/v2/remote.php
@@ -1,5 +1,7 @@
 <?php
 
+use OCA\DAV\Server;
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -15,5 +17,5 @@ ignore_user_abort(true);
 \OC_Util::obEnd();
 
 $request = \OC::$server->getRequest();
-$server = new \OCA\DAV\Server($request, $baseuri);
+$server = new Server($request, $baseuri);
 $server->exec();

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -19,8 +19,8 @@ use OCA\DAV\CalDAV\Reminder\NotificationProvider\EmailProvider;
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\PushProvider;
 use OCA\DAV\CalDAV\Reminder\NotificationProviderManager;
 use OCA\DAV\CalDAV\Reminder\Notifier;
-
 use OCA\DAV\Capabilities;
+
 use OCA\DAV\CardDAV\ContactsManager;
 use OCA\DAV\CardDAV\PhotoCache;
 use OCA\DAV\CardDAV\SyncService;
@@ -85,6 +85,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
 use OCP\Files\AppData\IAppDataFactory;
 use OCP\IUser;
+use OCP\Server;
 use OCP\User\Events\OutOfOfficeChangedEvent;
 use OCP\User\Events\OutOfOfficeClearedEvent;
 use OCP\User\Events\OutOfOfficeScheduledEvent;
@@ -222,7 +223,7 @@ class Application extends App implements IBootstrap {
 
 		$dispatcher->addListener(UserUpdatedEvent::class, function (UserUpdatedEvent $event) use ($container): void {
 			/** @var SyncService $syncService */
-			$syncService = \OCP\Server::get(SyncService::class);
+			$syncService = Server::get(SyncService::class);
 			$syncService->updateUser($event->getUser());
 		});
 

--- a/apps/dav/lib/BackgroundJob/EventReminderJob.php
+++ b/apps/dav/lib/BackgroundJob/EventReminderJob.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\BackgroundJob;
 
+use OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException;
+use OCA\DAV\CalDAV\Reminder\NotificationTypeDoesNotExistException;
 use OCA\DAV\CalDAV\Reminder\ReminderService;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
@@ -34,8 +36,8 @@ class EventReminderJob extends TimedJob {
 	}
 
 	/**
-	 * @throws \OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException
-	 * @throws \OCA\DAV\CalDAV\Reminder\NotificationTypeDoesNotExistException
+	 * @throws ProviderNotAvailableException
+	 * @throws NotificationTypeDoesNotExistException
 	 * @throws \OC\User\NoUserException
 	 */
 	public function run($argument):void {

--- a/apps/dav/lib/CalDAV/AppCalendar/AppCalendarPlugin.php
+++ b/apps/dav/lib/CalDAV/AppCalendar/AppCalendarPlugin.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OCA\DAV\CalDAV\AppCalendar;
 
+use OCA\DAV\CalDAV\CachedSubscriptionImpl;
+use OCA\DAV\CalDAV\CalendarImpl;
 use OCA\DAV\CalDAV\Integration\ExternalCalendar;
 use OCA\DAV\CalDAV\Integration\ICalendarProvider;
 use OCP\Calendar\IManager;
@@ -51,7 +53,7 @@ class AppCalendarPlugin implements ICalendarProvider {
 		return array_values(
 			array_filter($this->manager->getCalendarsForPrincipal($principalUri, $calendarUris), function ($c) {
 				// We must not provide a wrapper for DAV calendars
-				return ! (($c instanceof \OCA\DAV\CalDAV\CalendarImpl) || ($c instanceof \OCA\DAV\CalDAV\CachedSubscriptionImpl));
+				return ! (($c instanceof CalendarImpl) || ($c instanceof CachedSubscriptionImpl));
 			})
 		);
 	}

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3117,7 +3117,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 
 	/**
 	 * @param boolean $value
-	 * @param \OCA\DAV\CalDAV\Calendar $calendar
+	 * @param Calendar $calendar
 	 * @return string|null
 	 */
 	public function setPublishStatus($value, $calendar) {
@@ -3152,7 +3152,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	}
 
 	/**
-	 * @param \OCA\DAV\CalDAV\Calendar $calendar
+	 * @param Calendar $calendar
 	 * @return mixed
 	 */
 	public function getPublishStatus($calendar) {

--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -9,15 +9,20 @@ use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\Auth\CustomPrincipalPlugin;
 use OCA\DAV\CalDAV\Auth\PublicPrincipalPlugin;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
+use OCA\DAV\CalDAV\Publishing\PublishPlugin;
 use OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin;
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
 use OCA\DAV\Connector\Sabre\CachingTree;
 use OCA\DAV\Connector\Sabre\DavAclPlugin;
+use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
+use OCA\DAV\Connector\Sabre\LockPlugin;
+use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\DAV\RootCollection;
 use OCA\Theming\ThemingDefaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\ITip\Message;
 
@@ -30,22 +35,22 @@ class InvitationResponseServer {
 	 */
 	public function __construct(bool $public = true) {
 		$baseUri = \OC::$WEBROOT . '/remote.php/dav/';
-		$logger = \OCP\Server::get(LoggerInterface::class);
-		$dispatcher = \OCP\Server::get(IEventDispatcher::class);
+		$logger = Server::get(LoggerInterface::class);
+		$dispatcher = Server::get(IEventDispatcher::class);
 
 		$root = new RootCollection();
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
 
 		// Add maintenance plugin
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
+		$this->server->addPlugin(new MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
 
 		// Set URL explicitly due to reverse-proxy situations
 		$this->server->httpRequest->setUrl($baseUri);
 		$this->server->setBaseUri($baseUri);
 
 		$this->server->addPlugin(new BlockLegacyClientPlugin(
-			\OCP\Server::get(IConfig::class),
-			\OCP\Server::get(ThemingDefaults::class),
+			Server::get(IConfig::class),
+			Server::get(ThemingDefaults::class),
 		));
 		$this->server->addPlugin(new AnonymousOptionsPlugin());
 
@@ -60,8 +65,8 @@ class InvitationResponseServer {
 		$event = new SabrePluginAuthInitEvent($this->server);
 		$dispatcher->dispatchTyped($event);
 
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $logger));
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
+		$this->server->addPlugin(new ExceptionLoggerPlugin('webdav', $logger));
+		$this->server->addPlugin(new LockPlugin());
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 
 		// acl
@@ -78,7 +83,7 @@ class InvitationResponseServer {
 		$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
 		//$this->server->addPlugin(new \OCA\DAV\DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest()));
-		$this->server->addPlugin(new \OCA\DAV\CalDAV\Publishing\PublishPlugin(
+		$this->server->addPlugin(new PublishPlugin(
 			\OC::$server->getConfig(),
 			\OC::$server->getURLGenerator()
 		));

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -17,6 +17,7 @@ use OCP\L10N\IFactory as L10NFactory;
 use OCP\Mail\Headers\AutoSubmitted;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject;
 use Sabre\VObject\Component\VEvent;
@@ -87,7 +88,7 @@ class EmailProvider extends AbstractProvider {
 				$lang = $fallbackLanguage;
 			}
 			$l10n = $this->getL10NForLang($lang);
-			$fromEMail = \OCP\Util::getDefaultEmailAddress('reminders-noreply');
+			$fromEMail = Util::getDefaultEmailAddress('reminders-noreply');
 
 			$template = $this->mailer->createEMailTemplate('dav.calendarReminder');
 			$template->addHeader();

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  */
 namespace OCA\DAV\CalDAV\Reminder;
 
+use OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException;
+
 /**
  * Class NotificationProviderManager
  *
@@ -42,7 +44,7 @@ class NotificationProviderManager {
 			if (isset($this->providers[$type])) {
 				return $this->providers[$type];
 			}
-			throw new NotificationProvider\ProviderNotAvailableException($type);
+			throw new ProviderNotAvailableException($type);
 		}
 		throw new NotificationTypeDoesNotExistException($type);
 	}

--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -15,6 +15,8 @@ use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IUserSession;
 use OCP\Mail\IMailer;
+use OCP\Mail\Provider\Address;
+use OCP\Mail\Provider\Attachment;
 use OCP\Mail\Provider\IManager as IMailManager;
 use OCP\Mail\Provider\IMessageSend;
 use OCP\Util;
@@ -277,15 +279,15 @@ class IMipPlugin extends SabreIMipPlugin {
 				// construct mail message and set required parameters
 				$message = $mailService->initiateMessage();
 				$message->setFrom(
-					(new \OCP\Mail\Provider\Address($sender, $fromName))
+					(new Address($sender, $fromName))
 				);
 				$message->setTo(
-					(new \OCP\Mail\Provider\Address($recipient, $recipientName))
+					(new Address($recipient, $recipientName))
 				);
 				$message->setSubject($template->renderSubject());
 				$message->setBodyPlain($template->renderText());
 				$message->setBodyHtml($template->renderHtml());
-				$message->setAttachments((new \OCP\Mail\Provider\Attachment(
+				$message->setAttachments((new Attachment(
 					$itip_msg,
 					'event.ics',
 					'text/calendar; method=' . $iTipMessage->method,

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -9,6 +9,7 @@ use DateTimeZone;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Calendar;
 use OCA\DAV\CalDAV\CalendarHome;
+use OCA\DAV\CalDAV\CalendarObject;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
@@ -163,7 +164,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 				return;
 			}
 			
-			/** @var \OCA\DAV\CalDAV\Calendar $calendarNode */
+			/** @var Calendar $calendarNode */
 			$calendarNode = $this->server->tree->getNodeForPath($calendarPath);
 			// extract addresses for owner
 			$addresses = $this->getAddressesForPrincipal($calendarNode->getOwner());
@@ -178,7 +179,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 			// determine if we are updating a calendar event
 			if (!$isNew) {
 				// retrieve current calendar event node
-				/** @var \OCA\DAV\CalDAV\CalendarObject $currentNode */
+				/** @var CalendarObject $currentNode */
 				$currentNode = $this->server->tree->getNodeForPath($request->getPath());
 				// convert calendar event string data to VCalendar object
 				/** @var \Sabre\VObject\Component\VCalendar $currentObject */
@@ -561,7 +562,7 @@ EOF;
 		$calendarTimeZone = new DateTimeZone('UTC');
 
 		$homePath = $result[0][200]['{' . self::NS_CALDAV . '}calendar-home-set']->getHref();
-		/** @var \OCA\DAV\CalDAV\Calendar $node */
+		/** @var Calendar $node */
 		foreach ($this->server->tree->getNodeForPath($homePath)->getChildren() as $node) {
 			
 			if (!$node instanceof ICalendar) {

--- a/apps/dav/lib/CalDAV/Search/SearchPlugin.php
+++ b/apps/dav/lib/CalDAV/Search/SearchPlugin.php
@@ -108,7 +108,7 @@ class SearchPlugin extends ServerPlugin {
 	 * This report is used by clients to request calendar objects based on
 	 * complex conditions.
 	 *
-	 * @param Xml\Request\CalendarSearchReport $report
+	 * @param CalendarSearchReport $report
 	 * @return void
 	 */
 	private function calendarSearch($report) {

--- a/apps/dav/lib/CardDAV/ContactsManager.php
+++ b/apps/dav/lib/CardDAV/ContactsManager.php
@@ -56,7 +56,7 @@ class ContactsManager {
 	 */
 	private function register(IManager $cm, $addressBooks, $urlGenerator) {
 		foreach ($addressBooks as $addressBookInfo) {
-			$addressBook = new \OCA\DAV\CardDAV\AddressBook($this->backend, $addressBookInfo, $this->l10n);
+			$addressBook = new AddressBook($this->backend, $addressBookInfo, $this->l10n);
 			$cm->registerAddressBook(
 				new AddressBookImpl(
 					$addressBook,

--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -10,6 +10,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\Image;
 use Psr\Log\LoggerInterface;
 use Sabre\CardDAV\Card;
 use Sabre\VObject\Document;
@@ -109,7 +110,7 @@ class PhotoCache {
 				throw new NotFoundException;
 			}
 
-			$photo = new \OCP\Image();
+			$photo = new Image();
 			/** @var ISimpleFile $file */
 			$file = $folder->getFile('photo.' . $ext);
 			$photo->loadFromData($file->getContent());

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -20,6 +20,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Server;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Sabre\CardDAV\Backend;
@@ -98,7 +99,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 						$addressBook,
 						$this->l10n,
 						$this->config,
-						\OCP\Server::get(IUserSession::class),
+						Server::get(IUserSession::class),
 						$request,
 						$trustedServers,
 						$this->groupManager

--- a/apps/dav/lib/Comments/CommentsPlugin.php
+++ b/apps/dav/lib/Comments/CommentsPlugin.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Comments;
 
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
+use OCP\Comments\MessageTooLongException;
 use OCP\IUserSession;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\Exception\NotFound;
@@ -227,9 +228,9 @@ class CommentsPlugin extends ServerPlugin {
 			return $comment;
 		} catch (\InvalidArgumentException $e) {
 			throw new BadRequest('Invalid input values', 0, $e);
-		} catch (\OCP\Comments\MessageTooLongException $e) {
+		} catch (MessageTooLongException $e) {
 			$msg = 'Message exceeds allowed character limit of ';
-			throw new BadRequest($msg . \OCP\Comments\IComment::MAX_MESSAGE_LENGTH, 0, $e);
+			throw new BadRequest($msg . IComment::MAX_MESSAGE_LENGTH, 0, $e);
 		}
 	}
 }

--- a/apps/dav/lib/Connector/LegacyPublicAuth.php
+++ b/apps/dav/lib/Connector/LegacyPublicAuth.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Connector;
 
 use OCA\DAV\Connector\Sabre\PublicAuth;
+use OCP\Defaults;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\Bruteforce\IThrottler;
@@ -40,7 +41,7 @@ class LegacyPublicAuth extends AbstractBasic {
 		$this->throttler = $throttler;
 
 		// setup realm
-		$defaults = new \OCP\Defaults();
+		$defaults = new Defaults();
 		$this->realm = $defaults->getName() ?: 'Nextcloud';
 	}
 

--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -13,6 +13,7 @@ use OC\Authentication\TwoFactorAuth\Manager;
 use OC\User\Session;
 use OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden;
 use OCA\DAV\Connector\Sabre\Exception\TooManyRequests;
+use OCP\Defaults;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\Bruteforce\IThrottler;
@@ -48,7 +49,7 @@ class Auth extends AbstractBasic {
 		$this->principalPrefix = $principalPrefix;
 
 		// setup realm
-		$defaults = new \OCP\Defaults();
+		$defaults = new Defaults();
 		$this->realm = $defaults->getName() ?: 'Nextcloud';
 	}
 

--- a/apps/dav/lib/Connector/Sabre/BearerAuth.php
+++ b/apps/dav/lib/Connector/Sabre/BearerAuth.php
@@ -5,6 +5,7 @@
  */
 namespace OCA\DAV\Connector\Sabre;
 
+use OCP\Defaults;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUserSession;
@@ -28,7 +29,7 @@ class BearerAuth extends AbstractBearer {
 		$this->principalPrefix = $principalPrefix;
 
 		// setup realm
-		$defaults = new \OCP\Defaults();
+		$defaults = new Defaults();
 		$this->realm = $defaults->getName() ?: 'Nextcloud';
 	}
 

--- a/apps/dav/lib/Connector/Sabre/Exception/FileLocked.php
+++ b/apps/dav/lib/Connector/Sabre/Exception/FileLocked.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Connector\Sabre\Exception;
 
 use Exception;
+use OCP\Files\LockNotAcquiredException;
 
 class FileLocked extends \Sabre\DAV\Exception {
 	/**
@@ -15,7 +16,7 @@ class FileLocked extends \Sabre\DAV\Exception {
 	 * @param int $code
 	 */
 	public function __construct($message = '', $code = 0, ?Exception $previous = null) {
-		if ($previous instanceof \OCP\Files\LockNotAcquiredException) {
+		if ($previous instanceof LockNotAcquiredException) {
 			$message = sprintf('Target file %s is locked by another process.', $previous->path);
 		}
 		parent::__construct($message, $code, $previous);

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -18,6 +18,7 @@ use OCA\DAV\Connector\Sabre\Exception\EntityTooLarge;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden as DAVForbiddenException;
 use OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType;
+use OCP\App\IAppManager;
 use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\Files\EntityTooLargeException;
 use OCP\Files\FileInfo;
@@ -35,6 +36,7 @@ use OCP\IRequest;
 use OCP\L10N\IFactory as IL10NFactory;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use OCP\Server;
 use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Exception;
@@ -123,7 +125,7 @@ class File extends Node implements IFile {
 		}
 		$needsPartFile = $partStorage->needsPartFile() && (strlen($this->path) > 1);
 
-		$view = \OC\Files\Filesystem::getView();
+		$view = Filesystem::getView();
 
 		if ($needsPartFile) {
 			// mark file as partial while uploading (ignored by the scanner)
@@ -402,19 +404,19 @@ class File extends Node implements IFile {
 		$run = true;
 
 		if (!$exists) {
-			\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_create, [
-				\OC\Files\Filesystem::signal_param_path => $hookPath,
-				\OC\Files\Filesystem::signal_param_run => &$run,
+			\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_create, [
+				Filesystem::signal_param_path => $hookPath,
+				Filesystem::signal_param_run => &$run,
 			]);
 		} else {
-			\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_update, [
-				\OC\Files\Filesystem::signal_param_path => $hookPath,
-				\OC\Files\Filesystem::signal_param_run => &$run,
+			\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_update, [
+				Filesystem::signal_param_path => $hookPath,
+				Filesystem::signal_param_run => &$run,
 			]);
 		}
-		\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_write, [
-			\OC\Files\Filesystem::signal_param_path => $hookPath,
-			\OC\Files\Filesystem::signal_param_run => &$run,
+		\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_write, [
+			Filesystem::signal_param_path => $hookPath,
+			Filesystem::signal_param_run => &$run,
 		]);
 		return $run;
 	}
@@ -429,16 +431,16 @@ class File extends Node implements IFile {
 			return;
 		}
 		if (!$exists) {
-			\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_create, [
-				\OC\Files\Filesystem::signal_param_path => $hookPath
+			\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_create, [
+				Filesystem::signal_param_path => $hookPath
 			]);
 		} else {
-			\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_update, [
-				\OC\Files\Filesystem::signal_param_path => $hookPath
+			\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_update, [
+				Filesystem::signal_param_path => $hookPath
 			]);
 		}
-		\OC_Hook::emit(\OC\Files\Filesystem::CLASSNAME, \OC\Files\Filesystem::signal_post_write, [
-			\OC\Files\Filesystem::signal_param_path => $hookPath
+		\OC_Hook::emit(Filesystem::CLASSNAME, Filesystem::signal_post_write, [
+			Filesystem::signal_param_path => $hookPath
 		]);
 	}
 
@@ -535,7 +537,7 @@ class File extends Node implements IFile {
 	 * @return array|bool
 	 */
 	public function getDirectDownload() {
-		if (\OCP\Server::get(\OCP\App\IAppManager::class)->isEnabledForUser('encryption')) {
+		if (Server::get(IAppManager::class)->isEnabledForUser('encryption')) {
 			return [];
 		}
 		[$storage, $internalPath] = $this->fileView->resolvePath($this->path);

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -259,7 +259,7 @@ class FilesPlugin extends ServerPlugin {
 			}
 		}
 
-		if ($node instanceof \OCA\DAV\Connector\Sabre\File) {
+		if ($node instanceof File) {
 			//Add OC-Checksum header
 			$checksum = $node->getChecksum();
 			if ($checksum !== null && $checksum !== '') {
@@ -279,7 +279,7 @@ class FilesPlugin extends ServerPlugin {
 	public function handleGetProperties(PropFind $propFind, \Sabre\DAV\INode $node) {
 		$httpRequest = $this->server->httpRequest;
 
-		if ($node instanceof \OCA\DAV\Connector\Sabre\Node) {
+		if ($node instanceof Node) {
 			/**
 			 * This was disabled, because it made dir listing throw an exception,
 			 * so users were unable to navigate into folders where one subitem
@@ -415,7 +415,7 @@ class FilesPlugin extends ServerPlugin {
 			});
 		}
 
-		if ($node instanceof \OCA\DAV\Connector\Sabre\File) {
+		if ($node instanceof File) {
 			$propFind->handle(self::DOWNLOADURL_PROPERTYNAME, function () use ($node) {
 				try {
 					$directDownloadUrl = $node->getDirectDownload();
@@ -504,7 +504,7 @@ class FilesPlugin extends ServerPlugin {
 	 */
 	public function handleUpdateProperties($path, PropPatch $propPatch) {
 		$node = $this->tree->getNodeForPath($path);
-		if (!($node instanceof \OCA\DAV\Connector\Sabre\Node)) {
+		if (!($node instanceof Node)) {
 			return;
 		}
 
@@ -670,7 +670,7 @@ class FilesPlugin extends ServerPlugin {
 			return;
 		}
 		$node = $this->server->tree->getNodeForPath($filePath);
-		if ($node instanceof \OCA\DAV\Connector\Sabre\Node) {
+		if ($node instanceof Node) {
 			$fileId = $node->getFileId();
 			if (!is_null($fileId)) {
 				$this->server->httpResponse->setHeader('OC-FileId', $fileId);

--- a/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OC\Files\View;
+use OCA\Circles\Api\v1\Circles;
 use OCP\App\IAppManager;
 use OCP\Files\Folder;
 use OCP\Files\Node as INode;
@@ -355,7 +356,7 @@ class FilesReportPlugin extends ServerPlugin {
 		if (!$this->appManager->isEnabledForUser('circles') || !class_exists('\OCA\Circles\Api\v1\Circles')) {
 			return [];
 		}
-		return \OCA\Circles\Api\v1\Circles::getFilesForCircles($circlesIds);
+		return Circles::getFilesForCircles($circlesIds);
 	}
 
 
@@ -419,7 +420,7 @@ class FilesReportPlugin extends ServerPlugin {
 		return $results;
 	}
 
-	protected function wrapNode(\OCP\Files\Node $node): File|Directory {
+	protected function wrapNode(INode $node): File|Directory {
 		if ($node instanceof \OCP\Files\File) {
 			return new File($this->fileView, $node);
 		} else {

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -12,8 +12,10 @@ use OC\Files\Node\File;
 use OC\Files\Node\Folder;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCP\Constants;
 use OCP\Files\DavUtil;
 use OCP\Files\FileInfo;
+use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\ISharedStorage;
@@ -282,15 +284,15 @@ abstract class Node implements \Sabre\DAV\INode {
 			}
 
 			if (!$mountpoint->getOption('readonly', false) && $mountpointpath === $this->info->getPath()) {
-				$permissions |= \OCP\Constants::PERMISSION_DELETE | \OCP\Constants::PERMISSION_UPDATE;
+				$permissions |= Constants::PERMISSION_DELETE | Constants::PERMISSION_UPDATE;
 			}
 		}
 
 		/*
 		 * Files can't have create or delete permissions
 		 */
-		if ($this->info->getType() === \OCP\Files\FileInfo::TYPE_FILE) {
-			$permissions &= ~(\OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE);
+		if ($this->info->getType() === FileInfo::TYPE_FILE) {
+			$permissions &= ~(Constants::PERMISSION_CREATE | Constants::PERMISSION_DELETE);
 		}
 
 		return $permissions;
@@ -358,7 +360,7 @@ abstract class Node implements \Sabre\DAV\INode {
 				dirname($path),
 				basename($path),
 			);
-		} catch (\OCP\Files\InvalidPathException $ex) {
+		} catch (InvalidPathException $ex) {
 			throw new InvalidPath($ex->getMessage());
 		}
 	}

--- a/apps/dav/lib/Connector/Sabre/ObjectTree.php
+++ b/apps/dav/lib/Connector/Sabre/ObjectTree.php
@@ -9,10 +9,13 @@ namespace OCA\DAV\Connector\Sabre;
 
 use OC\Files\FileInfo;
 use OC\Files\Storage\FailedStorage;
+use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCP\Files\ForbiddenException;
+use OCP\Files\InvalidPathException;
+use OCP\Files\Mount\IMountManager;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Lock\LockedException;
@@ -40,7 +43,7 @@ class ObjectTree extends CachingTree {
 	 * @param \OC\Files\View $view
 	 * @param \OCP\Files\Mount\IMountManager $mountManager
 	 */
-	public function init(\Sabre\DAV\INode $rootNode, \OC\Files\View $view, \OCP\Files\Mount\IMountManager $mountManager) {
+	public function init(\Sabre\DAV\INode $rootNode, View $view, IMountManager $mountManager) {
 		$this->rootNode = $rootNode;
 		$this->fileView = $view;
 		$this->mountManager = $mountManager;
@@ -70,7 +73,7 @@ class ObjectTree extends CachingTree {
 		if ($path) {
 			try {
 				$this->fileView->verifyPath($path, basename($path));
-			} catch (\OCP\Files\InvalidPathException $ex) {
+			} catch (InvalidPathException $ex) {
 				throw new InvalidPath($ex->getMessage());
 			}
 		}
@@ -120,9 +123,9 @@ class ObjectTree extends CachingTree {
 		}
 
 		if ($info->getType() === 'dir') {
-			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info, $this);
+			$node = new Directory($this->fileView, $info, $this);
 		} else {
-			$node = new \OCA\DAV\Connector\Sabre\File($this->fileView, $info);
+			$node = new File($this->fileView, $info);
 		}
 
 		$this->cache[$path] = $node;
@@ -169,7 +172,7 @@ class ObjectTree extends CachingTree {
 		[$destinationDir, $destinationName] = \Sabre\Uri\split($destinationPath);
 		try {
 			$this->fileView->verifyPath($destinationDir, $destinationName);
-		} catch (\OCP\Files\InvalidPathException $ex) {
+		} catch (InvalidPathException $ex) {
 			throw new InvalidPath($ex->getMessage());
 		}
 

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -7,6 +7,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OC\KnownUser\KnownUserService;
+use OCA\Circles\Api\v1\Circles;
 use OCA\Circles\Exceptions\CircleNotFoundException;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\Traits\PrincipalProxyTrait;
@@ -530,7 +531,7 @@ class Principal implements BackendInterface {
 		}
 
 		try {
-			$circle = \OCA\Circles\Api\v1\Circles::detailsCircle($circleUniqueId, true);
+			$circle = Circles::detailsCircle($circleUniqueId, true);
 		} catch (QueryException $ex) {
 			return null;
 		} catch (CircleNotFoundException $ex) {
@@ -570,7 +571,7 @@ class Principal implements BackendInterface {
 				throw new Exception('Principal not found');
 			}
 
-			$circles = \OCA\Circles\Api\v1\Circles::joinedCircles($name, true);
+			$circles = Circles::joinedCircles($name, true);
 
 			$circles = array_map(function ($circle) {
 				/** @var \OCA\Circles\Model\Circle $circle */

--- a/apps/dav/lib/Connector/Sabre/PublicAuth.php
+++ b/apps/dav/lib/Connector/Sabre/PublicAuth.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Connector\Sabre;
 
+use OCP\Defaults;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\Bruteforce\IThrottler;
@@ -54,7 +55,7 @@ class PublicAuth extends AbstractBasic {
 		$this->logger = $logger;
 
 		// setup realm
-		$defaults = new \OCP\Defaults();
+		$defaults = new Defaults();
 		$this->realm = $defaults->getName();
 	}
 

--- a/apps/dav/lib/Connector/Sabre/TagsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/TagsPlugin.php
@@ -27,7 +27,7 @@ namespace OCA\DAV\Connector\Sabre;
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
+use OCP\ITagManager;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\PropPatch;
 
@@ -73,7 +73,7 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @param \Sabre\DAV\Tree $tree tree
 	 * @param \OCP\ITagManager $tagManager tag manager
 	 */
-	public function __construct(\Sabre\DAV\Tree $tree, \OCP\ITagManager $tagManager) {
+	public function __construct(\Sabre\DAV\Tree $tree, ITagManager $tagManager) {
 		$this->tree = $tree;
 		$this->tagManager = $tagManager;
 		$this->tagger = null;
@@ -191,12 +191,12 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 		PropFind $propFind,
 		\Sabre\DAV\INode $node,
 	) {
-		if (!($node instanceof \OCA\DAV\Connector\Sabre\Node)) {
+		if (!($node instanceof Node)) {
 			return;
 		}
 
 		// need prefetch ?
-		if ($node instanceof \OCA\DAV\Connector\Sabre\Directory
+		if ($node instanceof Directory
 			&& $propFind->getDepth() !== 0
 			&& (!is_null($propFind->getStatus(self::TAGS_PROPERTYNAME))
 			|| !is_null($propFind->getStatus(self::FAVORITE_PROPERTYNAME))
@@ -250,7 +250,7 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 	 */
 	public function handleUpdateProperties($path, PropPatch $propPatch) {
 		$node = $this->tree->getNodeForPath($path);
-		if (!($node instanceof \OCA\DAV\Connector\Sabre\Node)) {
+		if (!($node instanceof Node)) {
 			return;
 		}
 

--- a/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
@@ -91,7 +91,7 @@ class ZipFolderPlugin extends ServerPlugin {
 	 */
 	public function handleDownload(Request $request, Response $response): ?bool {
 		$node = $this->tree->getNodeForPath($request->getPath());
-		if (!($node instanceof \OCA\DAV\Connector\Sabre\Directory)) {
+		if (!($node instanceof Directory)) {
 			// only handle directories
 			return null;
 		}

--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -13,6 +13,7 @@ use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\CachingTree;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCP\Files\Cache\ICacheEntry;
@@ -206,9 +207,9 @@ class FileSearchBackend implements ISearchBackend {
 		/** @var SearchResult[] $nodes */
 		$nodes = array_map(function (Node $node) {
 			if ($node instanceof Folder) {
-				$davNode = new \OCA\DAV\Connector\Sabre\Directory($this->view, $node, $this->tree, $this->shareManager);
+				$davNode = new Directory($this->view, $node, $this->tree, $this->shareManager);
 			} else {
-				$davNode = new \OCA\DAV\Connector\Sabre\File($this->view, $node, $this->shareManager);
+				$davNode = new File($this->view, $node, $this->shareManager);
 			}
 			$path = $this->getHrefForNode($node);
 			$this->tree->cacheNode($davNode, $path);

--- a/apps/dav/lib/Files/FilesHome.php
+++ b/apps/dav/lib/Files/FilesHome.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\DAV\Files;
 
+use OC\Files\Filesystem;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCP\Files\FileInfo;
 use Sabre\DAV\Exception\Forbidden;
@@ -26,7 +27,7 @@ class FilesHome extends Directory {
 	 */
 	public function __construct($principalInfo, FileInfo $userFolder) {
 		$this->principalInfo = $principalInfo;
-		$view = \OC\Files\Filesystem::getView();
+		$view = Filesystem::getView();
 		parent::__construct($view, $userFolder);
 	}
 

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -23,6 +23,9 @@ use OCA\DAV\Connector\Sabre\Principal;
 use OCA\DAV\DAV\GroupPrincipalBackend;
 use OCA\DAV\DAV\SystemPrincipalBackend;
 use OCA\DAV\Provisioning\Apple\AppleProvisioningNode;
+use OCA\DAV\SystemTag\SystemTagsByIdCollection;
+use OCA\DAV\SystemTag\SystemTagsInUseCollection;
+use OCA\DAV\SystemTag\SystemTagsRelationsCollection;
 use OCA\DAV\Upload\CleanupService;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
@@ -30,6 +33,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\IConfig;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\SimpleCollection;
 
@@ -46,7 +50,7 @@ class RootCollection extends SimpleCollection {
 		$dispatcher = \OC::$server->get(IEventDispatcher::class);
 		$config = \OC::$server->get(IConfig::class);
 		$proxyMapper = \OC::$server->query(ProxyMapper::class);
-		$rootFolder = \OCP\Server::get(IRootFolder::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		$userPrincipalBackend = new Principal(
 			$userManager,
@@ -101,12 +105,12 @@ class RootCollection extends SimpleCollection {
 
 		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend, $l10n, $config, $logger);
 
-		$systemTagCollection = new SystemTag\SystemTagsByIdCollection(
+		$systemTagCollection = new SystemTagsByIdCollection(
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getUserSession(),
 			$groupManager
 		);
-		$systemTagRelationsCollection = new SystemTag\SystemTagsRelationsCollection(
+		$systemTagRelationsCollection = new SystemTagsRelationsCollection(
 			\OC::$server->getSystemTagManager(),
 			\OC::$server->getSystemTagObjectMapper(),
 			\OC::$server->getUserSession(),
@@ -114,7 +118,7 @@ class RootCollection extends SimpleCollection {
 			$dispatcher,
 			$rootFolder,
 		);
-		$systemTagInUseCollection = \OCP\Server::get(SystemTag\SystemTagsInUseCollection::class);
+		$systemTagInUseCollection = Server::get(SystemTagsInUseCollection::class);
 		$commentsCollection = new Comments\RootCollection(
 			\OC::$server->getCommentsManager(),
 			$userManager,

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -6,11 +6,17 @@
  */
 namespace OCA\DAV;
 
+use OC\Files\Filesystem;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\BulkUpload\BulkUploadPlugin;
+use OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin;
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
+use OCA\DAV\CalDAV\EventComparisonService;
+use OCA\DAV\CalDAV\ICSExportPlugin\ICSExportPlugin;
+use OCA\DAV\CalDAV\Publishing\PublishPlugin;
 use OCA\DAV\CalDAV\Schedule\IMipPlugin;
+use OCA\DAV\CalDAV\Schedule\IMipService;
 use OCA\DAV\CalDAV\Security\RateLimitingPlugin;
 use OCA\DAV\CalDAV\Validation\CalDavValidatePlugin;
 use OCA\DAV\CardDAV\HasPhotoPlugin;
@@ -21,6 +27,7 @@ use OCA\DAV\CardDAV\Security\CardDavRateLimitingPlugin;
 use OCA\DAV\CardDAV\Validation\CardDavValidatePlugin;
 use OCA\DAV\Comments\CommentsPlugin;
 use OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin;
+use OCA\DAV\Connector\Sabre\AppleQuirksPlugin;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\BearerAuth;
 use OCA\DAV\Connector\Sabre\BlockLegacyClientPlugin;
@@ -30,9 +37,12 @@ use OCA\DAV\Connector\Sabre\CommentPropertiesPlugin;
 use OCA\DAV\Connector\Sabre\CopyEtagHeaderPlugin;
 use OCA\DAV\Connector\Sabre\DavAclPlugin;
 use OCA\DAV\Connector\Sabre\DummyGetResponsePlugin;
+use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Connector\Sabre\FakeLockerPlugin;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCA\DAV\Connector\Sabre\FilesReportPlugin;
+use OCA\DAV\Connector\Sabre\LockPlugin;
+use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\PropfindCompressionPlugin;
 use OCA\DAV\Connector\Sabre\QuotaPlugin;
 use OCA\DAV\Connector\Sabre\RequestIdHeaderPlugin;
@@ -45,6 +55,7 @@ use OCA\DAV\DAV\ViewOnlyPlugin;
 use OCA\DAV\Events\SabrePluginAddEvent;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\DAV\Files\ErrorPagePlugin;
+use OCA\DAV\Files\FileSearchBackend;
 use OCA\DAV\Files\LazySearchBackend;
 use OCA\DAV\Profiler\ProfilerPlugin;
 use OCA\DAV\Provisioning\Apple\AppleProvisioningPlugin;
@@ -53,6 +64,8 @@ use OCA\DAV\Upload\ChunkingPlugin;
 use OCA\DAV\Upload\ChunkingV2Plugin;
 use OCA\Theming\ThemingDefaults;
 use OCP\AppFramework\Http\Response;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Defaults;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IFilenameValidator;
@@ -62,6 +75,7 @@ use OCP\IConfig;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\IUserSession;
+use OCP\Mail\IMailer;
 use OCP\Profiler\IProfiler;
 use OCP\SabrePluginEvent;
 use Psr\Log\LoggerInterface;
@@ -94,9 +108,9 @@ class Server {
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
 
 		// Add maintenance plugin
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
+		$this->server->addPlugin(new MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
 
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\AppleQuirksPlugin());
+		$this->server->addPlugin(new AppleQuirksPlugin());
 
 		// Backends
 		$authBackend = new Auth(
@@ -144,8 +158,8 @@ class Server {
 			$this->server->addPlugin(new DummyGetResponsePlugin());
 		}
 
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $logger));
-		$this->server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
+		$this->server->addPlugin(new ExceptionLoggerPlugin('webdav', $logger));
+		$this->server->addPlugin(new LockPlugin());
 		$this->server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 
 		// acl
@@ -162,7 +176,7 @@ class Server {
 		if ($this->requestIsForSubtree(['calendars', 'public-calendars', 'system-calendars', 'principals'])) {
 			$this->server->addPlugin(new DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest(), \OC::$server->getConfig()));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
-			$this->server->addPlugin(new \OCA\DAV\CalDAV\ICSExportPlugin\ICSExportPlugin(\OC::$server->getConfig(), $logger));
+			$this->server->addPlugin(new ICSExportPlugin(\OC::$server->getConfig(), $logger));
 			$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DefaultCalendarValidator::class)));
 
 			$this->server->addPlugin(\OC::$server->get(\OCA\DAV\CalDAV\Trashbin\Plugin::class));
@@ -172,7 +186,7 @@ class Server {
 			}
 
 			$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
-			$this->server->addPlugin(new \OCA\DAV\CalDAV\Publishing\PublishPlugin(
+			$this->server->addPlugin(new PublishPlugin(
 				\OC::$server->getConfig(),
 				\OC::$server->getURLGenerator()
 			));
@@ -247,7 +261,7 @@ class Server {
 			$userSession = \OC::$server->getUserSession();
 			$user = $userSession->getUser();
 			if ($user !== null) {
-				$view = \OC\Files\Filesystem::getView();
+				$view = Filesystem::getView();
 				$config = \OCP\Server::get(IConfig::class);
 				$this->server->addPlugin(
 					new FilesPlugin(
@@ -299,14 +313,14 @@ class Server {
 				));
 				if (\OC::$server->getConfig()->getAppValue('dav', 'sendInvitations', 'yes') === 'yes') {
 					$this->server->addPlugin(new IMipPlugin(
-						\OC::$server->get(\OCP\IConfig::class),
-						\OC::$server->get(\OCP\Mail\IMailer::class),
+						\OC::$server->get(IConfig::class),
+						\OC::$server->get(IMailer::class),
 						\OC::$server->get(LoggerInterface::class),
-						\OC::$server->get(\OCP\AppFramework\Utility\ITimeFactory::class),
-						\OC::$server->get(\OCP\Defaults::class),
+						\OC::$server->get(ITimeFactory::class),
+						\OC::$server->get(Defaults::class),
 						$userSession,
-						\OC::$server->get(\OCA\DAV\CalDAV\Schedule\IMipService::class),
-						\OC::$server->get(\OCA\DAV\CalDAV\EventComparisonService::class),
+						\OC::$server->get(IMipService::class),
+						\OC::$server->get(EventComparisonService::class),
 						\OC::$server->get(\OCP\Mail\Provider\IManager::class)
 					));
 				}
@@ -323,7 +337,7 @@ class Server {
 						$userFolder,
 						\OC::$server->getAppManager()
 					));
-					$lazySearchBackend->setBackend(new \OCA\DAV\Files\FileSearchBackend(
+					$lazySearchBackend->setBackend(new FileSearchBackend(
 						$this->server->tree,
 						$user,
 						\OC::$server->getRootFolder(),
@@ -338,7 +352,7 @@ class Server {
 						)
 					);
 				}
-				$this->server->addPlugin(new \OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin(
+				$this->server->addPlugin(new EnablePlugin(
 					\OC::$server->getConfig(),
 					\OC::$server->query(BirthdayService::class),
 					$user

--- a/apps/dav/tests/unit/BackgroundJob/CleanupInvitationTokenJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/CleanupInvitationTokenJobTest.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Tests\unit\BackgroundJob;
 
 use OCA\DAV\BackgroundJob\CleanupInvitationTokenJob;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use Test\TestCase;
@@ -21,7 +22,7 @@ class CleanupInvitationTokenJobTest extends TestCase {
 	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
 	private $timeFactory;
 
-	/** @var \OCA\DAV\BackgroundJob\CleanupInvitationTokenJob */
+	/** @var CleanupInvitationTokenJob */
 	private $backgroundJob;
 
 	protected function setUp(): void {
@@ -41,7 +42,7 @@ class CleanupInvitationTokenJobTest extends TestCase {
 			->willReturn(1337);
 
 		$queryBuilder = $this->createMock(IQueryBuilder::class);
-		$expr = $this->createMock(\OCP\DB\QueryBuilder\IExpressionBuilder::class);
+		$expr = $this->createMock(IExpressionBuilder::class);
 		$stmt = $this->createMock(\Doctrine\DBAL\Driver\Statement::class);
 
 		$this->dbConnection->expects($this->once())

--- a/apps/dav/tests/unit/BackgroundJob/GenerateBirthdayCalendarBackgroundJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/GenerateBirthdayCalendarBackgroundJobTest.php
@@ -26,7 +26,7 @@ class GenerateBirthdayCalendarBackgroundJobTest extends TestCase {
 	/** @var IConfig | MockObject */
 	private $config;
 
-	/** @var \OCA\DAV\BackgroundJob\GenerateBirthdayCalendarBackgroundJob */
+	/** @var GenerateBirthdayCalendarBackgroundJob */
 	private $backgroundJob;
 
 	protected function setUp(): void {

--- a/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/BirthdayCalendar/EnablePluginTest.php
@@ -27,7 +27,7 @@ class EnablePluginTest extends TestCase {
 	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
 	protected $user;
 
-	/** @var \OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin $plugin */
+	/** @var EnablePlugin $plugin */
 	protected $plugin;
 
 	protected $request;

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/EmailProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/EmailProviderTest.php
@@ -14,6 +14,7 @@ use OCP\IUser;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
+use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\VObject\Component\VCalendar;
 
@@ -350,7 +351,7 @@ class EmailProviderTest extends AbstractNotificationProviderTest {
 
 		$message->expects($this->once())
 			->method('setFrom')
-			->with([\OCP\Util::getDefaultEmailAddress('reminders-noreply')])
+			->with([Util::getDefaultEmailAddress('reminders-noreply')])
 			->willReturn($message);
 
 		if ($replyTo) {

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
@@ -36,7 +36,7 @@ class NotificationProviderManagerTest extends TestCase {
 	 * @throws NotificationTypeDoesNotExistException
 	 */
 	public function testGetProviderForUnknownType(): void {
-		$this->expectException(\OCA\DAV\CalDAV\Reminder\NotificationTypeDoesNotExistException::class);
+		$this->expectException(NotificationTypeDoesNotExistException::class);
 		$this->expectExceptionMessage('Type NOT EXISTENT is not an accepted type of notification');
 
 		$this->providerManager->getProvider('NOT EXISTENT');
@@ -47,7 +47,7 @@ class NotificationProviderManagerTest extends TestCase {
 	 * @throws ProviderNotAvailableException
 	 */
 	public function testGetProviderForUnRegisteredType(): void {
-		$this->expectException(\OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException::class);
+		$this->expectException(ProviderNotAvailableException::class);
 		$this->expectExceptionMessage('No notification provider for type AUDIO available');
 
 		$this->providerManager->getProvider('AUDIO');

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTest.php
@@ -7,6 +7,8 @@ namespace OCA\DAV\Tests\unit\CalDAV\ResourceBooking;
 
 use OCA\DAV\CalDAV\Proxy\Proxy;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
+use OCA\DAV\CalDAV\ResourceBooking\ResourcePrincipalBackend;
+use OCA\DAV\CalDAV\ResourceBooking\RoomPrincipalBackend;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -15,7 +17,7 @@ use Sabre\DAV\PropPatch;
 use Test\TestCase;
 
 abstract class AbstractPrincipalBackendTest extends TestCase {
-	/** @var \OCA\DAV\CalDAV\ResourceBooking\ResourcePrincipalBackend|\OCA\DAV\CalDAV\ResourceBooking\RoomPrincipalBackend */
+	/** @var ResourcePrincipalBackend|RoomPrincipalBackend */
 	protected $principalBackend;
 
 	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */

--- a/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Search/SearchPluginTest.php
@@ -14,7 +14,7 @@ use Test\TestCase;
 class SearchPluginTest extends TestCase {
 	protected $server;
 
-	/** @var \OCA\DAV\CalDAV\Search\SearchPlugin $plugin */
+	/** @var SearchPlugin $plugin */
 	protected $plugin;
 
 	protected function setUp(): void {

--- a/apps/dav/tests/unit/Command/ListAddressbooksTest.php
+++ b/apps/dav/tests/unit/Command/ListAddressbooksTest.php
@@ -21,7 +21,7 @@ use Test\TestCase;
  */
 class ListAddressbooksTest extends TestCase {
 
-	private \OCP\IUserManager|MockObject $userManager;
+	private IUserManager|MockObject $userManager;
 	private CardDavBackend|MockObject $cardDavBackend;
 	private ListAddressbooks $command;
 

--- a/apps/dav/tests/unit/Comments/EntityCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityCollectionTest.php
@@ -7,9 +7,11 @@
  */
 namespace OCA\DAV\Tests\unit\Comments;
 
+use OCA\DAV\Comments\CommentNode;
 use OCA\DAV\Comments\EntityCollection;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
+use OCP\Comments\NotFoundException;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -43,7 +45,7 @@ class EntityCollectionTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->collection = new \OCA\DAV\Comments\EntityCollection(
+		$this->collection = new EntityCollection(
 			'19',
 			'files',
 			$this->commentsManager,
@@ -68,7 +70,7 @@ class EntityCollectionTest extends \Test\TestCase {
 			);
 
 		$node = $this->collection->getChild('55');
-		$this->assertTrue($node instanceof \OCA\DAV\Comments\CommentNode);
+		$this->assertTrue($node instanceof CommentNode);
 	}
 
 
@@ -78,7 +80,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('55')
-			->will($this->throwException(new \OCP\Comments\NotFoundException()));
+			->will($this->throwException(new NotFoundException()));
 
 		$this->collection->getChild('55');
 	}
@@ -96,7 +98,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$result = $this->collection->getChildren();
 
 		$this->assertSame(count($result), 1);
-		$this->assertTrue($result[0] instanceof \OCA\DAV\Comments\CommentNode);
+		$this->assertTrue($result[0] instanceof CommentNode);
 	}
 
 	public function testFindChildren(): void {
@@ -113,7 +115,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$result = $this->collection->findChildren(5, 15, $dt);
 
 		$this->assertSame(count($result), 1);
-		$this->assertTrue($result[0] instanceof \OCA\DAV\Comments\CommentNode);
+		$this->assertTrue($result[0] instanceof CommentNode);
 	}
 
 	public function testChildExistsTrue(): void {
@@ -124,7 +126,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('44')
-			->will($this->throwException(new \OCP\Comments\NotFoundException()));
+			->will($this->throwException(new NotFoundException()));
 
 		$this->assertFalse($this->collection->childExists('44'));
 	}

--- a/apps/dav/tests/unit/Comments/EntityTypeCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityTypeCollectionTest.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Tests\unit\Comments;
 
 use OCA\DAV\Comments\EntityCollection as EntityCollectionImplemantation;
+use OCA\DAV\Comments\EntityTypeCollection;
 use OCP\Comments\ICommentsManager;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -21,7 +22,7 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var \OCA\DAV\Comments\EntityTypeCollection */
+	/** @var EntityTypeCollection */
 	protected $collection;
 	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
@@ -46,7 +47,7 @@ class EntityTypeCollectionTest extends \Test\TestCase {
 
 		$instance = $this;
 
-		$this->collection = new \OCA\DAV\Comments\EntityTypeCollection(
+		$this->collection = new EntityTypeCollection(
 			'files',
 			$this->commentsManager,
 			$this->userManager,

--- a/apps/dav/tests/unit/Comments/RootCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/RootCollectionTest.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Tests\unit\Comments;
 
 use OC\EventDispatcher\EventDispatcher;
 use OCA\DAV\Comments\EntityTypeCollection as EntityTypeCollectionImplementation;
+use OCA\DAV\Comments\RootCollection;
 use OCP\Comments\CommentsEntityEvent;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -25,7 +26,7 @@ class RootCollectionTest extends \Test\TestCase {
 	protected $userManager;
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
-	/** @var \OCA\DAV\Comments\RootCollection */
+	/** @var RootCollection */
 	protected $collection;
 	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userSession;
@@ -59,7 +60,7 @@ class RootCollectionTest extends \Test\TestCase {
 			$this->logger
 		);
 
-		$this->collection = new \OCA\DAV\Comments\RootCollection(
+		$this->collection = new RootCollection(
 			$this->commentsManager,
 			$this->userManager,
 			$this->userSession,

--- a/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\DAV\Tests\unit\Connector;
 
+use OCA\DAV\Connector\LegacyPublicAuth;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\Bruteforce\IThrottler;
@@ -29,7 +30,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 	private $request;
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $shareManager;
-	/** @var \OCA\DAV\Connector\LegacyPublicAuth */
+	/** @var LegacyPublicAuth */
 	private $auth;
 	/** @var IThrottler|\PHPUnit\Framework\MockObject\MockObject */
 	private $throttler;
@@ -53,7 +54,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->auth = new \OCA\DAV\Connector\LegacyPublicAuth(
+		$this->auth = new LegacyPublicAuth(
 			$this->request,
 			$this->shareManager,
 			$this->session,

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -7,8 +7,11 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
+use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\TwoFactorAuth\Manager;
 use OC\User\Session;
+use OCA\DAV\Connector\Sabre\Auth;
+use OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IUser;
@@ -28,7 +31,7 @@ use Test\TestCase;
 class AuthTest extends TestCase {
 	/** @var ISession&MockObject */
 	private $session;
-	/** @var \OCA\DAV\Connector\Sabre\Auth */
+	/** @var Auth */
 	private $auth;
 	/** @var Session&MockObject */
 	private $userSession;
@@ -53,7 +56,7 @@ class AuthTest extends TestCase {
 		$this->throttler = $this->getMockBuilder(IThrottler::class)
 			->disableOriginalConstructor()
 			->getMock();
-		$this->auth = new \OCA\DAV\Connector\Sabre\Auth(
+		$this->auth = new Auth(
 			$this->session,
 			$this->userSession,
 			$this->request,
@@ -201,7 +204,7 @@ class AuthTest extends TestCase {
 
 
 	public function testValidateUserPassWithPasswordLoginForbidden(): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden::class);
+		$this->expectException(PasswordLoginForbidden::class);
 
 		$this->userSession
 			->expects($this->once())
@@ -211,7 +214,7 @@ class AuthTest extends TestCase {
 			->expects($this->once())
 			->method('logClientIn')
 			->with('MyTestUser', 'MyTestPassword')
-			->will($this->throwException(new \OC\Authentication\Exceptions\PasswordLoginForbiddenException()));
+			->will($this->throwException(new PasswordLoginForbiddenException()));
 		$this->session
 			->expects($this->once())
 			->method('close');

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -5,6 +5,7 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
+use OC\User\Session;
 use OCA\DAV\Connector\Sabre\BearerAuth;
 use OCP\IRequest;
 use OCP\ISession;
@@ -30,7 +31,7 @@ class BearerAuthTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->userSession = $this->createMock(\OC\User\Session::class);
+		$this->userSession = $this->createMock(Session::class);
 		$this->session = $this->createMock(ISession::class);
 		$this->request = $this->createMock(IRequest::class);
 

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
+use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCP\IUser;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Tree;
@@ -34,7 +35,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 	private $tree;
 
 	/**
-	 * @var \OCA\DAV\DAV\CustomPropertiesBackend
+	 * @var CustomPropertiesBackend
 	 */
 	private $plugin;
 
@@ -64,7 +65,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 
 		$this->defaultCalendarValidator = $this->createMock(DefaultCalendarValidator::class);
 
-		$this->plugin = new \OCA\DAV\DAV\CustomPropertiesBackend(
+		$this->plugin = new CustomPropertiesBackend(
 			$this->server,
 			$this->tree,
 			\OC::$server->getDatabaseConnection(),

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -13,12 +13,16 @@ use OC\Files\Node\Node;
 use OC\Files\Storage\Wrapper\Quota;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCP\Constants;
 use OCP\Files\ForbiddenException;
+use OCP\Files\InvalidPathException;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\StorageNotAvailableException;
 use Test\Traits\UserTrait;
 
-class TestViewDirectory extends \OC\Files\View {
+class TestViewDirectory extends View {
 	private $updatables;
 	private $deletables;
 	private $canRename;
@@ -106,7 +110,7 @@ class DirectoryTest extends \Test\TestCase {
 
 
 	public function testDeleteForbidden(): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\Forbidden::class);
+		$this->expectException(Forbidden::class);
 
 		// deletion allowed
 		$this->info->expects($this->once())
@@ -250,7 +254,7 @@ class DirectoryTest extends \Test\TestCase {
 
 		$this->view->expects($this->once())
 			->method('getFileInfo')
-			->willThrowException(new \OCP\Files\StorageNotAvailableException());
+			->willThrowException(new StorageNotAvailableException());
 
 		$dir = new Directory($this->view, $this->info);
 		$dir->getChild('.');
@@ -258,11 +262,11 @@ class DirectoryTest extends \Test\TestCase {
 
 
 	public function testGetChildThrowInvalidPath(): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
+		$this->expectException(InvalidPath::class);
 
 		$this->view->expects($this->once())
 			->method('verifyPath')
-			->willThrowException(new \OCP\Files\InvalidPathException());
+			->willThrowException(new InvalidPathException());
 		$this->view->expects($this->never())
 			->method('getFileInfo');
 
@@ -398,7 +402,7 @@ class DirectoryTest extends \Test\TestCase {
 	 * @dataProvider moveFailedInvalidCharsProvider
 	 */
 	public function testMoveFailedInvalidChars($source, $destination, $updatables, $deletables): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
+		$this->expectException(InvalidPath::class);
 
 		$this->moveTest($source, $destination, $updatables, $deletables);
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -13,16 +13,29 @@ use OC\Files\Storage\Local;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\PermissionsMask;
 use OC\Files\View;
+use OCA\DAV\Connector\Sabre\Exception\FileLocked;
+use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCA\DAV\Connector\Sabre\File;
 use OCP\Constants;
+use OCP\Encryption\Exceptions\GenericEncryptionException;
+use OCP\Files\EntityTooLargeException;
 use OCP\Files\FileInfo;
 use OCP\Files\ForbiddenException;
+use OCP\Files\InvalidContentException;
+use OCP\Files\InvalidPathException;
+use OCP\Files\LockNotAcquiredException;
+use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\IStorage;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use OCP\IRequestId;
 use OCP\ITempManager;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+use OCP\Server;
+use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\HookHelper;
 use Test\TestCase;
@@ -66,7 +79,7 @@ class FileTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$userManager = \OCP\Server::get(IUserManager::class);
+		$userManager = Server::get(IUserManager::class);
 		$userManager->get($this->user)->delete();
 
 		parent::tearDown();
@@ -98,39 +111,39 @@ class FileTest extends TestCase {
 				false
 			],
 			[
-				new \OCP\Files\NotPermittedException(),
+				new NotPermittedException(),
 				'Sabre\DAV\Exception\Forbidden'
 			],
 			[
-				new \OCP\Files\EntityTooLargeException(),
+				new EntityTooLargeException(),
 				'OCA\DAV\Connector\Sabre\Exception\EntityTooLarge'
 			],
 			[
-				new \OCP\Files\InvalidContentException(),
+				new InvalidContentException(),
 				'OCA\DAV\Connector\Sabre\Exception\UnsupportedMediaType'
 			],
 			[
-				new \OCP\Files\InvalidPathException(),
+				new InvalidPathException(),
 				'Sabre\DAV\Exception\Forbidden'
 			],
 			[
-				new \OCP\Files\ForbiddenException('', true),
+				new ForbiddenException('', true),
 				'OCA\DAV\Connector\Sabre\Exception\Forbidden'
 			],
 			[
-				new \OCP\Files\LockNotAcquiredException('/test.txt', 1),
+				new LockNotAcquiredException('/test.txt', 1),
 				'OCA\DAV\Connector\Sabre\Exception\FileLocked'
 			],
 			[
-				new \OCP\Lock\LockedException('/test.txt'),
+				new LockedException('/test.txt'),
 				'OCA\DAV\Connector\Sabre\Exception\FileLocked'
 			],
 			[
-				new \OCP\Encryption\Exceptions\GenericEncryptionException(),
+				new GenericEncryptionException(),
 				'Sabre\DAV\Exception\ServiceUnavailable'
 			],
 			[
-				new \OCP\Files\StorageNotAvailableException(),
+				new StorageNotAvailableException(),
 				'Sabre\DAV\Exception\ServiceUnavailable'
 			],
 			[
@@ -152,9 +165,9 @@ class FileTest extends TestCase {
 		// setup
 		$storage = $this->getMockBuilder(Local::class)
 			->onlyMethods(['writeStream'])
-			->setConstructorArgs([['datadir' => \OCP\Server::get(ITempManager::class)->getTemporaryFolder()]])
+			->setConstructorArgs([['datadir' => Server::get(ITempManager::class)->getTemporaryFolder()]])
 			->getMock();
-		\OC\Files\Filesystem::mount($storage, [], $this->user . '/');
+		Filesystem::mount($storage, [], $this->user . '/');
 		/** @var View | MockObject $view */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['getRelativePath', 'resolvePath'])
@@ -182,11 +195,11 @@ class FileTest extends TestCase {
 			->willReturnArgument(0);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// action
 		$caughtException = null;
@@ -214,9 +227,9 @@ class FileTest extends TestCase {
 	 * @return null|string of the PUT operation which is usually the etag
 	 */
 	private function doPut($path, $viewRoot = null, ?Request $request = null) {
-		$view = \OC\Files\Filesystem::getView();
+		$view = Filesystem::getView();
 		if (!is_null($viewRoot)) {
-			$view = new \OC\Files\View($viewRoot);
+			$view = new View($viewRoot);
 		} else {
 			$viewRoot = '/' . $this->user . '/files';
 		}
@@ -226,14 +239,14 @@ class FileTest extends TestCase {
 			$this->getMockStorage(),
 			null,
 			[
-				'permissions' => \OCP\Constants::PERMISSION_ALL,
+				'permissions' => Constants::PERMISSION_ALL,
 				'type' => FileInfo::TYPE_FOLDER,
 			],
 			null
 		);
 
-		/** @var \OCA\DAV\Connector\Sabre\File | MockObject $file */
-		$file = $this->getMockBuilder(\OCA\DAV\Connector\Sabre\File::class)
+		/** @var File|MockObject $file */
+		$file = $this->getMockBuilder(File::class)
 			->setConstructorArgs([$view, $info, null, $request])
 			->onlyMethods(['header'])
 			->getMock();
@@ -367,7 +380,7 @@ class FileTest extends TestCase {
 	 * Test that putting a file triggers update hooks
 	 */
 	public function testPutOverwriteFileTriggersHooks(): void {
-		$view = \OC\Files\Filesystem::getView();
+		$view = Filesystem::getView();
 		$view->file_put_contents('/foo.txt', 'some content that will be replaced');
 
 		HookHelper::setUpHooks();
@@ -403,7 +416,7 @@ class FileTest extends TestCase {
 	 * where the root is the share root)
 	 */
 	public function testPutSingleFileTriggersHooksDifferentRoot(): void {
-		$view = \OC\Files\Filesystem::getView();
+		$view = Filesystem::getView();
 		$view->mkdir('noderoot');
 
 		HookHelper::setUpHooks();
@@ -445,7 +458,7 @@ class FileTest extends TestCase {
 	 * Test put file with cancelled hook
 	 */
 	public function testPutSingleFileCancelPreHook(): void {
-		\OCP\Util::connectHook(
+		Util::connectHook(
 			Filesystem::CLASSNAME,
 			Filesystem::signal_create,
 			'\Test\HookHelper',
@@ -493,11 +506,11 @@ class FileTest extends TestCase {
 		], $this->requestId, $this->config, null);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
+		$file = new File($view, $info, null, $request);
 
 		// action
 		$thrown = false;
@@ -521,17 +534,17 @@ class FileTest extends TestCase {
 	 * Test exception during final rename in simple upload mode
 	 */
 	public function testSimplePutFailsMoveFromStorage(): void {
-		$view = new \OC\Files\View('/' . $this->user . '/files');
+		$view = new View('/' . $this->user . '/files');
 
 		// simulate situation where the target file is locked
 		$view->lockFile('/test.txt', ILockingProvider::LOCK_EXCLUSIVE);
 
 		$info = new \OC\Files\FileInfo('/' . $this->user . '/files/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// action
 		$thrown = false;
@@ -543,7 +556,7 @@ class FileTest extends TestCase {
 
 			// afterMethod unlocks
 			$view->unlockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
-		} catch (\OCA\DAV\Connector\Sabre\Exception\FileLocked $e) {
+		} catch (FileLocked $e) {
 			$thrown = true;
 		}
 
@@ -565,10 +578,10 @@ class FileTest extends TestCase {
 			->willReturnArgument(0);
 
 		$info = new \OC\Files\FileInfo("/i\nvalid", $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// action
 		$thrown = false;
@@ -580,7 +593,7 @@ class FileTest extends TestCase {
 
 			// afterMethod unlocks
 			$view->unlockFile($info->getPath(), ILockingProvider::LOCK_SHARED);
-		} catch (\OCA\DAV\Connector\Sabre\Exception\InvalidPath $e) {
+		} catch (InvalidPath $e) {
 			$thrown = true;
 		}
 
@@ -593,7 +606,7 @@ class FileTest extends TestCase {
 	 *
 	 */
 	public function testSetNameInvalidChars(): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
+		$this->expectException(InvalidPath::class);
 
 		// setup
 		/** @var View|MockObject */
@@ -606,10 +619,10 @@ class FileTest extends TestCase {
 			->willReturnArgument(0);
 
 		$info = new \OC\Files\FileInfo('/valid', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		$file->setName("/i\nvalid");
 	}
@@ -640,11 +653,11 @@ class FileTest extends TestCase {
 		], $this->requestId, $this->config, null);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info, null, $request);
+		$file = new File($view, $info, null, $request);
 
 		// action
 		$thrown = false;
@@ -676,11 +689,11 @@ class FileTest extends TestCase {
 			->willReturn(true);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// action
 		$file->delete();
@@ -700,7 +713,7 @@ class FileTest extends TestCase {
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// action
 		$file->delete();
@@ -721,11 +734,11 @@ class FileTest extends TestCase {
 			->willReturn(false);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// action
 		$file->delete();
@@ -733,7 +746,7 @@ class FileTest extends TestCase {
 
 
 	public function testDeleteThrowsWhenDeletionThrows(): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\Forbidden::class);
+		$this->expectException(Forbidden::class);
 
 		// setup
 		/** @var View|MockObject */
@@ -746,11 +759,11 @@ class FileTest extends TestCase {
 			->willThrowException(new ForbiddenException('', true));
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// action
 		$file->delete();
@@ -776,7 +789,7 @@ class FileTest extends TestCase {
 	 * Test whether locks are set before and after the operation
 	 */
 	public function testPutLocking(): void {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
 		$path = 'test-locking.txt';
 		$info = new \OC\Files\FileInfo(
@@ -784,20 +797,20 @@ class FileTest extends TestCase {
 			$this->getMockStorage(),
 			null,
 			[
-				'permissions' => \OCP\Constants::PERMISSION_ALL,
+				'permissions' => Constants::PERMISSION_ALL,
 				'type' => FileInfo::TYPE_FOLDER,
 			],
 			null
 		);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		$this->assertFalse(
-			$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED),
+			$this->isFileLocked($view, $path, ILockingProvider::LOCK_SHARED),
 			'File unlocked before put'
 		);
 		$this->assertFalse(
-			$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE),
+			$this->isFileLocked($view, $path, ILockingProvider::LOCK_EXCLUSIVE),
 			'File unlocked before put'
 		);
 
@@ -813,26 +826,26 @@ class FileTest extends TestCase {
 			->method('writeCallback')
 			->willReturnCallback(
 				function () use ($view, $path, &$wasLockedPre): void {
-					$wasLockedPre = $this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED);
-					$wasLockedPre = $wasLockedPre && !$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
+					$wasLockedPre = $this->isFileLocked($view, $path, ILockingProvider::LOCK_SHARED);
+					$wasLockedPre = $wasLockedPre && !$this->isFileLocked($view, $path, ILockingProvider::LOCK_EXCLUSIVE);
 				}
 			);
 		$eventHandler->expects($this->once())
 			->method('postWriteCallback')
 			->willReturnCallback(
 				function () use ($view, $path, &$wasLockedPost): void {
-					$wasLockedPost = $this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED);
-					$wasLockedPost = $wasLockedPost && !$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE);
+					$wasLockedPost = $this->isFileLocked($view, $path, ILockingProvider::LOCK_SHARED);
+					$wasLockedPost = $wasLockedPost && !$this->isFileLocked($view, $path, ILockingProvider::LOCK_EXCLUSIVE);
 				}
 			);
 
-		\OCP\Util::connectHook(
+		Util::connectHook(
 			Filesystem::CLASSNAME,
 			Filesystem::signal_write,
 			$eventHandler,
 			'writeCallback'
 		);
-		\OCP\Util::connectHook(
+		Util::connectHook(
 			Filesystem::CLASSNAME,
 			Filesystem::signal_post_write,
 			$eventHandler,
@@ -851,11 +864,11 @@ class FileTest extends TestCase {
 		$this->assertTrue($wasLockedPost, 'File was locked during post-hooks');
 
 		$this->assertFalse(
-			$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_SHARED),
+			$this->isFileLocked($view, $path, ILockingProvider::LOCK_SHARED),
 			'File unlocked after put'
 		);
 		$this->assertFalse(
-			$this->isFileLocked($view, $path, \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE),
+			$this->isFileLocked($view, $path, ILockingProvider::LOCK_EXCLUSIVE),
 			'File unlocked after put'
 		);
 	}
@@ -868,9 +881,9 @@ class FileTest extends TestCase {
 	 *
 	 * @return array list of part files
 	 */
-	private function listPartFiles(?\OC\Files\View $userView = null, $path = '') {
+	private function listPartFiles(?View $userView = null, $path = '') {
 		if ($userView === null) {
-			$userView = \OC\Files\Filesystem::getView();
+			$userView = Filesystem::getView();
 		}
 		$files = [];
 		[$storage, $internalPath] = $userView->resolvePath($path);
@@ -919,18 +932,18 @@ class FileTest extends TestCase {
 			->willReturn(false);
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FILE,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		$file->get();
 	}
 
 
 	public function testGetFopenThrows(): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\Forbidden::class);
+		$this->expectException(Forbidden::class);
 
 		/** @var View|MockObject */
 		$view = $this->getMockBuilder(View::class)
@@ -941,11 +954,11 @@ class FileTest extends TestCase {
 			->willThrowException(new ForbiddenException('', true));
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_ALL,
+			'permissions' => Constants::PERMISSION_ALL,
 			'type' => FileInfo::TYPE_FILE,
 		], null);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		$file->get();
 	}
@@ -962,11 +975,11 @@ class FileTest extends TestCase {
 			->method('fopen');
 
 		$info = new \OC\Files\FileInfo('/test.txt', $this->getMockStorage(), null, [
-			'permissions' => \OCP\Constants::PERMISSION_CREATE, // no read perm
+			'permissions' => Constants::PERMISSION_CREATE, // no read perm
 			'type' => FileInfo::TYPE_FOLDER,
 		], null);
 
-		$file = new  \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new  File($view, $info);
 
 		$file->get();
 	}
@@ -1003,7 +1016,7 @@ class FileTest extends TestCase {
 	}
 
 	public function testPutLockExpired(): void {
-		$view = new \OC\Files\View('/' . $this->user . '/files/');
+		$view = new View('/' . $this->user . '/files/');
 
 		$path = 'test-locking.txt';
 		$info = new \OC\Files\FileInfo(
@@ -1011,13 +1024,13 @@ class FileTest extends TestCase {
 			$this->getMockStorage(),
 			null,
 			[
-				'permissions' => \OCP\Constants::PERMISSION_ALL,
+				'permissions' => Constants::PERMISSION_ALL,
 				'type' => FileInfo::TYPE_FOLDER,
 			],
 			null
 		);
 
-		$file = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$file = new File($view, $info);
 
 		// don't lock before the PUT to simulate an expired shared lock
 		$this->assertNotEmpty($file->put($this->getStream('test data')));

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -123,7 +123,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForFile(): void {
-		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
+		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 
 		$propFind = new PropFind(
@@ -180,7 +180,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesStorageNotAvailable(): void {
-		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
+		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 
 		$propFind = new PropFind(
@@ -227,7 +227,7 @@ class FilesPluginTest extends TestCase {
 			0
 		);
 
-		/** @var \OCA\DAV\Connector\Sabre\File | \PHPUnit\Framework\MockObject\MockObject $node */
+		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
 		$node->expects($this->any())
 			->method('getDavPermissions')
@@ -242,7 +242,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForDirectory(): void {
-		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit\Framework\MockObject\MockObject $node */
+		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
 
 		$propFind = new PropFind(
@@ -277,7 +277,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForRootDirectory(): void {
-		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $node */
+		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -312,8 +312,7 @@ class FilesPluginTest extends TestCase {
 		// No read permissions can be caused by files access control.
 		// But we still want to load the directory list, so this is okay for us.
 		// $this->expectException(\Sabre\DAV\Exception\NotFound::class);
-
-		/** @var \OCA\DAV\Connector\Sabre\Directory|\PHPUnit\Framework\MockObject\MockObject $node */
+		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -614,7 +613,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testHasPreview(): void {
-		/** @var \OCA\DAV\Connector\Sabre\Directory | \PHPUnit\Framework\MockObject\MockObject $node */
+		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
 
 		$propFind = new PropFind(

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\FilesPlugin;
 use OCA\DAV\Connector\Sabre\FilesReportPlugin as FilesReportPluginImplementation;
 use OCP\App\IAppManager;
 use OCP\Files\File;
@@ -289,7 +290,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 				$filesNode2,
 			);
 
-		/** @var \OCA\DAV\Connector\Sabre\Directory&MockObject $reportTargetNode */
+		/** @var Directory&MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);
@@ -342,7 +343,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 				$filesNode2,
 			);
 
-		/** @var \OCA\DAV\Connector\Sabre\Directory&MockObject $reportTargetNode */
+		/** @var Directory&MockObject $reportTargetNode */
 		$result = $this->plugin->findNodesByFileIds($reportTargetNode, ['111', '222']);
 
 		$this->assertCount(2, $result);
@@ -390,7 +391,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		$validator = $this->createMock(IFilenameValidator::class);
 
 		$this->server->addPlugin(
-			new \OCA\DAV\Connector\Sabre\FilesPlugin(
+			new FilesPlugin(
 				$this->tree,
 				$config,
 				$this->createMock(IRequest::class),

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -13,6 +13,7 @@ use OC\Files\Mount\MountPoint;
 use OC\Files\Node\Folder;
 use OC\Files\View;
 use OC\Share20\ShareAttributes;
+use OCA\DAV\Connector\Sabre\File;
 use OCA\Files_Sharing\SharedMount;
 use OCA\Files_Sharing\SharedStorage;
 use OCP\Constants;
@@ -97,7 +98,7 @@ class NodeTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$node = new  \OCA\DAV\Connector\Sabre\File($view, $info);
+		$node = new  File($view, $info);
 		$this->assertEquals($expected, $node->getDavPermissions());
 	}
 
@@ -180,7 +181,7 @@ class NodeTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$node = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$node = new File($view, $info);
 		$this->invokePrivate($node, 'shareManager', [$shareManager]);
 		$this->assertEquals($expected, $node->getSharePermissions($user));
 	}
@@ -217,7 +218,7 @@ class NodeTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$node = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$node = new File($view, $info);
 		$this->invokePrivate($node, 'shareManager', [$shareManager]);
 		$this->assertEquals($attributes->toArray(), $node->getShareAttributes());
 	}
@@ -243,7 +244,7 @@ class NodeTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$node = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$node = new File($view, $info);
 		$this->invokePrivate($node, 'shareManager', [$shareManager]);
 		$this->assertEquals([], $node->getShareAttributes());
 	}
@@ -266,7 +267,7 @@ class NodeTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$node = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$node = new File($view, $info);
 		$result = $this->invokePrivate($node, 'sanitizeMtime', [$mtime]);
 		$this->assertEquals($expected, $result);
 	}
@@ -290,7 +291,7 @@ class NodeTest extends \Test\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$node = new \OCA\DAV\Connector\Sabre\File($view, $info);
+		$node = new File($view, $info);
 		$result = $this->invokePrivate($node, 'sanitizeMtime', [$mtime]);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -10,9 +10,12 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OC\Files\FileInfo;
 use OC\Files\Filesystem;
 use OC\Files\Mount\Manager;
+use OC\Files\Storage\Common;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\ObjectTree;
 use OCP\Files\Mount\IMountManager;
 
@@ -73,7 +76,7 @@ class ObjectTreeTest extends \Test\TestCase {
 			->with($this->identicalTo($sourcePath))
 			->willReturn(false);
 
-		/** @var \OCA\DAV\Connector\Sabre\ObjectTree $objectTree */
+		/** @var ObjectTree $objectTree */
 		$mountManager = Filesystem::getMountManager();
 		$objectTree->init($rootDir, $view, $mountManager);
 		$objectTree->copy($sourcePath, $targetPath);
@@ -114,7 +117,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$objectTree->expects($this->never())
 			->method('getNodeForPath');
 
-		/** @var \OCA\DAV\Connector\Sabre\ObjectTree $objectTree */
+		/** @var ObjectTree $objectTree */
 		$mountManager = Filesystem::getMountManager();
 		$objectTree->init($rootDir, $view, $mountManager);
 		$objectTree->copy($sourcePath, $targetPath);
@@ -146,13 +149,13 @@ class ObjectTreeTest extends \Test\TestCase {
 		$fileInfo->method('getName')
 			->willReturn($outputFileName);
 		$fileInfo->method('getStorage')
-			->willReturn($this->createMock(\OC\Files\Storage\Common::class));
+			->willReturn($this->createMock(Common::class));
 
 		$view->method('getFileInfo')
 			->with($fileInfoQueryPath)
 			->willReturn($fileInfo);
 
-		$tree = new \OCA\DAV\Connector\Sabre\ObjectTree();
+		$tree = new ObjectTree();
 		$tree->init($rootNode, $view, $mountManager);
 
 		$node = $tree->getNodeForPath($inputFileName);
@@ -161,9 +164,9 @@ class ObjectTreeTest extends \Test\TestCase {
 		$this->assertEquals($outputFileName, $node->getName());
 
 		if ($type === 'file') {
-			$this->assertTrue($node instanceof \OCA\DAV\Connector\Sabre\File);
+			$this->assertTrue($node instanceof File);
 		} else {
-			$this->assertTrue($node instanceof \OCA\DAV\Connector\Sabre\Directory);
+			$this->assertTrue($node instanceof Directory);
 		}
 	}
 
@@ -202,7 +205,7 @@ class ObjectTreeTest extends \Test\TestCase {
 
 
 	public function testGetNodeForPathInvalidPath(): void {
-		$this->expectException(\OCA\DAV\Connector\Sabre\Exception\InvalidPath::class);
+		$this->expectException(InvalidPath::class);
 
 		$path = '/foo\bar';
 
@@ -223,7 +226,7 @@ class ObjectTreeTest extends \Test\TestCase {
 			->getMock();
 		$mountManager = $this->createMock(IMountManager::class);
 
-		$tree = new \OCA\DAV\Connector\Sabre\ObjectTree();
+		$tree = new ObjectTree();
 		$tree->init($rootNode, $view, $mountManager);
 
 		$tree->getNodeForPath($path);
@@ -249,7 +252,7 @@ class ObjectTreeTest extends \Test\TestCase {
 			->getMock();
 		$mountManager = $this->createMock(IMountManager::class);
 
-		$tree = new \OCA\DAV\Connector\Sabre\ObjectTree();
+		$tree = new ObjectTree();
 		$tree->init($rootNode, $view, $mountManager);
 
 		$this->assertInstanceOf('\Sabre\DAV\INode', $tree->getNodeForPath($path));

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\DAV\Tests\unit\Connector;
 
+use OCA\DAV\Connector\Sabre\PublicAuth;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\Bruteforce\IThrottler;
@@ -49,7 +50,7 @@ class PublicAuthTest extends \Test\TestCase {
 		$this->throttler = $this->createMock(IThrottler::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 
-		$this->auth = new \OCA\DAV\Connector\Sabre\PublicAuth(
+		$this->auth = new PublicAuth(
 			$this->request,
 			$this->shareManager,
 			$this->session,

--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -16,7 +16,7 @@ class QuotaPluginTest extends TestCase {
 	/** @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject */
 	private $server;
 
-	/** @var \OCA\DAV\Connector\Sabre\QuotaPlugin | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var QuotaPlugin|\PHPUnit\Framework\MockObject\MockObject */
 	private $plugin;
 
 	private function init($quota, $checkedPath = ''): void {

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
@@ -7,7 +7,9 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
-class ExceptionPlugin extends \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin {
+use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
+
+class ExceptionPlugin extends ExceptionLoggerPlugin {
 	/**
 	 * @var \Throwable[]
 	 */

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -25,7 +25,7 @@ abstract class RequestTestCase extends TestCase {
 	use MountProviderTrait;
 
 	/**
-	 * @var \OCA\DAV\Connector\Sabre\ServerFactory
+	 * @var ServerFactory
 	 */
 	protected $serverFactory;
 

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\Node;
+use OCA\DAV\Connector\Sabre\SharesPlugin;
 use OCA\DAV\Upload\UploadFile;
 use OCP\Files\Folder;
 use OCP\IUser;
@@ -19,7 +20,7 @@ use OCP\Share\IShare;
 use Sabre\DAV\Tree;
 
 class SharesPluginTest extends \Test\TestCase {
-	public const SHARETYPES_PROPERTYNAME = \OCA\DAV\Connector\Sabre\SharesPlugin::SHARETYPES_PROPERTYNAME;
+	public const SHARETYPES_PROPERTYNAME = SharesPlugin::SHARETYPES_PROPERTYNAME;
 
 	/**
 	 * @var \Sabre\DAV\Server
@@ -42,7 +43,7 @@ class SharesPluginTest extends \Test\TestCase {
 	private $userFolder;
 
 	/**
-	 * @var \OCA\DAV\Connector\Sabre\SharesPlugin
+	 * @var SharesPlugin
 	 */
 	private $plugin;
 
@@ -61,7 +62,7 @@ class SharesPluginTest extends \Test\TestCase {
 			->willReturn($user);
 		$this->userFolder = $this->createMock(Folder::class);
 
-		$this->plugin = new \OCA\DAV\Connector\Sabre\SharesPlugin(
+		$this->plugin = new SharesPlugin(
 			$this->tree,
 			$userSession,
 			$this->userFolder,

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -10,15 +10,17 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\Node;
+use OCA\DAV\Connector\Sabre\TagList;
+use OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCA\DAV\Upload\UploadFile;
 use OCP\ITagManager;
 use OCP\ITags;
 use Sabre\DAV\Tree;
 
 class TagsPluginTest extends \Test\TestCase {
-	public const TAGS_PROPERTYNAME = \OCA\DAV\Connector\Sabre\TagsPlugin::TAGS_PROPERTYNAME;
-	public const FAVORITE_PROPERTYNAME = \OCA\DAV\Connector\Sabre\TagsPlugin::FAVORITE_PROPERTYNAME;
-	public const TAG_FAVORITE = \OCA\DAV\Connector\Sabre\TagsPlugin::TAG_FAVORITE;
+	public const TAGS_PROPERTYNAME = TagsPlugin::TAGS_PROPERTYNAME;
+	public const FAVORITE_PROPERTYNAME = TagsPlugin::FAVORITE_PROPERTYNAME;
+	public const TAG_FAVORITE = TagsPlugin::TAG_FAVORITE;
 
 	/**
 	 * @var \Sabre\DAV\Server
@@ -41,7 +43,7 @@ class TagsPluginTest extends \Test\TestCase {
 	private $tagger;
 
 	/**
-	 * @var \OCA\DAV\Connector\Sabre\TagsPlugin
+	 * @var TagsPlugin
 	 */
 	private $plugin;
 
@@ -61,7 +63,7 @@ class TagsPluginTest extends \Test\TestCase {
 			->method('load')
 			->with('files')
 			->willReturn($this->tagger);
-		$this->plugin = new \OCA\DAV\Connector\Sabre\TagsPlugin($this->tree, $this->tagManager);
+		$this->plugin = new TagsPlugin($this->tree, $this->tagManager);
 		$this->plugin->initialize($this->server);
 	}
 
@@ -194,7 +196,7 @@ class TagsPluginTest extends \Test\TestCase {
 				[self::TAGS_PROPERTYNAME, self::FAVORITE_PROPERTYNAME],
 				[
 					200 => [
-						self::TAGS_PROPERTYNAME => new \OCA\DAV\Connector\Sabre\TagList(['tag1', 'tag2']),
+						self::TAGS_PROPERTYNAME => new TagList(['tag1', 'tag2']),
 						self::FAVORITE_PROPERTYNAME => true,
 					]
 				]
@@ -205,7 +207,7 @@ class TagsPluginTest extends \Test\TestCase {
 				[self::TAGS_PROPERTYNAME],
 				[
 					200 => [
-						self::TAGS_PROPERTYNAME => new \OCA\DAV\Connector\Sabre\TagList(['tag1', 'tag2']),
+						self::TAGS_PROPERTYNAME => new TagList(['tag1', 'tag2']),
 					]
 				]
 			],
@@ -233,7 +235,7 @@ class TagsPluginTest extends \Test\TestCase {
 				[self::TAGS_PROPERTYNAME, self::FAVORITE_PROPERTYNAME],
 				[
 					200 => [
-						self::TAGS_PROPERTYNAME => new \OCA\DAV\Connector\Sabre\TagList([]),
+						self::TAGS_PROPERTYNAME => new TagList([]),
 						self::FAVORITE_PROPERTYNAME => false,
 					]
 				]
@@ -296,7 +298,7 @@ class TagsPluginTest extends \Test\TestCase {
 
 		// properties to set
 		$propPatch = new \Sabre\DAV\PropPatch([
-			self::TAGS_PROPERTYNAME => new \OCA\DAV\Connector\Sabre\TagList(['tag1', 'tag2', 'tagkeep'])
+			self::TAGS_PROPERTYNAME => new TagList(['tag1', 'tag2', 'tagkeep'])
 		]);
 
 		$this->plugin->handleUpdateProperties(
@@ -342,7 +344,7 @@ class TagsPluginTest extends \Test\TestCase {
 
 		// properties to set
 		$propPatch = new \Sabre\DAV\PropPatch([
-			self::TAGS_PROPERTYNAME => new \OCA\DAV\Connector\Sabre\TagList(['tag1', 'tag2'])
+			self::TAGS_PROPERTYNAME => new TagList(['tag1', 'tag2'])
 		]);
 
 		$this->plugin->handleUpdateProperties(

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Tests\unit\SystemTag;
 
 use OC\SystemTag\SystemTag;
+use OCA\DAV\SystemTag\SystemTagMappingNode;
 use OCP\IUser;
 use OCP\SystemTag\ISystemTag;
 use OCP\SystemTag\ISystemTagManager;
@@ -34,7 +35,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 		if ($tag === null) {
 			$tag = new SystemTag(1, 'Test', true, true);
 		}
-		return new \OCA\DAV\SystemTag\SystemTagMappingNode(
+		return new SystemTagMappingNode(
 			$tag,
 			123,
 			'files',

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Tests\unit\SystemTag;
 
 use OC\SystemTag\SystemTag;
+use OCA\DAV\SystemTag\SystemTagNode;
 use OCP\IUser;
 use OCP\SystemTag\ISystemTag;
 use OCP\SystemTag\ISystemTagManager;
@@ -40,7 +41,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		if ($tag === null) {
 			$tag = new SystemTag(1, 'Test', true, true);
 		}
-		return new \OCA\DAV\SystemTag\SystemTagNode(
+		return new SystemTagNode(
 			$tag,
 			$this->user,
 			$isAdmin,

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Tests\unit\SystemTag;
 
 use OC\SystemTag\SystemTag;
 use OCA\DAV\SystemTag\SystemTagNode;
+use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\SystemTag\SystemTagsByIdCollection;
 use OCA\DAV\SystemTag\SystemTagsObjectMappingCollection;
 use OCP\IGroupManager;
@@ -23,12 +24,12 @@ use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 
 class SystemTagPluginTest extends \Test\TestCase {
-	public const ID_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::ID_PROPERTYNAME;
-	public const DISPLAYNAME_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::DISPLAYNAME_PROPERTYNAME;
-	public const USERVISIBLE_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::USERVISIBLE_PROPERTYNAME;
-	public const USERASSIGNABLE_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::USERASSIGNABLE_PROPERTYNAME;
-	public const CANASSIGN_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::CANASSIGN_PROPERTYNAME;
-	public const GROUPS_PROPERTYNAME = \OCA\DAV\SystemTag\SystemTagPlugin::GROUPS_PROPERTYNAME;
+	public const ID_PROPERTYNAME = SystemTagPlugin::ID_PROPERTYNAME;
+	public const DISPLAYNAME_PROPERTYNAME = SystemTagPlugin::DISPLAYNAME_PROPERTYNAME;
+	public const USERVISIBLE_PROPERTYNAME = SystemTagPlugin::USERVISIBLE_PROPERTYNAME;
+	public const USERASSIGNABLE_PROPERTYNAME = SystemTagPlugin::USERASSIGNABLE_PROPERTYNAME;
+	public const CANASSIGN_PROPERTYNAME = SystemTagPlugin::CANASSIGN_PROPERTYNAME;
+	public const GROUPS_PROPERTYNAME = SystemTagPlugin::GROUPS_PROPERTYNAME;
 
 	/**
 	 * @var \Sabre\DAV\Server
@@ -61,7 +62,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 	private $user;
 
 	/**
-	 * @var \OCA\DAV\SystemTag\SystemTagPlugin
+	 * @var SystemTagPlugin
 	 */
 	private $plugin;
 
@@ -97,7 +98,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$this->tagMapper = $this->getMockBuilder(ISystemTagObjectMapper::class)
 			->getMock();
 
-		$this->plugin = new \OCA\DAV\SystemTag\SystemTagPlugin(
+		$this->plugin = new SystemTagPlugin(
 			$this->tagManager,
 			$this->groupManager,
 			$this->userSession,

--- a/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Tests\unit\SystemTag;
 
 use OC\SystemTag\SystemTag;
+use OCA\DAV\SystemTag\SystemTagsByIdCollection;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -50,7 +51,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 			->method('isAdmin')
 			->with('testuser')
 			->willReturn($isAdmin);
-		return new \OCA\DAV\SystemTag\SystemTagsByIdCollection(
+		return new SystemTagsByIdCollection(
 			$this->tagManager,
 			$userSession,
 			$groupManager

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Tests\unit\SystemTag;
 
 use OC\SystemTag\SystemTag;
+use OCA\DAV\SystemTag\SystemTagsObjectMappingCollection;
 use OCP\IUser;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
@@ -31,7 +32,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	public function getNode(array $writableNodeIds = []) {
-		return new \OCA\DAV\SystemTag\SystemTagsObjectMappingCollection(
+		return new SystemTagsObjectMappingCollection(
 			111,
 			'files',
 			$this->user,

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
@@ -7,7 +7,9 @@
  */
 namespace OCA\DAV\Tests\unit\SystemTag;
 
+use OCA\DAV\SystemTag\SystemTagsObjectTypeCollection;
 use OCP\Files\Folder;
+use OCP\Files\Node;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -17,7 +19,7 @@ use OCP\SystemTag\ISystemTagObjectMapper;
 class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 
 	/**
-	 * @var \OCA\DAV\SystemTag\SystemTagsObjectTypeCollection
+	 * @var SystemTagsObjectTypeCollection
 	 */
 	private $node;
 
@@ -79,7 +81,7 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 			return false;
 		};
 
-		$this->node = new \OCA\DAV\SystemTag\SystemTagsObjectTypeCollection(
+		$this->node = new SystemTagsObjectTypeCollection(
 			'files',
 			$this->tagManager,
 			$this->tagMapper,
@@ -108,7 +110,7 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 		$this->userFolder->expects($this->once())
 			->method('getFirstNodeById')
 			->with('555')
-			->willReturn($this->createMock(\OCP\Files\Node::class));
+			->willReturn($this->createMock(Node::class));
 		$childNode = $this->node->getChild('555');
 
 		$this->assertInstanceOf('\OCA\DAV\SystemTag\SystemTagsObjectMappingCollection', $childNode);
@@ -137,7 +139,7 @@ class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
 		$this->userFolder->expects($this->once())
 			->method('getFirstNodeById')
 			->with('123')
-			->willReturn($this->createMock(\OCP\Files\Node::class));
+			->willReturn($this->createMock(Node::class));
 		$this->assertTrue($this->node->childExists('123'));
 	}
 

--- a/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\DAV\Tests\unit\Upload;
 
+use OCA\DAV\Upload\AssemblyStream;
 use Sabre\DAV\File;
 
 class AssemblyStreamTest extends \Test\TestCase {
@@ -15,7 +16,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 	 * @dataProvider providesNodes()
 	 */
 	public function testGetContents($expected, $nodes): void {
-		$stream = \OCA\DAV\Upload\AssemblyStream::wrap($nodes);
+		$stream = AssemblyStream::wrap($nodes);
 		$content = stream_get_contents($stream);
 
 		$this->assertEquals($expected, $content);
@@ -25,7 +26,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 	 * @dataProvider providesNodes()
 	 */
 	public function testGetContentsFread($expected, $nodes): void {
-		$stream = \OCA\DAV\Upload\AssemblyStream::wrap($nodes);
+		$stream = AssemblyStream::wrap($nodes);
 
 		$content = '';
 		while (!feof($stream)) {
@@ -39,7 +40,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 	 * @dataProvider providesNodes()
 	 */
 	public function testSeek($expected, $nodes): void {
-		$stream = \OCA\DAV\Upload\AssemblyStream::wrap($nodes);
+		$stream = AssemblyStream::wrap($nodes);
 
 		$offset = floor(strlen($expected) * 0.6);
 		if (fseek($stream, $offset) === -1) {

--- a/apps/dav/tests/unit/Upload/FutureFileTest.php
+++ b/apps/dav/tests/unit/Upload/FutureFileTest.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Tests\unit\Upload;
 
 use OCA\DAV\Connector\Sabre\Directory;
+use OCA\DAV\Upload\FutureFile;
 
 class FutureFileTest extends \Test\TestCase {
 	public function testGetContentType(): void {
@@ -50,7 +51,7 @@ class FutureFileTest extends \Test\TestCase {
 		$d->expects($this->once())
 			->method('delete');
 
-		$f = new \OCA\DAV\Upload\FutureFile($d, 'foo.txt');
+		$f = new FutureFile($d, 'foo.txt');
 		$f->delete();
 	}
 
@@ -71,7 +72,7 @@ class FutureFileTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @return \OCA\DAV\Upload\FutureFile
+	 * @return FutureFile
 	 */
 	private function mockFutureFile() {
 		$d = $this->getMockBuilder(Directory::class)
@@ -91,6 +92,6 @@ class FutureFileTest extends \Test\TestCase {
 			->method('getChildren')
 			->willReturn([]);
 
-		return new \OCA\DAV\Upload\FutureFile($d, 'foo.txt');
+		return new FutureFile($d, 'foo.txt');
 	}
 }

--- a/apps/encryption/lib/Crypto/DecryptAll.php
+++ b/apps/encryption/lib/Crypto/DecryptAll.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\Encryption\Crypto;
 
+use OCA\Encryption\Exceptions\PrivateKeyMissingException;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Session;
 use OCA\Encryption\Util;
@@ -118,7 +119,7 @@ class DecryptAll {
 	 * @param string $user
 	 * @param string $password
 	 * @return bool|string
-	 * @throws \OCA\Encryption\Exceptions\PrivateKeyMissingException
+	 * @throws PrivateKeyMissingException
 	 */
 	protected function getPrivateKey($user, $password) {
 		$recoveryKeyId = $this->keyManager->getRecoveryKeyId();

--- a/apps/encryption/lib/Crypto/Encryption.php
+++ b/apps/encryption/lib/Crypto/Encryption.php
@@ -10,6 +10,7 @@ namespace OCA\Encryption\Crypto;
 use OC\Encryption\Exceptions\DecryptionFailedException;
 use OC\Files\Cache\Scanner;
 use OC\Files\View;
+use OCA\Encryption\Exceptions\MultiKeyEncryptException;
 use OCA\Encryption\Exceptions\PublicKeyMissingException;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Session;
@@ -187,7 +188,7 @@ class Encryption implements IEncryptionModule {
 	 *                of a write operation
 	 * @throws PublicKeyMissingException
 	 * @throws \Exception
-	 * @throws \OCA\Encryption\Exceptions\MultiKeyEncryptException
+	 * @throws MultiKeyEncryptException
 	 */
 	public function end($path, $position = '0') {
 		$result = '';

--- a/apps/encryption/lib/Hooks/UserHooks.php
+++ b/apps/encryption/lib/Hooks/UserHooks.php
@@ -94,7 +94,7 @@ class UserHooks implements IHook {
 	 */
 	public function login($params) {
 		// ensure filesystem is loaded
-		if (!\OC\Files\Filesystem::$loaded) {
+		if (!Filesystem::$loaded) {
 			$this->setupFS($params['uid']);
 		}
 		if ($this->util->isMasterKeyEnabled() === false) {

--- a/apps/encryption/lib/Session.php
+++ b/apps/encryption/lib/Session.php
@@ -68,7 +68,7 @@ class Session {
 	public function getPrivateKey() {
 		$key = $this->session->get('privateKey');
 		if (is_null($key)) {
-			throw new Exceptions\PrivateKeyMissingException('please try to log-out and log-in again', 0);
+			throw new PrivateKeyMissingException('please try to log-out and log-in again', 0);
 		}
 		return $key;
 	}

--- a/apps/encryption/tests/Controller/RecoveryControllerTest.php
+++ b/apps/encryption/tests/Controller/RecoveryControllerTest.php
@@ -24,7 +24,7 @@ class RecoveryControllerTest extends TestCase {
 	private $configMock;
 	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	private $l10nMock;
-	/** @var \OCA\Encryption\Recovery|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Recovery|\PHPUnit\Framework\MockObject\MockObject */
 	private $recoveryMock;
 
 	public function adminRecoveryProvider() {

--- a/apps/encryption/tests/Controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/Controller/SettingsControllerTest.php
@@ -39,13 +39,13 @@ class SettingsControllerTest extends TestCase {
 	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	private $userSessionMock;
 
-	/** @var \OCA\Encryption\KeyManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var KeyManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $keyManagerMock;
 
-	/** @var \OCA\Encryption\Crypto\Crypt|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Crypt|\PHPUnit\Framework\MockObject\MockObject */
 	private $cryptMock;
 
-	/** @var \OCA\Encryption\Session|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Session|\PHPUnit\Framework\MockObject\MockObject */
 	private $sessionMock;
 	/** @var MockObject|IUser */
 	private $user;
@@ -53,7 +53,7 @@ class SettingsControllerTest extends TestCase {
 	/** @var \OCP\ISession|\PHPUnit\Framework\MockObject\MockObject */
 	private $ocSessionMock;
 
-	/** @var \OCA\Encryption\Util|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
 	private $utilMock;
 
 	protected function setUp(): void {

--- a/apps/encryption/tests/Controller/StatusControllerTest.php
+++ b/apps/encryption/tests/Controller/StatusControllerTest.php
@@ -22,7 +22,7 @@ class StatusControllerTest extends TestCase {
 	/** @var \OCP\IL10N|\PHPUnit\Framework\MockObject\MockObject */
 	private $l10nMock;
 
-	/** @var \OCA\Encryption\Session | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var Session|\PHPUnit\Framework\MockObject\MockObject */
 	protected $sessionMock;
 
 	/** @var IManager | \PHPUnit\Framework\MockObject\MockObject */

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -8,6 +8,7 @@
 namespace OCA\Encryption\Tests\Crypto;
 
 use OCA\Encryption\Crypto\Crypt;
+use OCP\Encryption\Exceptions\GenericEncryptionException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUserSession;
@@ -232,7 +233,7 @@ class CryptTest extends TestCase {
 	 * @dataProvider dataTestHasSignatureFail
 	 */
 	public function testHasSignatureFail($cipher): void {
-		$this->expectException(\OCP\Encryption\Exceptions\GenericEncryptionException::class);
+		$this->expectException(GenericEncryptionException::class);
 
 		$data = 'encryptedContent00iv001234567890123456xx';
 		$this->invokePrivate($this->crypt, 'hasSignature', [$data, $cipher]);
@@ -377,7 +378,7 @@ class CryptTest extends TestCase {
 				['encryption.use_legacy_base64_encoding', false])
 			->willReturnOnConsecutiveCalls(true, false);
 
-		/** @var \OCA\Encryption\Crypto\Crypt | \PHPUnit\Framework\MockObject\MockObject $crypt */
+		/** @var Crypt|\PHPUnit\Framework\MockObject\MockObject $crypt */
 		$crypt = $this->getMockBuilder(Crypt::class)
 			->setConstructorArgs(
 				[

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -29,16 +29,16 @@ use Test\TestCase;
 
 class EncryptAllTest extends TestCase {
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCA\Encryption\KeyManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|KeyManager */
 	protected $keyManager;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCA\Encryption\Util */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|Util */
 	protected $util;
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IUserManager */
 	protected $userManager;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCA\Encryption\Users\Setup */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|Setup */
 	protected $setupUser;
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \OC\Files\View */

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -7,6 +7,8 @@
  */
 namespace OCA\Encryption\Tests\Crypto;
 
+use OC\Encryption\Exceptions\DecryptionFailedException;
+use OC\Files\View;
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\Crypto\DecryptAll;
 use OCA\Encryption\Crypto\EncryptAll;
@@ -27,22 +29,22 @@ class EncryptionTest extends TestCase {
 	/** @var Encryption */
 	private $instance;
 
-	/** @var \OCA\Encryption\KeyManager|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var KeyManager|\PHPUnit\Framework\MockObject\MockObject */
 	private $keyManagerMock;
 
-	/** @var \OCA\Encryption\Crypto\EncryptAll|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var EncryptAll|\PHPUnit\Framework\MockObject\MockObject */
 	private $encryptAllMock;
 
-	/** @var \OCA\Encryption\Crypto\DecryptAll|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var DecryptAll|\PHPUnit\Framework\MockObject\MockObject */
 	private $decryptAllMock;
 
-	/** @var \OCA\Encryption\Session|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Session|\PHPUnit\Framework\MockObject\MockObject */
 	private $sessionMock;
 
-	/** @var \OCA\Encryption\Crypto\Crypt|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Crypt|\PHPUnit\Framework\MockObject\MockObject */
 	private $cryptMock;
 
-	/** @var \OCA\Encryption\Util|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
 	private $utilMock;
 
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
@@ -120,7 +122,7 @@ class EncryptionTest extends TestCase {
 			->method('decryptAllModeActivated')
 			->willReturn(false);
 
-		$this->expectException(\OCA\Encryption\Exceptions\PublicKeyMissingException::class);
+		$this->expectException(PublicKeyMissingException::class);
 
 		$this->instance->begin('/foo/bar', 'user2', 'r', [], ['users' => ['user1', 'user2', 'user3']]);
 		$this->endTest();
@@ -320,7 +322,7 @@ class EncryptionTest extends TestCase {
 			->willReturnCallback(function ($path, $version, $view): void {
 				$this->assertSame('path', $path);
 				$this->assertSame(2, $version);
-				$this->assertTrue($view instanceof \OC\Files\View);
+				$this->assertTrue($view instanceof View);
 			});
 		$this->instance->update('path', 'user1', []);
 	}
@@ -403,7 +405,7 @@ class EncryptionTest extends TestCase {
 
 
 	public function testDecrypt(): void {
-		$this->expectException(\OC\Encryption\Exceptions\DecryptionFailedException::class);
+		$this->expectException(DecryptionFailedException::class);
 		$this->expectExceptionMessage('Cannot decrypt this file, probably this is a shared file. Please ask the file owner to reshare the file with you.');
 
 		$this->instance->decrypt('abc');

--- a/apps/encryption/tests/HookManagerTest.php
+++ b/apps/encryption/tests/HookManagerTest.php
@@ -43,7 +43,7 @@ class HookManagerTest extends TestCase {
 	
 	public function testRegisterHooksWithInstance(): void {
 		$mock = $this->getMockBuilder(IHook::class)->disableOriginalConstructor()->getMock();
-		/** @var \OCA\Encryption\Hooks\Contracts\IHook $mock */
+		/** @var IHook $mock */
 		self::$instance->registerHook($mock);
 
 		$hookInstances = self::invokePrivate(self::$instance, 'hookInstances');

--- a/apps/encryption/tests/Hooks/UserHooksTest.php
+++ b/apps/encryption/tests/Hooks/UserHooksTest.php
@@ -305,7 +305,7 @@ class UserHooksTest extends TestCase {
 				]
 			)->setMethods(['initMountPoints'])->getMock();
 
-		/** @var \OCA\Encryption\Hooks\UserHooks $userHooks */
+		/** @var UserHooks $userHooks */
 		$this->assertNull($userHooks->setPassphrase($this->params));
 	}
 

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -10,6 +10,9 @@ namespace OCA\Encryption\Tests;
 use OC\Files\FileInfo;
 use OC\Files\View;
 use OCA\Encryption\Crypto\Crypt;
+use OCA\Encryption\Crypto\Encryption;
+use OCA\Encryption\Exceptions\PrivateKeyMissingException;
+use OCA\Encryption\Exceptions\PublicKeyMissingException;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Session;
 use OCA\Encryption\Util;
@@ -40,19 +43,19 @@ class KeyManagerTest extends TestCase {
 	/** @var \OCP\Encryption\Keys\IStorage|\PHPUnit\Framework\MockObject\MockObject */
 	private $keyStorageMock;
 
-	/** @var \OCA\Encryption\Crypto\Crypt|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Crypt|\PHPUnit\Framework\MockObject\MockObject */
 	private $cryptMock;
 
 	/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	private $userMock;
 
-	/** @var \OCA\Encryption\Session|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Session|\PHPUnit\Framework\MockObject\MockObject */
 	private $sessionMock;
 
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $logMock;
 
-	/** @var \OCA\Encryption\Util|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
 	private $utilMock;
 
 	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
@@ -207,7 +210,7 @@ class KeyManagerTest extends TestCase {
 
 
 	public function testUserHasKeysMissingPrivateKey(): void {
-		$this->expectException(\OCA\Encryption\Exceptions\PrivateKeyMissingException::class);
+		$this->expectException(PrivateKeyMissingException::class);
 
 		$this->keyStorageMock->expects($this->exactly(2))
 			->method('getUserKey')
@@ -223,7 +226,7 @@ class KeyManagerTest extends TestCase {
 
 
 	public function testUserHasKeysMissingPublicKey(): void {
-		$this->expectException(\OCA\Encryption\Exceptions\PublicKeyMissingException::class);
+		$this->expectException(PublicKeyMissingException::class);
 
 		$this->keyStorageMock->expects($this->exactly(2))
 			->method('getUserKey')
@@ -243,7 +246,7 @@ class KeyManagerTest extends TestCase {
 	 * @param bool $useMasterKey
 	 */
 	public function testInit($useMasterKey): void {
-		/** @var \OCA\Encryption\KeyManager|\PHPUnit\Framework\MockObject\MockObject $instance */
+		/** @var KeyManager|\PHPUnit\Framework\MockObject\MockObject $instance */
 		$instance = $this->getMockBuilder(KeyManager::class)
 			->setConstructorArgs(
 				[
@@ -527,7 +530,7 @@ class KeyManagerTest extends TestCase {
 
 	public function testGetPublicMasterKey(): void {
 		$this->keyStorageMock->expects($this->once())->method('getSystemUserKey')
-			->with('systemKeyId.publicKey', \OCA\Encryption\Crypto\Encryption::ID)
+			->with('systemKeyId.publicKey', Encryption::ID)
 			->willReturn(true);
 
 		$this->assertTrue(
@@ -560,7 +563,7 @@ class KeyManagerTest extends TestCase {
 	 * @param $masterKey
 	 */
 	public function testValidateMasterKey($masterKey): void {
-		/** @var \OCA\Encryption\KeyManager | \PHPUnit\Framework\MockObject\MockObject $instance */
+		/** @var KeyManager|\PHPUnit\Framework\MockObject\MockObject $instance */
 		$instance = $this->getMockBuilder(KeyManager::class)
 			->setConstructorArgs(
 				[
@@ -589,7 +592,7 @@ class KeyManagerTest extends TestCase {
 			$this->cryptMock->expects($this->once())->method('createKeyPair')
 				->willReturn(['publicKey' => 'public', 'privateKey' => 'private']);
 			$this->keyStorageMock->expects($this->once())->method('setSystemUserKey')
-				->with('systemKeyId.publicKey', 'public', \OCA\Encryption\Crypto\Encryption::ID);
+				->with('systemKeyId.publicKey', 'public', Encryption::ID);
 			$this->cryptMock->expects($this->once())->method('encryptPrivateKey')
 				->with('private', 'masterKeyPassword', 'systemKeyId')
 				->willReturn('EncryptedKey');
@@ -608,7 +611,7 @@ class KeyManagerTest extends TestCase {
 	}
 
 	public function testValidateMasterKeyLocked(): void {
-		/** @var \OCA\Encryption\KeyManager | \PHPUnit_Framework_MockObject_MockObject $instance */
+		/** @var KeyManager|\PHPUnit_Framework_MockObject_MockObject $instance */
 		$instance = $this->getMockBuilder(KeyManager::class)
 			->setConstructorArgs(
 				[

--- a/apps/encryption/tests/RecoveryTest.php
+++ b/apps/encryption/tests/RecoveryTest.php
@@ -37,7 +37,7 @@ class RecoveryTest extends TestCase {
 	 */
 	private $user;
 	/**
-	 * @var \OCA\Encryption\KeyManager|\PHPUnit\Framework\MockObject\MockObject
+	 * @var KeyManager|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $keyManagerMock;
 	/**
@@ -45,7 +45,7 @@ class RecoveryTest extends TestCase {
 	 */
 	private $configMock;
 	/**
-	 * @var \OCA\Encryption\Crypto\Crypt|\PHPUnit\Framework\MockObject\MockObject
+	 * @var Crypt|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $cryptMock;
 	/**

--- a/apps/encryption/tests/SessionTest.php
+++ b/apps/encryption/tests/SessionTest.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\Encryption\Tests;
 
+use OCA\Encryption\Exceptions\PrivateKeyMissingException;
 use OCA\Encryption\Session;
 use OCP\ISession;
 use Test\TestCase;
@@ -22,7 +23,7 @@ class SessionTest extends TestCase {
 
 
 	public function testThatGetPrivateKeyThrowsExceptionWhenNotSet(): void {
-		$this->expectException(\OCA\Encryption\Exceptions\PrivateKeyMissingException::class);
+		$this->expectException(PrivateKeyMissingException::class);
 		$this->expectExceptionMessage('Private Key missing for user: please try to log-out and log-in again');
 
 		$this->instance->getPrivateKey();
@@ -84,7 +85,7 @@ class SessionTest extends TestCase {
 	 * @expectExceptionMessage 'Please activate decrypt all mode first'
 	 */
 	public function testGetDecryptAllKeyException(): void {
-		$this->expectException(\OCA\Encryption\Exceptions\PrivateKeyMissingException::class);
+		$this->expectException(PrivateKeyMissingException::class);
 
 		$this->instance->getDecryptAllKey();
 	}
@@ -93,7 +94,7 @@ class SessionTest extends TestCase {
 	 * @expectExceptionMessage 'No key found while in decrypt all mode'
 	 */
 	public function testGetDecryptAllKeyException2(): void {
-		$this->expectException(\OCA\Encryption\Exceptions\PrivateKeyMissingException::class);
+		$this->expectException(PrivateKeyMissingException::class);
 
 		$this->instance->prepareDecryptAll('user', null);
 		$this->instance->getDecryptAllKey();

--- a/apps/encryption/tests/Users/SetupTest.php
+++ b/apps/encryption/tests/Users/SetupTest.php
@@ -14,11 +14,11 @@ use Test\TestCase;
 
 class SetupTest extends TestCase {
 	/**
-	 * @var \OCA\Encryption\KeyManager|\PHPUnit\Framework\MockObject\MockObject
+	 * @var KeyManager|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $keyManagerMock;
 	/**
-	 * @var \OCA\Encryption\Crypto\Crypt|\PHPUnit\Framework\MockObject\MockObject
+	 * @var Crypt|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $cryptMock;
 	/**

--- a/apps/encryption/tests/UtilTest.php
+++ b/apps/encryption/tests/UtilTest.php
@@ -64,7 +64,7 @@ class UtilTest extends TestCase {
 		$this->filesMock = $this->createMock(View::class);
 		$this->userManagerMock = $this->createMock(IUserManager::class);
 
-		/** @var \OCA\Encryption\Crypto\Crypt $cryptMock */
+		/** @var Crypt $cryptMock */
 		$cryptMock = $this->getMockBuilder(Crypt::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/federatedfilesharing/lib/AddressHandler.php
+++ b/apps/federatedfilesharing/lib/AddressHandler.php
@@ -11,6 +11,7 @@ use OCP\Federation\ICloudIdManager;
 use OCP\HintException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
+use OCP\Util;
 
 /**
  * Class AddressHandler - parse, modify and construct federated sharing addresses
@@ -86,12 +87,12 @@ class AddressHandler {
 
 		if (rtrim($normalizedServer1, '/') === rtrim($normalizedServer2, '/')) {
 			// FIXME this should be a method in the user management instead
-			\OCP\Util::emitHook(
+			Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',
 				['uid' => &$user1]
 			);
-			\OCP\Util::emitHook(
+			Util::emitHook(
 				'\OCA\Files_Sharing\API\Server2Server',
 				'preLoginNameUsedAsUserName',
 				['uid' => &$user2]

--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -15,6 +15,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCSController;
@@ -29,6 +30,7 @@ use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IUserManager;
 use OCP\Log\Audit\CriticalActionPerformedEvent;
+use OCP\Server;
 use OCP\Share;
 use OCP\Share\Exceptions\ShareNotFound;
 use Psr\Log\LoggerInterface;
@@ -170,7 +172,7 @@ class RequestHandlerController extends OCSController {
 			throw new OCSException('internal server error, was not able to add share from ' . $remote, 500);
 		}
 
-		return new Http\DataResponse();
+		return new DataResponse();
 	}
 
 	/**
@@ -206,7 +208,7 @@ class RequestHandlerController extends OCSController {
 		try {
 			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider('file');
 			[$newToken, $localId] = $provider->notificationReceived('REQUEST_RESHARE', $id, $notification);
-			return new Http\DataResponse([
+			return new DataResponse([
 				'token' => $newToken,
 				'remoteId' => $localId
 			]);
@@ -254,7 +256,7 @@ class RequestHandlerController extends OCSController {
 			$this->logger->debug('internal server error, can not process notification: ' . $e->getMessage(), ['exception' => $e]);
 		}
 
-		return new Http\DataResponse();
+		return new DataResponse();
 	}
 
 	/**
@@ -287,7 +289,7 @@ class RequestHandlerController extends OCSController {
 			$this->logger->debug('internal server error, can not process notification: ' . $e->getMessage(), ['exception' => $e]);
 		}
 
-		return new Http\DataResponse();
+		return new DataResponse();
 	}
 
 	/**
@@ -316,7 +318,7 @@ class RequestHandlerController extends OCSController {
 			$this->logger->debug('processing unshare notification failed: ' . $e->getMessage(), ['exception' => $e]);
 		}
 
-		return new Http\DataResponse();
+		return new DataResponse();
 	}
 
 	private function cleanupRemote($remote) {
@@ -343,7 +345,7 @@ class RequestHandlerController extends OCSController {
 			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider('file');
 			$notification = ['sharedSecret' => $token];
 			$provider->notificationReceived('RESHARE_UNDO', $id, $notification);
-			return new Http\DataResponse();
+			return new DataResponse();
 		} catch (\Exception $e) {
 			throw new OCSBadRequestException();
 		}
@@ -356,7 +358,7 @@ class RequestHandlerController extends OCSController {
 	 * @return bool
 	 */
 	private function isS2SEnabled($incoming = false) {
-		$result = \OCP\Server::get(IAppManager::class)->isEnabledForUser('files_sharing');
+		$result = Server::get(IAppManager::class)->isEnabledForUser('files_sharing');
 
 		if ($incoming) {
 			$result = $result && $this->federatedShareProvider->isIncomingServer2serverShareEnabled();
@@ -394,7 +396,7 @@ class RequestHandlerController extends OCSController {
 			throw new OCSBadRequestException();
 		}
 
-		return new Http\DataResponse();
+		return new DataResponse();
 	}
 
 	/**
@@ -454,7 +456,7 @@ class RequestHandlerController extends OCSController {
 		$affected = $query->executeStatement();
 
 		if ($affected > 0) {
-			return new Http\DataResponse(['remote' => $cloudId->getRemote(), 'owner' => $cloudId->getUser()]);
+			return new DataResponse(['remote' => $cloudId->getRemote(), 'owner' => $cloudId->getUser()]);
 		} else {
 			throw new OCSBadRequestException('Share not found or token invalid');
 		}

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -1043,8 +1043,8 @@ class FederatedShareProvider implements IShareProvider {
 			->from('share')
 			->where(
 				$qb->expr()->orX(
-					$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share\IShare::TYPE_REMOTE)),
-					$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share\IShare::TYPE_REMOTE_GROUP))
+					$qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_REMOTE)),
+					$qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_REMOTE_GROUP))
 				)
 			);
 

--- a/apps/federatedfilesharing/lib/Listeners/LoadAdditionalScriptsListener.php
+++ b/apps/federatedfilesharing/lib/Listeners/LoadAdditionalScriptsListener.php
@@ -14,6 +14,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
 
 /** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalScriptsListener implements IEventListener {
@@ -34,7 +35,7 @@ class LoadAdditionalScriptsListener implements IEventListener {
 
 		if ($this->federatedShareProvider->isIncomingServer2serverShareEnabled()) {
 			$this->initialState->provideInitialState('notificationsEnabled', $this->appManager->isEnabledForUser('notifications'));
-			\OCP\Util::addInitScript('federatedfilesharing', 'external');
+			Util::addInitScript('federatedfilesharing', 'external');
 		}
 	}
 }

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -11,6 +11,7 @@ use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\Activity\Providers\RemoteShares;
 use OCA\Files_Sharing\External\Manager;
+use OCA\GlobalSiteSelector\Service\SlaveService;
 use OCP\Activity\IManager as IActivityManager;
 use OCP\App\IAppManager;
 use OCP\Constants;
@@ -734,7 +735,7 @@ class CloudFederationProviderFiles implements ICloudFederationProvider {
 		}
 
 		try {
-			$slaveService = Server::get(\OCA\GlobalSiteSelector\Service\SlaveService::class);
+			$slaveService = Server::get(SlaveService::class);
 		} catch (\Throwable $e) {
 			Server::get(LoggerInterface::class)->error(
 				$e->getMessage(),

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -11,6 +11,7 @@ use OC\Federation\CloudIdManager;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCP\Contacts\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\HintException;
 use OCP\ICacheFactory;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -130,7 +131,7 @@ class AddressHandlerTest extends \Test\TestCase {
 	 * @param string $id
 	 */
 	public function testSplitUserRemoteError($id): void {
-		$this->expectException(\OCP\HintException::class);
+		$this->expectException(HintException::class);
 
 		$this->addressHandler->splitUserRemote($id);
 	}

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -7,6 +7,7 @@
 namespace OCA\FederatedFileSharing\Tests\Controller;
 
 use OC\Federation\CloudIdManager;
+use OC\Share20\Share;
 use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\Controller\MountPublicLinkController;
 use OCA\FederatedFileSharing\FederatedShareProvider;
@@ -83,7 +84,7 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->rootFolder = $this->getMockBuilder('OCP\Files\IRootFolder')->disableOriginalConstructor()->getMock();
 		$this->userManager = $this->getMockBuilder(IUserManager::class)->disableOriginalConstructor()->getMock();
-		$this->share = new \OC\Share20\Share($this->rootFolder, $this->userManager);
+		$this->share = new Share($this->rootFolder, $this->userManager);
 		$this->session = $this->getMockBuilder(ISession::class)->disableOriginalConstructor()->getMock();
 		$this->l10n = $this->getMockBuilder(IL10N::class)->disableOriginalConstructor()->getMock();
 		$this->userSession = $this->getMockBuilder(IUserSession::class)->disableOriginalConstructor()->getMock();

--- a/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/RequestHandlerControllerTest.php
@@ -7,7 +7,10 @@
  */
 namespace OCA\FederatedFileSharing\Tests;
 
+use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\Controller\RequestHandlerController;
+use OCA\FederatedFileSharing\FederatedShareProvider;
+use OCA\FederatedFileSharing\Notifications;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
@@ -39,13 +42,13 @@ class RequestHandlerControllerTest extends \Test\TestCase {
 	/** @var RequestHandlerController */
 	private $requestHandler;
 
-	/** @var \OCA\FederatedFileSharing\FederatedShareProvider|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var FederatedShareProvider|\PHPUnit\Framework\MockObject\MockObject */
 	private $federatedShareProvider;
 
-	/** @var \OCA\FederatedFileSharing\Notifications|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Notifications|\PHPUnit\Framework\MockObject\MockObject */
 	private $notifications;
 
-	/** @var \OCA\FederatedFileSharing\AddressHandler|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var AddressHandler|\PHPUnit\Framework\MockObject\MockObject */
 	private $addressHandler;
 
 	/** @var IUserManager|\PHPUnit\Framework\MockObject\MockObject */

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -12,6 +12,7 @@ use OCA\FederatedFileSharing\AddressHandler;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\FederatedFileSharing\Notifications;
 use OCA\FederatedFileSharing\TokenHandler;
+use OCP\Constants;
 use OCP\Contacts\IManager as IContactsManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationProviderManager;
@@ -895,7 +896,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$share1->setSharedWith('user@server.com')
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setShareType(IShare::TYPE_REMOTE)
 			->setNode($file1);
 		$this->provider->create($share1);
@@ -904,7 +905,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$share2->setSharedWith('user@server.com')
 			->setSharedBy($u2->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setShareType(IShare::TYPE_REMOTE)
 			->setNode($file2);
 		$this->provider->create($share2);
@@ -955,7 +956,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$share1->setSharedWith('user@server.com')
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setShareType(IShare::TYPE_REMOTE)
 			->setNode($file1);
 		$this->provider->create($share1);
@@ -964,7 +965,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$share2->setSharedWith('foobar@localhost')
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setShareType(IShare::TYPE_REMOTE)
 			->setNode($file1);
 		$this->provider->create($share2);

--- a/apps/federatedfilesharing/tests/Settings/AdminTest.php
+++ b/apps/federatedfilesharing/tests/Settings/AdminTest.php
@@ -17,7 +17,7 @@ use Test\TestCase;
 class AdminTest extends TestCase {
 	/** @var Admin */
 	private $admin;
-	/** @var \OCA\FederatedFileSharing\FederatedShareProvider */
+	/** @var FederatedShareProvider */
 	private $federatedShareProvider;
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $gsConfig;

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -90,7 +90,7 @@ abstract class TestCase extends \Test\TestCase {
 
 		\OC_Util::tearDownFS();
 		\OC::$server->getUserSession()->setUser(null);
-		\OC\Files\Filesystem::tearDown();
+		Filesystem::tearDown();
 		\OC::$server->getUserSession()->login($user, $password);
 		\OC::$server->getUserFolder($user);
 

--- a/apps/federation/lib/DAV/FedAuth.php
+++ b/apps/federation/lib/DAV/FedAuth.php
@@ -8,6 +8,7 @@
 namespace OCA\Federation\DAV;
 
 use OCA\Federation\DbHandler;
+use OCP\Defaults;
 use Sabre\DAV\Auth\Backend\AbstractBasic;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
@@ -27,7 +28,7 @@ class FedAuth extends AbstractBasic {
 		$this->principalPrefix = 'principals/system/';
 
 		// setup realm
-		$defaults = new \OCP\Defaults();
+		$defaults = new Defaults();
 		$this->realm = $defaults->getName();
 	}
 

--- a/apps/federation/tests/Controller/SettingsControllerTest.php
+++ b/apps/federation/tests/Controller/SettingsControllerTest.php
@@ -10,6 +10,7 @@ namespace OCA\Federation\Tests\Controller;
 use OCA\Federation\Controller\SettingsController;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\HintException;
 use OCP\IL10N;
 use OCP\IRequest;
 use Test\TestCase;
@@ -23,7 +24,7 @@ class SettingsControllerTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IL10N */
 	private $l10n;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCA\Federation\TrustedServers */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|TrustedServers */
 	private $trustedServers;
 
 	protected function setUp(): void {
@@ -67,7 +68,7 @@ class SettingsControllerTest extends TestCase {
 	 * @dataProvider checkServerFails
 	 */
 	public function testAddServerFail(bool $isTrustedServer, bool $isNextcloud): void {
-		$this->expectException(\OCP\HintException::class);
+		$this->expectException(HintException::class);
 
 		$this->trustedServers
 			->expects($this->any())
@@ -113,7 +114,7 @@ class SettingsControllerTest extends TestCase {
 	 * @dataProvider checkServerFails
 	 */
 	public function testCheckServerFail(bool $isTrustedServer, bool $isNextcloud): void {
-		$this->expectException(\OCP\HintException::class);
+		$this->expectException(HintException::class);
 
 		$this->trustedServers
 			->expects($this->any())

--- a/apps/federation/tests/SyncFederationAddressbooksTest.php
+++ b/apps/federation/tests/SyncFederationAddressbooksTest.php
@@ -8,8 +8,10 @@
 namespace OCA\Federation\Tests;
 
 use OC\OCS\DiscoveryService;
+use OCA\DAV\CardDAV\SyncService;
 use OCA\Federation\DbHandler;
 use OCA\Federation\SyncFederationAddressBooks;
+use OCA\Federation\TrustedServers;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -55,7 +57,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 		$syncService->expects($this->once())->method('syncRemoteAddressBook')
 			->willReturn('1');
 
-		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
+		/** @var SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
 		$s->syncThemAll(function ($url, $ex): void {
 			$this->callBacks[] = [$url, $ex];
@@ -83,7 +85,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 		$syncService->expects($this->once())->method('syncRemoteAddressBook')
 			->willThrowException(new \Exception('something did not work out'));
 
-		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
+		/** @var SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
 		$s->syncThemAll(function ($url, $ex): void {
 			$this->callBacks[] = [$url, $ex];
@@ -105,7 +107,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 					'sync_token' => '0'
 				]
 			]);
-		$dbHandler->method('getServerStatus')->willReturn(\OCA\Federation\TrustedServers::STATUS_FAILURE);
+		$dbHandler->method('getServerStatus')->willReturn(TrustedServers::STATUS_FAILURE);
 		$dbHandler->expects($this->once())->method('setServerStatus')->
 			with('https://cloud.drop.box', 1);
 		$syncService = $this->getMockBuilder('OCA\DAV\CardDAV\SyncService')
@@ -114,7 +116,7 @@ class SyncFederationAddressbooksTest extends \Test\TestCase {
 		$syncService->expects($this->once())->method('syncRemoteAddressBook')
 			->willReturn('0');
 
-		/** @var \OCA\DAV\CardDAV\SyncService $syncService */
+		/** @var SyncService $syncService */
 		$s = new SyncFederationAddressBooks($dbHandler, $syncService, $this->discoveryService, $this->logger);
 		$s->syncThemAll(function ($url, $ex): void {
 			$this->callBacks[] = [$url, $ex];

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -12,6 +12,8 @@ use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\Events\TrustedServerRemovedEvent;
+use OCP\HintException;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
@@ -145,7 +147,7 @@ class TrustedServersTest extends TestCase {
 		$this->dispatcher->expects($this->once())->method('dispatchTyped')
 			->willReturnCallback(
 				function ($event): void {
-					$this->assertSame(get_class($event), \OCP\Federation\Events\TrustedServerRemovedEvent::class);
+					$this->assertSame(get_class($event), TrustedServerRemovedEvent::class);
 					/** @var \OCP\Federated\Events\TrustedServerRemovedEvent $event */
 					$this->assertSame('url_hash', $event->getUrlHash());
 				}
@@ -277,7 +279,7 @@ class TrustedServersTest extends TestCase {
 	 * @dataProvider dataTestCheckNextcloudVersionTooLow
 	 */
 	public function testCheckNextcloudVersionTooLow(string $status): void {
-		$this->expectException(\OCP\HintException::class);
+		$this->expectException(HintException::class);
 		$this->expectExceptionMessage('Remote server version is too low. 9.0 is required.');
 
 		$this->invokePrivate($this->trustedServers, 'checkNextcloudVersion', [$status]);

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -11,6 +11,7 @@ use OC\Core\Command\Base;
 use OC\Core\Command\InterruptedException;
 use OC\DB\Connection;
 use OC\DB\ConnectionAdapter;
+use OC\Files\Utils\Scanner;
 use OC\FilesMetadata\FilesMetadataManager;
 use OC\ForbiddenException;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -98,7 +99,7 @@ class Scan extends Base {
 
 	protected function scanFiles(string $user, string $path, ?string $scanMetadata, OutputInterface $output, bool $backgroundScan = false, bool $recursive = true, bool $homeOnly = false): void {
 		$connection = $this->reconnectToDatabase($output);
-		$scanner = new \OC\Files\Utils\Scanner(
+		$scanner = new Scanner(
 			$user,
 			new ConnectionAdapter($connection),
 			\OC::$server->get(IEventDispatcher::class),

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -9,6 +9,7 @@ use OC\Core\Command\Base;
 use OC\Core\Command\InterruptedException;
 use OC\DB\Connection;
 use OC\DB\ConnectionAdapter;
+use OC\Files\Utils\Scanner;
 use OC\ForbiddenException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
@@ -65,7 +66,7 @@ class ScanAppData extends Base {
 		}
 
 		$connection = $this->reconnectToDatabase($output);
-		$scanner = new \OC\Files\Utils\Scanner(
+		$scanner = new Scanner(
 			null,
 			new ConnectionAdapter($connection),
 			\OC::$server->query(IEventDispatcher::class),

--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -8,6 +8,7 @@
 namespace OCA\Files\Controller;
 
 use OC\Files\Node\Node;
+use OCA\Files\Helper;
 use OCA\Files\ResponseDefinitions;
 use OCA\Files\Service\TagService;
 use OCA\Files\Service\UserConfig;
@@ -30,6 +31,7 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IPreview;
@@ -124,11 +126,11 @@ class ApiController extends Controller {
 		if (!is_null($tags)) {
 			try {
 				$this->tagService->updateFileTags($path, $tags);
-			} catch (\OCP\Files\NotFoundException $e) {
+			} catch (NotFoundException $e) {
 				return new DataResponse([
 					'message' => $e->getMessage()
 				], Http::STATUS_NOT_FOUND);
-			} catch (\OCP\Files\StorageNotAvailableException $e) {
+			} catch (StorageNotAvailableException $e) {
 				return new DataResponse([
 					'message' => $e->getMessage()
 				], Http::STATUS_SERVICE_UNAVAILABLE);
@@ -150,7 +152,7 @@ class ApiController extends Controller {
 		$shareTypesForNodes = $this->getShareTypesForNodes($nodes);
 		return array_values(array_map(function (Node $node) use ($shareTypesForNodes) {
 			$shareTypes = $shareTypesForNodes[$node->getId()] ?? [];
-			$file = \OCA\Files\Helper::formatFileInfo($node->getFileInfo());
+			$file = Helper::formatFileInfo($node->getFileInfo());
 			$file['hasPreview'] = $this->previewManager->isAvailable($node);
 			$parts = explode('/', dirname($node->getPath()), 4);
 			if (isset($parts[3])) {

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -8,6 +8,7 @@
 namespace OCA\Files\Controller;
 
 use OC\Files\FilenameValidator;
+use OC\Files\Filesystem;
 use OCA\Files\AppInfo\Application;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files\Event\LoadSearchPlugins;
@@ -36,6 +37,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use OCP\Util;
 
 /**
  * @package OCA\Files\Controller
@@ -69,7 +71,7 @@ class ViewController extends Controller {
 	 * @throws \OCP\Files\NotFoundException
 	 */
 	protected function getStorageInfo(string $dir = '/') {
-		$rootInfo = \OC\Files\Filesystem::getFileInfo('/', false);
+		$rootInfo = Filesystem::getFileInfo('/', false);
 
 		return \OC_Helper::getStorageInfo($dir, $rootInfo ?: null);
 	}
@@ -138,8 +140,8 @@ class ViewController extends Controller {
 		}
 
 		// Load the files we need
-		\OCP\Util::addInitScript('files', 'init');
-		\OCP\Util::addScript('files', 'main');
+		Util::addInitScript('files', 'init');
+		Util::addScript('files', 'main');
 
 		$userId = $this->userSession->getUser()->getUID();
 

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -7,8 +7,10 @@
  */
 namespace OCA\Files;
 
+use OC\Files\Filesystem;
 use OCP\Files\FileInfo;
 use OCP\ITagManager;
+use OCP\Util;
 
 /**
  * Helper class for manipulating file information
@@ -22,9 +24,9 @@ class Helper {
 	public static function buildFileStorageStatistics($dir) {
 		// information about storage capacities
 		$storageInfo = \OC_Helper::getStorageInfo($dir);
-		$l = \OCP\Util::getL10N('files');
-		$maxUploadFileSize = \OCP\Util::maxUploadFilesize($dir, $storageInfo['free']);
-		$maxHumanFileSize = \OCP\Util::humanFileSize($maxUploadFileSize);
+		$l = Util::getL10N('files');
+		$maxUploadFileSize = Util::maxUploadFilesize($dir, $storageInfo['free']);
+		$maxHumanFileSize = Util::humanFileSize($maxUploadFileSize);
 		$maxHumanFileSize = $l->t('Upload (max. %s)', [$maxHumanFileSize]);
 
 		return [
@@ -80,7 +82,7 @@ class Helper {
 		} elseif ($aType !== 'dir' and $bType === 'dir') {
 			return 1;
 		} else {
-			return \OCP\Util::naturalSortCompare($a->getName(), $b->getName());
+			return Util::naturalSortCompare($a->getName(), $b->getName());
 		}
 	}
 
@@ -181,7 +183,7 @@ class Helper {
 	 * @return \OCP\Files\FileInfo[] files
 	 */
 	public static function getFiles($dir, $sortAttribute = 'name', $sortDescending = false, $mimetypeFilter = '') {
-		$content = \OC\Files\Filesystem::getDirectoryContent($dir, $mimetypeFilter);
+		$content = Filesystem::getDirectoryContent($dir, $mimetypeFilter);
 
 		return self::sortFiles($content, $sortAttribute, $sortDescending);
 	}

--- a/apps/files/lib/Listener/LoadSearchPluginsListener.php
+++ b/apps/files/lib/Listener/LoadSearchPluginsListener.php
@@ -11,6 +11,7 @@ namespace OCA\Files\Listener;
 use OCA\Files\Event\LoadSearchPlugins;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
 
 /** @template-implements IEventListener<LoadSearchPlugins> */
 class LoadSearchPluginsListener implements IEventListener {
@@ -19,6 +20,6 @@ class LoadSearchPluginsListener implements IEventListener {
 			return;
 		}
 
-		\OCP\Util::addScript('files', 'search');
+		Util::addScript('files', 'search');
 	}
 }

--- a/apps/files/lib/Listener/RenderReferenceEventListener.php
+++ b/apps/files/lib/Listener/RenderReferenceEventListener.php
@@ -11,6 +11,7 @@ namespace OCA\Files\Listener;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Util;
 
 /** @template-implements IEventListener<RenderReferenceEvent> */
 class RenderReferenceEventListener implements IEventListener {
@@ -19,6 +20,6 @@ class RenderReferenceEventListener implements IEventListener {
 			return;
 		}
 
-		\OCP\Util::addScript('files', 'reference-files');
+		Util::addScript('files', 'reference-files');
 	}
 }

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -13,6 +13,7 @@ use Closure;
 use OC\Encryption\Manager as EncryptionManager;
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCA\Encryption\Util;
 use OCA\Files\Exception\TransferOwnershipException;
 use OCP\Encryption\IManager as IEncryptionManager;
 use OCP\Files\Config\IUserMountCache;
@@ -21,9 +22,11 @@ use OCP\Files\IHomeStorage;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
+use OCP\Files\NotFoundException;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
+use OCP\Server;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -227,7 +230,7 @@ class OwnershipTransferService {
 		$progress->start();
 
 		if ($this->encryptionManager->isEnabled()) {
-			$masterKeyEnabled = \OCP\Server::get(\OCA\Encryption\Util::class)->isMasterKeyEnabled();
+			$masterKeyEnabled = Server::get(Util::class)->isMasterKeyEnabled();
 		} else {
 			$masterKeyEnabled = false;
 		}
@@ -416,7 +419,7 @@ class OwnershipTransferService {
 	):void {
 		$output->writeln('Restoring shares ...');
 		$progress = new ProgressBar($output, count($shares));
-		$rootFolder = \OCP\Server::get(IRootFolder::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		foreach ($shares as ['share' => $share, 'suffix' => $suffix]) {
 			try {
@@ -453,7 +456,7 @@ class OwnershipTransferService {
 							// Normally the ID is preserved,
 							// but for transferes between different storages the ID might change
 							$newNodeId = $share->getNode()->getId();
-						} catch (\OCP\Files\NotFoundException) {
+						} catch (NotFoundException) {
 							// ID has changed due to transfer between different storages
 							// Try to get the new ID from the target path and suffix of the share
 							$node = $rootFolder->get(Filesystem::normalizePath($targetLocation . '/' . $suffix));
@@ -465,7 +468,7 @@ class OwnershipTransferService {
 						$this->shareManager->updateShare($share);
 					}
 				}
-			} catch (\OCP\Files\NotFoundException $e) {
+			} catch (NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
 			} catch (\Throwable $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getMessage() . ' : ' . $e->getTraceAsString() . '</error>');
@@ -545,7 +548,7 @@ class OwnershipTransferService {
 					$this->shareManager->moveShare($share, $destinationUid);
 					continue;
 				}
-			} catch (\OCP\Files\NotFoundException $e) {
+			} catch (NotFoundException $e) {
 				$output->writeln('<error>Share with id ' . $share->getId() . ' points at deleted file, skipping</error>');
 			} catch (\Throwable $e) {
 				$output->writeln('<error>Could not restore share with id ' . $share->getId() . ':' . $e->getTraceAsString() . '</error>');

--- a/apps/files/lib/Settings/PersonalSettings.php
+++ b/apps/files/lib/Settings/PersonalSettings.php
@@ -11,10 +11,11 @@ namespace OCA\Files\Settings;
 use OCA\Files\AppInfo\Application;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Settings\ISettings;
+use OCP\Util;
 
 class PersonalSettings implements ISettings {
 	public function getForm(): TemplateResponse {
-		\OCP\Util::addScript(Application::APP_ID, 'settings-personal');
+		Util::addScript(Application::APP_ID, 'settings-personal');
 		return new TemplateResponse(Application::APP_ID, 'settings-personal');
 	}
 

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -12,6 +12,7 @@ use OCA\Files\Command\DeleteOrphanedFiles;
 use OCP\Files\IRootFolder;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IDBConnection;
+use OCP\Server;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -32,7 +33,7 @@ class DeleteOrphanedFilesTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OCP\Server::get(IDBConnection::class);
+		$this->connection = Server::get(IDBConnection::class);
 
 		$this->user1 = $this->getUniqueID('user1_');
 
@@ -81,7 +82,7 @@ class DeleteOrphanedFilesTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$rootFolder = \OCP\Server::get(IRootFolder::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		// scan home storage so that mounts are properly setup
 		$rootFolder->getUserFolder($this->user1)->getStorage()->getScanner()->scan('');

--- a/apps/files/tests/Controller/ApiControllerTest.php
+++ b/apps/files/tests/Controller/ApiControllerTest.php
@@ -12,6 +12,8 @@ use OCA\Files\Service\UserConfig;
 use OCA\Files\Service\ViewConfig;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
@@ -211,7 +213,7 @@ class ApiControllerTest extends TestCase {
 		$ret = $this->apiController->getThumbnail(10, 10, 'known.jpg');
 
 		$this->assertEquals(Http::STATUS_OK, $ret->getStatus());
-		$this->assertInstanceOf(Http\FileDisplayResponse::class, $ret);
+		$this->assertInstanceOf(FileDisplayResponse::class, $ret);
 	}
 
 	public function testShowHiddenFiles(): void {
@@ -221,7 +223,7 @@ class ApiControllerTest extends TestCase {
 			->method('setUserValue')
 			->with($this->user->getUID(), 'files', 'show_hidden', '0');
 
-		$expected = new Http\Response();
+		$expected = new Response();
 		$actual = $this->apiController->showHiddenFiles($show);
 
 		$this->assertEquals($expected, $actual);
@@ -234,7 +236,7 @@ class ApiControllerTest extends TestCase {
 			->method('setUserValue')
 			->with($this->user->getUID(), 'files', 'crop_image_previews', '1');
 
-		$expected = new Http\Response();
+		$expected = new Response();
 		$actual = $this->apiController->cropImagePreviews($crop);
 
 		$this->assertEquals($expected, $actual);

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -12,7 +12,9 @@ use OCA\Files\Controller\ViewController;
 use OCA\Files\Service\UserConfig;
 use OCA\Files\Service\ViewConfig;
 use OCP\App\IAppManager;
-use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
@@ -133,11 +135,11 @@ class ViewControllerTest extends TestCase {
 			->method('getAppValue')
 			->willReturnArgument(2);
 
-		$expected = new Http\TemplateResponse(
+		$expected = new TemplateResponse(
 			'files',
 			'index',
 		);
-		$policy = new Http\ContentSecurityPolicy();
+		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedWorkerSrcDomain('\'self\'');
 		$policy->addAllowedFrameDomain('\'self\'');
 		$expected->setContentSecurityPolicy($policy);
@@ -193,7 +195,7 @@ class ViewControllerTest extends TestCase {
 			->with('files.view.indexViewFileid', ['view' => 'trashbin', 'dir' => '/test.d1462861890/sub', 'fileid' => '123'])
 			->willReturn('/apps/files/trashbin/123?dir=/test.d1462861890/sub');
 
-		$expected = new Http\RedirectResponse('/apps/files/trashbin/123?dir=/test.d1462861890/sub');
+		$expected = new RedirectResponse('/apps/files/trashbin/123?dir=/test.d1462861890/sub');
 		$this->assertEquals($expected, $this->viewController->index('', '', '123'));
 	}
 }

--- a/apps/files/tests/HelperTest.php
+++ b/apps/files/tests/HelperTest.php
@@ -1,5 +1,10 @@
 <?php
 
+use OC\Files\FileInfo;
+use OCA\Files\Helper;
+use OCP\ITagManager;
+use OCP\ITags;
+
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -7,7 +12,7 @@
  */
 class HelperTest extends \Test\TestCase {
 	private function makeFileInfo($name, $size, $mtime, $isDir = false) {
-		return new \OC\Files\FileInfo(
+		return new FileInfo(
 			'/' . $name,
 			null,
 			'/',
@@ -79,7 +84,7 @@ class HelperTest extends \Test\TestCase {
 			$this->markTestSkipped('Skip mtime sorting on 32bit');
 		}
 		$files = self::getTestFileList();
-		$files = \OCA\Files\Helper::sortFiles($files, $sort, $sortDescending);
+		$files = Helper::sortFiles($files, $sort, $sortDescending);
 		$fileNames = [];
 		foreach ($files as $fileInfo) {
 			$fileNames[] = $fileInfo->getName();
@@ -91,8 +96,8 @@ class HelperTest extends \Test\TestCase {
 	}
 
 	public function testPopulateTags(): void {
-		$tagManager = $this->createMock(\OCP\ITagManager::class);
-		$tagger = $this->createMock(\OCP\ITags::class);
+		$tagManager = $this->createMock(ITagManager::class);
+		$tagger = $this->createMock(ITags::class);
 
 		$tagManager->method('load')
 			->with('files')
@@ -113,7 +118,7 @@ class HelperTest extends \Test\TestCase {
 			->with([10, 22, 42])
 			->willReturn($tags);
 
-		$result = \OCA\Files\Helper::populateTags($data, 'id', $tagManager);
+		$result = Helper::populateTags($data, 'id', $tagManager);
 
 		$this->assertSame([
 			['id' => 10, 'tags' => ['tag3']],

--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -10,6 +10,7 @@ namespace OCA\Files\Tests\Service;
 use OCA\Files\Service\TagService;
 use OCP\Activity\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\NotFoundException;
 use OCP\ITags;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -43,7 +44,7 @@ class TagServiceTest extends \Test\TestCase {
 	private $dispatcher;
 
 	/**
-	 * @var \OCA\Files\Service\TagService|\PHPUnit\Framework\MockObject\MockObject
+	 * @var TagService|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $tagService;
 
@@ -134,7 +135,7 @@ class TagServiceTest extends \Test\TestCase {
 		$caught = false;
 		try {
 			$this->tagService->updateFileTags('subdir/unexist.txt', [$tag1]);
-		} catch (\OCP\Files\NotFoundException $e) {
+		} catch (NotFoundException $e) {
 			$caught = true;
 		}
 		$this->assertTrue($caught);

--- a/apps/files_external/lib/Command/Verify.php
+++ b/apps/files_external/lib/Command/Verify.php
@@ -9,6 +9,7 @@ namespace OCA\Files_External\Command;
 use OC\Core\Command\Base;
 use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
 use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\MountConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\AppFramework\Http;
@@ -92,7 +93,7 @@ class Verify extends Base {
 			$backend = $storage->getBackend();
 			// update status (can be time-consuming)
 			$storage->setStatus(
-				\OCA\Files_External\MountConfig::getBackendStatus(
+				MountConfig::getBackendStatus(
 					$backend->getStorageClass(),
 					$storage->getBackendOptions(),
 					false

--- a/apps/files_external/lib/Controller/ApiController.php
+++ b/apps/files_external/lib/Controller/ApiController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
+use OCP\Constants;
 use OCP\IRequest;
 
 /**
@@ -55,10 +56,10 @@ class ApiController extends OCSController {
 
 		$isSystemMount = $mountConfig->getType() === StorageConfig::MOUNT_TYPE_ADMIN;
 
-		$permissions = \OCP\Constants::PERMISSION_READ;
+		$permissions = Constants::PERMISSION_READ;
 		// personal mounts can be deleted
 		if (!$isSystemMount) {
-			$permissions |= \OCP\Constants::PERMISSION_DELETE;
+			$permissions |= Constants::PERMISSION_DELETE;
 		}
 
 		$entry = [

--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -10,6 +10,7 @@ use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Backend\Backend;
 use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
 use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\MountConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\StoragesService;
 use OCP\AppFramework\Controller;
@@ -220,7 +221,7 @@ abstract class StoragesController extends Controller {
 			$backend = $storage->getBackend();
 			// update status (can be time-consuming)
 			$storage->setStatus(
-				\OCA\Files_External\MountConfig::getBackendStatus(
+				MountConfig::getBackendStatus(
 					$backend->getStorageClass(),
 					$storage->getBackendOptions(),
 					false,

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -13,6 +13,7 @@ use Icewind\Streams\IteratorDirectory;
 use OC\Files\Cache\CacheEntry;
 use OC\Files\ObjectStore\S3ConnectionTrait;
 use OC\Files\ObjectStore\S3ObjectTrait;
+use OC\Files\Storage\Common;
 use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
 use OCP\Files\FileInfo;
@@ -22,7 +23,7 @@ use OCP\ICacheFactory;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 
-class AmazonS3 extends \OC\Files\Storage\Common {
+class AmazonS3 extends Common {
 	use S3ConnectionTrait;
 	use S3ObjectTrait;
 

--- a/apps/files_external/lib/Lib/Storage/OwnCloud.php
+++ b/apps/files_external/lib/Lib/Storage/OwnCloud.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_External\Lib\Storage;
 
+use OC\Files\Storage\DAV;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use Sabre\DAV\Client;
 
@@ -16,7 +17,7 @@ use Sabre\DAV\Client;
  * http://%host/%context/remote.php/webdav/%root
  *
  */
-class OwnCloud extends \OC\Files\Storage\DAV implements IDisableEncryptionStorage {
+class OwnCloud extends DAV implements IDisableEncryptionStorage {
 	public const OC_URL_SUFFIX = 'remote.php/webdav';
 
 	public function __construct($params) {

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -10,6 +10,7 @@ use Icewind\Streams\CountWrapper;
 use Icewind\Streams\IteratorDirectory;
 use Icewind\Streams\RetryWrapper;
 use OC\Files\Storage\Common;
+use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
@@ -174,7 +175,7 @@ class SFTP extends Common {
 				return false;
 			}
 
-			$view = new \OC\Files\View('/' . $userId . '/files_external');
+			$view = new View('/' . $userId . '/files_external');
 
 			return $view->getLocalFile('ssh_hostKeys');
 		} catch (\Exception $e) {

--- a/apps/files_external/lib/Lib/Storage/StreamWrapper.php
+++ b/apps/files_external/lib/Lib/Storage/StreamWrapper.php
@@ -6,7 +6,9 @@
  */
 namespace OCA\Files_External\Lib\Storage;
 
-abstract class StreamWrapper extends \OC\Files\Storage\Common {
+use OC\Files\Storage\Common;
+
+abstract class StreamWrapper extends Common {
 
 	abstract public function constructUrl(string $path): ?string;
 

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -12,7 +12,10 @@ namespace OCA\Files_External\Lib\Storage;
 use GuzzleHttp\Psr7\Uri;
 use Icewind\Streams\CallbackWrapper;
 use Icewind\Streams\IteratorDirectory;
+use OC\Files\Filesystem;
 use OC\Files\ObjectStore\SwiftFactory;
+use OC\Files\Storage\Common;
+use OCP\Cache\CappedMemoryCache;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\StorageBadConfigException;
 use OpenStack\Common\Error\BadResponseError;
@@ -20,7 +23,7 @@ use OpenStack\ObjectStore\v1\Models\Container;
 use OpenStack\ObjectStore\v1\Models\StorageObject;
 use Psr\Log\LoggerInterface;
 
-class Swift extends \OC\Files\Storage\Common {
+class Swift extends Common {
 	/** @var SwiftFactory */
 	private $connectionFactory;
 	/**
@@ -155,7 +158,7 @@ class Swift extends \OC\Files\Storage\Common {
 
 		$this->params = $params;
 		// FIXME: private class...
-		$this->objectCache = new \OCP\Cache\CappedMemoryCache();
+		$this->objectCache = new CappedMemoryCache();
 		$this->connectionFactory = new SwiftFactory(
 			\OC::$server->getMemCacheFactory()->createDistributed('swift/'),
 			$this->params,
@@ -216,7 +219,7 @@ class Swift extends \OC\Files\Storage\Common {
 
 		$dh = $this->opendir($path);
 		while (($file = readdir($dh)) !== false) {
-			if (\OC\Files\Filesystem::isIgnoredDir($file)) {
+			if (Filesystem::isIgnoredDir($file)) {
 				continue;
 			}
 
@@ -482,7 +485,7 @@ class Swift extends \OC\Files\Storage\Common {
 
 			$dh = $this->opendir($source);
 			while (($file = readdir($dh)) !== false) {
-				if (\OC\Files\Filesystem::isIgnoredDir($file)) {
+				if (Filesystem::isIgnoredDir($file)) {
 					continue;
 				}
 

--- a/apps/files_external/lib/Lib/StorageConfig.php
+++ b/apps/files_external/lib/Lib/StorageConfig.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_External\Lib;
 
+use OC\Files\Filesystem;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Auth\IUserProvided;
 use OCA\Files_External\Lib\Backend\Backend;
@@ -152,7 +153,7 @@ class StorageConfig implements \JsonSerializable {
 	 * @param string $mountPoint path
 	 */
 	public function setMountPoint($mountPoint) {
-		$this->mountPoint = \OC\Files\Filesystem::normalizePath($mountPoint);
+		$this->mountPoint = Filesystem::normalizePath($mountPoint);
 	}
 
 	/**
@@ -203,7 +204,7 @@ class StorageConfig implements \JsonSerializable {
 			foreach ($backendOptions as $key => $value) {
 				if (isset($parameters[$key])) {
 					switch ($parameters[$key]->getType()) {
-						case \OCA\Files_External\Lib\DefinitionParameter::VALUE_BOOLEAN:
+						case DefinitionParameter::VALUE_BOOLEAN:
 							$value = (bool)$value;
 							break;
 					}

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -14,6 +14,8 @@ use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\Files\StorageNotAvailableException;
+use OCP\IL10N;
+use OCP\Util;
 use phpseclib\Crypt\AES;
 use Psr\Log\LoggerInterface;
 
@@ -119,7 +121,7 @@ class MountConfig {
 	 * @param Backend[] $backends
 	 */
 	public static function dependencyMessage(array $backends): string {
-		$l = \OCP\Util::getL10N('files_external');
+		$l = Util::getL10N('files_external');
 		$message = '';
 		$dependencyGroups = [];
 
@@ -147,7 +149,7 @@ class MountConfig {
 	/**
 	 * Returns a dependency missing message
 	 */
-	private static function getSingleDependencyMessage(\OCP\IL10N $l, string $module, string $backend): string {
+	private static function getSingleDependencyMessage(IL10N $l, string $module, string $backend): string {
 		switch (strtolower($module)) {
 			case 'curl':
 				return $l->t('The cURL support in PHP is not enabled or installed. Mounting of %s is not possible. Please ask your system administrator to install it.', [$backend]);

--- a/apps/files_external/lib/Service/GlobalStoragesService.php
+++ b/apps/files_external/lib/Service/GlobalStoragesService.php
@@ -8,6 +8,7 @@ namespace OCA\Files_External\Service;
 
 use OC\Files\Filesystem;
 use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\MountConfig;
 
 /**
  * Service class to manage global external storage
@@ -29,7 +30,7 @@ class GlobalStoragesService extends StoragesService {
 			$this->triggerApplicableHooks(
 				$signal,
 				$storage->getMountPoint(),
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+				MountConfig::MOUNT_TYPE_USER,
 				['all']
 			);
 			return;
@@ -38,13 +39,13 @@ class GlobalStoragesService extends StoragesService {
 		$this->triggerApplicableHooks(
 			$signal,
 			$storage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			$applicableUsers
 		);
 		$this->triggerApplicableHooks(
 			$signal,
 			$storage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+			MountConfig::MOUNT_TYPE_GROUP,
 			$applicableGroups
 		);
 	}
@@ -78,7 +79,7 @@ class GlobalStoragesService extends StoragesService {
 			$this->triggerApplicableHooks(
 				Filesystem::signal_delete_mount,
 				$oldStorage->getMountPoint(),
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+				MountConfig::MOUNT_TYPE_USER,
 				['all']
 			);
 		}
@@ -87,7 +88,7 @@ class GlobalStoragesService extends StoragesService {
 		$this->triggerApplicableHooks(
 			Filesystem::signal_delete_mount,
 			$oldStorage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			$userDeletions
 		);
 
@@ -95,7 +96,7 @@ class GlobalStoragesService extends StoragesService {
 		$this->triggerApplicableHooks(
 			Filesystem::signal_delete_mount,
 			$oldStorage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+			MountConfig::MOUNT_TYPE_GROUP,
 			$groupDeletions
 		);
 
@@ -103,7 +104,7 @@ class GlobalStoragesService extends StoragesService {
 		$this->triggerApplicableHooks(
 			Filesystem::signal_create_mount,
 			$newStorage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			$userAdditions
 		);
 
@@ -111,7 +112,7 @@ class GlobalStoragesService extends StoragesService {
 		$this->triggerApplicableHooks(
 			Filesystem::signal_create_mount,
 			$newStorage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+			MountConfig::MOUNT_TYPE_GROUP,
 			$groupAdditions
 		);
 
@@ -123,7 +124,7 @@ class GlobalStoragesService extends StoragesService {
 			$this->triggerApplicableHooks(
 				Filesystem::signal_create_mount,
 				$newStorage->getMountPoint(),
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+				MountConfig::MOUNT_TYPE_USER,
 				['all']
 			);
 		}

--- a/apps/files_external/lib/Service/LegacyStoragesService.php
+++ b/apps/files_external/lib/Service/LegacyStoragesService.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_External\Service;
 
 use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\MountConfig;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -62,13 +63,13 @@ abstract class LegacyStoragesService {
 			$storageOptions['priority'] = $backend->getPriority();
 		}
 		$storageConfig->setPriority($storageOptions['priority']);
-		if ($mountType === \OCA\Files_External\MountConfig::MOUNT_TYPE_USER) {
+		if ($mountType === MountConfig::MOUNT_TYPE_USER) {
 			$applicableUsers = $storageConfig->getApplicableUsers();
 			if ($applicable !== 'all') {
 				$applicableUsers[] = $applicable;
 				$storageConfig->setApplicableUsers($applicableUsers);
 			}
-		} elseif ($mountType === \OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP) {
+		} elseif ($mountType === MountConfig::MOUNT_TYPE_GROUP) {
 			$applicableGroups = $storageConfig->getApplicableGroups();
 			$applicableGroups[] = $applicable;
 			$storageConfig->setApplicableGroups($applicableGroups);
@@ -129,7 +130,7 @@ abstract class LegacyStoragesService {
 					$relativeMountPath = rtrim($parts[2], '/');
 					// note: we cannot do this after the loop because the decrypted config
 					// options might be needed for the config hash
-					$storageOptions['options'] = \OCA\Files_External\MountConfig::decryptPasswords($storageOptions['options']);
+					$storageOptions['options'] = MountConfig::decryptPasswords($storageOptions['options']);
 					if (!isset($storageOptions['backend'])) {
 						$storageOptions['backend'] = $storageOptions['class']; // legacy compat
 					}
@@ -147,7 +148,7 @@ abstract class LegacyStoragesService {
 						// but at this point we don't know the max-id, so use
 						// first group it by config hash
 						$storageOptions['mountpoint'] = $rootMountPath;
-						$configId = \OCA\Files_External\MountConfig::makeConfigHash($storageOptions);
+						$configId = MountConfig::makeConfigHash($storageOptions);
 						if (isset($storagesWithConfigHash[$configId])) {
 							$currentStorage = $storagesWithConfigHash[$configId];
 						}

--- a/apps/files_external/lib/Service/StoragesService.php
+++ b/apps/files_external/lib/Service/StoragesService.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_External\Service;
 
+use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Auth\InvalidAuth;
@@ -18,6 +19,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -324,7 +326,7 @@ abstract class StoragesService {
 	protected function triggerApplicableHooks($signal, $mountPoint, $mountType, $applicableArray): void {
 		$this->eventDispatcher->dispatchTyped(new InvalidateMountCacheEvent(null));
 		foreach ($applicableArray as $applicable) {
-			\OCP\Util::emitHook(
+			Util::emitHook(
 				Filesystem::CLASSNAME,
 				$signal,
 				[
@@ -463,7 +465,7 @@ abstract class StoragesService {
 		$this->triggerHooks($deletedStorage, Filesystem::signal_delete_mount);
 
 		// delete oc_storages entries and oc_filecache
-		\OC\Files\Cache\Storage::cleanByMountId($id);
+		Storage::cleanByMountId($id);
 	}
 
 	/**

--- a/apps/files_external/lib/Service/UserStoragesService.php
+++ b/apps/files_external/lib/Service/UserStoragesService.php
@@ -8,6 +8,7 @@ namespace OCA\Files_External\Service;
 
 use OC\Files\Filesystem;
 use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\MountConfig;
 use OCA\Files_External\NotFoundException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IUserMountCache;
@@ -58,7 +59,7 @@ class UserStoragesService extends StoragesService {
 		$this->triggerApplicableHooks(
 			$signal,
 			$storage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			[$user]
 		);
 	}

--- a/apps/files_external/lib/Settings/Admin.php
+++ b/apps/files_external/lib/Settings/Admin.php
@@ -6,6 +6,7 @@
 namespace OCA\Files_External\Settings;
 
 use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
+use OCA\Files_External\MountConfig;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -48,7 +49,7 @@ class Admin implements ISettings {
 			'storages' => $this->globalStoragesService->getStorages(),
 			'backends' => $this->backendService->getAvailableBackends(),
 			'authMechanisms' => $this->backendService->getAuthMechanisms(),
-			'dependencies' => \OCA\Files_External\MountConfig::dependencyMessage($this->backendService->getBackends()),
+			'dependencies' => MountConfig::dependencyMessage($this->backendService->getBackends()),
 			'allowUserMounting' => $this->backendService->isUserMountingAllowed(),
 			'globalCredentials' => $this->globalAuth->getAuth(''),
 			'globalCredentialsUid' => '',

--- a/apps/files_external/lib/Settings/Personal.php
+++ b/apps/files_external/lib/Settings/Personal.php
@@ -6,6 +6,7 @@
 namespace OCA\Files_External\Settings;
 
 use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
+use OCA\Files_External\MountConfig;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -56,7 +57,7 @@ class Personal implements ISettings {
 			'storages' => $this->userGlobalStoragesService->getStorages(),
 			'backends' => $this->backendService->getAvailableBackends(),
 			'authMechanisms' => $this->backendService->getAuthMechanisms(),
-			'dependencies' => \OCA\Files_External\MountConfig::dependencyMessage($this->backendService->getBackends()),
+			'dependencies' => MountConfig::dependencyMessage($this->backendService->getBackends()),
 			'allowUserMounting' => $this->backendService->isUserMountingAllowed(),
 			'globalCredentials' => $this->globalAuth->getAuth($uid),
 			'globalCredentialsUid' => $uid,

--- a/apps/files_external/tests/Auth/Password/GlobalAuth.php
+++ b/apps/files_external/tests/Auth/Password/GlobalAuth.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_External\Tests\Auth\Password;
 
 use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
+use OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException;
 use OCA\Files_external\Lib\StorageConfig;
 use OCP\IL10N;
 use OCP\Security\ICredentialsManager;
@@ -90,7 +91,7 @@ class GlobalAuthTest extends TestCase {
 
 
 	public function testNoCredentialsPersonal(): void {
-		$this->expectException(\OCA\Files_External\Lib\InsufficientDataForMeaningfulAnswerException::class);
+		$this->expectException(InsufficientDataForMeaningfulAnswerException::class);
 
 		$this->credentialsManager->expects($this->never())
 			->method('retrieve');

--- a/apps/files_external/tests/Command/CommandTest.php
+++ b/apps/files_external/tests/Command/CommandTest.php
@@ -8,6 +8,7 @@ namespace OCA\Files_External\Tests\Command;
 
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\NotFoundException;
+use OCA\Files_External\Service\GlobalStoragesService;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\Input;
@@ -17,7 +18,7 @@ use Test\TestCase;
 abstract class CommandTest extends TestCase {
 	/**
 	 * @param StorageConfig[] $mounts
-	 * @return \OCA\Files_External\Service\GlobalStoragesService|\PHPUnit\Framework\MockObject\MockObject
+	 * @return GlobalStoragesService|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getGlobalStorageService(array $mounts = []) {
 		$mock = $this->getMockBuilder('OCA\Files_External\Service\GlobalStoragesService')

--- a/apps/files_external/tests/Controller/StoragesControllerTest.php
+++ b/apps/files_external/tests/Controller/StoragesControllerTest.php
@@ -9,8 +9,9 @@ namespace OCA\Files_External\Tests\Controller;
 use OCA\Files_External\Controller\GlobalStoragesController;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Backend\Backend;
-
 use OCA\Files_External\Lib\StorageConfig;
+
+use OCA\Files_External\MountConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;
@@ -30,11 +31,11 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	protected $service;
 
 	protected function setUp(): void {
-		\OCA\Files_External\MountConfig::$skipTest = true;
+		MountConfig::$skipTest = true;
 	}
 
 	protected function tearDown(): void {
-		\OCA\Files_External\MountConfig::$skipTest = false;
+		MountConfig::$skipTest = false;
 	}
 
 	/**
@@ -54,7 +55,7 @@ abstract class StoragesControllerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @return \OCA\Files_External\Lib\Auth\AuthMechanism|MockObject
+	 * @return AuthMechanism|MockObject
 	 */
 	protected function getAuthMechMock($scheme = 'null', $class = '\OCA\Files_External\Lib\Auth\NullMechanism') {
 		$authMech = $this->getMockBuilder(AuthMechanism::class)

--- a/apps/files_external/tests/OwnCloudFunctionsTest.php
+++ b/apps/files_external/tests/OwnCloudFunctionsTest.php
@@ -6,6 +6,8 @@
  */
 namespace OCA\Files_External\Tests;
 
+use OCA\Files_External\Lib\Storage\OwnCloud;
+
 /**
  * Class OwnCloudFunctions
  *
@@ -89,7 +91,7 @@ class OwnCloudFunctionsTest extends \Test\TestCase {
 	public function testConfig($config, $expectedUri): void {
 		$config['user'] = 'someuser';
 		$config['password'] = 'somepassword';
-		$instance = new \OCA\Files_External\Lib\Storage\OwnCloud($config);
+		$instance = new OwnCloud($config);
 		$this->assertEquals($expectedUri, $instance->createBaseUri());
 	}
 }

--- a/apps/files_external/tests/PersonalMountTest.php
+++ b/apps/files_external/tests/PersonalMountTest.php
@@ -10,12 +10,13 @@ use OC\Files\Mount\Manager;
 use OC\Files\SetupManagerFactory;
 use OCA\Files_External\Lib\PersonalMount;
 use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\Service\UserStoragesService;
 use Test\TestCase;
 
 class PersonalMountTest extends TestCase {
 	public function testFindByStorageId(): void {
 		$storageConfig = $this->createMock(StorageConfig::class);
-		/** @var \OCA\Files_External\Service\UserStoragesService $storageService */
+		/** @var UserStoragesService $storageService */
 		$storageService = $this->getMockBuilder('\OCA\Files_External\Service\UserStoragesService')
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -40,7 +40,7 @@ class BackendServiceTest extends \Test\TestCase {
 	/**
 	 * @param string $class
 	 *
-	 * @return \OCA\Files_External\Lib\Auth\AuthMechanism|\PHPUnit\Framework\MockObject\MockObject
+	 * @return AuthMechanism|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getAuthMechanismMock($class) {
 		$backend = $this->getMockBuilder(AuthMechanism::class)

--- a/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_External\Tests\Service;
 
 use OC\Files\Filesystem;
+use OCA\Files_External\MountConfig;
 
 use OCA\Files_External\Service\GlobalStoragesService;
 
@@ -181,7 +182,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'all'
 					],
 				],
@@ -194,7 +195,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user1',
 					],
 				],
@@ -207,7 +208,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group1',
 					],
 				],
@@ -219,12 +220,12 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user1',
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user2',
 					],
 				],
@@ -237,12 +238,12 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group1'
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group2'
 					],
 				],
@@ -255,22 +256,22 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user1',
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user2',
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group1'
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group2'
 					],
 				],
@@ -313,27 +314,27 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 					// delete the "all entry"
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'all',
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user1',
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user2',
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group1'
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group2'
 					],
 				],
@@ -348,12 +349,12 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user2',
 					],
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group2'
 					],
 				],
@@ -368,12 +369,12 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user2',
 					],
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group2'
 					],
 				],
@@ -388,18 +389,18 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user1',
 					],
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group1'
 					],
 					// create the "all" entry
 					[
 						Filesystem::signal_create_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'all'
 					],
 				],
@@ -470,50 +471,50 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 			[
 				Filesystem::signal_delete_mount,
 				'/mountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+				MountConfig::MOUNT_TYPE_USER,
 				'user1',
 			],
 			[
 				Filesystem::signal_delete_mount,
 				'/mountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+				MountConfig::MOUNT_TYPE_USER,
 				'user2',
 			],
 			[
 				Filesystem::signal_delete_mount,
 				'/mountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+				MountConfig::MOUNT_TYPE_GROUP,
 				'group1',
 			],
 			[
 				Filesystem::signal_delete_mount,
 				'/mountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+				MountConfig::MOUNT_TYPE_GROUP,
 				'group2',
 			],
 			// creates new one
 			[
 				Filesystem::signal_create_mount,
 				'/renamedMountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+				MountConfig::MOUNT_TYPE_USER,
 				'user1',
 			],
 			[
 				Filesystem::signal_create_mount,
 				'/renamedMountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+				MountConfig::MOUNT_TYPE_USER,
 				'user2',
 			],
 			[
 				Filesystem::signal_create_mount,
 				'/renamedMountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+				MountConfig::MOUNT_TYPE_GROUP,
 				'group1',
 			],
 			[
 				Filesystem::signal_create_mount,
 				'/renamedMountpoint',
-				\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+				MountConfig::MOUNT_TYPE_GROUP,
 				'group2',
 			],
 		];
@@ -540,22 +541,22 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user1',
 					],
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'user2',
 					],
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group1'
 					],
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_GROUP,
+						MountConfig::MOUNT_TYPE_GROUP,
 						'group2'
 					],
 				],
@@ -567,7 +568,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTest {
 				[
 					[
 						Filesystem::signal_delete_mount,
-						\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+						MountConfig::MOUNT_TYPE_USER,
 						'all',
 					],
 				],

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_External\Tests\Service;
 
+use OC\User\User;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\StoragesService;
@@ -46,7 +47,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 
 		$this->globalStoragesService = $this->service;
 
-		$this->user = new \OC\User\User(self::USER_ID, null, \OC::$server->get(IEventDispatcher::class));
+		$this->user = new User(self::USER_ID, null, \OC::$server->get(IEventDispatcher::class));
 		/** @var \OCP\IUserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession

--- a/apps/files_external/tests/Service/UserStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserStoragesServiceTest.php
@@ -7,8 +7,10 @@
 namespace OCA\Files_External\Tests\Service;
 
 use OC\Files\Filesystem;
-
 use OCA\Files_External\Lib\StorageConfig;
+use OCA\Files_External\MountConfig;
+
+use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserStoragesService;
@@ -85,7 +87,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 			current(self::$hookCalls),
 			Filesystem::signal_create_mount,
 			$storage->getMountPoint(),
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			$this->userId
 		);
 
@@ -136,7 +138,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 			self::$hookCalls[1],
 			Filesystem::signal_delete_mount,
 			'/mountpoint',
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			$this->userId
 		);
 	}
@@ -157,21 +159,21 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 			self::$hookCalls[0],
 			Filesystem::signal_delete_mount,
 			'/mountpoint',
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			$this->userId
 		);
 		$this->assertHookCall(
 			self::$hookCalls[1],
 			Filesystem::signal_create_mount,
 			'/renamedMountpoint',
-			\OCA\Files_External\MountConfig::MOUNT_TYPE_USER,
+			MountConfig::MOUNT_TYPE_USER,
 			$this->userId
 		);
 	}
 
 
 	public function testGetAdminStorage(): void {
-		$this->expectException(\OCA\Files_External\NotFoundException::class);
+		$this->expectException(NotFoundException::class);
 
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');

--- a/apps/files_external/tests/Settings/AdminTest.php
+++ b/apps/files_external/tests/Settings/AdminTest.php
@@ -6,6 +6,7 @@
 namespace OCA\Files_External\Tests\Settings;
 
 use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
+use OCA\Files_External\MountConfig;
 use OCA\Files_External\Service\BackendService;
 use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Settings\Admin;
@@ -76,7 +77,7 @@ class AdminTest extends TestCase {
 			'storages' => ['a', 'b', 'c'],
 			'backends' => ['d', 'e', 'f'],
 			'authMechanisms' => ['g', 'h', 'i'],
-			'dependencies' => \OCA\Files_External\MountConfig::dependencyMessage($this->backendService->getBackends()),
+			'dependencies' => MountConfig::dependencyMessage($this->backendService->getBackends()),
 			'allowUserMounting' => true,
 			'globalCredentials' => 'asdf:asdf',
 			'globalCredentialsUid' => '',

--- a/apps/files_sharing/lib/AppInfo/Application.php
+++ b/apps/files_sharing/lib/AppInfo/Application.php
@@ -120,9 +120,9 @@ class Application extends App implements IBootstrap {
 
 	public function registerEventsScripts(IEventDispatcher $dispatcher): void {
 		$dispatcher->addListener(ResourcesLoadAdditionalScriptsEvent::class, function (): void {
-			\OCP\Util::addScript('files_sharing', 'collaboration');
+			Util::addScript('files_sharing', 'collaboration');
 		});
-		$dispatcher->addListener(\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class, function (): void {
+		$dispatcher->addListener(BeforeTemplateRenderedEvent::class, function (): void {
 			/**
 			 * Always add main sharing script
 			 */

--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -122,7 +122,7 @@ class Cache extends CacheJail {
 		parent::remove($file);
 	}
 
-	public function moveFromCache(\OCP\Files\Cache\ICache $sourceCache, $sourcePath, $targetPath) {
+	public function moveFromCache(ICache $sourceCache, $sourcePath, $targetPath) {
 		$this->rootUnchanged = false;
 		return parent::moveFromCache($sourceCache, $sourcePath, $targetPath);
 	}

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\AppFramework\QueryException;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
@@ -105,7 +106,7 @@ class DeletedShareAPIController extends OCSController {
 		}
 
 		$result['path'] = $userFolder->getRelativePath($node->getPath());
-		if ($node instanceof \OCP\Files\Folder) {
+		if ($node instanceof Folder) {
 			$result['item_type'] = 'folder';
 		} else {
 			$result['item_type'] = 'file';

--- a/apps/files_sharing/lib/Controller/RemoteController.php
+++ b/apps/files_sharing/lib/Controller/RemoteController.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Sharing\Controller;
 
+use OC\Files\View;
 use OCA\Files_Sharing\External\Manager;
 use OCA\Files_Sharing\ResponseDefinitions;
 use OCP\AppFramework\Http;
@@ -96,7 +97,7 @@ class RemoteController extends OCSController {
 	 * @return array enriched share info with data from the filecache
 	 */
 	private static function extendShareInfo($share) {
-		$view = new \OC\Files\View('/' . \OC_User::getUser() . '/files/');
+		$view = new View('/' . \OC_User::getUser() . '/files/');
 		$info = $view->getFileInfo($share['mountpoint']);
 
 		if ($info === false) {

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -10,6 +10,7 @@ namespace OCA\Files_Sharing\Controller;
 
 use Generator;
 use OC\Collaboration\Collaborators\SearchResult;
+use OC\Share\Share;
 use OCA\Files_Sharing\ResponseDefinitions;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -362,7 +363,7 @@ class ShareesAPIController extends OCSController {
 	protected function isRemoteSharingAllowed(string $itemType): bool {
 		try {
 			// FIXME: static foo makes unit testing unnecessarily difficult
-			$backend = \OC\Share\Share::getBackend($itemType);
+			$backend = Share::getBackend($itemType);
 			return $backend->isShareTypeAllowed(IShare::TYPE_REMOTE);
 		} catch (\Exception $e) {
 			return false;
@@ -372,7 +373,7 @@ class ShareesAPIController extends OCSController {
 	protected function isRemoteGroupSharingAllowed(string $itemType): bool {
 		try {
 			// FIXME: static foo makes unit testing unnecessarily difficult
-			$backend = \OC\Share\Share::getBackend($itemType);
+			$backend = Share::getBackend($itemType);
 			return $backend->isShareTypeAllowed(IShare::TYPE_REMOTE_GROUP);
 		} catch (\Exception $e) {
 			return false;

--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -20,6 +20,7 @@ use OCP\AppFramework\Http\Template\PublicTemplateResponse;
 use OCP\AppFramework\Http\Template\SimpleMenuAction;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\Constants;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
@@ -78,8 +79,8 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 		if ($shareNode instanceof File) {
 			$view = 'public-file-share';
 			$this->initialState->provideInitialState('fileId', $shareNode->getId());
-		} elseif (($share->getPermissions() & \OCP\Constants::PERMISSION_CREATE)
-			&& !($share->getPermissions() & \OCP\Constants::PERMISSION_READ)
+		} elseif (($share->getPermissions() & Constants::PERMISSION_CREATE)
+			&& !($share->getPermissions() & Constants::PERMISSION_READ)
 		) {
 			// share is a folder with create but no read permissions -> file drop only
 			$view = 'public-file-drop';
@@ -97,10 +98,10 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 		$this->initialState->provideInitialState('view', $view);
 
 		// Load scripts and styles for UI
-		\OCP\Util::addInitScript('files', 'init');
-		\OCP\Util::addInitScript(Application::APP_ID, 'init');
-		\OCP\Util::addInitScript(Application::APP_ID, 'init-public');
-		\OCP\Util::addScript('files', 'main');
+		Util::addInitScript('files', 'init');
+		Util::addInitScript(Application::APP_ID, 'init');
+		Util::addInitScript(Application::APP_ID, 'init-public');
+		Util::addScript('files', 'main');
 
 		// Add file-request script if needed
 		$attributes = $share->getAttributes();
@@ -171,7 +172,7 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 		if ($shareNode->getMimePart() === 'image') {
 			// If this is a file and especially an image directly point to the image preview
 			$directLink = $this->urlGenerator->linkToRouteAbsolute('files_sharing.publicpreview.directLink', ['token' => $token]);
-		} elseif (($share->getPermissions() & \OCP\Constants::PERMISSION_READ) && !$share->getHideDownload()) {
+		} elseif (($share->getPermissions() & Constants::PERMISSION_READ) && !$share->getHideDownload()) {
 			// Can read and no download restriction, so just download it
 			$directLink = $downloadUrl ?? $shareUrl;
 		}

--- a/apps/files_sharing/lib/External/Cache.php
+++ b/apps/files_sharing/lib/External/Cache.php
@@ -16,7 +16,7 @@ class Cache extends \OC\Files\Cache\Cache {
 	private $storage;
 
 	/**
-	 * @param \OCA\Files_Sharing\External\Storage $storage
+	 * @param Storage $storage
 	 * @param ICloudId $cloudId
 	 */
 	public function __construct($storage, ICloudId $cloudId) {

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -16,6 +16,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
 use OCP\Files;
+use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\Http\Client\IClientService;
@@ -347,7 +348,7 @@ class Manager {
 				$this->sendFeedbackToRemote($share['remote'], $share['share_token'], $share['remote_id'], 'accept');
 				$event = new FederatedShareAddedEvent($share['remote']);
 				$this->eventDispatcher->dispatchTyped($event);
-				$this->eventDispatcher->dispatchTyped(new Files\Events\InvalidateMountCacheEvent($this->userManager->get($this->uid)));
+				$this->eventDispatcher->dispatchTyped(new InvalidateMountCacheEvent($this->userManager->get($this->uid)));
 				$result = true;
 			}
 		}
@@ -567,7 +568,7 @@ class Manager {
 		');
 		$result = (bool)$query->execute([$target, $targetHash, $sourceHash, $this->uid]);
 
-		$this->eventDispatcher->dispatchTyped(new Files\Events\InvalidateMountCacheEvent($this->userManager->get($this->uid)));
+		$this->eventDispatcher->dispatchTyped(new InvalidateMountCacheEvent($this->userManager->get($this->uid)));
 
 		return $result;
 	}

--- a/apps/files_sharing/lib/External/Scanner.php
+++ b/apps/files_sharing/lib/External/Scanner.php
@@ -12,7 +12,7 @@ use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 
 class Scanner extends \OC\Files\Cache\Scanner {
-	/** @var \OCA\Files_Sharing\External\Storage */
+	/** @var Storage */
 	protected $storage;
 
 	public function scan($path, $recursive = self::SCAN_RECURSIVE, $reuse = -1, $lock = true) {

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use OC\Files\Storage\DAV;
 use OC\ForbiddenException;
+use OC\Share\Share;
 use OCA\Files_Sharing\External\Manager as ExternalShareManager;
 use OCA\Files_Sharing\ISharedStorage;
 use OCP\AppFramework\Http;
@@ -35,6 +36,7 @@ use OCP\OCM\Exceptions\OCMArgumentException;
 use OCP\OCM\Exceptions\OCMProviderException;
 use OCP\OCM\IOCMDiscoveryService;
 use OCP\Server;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, IReliableEtagStorage {
@@ -144,7 +146,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		if (!isset($this->scanner)) {
 			$this->scanner = new Scanner($storage);
 		}
-		/** @var \OCA\Files_Sharing\External\Scanner */
+		/** @var Scanner */
 		return $this->scanner;
 	}
 
@@ -328,7 +330,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 	}
 
 	public function isSharable(string $path): bool {
-		if (\OCP\Util::isSharingDisabledForUser() || !\OC\Share\Share::isResharingAllowed()) {
+		if (Util::isSharingDisabledForUser() || !Share::isResharingAllowed()) {
 			return false;
 		}
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_SHARE);

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -9,13 +9,14 @@ namespace OCA\Files_Sharing;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files_Sharing\AppInfo\Application;
+use OCP\Util;
 
 class Helper {
 	public static function registerHooks() {
-		\OCP\Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook');
-		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
+		Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook');
+		Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
 
-		\OCP\Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');
+		Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser');
 	}
 
 	/**

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Sharing;
 
 use OC\Files\Filesystem;
+use OC\Files\View;
 
 class Hooks {
 	public static function deleteUser($params) {
@@ -17,10 +18,10 @@ class Hooks {
 
 	public static function unshareChildren($params) {
 		$path = Filesystem::getView()->getAbsolutePath($params['path']);
-		$view = new \OC\Files\View('/');
+		$view = new View('/');
 
 		// find share mount points within $path and unmount them
-		$mountManager = \OC\Files\Filesystem::getMountManager();
+		$mountManager = Filesystem::getMountManager();
 		$mountedShares = $mountManager->findIn($path);
 		foreach ($mountedShares as $mount) {
 			if ($mount->getStorage()->instanceOfStorage(ISharedStorage::class)) {

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -51,7 +51,7 @@ class MountProvider implements IMountProvider {
 
 
 		// filter out excluded shares and group shares that includes self
-		$shares = array_filter($shares, function (\OCP\Share\IShare $share) use ($user) {
+		$shares = array_filter($shares, function (IShare $share) use ($user) {
 			return $share->getPermissions() > 0 && $share->getShareOwner() !== $user->getUID();
 		});
 
@@ -165,7 +165,7 @@ class MountProvider implements IMountProvider {
 	 * @param \OCP\IUser $user user
 	 * @return array Tuple of [superShare, groupedShares]
 	 */
-	private function buildSuperShares(array $allShares, \OCP\IUser $user) {
+	private function buildSuperShares(array $allShares, IUser $user) {
 		$result = [];
 
 		$groupedShares = $this->groupShares($allShares);

--- a/apps/files_sharing/lib/Scanner.php
+++ b/apps/files_sharing/lib/Scanner.php
@@ -14,7 +14,7 @@ use OC\Files\ObjectStore\ObjectStoreScanner;
  */
 class Scanner extends \OC\Files\Cache\Scanner {
 	/**
-	 * @var \OCA\Files_Sharing\SharedStorage $storage
+	 * @var SharedStorage $storage
 	 */
 	protected $storage;
 

--- a/apps/files_sharing/lib/ShareBackend/Folder.php
+++ b/apps/files_sharing/lib/ShareBackend/Folder.php
@@ -6,7 +6,9 @@
  */
 namespace OCA\Files_Sharing\ShareBackend;
 
-class Folder extends File implements \OCP\Share_Backend_Collection {
+use OCP\Share_Backend_Collection;
+
+class Folder extends File implements Share_Backend_Collection {
 	public function getChildren($itemSource) {
 		$children = [];
 		$parents = [$itemSource];

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -11,13 +11,16 @@ use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\View;
+use OCA\Files_Sharing\Exceptions\BrokenPath;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\ICache;
 use OCP\IUser;
+use OCP\Server;
 use OCP\Share\Events\VerifyMountPointEvent;
+use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,7 +28,7 @@ use Psr\Log\LoggerInterface;
  */
 class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint {
 	/**
-	 * @var \OCA\Files_Sharing\SharedStorage $storage
+	 * @var SharedStorage $storage
 	 */
 	protected $storage = null;
 
@@ -79,7 +82,7 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 	 * @return string
 	 */
 	private function verifyMountPoint(
-		\OCP\Share\IShare $share,
+		IShare $share,
 		array $mountpoints,
 		CappedMemoryCache $folderExistCache,
 	) {
@@ -108,7 +111,7 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 		}
 
 		$newMountPoint = $this->generateUniqueTarget(
-			\OC\Files\Filesystem::normalizePath($parent . '/' . $mountPoint),
+			Filesystem::normalizePath($parent . '/' . $mountPoint),
 			$this->recipientView,
 			$mountpoints
 		);
@@ -169,7 +172,7 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 	 *
 	 * @param string $path the absolute path
 	 * @return string e.g. turns '/admin/files/test.txt' into '/test.txt'
-	 * @throws \OCA\Files_Sharing\Exceptions\BrokenPath
+	 * @throws BrokenPath
 	 */
 	protected function stripUserFilesPath($path) {
 		$trimmed = ltrim($path, '/');
@@ -177,8 +180,8 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 
 		// it is not a file relative to data/user/files
 		if (count($split) < 3 || $split[1] !== 'files') {
-			\OCP\Server::get(LoggerInterface::class)->error('Can not strip userid and "files/" from path: ' . $path, ['app' => 'files_sharing']);
-			throw new \OCA\Files_Sharing\Exceptions\BrokenPath('Path does not start with /user/files', 10);
+			Server::get(LoggerInterface::class)->error('Can not strip userid and "files/" from path: ' . $path, ['app' => 'files_sharing']);
+			throw new BrokenPath('Path does not start with /user/files', 10);
 		}
 
 		// skip 'user' and 'files'
@@ -205,7 +208,7 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 			$this->setMountPoint($target);
 			$this->storage->setMountPoint($relTargetPath);
 		} catch (\Exception $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Could not rename mount point for shared folder "' . $this->getMountPoint() . '" to "' . $target . '"',
 				[
 					'app' => 'files_sharing',
@@ -223,8 +226,8 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 	 * @return bool
 	 */
 	public function removeMount() {
-		$mountManager = \OC\Files\Filesystem::getMountManager();
-		/** @var \OCA\Files_Sharing\SharedStorage $storage */
+		$mountManager = Filesystem::getMountManager();
+		/** @var SharedStorage $storage */
 		$storage = $this->getStorage();
 		$result = $storage->unshareStorage();
 		$mountManager->removeMount($this->mountPoint);

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -14,8 +14,10 @@ use OC\Files\Storage\Common;
 use OC\Files\Storage\FailedStorage;
 use OC\Files\Storage\Home;
 use OC\Files\Storage\Storage;
+use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\PermissionsMask;
 use OC\Files\Storage\Wrapper\Wrapper;
+use OC\Share\Share;
 use OC\User\NoUserException;
 use OCA\Files_External\Config\ConfigAdapter;
 use OCA\Files_Sharing\ISharedStorage as LegacyISharedStorage;
@@ -35,12 +37,13 @@ use OCP\Files\Storage\ISharedStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\Lock\ILockingProvider;
 use OCP\Share\IShare;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
  * Convert target path to source path and pass the function call to the correct storage provider
  */
-class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISharedStorage, ISharedStorage, IDisableEncryptionStorage {
+class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage, IDisableEncryptionStorage {
 	/** @var \OCP\Share\IShare */
 	private $superShare;
 
@@ -242,18 +245,18 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 
 		// part files and the mount point always have delete permissions
 		if ($path === '' || pathinfo($path, PATHINFO_EXTENSION) === 'part') {
-			$permissions |= \OCP\Constants::PERMISSION_DELETE;
+			$permissions |= Constants::PERMISSION_DELETE;
 		}
 
 		if ($this->sharingDisabledForUser) {
-			$permissions &= ~\OCP\Constants::PERMISSION_SHARE;
+			$permissions &= ~Constants::PERMISSION_SHARE;
 		}
 
 		return $permissions;
 	}
 
 	public function isCreatable(string $path): bool {
-		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_CREATE);
+		return (bool)($this->getPermissions($path) & Constants::PERMISSION_CREATE);
 	}
 
 	public function isReadable(string $path): bool {
@@ -270,18 +273,18 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 	}
 
 	public function isUpdatable(string $path): bool {
-		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_UPDATE);
+		return (bool)($this->getPermissions($path) & Constants::PERMISSION_UPDATE);
 	}
 
 	public function isDeletable(string $path): bool {
-		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_DELETE);
+		return (bool)($this->getPermissions($path) & Constants::PERMISSION_DELETE);
 	}
 
 	public function isSharable(string $path): bool {
-		if (\OCP\Util::isSharingDisabledForUser() || !\OC\Share\Share::isResharingAllowed()) {
+		if (Util::isSharingDisabledForUser() || !Share::isResharingAllowed()) {
 			return false;
 		}
-		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_SHARE);
+		return (bool)($this->getPermissions($path) & Constants::PERMISSION_SHARE);
 	}
 
 	public function fopen(string $path, string $mode) {
@@ -332,7 +335,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 			'source' => $source,
 			'mode' => $mode,
 		];
-		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'fopen', $info);
+		Util::emitHook('\OC\Files\Storage\Shared', 'fopen', $info);
 		return $this->nonMaskedStorage->fopen($this->getUnjailedPath($path), $mode);
 	}
 
@@ -406,7 +409,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 			return new FailedCache();
 		}
 
-		$this->cache = new \OCA\Files_Sharing\Cache(
+		$this->cache = new Cache(
 			$storage,
 			$sourceRoot,
 			\OC::$server->get(CacheDependencies::class),
@@ -419,7 +422,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		if (!$storage) {
 			$storage = $this;
 		}
-		return new \OCA\Files_Sharing\Scanner($storage);
+		return new Scanner($storage);
 	}
 
 	public function getOwner(string $path): string|false {
@@ -529,7 +532,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 			'target' => $this->getMountPoint() . '/' . $path,
 			'source' => $this->getUnjailedPath($path),
 		];
-		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
+		Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info);
 		return parent::file_get_contents($path);
 	}
 
@@ -538,7 +541,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 			'target' => $this->getMountPoint() . '/' . $path,
 			'source' => $this->getUnjailedPath($path),
 		];
-		\OCP\Util::emitHook('\OC\Files\Storage\Shared', 'file_put_contents', $info);
+		Util::emitHook('\OC\Files\Storage\Shared', 'file_put_contents', $info);
 		return parent::file_put_contents($path, $data);
 	}
 

--- a/apps/files_sharing/lib/Updater.php
+++ b/apps/files_sharing/lib/Updater.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Sharing;
 
 use OC\Files\Cache\FileAccess;
+use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
 use OCP\Constants;
 use OCP\Files\Folder;
@@ -96,7 +97,7 @@ class Updater {
 				continue;
 			}
 
-			if ($dstMount instanceof \OCA\Files_Sharing\SharedMount) {
+			if ($dstMount instanceof SharedMount) {
 				if (!($dstMount->getShare()->getPermissions() & Constants::PERMISSION_SHARE)) {
 					$shareManager->deleteShare($share);
 					continue;
@@ -121,10 +122,10 @@ class Updater {
 	 * @param string $newPath new path relative to data/user/files
 	 */
 	private static function renameChildren($oldPath, $newPath) {
-		$absNewPath = \OC\Files\Filesystem::normalizePath('/' . \OC_User::getUser() . '/files/' . $newPath);
-		$absOldPath = \OC\Files\Filesystem::normalizePath('/' . \OC_User::getUser() . '/files/' . $oldPath);
+		$absNewPath = Filesystem::normalizePath('/' . \OC_User::getUser() . '/files/' . $newPath);
+		$absOldPath = Filesystem::normalizePath('/' . \OC_User::getUser() . '/files/' . $oldPath);
 
-		$mountManager = \OC\Files\Filesystem::getMountManager();
+		$mountManager = Filesystem::getMountManager();
 		$mountedShares = $mountManager->findIn('/' . \OC_User::getUser() . '/files/' . $oldPath);
 		foreach ($mountedShares as $mount) {
 			/** @var MountPoint $mount */

--- a/apps/files_sharing/lib/ViewOnly.php
+++ b/apps/files_sharing/lib/ViewOnly.php
@@ -88,7 +88,7 @@ class ViewOnly {
 		}
 
 		// Extract extra permissions
-		/** @var \OCA\Files_Sharing\SharedStorage $storage */
+		/** @var SharedStorage $storage */
 		$share = $storage->getShare();
 
 		$canDownload = true;

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -7,13 +7,17 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Cache\Scanner;
+use OC\Files\FileInfo;
 use OC\Files\Filesystem;
+use OC\Files\Storage\Temporary;
+use OC\Files\View;
 use OCA\Files_Sharing\Controller\ShareAPIController;
 use OCP\App\IAppManager;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCS\OCSNotFoundException;
+use OCP\Constants;
 use OCP\IConfig;
 use OCP\IDateTimeZone;
 use OCP\IL10N;
@@ -72,7 +76,7 @@ class ApiTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		if ($this->view instanceof \OC\Files\View) {
+		if ($this->view instanceof View) {
 			$this->view->unlink($this->filename);
 			$this->view->deleteAll($this->folder);
 		}
@@ -84,7 +88,7 @@ class ApiTest extends TestCase {
 
 	/**
 	 * @param string $userId The userId of the caller
-	 * @return \OCA\Files_Sharing\Controller\ShareAPIController
+	 * @return ShareAPIController
 	 */
 	private function createOCS($userId) {
 		$l = $this->getMockBuilder(IL10N::class)->getMock();
@@ -128,7 +132,7 @@ class ApiTest extends TestCase {
 	public function testCreateShareUserFile(): void {
 		$this->setUp(); // for some reasons phpunit refuses to do this for us only for this test
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$result = $ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -145,7 +149,7 @@ class ApiTest extends TestCase {
 
 	public function testCreateShareUserFolder(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -162,7 +166,7 @@ class ApiTest extends TestCase {
 
 	public function testCreateShareGroupFile(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
+		$result = $ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -178,7 +182,7 @@ class ApiTest extends TestCase {
 
 	public function testCreateShareGroupFolder(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -197,11 +201,11 @@ class ApiTest extends TestCase {
 	 */
 	public function testCreateShareLink(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK);
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
 		$ocs->cleanup();
 
 		$data = $result->getData();
-		$this->assertEquals(\OCP\Constants::PERMISSION_ALL,
+		$this->assertEquals(Constants::PERMISSION_ALL,
 			$data['permissions']);
 		$this->assertEmpty($data['expiration']);
 		$this->assertTrue(is_string($data['token']));
@@ -222,16 +226,16 @@ class ApiTest extends TestCase {
 	 */
 	public function testCreateShareLinkPublicUpload(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'true');
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'true');
 		$ocs->cleanup();
 
 		$data = $result->getData();
 		$this->assertEquals(
-			\OCP\Constants::PERMISSION_READ |
-			\OCP\Constants::PERMISSION_CREATE |
-			\OCP\Constants::PERMISSION_UPDATE |
-			\OCP\Constants::PERMISSION_DELETE |
-			\OCP\Constants::PERMISSION_SHARE,
+			Constants::PERMISSION_READ |
+			Constants::PERMISSION_CREATE |
+			Constants::PERMISSION_UPDATE |
+			Constants::PERMISSION_DELETE |
+			Constants::PERMISSION_SHARE,
 			$data['permissions']
 		);
 		$this->assertEmpty($data['expiration']);
@@ -255,7 +259,7 @@ class ApiTest extends TestCase {
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
-			$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK);
+			$ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
 			$this->fail();
 		} catch (OCSForbiddenException $e) {
 		}
@@ -263,7 +267,7 @@ class ApiTest extends TestCase {
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 		try {
-			$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '');
+			$ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '');
 			$this->fail();
 		} catch (OCSForbiddenException $e) {
 		}
@@ -271,7 +275,7 @@ class ApiTest extends TestCase {
 
 		// share with password should succeed
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', $password);
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', $password);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -308,7 +312,7 @@ class ApiTest extends TestCase {
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups', 'no');
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$result = $ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -324,7 +328,7 @@ class ApiTest extends TestCase {
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups_list', 'admin,group1,group2');
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$result = $ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -339,7 +343,7 @@ class ApiTest extends TestCase {
 		\OC::$server->getConfig()->setAppValue('core', 'shareapi_exclude_groups_list', 'admin,group');
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 
 		// cleanup
@@ -416,7 +420,7 @@ class ApiTest extends TestCase {
 	 */
 	public function testPublicLinkUrl(): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK);
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -1008,11 +1012,11 @@ class ApiTest extends TestCase {
 
 		$share1 = $this->shareManager->getShareById($share1->getFullId());
 		$this->assertEquals(
-			\OCP\Constants::PERMISSION_READ |
-			\OCP\Constants::PERMISSION_CREATE |
-			\OCP\Constants::PERMISSION_UPDATE |
-			\OCP\Constants::PERMISSION_DELETE |
-			\OCP\Constants::PERMISSION_SHARE,
+			Constants::PERMISSION_READ |
+			Constants::PERMISSION_CREATE |
+			Constants::PERMISSION_UPDATE |
+			Constants::PERMISSION_DELETE |
+			Constants::PERMISSION_SHARE,
 			$share1->getPermissions()
 		);
 
@@ -1172,7 +1176,7 @@ class ApiTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
@@ -1180,7 +1184,7 @@ class ApiTest extends TestCase {
 		// user2 shares a file from the folder as link
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$view->mkdir('localDir');
 
 		// move mount point to the folder "localDir"
@@ -1190,7 +1194,7 @@ class ApiTest extends TestCase {
 		// try to share "localDir"
 		$fileInfo2 = $view->getFileInfo('localDir');
 
-		$this->assertTrue($fileInfo2 instanceof \OC\Files\FileInfo);
+		$this->assertTrue($fileInfo2 instanceof FileInfo);
 
 		$pass = true;
 		try {
@@ -1199,7 +1203,7 @@ class ApiTest extends TestCase {
 				'localDir',
 				self::TEST_FILES_SHARING_API_USER2,
 				self::TEST_FILES_SHARING_API_USER3,
-				\OCP\Constants::PERMISSION_ALL
+				Constants::PERMISSION_ALL
 			);
 		} catch (\Exception $e) {
 			$pass = false;
@@ -1223,7 +1227,7 @@ class ApiTest extends TestCase {
 	 */
 	public static function initTestMountPointsHook($data) {
 		if ($data['user'] === self::TEST_FILES_SHARING_API_USER1) {
-			\OC\Files\Filesystem::mount(self::$tempStorage, [], '/' . self::TEST_FILES_SHARING_API_USER1 . '/files' . self::TEST_FOLDER_NAME);
+			Filesystem::mount(self::$tempStorage, [], '/' . self::TEST_FILES_SHARING_API_USER1 . '/files' . self::TEST_FOLDER_NAME);
 		}
 	}
 
@@ -1231,7 +1235,7 @@ class ApiTest extends TestCase {
 	 * Tests mounting a folder that is an external storage mount point.
 	 */
 	public function testShareStorageMountPoint(): void {
-		$tempStorage = new \OC\Files\Storage\Temporary([]);
+		$tempStorage = new Temporary([]);
 		$tempStorage->file_put_contents('test.txt', 'abcdef');
 		$tempStorage->getScanner()->scan('');
 
@@ -1246,7 +1250,7 @@ class ApiTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$share->setStatus(IShare::STATUS_ACCEPTED);
 		$this->shareManager->updateShare($share);
@@ -1254,7 +1258,7 @@ class ApiTest extends TestCase {
 		// user2: check that mount point name appears correctly
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		$this->assertTrue($view->file_exists($this->folder));
 		$this->assertTrue($view->file_exists($this->folder . '/test.txt'));
@@ -1290,7 +1294,7 @@ class ApiTest extends TestCase {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 
 		try {
-			$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date);
+			$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date);
 			$this->assertTrue($valid);
 		} catch (OCSNotFoundException $e) {
 			$this->assertFalse($valid);
@@ -1329,7 +1333,7 @@ class ApiTest extends TestCase {
 		$date->add(new \DateInterval('P5D'));
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date->format('Y-m-d'));
+		$result = $ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date->format('Y-m-d'));
 		$ocs->cleanup();
 
 		$data = $result->getData();
@@ -1363,7 +1367,7 @@ class ApiTest extends TestCase {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 
 		try {
-			$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date->format('Y-m-d'));
+			$ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date->format('Y-m-d'));
 			$this->fail();
 		} catch (OCSException $e) {
 			$this->assertEquals(404, $e->getCode());
@@ -1384,7 +1388,7 @@ class ApiTest extends TestCase {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 
 		try {
-			$ocs->createShare($this->filename, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date->format('Y-m-d'));
+			$ocs->createShare($this->filename, Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'false', '', null, $date->format('Y-m-d'));
 			$this->fail();
 		} catch (OCSException $e) {
 			$this->assertEquals(404, $e->getCode());
@@ -1403,7 +1407,7 @@ class ApiTest extends TestCase {
 	public function testInvisibleSharesUser(): void {
 		// simulate a post request
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_USER, self::TEST_FILES_SHARING_API_USER2);
 		$ocs->cleanup();
 		$data = $result->getData();
 
@@ -1414,7 +1418,7 @@ class ApiTest extends TestCase {
 		$ocs->cleanup();
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
-		$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK);
+		$ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
 		$ocs->cleanup();
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
@@ -1435,7 +1439,7 @@ class ApiTest extends TestCase {
 	public function testInvisibleSharesGroup(): void {
 		// simulate a post request
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
-		$result = $ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
+		$result = $ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_GROUP, self::TEST_FILES_SHARING_API_GROUP1);
 		$ocs->cleanup();
 		$data = $result->getData();
 
@@ -1448,7 +1452,7 @@ class ApiTest extends TestCase {
 		\OC_Util::tearDownFS();
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER2);
-		$ocs->createShare($this->folder, \OCP\Constants::PERMISSION_ALL, IShare::TYPE_LINK);
+		$ocs->createShare($this->folder, Constants::PERMISSION_ALL, IShare::TYPE_LINK);
 		$ocs->cleanup();
 
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -17,6 +17,7 @@ use OCP\Accounts\IAccount;
 use OCP\Accounts\IAccountManager;
 use OCP\Accounts\IAccountProperty;
 use OCP\Activity\IManager;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\Template\ExternalShareMenuAction;
 use OCP\AppFramework\Http\Template\LinkMenuAction;
@@ -39,6 +40,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
+use OCP\Server;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IPublicShareTemplateFactory;
 use OCP\Share\IShare;
@@ -115,7 +117,7 @@ class ShareControllerTest extends \Test\TestCase {
 				)
 			);
 
-		$this->shareController = new \OCA\Files_Sharing\Controller\ShareController(
+		$this->shareController = new ShareController(
 			$this->appName,
 			$this->createMock(IRequest::class),
 			$this->config,
@@ -236,7 +238,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->willReturn($account);
 
 		/** @var Manager */
-		$manager = \OCP\Server::get(Manager::class);
+		$manager = Server::get(Manager::class);
 		$share = $manager->newShare();
 		$share->setId(42)
 			->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE)
@@ -333,7 +335,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->assertEquals($expectedInitialState, $initialState);
 
-		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$expectedResponse = new PublicTemplateResponse('files', 'index');
 		$expectedResponse->setContentSecurityPolicy($csp);
@@ -382,7 +384,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->willReturn($account);
 
 		/** @var Manager */
-		$manager = \OCP\Server::get(Manager::class);
+		$manager = Server::get(Manager::class);
 		$share = $manager->newShare();
 		$share->setId(42)
 			->setPermissions(Constants::PERMISSION_CREATE)
@@ -472,7 +474,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->assertEquals($expectedInitialState, $initialState);
 
-		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$expectedResponse = new PublicTemplateResponse('files', 'index');
 		$expectedResponse->setContentSecurityPolicy($csp);
@@ -522,7 +524,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->willReturn($account);
 
 		/** @var IShare */
-		$share = \OCP\Server::get(Manager::class)->newShare();
+		$share = Server::get(Manager::class)->newShare();
 		$share->setId(42);
 		$share->setPassword('password')
 			->setShareOwner('ownerUID')
@@ -530,7 +532,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->setNode($file)
 			->setNote($note)
 			->setToken('token')
-			->setPermissions(\OCP\Constants::PERMISSION_ALL & ~\OCP\Constants::PERMISSION_SHARE)
+			->setPermissions(Constants::PERMISSION_ALL & ~Constants::PERMISSION_SHARE)
 			->setTarget("/$filename");
 
 		$this->session->method('exists')->with('public_link_authenticated')->willReturn(true);
@@ -599,7 +601,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$response = $this->shareController->showShare();
 
-		$csp = new \OCP\AppFramework\Http\ContentSecurityPolicy();
+		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$expectedResponse = new PublicTemplateResponse('files', 'index');
 		$expectedResponse->setContentSecurityPolicy($csp);
@@ -616,7 +618,7 @@ class ShareControllerTest extends \Test\TestCase {
 
 
 	public function testShowShareInvalid(): void {
-		$this->expectException(\OCP\Files\NotFoundException::class);
+		$this->expectException(NotFoundException::class);
 
 		$filename = 'file1.txt';
 		$this->shareController->setToken('token');
@@ -671,7 +673,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$share
 			->expects($this->once())
 			->method('getPermissions')
-			->willReturn(\OCP\Constants::PERMISSION_CREATE);
+			->willReturn(Constants::PERMISSION_CREATE);
 
 		$this->shareManager
 			->expects($this->once())

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -8,7 +8,6 @@ namespace OCA\Files_Sharing\Tests\Controller;
 
 use OCA\Files_Sharing\Controller\ShareesAPIController;
 use OCA\Files_Sharing\Tests\TestCase;
-use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\Collaboration\Collaborators\ISearch;
@@ -298,7 +297,7 @@ class ShareesAPIControllerTest extends TestCase {
 				}
 			});
 
-		$this->assertInstanceOf(Http\DataResponse::class, $sharees->search($search, $itemType, $page, $perPage, $shareType));
+		$this->assertInstanceOf(DataResponse::class, $sharees->search($search, $itemType, $page, $perPage, $shareType));
 	}
 
 	public function dataSearchInvalid(): array {
@@ -413,7 +412,7 @@ class ShareesAPIControllerTest extends TestCase {
 	}
 
 	public function testSearchNoItemType(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSBadRequestException::class);
+		$this->expectException(OCSBadRequestException::class);
 		$this->expectExceptionMessage('Missing itemType');
 
 		$this->sharees->search('', null, 1, 10, [], false);

--- a/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
+++ b/apps/files_sharing/tests/DeleteOrphanedSharesJobTest.php
@@ -6,7 +6,10 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Filesystem;
 use OCA\Files_Sharing\DeleteOrphanedSharesJob;
+use OCP\Constants;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -48,7 +51,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 		$appManager->disableApp('files_trashbin');
 
 		// just in case...
-		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 	}
 
 	public static function tearDownAfterClass(): void {
@@ -73,7 +76,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		\OC::registerShareHooks(\OC::$server->getSystemConfig());
 
-		$this->job = \OCP\Server::get(DeleteOrphanedSharesJob::class);
+		$this->job = Server::get(DeleteOrphanedSharesJob::class);
 	}
 
 	protected function tearDown(): void {
@@ -119,7 +122,7 @@ class DeleteOrphanedSharesJobTest extends \Test\TestCase {
 
 		$share->setNode($testSubFolder)
 			->setShareType(IShare::TYPE_USER)
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setSharedWith($this->user2)
 			->setSharedBy($this->user1);
 

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -8,6 +8,7 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\Constants;
 use OCP\Share\IShare;
 
 /**
@@ -56,7 +57,7 @@ class EtagPropagationTest extends PropagationTestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE);
+			->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE);
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 		$node = $rootFolder->getUserFolder(self::TEST_FILES_SHARING_API_USER1)
@@ -67,7 +68,7 @@ class EtagPropagationTest extends PropagationTestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 
@@ -76,7 +77,7 @@ class EtagPropagationTest extends PropagationTestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER3)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER3);
 
@@ -90,7 +91,7 @@ class EtagPropagationTest extends PropagationTestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 
@@ -117,7 +118,7 @@ class EtagPropagationTest extends PropagationTestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER4)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER4);
 
@@ -131,7 +132,7 @@ class EtagPropagationTest extends PropagationTestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedWith(self::TEST_FILES_SHARING_API_USER4)
 			->setSharedBy(self::TEST_FILES_SHARING_API_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = $shareManager->createShare($share);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER4);
 
@@ -437,13 +438,13 @@ class EtagPropagationTest extends PropagationTestCase {
 
 		$shares = $this->shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, IShare::TYPE_USER, $node);
 		/** @var \OCP\Share\IShare[] $shares */
-		$shares = array_filter($shares, function (\OCP\Share\IShare $share) {
+		$shares = array_filter($shares, function (IShare $share) {
 			return $share->getSharedWith() === self::TEST_FILES_SHARING_API_USER2;
 		});
 		$this->assertCount(1, $shares);
 
 		$share = $shares[0];
-		$share->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE);
+		$share->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE);
 		$this->shareManager->updateShare($share);
 
 		$this->assertEtagsForFoldersChanged([self::TEST_FILES_SHARING_API_USER2]);

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -8,6 +8,7 @@ namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\ExpireSharesJob;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Constants;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 
@@ -118,7 +119,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 
 		$share->setNode($testFolder)
 			->setShareType(IShare::TYPE_LINK)
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setSharedBy($this->user1);
 
 		$shareManager->createShare($share);
@@ -175,7 +176,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 
 		$share->setNode($testFolder)
 			->setShareType(IShare::TYPE_USER)
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setSharedBy($this->user1)
 			->setSharedWith($this->user2);
 

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Sharing\Tests\External;
 
 use OC\Federation\CloudIdManager;
+use OCA\Files_Sharing\External\Cache;
 use OCA\Files_Sharing\Tests\TestCase;
 use OCP\Contacts\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -33,7 +34,7 @@ class CacheTest extends TestCase {
 	private $storage;
 
 	/**
-	 * @var \OCA\Files_Sharing\External\Cache
+	 * @var Cache
 	 */
 	private $cache;
 
@@ -71,7 +72,7 @@ class CacheTest extends TestCase {
 			->method('search')
 			->willReturn([]);
 
-		$this->cache = new \OCA\Files_Sharing\External\Cache(
+		$this->cache = new Cache(
 			$this->storage,
 			$this->cloudIdManager->getCloudId($this->remoteUser, 'http://example.com/owncloud')
 		);

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -28,6 +28,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\OCS\IDiscoveryService;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 use Test\Traits\UserTrait;
@@ -156,7 +157,7 @@ class ManagerTest extends TestCase {
 					new StorageFactory(),
 					$this->clientService,
 					\OC::$server->getNotificationManager(),
-					\OC::$server->query(\OCP\OCS\IDiscoveryService::class),
+					\OC::$server->query(IDiscoveryService::class),
 					$this->cloudFederationProviderManager,
 					$this->cloudFederationFactory,
 					$this->groupManager,

--- a/apps/files_sharing/tests/External/ScannerTest.php
+++ b/apps/files_sharing/tests/External/ScannerTest.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Sharing\Tests\External;
 
 use OCA\Files_Sharing\External\Scanner;
+use OCA\Files_Sharing\External\Storage;
 use Test\TestCase;
 
 /**
@@ -14,7 +15,7 @@ use Test\TestCase;
  */
 class ScannerTest extends TestCase {
 	protected Scanner $scanner;
-	/** @var \OCA\Files_Sharing\External\Storage|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var Storage|\PHPUnit\Framework\MockObject\MockObject */
 	protected $storage;
 	/** @var \OC\Files\Cache\Cache|\PHPUnit\Framework\MockObject\MockObject */
 	protected $cache;

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -8,6 +8,7 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Federation\CloudId;
 use OCA\Files_Sharing\External\Manager as ExternalShareManager;
+use OCA\Files_Sharing\External\Storage;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
@@ -104,7 +105,7 @@ class ExternalStorageTest extends \Test\TestCase {
 /**
  * Dummy subclass to make it possible to access private members
  */
-class TestSharingExternalStorage extends \OCA\Files_Sharing\External\Storage {
+class TestSharingExternalStorage extends Storage {
 	public function getBaseUri() {
 		return $this->createBaseUri();
 	}

--- a/apps/files_sharing/tests/GroupEtagPropagationTest.php
+++ b/apps/files_sharing/tests/GroupEtagPropagationTest.php
@@ -8,6 +8,7 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\Constants;
 use OCP\Share\IShare;
 
 /**
@@ -38,7 +39,7 @@ class GroupEtagPropagationTest extends PropagationTestCase {
 			'/test',
 			self::TEST_FILES_SHARING_API_USER1,
 			'group1',
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER1][''] = $view1->getFileInfo('')->getId();
@@ -53,7 +54,7 @@ class GroupEtagPropagationTest extends PropagationTestCase {
 			'/test',
 			self::TEST_FILES_SHARING_API_USER2,
 			'group2',
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER3);
 		$share = $this->share(
@@ -61,7 +62,7 @@ class GroupEtagPropagationTest extends PropagationTestCase {
 			'/test/sub',
 			self::TEST_FILES_SHARING_API_USER2,
 			'group3',
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER4);
 

--- a/apps/files_sharing/tests/HelperTest.php
+++ b/apps/files_sharing/tests/HelperTest.php
@@ -6,6 +6,9 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Filesystem;
+use OCA\Files_Sharing\Helper;
+
 /**
  * Class HelperTest
  *
@@ -17,13 +20,13 @@ class HelperTest extends TestCase {
 	 * test set and get share folder
 	 */
 	public function testSetGetShareFolder(): void {
-		$this->assertSame('/', \OCA\Files_Sharing\Helper::getShareFolder());
+		$this->assertSame('/', Helper::getShareFolder());
 
-		\OCA\Files_Sharing\Helper::setShareFolder('/Shared/Folder');
+		Helper::setShareFolder('/Shared/Folder');
 
-		$sharedFolder = \OCA\Files_Sharing\Helper::getShareFolder();
-		$this->assertSame('/Shared/Folder', \OCA\Files_Sharing\Helper::getShareFolder());
-		$this->assertTrue(\OC\Files\Filesystem::is_dir($sharedFolder));
+		$sharedFolder = Helper::getShareFolder();
+		$this->assertSame('/Shared/Folder', Helper::getShareFolder());
+		$this->assertTrue(Filesystem::is_dir($sharedFolder));
 
 		// cleanup
 		\OC::$server->getConfig()->deleteSystemValue('share_folder');

--- a/apps/files_sharing/tests/LockingTest.php
+++ b/apps/files_sharing/tests/LockingTest.php
@@ -8,7 +8,9 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\Constants;
 use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
 use OCP\Share\IShare;
 
 /**
@@ -48,7 +50,7 @@ class LockingTest extends TestCase {
 			'/foo/bar.txt',
 			$this->ownerUid,
 			$this->recipientUid,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 
 		$this->loginAsUser($this->recipientUid);
@@ -62,7 +64,7 @@ class LockingTest extends TestCase {
 
 
 	public function testLockAsRecipient(): void {
-		$this->expectException(\OCP\Lock\LockedException::class);
+		$this->expectException(LockedException::class);
 
 		$this->loginAsUser($this->ownerUid);
 

--- a/apps/files_sharing/tests/Middleware/ShareInfoMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/ShareInfoMiddlewareTest.php
@@ -11,6 +11,7 @@ use OCA\Files_Sharing\Middleware\ShareInfoMiddleware;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\Share\IManager as ShareManager;
 use Test\TestCase;
 
@@ -86,7 +87,7 @@ class ShareInfoMiddlewareTest extends TestCase {
 	}
 
 	public function testAfterControllerNoShareInfo(): void {
-		$response = $this->createMock(Http\Response::class);
+		$response = $this->createMock(Response::class);
 
 		$this->assertEquals(
 			$response,
@@ -95,7 +96,7 @@ class ShareInfoMiddlewareTest extends TestCase {
 	}
 
 	public function testAfterControllerNoJSON(): void {
-		$response = $this->createMock(Http\Response::class);
+		$response = $this->createMock(Response::class);
 
 		$this->assertEquals(
 			$response,

--- a/apps/files_sharing/tests/Middleware/SharingCheckMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/SharingCheckMiddlewareTest.php
@@ -178,7 +178,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 
 
 	public function testBeforeControllerWithSharingDisabled(): void {
-		$this->expectException(\OCP\Files\NotFoundException::class);
+		$this->expectException(NotFoundException::class);
 		$this->expectExceptionMessage('Sharing is disabled.');
 
 		$this->appManager

--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OC\Memcache\NullCache;
+use OC\Share20\Share;
 use OCA\Files_Sharing\MountProvider;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
@@ -165,7 +166,7 @@ class MountProviderTest extends \Test\TestCase {
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->willReturnCallback(function () use ($rootFolder, $userManager) {
-				return new \OC\Share20\Share($rootFolder, $userManager);
+				return new Share($rootFolder, $userManager);
 			});
 		$mounts = $this->provider->getMountsForUser($this->user, $this->loader);
 		$this->assertCount(4, $mounts);
@@ -386,7 +387,7 @@ class MountProviderTest extends \Test\TestCase {
 		$this->shareManager->expects($this->any())
 			->method('newShare')
 			->willReturnCallback(function () use ($rootFolder, $userManager) {
-				return new \OC\Share20\Share($rootFolder, $userManager);
+				return new Share($rootFolder, $userManager);
 			});
 
 		if ($moveFails) {

--- a/apps/files_sharing/tests/PropagationTestCase.php
+++ b/apps/files_sharing/tests/PropagationTestCase.php
@@ -6,6 +6,8 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OCA\Files_Sharing\Helper;
+
 abstract class PropagationTestCase extends TestCase {
 	/**
 	 * @var \OC\Files\View
@@ -16,7 +18,7 @@ abstract class PropagationTestCase extends TestCase {
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
-		\OCA\Files_Sharing\Helper::registerHooks();
+		Helper::registerHooks();
 	}
 
 	protected function setUp(): void {

--- a/apps/files_sharing/tests/ShareTest.php
+++ b/apps/files_sharing/tests/ShareTest.php
@@ -6,6 +6,9 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Filesystem;
+use OCA\Files_Sharing\Helper;
+use OCP\Constants;
 use OCP\Share\IShare;
 
 /**
@@ -63,7 +66,7 @@ class ShareTest extends TestCase {
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 
 		$share2 = $this->share(
@@ -71,26 +74,26 @@ class ShareTest extends TestCase {
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			'testGroup',
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 		$this->shareManager->acceptShare($share2, self::TEST_FILES_SHARING_API_USER2);
 		$this->shareManager->acceptShare($share2, self::TEST_FILES_SHARING_API_USER3);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		\OC\Files\Filesystem::unlink($this->filename);
+		Filesystem::unlink($this->filename);
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		// both group share and user share should be gone
-		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename));
+		$this->assertFalse(Filesystem::file_exists($this->filename));
 
 		// for user3 nothing should change
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
 
 		$this->shareManager->deleteShare($share1);
 		$this->shareManager->deleteShare($share2);
@@ -117,23 +120,23 @@ class ShareTest extends TestCase {
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 
-		\OCA\Files_Sharing\Helper::setShareFolder('/Shared/subfolder');
+		Helper::setShareFolder('/Shared/subfolder');
 
 		$share = $this->share(
 			IShare::TYPE_USER,
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
-		$this->assertTrue(\OC\Files\Filesystem::file_exists('/Shared/subfolder/' . $this->folder));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
+		$this->assertTrue(Filesystem::file_exists('/Shared/subfolder/' . $this->folder));
 
 		//cleanup
 		\OC::$server->getConfig()->deleteSystemValue('share_folder');
@@ -143,14 +146,14 @@ class ShareTest extends TestCase {
 		$this->markTestSkipped('TODO: Disable because fails on drone');
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		\OC\Files\Filesystem::file_put_contents('test.txt', 'test');
+		Filesystem::file_put_contents('test.txt', 'test');
 
 		$share = $this->share(
 			IShare::TYPE_GROUP,
 			'test.txt',
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_GROUP1,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -160,14 +163,14 @@ class ShareTest extends TestCase {
 		$this->assertSame('/test.txt', $share->getTarget());
 		$this->assertSame(19, $share->getPermissions());
 
-		\OC\Files\Filesystem::rename('test.txt', 'new test.txt');
+		Filesystem::rename('test.txt', 'new test.txt');
 
 		$shares = $this->shareManager->getSharedWith(self::TEST_FILES_SHARING_API_USER2, IShare::TYPE_GROUP);
 		$share = $shares[0];
 		$this->assertSame('/new test.txt', $share->getTarget());
 		$this->assertSame(19, $share->getPermissions());
 
-		$share->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE);
+		$share->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE);
 		$this->shareManager->updateShare($share);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -200,11 +203,11 @@ class ShareTest extends TestCase {
 	}
 
 	public function dataProviderTestFileSharePermissions() {
-		$permission1 = \OCP\Constants::PERMISSION_ALL;
-		$permission3 = \OCP\Constants::PERMISSION_READ;
-		$permission4 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE;
-		$permission5 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE;
-		$permission6 = \OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_DELETE;
+		$permission1 = Constants::PERMISSION_ALL;
+		$permission3 = Constants::PERMISSION_READ;
+		$permission4 = Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE;
+		$permission5 = Constants::PERMISSION_READ | Constants::PERMISSION_DELETE;
+		$permission6 = Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE;
 
 		return [
 			[$permission1, false],
@@ -221,12 +224,12 @@ class ShareTest extends TestCase {
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ
+			Constants::PERMISSION_READ
 		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$info = \OC\Files\Filesystem::getFileInfo($this->filename);
+		$info = Filesystem::getFileInfo($this->filename);
 
 		$this->assertSame(self::TEST_FILES_SHARING_API_USER1, $info->getOwner()->getUID());
 	}

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -6,11 +6,16 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Filesystem;
+use OC\Files\View;
 use OC\Memcache\ArrayCache;
 use OCA\Files_Sharing\MountProvider;
+use OCA\Files_Sharing\SharedMount;
+use OCP\Constants;
 use OCP\ICacheFactory;
 use OCP\IGroupManager;
 use OCP\IUserManager;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -73,7 +78,7 @@ class SharedMountTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL);
+			Constants::PERMISSION_ALL);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 
 		$share->setTarget('/foo/bar' . $this->folder);
@@ -104,11 +109,11 @@ class SharedMountTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$this->assertTrue($user2View->file_exists($this->folder));
 
 		// create a local folder
@@ -143,25 +148,25 @@ class SharedMountTest extends TestCase {
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		\OC\Files\Filesystem::rename($this->filename, $this->filename . '_renamed');
+		Filesystem::rename($this->filename, $this->filename . '_renamed');
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename . '_renamed'));
-		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename));
+		$this->assertTrue(Filesystem::file_exists($this->filename . '_renamed'));
+		$this->assertFalse(Filesystem::file_exists($this->filename));
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
-		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename . '_renamed'));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
+		$this->assertFalse(Filesystem::file_exists($this->filename . '_renamed'));
 
 		// rename back to original name
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		\OC\Files\Filesystem::rename($this->filename . '_renamed', $this->filename);
-		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename . '_renamed'));
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
+		Filesystem::rename($this->filename . '_renamed', $this->filename);
+		$this->assertFalse(Filesystem::file_exists($this->filename . '_renamed'));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
 
 		//cleanup
 		$this->shareManager->deleteShare($share);
@@ -186,7 +191,7 @@ class SharedMountTest extends TestCase {
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			'testGroup',
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 		$this->shareManager->acceptShare($share, $user1->getUID());
 		$this->shareManager->acceptShare($share, $user2->getUID());
@@ -194,20 +199,20 @@ class SharedMountTest extends TestCase {
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
 
-		\OC\Files\Filesystem::rename($this->filename, 'newFileName');
+		Filesystem::rename($this->filename, 'newFileName');
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists('newFileName'));
-		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->filename));
-
-		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
-		$this->assertFalse(\OC\Files\Filesystem::file_exists('newFileName'));
+		$this->assertTrue(Filesystem::file_exists('newFileName'));
+		$this->assertFalse(Filesystem::file_exists($this->filename));
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->filename));
-		$this->assertFalse(\OC\Files\Filesystem::file_exists('newFileName'));
+		$this->assertTrue(Filesystem::file_exists($this->filename));
+		$this->assertFalse(Filesystem::file_exists('newFileName'));
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
+		$this->assertTrue(Filesystem::file_exists($this->filename));
+		$this->assertFalse(Filesystem::file_exists('newFileName'));
 
 		//cleanup
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
@@ -270,7 +275,7 @@ class SharedMountTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			'testGroup',
-			\OCP\Constants::PERMISSION_READ
+			Constants::PERMISSION_READ
 		);
 		$this->shareManager->acceptShare($share, $user1->getUID());
 		$this->shareManager->acceptShare($share, $user2->getUID());
@@ -278,14 +283,14 @@ class SharedMountTest extends TestCase {
 
 		// Login as user 2 and verify the item exists
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->folder));
+		$this->assertTrue(Filesystem::file_exists($this->folder));
 		$result = $this->shareManager->getShareById($share->getFullId(), self::TEST_FILES_SHARING_API_USER2);
 		$this->assertNotEmpty($result);
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ, $result->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ, $result->getPermissions());
 
 		// Delete the share
-		$this->assertTrue(\OC\Files\Filesystem::rmdir($this->folder));
-		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->folder));
+		$this->assertTrue(Filesystem::rmdir($this->folder));
+		$this->assertFalse(Filesystem::file_exists($this->folder));
 
 		// Verify we do not get a share
 		$result = $this->shareManager->getShareById($share->getFullId(), self::TEST_FILES_SHARING_API_USER2);
@@ -293,12 +298,12 @@ class SharedMountTest extends TestCase {
 
 		// Login as user 1 again and change permissions
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$share->setPermissions(\OCP\Constants::PERMISSION_ALL);
+		$share->setPermissions(Constants::PERMISSION_ALL);
 		$share = $this->shareManager->updateShare($share);
 
 		// Login as user 2 and verify
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$this->assertFalse(\OC\Files\Filesystem::file_exists($this->folder));
+		$this->assertFalse(Filesystem::file_exists($this->folder));
 		$result = $this->shareManager->getShareById($share->getFullId(), self::TEST_FILES_SHARING_API_USER2);
 		$this->assertEquals(0, $result->getPermissions());
 
@@ -326,7 +331,7 @@ class SharedMountTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL);
+			Constants::PERMISSION_ALL);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 
 		$share->setTarget('/bar');
@@ -369,7 +374,7 @@ class SharedMountTest extends TestCase {
 			});
 
 		// hack to overwrite the cache factory, we can't use the proper "overwriteService" since the mount provider is created before this test is called
-		$mountProvider = \OCP\Server::get(MountProvider::class);
+		$mountProvider = Server::get(MountProvider::class);
 		$reflectionClass = new \ReflectionClass($mountProvider);
 		$reflectionCacheFactory = $reflectionClass->getProperty('cacheFactory');
 		$reflectionCacheFactory->setAccessible(true);
@@ -381,7 +386,7 @@ class SharedMountTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL);
+			Constants::PERMISSION_ALL);
 		$this->shareManager->acceptShare($share, self::TEST_FILES_SHARING_API_USER2);
 
 		$share->setTarget('/foobar');
@@ -394,7 +399,7 @@ class SharedMountTest extends TestCase {
 			$this->folder2,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL);
+			Constants::PERMISSION_ALL);
 		$this->shareManager->acceptShare($share2, self::TEST_FILES_SHARING_API_USER2);
 
 		$share2->setTarget('/foobar');
@@ -418,7 +423,7 @@ class SharedMountTest extends TestCase {
 	}
 }
 
-class DummyTestClassSharedMount extends \OCA\Files_Sharing\SharedMount {
+class DummyTestClassSharedMount extends SharedMount {
 	public function __construct($storage, $mountpoint, $arguments = null, $loader = null) {
 		// noop
 	}

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -6,10 +6,15 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Cache\FailedCache;
+use OC\Files\Filesystem;
+use OC\Files\Storage\FailedStorage;
+use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OCA\Files_Sharing\SharedStorage;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\Constants;
 use OCP\Files\NotFoundException;
 use OCP\Share\IShare;
 
@@ -46,7 +51,7 @@ class SharedStorageTest extends TestCase {
 			}
 		}
 
-		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 
 		parent::tearDown();
 	}
@@ -64,11 +69,11 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$this->assertTrue($user2View->file_exists($this->folder));
 
 		// create a local folder
@@ -84,7 +89,7 @@ class SharedStorageTest extends TestCase {
 
 		// delete the local folder
 		/** @var \OC\Files\Storage\Storage $storage */
-		[$storage, $internalPath] = \OC\Files\Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/localfolder');
+		[$storage, $internalPath] = Filesystem::resolvePath('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/localfolder');
 		$storage->rmdir($internalPath);
 
 		//enforce reload of the mount points
@@ -109,12 +114,12 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		$this->assertTrue($user2View->file_exists($this->folder));
 
@@ -149,7 +154,7 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		$share2 = $this->share(
@@ -157,16 +162,16 @@ class SharedStorageTest extends TestCase {
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
 		// compare file size between user1 and user2, should always be the same
-		$this->assertSame($folderSize, \OC\Files\Filesystem::filesize($this->folder));
-		$this->assertSame($file1Size, \OC\Files\Filesystem::filesize($this->folder . $this->filename));
-		$this->assertSame($file2Size, \OC\Files\Filesystem::filesize($this->filename));
+		$this->assertSame($folderSize, Filesystem::filesize($this->folder));
+		$this->assertSame($file1Size, Filesystem::filesize($this->folder . $this->filename));
+		$this->assertSame($file2Size, Filesystem::filesize($this->filename));
 
 		//cleanup
 		$this->shareManager->deleteShare($share1);
@@ -179,23 +184,23 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ
+			Constants::PERMISSION_READ
 		);
 
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$this->assertTrue(\OC\Files\Filesystem::is_dir($this->folder));
+		$this->assertTrue(Filesystem::is_dir($this->folder));
 
 		// for the share root we expect:
 		// the read permissions (1)
 		// the delete permission (8), to enable unshare
-		$rootInfo = \OC\Files\Filesystem::getFileInfo($this->folder);
+		$rootInfo = Filesystem::getFileInfo($this->folder);
 		$this->assertSame(9, $rootInfo->getPermissions());
 
 		// for the file within the shared folder we expect:
 		// the read permissions (1)
-		$subfileInfo = \OC\Files\Filesystem::getFileInfo($this->folder . $this->filename);
+		$subfileInfo = Filesystem::getFileInfo($this->folder . $this->filename);
 		$this->assertSame(1, $subfileInfo->getPermissions());
 
 
@@ -211,11 +216,11 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ
+			Constants::PERMISSION_READ
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		// part file should be forbidden
 		$handle = $user2View->fopen($this->folder . '/test.txt.part', 'w');
@@ -244,11 +249,11 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE
+			Constants::PERMISSION_READ | Constants::PERMISSION_CREATE
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		// create part file allowed
 		$handle = $user2View->fopen($this->folder . '/test.txt.part', 'w');
@@ -290,11 +295,11 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		// create part file allowed
 		$handle = $user2View->fopen($this->folder . '/test.txt.part', 'w');
@@ -336,11 +341,11 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_DELETE
+			Constants::PERMISSION_READ | Constants::PERMISSION_DELETE
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$user2View = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$user2View = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		// part file should be forbidden
 		$handle = $user2View->fopen($this->folder . '/test.txt.part', 'w');
@@ -361,7 +366,7 @@ class SharedStorageTest extends TestCase {
 	}
 
 	public function testMountSharesOtherUser(): void {
-		$rootView = new \OC\Files\View('');
+		$rootView = new View('');
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		// share 2 different files with 2 different users
@@ -370,14 +375,14 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$share2 = $this->share(
 			IShare::TYPE_USER,
 			$this->filename,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER3,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -385,7 +390,7 @@ class SharedStorageTest extends TestCase {
 
 		$mountConfigManager = \OC::$server->getMountProviderCollection();
 		$mounts = $mountConfigManager->getMountsForUser(\OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER3));
-		array_walk($mounts, [\OC\Files\Filesystem::getMountManager(), 'addMount']);
+		array_walk($mounts, [Filesystem::getMountManager(), 'addMount']);
 
 		$this->assertTrue($rootView->file_exists('/' . self::TEST_FILES_SHARING_API_USER3 . '/files/' . $this->filename));
 
@@ -409,17 +414,17 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$this->assertTrue($view->file_exists($this->folder));
 
 		[$sharedStorage,] = $view->resolvePath($this->folder);
 		$this->assertTrue($sharedStorage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage'));
 
-		$sourceStorage = new \OC\Files\Storage\Temporary([]);
+		$sourceStorage = new Temporary([]);
 		$sourceStorage->file_put_contents('foo.txt', 'asd');
 
 		$sharedStorage->copyFromStorage($sourceStorage, 'foo.txt', 'bar.txt');
@@ -439,17 +444,17 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$this->assertTrue($view->file_exists($this->folder));
 
 		[$sharedStorage,] = $view->resolvePath($this->folder);
 		$this->assertTrue($sharedStorage->instanceOfStorage('OCA\Files_Sharing\ISharedStorage'));
 
-		$sourceStorage = new \OC\Files\Storage\Temporary([]);
+		$sourceStorage = new Temporary([]);
 		$sourceStorage->file_put_contents('foo.txt', 'asd');
 		$sourceStorage->getScanner()->scan('');
 
@@ -464,11 +469,11 @@ class SharedStorageTest extends TestCase {
 
 	public function testNameConflict(): void {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
-		$view1 = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
+		$view1 = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
 		$view1->mkdir('foo');
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER3);
-		$view3 = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER3 . '/files');
+		$view3 = new View('/' . self::TEST_FILES_SHARING_API_USER3 . '/files');
 		$view3->mkdir('foo');
 
 		// share a folder with the same name from two different users to the same user
@@ -479,7 +484,7 @@ class SharedStorageTest extends TestCase {
 			'foo',
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_GROUP1,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$this->shareManager->acceptShare($share1, self::TEST_FILES_SHARING_API_USER2);
 
@@ -492,19 +497,19 @@ class SharedStorageTest extends TestCase {
 			'foo',
 			self::TEST_FILES_SHARING_API_USER3,
 			self::TEST_FILES_SHARING_API_GROUP1,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$this->shareManager->acceptShare($share2, self::TEST_FILES_SHARING_API_USER2);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$view2 = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		$this->assertTrue($view2->file_exists('/foo'));
 		$this->assertTrue($view2->file_exists('/foo (2)'));
 
 		$mount = $view2->getMount('/foo');
 		$this->assertInstanceOf('\OCA\Files_Sharing\SharedMount', $mount);
-		/** @var \OCA\Files_Sharing\SharedStorage $storage */
+		/** @var SharedStorage $storage */
 		$storage = $mount->getStorage();
 
 		$this->assertEquals(self::TEST_FILES_SHARING_API_USER1, $storage->getOwner(''));
@@ -521,11 +526,11 @@ class SharedStorageTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_DELETE
+			Constants::PERMISSION_ALL - Constants::PERMISSION_DELETE
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		$this->assertTrue($view->file_exists($this->folder));
 
 		$view->file_put_contents($this->folder . '/newfile.txt', 'asd');
@@ -533,7 +538,7 @@ class SharedStorageTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		$this->assertTrue($this->view->file_exists($this->folder . '/newfile.txt'));
-		$this->assertEquals(\OCP\Constants::PERMISSION_ALL - \OCP\Constants::PERMISSION_CREATE,
+		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE,
 			$this->view->getFileInfo($this->folder . '/newfile.txt')->getPermissions());
 
 		$this->view->unlink($this->folder);
@@ -552,8 +557,8 @@ class SharedStorageTest extends TestCase {
 		]);
 
 		// trigger init
-		$this->assertInstanceOf(\OC\Files\Storage\FailedStorage::class, $storage->getSourceStorage());
-		$this->assertInstanceOf(\OC\Files\Cache\FailedCache::class, $storage->getCache());
+		$this->assertInstanceOf(FailedStorage::class, $storage->getSourceStorage());
+		$this->assertInstanceOf(FailedCache::class, $storage->getCache());
 	}
 
 	public function testInitWithNotFoundSource(): void {
@@ -570,7 +575,7 @@ class SharedStorageTest extends TestCase {
 		]);
 
 		// trigger init
-		$this->assertInstanceOf(\OC\Files\Storage\FailedStorage::class, $storage->getSourceStorage());
-		$this->assertInstanceOf(\OC\Files\Cache\FailedCache::class, $storage->getCache());
+		$this->assertInstanceOf(FailedStorage::class, $storage->getSourceStorage());
+		$this->assertInstanceOf(FailedCache::class, $storage->getCache());
 	}
 }

--- a/apps/files_sharing/tests/SizePropagationTest.php
+++ b/apps/files_sharing/tests/SizePropagationTest.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\View;
+use OCP\Constants;
 use OCP\Share\IShare;
 use Test\Traits\UserTrait;
 
@@ -40,7 +41,7 @@ class SizePropagationTest extends TestCase {
 			'/sharedfolder',
 			self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER1,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$ownerRootInfo = $ownerView->getFileInfo('', false);
 
@@ -75,7 +76,7 @@ class SizePropagationTest extends TestCase {
 			'/sharedfolder',
 			self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER1,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		$ownerRootInfo = $ownerView->getFileInfo('', false);
 

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -6,7 +6,10 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
+use OC\Files\View;
+use OC\Group\Database;
 use OC\User\DisplayNameCache;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Sharing\External\MountProvider as ExternalMountProvider;
@@ -101,8 +104,8 @@ abstract class TestCase extends \Test\TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		$this->data = 'foobar';
-		$this->view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
-		$this->view2 = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$this->view = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
+		$this->view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		$this->shareManager = \OC::$server->getShareManager();
 		$this->rootFolder = \OC::$server->getRootFolder();
@@ -153,7 +156,7 @@ abstract class TestCase extends \Test\TestCase {
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
 		\OC::$server->getGroupManager()->clearBackends();
-		\OC::$server->getGroupManager()->addBackend(new \OC\Group\Database());
+		\OC::$server->getGroupManager()->addBackend(new Database());
 
 		parent::tearDownAfterClass();
 	}
@@ -181,9 +184,9 @@ abstract class TestCase extends \Test\TestCase {
 		}
 
 		\OC_Util::tearDownFS();
-		\OC\Files\Cache\Storage::getGlobalCache()->clearCache();
+		Storage::getGlobalCache()->clearCache();
 		\OC::$server->getUserSession()->setUser(null);
-		\OC\Files\Filesystem::tearDown();
+		Filesystem::tearDown();
 		\OC::$server->getUserSession()->login($user, $password);
 		\OC::$server->getUserFolder($user);
 

--- a/apps/files_sharing/tests/UnshareChildrenTest.php
+++ b/apps/files_sharing/tests/UnshareChildrenTest.php
@@ -6,7 +6,10 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\Filesystem;
+use OCP\Constants;
 use OCP\Share\IShare;
+use OCP\Util;
 
 /**
  * Class UnshareChildrenTest
@@ -25,7 +28,7 @@ class UnshareChildrenTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		\OCP\Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
+		Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren');
 
 		$this->folder = self::TEST_FOLDER_NAME;
 		$this->subfolder = '/subfolder_share_api_test';
@@ -55,14 +58,14 @@ class UnshareChildrenTest extends TestCase {
 	 * @medium
 	 */
 	public function testUnshareChildren(): void {
-		$fileInfo2 = \OC\Files\Filesystem::getFileInfo($this->folder);
+		$fileInfo2 = Filesystem::getFileInfo($this->folder);
 
 		$this->share(
 			IShare::TYPE_USER,
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
@@ -72,11 +75,11 @@ class UnshareChildrenTest extends TestCase {
 		$this->assertCount(1, $shares);
 
 		// move shared folder to 'localDir'
-		\OC\Files\Filesystem::mkdir('localDir');
-		$result = \OC\Files\Filesystem::rename($this->folder, '/localDir/' . $this->folder);
+		Filesystem::mkdir('localDir');
+		$result = Filesystem::rename($this->folder, '/localDir/' . $this->folder);
 		$this->assertTrue($result);
 
-		\OC\Files\Filesystem::unlink('localDir');
+		Filesystem::unlink('localDir');
 
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
@@ -87,6 +90,6 @@ class UnshareChildrenTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
 
 		// the folder for the owner should still exists
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->folder));
+		$this->assertTrue(Filesystem::file_exists($this->folder));
 	}
 }

--- a/apps/files_sharing/tests/UpdaterTest.php
+++ b/apps/files_sharing/tests/UpdaterTest.php
@@ -6,8 +6,13 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\FileInfo;
+use OC\Files\Filesystem;
+use OC\Files\View;
+use OCA\Files_Sharing\Helper;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\Constants;
 use OCP\Share\IShare;
 
 /**
@@ -20,7 +25,7 @@ class UpdaterTest extends TestCase {
 
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
-		\OCA\Files_Sharing\Helper::registerHooks();
+		Helper::registerHooks();
 	}
 
 	protected function setUp(): void {
@@ -58,19 +63,19 @@ class UpdaterTest extends TestCase {
 		$trashbinApp = new Application();
 		$trashbinApp->boot($this->createMock(IBootContext::class));
 
-		$fileinfo = \OC\Files\Filesystem::getFileInfo($this->folder);
-		$this->assertTrue($fileinfo instanceof \OC\Files\FileInfo);
+		$fileinfo = Filesystem::getFileInfo($this->folder);
+		$this->assertTrue($fileinfo instanceof FileInfo);
 
 		$this->share(
 			IShare::TYPE_USER,
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$view = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$view = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
 		// check if user2 can see the shared folder
 		$this->assertTrue($view->file_exists($this->folder));
@@ -96,7 +101,7 @@ class UpdaterTest extends TestCase {
 		$this->assertCount(0, $foldersShared);
 
 		// trashbin should contain the local file but not the mount point
-		$rootView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2);
+		$rootView = new View('/' . self::TEST_FILES_SHARING_API_USER2);
 		$trashContent = \OCA\Files_Trashbin\Helper::getTrashFiles('/', self::TEST_FILES_SHARING_API_USER2);
 		$this->assertSame(1, count($trashContent));
 		$firstElement = reset($trashContent);
@@ -111,7 +116,7 @@ class UpdaterTest extends TestCase {
 			\OC::$server->getAppManager()->disableApp('files_trashbin');
 		}
 
-		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 	}
 
 	public function shareFolderProvider() {
@@ -135,12 +140,12 @@ class UpdaterTest extends TestCase {
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$beforeShareRoot = \OC\Files\Filesystem::getFileInfo('');
+		$beforeShareRoot = Filesystem::getFileInfo('');
 		$etagBeforeShareRoot = $beforeShareRoot->getEtag();
 
-		\OC\Files\Filesystem::mkdir($shareFolder);
+		Filesystem::mkdir($shareFolder);
 
-		$beforeShareDir = \OC\Files\Filesystem::getFileInfo($shareFolder);
+		$beforeShareDir = Filesystem::getFileInfo($shareFolder);
 		$etagBeforeShareDir = $beforeShareDir->getEtag();
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER1);
@@ -150,15 +155,15 @@ class UpdaterTest extends TestCase {
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$afterShareRoot = \OC\Files\Filesystem::getFileInfo('');
+		$afterShareRoot = Filesystem::getFileInfo('');
 		$etagAfterShareRoot = $afterShareRoot->getEtag();
 
-		$afterShareDir = \OC\Files\Filesystem::getFileInfo($shareFolder);
+		$afterShareDir = Filesystem::getFileInfo($shareFolder);
 		$etagAfterShareDir = $afterShareDir->getEtag();
 
 		$this->assertTrue(is_string($etagBeforeShareRoot));
@@ -179,36 +184,36 @@ class UpdaterTest extends TestCase {
 	 * if a folder gets renamed all children mount points should be renamed too
 	 */
 	public function testRename(): void {
-		$fileinfo = \OC\Files\Filesystem::getFileInfo($this->folder);
+		$fileinfo = Filesystem::getFileInfo($this->folder);
 
 		$share = $this->share(
 			IShare::TYPE_USER,
 			$this->folder,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
 		// make sure that the shared folder exists
-		$this->assertTrue(\OC\Files\Filesystem::file_exists($this->folder));
+		$this->assertTrue(Filesystem::file_exists($this->folder));
 
-		\OC\Files\Filesystem::mkdir('oldTarget');
-		\OC\Files\Filesystem::mkdir('oldTarget/subfolder');
-		\OC\Files\Filesystem::mkdir('newTarget');
+		Filesystem::mkdir('oldTarget');
+		Filesystem::mkdir('oldTarget/subfolder');
+		Filesystem::mkdir('newTarget');
 
-		\OC\Files\Filesystem::rename($this->folder, 'oldTarget/subfolder/' . $this->folder);
-
-		// re-login to make sure that the new mount points are initialized
-		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
-
-		\OC\Files\Filesystem::rename('/oldTarget', '/newTarget/oldTarget');
+		Filesystem::rename($this->folder, 'oldTarget/subfolder/' . $this->folder);
 
 		// re-login to make sure that the new mount points are initialized
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists('/newTarget/oldTarget/subfolder/' . $this->folder));
+		Filesystem::rename('/oldTarget', '/newTarget/oldTarget');
+
+		// re-login to make sure that the new mount points are initialized
+		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$this->assertTrue(Filesystem::file_exists('/newTarget/oldTarget/subfolder/' . $this->folder));
 
 		// cleanup
 		$this->shareManager->deleteShare($share);
@@ -229,7 +234,7 @@ class UpdaterTest extends TestCase {
 		$this->markTestSkipped('Skipped because this is failing with S3 as primary as file id are change when moved.');
 
 		// user1 creates folder1
-		$viewUser1 = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
+		$viewUser1 = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
 		$folder1 = 'folder1';
 		$viewUser1->mkdir($folder1);
 
@@ -239,11 +244,11 @@ class UpdaterTest extends TestCase {
 			$folder1,
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_SHARE
 		);
 
 		$this->loginHelper(self::TEST_FILES_SHARING_API_USER2);
-		$viewUser2 = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
+		$viewUser2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 		// Create user2 files
 		$folder2 = 'folder2';
 		$viewUser2->mkdir($folder2);
@@ -262,7 +267,7 @@ class UpdaterTest extends TestCase {
 			$folder2,
 			self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER3,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		// user2 shares folder2/file1 to user3
 		$file1Share = $this->share(
@@ -270,7 +275,7 @@ class UpdaterTest extends TestCase {
 			$file1,
 			self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER3,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_SHARE
 		);
 		// user2 shares subfolder1 to user3
 		$subfolder1Share = $this->share(
@@ -278,7 +283,7 @@ class UpdaterTest extends TestCase {
 			$subfolder1,
 			self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER3,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 		// user2 shares subfolder2/file2.txt to user3
 		$file2Share = $this->share(
@@ -286,7 +291,7 @@ class UpdaterTest extends TestCase {
 			$file2,
 			self::TEST_FILES_SHARING_API_USER2,
 			self::TEST_FILES_SHARING_API_USER3,
-			\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE
+			Constants::PERMISSION_READ | Constants::PERMISSION_SHARE
 		);
 
 		// user2 moves folder2 into folder1
@@ -302,10 +307,10 @@ class UpdaterTest extends TestCase {
 		$this->assertEquals(self::TEST_FILES_SHARING_API_USER1, $subfolder1Share->getShareOwner());
 		$this->assertEquals(self::TEST_FILES_SHARING_API_USER1, $file2Share->getShareOwner());
 		// Expect permissions to be limited by the permissions of the destination share
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $folder2Share->getPermissions());
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $file1Share->getPermissions());
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $subfolder1Share->getPermissions());
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $file2Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $folder2Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $file1Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $subfolder1Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $file2Share->getPermissions());
 
 		// user2 moves folder2 out of folder1
 		$viewUser2->rename($folder1 . '/' . $folder2, $folder2);
@@ -320,10 +325,10 @@ class UpdaterTest extends TestCase {
 		$this->assertEquals(self::TEST_FILES_SHARING_API_USER2, $subfolder1Share->getShareOwner());
 		$this->assertEquals(self::TEST_FILES_SHARING_API_USER2, $file2Share->getShareOwner());
 		// Expect permissions to not change
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $folder2Share->getPermissions());
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $file1Share->getPermissions());
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $subfolder1Share->getPermissions());
-		$this->assertEquals(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_SHARE, $file2Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $folder2Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $file1Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $subfolder1Share->getPermissions());
+		$this->assertEquals(Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, $file2Share->getPermissions());
 
 		// cleanup
 		$this->shareManager->deleteShare($folder1Share);

--- a/apps/files_sharing/tests/WatcherTest.php
+++ b/apps/files_sharing/tests/WatcherTest.php
@@ -6,6 +6,8 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\Files\View;
+use OCP\Constants;
 use OCP\Share\IShare;
 
 /**
@@ -50,7 +52,7 @@ class WatcherTest extends TestCase {
 			'container/shareddir',
 			self::TEST_FILES_SHARING_API_USER1,
 			self::TEST_FILES_SHARING_API_USER2,
-			\OCP\Constants::PERMISSION_ALL
+			Constants::PERMISSION_ALL
 		);
 
 		$this->_share->setStatus(IShare::STATUS_ACCEPTED);
@@ -60,7 +62,7 @@ class WatcherTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 
 		// retrieve the shared storage
-		$secondView = new \OC\Files\View('/' . self::TEST_FILES_SHARING_API_USER2);
+		$secondView = new View('/' . self::TEST_FILES_SHARING_API_USER2);
 		[$this->sharedStorage, $internalPath] = $secondView->resolvePath('files/shareddir');
 		$this->sharedCache = $this->sharedStorage->getCache();
 	}

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Trashbin\BackgroundJob;
 
+use OC\Files\View;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Helper;
 use OCA\Files_Trashbin\Trashbin;
@@ -70,7 +71,7 @@ class ExpireTrash extends TimedJob {
 		\OC_Util::setupFS($user);
 
 		// Check if this user has a trashbin directory
-		$view = new \OC\Files\View('/' . $user);
+		$view = new View('/' . $user);
 		if (!$view->is_dir('/files_trashbin/files')) {
 			return false;
 		}

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Trashbin\Command;
 
+use OC\Files\View;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Helper;
 use OCA\Files_Trashbin\Trashbin;
@@ -103,7 +104,7 @@ class ExpireTrash extends Command {
 		\OC_Util::setupFS($user);
 
 		// Check if this user has a trashbin directory
-		$view = new \OC\Files\View('/' . $user);
+		$view = new View('/' . $user);
 		if (!$view->is_dir('/files_trashbin/files')) {
 			return false;
 		}

--- a/apps/files_trashbin/lib/Command/RestoreAllFiles.php
+++ b/apps/files_trashbin/lib/Command/RestoreAllFiles.php
@@ -7,6 +7,7 @@ namespace OCA\Files_Trashbin\Command;
 
 use OC\Core\Command\Base;
 use OCA\Files_Trashbin\Trash\ITrashManager;
+use OCA\Files_Trashbin\Trash\TrashItem;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
 use OCP\IL10N;
@@ -246,7 +247,7 @@ class RestoreAllFiles extends Base {
 			$trashItemClass = get_class($trashItem);
 
 			// Check scope with exact class name for locally deleted files
-			if ($scope === self::SCOPE_USER && $trashItemClass !== \OCA\Files_Trashbin\Trash\TrashItem::class) {
+			if ($scope === self::SCOPE_USER && $trashItemClass !== TrashItem::class) {
 				$output->writeln('Skipping <info>' . $trashItem->getName() . '</info> because it is not a user trash item', OutputInterface::VERBOSITY_VERBOSE);
 				continue;
 			}

--- a/apps/files_trashbin/lib/Controller/PreviewController.php
+++ b/apps/files_trashbin/lib/Controller/PreviewController.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\Folder;
 use OCP\Files\IMimeTypeDetector;
@@ -111,7 +112,7 @@ class PreviewController extends Controller {
 			}
 
 			$f = $this->previewManager->getPreview($file, $x, $y, !$a, IPreview::MODE_FILL, $mimeType);
-			$response = new Http\FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
+			$response = new FileDisplayResponse($f, Http::STATUS_OK, ['Content-Type' => $f->getMimeType()]);
 
 			// Cache previews for 24H
 			$response->cacheFor(3600 * 24);

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Trashbin;
 
 use OC\Files\FileInfo;
+use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
 
@@ -25,7 +26,7 @@ class Helper {
 		$result = [];
 		$timestamp = null;
 
-		$view = new \OC\Files\View('/' . $user . '/files_trashbin/files');
+		$view = new View('/' . $user . '/files_trashbin/files');
 
 		if (ltrim($dir, '/') !== '' && !$view->is_dir($dir)) {
 			throw new \Exception('Directory does not exists');
@@ -36,7 +37,7 @@ class Helper {
 		$absoluteDir = $view->getAbsolutePath($dir);
 		$internalPath = $mount->getInternalPath($absoluteDir);
 
-		$extraData = \OCA\Files_Trashbin\Trashbin::getExtraData($user);
+		$extraData = Trashbin::getExtraData($user);
 		$dirContent = $storage->getCache()->getFolderContents($mount->getInternalPath($view->getAbsolutePath($dir)));
 		foreach ($dirContent as $entry) {
 			$entryName = $entry->getName();
@@ -98,7 +99,7 @@ class Helper {
 			$entry = \OCA\Files\Helper::formatFileInfo($i);
 			$entry['id'] = $i->getId();
 			$entry['etag'] = $entry['mtime']; // add fake etag, it is only needed to identify the preview image
-			$entry['permissions'] = \OCP\Constants::PERMISSION_READ;
+			$entry['permissions'] = Constants::PERMISSION_READ;
 			$files[] = $entry;
 		}
 		return $files;

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -10,6 +10,7 @@ namespace OCA\Files_Trashbin\Sabre;
 
 use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\Files_Trashbin\Trash\ITrashManager;
+use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\FileInfo;
 use OCP\IUser;
 use Sabre\DAV\Exception\Forbidden;
@@ -30,7 +31,7 @@ class TrashRoot implements ICollection {
 	}
 
 	public function delete() {
-		\OCA\Files_Trashbin\Trashbin::deleteAll();
+		Trashbin::deleteAll();
 		foreach ($this->trashManager->listTrashRoot($this->user) as $trashItem) {
 			$this->trashManager->removeItem($trashItem);
 		}

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -92,7 +92,7 @@ class LegacyTrashBackend implements ITrashBackend {
 			$this->deletedFiles[$normalized] = $normalized;
 			if ($filesPath = $view->getRelativePath($normalized)) {
 				$filesPath = trim($filesPath, '/');
-				$result = \OCA\Files_Trashbin\Trashbin::move2trash($filesPath);
+				$result = Trashbin::move2trash($filesPath);
 			} else {
 				$result = false;
 			}

--- a/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
+++ b/apps/files_trashbin/lib/UserMigration/TrashbinMigrator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\Files_Trashbin\UserMigration;
 
 use OCA\Files_Trashbin\AppInfo\Application;
+use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -81,7 +82,7 @@ class TrashbinMigrator implements IMigrator, ISizeEstimationMigrator {
 			$exportDestination->copyFolder($trashbinFolder, static::PATH_FILES_FOLDER);
 			$originalLocations = [];
 			// TODO Export all extra data and bump migrator to v2
-			foreach (\OCA\Files_Trashbin\Trashbin::getExtraData($uid) as $filename => $extraData) {
+			foreach (Trashbin::getExtraData($uid) as $filename => $extraData) {
 				$locationData = [];
 				foreach ($extraData as $timestamp => ['location' => $location]) {
 					$locationData[$timestamp] = $location;

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -10,6 +10,7 @@ use OC\User\Manager;
 use OCA\Files_Trashbin\Command\CleanUp;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
+use OCP\UserInterface;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
@@ -175,7 +176,7 @@ class CleanUpTest extends TestCase {
 			->setMethods(['removeDeletedFiles'])
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->dbConnection])
 			->getMock();
-		$backend = $this->createMock(\OCP\UserInterface::class);
+		$backend = $this->createMock(UserInterface::class);
 		$backend->method('getUsers')
 			->with('', 500, 0)
 			->willReturn($backendUsers);

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -9,12 +9,14 @@ namespace OCA\Files_Trashbin\Tests;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Common;
 use OC\Files\Storage\Temporary;
+use OC\Files\View;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCA\Files_Trashbin\Events\MoveToTrashEvent;
 use OCA\Files_Trashbin\Storage;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Folder;
@@ -83,10 +85,10 @@ class StorageTest extends \Test\TestCase {
 		// this will setup the FS
 		$this->loginAsUser($this->user);
 
-		\OCA\Files_Trashbin\Storage::setupStorage();
+		Storage::setupStorage();
 
-		$this->rootView = new \OC\Files\View('/');
-		$this->userView = new \OC\Files\View('/' . $this->user . '/files/');
+		$this->rootView = new View('/');
+		$this->userView = new View('/' . $this->user . '/files/');
 		$this->userView->file_put_contents('test.txt', 'foo');
 		$this->userView->file_put_contents(static::LONG_FILENAME, 'foo');
 		$this->userView->file_put_contents(static::MAX_FILENAME, 'foo');
@@ -96,7 +98,7 @@ class StorageTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		\OC\Files\Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
+		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 		$this->logout();
 		$user = \OC::$server->getUserManager()->get($this->user);
 		if ($user !== null) {
@@ -191,7 +193,7 @@ class StorageTest extends \Test\TestCase {
 	 */
 	public function testCrossStorageDeleteFile(): void {
 		$storage2 = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage2, [], $this->user . '/files/substorage');
+		Filesystem::mount($storage2, [], $this->user . '/files/substorage');
 
 		$this->userView->file_put_contents('substorage/subfile.txt', 'foo');
 		$storage2->getScanner()->scan('');
@@ -217,7 +219,7 @@ class StorageTest extends \Test\TestCase {
 	 */
 	public function testCrossStorageDeleteFolder(): void {
 		$storage2 = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage2, [], $this->user . '/files/substorage');
+		Filesystem::mount($storage2, [], $this->user . '/files/substorage');
 
 		$this->userView->mkdir('substorage/folder');
 		$this->userView->file_put_contents('substorage/folder/subfile.txt', 'bar');
@@ -322,14 +324,14 @@ class StorageTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy($this->user)
 			->setSharedWith($recipientUser)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, $recipientUser);
 
 		$this->loginAsUser($recipientUser);
 
 		// delete as recipient
-		$recipientView = new \OC\Files\View('/' . $recipientUser . '/files');
+		$recipientView = new View('/' . $recipientUser . '/files');
 		$recipientView->unlink('share/test.txt');
 
 		// rescan trash storage for both users
@@ -374,14 +376,14 @@ class StorageTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy($this->user)
 			->setSharedWith($recipientUser)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, $recipientUser);
 
 		$this->loginAsUser($recipientUser);
 
 		// delete as recipient
-		$recipientView = new \OC\Files\View('/' . $recipientUser . '/files');
+		$recipientView = new View('/' . $recipientUser . '/files');
 		$recipientView->rmdir('share/folder');
 
 		// rescan trash storage
@@ -424,7 +426,7 @@ class StorageTest extends \Test\TestCase {
 	 */
 	public function testKeepFileAndVersionsWhenMovingFileBetweenStorages(): void {
 		$storage2 = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage2, [], $this->user . '/files/substorage');
+		Filesystem::mount($storage2, [], $this->user . '/files/substorage');
 
 		// trigger a version (multiple would not work because of the expire logic)
 		$this->userView->file_put_contents('test.txt', 'v1');
@@ -463,7 +465,7 @@ class StorageTest extends \Test\TestCase {
 	 */
 	public function testKeepFileAndVersionsWhenMovingFolderBetweenStorages(): void {
 		$storage2 = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage2, [], $this->user . '/files/substorage');
+		Filesystem::mount($storage2, [], $this->user . '/files/substorage');
 
 		// trigger a version (multiple would not work because of the expire logic)
 		$this->userView->file_put_contents('folder/inside.txt', 'v1');

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Versions\BackgroundJob;
 
+use OC\Files\View;
 use OCA\Files_Versions\Expiration;
 use OCA\Files_Versions\Storage;
 use OCP\AppFramework\Utility\ITimeFactory;
@@ -59,7 +60,7 @@ class ExpireVersions extends TimedJob {
 		\OC_Util::setupFS($user);
 
 		// Check if this user has a versions directory
-		$view = new \OC\Files\View('/' . $user);
+		$view = new View('/' . $user);
 		if (!$view->is_dir('/files_versions')) {
 			return false;
 		}

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Versions\Command;
 
+use OC\Files\View;
 use OCA\Files_Versions\Expiration;
 use OCA\Files_Versions\Storage;
 use OCP\IUser;
@@ -84,7 +85,7 @@ class ExpireVersions extends Command {
 		\OC_Util::setupFS($user);
 
 		// Check if this user has a version directory
-		$view = new \OC\Files\View('/' . $user);
+		$view = new View('/' . $user);
 		if (!$view->is_dir('/files_versions')) {
 			return false;
 		}

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -12,6 +12,7 @@ use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\View;
+use OC\User\NoUserException;
 use OC_User;
 use OCA\Files_Sharing\SharedMount;
 use OCA\Files_Versions\AppInfo\Application;
@@ -37,6 +38,8 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
+use OCP\Server;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class Storage {
@@ -68,7 +71,7 @@ class Storage {
 		6 => ['intervalEndsAfter' => -1,      'step' => 604800],
 	];
 
-	/** @var \OCA\Files_Versions\AppInfo\Application */
+	/** @var Application */
 	private static $application;
 
 	/**
@@ -598,7 +601,7 @@ class Storage {
 				$version->delete();
 				\OC_Hook::emit('\OCP\Versions', 'delete', ['path' => $internalPath, 'trigger' => self::DELETE_TRIGGER_RETENTION_CONSTRAINT]);
 			} catch (NotPermittedException $e) {
-				\OCP\Server::get(LoggerInterface::class)->error("Missing permissions to delete version: {$internalPath}", ['app' => 'files_versions', 'exception' => $e]);
+				Server::get(LoggerInterface::class)->error("Missing permissions to delete version: {$internalPath}", ['app' => 'files_versions', 'exception' => $e]);
 			}
 		}
 	}
@@ -814,7 +817,7 @@ class Storage {
 			$user = \OC::$server->get(IUserManager::class)->get($uid);
 			if (is_null($user)) {
 				$logger->error('Backends provided no user object for ' . $uid, ['app' => 'files_versions']);
-				throw new \OC\User\NoUserException('Backends provided no user object for ' . $uid);
+				throw new NoUserException('Backends provided no user object for ' . $uid);
 			}
 
 			\OC_Util::setupFS($uid);
@@ -841,7 +844,7 @@ class Storage {
 				$quota = Filesystem::free_space('/');
 				$softQuota = false;
 			} else {
-				$quota = \OCP\Util::computerFileSize($quota);
+				$quota = Util::computerFileSize($quota);
 			}
 
 			// make sure that we have the current size of the version history

--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -15,6 +15,7 @@ use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\Files_Versions\Db\VersionEntity;
 use OCA\Files_Versions\Db\VersionsMapper;
 use OCA\Files_Versions\Storage;
+use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
@@ -162,7 +163,7 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 	}
 
 	public function rollback(IVersion $version) {
-		if (!$this->currentUserHasPermissions($version->getSourceFile(), \OCP\Constants::PERMISSION_UPDATE)) {
+		if (!$this->currentUserHasPermissions($version->getSourceFile(), Constants::PERMISSION_UPDATE)) {
 			throw new Forbidden('You cannot restore this version because you do not have update permissions on the source file.');
 		}
 
@@ -212,7 +213,7 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 	}
 
 	public function deleteVersion(IVersion $version): void {
-		if (!$this->currentUserHasPermissions($version->getSourceFile(), \OCP\Constants::PERMISSION_DELETE)) {
+		if (!$this->currentUserHasPermissions($version->getSourceFile(), Constants::PERMISSION_DELETE)) {
 			throw new Forbidden('You cannot delete this version because you do not have delete permissions on the source file.');
 		}
 
@@ -303,7 +304,7 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 	}
 
 	public function setMetadataValue(Node $node, int $revision, string $key, string $value): void {
-		if (!$this->currentUserHasPermissions($node, \OCP\Constants::PERMISSION_UPDATE)) {
+		if (!$this->currentUserHasPermissions($node, Constants::PERMISSION_UPDATE)) {
 			throw new Forbidden('You cannot update the version\'s metadata because you do not have update permissions on the source file.');
 		}
 

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -12,6 +12,7 @@ use OCP\Files\Cache\ICache;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\Storage\IStorage;
+use OCP\UserInterface;
 use Test\TestCase;
 
 /**
@@ -142,7 +143,7 @@ class CleanupTest extends TestCase {
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->versionMapper])
 			->getMock();
 
-		$backend = $this->getMockBuilder(\OCP\UserInterface::class)
+		$backend = $this->getMockBuilder(UserInterface::class)
 			->disableOriginalConstructor()->getMock();
 		$backend->expects($this->once())->method('getUsers')
 			->with('', 500, 0)

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -6,14 +6,24 @@
  */
 namespace OCA\Files_Versions\Tests;
 
+use OC\AllConfig;
+use OC\Files\Cache\Watcher;
+use OC\Files\Filesystem;
 use OC\Files\Storage\Temporary;
+use OC\Files\View;
+use OC\User\NoUserException;
+use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Versions\Db\VersionEntity;
 use OCA\Files_Versions\Db\VersionsMapper;
+use OCA\Files_Versions\Storage;
 use OCA\Files_Versions\Versions\IVersionManager;
+use OCP\Constants;
 use OCP\Files\IMimeTypeLoader;
 use OCP\IConfig;
 use OCP\IUser;
+use OCP\Server;
 use OCP\Share\IShare;
+use OCP\Util;
 
 /**
  * Class Test_Files_versions
@@ -44,7 +54,7 @@ class VersioningTest extends \Test\TestCase {
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 
-		$application = new \OCA\Files_Sharing\AppInfo\Application();
+		$application = new Application();
 
 		// create test user
 		self::loginHelper(self::TEST_VERSIONS_USER2, true);
@@ -74,12 +84,12 @@ class VersioningTest extends \Test\TestCase {
 			->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) use ($config) {
 				if ($key === 'filesystem_check_changes') {
-					return \OC\Files\Cache\Watcher::CHECK_ONCE;
+					return Watcher::CHECK_ONCE;
 				} else {
 					return $config->getSystemValue($key, $default);
 				}
 			});
-		$this->overwriteService(\OC\AllConfig::class, $mockConfig);
+		$this->overwriteService(AllConfig::class, $mockConfig);
 
 		// clear hooks
 		\OC_Hook::clear();
@@ -87,13 +97,13 @@ class VersioningTest extends \Test\TestCase {
 		\OC::$server->boot();
 
 		self::loginHelper(self::TEST_VERSIONS_USER);
-		$this->rootView = new \OC\Files\View();
+		$this->rootView = new View();
 		if (!$this->rootView->file_exists(self::USERS_VERSIONS_ROOT)) {
 			$this->rootView->mkdir(self::USERS_VERSIONS_ROOT);
 		}
 
-		$this->versionsMapper = \OCP\Server::get(VersionsMapper::class);
-		$this->mimeTypeLoader = \OCP\Server::get(IMimeTypeLoader::class);
+		$this->versionsMapper = Server::get(VersionsMapper::class);
+		$this->mimeTypeLoader = Server::get(IMimeTypeLoader::class);
 
 		$this->user1 = $this->createMock(IUser::class);
 		$this->user1->method('getUID')
@@ -104,7 +114,7 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->restoreService(\OC\AllConfig::class);
+		$this->restoreService(AllConfig::class);
 
 		if ($this->rootView) {
 			$this->rootView->deleteAll(self::TEST_VERSIONS_USER . '/files/');
@@ -270,7 +280,7 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	public function testRename(): void {
-		\OC\Files\Filesystem::file_put_contents('test.txt', 'test file');
+		Filesystem::file_put_contents('test.txt', 'test file');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -287,7 +297,7 @@ class VersioningTest extends \Test\TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		// execute rename hook of versions app
-		\OC\Files\Filesystem::rename('test.txt', 'test2.txt');
+		Filesystem::rename('test.txt', 'test2.txt');
 
 		$this->runCommands();
 
@@ -299,9 +309,9 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	public function testRenameInSharedFolder(): void {
-		\OC\Files\Filesystem::mkdir('folder1');
-		\OC\Files\Filesystem::mkdir('folder1/folder2');
-		\OC\Files\Filesystem::file_put_contents('folder1/test.txt', 'test file');
+		Filesystem::mkdir('folder1');
+		Filesystem::mkdir('folder1/folder2');
+		Filesystem::file_put_contents('folder1/test.txt', 'test file');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -324,16 +334,16 @@ class VersioningTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy(self::TEST_VERSIONS_USER)
 			->setSharedWith(self::TEST_VERSIONS_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, self::TEST_VERSIONS_USER2);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists('folder1/test.txt'));
+		$this->assertTrue(Filesystem::file_exists('folder1/test.txt'));
 
 		// execute rename hook of versions app
-		\OC\Files\Filesystem::rename('/folder1/test.txt', '/folder1/folder2/test.txt');
+		Filesystem::rename('/folder1/test.txt', '/folder1/folder2/test.txt');
 
 		$this->runCommands();
 
@@ -349,9 +359,9 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	public function testMoveFolder(): void {
-		\OC\Files\Filesystem::mkdir('folder1');
-		\OC\Files\Filesystem::mkdir('folder2');
-		\OC\Files\Filesystem::file_put_contents('folder1/test.txt', 'test file');
+		Filesystem::mkdir('folder1');
+		Filesystem::mkdir('folder2');
+		Filesystem::file_put_contents('folder1/test.txt', 'test file');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -369,7 +379,7 @@ class VersioningTest extends \Test\TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		// execute rename hook of versions app
-		\OC\Files\Filesystem::rename('folder1', 'folder2/folder1');
+		Filesystem::rename('folder1', 'folder2/folder1');
 
 		$this->runCommands();
 
@@ -382,8 +392,8 @@ class VersioningTest extends \Test\TestCase {
 
 
 	public function testMoveFileIntoSharedFolderAsRecipient(): void {
-		\OC\Files\Filesystem::mkdir('folder1');
-		$fileInfo = \OC\Files\Filesystem::getFileInfo('folder1');
+		Filesystem::mkdir('folder1');
+		$fileInfo = Filesystem::getFileInfo('folder1');
 
 		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('folder1');
 		$share = \OC::$server->getShareManager()->newShare();
@@ -391,13 +401,13 @@ class VersioningTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy(self::TEST_VERSIONS_USER)
 			->setSharedWith(self::TEST_VERSIONS_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, self::TEST_VERSIONS_USER2);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 		$versionsFolder2 = '/' . self::TEST_VERSIONS_USER2 . '/files_versions';
-		\OC\Files\Filesystem::file_put_contents('test.txt', 'test file');
+		Filesystem::file_put_contents('test.txt', 'test file');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -413,7 +423,7 @@ class VersioningTest extends \Test\TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		// move file into the shared folder as recipient
-		\OC\Files\Filesystem::rename('/test.txt', '/folder1/test.txt');
+		Filesystem::rename('/test.txt', '/folder1/test.txt');
 
 		$this->assertFalse($this->rootView->file_exists($v1));
 		$this->assertFalse($this->rootView->file_exists($v2));
@@ -432,7 +442,7 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	public function testMoveFolderIntoSharedFolderAsRecipient(): void {
-		\OC\Files\Filesystem::mkdir('folder1');
+		Filesystem::mkdir('folder1');
 
 		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('folder1');
 		$share = \OC::$server->getShareManager()->newShare();
@@ -440,14 +450,14 @@ class VersioningTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy(self::TEST_VERSIONS_USER)
 			->setSharedWith(self::TEST_VERSIONS_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, self::TEST_VERSIONS_USER2);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 		$versionsFolder2 = '/' . self::TEST_VERSIONS_USER2 . '/files_versions';
-		\OC\Files\Filesystem::mkdir('folder2');
-		\OC\Files\Filesystem::file_put_contents('folder2/test.txt', 'test file');
+		Filesystem::mkdir('folder2');
+		Filesystem::file_put_contents('folder2/test.txt', 'test file');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -464,7 +474,7 @@ class VersioningTest extends \Test\TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		// move file into the shared folder as recipient
-		\OC\Files\Filesystem::rename('/folder2', '/folder1/folder2');
+		Filesystem::rename('/folder2', '/folder1/folder2');
 
 		$this->assertFalse($this->rootView->file_exists($v1));
 		$this->assertFalse($this->rootView->file_exists($v2));
@@ -483,7 +493,7 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	public function testRenameSharedFile(): void {
-		\OC\Files\Filesystem::file_put_contents('test.txt', 'test file');
+		Filesystem::file_put_contents('test.txt', 'test file');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -507,16 +517,16 @@ class VersioningTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy(self::TEST_VERSIONS_USER)
 			->setSharedWith(self::TEST_VERSIONS_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_SHARE);
+			->setPermissions(Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE | Constants::PERMISSION_SHARE);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, self::TEST_VERSIONS_USER2);
 
 		self::loginHelper(self::TEST_VERSIONS_USER2);
 
-		$this->assertTrue(\OC\Files\Filesystem::file_exists('test.txt'));
+		$this->assertTrue(Filesystem::file_exists('test.txt'));
 
 		// execute rename hook of versions app
-		\OC\Files\Filesystem::rename('test.txt', 'test2.txt');
+		Filesystem::rename('test.txt', 'test2.txt');
 
 		self::loginHelper(self::TEST_VERSIONS_USER);
 
@@ -532,7 +542,7 @@ class VersioningTest extends \Test\TestCase {
 	}
 
 	public function testCopy(): void {
-		\OC\Files\Filesystem::file_put_contents('test.txt', 'test file');
+		Filesystem::file_put_contents('test.txt', 'test file');
 
 		$t1 = time();
 		// second version is two weeks older, this way we make sure that no
@@ -549,7 +559,7 @@ class VersioningTest extends \Test\TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		// execute copy hook of versions app
-		\OC\Files\Filesystem::copy('test.txt', 'test2.txt');
+		Filesystem::copy('test.txt', 'test2.txt');
 
 		$this->runCommands();
 
@@ -580,7 +590,7 @@ class VersioningTest extends \Test\TestCase {
 		$this->rootView->file_put_contents($v2, 'version2');
 
 		// execute copy hook of versions app
-		$versions = \OCA\Files_Versions\Storage::getVersions(self::TEST_VERSIONS_USER, '/subfolder/test.txt');
+		$versions = Storage::getVersions(self::TEST_VERSIONS_USER, '/subfolder/test.txt');
 
 		$this->assertCount(2, $versions);
 
@@ -599,10 +609,10 @@ class VersioningTest extends \Test\TestCase {
 	 */
 	public function testGetVersionsEmptyFile(): void {
 		// execute copy hook of versions app
-		$versions = \OCA\Files_Versions\Storage::getVersions(self::TEST_VERSIONS_USER, '');
+		$versions = Storage::getVersions(self::TEST_VERSIONS_USER, '');
 		$this->assertCount(0, $versions);
 
-		$versions = \OCA\Files_Versions\Storage::getVersions(self::TEST_VERSIONS_USER, null);
+		$versions = Storage::getVersions(self::TEST_VERSIONS_USER, null);
 		$this->assertCount(0, $versions);
 	}
 
@@ -611,29 +621,29 @@ class VersioningTest extends \Test\TestCase {
 		// needed to have a FS setup (the background job does this)
 		\OC_Util::setupFS(self::TEST_VERSIONS_USER);
 
-		$this->assertFalse(\OCA\Files_Versions\Storage::expire('/void/unexist.txt', self::TEST_VERSIONS_USER));
+		$this->assertFalse(Storage::expire('/void/unexist.txt', self::TEST_VERSIONS_USER));
 	}
 
 
 	public function testExpireNonexistingUser(): void {
-		$this->expectException(\OC\User\NoUserException::class);
+		$this->expectException(NoUserException::class);
 
 		$this->logout();
 		// needed to have a FS setup (the background job does this)
 		\OC_Util::setupFS(self::TEST_VERSIONS_USER);
-		\OC\Files\Filesystem::file_put_contents('test.txt', 'test file');
+		Filesystem::file_put_contents('test.txt', 'test file');
 
-		$this->assertFalse(\OCA\Files_Versions\Storage::expire('test.txt', 'unexist'));
+		$this->assertFalse(Storage::expire('test.txt', 'unexist'));
 	}
 
 	public function testRestoreSameStorage(): void {
-		\OC\Files\Filesystem::mkdir('sub');
+		Filesystem::mkdir('sub');
 		$this->doTestRestore();
 	}
 
 	public function testRestoreCrossStorage(): void {
 		$storage2 = new Temporary([]);
-		\OC\Files\Filesystem::mount($storage2, [], self::TEST_VERSIONS_USER . '/files/sub');
+		Filesystem::mount($storage2, [], self::TEST_VERSIONS_USER . '/files/sub');
 
 		$this->doTestRestore();
 	}
@@ -650,12 +660,12 @@ class VersioningTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy(self::TEST_VERSIONS_USER)
 			->setSharedWith(self::TEST_VERSIONS_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_READ);
+			->setPermissions(Constants::PERMISSION_READ);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, self::TEST_VERSIONS_USER2);
 
 		$versions = $this->createAndCheckVersions(
-			\OC\Files\Filesystem::getView(),
+			Filesystem::getView(),
 			'folder/test.txt'
 		);
 
@@ -665,7 +675,7 @@ class VersioningTest extends \Test\TestCase {
 
 		$firstVersion = current($versions);
 
-		$this->assertFalse(\OCA\Files_Versions\Storage::rollback('folder/test.txt', $firstVersion['version'], $this->user2), 'Revert did not happen');
+		$this->assertFalse(Storage::rollback('folder/test.txt', $firstVersion['version'], $this->user2), 'Revert did not happen');
 
 		$this->loginAsUser(self::TEST_VERSIONS_USER);
 
@@ -689,7 +699,7 @@ class VersioningTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy(self::TEST_VERSIONS_USER)
 			->setSharedWith(self::TEST_VERSIONS_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		$shareManager = \OC::$server->getShareManager();
 		$shareManager->acceptShare($share, self::TEST_VERSIONS_USER2);
@@ -698,7 +708,7 @@ class VersioningTest extends \Test\TestCase {
 		$shareManager->moveShare($share, self::TEST_VERSIONS_USER2);
 
 		$versions = $this->createAndCheckVersions(
-			\OC\Files\Filesystem::getView(),
+			Filesystem::getView(),
 			'folder/test.txt'
 		);
 
@@ -708,7 +718,7 @@ class VersioningTest extends \Test\TestCase {
 
 		$firstVersion = current($versions);
 
-		$this->assertTrue(\OCA\Files_Versions\Storage::rollback('folder/test.txt', $firstVersion['version'], $this->user1));
+		$this->assertTrue(Storage::rollback('folder/test.txt', $firstVersion['version'], $this->user1));
 
 		$this->loginAsUser(self::TEST_VERSIONS_USER);
 
@@ -737,7 +747,7 @@ class VersioningTest extends \Test\TestCase {
 				}
 			);
 
-		\OCP\Util::connectHook(
+		Util::connectHook(
 			'\OCP\Versions',
 			$hookName,
 			$eventHandler,
@@ -783,7 +793,7 @@ class VersioningTest extends \Test\TestCase {
 		$versionEntity->setMetadata([]);
 		$this->versionsMapper->insert($versionEntity);
 
-		$oldVersions = \OCA\Files_Versions\Storage::getVersions(
+		$oldVersions = Storage::getVersions(
 			self::TEST_VERSIONS_USER, '/sub/test.txt'
 		);
 
@@ -795,7 +805,7 @@ class VersioningTest extends \Test\TestCase {
 		$params = [];
 		$this->connectMockHooks('rollback', $params);
 
-		$versionManager = \OCP\Server::get(IVersionManager::class);
+		$versionManager = Server::get(IVersionManager::class);
 		$versions = $versionManager->getVersionsForFile($this->user1, $info1);
 		$version = array_filter($versions, function ($version) use ($t2) {
 			return $version->getRevisionId() === $t2;
@@ -828,7 +838,7 @@ class VersioningTest extends \Test\TestCase {
 			'Restored file has mtime from version'
 		);
 
-		$newVersions = \OCA\Files_Versions\Storage::getVersions(
+		$newVersions = Storage::getVersions(
 			self::TEST_VERSIONS_USER, '/sub/test.txt'
 		);
 
@@ -868,7 +878,7 @@ class VersioningTest extends \Test\TestCase {
 		$this->loginAsUser(self::TEST_VERSIONS_USER);
 
 		$this->createAndCheckVersions(
-			\OC\Files\Filesystem::getView(),
+			Filesystem::getView(),
 			'test.txt'
 		);
 	}
@@ -879,8 +889,8 @@ class VersioningTest extends \Test\TestCase {
 	public function testStoreVersionAsRecipient(): void {
 		$this->loginAsUser(self::TEST_VERSIONS_USER);
 
-		\OC\Files\Filesystem::mkdir('folder');
-		\OC\Files\Filesystem::file_put_contents('folder/test.txt', 'test file');
+		Filesystem::mkdir('folder');
+		Filesystem::file_put_contents('folder/test.txt', 'test file');
 
 		$node = \OC::$server->getUserFolder(self::TEST_VERSIONS_USER)->get('folder');
 		$share = \OC::$server->getShareManager()->newShare();
@@ -888,14 +898,14 @@ class VersioningTest extends \Test\TestCase {
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy(self::TEST_VERSIONS_USER)
 			->setSharedWith(self::TEST_VERSIONS_USER2)
-			->setPermissions(\OCP\Constants::PERMISSION_ALL);
+			->setPermissions(Constants::PERMISSION_ALL);
 		$share = \OC::$server->getShareManager()->createShare($share);
 		\OC::$server->getShareManager()->acceptShare($share, self::TEST_VERSIONS_USER2);
 
 		$this->loginAsUser(self::TEST_VERSIONS_USER2);
 
 		$this->createAndCheckVersions(
-			\OC\Files\Filesystem::getView(),
+			Filesystem::getView(),
 			'folder/test.txt'
 		);
 
@@ -916,7 +926,7 @@ class VersioningTest extends \Test\TestCase {
 		// needed to make the hooks fire
 		\OC_Util::setupFS(self::TEST_VERSIONS_USER);
 
-		$userView = new \OC\Files\View('/' . self::TEST_VERSIONS_USER . '/files');
+		$userView = new View('/' . self::TEST_VERSIONS_USER . '/files');
 		$this->createAndCheckVersions(
 			$userView,
 			'test.txt'
@@ -927,7 +937,7 @@ class VersioningTest extends \Test\TestCase {
 	 * @param \OC\Files\View $view
 	 * @param string $path
 	 */
-	private function createAndCheckVersions(\OC\Files\View $view, $path) {
+	private function createAndCheckVersions(View $view, $path) {
 		$view->file_put_contents($path, 'test file');
 		$view->file_put_contents($path, 'version 1');
 		$view->file_put_contents($path, 'version 2');
@@ -938,7 +948,7 @@ class VersioningTest extends \Test\TestCase {
 		[$rootStorage,] = $this->rootView->resolvePath(self::TEST_VERSIONS_USER . '/files_versions');
 		$rootStorage->getScanner()->scan('files_versions');
 
-		$versions = \OCA\Files_Versions\Storage::getVersions(
+		$versions = Storage::getVersions(
 			self::TEST_VERSIONS_USER, '/' . $path
 		);
 
@@ -962,7 +972,7 @@ class VersioningTest extends \Test\TestCase {
 
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
-		\OC\Files\Filesystem::tearDown();
+		Filesystem::tearDown();
 		\OC_User::setUserId($user);
 		\OC_Util::setupFS($user);
 		\OC::$server->getUserFolder($user);
@@ -970,7 +980,7 @@ class VersioningTest extends \Test\TestCase {
 }
 
 // extend the original class to make it possible to test protected methods
-class VersionStorageToTest extends \OCA\Files_Versions\Storage {
+class VersionStorageToTest extends Storage {
 
 	/**
 	 * @param integer $time

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -7,6 +7,7 @@ namespace OCA\OAuth2\Tests\Db;
 
 use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;
+use OCA\OAuth2\Exceptions\AccessTokenNotFoundException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use Test\TestCase;
 
@@ -39,7 +40,7 @@ class AccessTokenMapperTest extends TestCase {
 
 
 	public function testDeleteByClientId(): void {
-		$this->expectException(\OCA\OAuth2\Exceptions\AccessTokenNotFoundException::class);
+		$this->expectException(AccessTokenNotFoundException::class);
 
 		$this->accessTokenMapper->deleteByClientId(1234);
 		$token = new AccessToken();

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -7,6 +7,7 @@ namespace OCA\OAuth2\Tests\Db;
 
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
+use OCA\OAuth2\Exceptions\ClientNotFoundException;
 use Test\TestCase;
 
 /**
@@ -40,7 +41,7 @@ class ClientMapperTest extends TestCase {
 	}
 
 	public function testGetByIdentifierNotExisting(): void {
-		$this->expectException(\OCA\OAuth2\Exceptions\ClientNotFoundException::class);
+		$this->expectException(ClientNotFoundException::class);
 
 		$this->clientMapper->getByIdentifier('MyTotallyNotExistingClient');
 	}
@@ -57,7 +58,7 @@ class ClientMapperTest extends TestCase {
 	}
 
 	public function testGetByUidNotExisting(): void {
-		$this->expectException(\OCA\OAuth2\Exceptions\ClientNotFoundException::class);
+		$this->expectException(ClientNotFoundException::class);
 
 		$this->clientMapper->getByUid(1234);
 	}

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -47,6 +47,7 @@ use OCP\L10N\IFactory;
 use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\ISecureRandom;
 use OCP\User\Backend\ISetDisplayNameBackend;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -1032,7 +1033,7 @@ class UsersController extends AUserData {
 					if (is_numeric($quota)) {
 						$quota = (float)$quota;
 					} else {
-						$quota = \OCP\Util::computerFileSize($quota);
+						$quota = Util::computerFileSize($quota);
 					}
 					if ($quota === false) {
 						throw new OCSException($this->l10n->t('Invalid quota value: %1$s', [$value]), 101);
@@ -1044,7 +1045,7 @@ class UsersController extends AUserData {
 						if ($maxQuota !== -1 && $quota > $maxQuota) {
 							throw new OCSException($this->l10n->t('Invalid quota value. %1$s is exceeding the maximum quota', [$value]), 101);
 						}
-						$quota = \OCP\Util::humanFileSize($quota);
+						$quota = Util::humanFileSize($quota);
 					}
 				}
 				// no else block because quota can be set to 'none' in previous if

--- a/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
@@ -17,6 +17,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Server;
 use OCP\Settings\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -45,7 +46,7 @@ class AppConfigControllerTest extends TestCase {
 		$this->l10n = $this->createMock(IL10N::class);
 		$this->settingManager = $this->createMock(IManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
-		$this->appManager = \OCP\Server::get(IAppManager::class);
+		$this->appManager = Server::get(IAppManager::class);
 	}
 
 	/**

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -8,7 +8,9 @@
 namespace OCA\Provisioning_API\Tests\Controller;
 
 use OCA\Provisioning_API\Controller\AppsController;
+use OCA\Provisioning_API\Tests\TestCase;
 use OCP\App\IAppManager;
+use OCP\AppFramework\OCS\OCSException;
 use OCP\IRequest;
 use OCP\IUserSession;
 
@@ -19,7 +21,7 @@ use OCP\IUserSession;
  *
  * @package OCA\Provisioning_API\Tests
  */
-class AppsControllerTest extends \OCA\Provisioning_API\Tests\TestCase {
+class AppsControllerTest extends TestCase {
 	/** @var IAppManager */
 	private $appManager;
 	/** @var AppsController */
@@ -57,7 +59,7 @@ class AppsControllerTest extends \OCA\Provisioning_API\Tests\TestCase {
 
 
 	public function testGetAppInfoOnBadAppID(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$this->api->getAppInfo('not_provisioning_api');
@@ -94,7 +96,7 @@ class AppsControllerTest extends \OCA\Provisioning_API\Tests\TestCase {
 
 	
 	public function testGetAppsInvalidFilter(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$this->api->getApps('foo');

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -11,6 +11,7 @@ use OC\Group\Manager;
 use OC\User\NoUserException;
 use OCA\Provisioning_API\Controller\GroupsController;
 use OCP\Accounts\IAccountManager;
+use OCP\AppFramework\OCS\OCSException;
 use OCP\Group\ISubAdmin;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -255,7 +256,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 
 	public function testGetGroupAsIrrelevantSubadmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(403);
 
 		$group = $this->createGroup('group');
@@ -300,7 +301,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 
 	public function testGetGroupNonExisting(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('The requested group could not be found');
 		$this->expectExceptionCode(404);
 
@@ -311,7 +312,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 
 	public function testGetSubAdminsOfGroupsNotExists(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Group does not exist');
 		$this->expectExceptionCode(101);
 
@@ -358,7 +359,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 
 	public function testAddGroupEmptyGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Invalid group name');
 		$this->expectExceptionCode(101);
 
@@ -367,7 +368,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 
 	public function testAddGroupExistingGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(102);
 
 		$this->groupManager
@@ -412,7 +413,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 
 	public function testDeleteGroupNonExisting(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$this->api->deleteGroup('NonExistingGroup');
@@ -420,7 +421,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 
 	public function testDeleteAdminGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(102);
 
 		$this->groupManager

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -221,7 +221,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserAlreadyExisting(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(102);
 
 		$this->userManager
@@ -255,7 +255,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserNonExistingGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Group NonExistingGroup does not exist');
 		$this->expectExceptionCode(104);
 
@@ -291,7 +291,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserExistingGroupNonExistingGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Group NonExistingGroup does not exist');
 		$this->expectExceptionCode(104);
 
@@ -533,7 +533,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserFailedToGenerateUserID(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Could not create non-existing user ID');
 		$this->expectExceptionCode(111);
 
@@ -576,7 +576,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserEmailRequired(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Required email address was not provided');
 		$this->expectExceptionCode(110);
 
@@ -683,7 +683,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserUnsuccessful(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Bad request');
 		$this->expectExceptionCode(101);
 
@@ -730,7 +730,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserAsSubAdminNoGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('No group specified (required for sub-admins)');
 		$this->expectExceptionCode(106);
 
@@ -763,7 +763,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddUserAsSubAdminValidGroupNotSubAdmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Insufficient privileges for group ExistingGroup');
 		$this->expectExceptionCode(105);
 
@@ -906,7 +906,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testGetUserTargetDoesNotExist(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('User does not exist');
 		$this->expectExceptionCode(404);
 
@@ -1218,7 +1218,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testGetUserDataAsSubAdminAndUserIsNotAccessible(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)
@@ -1681,7 +1681,7 @@ class UsersControllerTest extends TestCase {
 	}
 
 	public function testEditUserRegularUserSelfEditChangeEmailInvalid(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)
@@ -1915,7 +1915,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testEditUserRegularUserSelfEditChangeQuota(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(113);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)
@@ -2001,7 +2001,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testEditUserAdminUserSelfEditChangeInvalidQuota(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Invalid quota value: ABC');
 		$this->expectExceptionCode(101);
 
@@ -2152,7 +2152,7 @@ class UsersControllerTest extends TestCase {
 	 * @dataProvider dataEditUserSelfEditChangeLanguageButForced
 	 */
 	public function testEditUserSelfEditChangeLanguageButForced($forced): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 
 		$this->config->expects($this->any())
 			->method('getSystemValue')
@@ -2248,7 +2248,7 @@ class UsersControllerTest extends TestCase {
 	 * @dataProvider dataEditUserSelfEditChangeLanguageButForced
 	 */
 	public function testEditUserAdminEditChangeLanguageInvalidLanguage(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 
 
 		$this->l10nFactory->expects($this->once())
@@ -2352,7 +2352,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testEditUserSubadminUserInaccessible(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2392,7 +2392,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testDeleteUserNotExistingUser(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2415,7 +2415,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testDeleteUserSelf(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2476,7 +2476,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testDeleteUnsuccessfulUserAsAdmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2557,7 +2557,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testDeleteUnsuccessfulUserAsSubadmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2605,7 +2605,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testDeleteUserAsSubAdminAndUserIsNotAccessible(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2649,7 +2649,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testGetUsersGroupsTargetUserNotExisting(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2786,7 +2786,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testGetUsersGroupsForSubAdminUserAndUserIsInaccessible(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -2835,7 +2835,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddToGroupWithTargetGroupNotExisting(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(102);
 
 		$this->groupManager->expects($this->once())
@@ -2848,7 +2848,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddToGroupWithNoGroupSpecified(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$this->api->addToGroup('TargetUser');
@@ -2856,7 +2856,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddToGroupWithTargetUserNotExisting(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(103);
 
 		$targetGroup = $this->createMock(IGroup::class);
@@ -2870,7 +2870,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddToGroupNoSubadmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(104);
 
 		$targetUser = $this->createMock(IUser::class);
@@ -3004,7 +3004,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupWithNoTargetGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -3018,7 +3018,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupWithEmptyTargetGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -3032,7 +3032,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupWithNotExistingTargetGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(102);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -3051,7 +3051,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupWithNotExistingTargetUser(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(103);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -3076,7 +3076,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupWithoutPermission(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(104);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -3117,7 +3117,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupAsAdminFromAdmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Cannot remove yourself from the admin group');
 		$this->expectExceptionCode(105);
 
@@ -3167,7 +3167,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupAsSubAdminFromSubAdmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Cannot remove yourself from this group as you are a sub-admin');
 		$this->expectExceptionCode(105);
 
@@ -3222,7 +3222,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveFromGroupAsSubAdminFromLastSubAdminGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Not viable to remove user from the last group you are sub-admin of');
 		$this->expectExceptionCode(105);
 
@@ -3325,7 +3325,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddSubAdminWithNotExistingTargetUser(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('User does not exist');
 		$this->expectExceptionCode(101);
 
@@ -3340,7 +3340,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddSubAdminWithNotExistingTargetGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Group does not exist');
 		$this->expectExceptionCode(102);
 
@@ -3362,7 +3362,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testAddSubAdminToAdminGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Cannot create sub-admins for admin group');
 		$this->expectExceptionCode(103);
 
@@ -3448,7 +3448,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveSubAdminNotExistingTargetUser(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('User does not exist');
 		$this->expectExceptionCode(101);
 
@@ -3463,7 +3463,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveSubAdminNotExistingTargetGroup(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Group does not exist');
 		$this->expectExceptionCode(101);
 
@@ -3485,7 +3485,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testRemoveSubAdminFromNotASubadmin(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('User is not a sub-admin of this group');
 		$this->expectExceptionCode(102);
 
@@ -3550,7 +3550,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testGetUserSubAdminGroupsNotExistingTargetUser(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('User does not exist');
 		$this->expectExceptionCode(404);
 
@@ -3723,7 +3723,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testGetCurrentUserNotLoggedIn(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 
 
 		$this->userSession->expects($this->once())->method('getUser')
@@ -3800,7 +3800,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testResendWelcomeMessageWithNotExistingTargetUser(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$this->userManager
@@ -3814,7 +3814,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testResendWelcomeMessageAsSubAdminAndUserIsNotAccessible(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(998);
 
 		$loggedInUser = $this->getMockBuilder(IUser::class)
@@ -3859,7 +3859,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testResendWelcomeMessageNoEmail(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Email address not available');
 		$this->expectExceptionCode(101);
 
@@ -3904,7 +3904,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testResendWelcomeMessageNullEmail(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Email address not available');
 		$this->expectExceptionCode(101);
 
@@ -4051,7 +4051,7 @@ class UsersControllerTest extends TestCase {
 
 
 	public function testResendWelcomeMessageFailed(): void {
-		$this->expectException(\OCP\AppFramework\OCS\OCSException::class);
+		$this->expectException(OCSException::class);
 		$this->expectExceptionMessage('Sending email failed');
 		$this->expectExceptionCode(102);
 

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -37,11 +37,13 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
+use OCP\IGroup;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
@@ -93,8 +95,8 @@ class AppSettingsController extends Controller {
 		$templateResponse = new TemplateResponse('settings', 'settings/empty', ['pageTitle' => $this->l10n->t('Settings')]);
 		$templateResponse->setContentSecurityPolicy($policy);
 
-		\OCP\Util::addStyle('settings', 'settings');
-		\OCP\Util::addScript('settings', 'vue-settings-apps-users-management');
+		Util::addStyle('settings', 'settings');
+		Util::addScript('settings', 'vue-settings-apps-users-management');
 
 		return $templateResponse;
 	}
@@ -512,7 +514,7 @@ class AppSettingsController extends Controller {
 		$groupsList = [];
 		foreach ($groups as $group) {
 			$groupItem = $groupManager->get($group);
-			if ($groupItem instanceof \OCP\IGroup) {
+			if ($groupItem instanceof IGroup) {
 				$groupsList[] = $groupManager->get($group);
 			}
 		}

--- a/apps/settings/lib/Controller/ChangePasswordController.php
+++ b/apps/settings/lib/Controller/ChangePasswordController.php
@@ -11,6 +11,8 @@ namespace OCA\Settings\Controller;
 
 use OC\Group\Manager as GroupManager;
 use OC\User\Session;
+use OCA\Encryption\KeyManager;
+use OCA\Encryption\Recovery;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\BruteForceProtection;
@@ -24,6 +26,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 
 class ChangePasswordController extends Controller {
 	private ?string $userId;
@@ -146,8 +149,8 @@ class ChangePasswordController extends Controller {
 
 		if ($this->appManager->isEnabledForUser('encryption')) {
 			//handle the recovery case
-			$keyManager = \OCP\Server::get(\OCA\Encryption\KeyManager::class);
-			$recovery = \OCP\Server::get(\OCA\Encryption\Recovery::class);
+			$keyManager = Server::get(KeyManager::class);
+			$recovery = Server::get(Recovery::class);
 			$recoveryAdminEnabled = $recovery->isRecoveryKeyEnabled();
 
 			$validRecoveryPassword = false;

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -14,6 +14,7 @@ use InvalidArgumentException;
 use OC\AppFramework\Http;
 use OC\Encryption\Exceptions\ModuleDoesNotExistsException;
 use OC\ForbiddenException;
+use OC\Group\MetaData;
 use OC\KnownUser\KnownUserService;
 use OC\Security\IdentityProof\Manager;
 use OC\User\Manager as UserManager;
@@ -46,6 +47,7 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
+use OCP\Util;
 use function in_array;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
@@ -101,17 +103,17 @@ class UsersController extends Controller {
 		\OC::$server->getNavigationManager()->setActiveEntry('core_users');
 
 		/* SORT OPTION: SORT_USERCOUNT or SORT_GROUPNAME */
-		$sortGroupsBy = \OC\Group\MetaData::SORT_USERCOUNT;
+		$sortGroupsBy = MetaData::SORT_USERCOUNT;
 		$isLDAPUsed = false;
 		if ($this->config->getSystemValueBool('sort_groups_by_name', false)) {
-			$sortGroupsBy = \OC\Group\MetaData::SORT_GROUPNAME;
+			$sortGroupsBy = MetaData::SORT_GROUPNAME;
 		} else {
 			if ($this->appManager->isEnabledForUser('user_ldap')) {
 				$isLDAPUsed =
 					$this->groupManager->isBackendUsed('\OCA\User_LDAP\Group_Proxy');
 				if ($isLDAPUsed) {
 					// LDAP user count can be slow, so we sort by group name here
-					$sortGroupsBy = \OC\Group\MetaData::SORT_GROUPNAME;
+					$sortGroupsBy = MetaData::SORT_GROUPNAME;
 				}
 			}
 		}
@@ -119,7 +121,7 @@ class UsersController extends Controller {
 		$canChangePassword = $this->canAdminChangeUserPasswords();
 
 		/* GROUPS */
-		$groupsInfo = new \OC\Group\MetaData(
+		$groupsInfo = new MetaData(
 			$uid,
 			$isAdmin,
 			$isDelegatedAdmin,
@@ -192,7 +194,7 @@ class UsersController extends Controller {
 		$languages = $this->l10nFactory->getLanguages();
 
 		/** Using LDAP or admins (system config) can enfore sorting by group name, in this case the frontend setting is overwritten */
-		$forceSortGroupByName = $sortGroupsBy === \OC\Group\MetaData::SORT_GROUPNAME;
+		$forceSortGroupByName = $sortGroupsBy === MetaData::SORT_GROUPNAME;
 
 		/* FINAL DATA */
 		$serverData = [];
@@ -202,8 +204,8 @@ class UsersController extends Controller {
 		$serverData['isAdmin'] = $isAdmin;
 		$serverData['isDelegatedAdmin'] = $isDelegatedAdmin;
 		$serverData['sortGroups'] = $forceSortGroupByName
-			? \OC\Group\MetaData::SORT_GROUPNAME
-			: (int)$this->config->getAppValue('core', 'group.sortBy', (string)\OC\Group\MetaData::SORT_USERCOUNT);
+			? MetaData::SORT_GROUPNAME
+			: (int)$this->config->getAppValue('core', 'group.sortBy', (string)MetaData::SORT_USERCOUNT);
 		$serverData['forceSortGroupByName'] = $forceSortGroupByName;
 		$serverData['quotaPreset'] = $quotaPreset;
 		$serverData['allowUnlimitedQuota'] = $allowUnlimitedQuota;
@@ -220,8 +222,8 @@ class UsersController extends Controller {
 
 		$this->initialState->provideInitialState('usersSettings', $serverData);
 
-		\OCP\Util::addStyle('settings', 'settings');
-		\OCP\Util::addScript('settings', 'vue-settings-apps-users-management');
+		Util::addStyle('settings', 'settings');
+		Util::addScript('settings', 'vue-settings-apps-users-management');
 
 		return new TemplateResponse('settings', 'settings/empty', ['pageTitle' => $this->l10n->t('Settings')]);
 	}

--- a/apps/settings/lib/Settings/Admin/Mail.php
+++ b/apps/settings/lib/Settings/Admin/Mail.php
@@ -9,6 +9,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IBinaryFinder;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\Server;
 use OCP\Settings\IDelegatedSettings;
 
 class Mail implements IDelegatedSettings {
@@ -33,7 +34,7 @@ class Mail implements IDelegatedSettings {
 	public function getForm() {
 		$parameters = [
 			// Mail
-			'sendmail_is_available' => (bool)\OCP\Server::get(IBinaryFinder::class)->findBinaryPath('sendmail'),
+			'sendmail_is_available' => (bool)Server::get(IBinaryFinder::class)->findBinaryPath('sendmail'),
 			'mail_domain' => $this->config->getSystemValue('mail_domain', ''),
 			'mail_from_address' => $this->config->getSystemValue('mail_from_address', ''),
 			'mail_smtpmode' => $this->config->getSystemValue('mail_smtpmode', ''),

--- a/apps/settings/lib/Settings/Admin/Sharing.php
+++ b/apps/settings/lib/Settings/Admin/Sharing.php
@@ -77,7 +77,7 @@ class Sharing implements IDelegatedSettings {
 		$this->initialState->provideInitialState('sharingDocumentation', $this->urlGenerator->linkToDocs('admin-sharing'));
 		$this->initialState->provideInitialState('sharingSettings', $parameters);
 
-		\OCP\Util::addScript($this->appName, 'vue-settings-admin-sharing');
+		Util::addScript($this->appName, 'vue-settings-admin-sharing');
 		return new TemplateResponse($this->appName, 'settings/admin/sharing', [], '');
 	}
 

--- a/apps/settings/lib/SetupChecks/MemcacheConfigured.php
+++ b/apps/settings/lib/SetupChecks/MemcacheConfigured.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\Settings\SetupChecks;
 
+use OC\Memcache\Memcached;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -35,7 +36,7 @@ class MemcacheConfigured implements ISetupCheck {
 		$memcacheLockingClass = $this->config->getSystemValue('memcache.locking', null);
 		$memcacheLocalClass = $this->config->getSystemValue('memcache.local', null);
 		$caches = array_filter([$memcacheDistributedClass,$memcacheLockingClass,$memcacheLocalClass]);
-		if (in_array(\OC\Memcache\Memcached::class, array_map(fn (string $class) => ltrim($class, '\\'), $caches))) {
+		if (in_array(Memcached::class, array_map(fn (string $class) => ltrim($class, '\\'), $caches))) {
 			// wrong PHP module is installed
 			if (extension_loaded('memcache') && !extension_loaded('memcached')) {
 				return SetupResult::warning(

--- a/apps/settings/lib/UserMigration/AccountMigrator.php
+++ b/apps/settings/lib/UserMigration/AccountMigrator.php
@@ -18,6 +18,7 @@ use OCA\Settings\AppInfo\Application;
 use OCP\Accounts\IAccountManager;
 use OCP\IAvatarManager;
 use OCP\IL10N;
+use OCP\Image;
 use OCP\IUser;
 use OCP\UserMigration\IExportDestination;
 use OCP\UserMigration\IImportSource;
@@ -156,7 +157,7 @@ class AccountMigrator implements IMigrator, ISizeEstimationMigrator {
 
 			$output->writeln('Importing avatar from ' . $importPath . '…');
 			$stream = $importSource->getFileAsStream($importPath);
-			$image = new \OCP\Image();
+			$image = new Image();
 			$image->loadFromFileHandle($stream);
 
 			try {

--- a/apps/settings/tests/Controller/AdminSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AdminSettingsControllerTest.php
@@ -16,6 +16,7 @@ use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 use OCP\Settings\IDeclarativeManager;
 use OCP\Settings\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -66,17 +67,17 @@ class AdminSettingsControllerTest extends TestCase {
 			$this->initialState,
 		);
 
-		$user = \OCP\Server::get(IUserManager::class)->createUser($this->adminUid, 'mylongrandompassword');
+		$user = Server::get(IUserManager::class)->createUser($this->adminUid, 'mylongrandompassword');
 		\OC_User::setUserId($user->getUID());
-		\OCP\Server::get(IGroupManager::class)->createGroup('admin')->addUser($user);
+		Server::get(IGroupManager::class)->createGroup('admin')->addUser($user);
 	}
 
 	protected function tearDown(): void {
-		\OCP\Server::get(IUserManager::class)
+		Server::get(IUserManager::class)
 			->get($this->adminUid)
 			->delete();
 		\OC_User::setUserId(null);
-		\OCP\Server::get(IUserSession::class)->setUser(null);
+		Server::get(IUserSession::class)->setUser(null);
 
 		parent::tearDown();
 	}

--- a/apps/settings/tests/Mailer/NewUserMailHelperTest.php
+++ b/apps/settings/tests/Mailer/NewUserMailHelperTest.php
@@ -7,6 +7,7 @@ namespace OCA\Settings\Tests\Mailer;
 
 use OC\Mail\EMailTemplate;
 use OC\Mail\Message;
+use OCA\Settings\Mailer\NewUserMailHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Defaults;
 use OCP\IConfig;
@@ -40,7 +41,7 @@ class NewUserMailHelperTest extends TestCase {
 	private $config;
 	/** @var ICrypto|\PHPUnit\Framework\MockObject\MockObject */
 	private $crypto;
-	/** @var \OCA\Settings\Mailer\NewUserMailHelper */
+	/** @var NewUserMailHelper */
 	private $newUserMailHelper;
 
 	protected function setUp(): void {
@@ -89,7 +90,7 @@ class NewUserMailHelperTest extends TestCase {
 				return $this->l10n;
 			});
 
-		$this->newUserMailHelper = new \OCA\Settings\Mailer\NewUserMailHelper(
+		$this->newUserMailHelper = new NewUserMailHelper(
 			$this->defaults,
 			$this->urlGenerator,
 			$this->l10nFactory,

--- a/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
+++ b/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
@@ -45,7 +45,7 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 
 
 	public function testBeforeControllerAsUserWithExemption(): void {
-		$this->expectException(\OC\AppFramework\Middleware\Security\Exceptions\NotAdminException::class);
+		$this->expectException(NotAdminException::class);
 
 		$this->reflector
 			->expects($this->exactly(2))

--- a/apps/settings/tests/Settings/Admin/MailTest.php
+++ b/apps/settings/tests/Settings/Admin/MailTest.php
@@ -10,6 +10,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IBinaryFinder;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\Server;
 use Test\TestCase;
 
 class MailTest extends TestCase {
@@ -52,7 +53,7 @@ class MailTest extends TestCase {
 			'settings',
 			'settings/admin/additional-mail',
 			[
-				'sendmail_is_available' => (bool)\OCP\Server::get(IBinaryFinder::class)->findBinaryPath('sendmail'),
+				'sendmail_is_available' => (bool)Server::get(IBinaryFinder::class)->findBinaryPath('sendmail'),
 				'mail_domain' => 'mx.nextcloud.com',
 				'mail_from_address' => 'no-reply@nextcloud.com',
 				'mail_smtpmode' => 'smtp',

--- a/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
+++ b/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
@@ -12,6 +12,7 @@ use OCA\Settings\SetupChecks\SupportedDatabase;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IUrlGenerator;
+use OCP\Server;
 use OCP\SetupCheck\SetupResult;
 use Test\TestCase;
 
@@ -30,12 +31,12 @@ class SupportedDatabaseTest extends TestCase {
 
 		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->urlGenerator = $this->getMockBuilder(IUrlGenerator::class)->getMock();
-		$this->connection = \OCP\Server::get(IDBConnection::class);
+		$this->connection = Server::get(IDBConnection::class);
 
 		$this->check = new SupportedDatabase(
 			$this->l10n,
 			$this->urlGenerator,
-			\OCP\Server::get(IDBConnection::class)
+			Server::get(IDBConnection::class)
 		);
 	}
 

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -35,6 +35,7 @@ use OCP\Share\IAttributes;
 use OCP\Share\IManager as IShareManager;
 use OCP\Share\IShare;
 use OCP\Share\IShareProviderWithNotification;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -382,7 +383,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				]
 			);
 		}
-		$message->setFrom([\OCP\Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$message->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
 
 		// The "Reply-To" is set to the sharer if an mail address is configured
 		// also the default footer contains a "Do not reply" which needs to be adjusted.
@@ -478,7 +479,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				]
 			);
 		}
-		$message->setFrom([\OCP\Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$message->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
 
 		// The "Reply-To" is set to the sharer if an mail address is configured
 		// also the default footer contains a "Do not reply" which needs to be adjusted.
@@ -548,7 +549,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				]
 			);
 		}
-		$message->setFrom([\OCP\Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$message->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
 		if ($this->settingsManager->replyToInitiator() && $initiatorEmailAddress !== null) {
 			$message->setReplyTo([$initiatorEmailAddress => $initiatorDisplayName]);
 			$emailTemplate->addFooter($instanceName . ' - ' . $this->defaults->getSlogan());
@@ -617,7 +618,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				$instanceName
 			]
 		);
-		$message->setFrom([\OCP\Util::getDefaultEmailAddress($instanceName) => $senderName]);
+		$message->setFrom([Util::getDefaultEmailAddress($instanceName) => $senderName]);
 		$message->setTo([$initiatorEMailAddress => $initiatorDisplayName]);
 		$message->useTemplate($emailTemplate);
 		$this->mailer->send($message);
@@ -1203,7 +1204,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 			->from('share')
 			->where(
 				$qb->expr()->orX(
-					$qb->expr()->eq('share_type', $qb->createNamedParameter(\OCP\Share\IShare::TYPE_EMAIL))
+					$qb->expr()->eq('share_type', $qb->createNamedParameter(IShare::TYPE_EMAIL))
 				)
 			);
 

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -7,9 +7,11 @@ namespace OCA\ShareByMail\Tests;
 
 use DateTime;
 use OC\Mail\Message;
+use OC\Share20\Share;
 use OCA\ShareByMail\Settings\SettingsManager;
 use OCA\ShareByMail\ShareByMailProvider;
 use OCP\Activity\IManager as IActivityManager;
+use OCP\Constants;
 use OCP\Defaults;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
@@ -28,9 +30,12 @@ use OCP\Security\Events\GenerateSecurePasswordEvent;
 use OCP\Security\IHasher;
 use OCP\Security\ISecureRandom;
 use OCP\Security\PasswordContext;
+use OCP\Server;
+use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IAttributes;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -64,7 +69,7 @@ class ShareByMailProviderTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OCP\Server::get(IDBConnection::class);
+		$this->connection = Server::get(IDBConnection::class);
 
 		$this->l = $this->getMockBuilder(IL10N::class)->getMock();
 		$this->l->method('t')
@@ -885,7 +890,7 @@ class ShareByMailProviderTest extends TestCase {
 
 
 	public function testGetShareByIdFailed(): void {
-		$this->expectException(\OCP\Share\Exceptions\ShareNotFound::class);
+		$this->expectException(ShareNotFound::class);
 
 		$instance = $this->getInstance(['createShareObject']);
 
@@ -968,7 +973,7 @@ class ShareByMailProviderTest extends TestCase {
 
 
 	public function testGetShareByTokenFailed(): void {
-		$this->expectException(\OCP\Share\Exceptions\ShareNotFound::class);
+		$this->expectException(ShareNotFound::class);
 
 
 		$itemSource = 11;
@@ -1095,7 +1100,7 @@ class ShareByMailProviderTest extends TestCase {
 
 
 	public function testGetRawShareFailed(): void {
-		$this->expectException(\OCP\Share\Exceptions\ShareNotFound::class);
+		$this->expectException(ShareNotFound::class);
 
 		$itemSource = 11;
 		$itemType = 'file';
@@ -1145,7 +1150,7 @@ class ShareByMailProviderTest extends TestCase {
 
 		$this->shareManager->expects($this->any())
 			->method('newShare')
-			->willReturn(new \OC\Share20\Share($rootFolder, $userManager));
+			->willReturn(new Share($rootFolder, $userManager));
 
 		$provider = $this->getInstance(['sendMailNotification', 'createShareActivity']);
 		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
@@ -1161,7 +1166,7 @@ class ShareByMailProviderTest extends TestCase {
 		$share1->setSharedWith('user@server.com')
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setNode($file1);
 		$provider->create($share1);
 
@@ -1169,7 +1174,7 @@ class ShareByMailProviderTest extends TestCase {
 		$share2->setSharedWith('user@server.com')
 			->setSharedBy($u2->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setNode($file2);
 		$provider->create($share2);
 
@@ -1192,7 +1197,7 @@ class ShareByMailProviderTest extends TestCase {
 
 		$this->shareManager->expects($this->any())
 			->method('newShare')
-			->willReturn(new \OC\Share20\Share($rootFolder, $userManager));
+			->willReturn(new Share($rootFolder, $userManager));
 
 		$provider = $this->getInstance(['sendMailNotification', 'createShareActivity']);
 		$this->mailer->expects($this->any())->method('validateMailAddress')->willReturn(true);
@@ -1213,7 +1218,7 @@ class ShareByMailProviderTest extends TestCase {
 		$share1->setSharedWith('user@server.com')
 			->setSharedBy($u1->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setNode($folder);
 		$share1 = $provider->create($share1);
 
@@ -1221,7 +1226,7 @@ class ShareByMailProviderTest extends TestCase {
 		$share2->setSharedWith('user2@server.com')
 			->setSharedBy($u2->getUID())
 			->setShareOwner($u1->getUID())
-			->setPermissions(\OCP\Constants::PERMISSION_READ)
+			->setPermissions(Constants::PERMISSION_READ)
 			->setNode($folder);
 		$share2 = $provider->create($share2);
 
@@ -1310,7 +1315,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('setFrom')
 			->with([
-				\OCP\Util::getDefaultEmailAddress('UnitTestCloud') => 'Mrs. Owner User via UnitTestCloud'
+				Util::getDefaultEmailAddress('UnitTestCloud') => 'Mrs. Owner User via UnitTestCloud'
 			]);
 		$user
 			->expects($this->once())
@@ -1436,7 +1441,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('setFrom')
 			->with([
-				\OCP\Util::getDefaultEmailAddress('UnitTestCloud') => 'Mrs. Owner User via UnitTestCloud'
+				Util::getDefaultEmailAddress('UnitTestCloud') => 'Mrs. Owner User via UnitTestCloud'
 			]);
 		$user
 			->expects($this->once())
@@ -1567,7 +1572,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('setFrom')
 			->with([
-				\OCP\Util::getDefaultEmailAddress('UnitTestCloud') => 'Mrs. Owner User via UnitTestCloud'
+				Util::getDefaultEmailAddress('UnitTestCloud') => 'Mrs. Owner User via UnitTestCloud'
 			]);
 		$user
 			->expects($this->once())
@@ -1681,7 +1686,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('setFrom')
 			->with([
-				\OCP\Util::getDefaultEmailAddress('UnitTestCloud') => 'Mr. Initiator User via UnitTestCloud'
+				Util::getDefaultEmailAddress('UnitTestCloud') => 'Mr. Initiator User via UnitTestCloud'
 			]);
 		$message
 			->expects($this->never())
@@ -1785,7 +1790,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('setFrom')
 			->with([
-				\OCP\Util::getDefaultEmailAddress('UnitTestCloud') => 'UnitTestCloud'
+				Util::getDefaultEmailAddress('UnitTestCloud') => 'UnitTestCloud'
 			]);
 		// Since replyToInitiator is false, we never get the initiator email address
 		$user
@@ -1893,7 +1898,7 @@ class ShareByMailProviderTest extends TestCase {
 			->expects($this->once())
 			->method('setFrom')
 			->with([
-				\OCP\Util::getDefaultEmailAddress('UnitTestCloud') => 'UnitTestCloud'
+				Util::getDefaultEmailAddress('UnitTestCloud') => 'UnitTestCloud'
 			]);
 		$message
 			->expects($this->never())

--- a/apps/systemtags/lib/AppInfo/Application.php
+++ b/apps/systemtags/lib/AppInfo/Application.php
@@ -24,6 +24,7 @@ use OCP\BeforeSabrePubliclyLoadedEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\SystemTag\ManagerEvent;
 use OCP\SystemTag\MapperEvent;
+use OCP\Util;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'systemtags';
@@ -48,13 +49,13 @@ class Application extends App implements IBootstrap {
 			$dispatcher->addListener(
 				LoadAdditionalScriptsEvent::class,
 				function (): void {
-					\OCP\Util::addScript('core', 'systemtags');
-					\OCP\Util::addInitScript(self::APP_ID, 'init');
+					Util::addScript('core', 'systemtags');
+					Util::addInitScript(self::APP_ID, 'init');
 				}
 			);
 
 			$managerListener = function (ManagerEvent $event) use ($context): void {
-				/** @var \OCA\SystemTags\Activity\Listener $listener */
+				/** @var Listener $listener */
 				$listener = $context->getServerContainer()->query(Listener::class);
 				$listener->event($event);
 			};
@@ -63,7 +64,7 @@ class Application extends App implements IBootstrap {
 			$dispatcher->addListener(ManagerEvent::EVENT_UPDATE, $managerListener);
 
 			$mapperListener = function (MapperEvent $event) use ($context): void {
-				/** @var \OCA\SystemTags\Activity\Listener $listener */
+				/** @var Listener $listener */
 				$listener = $context->getServerContainer()->query(Listener::class);
 				$listener->mapperEvent($event);
 			};

--- a/apps/systemtags/lib/Settings/Admin.php
+++ b/apps/systemtags/lib/Settings/Admin.php
@@ -7,6 +7,7 @@ namespace OCA\SystemTags\Settings;
 
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\Settings\ISettings;
+use OCP\Util;
 
 class Admin implements ISettings {
 
@@ -14,7 +15,7 @@ class Admin implements ISettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm() {
-		\OCP\Util::addScript('systemtags', 'admin');
+		Util::addScript('systemtags', 'admin');
 		return new TemplateResponse('systemtags', 'admin', [], '');
 	}
 

--- a/apps/testing/lib/AlternativeHomeUserBackend.php
+++ b/apps/testing/lib/AlternativeHomeUserBackend.php
@@ -5,6 +5,8 @@
  */
 namespace OCA\Testing;
 
+use OC\User\Database;
+
 /**
  * Alternative home user backend.
  *
@@ -17,7 +19,7 @@ namespace OCA\Testing;
  *			],
  *	]
  */
-class AlternativeHomeUserBackend extends \OC\User\Database {
+class AlternativeHomeUserBackend extends Database {
 	public function __construct() {
 		parent::__construct();
 	}

--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Http\Attribute\AuthorizedAdminSetting;
 use OCP\AppFramework\Http\Attribute\BruteForceProtection;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\PublicPage;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
@@ -346,7 +347,7 @@ class ThemingController extends Controller {
 		}
 
 		$response = new FileDisplayResponse($file);
-		$csp = new Http\ContentSecurityPolicy();
+		$csp = new ContentSecurityPolicy();
 		$csp->allowInlineStyle();
 		$response->setContentSecurityPolicy($csp);
 		$response->cacheFor(3600);

--- a/apps/theming/lib/Controller/UserThemeController.php
+++ b/apps/theming/lib/Controller/UserThemeController.php
@@ -21,6 +21,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\FileDisplayResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\NotFoundResponse;
+use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\OCS\OCSBadRequestException;
 use OCP\AppFramework\OCS\OCSForbiddenException;
 use OCP\AppFramework\OCSController;
@@ -136,7 +137,7 @@ class UserThemeController extends OCSController {
 	 */
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
-	public function getBackground(): Http\Response {
+	public function getBackground(): Response {
 		$file = $this->backgroundService->getBackground();
 		if ($file !== null) {
 			$response = new FileDisplayResponse($file, Http::STATUS_OK, ['Content-Type' => $file->getMimeType()]);

--- a/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/apps/theming/lib/Listener/BeforeTemplateRenderedListener.php
@@ -19,6 +19,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IConfig;
 use OCP\IUserSession;
+use OCP\Util;
 use Psr\Container\ContainerInterface;
 
 /** @template-implements IEventListener<BeforeTemplateRenderedEvent|BeforeLoginTemplateRenderedEvent> */
@@ -64,6 +65,6 @@ class BeforeTemplateRenderedListener implements IEventListener {
 		$this->themeInjectionService->injectHeaders();
 
 		// Making sure to inject just after core
-		\OCP\Util::addScript('theming', 'theming', 'core');
+		Util::addScript('theming', 'theming', 'core');
 	}
 }

--- a/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
+++ b/apps/theming/lib/Migration/InitBackgroundImagesMigration.php
@@ -12,8 +12,9 @@ namespace OCA\Theming\Migration;
 use OCA\Theming\Jobs\MigrateBackgroundImages;
 use OCP\BackgroundJob\IJobList;
 use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
 
-class InitBackgroundImagesMigration implements \OCP\Migration\IRepairStep {
+class InitBackgroundImagesMigration implements IRepairStep {
 
 	private IJobList $jobList;
 

--- a/apps/theming/lib/Migration/Version2006Date20240905111627.php
+++ b/apps/theming/lib/Migration/Version2006Date20240905111627.php
@@ -15,11 +15,12 @@ use OCA\Theming\Jobs\RestoreBackgroundImageColor;
 use OCP\BackgroundJob\IJobList;
 use OCP\IAppConfig;
 use OCP\IDBConnection;
+use OCP\Migration\IMigrationStep;
 use OCP\Migration\IOutput;
 
 // This can only be executed once because `background_color` is again used with Nextcloud 30,
 // so this part only works when updating -> Nextcloud 29 -> 30
-class Version2006Date20240905111627 implements \OCP\Migration\IMigrationStep {
+class Version2006Date20240905111627 implements IMigrationStep {
 
 	public function __construct(
 		private IJobList $jobList,

--- a/apps/theming/lib/Service/BackgroundService.php
+++ b/apps/theming/lib/Service/BackgroundService.php
@@ -20,6 +20,7 @@ use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IAppConfig;
 use OCP\IConfig;
+use OCP\Image;
 use OCP\Lock\LockedException;
 use OCP\PreConditionNotMetException;
 use RuntimeException;
@@ -241,7 +242,7 @@ class BackgroundService {
 	public function recalculateMeanColor(?string $userId = null): void {
 		$userId = $userId ?? $this->getUserId();
 
-		$image = new \OCP\Image();
+		$image = new Image();
 		$handle = $this->getAppDataFolder($userId)->getFile('background.jpg')->read();
 		if ($handle === false || $image->loadFromFileHandle($handle) === false) {
 			throw new InvalidArgumentException('Invalid image file');
@@ -311,7 +312,7 @@ class BackgroundService {
 	 * @return string|null The fallback background color - if any
 	 */
 	public function setGlobalBackground($path): ?string {
-		$image = new \OCP\Image();
+		$image = new Image();
 		$handle = is_resource($path) ? $path : fopen($path, 'rb');
 
 		if ($handle && $image->loadFromFileHandle($handle) !== false) {
@@ -328,7 +329,7 @@ class BackgroundService {
 	 * Calculate mean color of an given image
 	 * It only takes the upper part into account so that a matching text color can be derived for the app menu
 	 */
-	private function calculateMeanColor(\OCP\Image $image): false|string {
+	private function calculateMeanColor(Image $image): false|string {
 		/**
 		 * Small helper to ensure one channel is returned as 8byte hex
 		 */
@@ -342,7 +343,7 @@ class BackgroundService {
 			};
 		}
 
-		$tempImage = new \OCP\Image();
+		$tempImage = new Image();
 
 		// Crop to only analyze top bar
 		$resource = $image->cropNew(0, 0, $image->width(), min(max(50, (int)($image->height() * 0.125)), $image->height()));

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -12,7 +12,11 @@ use OCA\Theming\Service\ThemesService;
 use OCA\Theming\ThemingDefaults;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\NotFoundResponse;
 use OCP\AppFramework\Services\IAppConfig;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Files\NotFoundException;
@@ -638,7 +642,7 @@ class ThemingControllerTest extends TestCase {
 			->with($this->equalTo('logo'))
 			->willThrowException(new NotFoundException());
 
-		$expected = new Http\NotFoundResponse();
+		$expected = new NotFoundResponse();
 		$this->assertEquals($expected, $this->themingController->getImage('logo'));
 	}
 
@@ -655,11 +659,11 @@ class ThemingControllerTest extends TestCase {
 			->with('theming', 'logoMime', '')
 			->willReturn('text/svg');
 
-		@$expected = new Http\FileDisplayResponse($file);
+		@$expected = new FileDisplayResponse($file);
 		$expected->cacheFor(3600);
 		$expected->addHeader('Content-Type', 'text/svg');
 		$expected->addHeader('Content-Disposition', 'attachment; filename="logo"');
-		$csp = new Http\ContentSecurityPolicy();
+		$csp = new ContentSecurityPolicy();
 		$csp->allowInlineStyle();
 		$expected->setContentSecurityPolicy($csp);
 		@$this->assertEquals($expected, $this->themingController->getImage('logo'));
@@ -670,7 +674,7 @@ class ThemingControllerTest extends TestCase {
 		$this->imageManager->method('getImage')
 			->with($this->equalTo('background'))
 			->willThrowException(new NotFoundException());
-		$expected = new Http\NotFoundResponse();
+		$expected = new NotFoundResponse();
 		$this->assertEquals($expected, $this->themingController->getImage('background'));
 	}
 
@@ -688,11 +692,11 @@ class ThemingControllerTest extends TestCase {
 			->with('theming', 'backgroundMime', '')
 			->willReturn('image/png');
 
-		@$expected = new Http\FileDisplayResponse($file);
+		@$expected = new FileDisplayResponse($file);
 		$expected->cacheFor(3600);
 		$expected->addHeader('Content-Type', 'image/png');
 		$expected->addHeader('Content-Disposition', 'attachment; filename="background"');
-		$csp = new Http\ContentSecurityPolicy();
+		$csp = new ContentSecurityPolicy();
 		$csp->allowInlineStyle();
 		$expected->setContentSecurityPolicy($csp);
 		@$this->assertEquals($expected, $this->themingController->getImage('background'));
@@ -719,7 +723,7 @@ class ThemingControllerTest extends TestCase {
 				['theming.Icon.getTouchIcon', ['app' => 'core'], 'touchicon'],
 				['theming.Icon.getFavicon', ['app' => 'core'], 'favicon'],
 			]);
-		$response = new Http\JSONResponse([
+		$response = new JSONResponse([
 			'name' => 'Nextcloud',
 			'start_url' => 'localhost',
 			'icons' =>

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -168,7 +168,7 @@ class ImageManagerTest extends TestCase {
 
 
 	public function testGetImageUnset(): void {
-		$this->expectException(\OCP\Files\NotFoundException::class);
+		$this->expectException(NotFoundException::class);
 
 		$this->config->expects($this->once())
 			->method('getAppValue')->with('theming', 'logoMime', false)
@@ -223,13 +223,13 @@ class ImageManagerTest extends TestCase {
 
 
 	public function testGetCachedImageNotFound(): void {
-		$this->expectException(\OCP\Files\NotFoundException::class);
+		$this->expectException(NotFoundException::class);
 
 		$folder = $this->setupCacheFolder();
 		$folder->expects($this->once())
 			->method('getFile')
 			->with('filename')
-			->will($this->throwException(new \OCP\Files\NotFoundException()));
+			->will($this->throwException(new NotFoundException()));
 		$image = $this->imageManager->getCachedImage('filename');
 	}
 

--- a/apps/theming/tests/Themes/DyslexiaFontTest.php
+++ b/apps/theming/tests/Themes/DyslexiaFontTest.php
@@ -6,6 +6,7 @@
 namespace OCA\Theming\Tests\Service;
 
 use OC\Route\Router;
+use OC\URLGenerator;
 use OCA\Theming\ImageManager;
 use OCA\Theming\ITheme;
 use OCA\Theming\Themes\DyslexiaFont;
@@ -61,7 +62,7 @@ class DyslexiaFontTest extends TestCase {
 		$cacheFactory = $this->createMock(ICacheFactory::class);
 		$request = $this->createMock(IRequest::class);
 		$router = $this->createMock(Router::class);
-		$this->urlGenerator = new \OC\URLGenerator(
+		$this->urlGenerator = new URLGenerator(
 			$this->config,
 			$userSession,
 			$cacheFactory,

--- a/apps/theming/tests/UtilTest.php
+++ b/apps/theming/tests/UtilTest.php
@@ -13,6 +13,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\IConfig;
+use OCP\Server;
 use OCP\ServerVersion;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
@@ -29,7 +30,7 @@ class UtilTest extends TestCase {
 		parent::setUp();
 		$this->config = $this->createMock(IConfig::class);
 		$this->appData = $this->createMock(IAppData::class);
-		$this->appManager = \OCP\Server::get(IAppManager::class);
+		$this->appManager = Server::get(IAppManager::class);
 		$this->imageManager = $this->createMock(ImageManager::class);
 		$this->util = new Util($this->createMock(ServerVersion::class), $this->config, $this->appManager, $this->appData, $this->imageManager);
 	}
@@ -154,9 +155,9 @@ class UtilTest extends TestCase {
 
 	public function dataGetAppIcon() {
 		return [
-			['user_ldap', \OCP\Server::get(IAppManager::class)->getAppPath('user_ldap') . '/img/app.svg'],
+			['user_ldap', Server::get(IAppManager::class)->getAppPath('user_ldap') . '/img/app.svg'],
 			['noapplikethis', \OC::$SERVERROOT . '/core/img/logo/logo.svg'],
-			['comments', \OCP\Server::get(IAppManager::class)->getAppPath('comments') . '/img/comments.svg'],
+			['comments', Server::get(IAppManager::class)->getAppPath('comments') . '/img/comments.svg'],
 		];
 	}
 

--- a/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\TwoFactorBackupCodes\Tests\Service;
 
 use OCA\TwoFactorBackupCodes\Service\BackupCodeStorage;
+use OCP\IUser;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use Test\TestCase;
@@ -39,7 +40,7 @@ class BackupCodeStorageTest extends TestCase {
 	}
 
 	public function testSimpleWorkFlow(): void {
-		$user = $this->getMockBuilder(\OCP\IUser::class)->getMock();
+		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn($this->testUID);

--- a/apps/updatenotification/lib/Controller/ChangelogController.php
+++ b/apps/updatenotification/lib/Controller/ChangelogController.php
@@ -17,6 +17,7 @@ use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IRequest;
+use OCP\Util;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ChangelogController extends Controller {
@@ -55,7 +56,7 @@ class ChangelogController extends Controller {
 			'text' => $changes,
 		]);
 
-		\OCP\Util::addScript($this->appName, 'view-changelog-page');
+		Util::addScript($this->appName, 'view-changelog-page');
 		return new TemplateResponse($this->appName, 'empty');
 	}
 }

--- a/apps/updatenotification/lib/Listener/BeforeTemplateRenderedEventListener.php
+++ b/apps/updatenotification/lib/Listener/BeforeTemplateRenderedEventListener.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IAppConfig;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /** @template-implements IEventListener<BeforeTemplateRenderedEvent> */
@@ -48,6 +49,6 @@ class BeforeTemplateRenderedEventListener implements IEventListener {
 			return;
 		}
 
-		\OCP\Util::addInitScript(Application::APP_NAME, 'init');
+		Util::addInitScript(Application::APP_NAME, 'init');
 	}
 }

--- a/apps/updatenotification/lib/Migration/Version011901Date20240305120000.php
+++ b/apps/updatenotification/lib/Migration/Version011901Date20240305120000.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace OCA\UpdateNotification\Migration;
 
 use OCA\UpdateNotification\BackgroundJob\ResetToken;
+use OCA\UpdateNotification\Notification\BackgroundJob;
+use OCA\UpdateNotification\ResetTokenBackgroundJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -30,13 +32,13 @@ class Version011901Date20240305120000 extends SimpleMigrationStep {
 		 * This class was renamed so it is now unknow but we still need to remove it
 		 * @psalm-suppress UndefinedClass, InvalidArgument
 		 */
-		$hasOldResetToken = $this->joblist->has(\OCA\UpdateNotification\ResetTokenBackgroundJob::class, null);
+		$hasOldResetToken = $this->joblist->has(ResetTokenBackgroundJob::class, null);
 		$hasNewResetToken = $this->joblist->has(ResetToken::class, null);
 		if ($hasOldResetToken) {
 			/**
 			 * @psalm-suppress UndefinedClass, InvalidArgument
 			 */
-			$this->joblist->remove(\OCA\UpdateNotification\ResetTokenBackgroundJob::class);
+			$this->joblist->remove(ResetTokenBackgroundJob::class);
 			if (!$hasNewResetToken) {
 				$this->joblist->add(ResetToken::class);
 			}
@@ -46,11 +48,11 @@ class Version011901Date20240305120000 extends SimpleMigrationStep {
 		 * Remove the "has updates" background job, the new one is automatically started from the info.xml
 		 * @psalm-suppress UndefinedClass, InvalidArgument
 		 */
-		if ($this->joblist->has(\OCA\UpdateNotification\Notification\BackgroundJob::class, null)) {
+		if ($this->joblist->has(BackgroundJob::class, null)) {
 			/**
 			 * @psalm-suppress UndefinedClass, InvalidArgument
 			 */
-			$this->joblist->remove(\OCA\UpdateNotification\Notification\BackgroundJob::class);
+			$this->joblist->remove(BackgroundJob::class);
 		}
 	}
 }

--- a/apps/updatenotification/lib/Notification/Notifier.php
+++ b/apps/updatenotification/lib/Notification/Notifier.php
@@ -20,6 +20,7 @@ use OCP\Notification\IManager;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\Notification\UnknownNotificationException;
+use OCP\Server;
 use OCP\Util;
 
 class Notifier implements INotifier {
@@ -188,6 +189,6 @@ class Notifier implements INotifier {
 	}
 
 	protected function getAppInfo($appId, $languageCode) {
-		return \OCP\Server::get(IAppManager::class)->getAppInfo($appId, false, $languageCode);
+		return Server::get(IAppManager::class)->getAppInfo($appId, false, $languageCode);
 	}
 }

--- a/apps/user_ldap/ajax/clearMappings.php
+++ b/apps/user_ldap/ajax/clearMappings.php
@@ -5,13 +5,13 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Server;
 use OCP\User\Events\BeforeUserIdUnassignedEvent;
 use OCP\User\Events\UserIdUnassignedEvent;
+use OCP\Util;
 
 // Check user and app status
 \OC_JSON::checkAdminUser();
@@ -41,7 +41,7 @@ try {
 	}
 
 	if ($mapping === null || !$result) {
-		$l = \OCP\Util::getL10N('user_ldap');
+		$l = Util::getL10N('user_ldap');
 		throw new \Exception($l->t('Failed to clear the mappings.'));
 	}
 	\OC_JSON::success();

--- a/apps/user_ldap/ajax/deleteConfiguration.php
+++ b/apps/user_ldap/ajax/deleteConfiguration.php
@@ -1,5 +1,8 @@
 <?php
 
+use OCA\User_LDAP\Helper;
+use OCP\Util;
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -11,10 +14,10 @@
 \OC_JSON::callCheck();
 
 $prefix = (string)$_POST['ldap_serverconfig_chooser'];
-$helper = new \OCA\User_LDAP\Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
 if ($helper->deleteServerConfiguration($prefix)) {
 	\OC_JSON::success();
 } else {
-	$l = \OCP\Util::getL10N('user_ldap');
+	$l = Util::getL10N('user_ldap');
 	\OC_JSON::error(['message' => $l->t('Failed to delete the server configuration')]);
 }

--- a/apps/user_ldap/ajax/getConfiguration.php
+++ b/apps/user_ldap/ajax/getConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+use OCA\User_LDAP\LDAP;
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -11,7 +13,7 @@
 \OC_JSON::callCheck();
 
 $prefix = (string)$_POST['ldap_serverconfig_chooser'];
-$ldapWrapper = new OCA\User_LDAP\LDAP();
+$ldapWrapper = new LDAP();
 $connection = new \OCA\User_LDAP\Connection($ldapWrapper, $prefix);
 $configuration = $connection->getConfiguration();
 if (isset($configuration['ldap_agent_password']) && $configuration['ldap_agent_password'] !== '') {

--- a/apps/user_ldap/ajax/getNewServerConfigPrefix.php
+++ b/apps/user_ldap/ajax/getNewServerConfigPrefix.php
@@ -1,5 +1,8 @@
 <?php
 
+use OCA\User_LDAP\Configuration;
+use OCA\User_LDAP\Helper;
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -10,7 +13,7 @@
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();
 
-$helper = new \OCA\User_LDAP\Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
 $serverConnections = $helper->getServerConfigurationPrefixes();
 sort($serverConnections);
 $lk = array_pop($serverConnections);
@@ -19,12 +22,12 @@ $nk = 's' . str_pad($ln + 1, 2, '0', STR_PAD_LEFT);
 
 $resultData = ['configPrefix' => $nk];
 
-$newConfig = new \OCA\User_LDAP\Configuration($nk, false);
+$newConfig = new Configuration($nk, false);
 if (isset($_POST['copyConfig'])) {
-	$originalConfig = new \OCA\User_LDAP\Configuration($_POST['copyConfig']);
+	$originalConfig = new Configuration($_POST['copyConfig']);
 	$newConfig->setConfiguration($originalConfig->getConfiguration());
 } else {
-	$configuration = new \OCA\User_LDAP\Configuration($nk, false);
+	$configuration = new Configuration($nk, false);
 	$newConfig->setConfiguration($configuration->getDefaults());
 	$resultData['defaults'] = $configuration->getDefaults();
 }

--- a/apps/user_ldap/ajax/setConfiguration.php
+++ b/apps/user_ldap/ajax/setConfiguration.php
@@ -1,5 +1,7 @@
 <?php
 
+use OCA\User_LDAP\LDAP;
+
 /**
  * SPDX-FileCopyrightText: 2018-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -23,7 +25,7 @@ foreach ($chkboxes as $boxid) {
 	}
 }
 
-$ldapWrapper = new OCA\User_LDAP\LDAP();
+$ldapWrapper = new LDAP();
 $connection = new \OCA\User_LDAP\Connection($ldapWrapper, $prefix);
 $connection->setConfiguration($_POST);
 $connection->saveConfiguration();

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -1,5 +1,8 @@
 <?php
 
+use OCA\User_LDAP\LDAP;
+use OCP\Util;
+
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -10,9 +13,9 @@
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();
 
-$l = \OCP\Util::getL10N('user_ldap');
+$l = Util::getL10N('user_ldap');
 
-$ldapWrapper = new OCA\User_LDAP\LDAP();
+$ldapWrapper = new LDAP();
 $connection = new \OCA\User_LDAP\Connection($ldapWrapper, $_POST['ldap_serverconfig_chooser']);
 
 

--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -1,5 +1,11 @@
 <?php
 
+use OCA\User_LDAP\AccessFactory;
+use OCA\User_LDAP\Configuration;
+use OCA\User_LDAP\LDAP;
+use OCA\User_LDAP\Wizard;
+use OCP\Util;
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -10,7 +16,7 @@
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();
 
-$l = \OCP\Util::getL10N('user_ldap');
+$l = Util::getL10N('user_ldap');
 
 if (!isset($_POST['action'])) {
 	\OC_JSON::error(['message' => $l->t('No action specified')]);
@@ -22,18 +28,18 @@ if (!isset($_POST['ldap_serverconfig_chooser'])) {
 }
 $prefix = (string)$_POST['ldap_serverconfig_chooser'];
 
-$ldapWrapper = new \OCA\User_LDAP\LDAP();
-$configuration = new \OCA\User_LDAP\Configuration($prefix);
+$ldapWrapper = new LDAP();
+$configuration = new Configuration($prefix);
 
 $con = new \OCA\User_LDAP\Connection($ldapWrapper, $prefix, null);
 $con->setConfiguration($configuration->getConfiguration());
 $con->ldapConfigurationActive = (string)true;
 $con->setIgnoreValidation(true);
 
-$factory = \OC::$server->get(\OCA\User_LDAP\AccessFactory::class);
+$factory = \OC::$server->get(AccessFactory::class);
 $access = $factory->get($con);
 
-$wizard = new \OCA\User_LDAP\Wizard($configuration, $ldapWrapper, $access);
+$wizard = new Wizard($configuration, $ldapWrapper, $access);
 
 switch ($action) {
 	case 'guessPortAndTLS':

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use OCA\User_LDAP\AppInfo\Application;
+use OCP\AppFramework\App;
+
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -22,7 +25,7 @@ $this->create('user_ldap_ajax_testConfiguration', 'apps/user_ldap/ajax/testConfi
 $this->create('user_ldap_ajax_wizard', 'apps/user_ldap/ajax/wizard.php')
 	->actionInclude('user_ldap/ajax/wizard.php');
 
-$application = new \OCP\AppFramework\App('user_ldap');
+$application = new App('user_ldap');
 $application->registerRoutes($this, [
 	'ocs' => [
 		['name' => 'ConfigAPI#create', 'url' => '/api/v1/config', 'verb' => 'POST'],
@@ -32,8 +35,8 @@ $application->registerRoutes($this, [
 	]
 ]);
 
-/** @var \OCA\User_LDAP\AppInfo\Application $application */
-$application = \OC::$server->query(\OCA\User_LDAP\AppInfo\Application::class);
+/** @var Application $application */
+$application = \OC::$server->query(Application::class);
 $application->registerRoutes($this, [
 	'routes' => [
 		['name' => 'renewPassword#tryRenewPassword', 'url' => '/renewpassword', 'verb' => 'POST'],

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -21,6 +21,7 @@ use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IUserManager;
 use OCP\User\Events\UserIdAssignedEvent;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 use function strlen;
 use function substr;
@@ -260,7 +261,7 @@ class Access extends LDAPUtility {
 			return false;
 		}
 		//LDAP attributes are not case sensitive
-		$result = \OCP\Util::mb_array_change_key_case(
+		$result = Util::mb_array_change_key_case(
 			$this->invokeLDAPMethod('getAttributes', $er), MB_CASE_LOWER, 'UTF-8');
 
 		return $result;
@@ -341,7 +342,7 @@ class Access extends LDAPUtility {
 			return @$this->invokeLDAPMethod('exopPasswd', $userDN, '', $password) ||
 				@$this->invokeLDAPMethod('modReplace', $userDN, $password);
 		} catch (ConstraintViolationException $e) {
-			throw new HintException('Password change rejected.', \OCP\Util::getL10N('user_ldap')->t('Password change rejected. Hint: ') . $e->getMessage(), (int)$e->getCode());
+			throw new HintException('Password change rejected.', Util::getL10N('user_ldap')->t('Password change rejected. Hint: ') . $e->getMessage(), (int)$e->getCode());
 		}
 	}
 
@@ -1329,7 +1330,7 @@ class Access extends LDAPUtility {
 				if (!is_array($item)) {
 					continue;
 				}
-				$item = \OCP\Util::mb_array_change_key_case($item, MB_CASE_LOWER, 'UTF-8');
+				$item = Util::mb_array_change_key_case($item, MB_CASE_LOWER, 'UTF-8');
 				foreach ($attr as $key) {
 					if (isset($item[$key])) {
 						if (is_array($item[$key]) && isset($item[$key]['count'])) {

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -40,6 +40,7 @@ use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Share\IManager as IShareManager;
 use OCP\User\Events\PostLoginEvent;
+use OCP\Util;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -129,7 +130,7 @@ class Application extends App implements IBootstrap {
 
 		$context->injectFn(Closure::fromCallable([$this, 'registerBackendDependents']));
 
-		\OCP\Util::connectHook(
+		Util::connectHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',
 			'\OCA\User_LDAP\Helper',

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\User_LDAP;
 
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -673,7 +674,7 @@ class Configuration {
 			return [strtolower($attribute)];
 		}
 		if ($value !== self::AVATAR_PREFIX_DEFAULT) {
-			\OCP\Server::get(LoggerInterface::class)->warning('Invalid config value to ldapUserAvatarRule; falling back to default.');
+			Server::get(LoggerInterface::class)->warning('Invalid config value to ldapUserAvatarRule; falling back to default.');
 		}
 		return $defaultAttributes;
 	}

--- a/apps/user_ldap/lib/FilesystemHelper.php
+++ b/apps/user_ldap/lib/FilesystemHelper.php
@@ -7,6 +7,8 @@
  */
 namespace OCA\User_LDAP;
 
+use OC\Files\Filesystem;
+
 /**
  * @brief wraps around static Nextcloud core methods
  */
@@ -17,7 +19,7 @@ class FilesystemHelper {
 	 * @return bool
 	 */
 	public function isLoaded() {
-		return \OC\Files\Filesystem::$loaded;
+		return Filesystem::$loaded;
 	}
 
 	/**

--- a/apps/user_ldap/lib/GroupPluginManager.php
+++ b/apps/user_ldap/lib/GroupPluginManager.php
@@ -6,6 +6,7 @@
 namespace OCA\User_LDAP;
 
 use OCP\GroupInterface;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class GroupPluginManager {
@@ -41,7 +42,7 @@ class GroupPluginManager {
 		foreach ($this->which as $action => $v) {
 			if ((bool)($respondToActions & $action)) {
 				$this->which[$action] = $plugin;
-				\OCP\Server::get(LoggerInterface::class)->debug('Registered action ' . $action . ' to plugin ' . get_class($plugin), ['app' => 'user_ldap']);
+				Server::get(LoggerInterface::class)->debug('Registered action ' . $action . ' to plugin ' . get_class($plugin), ['app' => 'user_ldap']);
 			}
 		}
 	}

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -18,7 +18,7 @@ use OCP\GroupInterface;
 use OCP\IConfig;
 use OCP\IUserManager;
 
-class Group_Proxy extends Proxy implements \OCP\GroupInterface, IGroupLDAP, IGetDisplayNameBackend, INamedBackend, IDeleteGroupBackend, IBatchMethodsBackend, IIsAdminBackend {
+class Group_Proxy extends Proxy implements GroupInterface, IGroupLDAP, IGetDisplayNameBackend, INamedBackend, IDeleteGroupBackend, IBatchMethodsBackend, IIsAdminBackend {
 	private $backends = [];
 	private ?Group_LDAP $refBackend = null;
 	private Helper $helper;

--- a/apps/user_ldap/lib/Jobs/CleanUp.php
+++ b/apps/user_ldap/lib/Jobs/CleanUp.php
@@ -14,6 +14,7 @@ use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\User_Proxy;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\Server;
 
 /**
  * Class CleanUp
@@ -95,7 +96,7 @@ class CleanUp extends TimedJob {
 		if (isset($arguments['mapping'])) {
 			$this->mapping = $arguments['mapping'];
 		} else {
-			$this->mapping = \OCP\Server::get(UserMapping::class);
+			$this->mapping = Server::get(UserMapping::class);
 		}
 
 		if (isset($arguments['deletedUsersIndex'])) {

--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -12,6 +12,7 @@ use OCA\User_LDAP\DataCollector\LdapDataCollector;
 use OCA\User_LDAP\Exceptions\ConstraintViolationException;
 use OCP\IConfig;
 use OCP\Profiler\IProfiler;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class LDAP implements ILDAPWrapper {
@@ -31,7 +32,7 @@ class LDAP implements ILDAPWrapper {
 			$profiler->add($this->dataCollector);
 		}
 
-		$this->logger = \OCP\Server::get(LoggerInterface::class);
+		$this->logger = Server::get(LoggerInterface::class);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Mapping/AbstractMapping.php
+++ b/apps/user_ldap/lib/Mapping/AbstractMapping.php
@@ -11,6 +11,7 @@ use Doctrine\DBAL\Exception;
 use OCP\DB\IPreparedStatement;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -34,7 +35,7 @@ abstract class AbstractMapping {
 	/**
 	 * @param \OCP\IDBConnection $dbc
 	 */
-	public function __construct(\OCP\IDBConnection $dbc) {
+	public function __construct(IDBConnection $dbc) {
 		$this->dbc = $dbc;
 	}
 
@@ -333,7 +334,7 @@ abstract class AbstractMapping {
 	 */
 	public function map($fdn, $name, $uuid) {
 		if (mb_strlen($fdn) > 4000) {
-			\OCP\Server::get(LoggerInterface::class)->error(
+			Server::get(LoggerInterface::class)->error(
 				'Cannot map, because the DN exceeds 4000 characters: {dn}',
 				[
 					'app' => 'user_ldap',

--- a/apps/user_ldap/lib/Notification/Notifier.php
+++ b/apps/user_ldap/lib/Notification/Notifier.php
@@ -18,7 +18,7 @@ class Notifier implements INotifier {
 	/**
 	 * @param IFactory $l10nFactory
 	 */
-	public function __construct(\OCP\L10N\IFactory $l10nFactory) {
+	public function __construct(IFactory $l10nFactory) {
 		$this->l10nFactory = $l10nFactory;
 	}
 

--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -77,7 +77,7 @@ class Manager {
 	 * property array
 	 * @param string $dn the DN of the user
 	 * @param string $uid the internal (owncloud) username
-	 * @return \OCA\User_LDAP\User\User
+	 * @return User
 	 */
 	private function createAndCache($dn, $uid) {
 		$this->checkAccess();
@@ -188,7 +188,7 @@ class Manager {
 	/**
 	 * creates and returns an instance of OfflineUser for the specified user
 	 * @param string $id
-	 * @return \OCA\User_LDAP\User\OfflineUser
+	 * @return OfflineUser
 	 */
 	public function getDeletedUser($id) {
 		return new OfflineUser(
@@ -202,7 +202,7 @@ class Manager {
 	/**
 	 * @brief returns a User object by its Nextcloud username
 	 * @param string $id the DN or username of the user
-	 * @return \OCA\User_LDAP\User\User|\OCA\User_LDAP\User\OfflineUser|null
+	 * @return User|OfflineUser|null
 	 */
 	protected function createInstancyByUserName($id) {
 		//most likely a uid. Check whether it is a deleted user
@@ -219,7 +219,7 @@ class Manager {
 	/**
 	 * @brief returns a User object by its DN or Nextcloud username
 	 * @param string $id the DN or username of the user
-	 * @return \OCA\User_LDAP\User\User|\OCA\User_LDAP\User\OfflineUser|null
+	 * @return User|OfflineUser|null
 	 * @throws \Exception when connection could not be established
 	 */
 	public function get($id) {

--- a/apps/user_ldap/lib/User/OfflineUser.php
+++ b/apps/user_ldap/lib/User/OfflineUser.php
@@ -60,7 +60,7 @@ class OfflineUser {
 	 */
 	protected $db;
 	/**
-	 * @var \OCA\User_LDAP\Mapping\UserMapping
+	 * @var UserMapping
 	 */
 	protected $mapping;
 	/** @var IManager */

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -23,6 +23,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Server;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -121,7 +122,7 @@ class User {
 		$this->notificationManager = $notificationManager;
 		$this->birthdateParser = new BirthdateParserService();
 
-		\OCP\Util::connectHook('OC_User', 'post_login', $this, 'handlePasswordExpiry');
+		Util::connectHook('OC_User', 'post_login', $this, 'handlePasswordExpiry');
 	}
 
 	/**
@@ -228,7 +229,7 @@ class User {
 			//User Profile Field - Phone number
 			$attr = strtolower($this->connection->ldapAttributePhone);
 			if (!empty($attr)) { // attribute configured
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_PHONE]
+				$profileValues[IAccountManager::PROPERTY_PHONE]
 					= $ldapEntry[$attr][0] ?? '';
 			}
 			//User Profile Field - website
@@ -237,57 +238,57 @@ class User {
 				$cutPosition = strpos($ldapEntry[$attr][0], ' ');
 				if ($cutPosition) {
 					// drop appended label
-					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_WEBSITE]
+					$profileValues[IAccountManager::PROPERTY_WEBSITE]
 						= substr($ldapEntry[$attr][0], 0, $cutPosition);
 				} else {
-					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_WEBSITE]
+					$profileValues[IAccountManager::PROPERTY_WEBSITE]
 						= $ldapEntry[$attr][0];
 				}
 			} elseif (!empty($attr)) {	// configured, but not defined
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_WEBSITE] = '';
+				$profileValues[IAccountManager::PROPERTY_WEBSITE] = '';
 			}
 			//User Profile Field - Address
 			$attr = strtolower($this->connection->ldapAttributeAddress);
 			if (isset($ldapEntry[$attr])) {
 				if (str_contains($ldapEntry[$attr][0], '$')) {
 					// basic format conversion from postalAddress syntax to commata delimited
-					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ADDRESS]
+					$profileValues[IAccountManager::PROPERTY_ADDRESS]
 						= str_replace('$', ', ', $ldapEntry[$attr][0]);
 				} else {
-					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ADDRESS]
+					$profileValues[IAccountManager::PROPERTY_ADDRESS]
 						= $ldapEntry[$attr][0];
 				}
 			} elseif (!empty($attr)) {	// configured, but not defined
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ADDRESS] = '';
+				$profileValues[IAccountManager::PROPERTY_ADDRESS] = '';
 			}
 			//User Profile Field - Twitter
 			$attr = strtolower($this->connection->ldapAttributeTwitter);
 			if (!empty($attr)) {
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_TWITTER]
+				$profileValues[IAccountManager::PROPERTY_TWITTER]
 					= $ldapEntry[$attr][0] ?? '';
 			}
 			//User Profile Field - fediverse
 			$attr = strtolower($this->connection->ldapAttributeFediverse);
 			if (!empty($attr)) {
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_FEDIVERSE]
+				$profileValues[IAccountManager::PROPERTY_FEDIVERSE]
 					= $ldapEntry[$attr][0] ?? '';
 			}
 			//User Profile Field - organisation
 			$attr = strtolower($this->connection->ldapAttributeOrganisation);
 			if (!empty($attr)) {
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ORGANISATION]
+				$profileValues[IAccountManager::PROPERTY_ORGANISATION]
 					= $ldapEntry[$attr][0] ?? '';
 			}
 			//User Profile Field - role
 			$attr = strtolower($this->connection->ldapAttributeRole);
 			if (!empty($attr)) {
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_ROLE]
+				$profileValues[IAccountManager::PROPERTY_ROLE]
 					= $ldapEntry[$attr][0] ?? '';
 			}
 			//User Profile Field - headline
 			$attr = strtolower($this->connection->ldapAttributeHeadline);
 			if (!empty($attr)) {
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_HEADLINE]
+				$profileValues[IAccountManager::PROPERTY_HEADLINE]
 					= $ldapEntry[$attr][0] ?? '';
 			}
 			//User Profile Field - biography
@@ -295,14 +296,14 @@ class User {
 			if (isset($ldapEntry[$attr])) {
 				if (str_contains($ldapEntry[$attr][0], '\r')) {
 					// convert line endings
-					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_BIOGRAPHY]
+					$profileValues[IAccountManager::PROPERTY_BIOGRAPHY]
 						= str_replace(["\r\n","\r"], "\n", $ldapEntry[$attr][0]);
 				} else {
-					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_BIOGRAPHY]
+					$profileValues[IAccountManager::PROPERTY_BIOGRAPHY]
 						= $ldapEntry[$attr][0];
 				}
 			} elseif (!empty($attr)) {	// configured, but not defined
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_BIOGRAPHY] = '';
+				$profileValues[IAccountManager::PROPERTY_BIOGRAPHY] = '';
 			}
 			//User Profile Field - birthday
 			$attr = strtolower($this->connection->ldapAttributeBirthDate);
@@ -310,7 +311,7 @@ class User {
 				$value = $ldapEntry[$attr][0];
 				try {
 					$birthdate = $this->birthdateParser->parseBirthdate($value);
-					$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_BIRTHDATE]
+					$profileValues[IAccountManager::PROPERTY_BIRTHDATE]
 						= $birthdate->format('Y-m-d');
 				} catch (InvalidArgumentException $e) {
 					// Invalid date -> just skip the property
@@ -323,7 +324,7 @@ class User {
 			//User Profile Field - pronouns
 			$attr = strtolower($this->connection->ldapAttributePronouns);
 			if (!empty($attr)) {
-				$profileValues[\OCP\Accounts\IAccountManager::PROPERTY_PRONOUNS]
+				$profileValues[IAccountManager::PROPERTY_PRONOUNS]
 					= $ldapEntry[$attr][0] ?? '';
 			}
 			// check for changed data and cache just for TTL checking
@@ -354,7 +355,7 @@ class User {
 				// system must be postponed after the login. It is to ensure
 				// external mounts are mounted properly (e.g. with login
 				// credentials from the session).
-				\OCP\Util::connectHook('OC_User', 'post_login', $this, 'updateAvatarPostLogin');
+				Util::connectHook('OC_User', 'post_login', $this, 'updateAvatarPostLogin');
 				break;
 			}
 		}

--- a/apps/user_ldap/lib/UserPluginManager.php
+++ b/apps/user_ldap/lib/UserPluginManager.php
@@ -6,6 +6,7 @@
 namespace OCA\User_LDAP;
 
 use OC\User\Backend;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class UserPluginManager {
@@ -43,12 +44,12 @@ class UserPluginManager {
 		foreach ($this->which as $action => $v) {
 			if (is_int($action) && (bool)($respondToActions & $action)) {
 				$this->which[$action] = $plugin;
-				\OCP\Server::get(LoggerInterface::class)->debug('Registered action ' . $action . ' to plugin ' . get_class($plugin), ['app' => 'user_ldap']);
+				Server::get(LoggerInterface::class)->debug('Registered action ' . $action . ' to plugin ' . get_class($plugin), ['app' => 'user_ldap']);
 			}
 		}
 		if (method_exists($plugin, 'deleteUser')) {
 			$this->which['deleteUser'] = $plugin;
-			\OCP\Server::get(LoggerInterface::class)->debug('Registered action deleteUser to plugin ' . get_class($plugin), ['app' => 'user_ldap']);
+			Server::get(LoggerInterface::class)->debug('Registered action deleteUser to plugin ' . get_class($plugin), ['app' => 'user_ldap']);
 		}
 	}
 

--- a/apps/user_ldap/lib/User_LDAP.php
+++ b/apps/user_ldap/lib/User_LDAP.php
@@ -258,8 +258,8 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface, I
 	/**
 	 * checks whether a user is still available on LDAP
 	 *
-	 * @param string|\OCA\User_LDAP\User\User $user either the Nextcloud user
-	 *                                              name or an instance of that user
+	 * @param string|User $user either the Nextcloud user
+	 *                          name or an instance of that user
 	 * @throws \Exception
 	 * @throws \OC\ServerNotAvailableException
 	 */

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -220,8 +220,8 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 	/**
 	 * check if a user exists on LDAP
 	 *
-	 * @param string|\OCA\User_LDAP\User\User $user either the Nextcloud user
-	 *                                              name or an instance of that user
+	 * @param string|User $user either the Nextcloud user
+	 *                          name or an instance of that user
 	 */
 	public function userExistsOnLDAP($user, bool $ignoreCache = false): bool {
 		$id = ($user instanceof User) ? $user->getUsername() : $user;

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -11,6 +11,7 @@ namespace OCA\User_LDAP;
 use OC\ServerNotAvailableException;
 use OCP\IL10N;
 use OCP\L10N\IFactory as IL10NFactory;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 class Wizard extends LDAPUtility {
@@ -1253,7 +1254,7 @@ class Wizard extends LDAPUtility {
 		}
 
 		// strtolower on all keys for proper comparison
-		$result = \OCP\Util::mb_array_change_key_case($result);
+		$result = Util::mb_array_change_key_case($result);
 		$attribute = strtolower($attribute);
 		if (isset($result[$attribute])) {
 			foreach ($result[$attribute] as $key => $val) {

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\User_LDAP\Tests;
 
+use OC\ServerNotAvailableException;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\Exceptions\ConstraintViolationException;
@@ -19,6 +20,7 @@ use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\User\OfflineUser;
 use OCA\User_LDAP\User\User;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\HintException;
 use OCP\IAppConfig;
 use OCP\IAvatarManager;
 use OCP\IConfig;
@@ -470,19 +472,19 @@ class AccessTest extends TestCase {
 		$this->connection
 			->expects($this->once())
 			->method('getConnectionResource')
-			->willThrowException(new \OC\ServerNotAvailableException('Connection to LDAP server could not be established'));
+			->willThrowException(new ServerNotAvailableException('Connection to LDAP server could not be established'));
 		$this->ldap
 			->expects($this->never())
 			->method('isResource');
 
-		$this->expectException(\OC\ServerNotAvailableException::class);
+		$this->expectException(ServerNotAvailableException::class);
 		$this->expectExceptionMessage('Connection to LDAP server could not be established');
 		$this->access->setPassword('CN=foo', 'MyPassword');
 	}
 
 
 	public function testSetPasswordWithRejectedChange(): void {
-		$this->expectException(\OCP\HintException::class);
+		$this->expectException(HintException::class);
 		$this->expectExceptionMessage('Password change rejected.');
 
 		$this->connection

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\User_LDAP\Tests;
 
+use OC\ServerNotAvailableException;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\ILDAPWrapper;
 
@@ -18,7 +19,7 @@ use OCA\User_LDAP\ILDAPWrapper;
  * @package OCA\User_LDAP\Tests
  */
 class ConnectionTest extends \Test\TestCase {
-	/** @var \OCA\User_LDAP\ILDAPWrapper|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ILDAPWrapper|\PHPUnit\Framework\MockObject\MockObject */
 	protected $ldap;
 
 	/** @var Connection */
@@ -114,7 +115,7 @@ class ConnectionTest extends \Test\TestCase {
 			->willReturnCallback(function () use (&$isThrown) {
 				if (!$isThrown) {
 					$isThrown = true;
-					throw new \OC\ServerNotAvailableException();
+					throw new ServerNotAvailableException();
 				}
 				return true;
 			});
@@ -212,7 +213,7 @@ class ConnectionTest extends \Test\TestCase {
 
 		try {
 			$this->assertFalse($this->connection->bind(), 'Connection::bind() should not return true with invalid credentials.');
-		} catch (\OC\ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException $e) {
 			$this->fail('Failed asserting that exception of type "OC\ServerNotAvailableException" is not thrown.');
 		}
 	}
@@ -260,7 +261,7 @@ class ConnectionTest extends \Test\TestCase {
 			->method('startTls')
 			->willReturn(false);
 
-		$this->expectException(\OC\ServerNotAvailableException::class);
+		$this->expectException(ServerNotAvailableException::class);
 		$this->expectExceptionMessage('Start TLS failed, when connecting to LDAP host ' . $host . '.');
 
 		$this->connection->init();

--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -16,6 +16,8 @@ use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\UserPluginManager;
 use OCP\IAvatarManager;
+use OCP\Image;
+use OCP\Server;
 use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
 
@@ -57,10 +59,10 @@ abstract class AbstractIntegrationTest {
 	 */
 	public function init() {
 		\OC::$server->registerService(UserPluginManager::class, function () {
-			return new \OCA\User_LDAP\UserPluginManager();
+			return new UserPluginManager();
 		});
 		\OC::$server->registerService(GroupPluginManager::class, function () {
-			return new \OCA\User_LDAP\GroupPluginManager();
+			return new GroupPluginManager();
 		});
 
 		$this->initLDAPWrapper();
@@ -106,7 +108,7 @@ abstract class AbstractIntegrationTest {
 			new FilesystemHelper(),
 			\OC::$server->get(LoggerInterface::class),
 			\OC::$server->get(IAvatarManager::class),
-			new \OCP\Image(),
+			new Image(),
 			\OC::$server->getUserManager(),
 			\OC::$server->getNotificationManager(),
 			\OC::$server->get(IManager::class)
@@ -124,7 +126,7 @@ abstract class AbstractIntegrationTest {
 	 * initializes the Access test instance
 	 */
 	protected function initAccess() {
-		$this->access = new Access($this->connection, $this->ldap, $this->userManager, $this->helper, \OC::$server->getConfig(), \OCP\Server::get(LoggerInterface::class));
+		$this->access = new Access($this->connection, $this->ldap, $this->userManager, $this->helper, \OC::$server->getConfig(), Server::get(LoggerInterface::class));
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/ExceptionOnLostConnection.php
+++ b/apps/user_ldap/tests/Integration/ExceptionOnLostConnection.php
@@ -39,7 +39,7 @@ class ExceptionOnLostConnection {
 	/** @var string */
 	private $ldapHost;
 
-	/** @var \OCA\User_LDAP\LDAP */
+	/** @var LDAP */
 	private $ldap;
 
 	/** @var bool */

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -5,12 +5,15 @@
  */
 namespace OCA\User_LDAP\Tests;
 
+use OC\Config;
 use OC\User\Manager;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\Group_LDAP;
+use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\IGroupLDAP;
 use OCA\User_LDAP\IUserLDAP;
+use OCA\User_LDAP\LDAPProviderFactory;
 use OCA\User_LDAP\User_LDAP;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
@@ -33,7 +36,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	private function getServerMock(IUserLDAP $userBackend, IGroupLDAP $groupBackend) {
 		$server = $this->getMockBuilder('OC\Server')
 			->setMethods(['getUserManager', 'getBackends', 'getGroupManager'])
-			->setConstructorArgs(['', new \OC\Config(\OC::$configDir)])
+			->setConstructorArgs(['', new Config(\OC::$configDir)])
 			->getMock();
 		$server->expects($this->any())
 			->method('getUserManager')
@@ -84,7 +87,7 @@ class LDAPProviderTest extends \Test\TestCase {
 	}
 
 	private function getLDAPProvider(IServerContainer $serverContainer) {
-		$factory = new \OCA\User_LDAP\LDAPProviderFactory($serverContainer);
+		$factory = new LDAPProviderFactory($serverContainer);
 		return $factory->getLDAPProvider();
 	}
 
@@ -201,7 +204,7 @@ class LDAPProviderTest extends \Test\TestCase {
 
 		$server = $this->getServerMock($userBackend, $this->getDefaultGroupBackendMock());
 
-		$helper = new \OCA\User_LDAP\Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
 
 		$ldapProvider = $this->getLDAPProvider($server);
 		$this->assertEquals(
@@ -217,7 +220,7 @@ class LDAPProviderTest extends \Test\TestCase {
 
 		$server = $this->getServerMock($userBackend, $this->getDefaultGroupBackendMock());
 
-		$helper = new \OCA\User_LDAP\Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
 
 		$ldapProvider = $this->getLDAPProvider($server);
 		$this->assertEquals(

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
@@ -11,7 +11,7 @@ use OCA\User_LDAP\Mapping\AbstractMapping;
 use OCP\IDBConnection;
 
 abstract class AbstractMappingTest extends \Test\TestCase {
-	abstract public function getMapper(\OCP\IDBConnection $dbMock);
+	abstract public function getMapper(IDBConnection $dbMock);
 
 	/**
 	 * kiss test on isColNameValid
@@ -52,7 +52,7 @@ abstract class AbstractMappingTest extends \Test\TestCase {
 
 	/**
 	 * calls map() on the given mapper and asserts result for true
-	 * @param \OCA\User_LDAP\Mapping\AbstractMapping $mapper
+	 * @param AbstractMapping $mapper
 	 * @param array $data
 	 */
 	protected function mapEntries($mapper, $data) {

--- a/apps/user_ldap/tests/Mapping/GroupMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/GroupMappingTest.php
@@ -8,6 +8,7 @@
 namespace OCA\User_LDAP\Tests\Mapping;
 
 use OCA\User_LDAP\Mapping\GroupMapping;
+use OCP\IDBConnection;
 
 /**
  * Class GroupMappingTest
@@ -17,7 +18,7 @@ use OCA\User_LDAP\Mapping\GroupMapping;
  * @package OCA\User_LDAP\Tests\Mapping
  */
 class GroupMappingTest extends AbstractMappingTest {
-	public function getMapper(\OCP\IDBConnection $dbMock) {
+	public function getMapper(IDBConnection $dbMock) {
 		return new GroupMapping($dbMock);
 	}
 }

--- a/apps/user_ldap/tests/Mapping/UserMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/UserMappingTest.php
@@ -8,6 +8,7 @@
 namespace OCA\User_LDAP\Tests\Mapping;
 
 use OCA\User_LDAP\Mapping\UserMapping;
+use OCP\IDBConnection;
 use OCP\Support\Subscription\IAssertion;
 
 /**
@@ -18,7 +19,7 @@ use OCP\Support\Subscription\IAssertion;
  * @package OCA\User_LDAP\Tests\Mapping
  */
 class UserMappingTest extends AbstractMappingTest {
-	public function getMapper(\OCP\IDBConnection $dbMock) {
+	public function getMapper(IDBConnection $dbMock) {
 		return new UserMapping($dbMock, $this->createMock(IAssertion::class));
 	}
 }

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -19,6 +19,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
 use OCP\Notification\INotification;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -1149,7 +1150,7 @@ class UserTest extends \Test\TestCase {
 			->method('notify');
 
 		\OC_Hook::clear();//disconnect irrelevant hooks
-		\OCP\Util::connectHook('OC_User', 'post_login', $this->user, 'handlePasswordExpiry');
+		Util::connectHook('OC_User', 'post_login', $this->user, 'handlePasswordExpiry');
 		/** @noinspection PhpUnhandledExceptionInspection */
 		\OC_Hook::emit('OC_User', 'post_login', ['uid' => $this->uid]);
 	}
@@ -1213,7 +1214,7 @@ class UserTest extends \Test\TestCase {
 			->method('notify');
 
 		\OC_Hook::clear();//disconnect irrelevant hooks
-		\OCP\Util::connectHook('OC_User', 'post_login', $this->user, 'handlePasswordExpiry');
+		Util::connectHook('OC_User', 'post_login', $this->user, 'handlePasswordExpiry');
 		/** @noinspection PhpUnhandledExceptionInspection */
 		\OC_Hook::emit('OC_User', 'post_login', ['uid' => $this->uid]);
 	}

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1238,7 +1238,7 @@ class User_LDAPTest extends TestCase {
 
 
 	public function testSetPasswordInvalid(): void {
-		$this->expectException(\OCP\HintException::class);
+		$this->expectException(HintException::class);
 		$this->expectExceptionMessage('Password fails quality checking policy');
 
 		$this->prepareAccessForSetPassword($this->access);
@@ -1383,7 +1383,7 @@ class User_LDAPTest extends TestCase {
 
 
 	public function testSetDisplayNameErrorWithPlugin(): void {
-		$this->expectException(\OCP\HintException::class);
+		$this->expectException(HintException::class);
 
 		$newDisplayName = 'J. Baker';
 		$this->pluginManager->expects($this->once())

--- a/apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php
+++ b/apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php
@@ -18,6 +18,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IInitialStateService;
 use OCP\IUserSession;
+use OCP\Util;
 
 /** @template-implements IEventListener<BeforeTemplateRenderedEvent> */
 class BeforeTemplateRenderedListener implements IEventListener {
@@ -80,7 +81,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			return ['profileEnabled' => $this->profileManager->isProfileEnabled($user)];
 		});
 
-		\OCP\Util::addScript('user_status', 'menu');
-		\OCP\Util::addStyle('user_status', 'user-status-menu');
+		Util::addScript('user_status', 'menu');
+		Util::addStyle('user_status', 'user-status-menu');
 	}
 }

--- a/apps/webhook_listeners/lib/BackgroundJobs/WebhookCall.php
+++ b/apps/webhook_listeners/lib/BackgroundJobs/WebhookCall.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\WebhookListeners\BackgroundJobs;
 
+use OCA\AppAPI\PublicFunctions;
 use OCA\WebhookListeners\Db\AuthMethod;
 use OCA\WebhookListeners\Db\WebhookListenerMapper;
 use OCP\App\IAppManager;
@@ -16,6 +17,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\QueuedJob;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
+use OCP\Server;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
@@ -62,7 +64,7 @@ class WebhookCall extends QueuedJob {
 					throw new RuntimeException('AppAPI is disabled or not installed.');
 				}
 				try {
-					$appApiFunctions = \OCP\Server::get(\OCA\AppAPI\PublicFunctions::class);
+					$appApiFunctions = Server::get(PublicFunctions::class);
 				} catch (ContainerExceptionInterface|NotFoundExceptionInterface) {
 					throw new RuntimeException('Could not get AppAPI public functions.');
 				}

--- a/apps/webhook_listeners/lib/Db/WebhookListener.php
+++ b/apps/webhook_listeners/lib/Db/WebhookListener.php
@@ -11,6 +11,7 @@ namespace OCA\WebhookListeners\Db;
 
 use OCP\AppFramework\Db\Entity;
 use OCP\Security\ICrypto;
+use OCP\Server;
 
 /**
  * @method void setUserId(?string $userId)
@@ -89,7 +90,7 @@ class WebhookListener extends Entity implements \JsonSerializable {
 		?ICrypto $crypto = null,
 	) {
 		if ($crypto === null) {
-			$crypto = \OCP\Server::get(ICrypto::class);
+			$crypto = Server::get(ICrypto::class);
 		}
 		$this->crypto = $crypto;
 		$this->addType('appId', 'string');

--- a/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
+++ b/apps/webhook_listeners/tests/Db/WebhookListenerMapperTest.php
@@ -14,6 +14,7 @@ use OCA\WebhookListeners\Db\WebhookListenerMapper;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\ICacheFactory;
 use OCP\IDBConnection;
+use OCP\Server;
 use OCP\User\Events\UserCreatedEvent;
 use Test\TestCase;
 
@@ -28,8 +29,8 @@ class WebhookListenerMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OCP\Server::get(IDBConnection::class);
-		$this->cacheFactory = \OCP\Server::get(ICacheFactory::class);
+		$this->connection = Server::get(IDBConnection::class);
+		$this->cacheFactory = Server::get(ICacheFactory::class);
 		$this->pruneTables();
 
 		$this->mapper = new WebhookListenerMapper(

--- a/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
+++ b/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
@@ -5,6 +5,7 @@
  */
 namespace OCA\WorkflowEngine\Tests\Check;
 
+use OCA\WorkflowEngine\Check\AbstractStringCheck;
 use OCP\IL10N;
 
 class AbstractStringCheckTest extends \Test\TestCase {
@@ -55,7 +56,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 	public function testExecuteStringCheck($operation, $checkValue, $actualValue, $expected): void {
 		$check = $this->getCheckMock();
 
-		/** @var \OCA\WorkflowEngine\Check\AbstractStringCheck $check */
+		/** @var AbstractStringCheck $check */
 		$this->assertEquals($expected, $this->invokePrivate($check, 'executeStringCheck', [$operation, $checkValue, $actualValue]));
 	}
 
@@ -76,7 +77,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 	public function testValidateCheck($operator, $value): void {
 		$check = $this->getCheckMock();
 
-		/** @var \OCA\WorkflowEngine\Check\AbstractStringCheck $check */
+		/** @var AbstractStringCheck $check */
 		$check->validateCheck($operator, $value);
 
 		$this->addToAssertionCount(1);
@@ -102,7 +103,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		$check = $this->getCheckMock();
 
 		try {
-			/** @var \OCA\WorkflowEngine\Check\AbstractStringCheck $check */
+			/** @var AbstractStringCheck $check */
 			$check->validateCheck($operator, $value);
 		} catch (\UnexpectedValueException $e) {
 			$this->assertEquals($exceptionCode, $e->getCode());

--- a/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
+++ b/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
@@ -5,6 +5,7 @@
  */
 namespace OCA\WorkflowEngine\Tests\Check;
 
+use OCA\WorkflowEngine\Check\RequestRemoteAddress;
 use OCP\IL10N;
 use OCP\IRequest;
 
@@ -53,7 +54,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testExecuteCheckMatchesIPv4($value, $ip, $expected): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestRemoteAddress($this->getL10NMock(), $this->request);
+		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
 		$this->request->expects($this->once())
 			->method('getRemoteAddress')
@@ -69,7 +70,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testExecuteCheckNotMatchesIPv4($value, $ip, $expected): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestRemoteAddress($this->getL10NMock(), $this->request);
+		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
 		$this->request->expects($this->once())
 			->method('getRemoteAddress')
@@ -97,7 +98,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testExecuteCheckMatchesIPv6($value, $ip, $expected): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestRemoteAddress($this->getL10NMock(), $this->request);
+		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
 		$this->request->expects($this->once())
 			->method('getRemoteAddress')
@@ -113,7 +114,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testExecuteCheckNotMatchesIPv6($value, $ip, $expected): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestRemoteAddress($this->getL10NMock(), $this->request);
+		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
 		$this->request->expects($this->once())
 			->method('getRemoteAddress')

--- a/apps/workflowengine/tests/Check/RequestTimeTest.php
+++ b/apps/workflowengine/tests/Check/RequestTimeTest.php
@@ -5,6 +5,7 @@
  */
 namespace OCA\WorkflowEngine\Tests\Check;
 
+use OCA\WorkflowEngine\Check\RequestTime;
 use OCP\IL10N;
 
 class RequestTimeTest extends \Test\TestCase {
@@ -72,7 +73,7 @@ class RequestTimeTest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testExecuteCheckIn($value, $timestamp, $expected): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestTime($this->getL10NMock(), $this->timeFactory);
+		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 
 		$this->timeFactory->expects($this->once())
 			->method('getTime')
@@ -88,7 +89,7 @@ class RequestTimeTest extends \Test\TestCase {
 	 * @param bool $expected
 	 */
 	public function testExecuteCheckNotIn($value, $timestamp, $expected): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestTime($this->getL10NMock(), $this->timeFactory);
+		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 
 		$this->timeFactory->expects($this->once())
 			->method('getTime')
@@ -111,7 +112,7 @@ class RequestTimeTest extends \Test\TestCase {
 	 * @param string $value
 	 */
 	public function testValidateCheck($operator, $value): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestTime($this->getL10NMock(), $this->timeFactory);
+		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 		$check->validateCheck($operator, $value);
 		$this->addToAssertionCount(1);
 	}
@@ -136,7 +137,7 @@ class RequestTimeTest extends \Test\TestCase {
 	 * @param string $exceptionMessage
 	 */
 	public function testValidateCheckInvalid($operator, $value, $exceptionCode, $exceptionMessage): void {
-		$check = new \OCA\WorkflowEngine\Check\RequestTime($this->getL10NMock(), $this->timeFactory);
+		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 
 		try {
 			$check->validateCheck($operator, $value);

--- a/apps/workflowengine/tests/Check/RequestUserAgentTest.php
+++ b/apps/workflowengine/tests/Check/RequestUserAgentTest.php
@@ -5,6 +5,7 @@
  */
 namespace OCA\WorkflowEngine\Tests\Check;
 
+use OCA\WorkflowEngine\Check\AbstractStringCheck;
 use OCA\WorkflowEngine\Check\RequestUserAgent;
 use OCP\IL10N;
 use OCP\IRequest;
@@ -95,7 +96,7 @@ class RequestUserAgentTest extends TestCase {
 			->method('getHeader')
 			->willReturn($actualValue);
 
-		/** @var \OCA\WorkflowEngine\Check\AbstractStringCheck $check */
+		/** @var AbstractStringCheck $check */
 		$this->assertEquals($expected, $this->check->executeCheck($operation, $checkValue));
 	}
 }

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -56,8 +56,8 @@
   </file>
   <file src="apps/dav/appinfo/v1/publicwebdav.php">
     <InternalMethod>
-      <code><![CDATA[\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog)]]></code>
-      <code><![CDATA[\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false)]]></code>
+      <code><![CDATA[Filesystem::logWarningWhenAddingStorageWrapper($previousLog)]]></code>
+      <code><![CDATA[Filesystem::logWarningWhenAddingStorageWrapper(false)]]></code>
     </InternalMethod>
     <UndefinedGlobalVariable>
       <code><![CDATA[$baseuri]]></code>
@@ -407,7 +407,7 @@
       <code><![CDATA[new PreconditionFailed('Cannot filter by non-existing tag', 0, $e)]]></code>
     </TooManyArguments>
     <UndefinedClass>
-      <code><![CDATA[\OCA\Circles\Api\v1\Circles]]></code>
+      <code><![CDATA[Circles]]></code>
     </UndefinedClass>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getPath]]></code>
@@ -448,13 +448,13 @@
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
     <UndefinedClass>
-      <code><![CDATA[\OCA\Circles\Api\v1\Circles]]></code>
-      <code><![CDATA[\OCA\Circles\Api\v1\Circles]]></code>
+      <code><![CDATA[Circles]]></code>
+      <code><![CDATA[Circles]]></code>
     </UndefinedClass>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ServerFactory.php">
     <TooManyArguments>
-      <code><![CDATA[new \OCA\DAV\Connector\Sabre\QuotaPlugin($view, true)]]></code>
+      <code><![CDATA[new QuotaPlugin($view, true)]]></code>
     </TooManyArguments>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ShareTypeList.php">
@@ -684,7 +684,7 @@
   </file>
   <file src="apps/encryption/lib/Session.php">
     <TooManyArguments>
-      <code><![CDATA[new Exceptions\PrivateKeyMissingException('please try to log-out and log-in again', 0)]]></code>
+      <code><![CDATA[new PrivateKeyMissingException('please try to log-out and log-in again', 0)]]></code>
     </TooManyArguments>
   </file>
   <file src="apps/encryption/lib/Util.php">
@@ -871,8 +871,8 @@
       <code><![CDATA[(int)$code]]></code>
     </RedundantCast>
     <UndefinedClass>
-      <code><![CDATA[\OCA\Circles\Api\v1\Circles]]></code>
-      <code><![CDATA[\OCA\Circles\Api\v1\Circles]]></code>
+      <code><![CDATA[Circles]]></code>
+      <code><![CDATA[Circles]]></code>
     </UndefinedClass>
     <UndefinedDocblockClass>
       <code><![CDATA[$this->getRoomShareHelper()]]></code>

--- a/build/rector.php
+++ b/build/rector.php
@@ -7,9 +7,31 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use PhpParser\Node;
+use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
 use Rector\Config\RectorConfig;
+use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Rector\ValueObject\Application\File;
 
 $nextcloudDir = dirname(__DIR__);
+
+class NextcloudNamespaceSkipVoter implements ClassNameImportSkipVoterInterface {
+	private array $namespacePrefixes = [
+		'OC',
+		'OCA',
+		'OCP',
+	];
+	public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node) : bool {
+		foreach ($this->namespacePrefixes as $prefix) {
+			if (str_starts_with($fullyQualifiedObjectType->getClassName(), $prefix . '\\')) {
+				// Import Nextcloud namespaces
+				return false;
+			}
+		}
+		// Skip everything else
+		return true;
+	}
+}
 
 $config = RectorConfig::configure()
 	->withPaths([
@@ -30,9 +52,12 @@ $config = RectorConfig::configure()
 	])
 	// uncomment to reach your current PHP version
 	// ->withPhpSets()
+	->withImportNames(importShortClasses:false)
 	->withTypeCoverageLevel(0);
 
+$config->registerService(NextcloudNamespaceSkipVoter::class, tag:ClassNameImportSkipVoterInterface::class);
 
+/* Ignore all files ignored by git */
 $ignoredEntries = shell_exec('git status --porcelain --ignored ' . escapeshellarg($nextcloudDir));
 $ignoredEntries = explode("\n", $ignoredEntries);
 $ignoredEntries = array_filter($ignoredEntries, static fn (string $line) => str_starts_with($line, '!! '));

--- a/build/rector.php
+++ b/build/rector.php
@@ -21,7 +21,21 @@ class NextcloudNamespaceSkipVoter implements ClassNameImportSkipVoterInterface {
 		'OCA',
 		'OCP',
 	];
+	private array $skippedClassNames = [
+		'Backend',
+		'Connection',
+		'Exception',
+		'IManager',
+		'IProvider',
+		'Manager',
+		'Plugin',
+		'Provider',
+	];
 	public function shouldSkip(File $file, FullyQualifiedObjectType $fullyQualifiedObjectType, Node $node) : bool {
+		if (in_array($fullyQualifiedObjectType->getShortName(), $this->skippedClassNames)) {
+			// Skip common class names to avoid confusion
+			return true;
+		}
 		foreach ($this->namespacePrefixes as $prefix) {
 			if (str_starts_with($fullyQualifiedObjectType->getClassName(), $prefix . '\\')) {
 				// Import Nextcloud namespaces


### PR DESCRIPTION
## Summary

When using rector, fully qualified names are often outputted by the rules, like `\OCP\Server` or `\OCP\Http\Client\IClientService`. To avoid that, one can use `withImportNames()` to tell rector to import names with use statements, but then it will import all names.

This is not always desirable, for instance `\LDAP\Connection` in user_ldap would be confusing because there is an `\OCA\User_LDAP\Connection` class as well.

So I added a custom "SkipVoter" which skips auto-import for all classes outside of OC/OCA/OCP.

It may still be a bit confusing for common names like IManager, but I think we can live with that? Or I can add other exceptions if needed.
Note that rector is smart enough to not import two classes with the same name, but it will randomly import one of them and keep the fully qualified name for the other one.

I’m doing that so that when we apply Nextcloud rules set later we do not get fully qualified names everywhere but nice use statements instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
