### PR TITLE
fix(ShareAPI): Send mails for mail shares by default

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -659,7 +659,16 @@ class ShareAPIController extends OCSController {
 		$this->checkInheritedAttributes($share);
 
 		// Handle mail send
-		if ($sendMail === 'true' || $sendMail === 'false') {
+		if (is_null($sendMail)) {
+			// Define a default behavior when sendMail is not provided
+			if ($shareType === IShare::TYPE_EMAIL && strlen($shareWith) !== 0) {
+				// For email shares, the default is to send the mail
+				$share->setMailSend(true);
+			} else {
+				// For all other share types, the default is to not send the mail
+				$share->setMailSend(false);
+			}
+		} else {
 			$share->setMailSend($sendMail === 'true');
 		}
 


### PR DESCRIPTION
## Summary

It looks like, the frontend it needs to provide the `sendMail` param for the backend to decide whether mails would be sent.

Our UI does not have that at the moment so it should default to sending emails always for mail shares.

Not exactly sure how this was handled earlier but this is a good starting point.

Resolves : https://github.com/nextcloud/server/issues/48012


## Checklist

- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
