### PR TITLE
feat: configurable request timeout for carddav sync

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\CardDAV;
 
 use OCP\AppFramework\Db\TTransactional;
 use OCP\AppFramework\Http;
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -155,7 +156,7 @@ class SyncService {
 			'auth' => [$userName, $sharedSecret],
 			'body' => $this->buildSyncCollectionRequestBody($syncToken),
 			'headers' => ['Content-Type' => 'application/xml'],
-			'timeout' => $this->config->getSystemValueInt('carddav_sync_request_timeout', 30)
+			'timeout' => $this->config->getSystemValueInt('carddav_sync_request_timeout', IClient::DEFAULT_REQUEST_TIMEOUT)
 		];
 
 		$response = $client->request(

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -11,6 +11,7 @@ namespace OCA\DAV\CardDAV;
 use OCP\AppFramework\Db\TTransactional;
 use OCP\AppFramework\Http;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -33,13 +34,15 @@ class SyncService {
 	private Converter $converter;
 	protected string $certPath;
 	private IClientService $clientService;
+	private IConfig $config;
 
 	public function __construct(CardDavBackend $backend,
 		IUserManager $userManager,
 		IDBConnection $dbConnection,
 		LoggerInterface $logger,
 		Converter $converter,
-		IClientService $clientService) {
+		IClientService $clientService,
+		IConfig $config) {
 		$this->backend = $backend;
 		$this->userManager = $userManager;
 		$this->logger = $logger;
@@ -47,6 +50,7 @@ class SyncService {
 		$this->certPath = '';
 		$this->dbConnection = $dbConnection;
 		$this->clientService = $clientService;
+		$this->config = $config;
 	}
 
 	/**
@@ -150,7 +154,8 @@ class SyncService {
 		$options = [
 			'auth' => [$userName, $sharedSecret],
 			'body' => $this->buildSyncCollectionRequestBody($syncToken),
-			'headers' => ['Content-Type' => 'application/xml']
+			'headers' => ['Content-Type' => 'application/xml'],
+			'timeout' => $this->config->getSystemValueInt('carddav_sync_request_timeout', 30)
 		];
 
 		$response = $client->request(

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -16,6 +16,7 @@ use OCA\DAV\CardDAV\Converter;
 use OCA\DAV\CardDAV\SyncService;
 use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -33,6 +34,7 @@ class SyncServiceTest extends TestCase {
 	protected LoggerInterface $logger;
 	protected Converter $converter;
 	protected IClient $client;
+	protected IConfig $config;
 	protected SyncService $service;
 	public function setUp(): void {
 		$addressBook = [
@@ -53,6 +55,7 @@ class SyncServiceTest extends TestCase {
 		$this->logger = new NullLogger();
 		$this->converter = $this->createMock(Converter::class);
 		$this->client = $this->createMock(IClient::class);
+		$this->config = $this->createMock(IConfig::class);
 
 		$clientService = $this->createMock(IClientService::class);
 		$clientService->method('newClient')
@@ -64,7 +67,8 @@ class SyncServiceTest extends TestCase {
 			$this->dbConnection,
 			$this->logger,
 			$this->converter,
-			$clientService
+			$clientService,
+			$this->config
 		);
 	}
 
@@ -305,8 +309,9 @@ END:VCARD';
 		$logger = $this->getMockBuilder(LoggerInterface::class)->disableOriginalConstructor()->getMock();
 		$converter = $this->createMock(Converter::class);
 		$clientService = $this->createMock(IClientService::class);
+		$config = $this->createMock(IConfig::class);
 
-		$ss = new SyncService($backend, $userManager, $dbConnection, $logger, $converter, $clientService);
+		$ss = new SyncService($backend, $userManager, $dbConnection, $logger, $converter, $clientService, $config);
 		$ss->ensureSystemAddressBookExists('principals/users/adam', 'contacts', []);
 	}
 
@@ -360,8 +365,9 @@ END:VCARD';
 			->willReturn($this->createMock(VCard::class));
 
 		$clientService = $this->createMock(IClientService::class);
+		$config = $this->createMock(IConfig::class);
 
-		$ss = new SyncService($backend, $userManager, $dbConnection, $logger, $converter, $clientService);
+		$ss = new SyncService($backend, $userManager, $dbConnection, $logger, $converter, $clientService, $config);
 		$ss->updateUser($user);
 
 		$ss->updateUser($user);

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -341,6 +341,13 @@ $CONFIG = [
 'davstorage.request_timeout' => 30,
 
 /**
+ * The timeout in seconds for synchronizing address books, e.g. federated system address books (as run by `occ federation:sync-addressbooks`).
+ * 
+ * Defaults to ``30`` seconds
+ */
+'carddav_sync_request_timeout' => 30,
+
+/**
  * `true` enabled a relaxed session timeout, where the session timeout would no longer be
  * handled by Nextcloud but by either the PHP garbage collection or the expiration of
  * potential other session backends like redis.


### PR DESCRIPTION
Big federated setups may need a longer timeout, which they now can configure.

This is motivated by a debugging session, in which we had to raise the timeout but could do so only via a patch.

The default timeout length doesn't change with this PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
