### PR TITLE
fix(l10n): Fix list of RTL languages

### DIFF
--- a/build/translation-checker.php
+++ b/build/translation-checker.php
@@ -42,7 +42,6 @@ $rtlLanguages = [
 	'ps', // Pashto,
 	'ug', // 'Uyghurche / Uyghur
 	'ur_PK', // Urdu
-	'uz', // Uzbek Afghan
 ];
 
 $valid = 0;

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -68,7 +68,6 @@ class Factory implements IFactory {
 		'ps', // Pashto,
 		'ug', // 'Uyghurche / Uyghur
 		'ur_PK', // Urdu
-		'uz', // Uzbek Afghan
 	];
 
 	private ICache $cache;


### PR DESCRIPTION
- Uzbek Afghan is RTL but currently not translated.
- "Normal" Uzbek is LTR, so removing it from the list.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
