### PR TITLE
fix: use nc's binary finding logic for smb

### DIFF
--- a/apps/files_external/composer/composer/autoload_classmap.php
+++ b/apps/files_external/composer/composer/autoload_classmap.php
@@ -96,6 +96,7 @@ return array(
     'OCA\\Files_External\\Lib\\Storage\\SMB' => $baseDir . '/../lib/Lib/Storage/SMB.php',
     'OCA\\Files_External\\Lib\\Storage\\StreamWrapper' => $baseDir . '/../lib/Lib/Storage/StreamWrapper.php',
     'OCA\\Files_External\\Lib\\Storage\\Swift' => $baseDir . '/../lib/Lib/Storage/Swift.php',
+    'OCA\\Files_External\\Lib\\Storage\\SystemBridge' => $baseDir . '/../lib/Lib/Storage/SystemBridge.php',
     'OCA\\Files_External\\Lib\\VisibilityTrait' => $baseDir . '/../lib/Lib/VisibilityTrait.php',
     'OCA\\Files_External\\Listener\\GroupDeletedListener' => $baseDir . '/../lib/Listener/GroupDeletedListener.php',
     'OCA\\Files_External\\Listener\\LoadAdditionalListener' => $baseDir . '/../lib/Listener/LoadAdditionalListener.php',

--- a/apps/files_external/composer/composer/autoload_static.php
+++ b/apps/files_external/composer/composer/autoload_static.php
@@ -111,6 +111,7 @@ class ComposerStaticInitFiles_External
         'OCA\\Files_External\\Lib\\Storage\\SMB' => __DIR__ . '/..' . '/../lib/Lib/Storage/SMB.php',
         'OCA\\Files_External\\Lib\\Storage\\StreamWrapper' => __DIR__ . '/..' . '/../lib/Lib/Storage/StreamWrapper.php',
         'OCA\\Files_External\\Lib\\Storage\\Swift' => __DIR__ . '/..' . '/../lib/Lib/Storage/Swift.php',
+        'OCA\\Files_External\\Lib\\Storage\\SystemBridge' => __DIR__ . '/..' . '/../lib/Lib/Storage/SystemBridge.php',
         'OCA\\Files_External\\Lib\\VisibilityTrait' => __DIR__ . '/..' . '/../lib/Lib/VisibilityTrait.php',
         'OCA\\Files_External\\Listener\\GroupDeletedListener' => __DIR__ . '/..' . '/../lib/Listener/GroupDeletedListener.php',
         'OCA\\Files_External\\Listener\\LoadAdditionalListener' => __DIR__ . '/..' . '/../lib/Listener/LoadAdditionalListener.php',

--- a/apps/files_external/lib/Lib/Storage/SystemBridge.php
+++ b/apps/files_external/lib/Lib/Storage/SystemBridge.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Robin Appelman <robin@icewind.nl>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_External\Lib\Storage;
+
+use Icewind\SMB\System;
+use OCP\IBinaryFinder;
+
+/**
+ * Bridge the NC and SMB binary finding logic
+ */
+class SystemBridge extends System {
+	public function __construct(
+		private IBinaryFinder $binaryFinder,
+	) {
+	}
+
+	protected function getBinaryPath(string $binary): ?string {
+		$path = $this->binaryFinder->findBinaryPath($binary);
+		return $path !== false ? $path : null;
+	}
+}

--- a/lib/public/IBinaryFinder.php
+++ b/lib/public/IBinaryFinder.php
@@ -11,7 +11,7 @@ namespace OCP;
 /**
  * Service that find the binary path for a program.
  *
- * This interface should be injected via depency injection and must
+ * This interface should be injected via dependency injection and must
  * not be implemented in applications.
  *
  * @since 25.0.0


### PR DESCRIPTION
Bridge the nc and smb binary finding logic.

This should make the logic around finding the smb binaries less surprising.