### PR TITLE
fix(config): Suppress `config.php` fopen error at install time

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -186,7 +186,8 @@ class Config {
 				@opcache_invalidate($file, false);
 			}
 
-			$filePointer = @fopen($file, 'r');
+			// suppressor doesn't work here at boot time since it'll go via our onError custom error handler
+			$filePointer = file_exists($file) ? @fopen($file, 'r') : false;
 			if ($filePointer === false) {
 				// e.g. wrong permissions are set
 				if ($file === $this->configFilePath) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #45671 (config.php error not the second one in that report)
 
## Summary

The changes in #44230 brought back a regression from the OC days which is generating a non-operational error immediately after install time: 

owncloud/core#13736
owncloud/core#21923

```
{"reqId":"58mbKNITzcU0stL3faUH","level":3,"time":"2024-09-26T19:52:18+00:00","remoteAddr":"","user":"ncadmin","app":"PHP","method":"","url":"--","message":"fopen(/var/www/html/config/config.php): Failed to open stream: No such file or directory at /var/www/html/lib/private/Config.php#190","userAgent":"--","version":"30.0.0.14","data":{"app":"PHP"},"id":"66f5bc6a0d035"}
```

It becomes the very first log entry you see after a new install. While harmless from a technical standpoint, it is needless to say, not a great way for someone to be introduced to Nextcloud right after installation. And it gives the impression something is wrong, when it really isn't.

### Cause

At install time we use our `onError` error handler:

https://github.com/nextcloud/server/blob/341b31b1943943c4cb8cf0e48a5e6eb444949526/lib/base.php#L651

This handler lacks handling to exclude suppressors:

https://github.com/nextcloud/server/blob/341b31b1943943c4cb8cf0e48a5e6eb444949526/lib/private/Log/ErrorHandler.php#L53-L61

The easiest solution is simply to add back the `file_exists()` check here before we call `fopen()`.

### Additional thoughts

Despite this PR, I was tempted to add support in the `onError` handler for the suppressor. That way things behave in a standard way. If we want to suppress, it's been decided upon for a good reason. I took the approach here in this PR for now though because it seemed more conservative, by simply bringing back the `file_exists()` check and relying on that instead of the non-functioning suppressor. This PR should be sufficient though since there aren't currently any other known situations where the suppressor handling is an issue. If/when other spots with the suppressor pop up, we could reconsider.

## TODO


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
