### PR TITLE
fix: correctly count disabled users for subadmins

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -147,13 +147,13 @@ class UsersController extends Controller {
 				}, 0);
 			} else {
 				// User is subadmin !
-				// Map group list to names to retrieve the countDisabledUsersOfGroups
+				// Map group list to ids to retrieve the countDisabledUsersOfGroups
 				$userGroups = $this->groupManager->getUserGroups($user);
-				$groupsNames = [];
+				$groupsIds = [];
 
 				foreach ($groups as $key => $group) {
 					// $userCount += (int)$group['usercount'];
-					$groupsNames[] = $group['name'];
+					$groupsIds[] = $group['id'];
 					// we prevent subadmins from looking up themselves
 					// so we lower the count of the groups he belongs to
 					if (array_key_exists($group['id'], $userGroups)) {
@@ -163,7 +163,7 @@ class UsersController extends Controller {
 				}
 
 				$userCount += $this->userManager->countUsersOfGroups($groupsInfo->getGroups());
-				$disabledUsers = $this->userManager->countDisabledUsersOfGroups($groupsNames);
+				$disabledUsers = $this->userManager->countDisabledUsersOfGroups($groupsIds);
 			}
 
 			$userCount -= $disabledUsers;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

`countDisabledUsersOfGroups` expects array of groups ids, groups name were given instead. Due to this, users count might be faulty (usually name === id, but could be changed)

Before | After
-- | --
![image](https://github.com/user-attachments/assets/f233d5fe-b624-4afa-9e53-dc763a32f773) | ![image](https://github.com/user-attachments/assets/2539e558-c55b-4314-9d5e-7a7c823efd18)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
