### PR TITLE
fix(dav): Emit `BeforeZipCreatedEvent` when creating folder zip archive

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -28,39 +28,19 @@ use Psr\Log\LoggerInterface;
 use Sabre\DAV\Auth\Plugin;
 
 class ServerFactory {
-	private IConfig $config;
-	private LoggerInterface $logger;
-	private IDBConnection $databaseConnection;
-	private IUserSession $userSession;
-	private IMountManager $mountManager;
-	private ITagManager $tagManager;
-	private IRequest $request;
-	private IPreview $previewManager;
-	private IEventDispatcher $eventDispatcher;
-	private IL10N $l10n;
 
 	public function __construct(
-		IConfig $config,
-		LoggerInterface $logger,
-		IDBConnection $databaseConnection,
-		IUserSession $userSession,
-		IMountManager $mountManager,
-		ITagManager $tagManager,
-		IRequest $request,
-		IPreview $previewManager,
-		IEventDispatcher $eventDispatcher,
-		IL10N $l10n,
+		private IConfig $config,
+		private LoggerInterface $logger,
+		private IDBConnection $databaseConnection,
+		private IUserSession $userSession,
+		private IMountManager $mountManager,
+		private ITagManager $tagManager,
+		private IRequest $request,
+		private IPreview $previewManager,
+		private IEventDispatcher $eventDispatcher,
+		private IL10N $l10n,
 	) {
-		$this->config = $config;
-		$this->logger = $logger;
-		$this->databaseConnection = $databaseConnection;
-		$this->userSession = $userSession;
-		$this->mountManager = $mountManager;
-		$this->tagManager = $tagManager;
-		$this->request = $request;
-		$this->previewManager = $previewManager;
-		$this->eventDispatcher = $eventDispatcher;
-		$this->l10n = $l10n;
 	}
 
 	/**
@@ -80,7 +60,7 @@ class ServerFactory {
 		// Load plugins
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\MaintenancePlugin($this->config, $this->l10n));
 		$server->addPlugin(new BlockLegacyClientPlugin(
-			\OCP\Server::get(IConfig::class),
+			$this->config,
 			\OCP\Server::get(ThemingDefaults::class),
 		));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin());
@@ -90,11 +70,12 @@ class ServerFactory {
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin('webdav', $this->logger));
 		$server->addPlugin(new \OCA\DAV\Connector\Sabre\LockPlugin());
 
-		$server->addPlugin(new RequestIdHeaderPlugin(\OC::$server->get(IRequest::class)));
+		$server->addPlugin(new RequestIdHeaderPlugin($this->request));
 
 		$server->addPlugin(new ZipFolderPlugin(
 			$objectTree,
 			$this->logger,
+			$this->eventDispatcher,
 		));
 
 		// Some WebDAV clients do require Class 2 WebDAV support (locking), since

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -86,9 +86,9 @@ class Server {
 
 		$this->request = $request;
 		$this->baseUri = $baseUri;
-		$logger = \OC::$server->get(LoggerInterface::class);
-		/** @var IEventDispatcher $dispatcher */
-		$dispatcher = \OC::$server->get(IEventDispatcher::class);
+
+		$logger = \OCP\Server::get(LoggerInterface::class);
+		$eventDispatcher = \OCP\Server::get(IEventDispatcher::class);
 
 		$root = new RootCollection();
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
@@ -123,10 +123,10 @@ class Server {
 
 		// allow setup of additional auth backends
 		$event = new SabrePluginEvent($this->server);
-		$dispatcher->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
+		$eventDispatcher->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
 
 		$newAuthEvent = new SabrePluginAuthInitEvent($this->server);
-		$dispatcher->dispatchTyped($newAuthEvent);
+		$eventDispatcher->dispatchTyped($newAuthEvent);
 
 		$bearerAuthBackend = new BearerAuth(
 			\OC::$server->getUserSession(),
@@ -213,12 +213,13 @@ class Server {
 		$this->server->addPlugin(new ZipFolderPlugin(
 			$this->server->tree,
 			$logger,
+			$eventDispatcher,
 		));
 
 		// allow setup of additional plugins
-		$dispatcher->dispatch('OCA\DAV\Connector\Sabre::addPlugin', $event);
+		$eventDispatcher->dispatch('OCA\DAV\Connector\Sabre::addPlugin', $event);
 		$typedEvent = new SabrePluginAddEvent($this->server);
-		$dispatcher->dispatchTyped($typedEvent);
+		$eventDispatcher->dispatchTyped($typedEvent);
 
 		// Some WebDAV clients do require Class 2 WebDAV support (locking), since
 		// we do not provide locking we emulate it using a fake locking plugin.

--- a/lib/public/Files/Events/BeforeZipCreatedEvent.php
+++ b/lib/public/Files/Events/BeforeZipCreatedEvent.php
@@ -10,23 +10,45 @@ declare(strict_types=1);
 namespace OCP\Files\Events;
 
 use OCP\EventDispatcher\Event;
+use OCP\Files\Folder;
 
 /**
+ * This event is triggered before a archive is created when a user requested
+ * downloading a folder or multiple files.
+ *
+ * By setting `successful` to false the tar creation can be aborted and the download denied.
+ *
  * @since 25.0.0
  */
 class BeforeZipCreatedEvent extends Event {
 	private string $directory;
-	private array $files;
 	private bool $successful = true;
 	private ?string $errorMessage = null;
+	private ?Folder $folder = null;
 
 	/**
+	 * @param list<string> $files
 	 * @since 25.0.0
+	 * @since 31.0.0 support `OCP\Files\Folder` as `$directory` parameter - passing a string is deprecated now
 	 */
-	public function __construct(string $directory, array $files) {
+	public function __construct(
+		string|Folder $directory,
+		private array $files,
+	) {
 		parent::__construct();
-		$this->directory = $directory;
-		$this->files = $files;
+		if ($directory instanceof Folder) {
+			$this->directory = $directory->getPath();
+			$this->folder = $directory;
+		} else {
+			$this->directory = $directory;
+		}
+	}
+
+	/**
+	 * @since 31.0.0
+	 */
+	public function getFolder(): ?Folder {
+		return $this->folder;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

I have overseen this while implementing the zip folder DAV plugin.
This is required to not break behavior on zip download (apps should be able to react to zip download especially for shares).

(the event in server is pretty useless but apps might rely on it, also there is room for cleanup of all of that logic where I did now some preparation while touching it, will do in a followup the full cleanup soon).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
