### PR TITLE
fix(theming): Use `AppConfig` for setting background image

### DIFF
--- a/apps/theming/lib/Service/BackgroundService.php
+++ b/apps/theming/lib/Service/BackgroundService.php
@@ -18,6 +18,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\Lock\LockedException;
 use OCP\PreConditionNotMetException;
@@ -200,6 +201,7 @@ class BackgroundService {
 	public function __construct(
 		private IRootFolder $rootFolder,
 		private IAppData $appData,
+		private IAppConfig $appConfig,
 		private IConfig $config,
 		private ?string $userId,
 	) {
@@ -328,7 +330,7 @@ class BackgroundService {
 		if ($handle && $image->loadFromFileHandle($handle) !== false) {
 			$meanColor = $this->calculateMeanColor($image);
 			if ($meanColor !== false) {
-				$this->config->setAppValue(Application::APP_ID, 'background_color', $meanColor);
+				$this->appConfig->setValueString(Application::APP_ID, 'background_color', $meanColor);
 				return $meanColor;
 			}
 		}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1041,6 +1041,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$backgroundService = new BackgroundService(
 					$c->get(IRootFolder::class),
 					$c->getAppDataDir('theming'),
+					$c->get(IAppConfig::class),
 					$c->get(\OCP\IConfig::class),
 					$c->get(ISession::class)->get('user_id'),
 				);


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/48436

## Summary
We need to use the `AppConfig` consistently otherwise it will hard-fail like it does currently.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
