### PR TITLE
fix: Fix test of IConstructableStorage implentation by storage classes

### DIFF
--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -64,7 +64,7 @@ class ConfigAdapter implements IMountProvider {
 	 */
 	private function constructStorage(StorageConfig $storageConfig): IStorage {
 		$class = $storageConfig->getBackend()->getStorageClass();
-		if (!$class instanceof IConstructableStorage) {
+		if (!is_a($class, IConstructableStorage::class, true)) {
 			\OCP\Server::get(LoggerInterface::class)->warning('Building a storage not implementing IConstructableStorage is deprecated since 31.0.0', ['class' => $class]);
 		}
 		$storage = new $class($storageConfig->getBackendOptions());

--- a/lib/private/Files/Storage/StorageFactory.php
+++ b/lib/private/Files/Storage/StorageFactory.php
@@ -52,7 +52,7 @@ class StorageFactory implements IStorageFactory {
 	 * @return IStorage
 	 */
 	public function getInstance(IMountPoint $mountPoint, $class, $arguments): IStorage {
-		if (!($class instanceof IConstructableStorage)) {
+		if (!is_a($class, IConstructableStorage::class, true)) {
 			\OCP\Server::get(LoggerInterface::class)->warning('Building a storage not implementing IConstructableStorage is deprecated since 31.0.0', ['class' => $class]);
 		}
 		return $this->wrap($mountPoint, new $class($arguments));


### PR DESCRIPTION
## Summary

`instanceof` cannot work on string, we need to use `is_a`.
This fixes an erronous warning in the logs for classes implementing IConstructableStorage.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
