### PR TITLE
fix(psalm): Update baseline

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2764,16 +2764,6 @@
       <code><![CDATA[$appId === null]]></code>
     </TypeDoesNotContainNull>
   </file>
-  <file src="lib/private/legacy/OC_Files.php">
-    <RedundantCondition>
-      <code><![CDATA[$getType === self::ZIP_DIR]]></code>
-      <code><![CDATA[$getType === self::ZIP_DIR]]></code>
-    </RedundantCondition>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[get]]></code>
-      <code><![CDATA[get]]></code>
-    </UndefinedInterfaceMethod>
-  </file>
   <file src="lib/private/legacy/OC_Helper.php">
     <InvalidArrayOffset>
       <code><![CDATA[$matches[0][$last_match]]]></code>


### PR DESCRIPTION
## Summary

Caused by https://github.com/nextcloud/server/pull/48098, no idea why psalm wasn't red on there.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
