### PR TITLE
update docs for Folder.get and call for Folder.nodeExists

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1976,7 +1976,6 @@
   </file>
   <file src="lib/private/Files/Node/Folder.php">
     <LessSpecificReturnStatement>
-      <code><![CDATA[$this->root->get($this->getFullPath($path))]]></code>
       <code><![CDATA[array_map(function (FileInfo $file) {
 			return $this->createNode($file->getPath(), $file);
 		}, $files)]]></code>
@@ -1985,7 +1984,6 @@
       <code><![CDATA[$node]]></code>
     </MoreSpecificImplementedParamType>
     <MoreSpecificReturnType>
-      <code><![CDATA[\OC\Files\Node\Node]]></code>
       <code><![CDATA[\OC\Files\Node\Node[]]]></code>
     </MoreSpecificReturnType>
   </file>
@@ -2046,7 +2044,6 @@
   <file src="lib/private/Files/Node/Root.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$folders]]></code>
-      <code><![CDATA[$this->createNode($fullPath, $fileInfo, false)]]></code>
       <code><![CDATA[$this->mountManager->findByNumericId($numericId)]]></code>
       <code><![CDATA[$this->mountManager->findByStorageId($storageId)]]></code>
       <code><![CDATA[$this->mountManager->findIn($mountPoint)]]></code>
@@ -2054,7 +2051,6 @@
     </LessSpecificReturnStatement>
     <MoreSpecificReturnType>
       <code><![CDATA[MountPoint[]]]></code>
-      <code><![CDATA[Node]]></code>
       <code><![CDATA[\OC\Files\Mount\MountPoint[]]]></code>
       <code><![CDATA[\OC\Files\Mount\MountPoint[]]]></code>
       <code><![CDATA[\OC\User\User]]></code>

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -111,7 +111,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 		try {
 			$this->get($path);
 			return true;
-		} catch (NotFoundException $e) {
+		} catch (NotFoundException|NotPermittedException) {
 			return false;
 		}
 	}

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -103,21 +103,10 @@ class Folder extends Node implements \OCP\Files\Folder {
 		}
 	}
 
-	/**
-	 * Get the node at $path
-	 *
-	 * @param string $path
-	 * @return \OC\Files\Node\Node
-	 * @throws \OCP\Files\NotFoundException
-	 */
 	public function get($path) {
 		return $this->root->get($this->getFullPath($path));
 	}
 
-	/**
-	 * @param string $path
-	 * @return bool
-	 */
 	public function nodeExists($path) {
 		try {
 			$this->get($path);

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -134,9 +134,6 @@ class LazyFolder implements Folder {
 		$this->__call(__FUNCTION__, func_get_args());
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function get($path) {
 		return $this->getRootFolder()->get($this->getFullPath($path));
 	}
@@ -422,9 +419,6 @@ class LazyFolder implements Folder {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function nodeExists($path) {
 		return $this->__call(__FUNCTION__, func_get_args());
 	}

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -171,12 +171,6 @@ class Root extends Folder implements IRootFolder {
 		$this->mountManager->remove($mount);
 	}
 
-	/**
-	 * @param string $path
-	 * @return Node
-	 * @throws \OCP\Files\NotPermittedException
-	 * @throws \OCP\Files\NotFoundException
-	 */
 	public function get($path) {
 		$path = $this->normalizePath($path);
 		if ($this->isValidPath($path)) {

--- a/lib/public/Files/Folder.php
+++ b/lib/public/Files/Folder.php
@@ -60,6 +60,7 @@ interface Folder extends Node {
 	 * @param string $path relative path of the file or folder
 	 * @return \OCP\Files\Node
 	 * @throws \OCP\Files\NotFoundException
+	 * @throws \OCP\Files\NotPermittedException
 	 * @since 6.0.0
 	 */
 	public function get($path);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: Incomplete documentation for Folder.get

## Summary

The main implemention already documents it, now the interface does as well. The other `OCP/Files/Folder` implementations (Folder, LazyFolder) wrap IRootFolder and therefore will throw as well.  

https://github.com/nextcloud/server/blob/be87dec2d9a5f8ab311651c25a22d871a567d2d1/lib/private/Files/Node/Root.php#L174-L192


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
