### PR TITLE
ci: fail psalm when baseline update required

### DIFF
--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Show potential changes in Psalm baseline
         if: always()
-        run: git diff -- . ':!lib/composer'
+        run: git diff --exit-code -- . ':!lib/composer'
 
       - name: Upload Analysis results to GitHub
         if: always()
@@ -100,4 +100,4 @@ jobs:
 
       - name: Show potential changes in Psalm baseline
         if: always()
-        run: git diff -- . ':!lib/composer'
+        run: git diff --exit-code -- . ':!lib/composer'


### PR DESCRIPTION
## Summary

Psalm now fails when a baseline update is needed. 


## TODO

- [x] CI
- [x] No warning about invalid sarif file

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
