### PR TITLE
ci: Don't upload output of normal psalm to GitHub Security section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,9 +37,9 @@
 /apps/files_trashbin/src*         @skjnldsv
 
 # Security team
+/build/psalm-baseline-security.xml  @nickvergessen
 /resources/codesigning              @mgallien @miaulalala @nickvergessen
 /resources/config/ca-bundle.crt     @ChristophWurst @miaulalala @nickvergessen
-/.drone.yml                         @nickvergessen
 
 # Two-Factor Authentication
 # https://github.com/nextcloud/wg-two-factor-authentication#members

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -60,7 +60,11 @@ jobs:
         run: composer i
 
       - name: Psalm taint analysis
-        run: composer run psalm:security -- --threads=1 --monochrome --no-progress --output-format=github --report=results.sarif
+        run: composer run psalm:security -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline --report=results.sarif
+
+      - name: Show potential changes in Psalm baseline
+        if: always()
+        run: git diff --exit-code -- . ':!lib/composer'
 
       - name: Upload Security Analysis results to GitHub
         if: always()

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -34,7 +34,7 @@ jobs:
         run: composer i
 
       - name: Psalm
-        run: composer run psalm:ci -- --monochrome --no-progress --output-format=github --update-baseline --report=results.sarif
+        run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline --report=results.sarif
 
       - name: Show potential changes in Psalm baseline
         if: always()
@@ -66,7 +66,7 @@ jobs:
         run: composer i
 
       - name: Psalm taint analysis
-        run: composer run psalm:ci -- --monochrome --no-progress --output-format=github --report=results.sarif --taint-analysis --ignore-baseline
+        run: composer run psalm:security -- --threads=1 --monochrome --no-progress --output-format=github --report=results.sarif
 
       - name: Upload Security Analysis results to GitHub
         if: always()
@@ -96,7 +96,7 @@ jobs:
         run: composer i
 
       - name: Psalm
-        run: composer run psalm:ci -- -c psalm-ocp.xml --monochrome --no-progress --output-format=github --update-baseline
+        run: composer run psalm:ocp -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline
 
       - name: Show potential changes in Psalm baseline
         if: always()

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -34,17 +34,11 @@ jobs:
         run: composer i
 
       - name: Psalm
-        run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline --report=results.sarif
+        run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github --update-baseline
 
       - name: Show potential changes in Psalm baseline
         if: always()
         run: git diff --exit-code -- . ':!lib/composer'
-
-      - name: Upload Analysis results to GitHub
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
 
   static-code-analysis-security:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ Vagrantfile
 
 # Tests - auto-generated files
 /data-autotest
+/results.sarif
 /tests/.phpunit.result.cache
 /tests/coverage*
 /tests/css

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -103,7 +103,7 @@ Files: core/img/desktopapp.svg
 Copyright: 2016-2024 Nextcloud GmbH and Nextcloud contributors
 License: AGPL-3.0-or-later
 
-Files: build/psalm-baseline-ocp.xml build/psalm-baseline.xml build/stubs/xsl.php build/stubs/gd.php build/stubs/imagick.php build/stubs/intl.php build/stubs/IntlChar.php build/stubs/ldap.php build/stubs/memcached.php build/stubs/redis.php build/stubs/redis_cluster.php build/stubs/sftp.php build/stubs/ssh2.php build/stubs/apcu.php
+Files: build/psalm-baseline-ocp.xml build/psalm-baseline-security.xml build/psalm-baseline.xml build/stubs/xsl.php build/stubs/gd.php build/stubs/imagick.php build/stubs/intl.php build/stubs/IntlChar.php build/stubs/ldap.php build/stubs/memcached.php build/stubs/redis.php build/stubs/redis_cluster.php build/stubs/sftp.php build/stubs/ssh2.php build/stubs/apcu.php
 Copyright: 2020 Nextcloud GmbH and Nextcloud contributors
 License: AGPL-3.0-or-later
 

--- a/build/psalm-baseline-security.xml
+++ b/build/psalm-baseline-security.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+  <file src="apps/admin_audit/lib/Actions/Action.php">
+    <TaintedHtml>
+      <code><![CDATA[$params]]></code>
+    </TaintedHtml>
+  </file>
+  <file src="apps/files_external/lib/Config/ConfigAdapter.php">
+    <TaintedCallable>
+      <code><![CDATA[$objectClass]]></code>
+    </TaintedCallable>
+  </file>
+  <file src="apps/theming/lib/IconBuilder.php">
+    <TaintedFile>
+      <code><![CDATA[$appIcon]]></code>
+      <code><![CDATA[$imageFile]]></code>
+    </TaintedFile>
+  </file>
+  <file src="lib/base.php">
+    <TaintedHeader>
+      <code><![CDATA['Location: ' . $url]]></code>
+      <code><![CDATA['Location: ' . \OC::$WEBROOT . '/']]></code>
+    </TaintedHeader>
+  </file>
+  <file src="lib/private/App/InfoParser.php">
+    <TaintedFile>
+      <code><![CDATA[$file]]></code>
+    </TaintedFile>
+  </file>
+  <file src="lib/private/AppFramework/Utility/SimpleContainer.php">
+    <TaintedCallable>
+      <code><![CDATA[$name]]></code>
+    </TaintedCallable>
+  </file>
+  <file src="lib/private/Config.php">
+    <TaintedHtml>
+      <code><![CDATA[$this->cache]]></code>
+    </TaintedHtml>
+  </file>
+  <file src="lib/private/EventSource.php">
+    <TaintedHeader>
+      <code><![CDATA['Location: ' . \OC::$WEBROOT]]></code>
+    </TaintedHeader>
+  </file>
+  <file src="lib/private/Http/CookieHelper.php">
+    <TaintedHeader>
+      <code><![CDATA[$header]]></code>
+    </TaintedHeader>
+  </file>
+  <file src="lib/private/Installer.php">
+    <TaintedFile>
+      <code><![CDATA[$baseDir]]></code>
+    </TaintedFile>
+  </file>
+  <file src="lib/private/OCS/ApiHelper.php">
+    <TaintedHtml>
+      <code><![CDATA[$body]]></code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes>
+      <code><![CDATA[$body]]></code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="lib/private/Route/Router.php">
+    <TaintedCallable>
+      <code><![CDATA[$appNameSpace . '\\Controller\\' . basename($file->getPathname(), '.php')]]></code>
+    </TaintedCallable>
+  </file>
+  <file src="lib/private/ServerContainer.php">
+    <TaintedCallable>
+      <code><![CDATA[$applicationClassName]]></code>
+    </TaintedCallable>
+  </file>
+  <file src="lib/private/Session/CryptoWrapper.php">
+    <TaintedCookie>
+      <code><![CDATA[$this->passphrase]]></code>
+    </TaintedCookie>
+  </file>
+  <file src="lib/private/Setup.php">
+    <TaintedFile>
+      <code><![CDATA[$dataDir]]></code>
+    </TaintedFile>
+  </file>
+  <file src="lib/private/Setup/Sqlite.php">
+    <TaintedFile>
+      <code><![CDATA[$sqliteFile]]></code>
+    </TaintedFile>
+  </file>
+  <file src="lib/private/legacy/OC_Helper.php">
+    <TaintedFile>
+      <code><![CDATA[$dest]]></code>
+      <code><![CDATA[$dest]]></code>
+      <code><![CDATA[$dir]]></code>
+      <code><![CDATA[$dir]]></code>
+    </TaintedFile>
+  </file>
+  <file src="lib/private/legacy/OC_JSON.php">
+    <TaintedHeader>
+      <code><![CDATA['Location: ' . \OC::$WEBROOT]]></code>
+    </TaintedHeader>
+    <TaintedHtml>
+      <code><![CDATA[self::encode($data)]]></code>
+      <code><![CDATA[self::encode($data)]]></code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes>
+      <code><![CDATA[self::encode($data)]]></code>
+      <code><![CDATA[self::encode($data)]]></code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="lib/private/legacy/OC_Template.php">
+    <TaintedHtml>
+      <code><![CDATA[$exception->getTraceAsString()]]></code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes>
+      <code><![CDATA[$exception->getTraceAsString()]]></code>
+    </TaintedTextWithQuotes>
+  </file>
+  <file src="lib/public/DB/QueryBuilder/IQueryBuilder.php">
+    <TaintedSql>
+      <code><![CDATA[$column]]></code>
+    </TaintedSql>
+  </file>
+  <file src="lib/public/IDBConnection.php">
+    <TaintedSql>
+      <code><![CDATA[$sql]]></code>
+      <code><![CDATA[$sql]]></code>
+      <code><![CDATA[$sql]]></code>
+      <code><![CDATA[$sql]]></code>
+    </TaintedSql>
+  </file>
+  <file src="ocs-provider/index.php">
+    <TaintedHtml>
+      <code><![CDATA[$controller->buildProviderList()->render()]]></code>
+    </TaintedHtml>
+    <TaintedTextWithQuotes>
+      <code><![CDATA[$controller->buildProviderList()->render()]]></code>
+    </TaintedTextWithQuotes>
+  </file>
+</files>

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
 		"lint": "find . -name \\*.php -not -path './lib/composer/*' -not -path './build/stubs/*' -print0 | xargs -0 -n1 php -l",
 		"psalm": "psalm --no-cache --threads=$(nproc)",
 		"psalm:ocp": "psalm --no-cache --threads=$(nproc) -c psalm-ocp.xml",
-		"psalm:security": "psalm --no-cache --threads=$(nproc) --taint-analysis --ignore-baseline",
+		"psalm:security": "psalm --no-cache --threads=$(nproc) --taint-analysis --use-baseline=build/psalm-baseline-security.xml",
 		"psalm:update-baseline": "psalm --no-cache --threads=$(nproc) --update-baseline",
 		"serve": [
 			"Composer\\Config::disableProcessTimeout",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
 		"cs:check": "php-cs-fixer fix --dry-run --diff",
 		"lint": "find . -name \\*.php -not -path './lib/composer/*' -not -path './build/stubs/*' -print0 | xargs -0 -n1 php -l",
 		"psalm": "psalm --no-cache --threads=$(nproc)",
-		"psalm:ci": "psalm --no-cache --threads=1",
+		"psalm:ocp": "psalm --no-cache --threads=$(nproc) -c psalm-ocp.xml",
+		"psalm:security": "psalm --no-cache --threads=$(nproc) --taint-analysis --ignore-baseline",
 		"psalm:update-baseline": "psalm --no-cache --threads=$(nproc) --update-baseline",
 		"serve": [
 			"Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
## Summary

- Start tracking psalm:security baseline
- Fail CI when it increases
- Don't pollute GitHub security tab with normal psalm deprecations

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
