### PR TITLE
[taskprocessing] Include error message in tasks returned by the API

### DIFF
--- a/lib/public/TaskProcessing/Task.php
+++ b/lib/public/TaskProcessing/Task.php
@@ -266,6 +266,7 @@ final class Task implements \JsonSerializable {
 			'appId' => $this->getAppId(),
 			'input' => $this->getInput(),
 			'output' => $this->getOutput(),
+			'error_message' => $this->getErrorMessage(),
 			'customId' => $this->getCustomId(),
 			'completionExpectedAt' => $this->getCompletionExpectedAt()?->getTimestamp(),
 			'progress' => $this->getProgress(),


### PR DESCRIPTION
This will allow the frontend to display it in a few places.