### PR TITLE
refactor(Storage): Make all parameter types strong types

### DIFF
--- a/apps/dav/lib/Storage/PublicOwnerWrapper.php
+++ b/apps/dav/lib/Storage/PublicOwnerWrapper.php
@@ -25,7 +25,7 @@ class PublicOwnerWrapper extends Wrapper {
 		$this->owner = $arguments['owner'];
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		$owner = parent::getOwner($path);
 		if ($owner !== false) {
 			return $owner;

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -314,6 +314,10 @@ class DirectoryTest extends \Test\TestCase {
 			->method('getRelativePath')
 			->willReturn('/foo');
 
+		$this->info->expects($this->once())
+			->method('getInternalPath')
+			->willReturn('/foo');
+
 		$mountPoint->method('getMountPoint')
 			->willReturn('/user/files/mymountpoint');
 
@@ -357,6 +361,10 @@ class DirectoryTest extends \Test\TestCase {
 		$this->info->expects($this->once())
 			->method('getMountPoint')
 			->willReturn($mountPoint);
+
+		$this->info->expects($this->once())
+			->method('getInternalPath')
+			->willReturn('/foo');
 
 		$mountPoint->method('getMountPoint')
 			->willReturn('/user/files/mymountpoint');

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -59,11 +59,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$this->logger = Server::get(LoggerInterface::class);
 	}
 
-	/**
-	 * @param string $path
-	 * @return string correctly encoded path
-	 */
-	private function normalizePath($path): string {
+	private function normalizePath(string $path): string {
 		$path = trim($path, '/');
 
 		if (!$path) {
@@ -73,11 +69,11 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return $path;
 	}
 
-	private function isRoot($path): bool {
+	private function isRoot(string $path): bool {
 		return $path === '.';
 	}
 
-	private function cleanKey($path): string {
+	private function cleanKey(string $path): string {
 		if ($this->isRoot($path)) {
 			return '/';
 		}
@@ -90,7 +86,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		$this->filesCache = new CappedMemoryCache();
 	}
 
-	private function invalidateCache($key): void {
+	private function invalidateCache(string $key): void {
 		unset($this->objectCache[$key]);
 		$keys = array_keys($this->objectCache->getData());
 		$keyLength = strlen($key);
@@ -143,7 +139,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	 *
 	 * @throws \Exception
 	 */
-	private function doesDirectoryExist($path): bool {
+	private function doesDirectoryExist(string $path): bool {
 		if ($path === '.' || $path === '') {
 			return true;
 		}
@@ -185,7 +181,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	protected function remove($path): bool {
+	protected function remove(string $path): bool {
 		// remember fileType to reduce http calls
 		$fileType = $this->filetype($path);
 		if ($fileType === 'dir') {
@@ -197,7 +193,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -225,12 +221,12 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		return $this->filetype($path) !== false;
 	}
 
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->isRoot($path)) {
@@ -250,7 +246,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return $this->batchDelete();
 	}
 
-	private function batchDelete($path = null): bool {
+	private function batchDelete(?string $path = null): bool {
 		// TODO explore using https://docs.aws.amazon.com/aws-sdk-php/v3/api/class-Aws.S3.BatchDelete.html
 		$params = [
 			'Bucket' => $this->bucket
@@ -290,7 +286,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		try {
 			$content = iterator_to_array($this->getDirectoryContent($path));
 			return IteratorDirectory::wrap(array_map(function (array $item) {
@@ -301,7 +297,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -324,7 +320,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	 * When the information is already present (e.g. opendir has been called before)
 	 * this value is return. Otherwise a headObject is emitted.
 	 */
-	private function getContentLength($path): int {
+	private function getContentLength(string $path): int {
 		if (isset($this->filesCache[$path])) {
 			return (int)$this->filesCache[$path]['ContentLength'];
 		}
@@ -343,7 +339,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 	 * When the information is already present (e.g. opendir has been called before)
 	 * this value is return. Otherwise a headObject is emitted.
 	 */
-	private function getLastModified($path): string {
+	private function getLastModified(string $path): string {
 		if (isset($this->filesCache[$path])) {
 			return $this->filesCache[$path]['LastModified'];
 		}
@@ -356,7 +352,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return 'now';
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if (isset($this->filesCache[$path])) {
@@ -374,7 +370,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		$path = $this->normalizePath($path);
 
 		if ($this->isRoot($path)) {
@@ -402,7 +398,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		$type = $this->filetype($path);
 		if (!$type) {
 			return 0;
@@ -410,7 +406,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return $type === 'dir' ? Constants::PERMISSION_ALL : Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE;
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -431,7 +427,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$path = $this->normalizePath($path);
 
 		switch ($mode) {
@@ -489,7 +485,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return false;
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		if (is_null($mtime)) {
 			$mtime = time();
 		}
@@ -524,7 +520,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function copy($source, $target, $isFile = null): bool {
+	public function copy(string $source, string $target, ?bool $isFile = null): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -567,7 +563,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -605,7 +601,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return $this->id;
 	}
 
-	public function writeBack($tmpFile, $path): bool {
+	public function writeBack(string $tmpFile, string $path): bool {
 		try {
 			$source = fopen($tmpFile, 'r');
 			$this->writeObject($path, $source, $this->mimeDetector->detectPath($path));
@@ -629,7 +625,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		$path = $this->normalizePath($directory);
 
 		if ($this->isRoot($path)) {
@@ -726,7 +722,7 @@ class AmazonS3 extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		// for files we can get the proper mtime
 		if ($path !== '' && $object = $this->headObject($path)) {
 			$stat = $this->objectToMetaData($object);

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -82,7 +82,7 @@ class FTP extends Common {
 		return 'ftp::' . $this->username . '@' . $this->host . '/' . $this->root;
 	}
 
-	protected function buildPath($path): string {
+	protected function buildPath(string $path): string {
 		return rtrim($this->root . '/' . $path, '/');
 	}
 
@@ -94,7 +94,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		$result = $this->getConnection()->mdtm($this->buildPath($path));
 
 		if ($result === -1) {
@@ -126,7 +126,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function filesize($path): false|int|float {
+	public function filesize(string $path): false|int|float {
 		$result = $this->getConnection()->size($this->buildPath($path));
 		if ($result === -1) {
 			return false;
@@ -135,7 +135,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		if ($this->is_dir($path)) {
 			$result = $this->getConnection()->rmdir($this->buildPath($path));
 			// recursive rmdir support depends on the ftp server
@@ -151,10 +151,7 @@ class FTP extends Common {
 		}
 	}
 
-	/**
-	 * @param string $path
-	 */
-	private function recursiveRmDir($path): bool {
+	private function recursiveRmDir(string $path): bool {
 		$contents = $this->getDirectoryContent($path);
 		$result = true;
 		foreach ($contents as $content) {
@@ -177,7 +174,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		if (!$this->file_exists($path)) {
 			return false;
 		}
@@ -187,14 +184,14 @@ class FTP extends Common {
 		];
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		if ($path === '' || $path === '.' || $path === '/') {
 			return true;
 		}
 		return $this->filetype($path) !== false;
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		switch ($this->filetype($path)) {
 			case 'dir':
 				return $this->rmdir($path);
@@ -205,19 +202,19 @@ class FTP extends Common {
 		}
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		$files = $this->getConnection()->nlist($this->buildPath($path));
 		return IteratorDirectory::wrap($files);
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		if ($this->is_dir($path)) {
 			return false;
 		}
 		return $this->getConnection()->mkdir($this->buildPath($path)) !== false;
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		if ($path === '') {
 			return true;
 		}
@@ -229,11 +226,11 @@ class FTP extends Common {
 		}
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		return $this->filesize($path) !== false;
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		if ($this->is_dir($path)) {
 			return 'dir';
 		} elseif ($this->is_file($path)) {
@@ -243,7 +240,7 @@ class FTP extends Common {
 		}
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$useExisting = true;
 		switch ($mode) {
 			case 'r':
@@ -309,7 +306,7 @@ class FTP extends Common {
 		return $stream;
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		if ($this->file_exists($path)) {
 			return false;
 		} else {
@@ -318,12 +315,12 @@ class FTP extends Common {
 		}
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$this->unlink($target);
 		return $this->getConnection()->rename($this->buildPath($source), $this->buildPath($target));
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		$files = $this->getConnection()->mlsd($this->buildPath($directory));
 		$mimeTypeDetector = \OC::$server->getMimeTypeDetector();
 

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -39,7 +39,7 @@ class SFTP extends Common {
 	 * @param string $host protocol://server:port
 	 * @return array [$server, $port]
 	 */
-	private function splitHost($host): array {
+	private function splitHost(string $host): array {
 		$input = $host;
 		if (!str_contains($host, '://')) {
 			// add a protocol to fix parse_url behavior with ipv6
@@ -163,10 +163,7 @@ class SFTP extends Common {
 		return $this->user;
 	}
 
-	/**
-	 * @param string $path
-	 */
-	private function absPath($path): string {
+	private function absPath(string $path): string {
 		return $this->root . $this->cleanPath($path);
 	}
 
@@ -185,7 +182,7 @@ class SFTP extends Common {
 		return false;
 	}
 
-	protected function writeHostKeys($keys): bool {
+	protected function writeHostKeys(array $keys): bool {
 		try {
 			$keyPath = $this->hostKeysPath();
 			if ($keyPath && file_exists($keyPath)) {
@@ -224,7 +221,7 @@ class SFTP extends Common {
 		return [];
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		try {
 			return $this->getConnection()->mkdir($this->absPath($path));
 		} catch (\Exception $e) {
@@ -232,7 +229,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		try {
 			$result = $this->getConnection()->delete($this->absPath($path), true);
 			// workaround: stray stat cache entry when deleting empty folders
@@ -244,7 +241,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		try {
 			$list = $this->getConnection()->nlist($this->absPath($path));
 			if ($list === false) {
@@ -264,7 +261,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		try {
 			$stat = $this->getConnection()->stat($this->absPath($path));
 			if (!is_array($stat) || !array_key_exists('type', $stat)) {
@@ -282,7 +279,7 @@ class SFTP extends Common {
 		return false;
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		try {
 			return $this->getConnection()->stat($this->absPath($path)) !== false;
 		} catch (\Exception $e) {
@@ -290,7 +287,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		try {
 			return $this->getConnection()->delete($this->absPath($path), true);
 		} catch (\Exception $e) {
@@ -298,7 +295,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		try {
 			$absPath = $this->absPath($path);
 			$connection = $this->getConnection();
@@ -339,7 +336,7 @@ class SFTP extends Common {
 		return false;
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		try {
 			if (!is_null($mtime)) {
 				return false;
@@ -356,15 +353,13 @@ class SFTP extends Common {
 	}
 
 	/**
-	 * @param string $path
-	 * @param string $target
 	 * @throws \Exception
 	 */
-	public function getFile($path, $target): void {
+	public function getFile(string $path, string $target): void {
 		$this->getConnection()->get($path, $target);
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		try {
 			if ($this->file_exists($target)) {
 				$this->unlink($target);
@@ -381,7 +376,7 @@ class SFTP extends Common {
 	/**
 	 * @return array{mtime: int, size: int, ctime: int}|false
 	 */
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		try {
 			$stat = $this->getConnection()->stat($this->absPath($path));
 
@@ -398,10 +393,7 @@ class SFTP extends Common {
 		}
 	}
 
-	/**
-	 * @param string $path
-	 */
-	public function constructUrl($path): string {
+	public function constructUrl(string $path): string {
 		// Do not pass the password here. We want to use the Net_SFTP object
 		// supplied via stream context or fail. We only supply username and
 		// hostname because this might show up in logs (they are not used).
@@ -409,7 +401,7 @@ class SFTP extends Common {
 		return $url;
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		/** @psalm-suppress InternalMethod */
 		$result = $this->getConnection()->put($this->absPath($path), $data);
 		if ($result) {
@@ -441,7 +433,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		if ($this->is_dir($source) || $this->is_dir($target)) {
 			return parent::copy($source, $target);
 		} else {
@@ -468,7 +460,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		$stat = $this->getConnection()->stat($this->absPath($path));
 		if (!$stat) {
 			return 0;
@@ -480,7 +472,7 @@ class SFTP extends Common {
 		}
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		$stat = $this->getConnection()->stat($this->absPath($path));
 		if (!$stat) {
 			return null;

--- a/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPReadStream.php
@@ -44,10 +44,9 @@ class SFTPReadStream implements File {
 	/**
 	 * Load the source from the stream context and return the context options
 	 *
-	 * @param string $name
 	 * @throws \BadMethodCallException
 	 */
-	protected function loadContext($name) {
+	protected function loadContext(string $name) {
 		$context = stream_context_get_options($this->context);
 		if (isset($context[$name])) {
 			$context = $context[$name];
@@ -146,7 +145,7 @@ class SFTPReadStream implements File {
 		return $data;
 	}
 
-	private function request_chunk($size) {
+	private function request_chunk(int $size) {
 		if ($this->pendingRead) {
 			$this->sftp->_get_sftp_packet();
 		}

--- a/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
+++ b/apps/files_external/lib/Lib/Storage/SFTPWriteStream.php
@@ -42,10 +42,9 @@ class SFTPWriteStream implements File {
 	/**
 	 * Load the source from the stream context and return the context options
 	 *
-	 * @param string $name
 	 * @throws \BadMethodCallException
 	 */
-	protected function loadContext($name) {
+	protected function loadContext(string $name) {
 		$context = stream_context_get_options($this->context);
 		if (isset($context[$name])) {
 			$context = $context[$name];

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -120,7 +120,7 @@ class SMB extends Common implements INotifyStorage {
 		parent::__construct($params);
 	}
 
-	private function splitUser($user): array {
+	private function splitUser(string $user): array {
 		if (str_contains($user, '/')) {
 			return explode('/', $user, 2);
 		} elseif (str_contains($user, '\\')) {
@@ -137,14 +137,11 @@ class SMB extends Common implements INotifyStorage {
 		return 'smb::' . $this->server->getAuth()->getUsername() . '@' . $this->server->getHost() . '//' . $this->share->getName() . '/' . $this->root;
 	}
 
-	/**
-	 * @param string $path
-	 */
-	protected function buildPath($path): string {
+	protected function buildPath(string $path): string {
 		return Filesystem::normalizePath($this->root . '/' . $path, true, false, true);
 	}
 
-	protected function relativePath($fullPath): ?string {
+	protected function relativePath(string $fullPath): ?string {
 		if ($fullPath === $this->root) {
 			return '';
 		} elseif (substr($fullPath, 0, strlen($this->root)) === $this->root) {
@@ -155,12 +152,11 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	/**
-	 * @param string $path
 	 * @throws StorageAuthException
 	 * @throws \OCP\Files\NotFoundException
 	 * @throws \OCP\Files\ForbiddenException
 	 */
-	protected function getFileInfo($path): IFileInfo {
+	protected function getFileInfo(string $path): IFileInfo {
 		try {
 			$path = $this->buildPath($path);
 			$cached = $this->statCache[$path] ?? null;
@@ -186,7 +182,6 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	/**
-	 * @param \Exception $e
 	 * @throws StorageAuthException
 	 */
 	protected function throwUnavailable(\Exception $e): never {
@@ -196,8 +191,6 @@ class SMB extends Common implements INotifyStorage {
 
 	/**
 	 * get the acl from fileinfo that is relevant for the configured user
-	 *
-	 * @param IFileInfo $file
 	 */
 	private function getACL(IFileInfo $file): ?ACL {
 		$acls = $file->getAcls();
@@ -212,11 +205,10 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	/**
-	 * @param string $path
 	 * @return \Generator<IFileInfo>
 	 * @throws StorageNotAvailableException
 	 */
-	protected function getFolderContents($path): iterable {
+	protected function getFolderContents(string $path): iterable {
 		try {
 			$path = ltrim($this->buildPath($path), '/');
 			try {
@@ -267,10 +259,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	/**
-	 * @param IFileInfo $info
-	 */
-	protected function formatInfo($info): array {
+	protected function formatInfo(IFileInfo $info): array {
 		$result = [
 			'size' => $info->getSize(),
 			'mtime' => $info->getMTime(),
@@ -289,7 +278,7 @@ class SMB extends Common implements INotifyStorage {
 	 * @param string $source the old name of the path
 	 * @param string $target the new name of the path
 	 */
-	public function rename($source, $target, $retry = true): bool {
+	public function rename(string $source, string $target, bool $retry = true): bool {
 		if ($this->isRootDir($source) || $this->isRootDir($target)) {
 			return false;
 		}
@@ -328,7 +317,7 @@ class SMB extends Common implements INotifyStorage {
 		return $result;
 	}
 
-	public function stat($path, $retry = true): array|false {
+	public function stat(string $path, bool $retry = true): array|false {
 		try {
 			$result = $this->formatInfo($this->getFileInfo($path));
 		} catch (\OCP\Files\ForbiddenException $e) {
@@ -370,10 +359,8 @@ class SMB extends Common implements INotifyStorage {
 
 	/**
 	 * Check if the path is our root dir (not the smb one)
-	 *
-	 * @param string $path the path
 	 */
-	private function isRootDir($path): bool {
+	private function isRootDir(string $path): bool {
 		return $path === '' || $path === '/' || $path === '.';
 	}
 
@@ -384,10 +371,7 @@ class SMB extends Common implements INotifyStorage {
 		return $this->share->getName() && (!$this->root || $this->root === '/');
 	}
 
-	/**
-	 * @param string $path
-	 */
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		if ($this->isRootDir($path)) {
 			return false;
 		}
@@ -413,11 +397,8 @@ class SMB extends Common implements INotifyStorage {
 
 	/**
 	 * check if a file or folder has been updated since $time
-	 *
-	 * @param string $path
-	 * @param int $time
 	 */
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		if (!$path and $this->root === '/') {
 			// mtime doesn't work for shares, but giving the nature of the backend,
 			// doing a full update is still just fast enough
@@ -429,11 +410,9 @@ class SMB extends Common implements INotifyStorage {
 	}
 
 	/**
-	 * @param string $path
-	 * @param string $mode
 	 * @return resource|false
 	 */
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$fullPath = $this->buildPath($path);
 		try {
 			switch ($mode) {
@@ -497,7 +476,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		if ($this->isRootDir($path)) {
 			return false;
 		}
@@ -524,7 +503,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		try {
 			if (!$this->file_exists($path)) {
 				$fh = $this->share->write($this->buildPath($path));
@@ -540,7 +519,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		try {
 			$fileInfo = $this->getFileInfo($path);
 		} catch (\OCP\Files\NotFoundException $e) {
@@ -585,7 +564,7 @@ class SMB extends Common implements INotifyStorage {
 		return $data;
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		try {
 			$files = $this->getFolderContents($path);
 		} catch (NotFoundException $e) {
@@ -600,7 +579,7 @@ class SMB extends Common implements INotifyStorage {
 		return IteratorDirectory::wrap($names);
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		try {
 			$files = $this->getFolderContents($directory);
 			foreach ($files as $file) {
@@ -613,7 +592,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		try {
 			return $this->getFileInfo($path)->isDirectory() ? 'dir' : 'file';
 		} catch (\OCP\Files\NotFoundException $e) {
@@ -623,7 +602,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		$path = $this->buildPath($path);
 		try {
 			$this->share->mkdir($path);
@@ -636,7 +615,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		try {
 			// Case sensitive filesystem doesn't matter for root directory
 			if ($this->caseSensitive === false && $path !== '') {
@@ -660,7 +639,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		try {
 			$info = $this->getFileInfo($path);
 			return $this->showHidden || !$info->isHidden();
@@ -671,7 +650,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		try {
 			$info = $this->getFileInfo($path);
 			// following windows behaviour for read-only folders: they can be written into
@@ -684,7 +663,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		try {
 			$info = $this->getFileInfo($path);
 			return ($this->showHidden || !$info->isHidden()) && !$info->isReadOnly();
@@ -716,7 +695,7 @@ class SMB extends Common implements INotifyStorage {
 		}
 	}
 
-	public function listen($path, callable $callback): void {
+	public function listen(string $path, callable $callback): void {
 		$this->notify($path)->listen(function (IChange $change) use ($callback) {
 			if ($change instanceof IRenameChange) {
 				return $callback($change->getType(), $change->getPath(), $change->getTargetPath());
@@ -726,7 +705,7 @@ class SMB extends Common implements INotifyStorage {
 		});
 	}
 
-	public function notify($path): SMBNotifyHandler {
+	public function notify(string $path): SMBNotifyHandler {
 		$path = '/' . ltrim($path, '/');
 		$shareNotifyHandler = $this->share->notify($this->buildPath($path));
 		return new SMBNotifyHandler($shareNotifyHandler, $this->root);

--- a/apps/files_external/lib/Lib/Storage/StreamWrapper.php
+++ b/apps/files_external/lib/Lib/Storage/StreamWrapper.php
@@ -8,17 +8,13 @@ namespace OCA\Files_External\Lib\Storage;
 
 abstract class StreamWrapper extends \OC\Files\Storage\Common {
 
-	/**
-	 * @param string $path
-	 * @return string|null
-	 */
-	abstract public function constructUrl($path): ?string;
+	abstract public function constructUrl(string $path): ?string;
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		return mkdir($this->constructUrl($path));
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		if ($this->is_dir($path) && $this->isDeletable($path)) {
 			$dh = $this->opendir($path);
 			if (!is_resource($dh)) {
@@ -40,19 +36,19 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		return opendir($this->constructUrl($path));
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		return @filetype($this->constructUrl($path));
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		return file_exists($this->constructUrl($path));
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$url = $this->constructUrl($path);
 		$success = unlink($url);
 		// normally unlink() is supposed to do this implicitly,
@@ -61,11 +57,11 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common {
 		return $success;
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		return fopen($this->constructUrl($path), $mode);
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		if ($this->file_exists($path)) {
 			if (is_null($mtime)) {
 				$fh = $this->fopen($path, 'a');
@@ -82,26 +78,19 @@ abstract class StreamWrapper extends \OC\Files\Storage\Common {
 		}
 	}
 
-	/**
-	 * @param string $path
-	 * @param string $target
-	 */
-	public function getFile($path, $target): bool {
+	public function getFile(string $path, string $target): bool {
 		return copy($this->constructUrl($path), $target);
 	}
 
-	/**
-	 * @param string $target
-	 */
-	public function uploadFile($path, $target): bool {
+	public function uploadFile(string $path, string $target): bool {
 		return copy($path, $this->constructUrl($target));
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		return rename($this->constructUrl($source), $this->constructUrl($target));
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		return stat($this->constructUrl($path));
 	}
 }

--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -71,19 +71,11 @@ class Swift extends \OC\Files\Storage\Common {
 	public const SUBCONTAINER_FILE = '.subcontainers';
 
 	/**
-	 * translate directory path to container name
-	 *
-	 * @param string $path
-	 * @return string
-	 */
-
-	/**
 	 * Fetches an object from the API.
 	 * If the object is cached already or a
 	 * failed "doesn't exist" response was cached,
 	 * that one will be returned.
 	 *
-	 * @param string $path
 	 * @return StorageObject|false object
 	 *                             or false if the object did not exist
 	 * @throws \OCP\Files\StorageAuthException
@@ -116,13 +108,11 @@ class Swift extends \OC\Files\Storage\Common {
 	/**
 	 * Returns whether the given path exists.
 	 *
-	 * @param string $path
-	 *
 	 * @return bool true if the object exist, false otherwise
 	 * @throws \OCP\Files\StorageAuthException
 	 * @throws \OCP\Files\StorageNotAvailableException
 	 */
-	private function doesObjectExist($path): bool {
+	private function doesObjectExist(string $path): bool {
 		return $this->fetchObject($path) !== false;
 	}
 
@@ -176,7 +166,7 @@ class Swift extends \OC\Files\Storage\Common {
 		$this->mimeDetector = \OC::$server->get(IMimeTypeDetector::class);
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -207,7 +197,7 @@ class Swift extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($path !== '.' && $this->is_dir($path)) {
@@ -217,7 +207,7 @@ class Swift extends \OC\Files\Storage\Common {
 		return $this->doesObjectExist($path);
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if (!$this->is_dir($path) || !$this->isDeletable($path)) {
@@ -251,7 +241,7 @@ class Swift extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		$path = $this->normalizePath($path);
 
 		if ($path === '.') {
@@ -287,7 +277,7 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		$path = $this->normalizePath($path);
 
 		if ($path === '.') {
@@ -327,7 +317,7 @@ class Swift extends \OC\Files\Storage\Common {
 		return $stat;
 	}
 
-	public function filetype($path) {
+	public function filetype(string $path) {
 		$path = $this->normalizePath($path);
 
 		if ($path !== '.' && $this->doesObjectExist($path)) {
@@ -343,7 +333,7 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$path = $this->normalizePath($path);
 
 		if ($this->is_dir($path)) {
@@ -367,7 +357,7 @@ class Swift extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$path = $this->normalizePath($path);
 
 		switch ($mode) {
@@ -417,7 +407,7 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		$path = $this->normalizePath($path);
 		if (is_null($mtime)) {
 			$mtime = time();
@@ -447,7 +437,7 @@ class Swift extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -508,7 +498,7 @@ class Swift extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 
@@ -555,7 +545,7 @@ class Swift extends \OC\Files\Storage\Common {
 		return $this->container;
 	}
 
-	public function writeBack($tmpFile, $path): void {
+	public function writeBack(string $tmpFile, string $path): void {
 		$fileData = fopen($tmpFile, 'r');
 		$this->objectStore->writeObject($path, $fileData, $this->mimeDetector->detectPath($path));
 		// invalidate target object to force repopulation on fetch
@@ -563,7 +553,7 @@ class Swift extends \OC\Files\Storage\Common {
 		unlink($tmpFile);
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		if ($this->is_file($path)) {
 			return parent::hasUpdated($path, $time);
 		}

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -24,6 +24,7 @@ use OCP\Files\Cache\IWatcher;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IDisableEncryptionStorage;
 use OCP\Files\Storage\IReliableEtagStorage;
+use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\Http\Client\IClientService;
@@ -94,7 +95,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		);
 	}
 
-	public function getWatcher($path = '', $storage = null): IWatcher {
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -129,14 +130,14 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return 'shared::' . md5($this->token . '@' . $this->getRemote());
 	}
 
-	public function getCache($path = '', $storage = null): ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache {
 		if (is_null($this->cache)) {
 			$this->cache = new Cache($this, $this->cloudId);
 		}
 		return $this->cache;
 	}
 
-	public function getScanner($path = '', $storage = null): IScanner {
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -147,7 +148,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return $this->scanner;
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		// since for owncloud webdav servers we can rely on etag propagation we only need to check the root of the storage
 		// because of that we only do one check for the entire storage per request
 		if ($this->updateChecked) {
@@ -217,7 +218,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		}
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		if ($path === '') {
 			return true;
 		} else {
@@ -322,18 +323,18 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return json_decode($response->getBody(), true);
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		return $this->cloudId->getDisplayId();
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		if (\OCP\Util::isSharingDisabledForUser() || !\OC\Share\Share::isResharingAllowed()) {
 			return false;
 		}
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_SHARE);
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		$response = $this->propfind($path);
 		if ($response === false) {
 			return 0;
@@ -408,7 +409,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		return $permissions;
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		return parent::free_space('');
 	}
 

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -202,7 +202,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		self::$initDepth--;
 	}
 
-	public function instanceOfStorage($class): bool {
+	public function instanceOfStorage(string $class): bool {
 		if ($class === '\OC\Files\Storage\Common' || $class == Common::class) {
 			return true;
 		}
@@ -234,7 +234,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return 'shared::' . $this->getMountPoint();
 	}
 
-	public function getPermissions($path = ''): int {
+	public function getPermissions(string $path = ''): int {
 		if (!$this->isValid()) {
 			return 0;
 		}
@@ -252,11 +252,11 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return $permissions;
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_CREATE);
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		if (!$this->isValid()) {
 			return false;
 		}
@@ -269,22 +269,22 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return $storage->isReadable($internalPath);
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_UPDATE);
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_DELETE);
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		if (\OCP\Util::isSharingDisabledForUser() || !\OC\Share\Share::isResharingAllowed()) {
 			return false;
 		}
 		return (bool)($this->getPermissions($path) & \OCP\Constants::PERMISSION_SHARE);
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$source = $this->getUnjailedPath($path);
 		switch ($mode) {
 			case 'r+':
@@ -336,7 +336,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return $this->nonMaskedStorage->fopen($this->getUnjailedPath($path), $mode);
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$this->init();
 		$isPartFile = pathinfo($source, PATHINFO_EXTENSION) === 'part';
 		$targetExists = $this->file_exists($target);
@@ -364,10 +364,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return $this->superShare->getTarget();
 	}
 
-	/**
-	 * @param string $path
-	 */
-	public function setMountPoint($path): void {
+	public function setMountPoint(string $path): void {
 		$this->superShare->setTarget($path);
 
 		foreach ($this->groupedShares as $share) {
@@ -397,7 +394,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return $this->superShare->getNodeType();
 	}
 
-	public function getCache($path = '', $storage = null): ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache {
 		if ($this->cache) {
 			return $this->cache;
 		}
@@ -418,18 +415,18 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return $this->cache;
 	}
 
-	public function getScanner($path = '', $storage = null): IScanner {
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return new \OCA\Files_Sharing\Scanner($storage);
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		return $this->superShare->getShareOwner();
 	}
 
-	public function getWatcher($path = '', $storage = null): IWatcher {
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher {
 		if ($this->watcher) {
 			return $this->watcher;
 		}
@@ -467,7 +464,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return true;
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider): void {
+	public function acquireLock(string $path, int $type, ILockingProvider $provider): void {
 		/** @var ILockingStorage $targetStorage */
 		[$targetStorage, $targetInternalPath] = $this->resolvePath($path);
 		$targetStorage->acquireLock($targetInternalPath, $type, $provider);
@@ -478,7 +475,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		}
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider): void {
+	public function releaseLock(string $path, int $type, ILockingProvider $provider): void {
 		/** @var ILockingStorage $targetStorage */
 		[$targetStorage, $targetInternalPath] = $this->resolvePath($path);
 		$targetStorage->releaseLock($targetInternalPath, $type, $provider);
@@ -489,7 +486,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		}
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider): void {
+	public function changeLock(string $path, int $type, ILockingProvider $provider): void {
 		/** @var ILockingStorage $targetStorage */
 		[$targetStorage, $targetInternalPath] = $this->resolvePath($path);
 		$targetStorage->changeLock($targetInternalPath, $type, $provider);
@@ -503,7 +500,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		];
 	}
 
-	public function setAvailability($isAvailable): void {
+	public function setAvailability(bool $isAvailable): void {
 		// shares do not participate in availability logic
 	}
 
@@ -527,7 +524,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return $this->storage;
 	}
 
-	public function file_get_contents($path): string|false {
+	public function file_get_contents(string $path): string|false {
 		$info = [
 			'target' => $this->getMountPoint() . '/' . $path,
 			'source' => $this->getUnjailedPath($path),
@@ -536,7 +533,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return parent::file_get_contents($path);
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		$info = [
 			'target' => $this->getMountPoint() . '/' . $path,
 			'source' => $this->getUnjailedPath($path),
@@ -545,15 +542,12 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 		return parent::file_put_contents($path, $data);
 	}
 
-	/**
-	 * @return void
-	 */
-	public function setMountOptions(array $options) {
+	public function setMountOptions(array $options): void {
 		/* Note: This value is never read */
 		$this->mountOptions = $options;
 	}
 
-	public function getUnjailedPath($path): string {
+	public function getUnjailedPath(string $path): string {
 		$this->init();
 		return parent::getUnjailedPath($path);
 	}

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -109,7 +109,7 @@ class TestSharingExternalStorage extends \OCA\Files_Sharing\External\Storage {
 		return $this->createBaseUri();
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		if ($path === '') {
 			return ['key' => 'value'];
 		}

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -48,7 +48,7 @@ class Storage extends Wrapper {
 		parent::__construct($parameters);
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		if ($this->trashEnabled) {
 			try {
 				return $this->doDelete($path, 'unlink');
@@ -65,7 +65,7 @@ class Storage extends Wrapper {
 		}
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		if ($this->trashEnabled) {
 			return $this->doDelete($path, 'rmdir');
 		} else {
@@ -76,11 +76,8 @@ class Storage extends Wrapper {
 	/**
 	 * check if it is a file located in data/user/files only files in the
 	 * 'files' directory should be moved to the trash
-	 *
-	 * @param $path
-	 * @return bool
 	 */
-	protected function shouldMoveToTrash($path): bool {
+	protected function shouldMoveToTrash(string $path): bool {
 		$normalized = Filesystem::normalizePath($this->mountPoint . '/' . $path);
 		$parts = explode('/', $normalized);
 		if (count($parts) < 4 || strpos($normalized, '/appdata_') === 0) {
@@ -130,7 +127,7 @@ class Storage extends Wrapper {
 	 *
 	 * @return bool true if the operation succeeded, false otherwise
 	 */
-	private function doDelete($path, $method): bool {
+	private function doDelete(string $path, string $method): bool {
 		if (
 			!\OC::$server->getAppManager()->isEnabledForUser('files_trashbin')
 			|| (pathinfo($path, PATHINFO_EXTENSION) === 'part')
@@ -181,7 +178,7 @@ class Storage extends Wrapper {
 		return $this->mountPoint;
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		$sourceIsTrashbin = $sourceStorage->instanceOfStorage(Storage::class);
 		try {
 			// the fallback for moving between storage involves a copy+delete

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -28,11 +28,11 @@ use Psr\Log\LoggerInterface;
 use Test\Traits\MountProviderTrait;
 
 class TemporaryNoCross extends Temporary {
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, ?bool $preserveMtime = null): bool {
 		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		return Common::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 }

--- a/apps/workflowengine/tests/Check/FileMimeTypeTest.php
+++ b/apps/workflowengine/tests/Check/FileMimeTypeTest.php
@@ -16,11 +16,11 @@ use OCP\IRequest;
 use Test\TestCase;
 
 class TemporaryNoLocal extends Temporary {
-	public function instanceOfStorage($className): bool {
-		if ($className === '\OC\Files\Storage\Local') {
+	public function instanceOfStorage(string $class): bool {
+		if ($class === '\OC\Files\Storage\Local') {
 			return false;
 		} else {
-			return parent::instanceOfStorage($className);
+			return parent::instanceOfStorage($class);
 		}
 	}
 }

--- a/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/HomeObjectStoreStorage.php
@@ -32,7 +32,7 @@ class HomeObjectStoreStorage extends ObjectStoreStorage implements IHomeStorage 
 		return 'object::user:' . $this->user->getUID();
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		return $this->user->getUID();
 	}
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -66,7 +66,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$this->logger = \OCP\Server::get(LoggerInterface::class);
 	}
 
-	public function mkdir($path, bool $force = false): bool {
+	public function mkdir(string $path, bool $force = false): bool {
 		$path = $this->normalizePath($path);
 		if (!$force && $this->file_exists($path)) {
 			$this->logger->warning("Tried to create an object store folder that already exists: $path");
@@ -111,11 +111,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		}
 	}
 
-	/**
-	 * @param string $path
-	 * @return string
-	 */
-	private function normalizePath($path) {
+	private function normalizePath(string $path): string {
 		$path = trim($path, '/');
 		//FIXME why do we sometimes get a path like 'files//username'?
 		$path = str_replace('//', '/', $path);
@@ -132,7 +128,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	 * Object Stores use a NoopScanner because metadata is directly stored in
 	 * the file cache and cannot really scan the filesystem. The storage passed in is not used anywhere.
 	 */
-	public function getScanner($path = '', $storage = null): IScanner {
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -147,7 +143,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return $this->id;
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		$path = $this->normalizePath($path);
 		$entry = $this->getCache()->get($path);
 
@@ -179,7 +175,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return true;
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$path = $this->normalizePath($path);
 		$entry = $this->getCache()->get($path);
 
@@ -215,7 +211,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return true;
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		$path = $this->normalizePath($path);
 		$cacheEntry = $this->getCache()->get($path);
 		if ($cacheEntry instanceof CacheEntry) {
@@ -232,7 +228,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		}
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		$stat = $this->stat($path);
 
 		if (is_array($stat) && isset($stat['permissions'])) {
@@ -247,17 +243,13 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	 * The default implementations just appends the fileId to 'urn:oid:'. Make sure the URN is unique over all users.
 	 * You may need a mapping table to store your URN if it cannot be generated from the fileid.
 	 *
-	 * @param int $fileId the fileid
-	 * @return null|string the unified resource name used to identify the object
+	 * @return string the unified resource name used to identify the object
 	 */
-	public function getURN($fileId) {
-		if (is_numeric($fileId)) {
-			return $this->objectPrefix . $fileId;
-		}
-		return null;
+	public function getURN(int $fileId): string {
+		return $this->objectPrefix . $fileId;
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		$path = $this->normalizePath($path);
 
 		try {
@@ -274,7 +266,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		}
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		$path = $this->normalizePath($path);
 		$stat = $this->stat($path);
 		if ($stat) {
@@ -287,7 +279,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		}
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$path = $this->normalizePath($path);
 
 		if (strrpos($path, '.') !== false) {
@@ -379,12 +371,12 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return false;
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		$path = $this->normalizePath($path);
 		return (bool)$this->stat($path);
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 		$this->remove($target);
@@ -393,12 +385,12 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return true;
 	}
 
-	public function getMimeType($path): string|false {
+	public function getMimeType(string $path): string|false {
 		$path = $this->normalizePath($path);
 		return parent::getMimeType($path);
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		if (is_null($mtime)) {
 			$mtime = time();
 		}
@@ -444,12 +436,12 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return true;
 	}
 
-	public function writeBack($tmpFile, $path) {
+	public function writeBack(string $tmpFile, string $path) {
 		$size = filesize($tmpFile);
 		$this->writeStream($path, fopen($tmpFile, 'r'), $size);
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		return false;
 	}
 
@@ -457,7 +449,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return false;
 	}
 
-	public function file_put_contents($path, $data): int {
+	public function file_put_contents(string $path, mixed $data): int {
 		$fh = fopen('php://temp', 'w+');
 		fwrite($fh, $data);
 		rewind($fh);
@@ -567,9 +559,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 
 	public function copyFromStorage(
 		IStorage $sourceStorage,
-		$sourceInternalPath,
-		$targetInternalPath,
-		$preserveMtime = false,
+		string $sourceInternalPath,
+		string $targetInternalPath,
+		bool $preserveMtime = false,
 	): bool {
 		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class)) {
 			/** @var ObjectStoreStorage $sourceStorage */
@@ -591,7 +583,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, ?ICacheEntry $sourceCacheEntry = null): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, ?ICacheEntry $sourceCacheEntry = null): bool {
 		$sourceCache = $sourceStorage->getCache();
 		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class) && $sourceStorage->getObjectStore()->getStorageId() === $this->getObjectStore()->getStorageId()) {
 			$this->getCache()->moveFromCache($sourceCache, $sourceInternalPath, $targetInternalPath);
@@ -663,7 +655,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		}
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		$source = $this->normalizePath($source);
 		$target = $this->normalizePath($target);
 

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -68,12 +68,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	public function __construct($parameters) {
 	}
 
-	/**
-	 * Remove a file or folder
-	 *
-	 * @param string $path
-	 */
-	protected function remove($path): bool {
+	protected function remove(string $path): bool {
 		if ($this->is_dir($path)) {
 			return $this->rmdir($path);
 		} elseif ($this->is_file($path)) {
@@ -83,15 +78,15 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		return $this->filetype($path) === 'dir';
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		return $this->filetype($path) === 'file';
 	}
 
-	public function filesize($path): int|float|false {
+	public function filesize(string $path): int|float|false {
 		if ($this->is_dir($path)) {
 			return 0; //by definition
 		} else {
@@ -104,27 +99,27 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		// at least check whether it exists
 		// subclasses might want to implement this more thoroughly
 		return $this->file_exists($path);
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		// at least check whether it exists
 		// subclasses might want to implement this more thoroughly
 		// a non-existing file/folder isn't updatable
 		return $this->file_exists($path);
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		if ($this->is_dir($path) && $this->isUpdatable($path)) {
 			return true;
 		}
 		return false;
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		if ($path === '' || $path === '/') {
 			return $this->isUpdatable($path);
 		}
@@ -132,11 +127,11 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $this->isUpdatable($parent) && $this->isUpdatable($path);
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		return $this->isReadable($path);
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		$permissions = 0;
 		if ($this->isCreatable($path)) {
 			$permissions |= \OCP\Constants::PERMISSION_CREATE;
@@ -156,7 +151,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $permissions;
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		$stat = $this->stat($path);
 		if (isset($stat['mtime']) && $stat['mtime'] > 0) {
 			return $stat['mtime'];
@@ -165,7 +160,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function file_get_contents($path): string|false {
+	public function file_get_contents(string $path): string|false {
 		$handle = $this->fopen($path, 'r');
 		if (!$handle) {
 			return false;
@@ -175,7 +170,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $data;
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		$handle = $this->fopen($path, 'w');
 		if (!$handle) {
 			return false;
@@ -186,14 +181,14 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $count;
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$this->remove($target);
 
 		$this->removeCachedFile($source);
 		return $this->copy($source, $target) and $this->remove($source);
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		if ($this->is_dir($source)) {
 			$this->remove($target);
 			$dir = $this->opendir($source);
@@ -220,7 +215,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function getMimeType($path): string|false {
+	public function getMimeType(string $path): string|false {
 		if ($this->is_dir($path)) {
 			return 'httpd/unix-directory';
 		} elseif ($this->file_exists($path)) {
@@ -230,7 +225,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function hash($type, $path, $raw = false): string|false {
+	public function hash(string $type, string $path, bool $raw = false): string|false {
 		$fh = $this->fopen($path, 'rb');
 		$ctx = hash_init($type);
 		hash_update_stream($ctx, $fh);
@@ -238,11 +233,11 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return hash_final($ctx, $raw);
 	}
 
-	public function getLocalFile($path): string|false {
+	public function getLocalFile(string $path): string|false {
 		return $this->getCachedFile($path);
 	}
 
-	private function addLocalFolder($path, $target): void {
+	private function addLocalFolder(string $path, string $target): void {
 		$dh = $this->opendir($path);
 		if (is_resource($dh)) {
 			while (($file = readdir($dh)) !== false) {
@@ -259,7 +254,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	protected function searchInDir($query, $dir = ''): array {
+	protected function searchInDir(string $query, string $dir = ''): array {
 		$files = [];
 		$dh = $this->opendir($dir);
 		if (is_resource($dh)) {
@@ -288,7 +283,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	 * exclusive access to the backend and will not pick up files that have been added in a way that circumvents
 	 * Nextcloud filesystem.
 	 */
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		return $this->filemtime($path) > $time;
 	}
 
@@ -300,7 +295,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $dependencies;
 	}
 
-	public function getCache($path = '', $storage = null): ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -311,7 +306,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $storage->cache;
 	}
 
-	public function getScanner($path = '', $storage = null): IScanner {
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -324,7 +319,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $storage->scanner;
 	}
 
-	public function getWatcher($path = '', $storage = null): IWatcher {
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -336,7 +331,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $this->watcher;
 	}
 
-	public function getPropagator($storage = null): IPropagator {
+	public function getPropagator(?IStorage $storage = null): IPropagator {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -351,7 +346,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $storage->propagator;
 	}
 
-	public function getUpdater($storage = null): IUpdater {
+	public function getUpdater(?IStorage $storage = null): IUpdater {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -365,13 +360,13 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $storage->updater;
 	}
 
-	public function getStorageCache($storage = null): \OC\Files\Cache\Storage {
+	public function getStorageCache(?IStorage $storage = null): \OC\Files\Cache\Storage {
 		/** @var Cache $cache */
-		$cache = $this->getCache($storage);
+		$cache = $this->getCache(storage: $storage);
 		return $cache->getStorageCache();
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		if ($this->owner === null) {
 			$this->owner = \OC_User::getUser();
 		}
@@ -379,7 +374,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $this->owner;
 	}
 
-	public function getETag($path): string|false {
+	public function getETag(string $path): string|false {
 		return uniqid();
 	}
 
@@ -390,7 +385,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	 * @param string $path The path to clean
 	 * @return string cleaned path
 	 */
-	public function cleanPath($path): string {
+	public function cleanPath(string $path): string {
 		if (strlen($path) == 0 or $path[0] != '/') {
 			$path = '/' . $path;
 		}
@@ -426,7 +421,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		return \OCP\Files\FileInfo::SPACE_UNKNOWN;
 	}
 
@@ -438,10 +433,8 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 
 	/**
 	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
-	 *
-	 * @param string $class
 	 */
-	public function instanceOfStorage($class): bool {
+	public function instanceOfStorage(string $class): bool {
 		if (ltrim($class, '\\') === 'OC\Files\Storage\Shared') {
 			// FIXME Temporary fix to keep existing checks working
 			$class = '\OCA\Files_Sharing\SharedStorage';
@@ -453,14 +446,12 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	 * A custom storage implementation can return an url for direct download of a give file.
 	 *
 	 * For now the returned array can hold the parameter url - in future more attributes might follow.
-	 *
-	 * @param string $path
 	 */
-	public function getDirectDownload($path): array|false {
+	public function getDirectDownload(string $path): array|false {
 		return [];
 	}
 
-	public function verifyPath($path, $fileName): void {
+	public function verifyPath(string $path, string $fileName): void {
 		$this->getFilenameValidator()
 			->validateFilename($fileName);
 
@@ -493,20 +484,11 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		$this->mountOptions = $options;
 	}
 
-	/**
-	 * @param string $name
-	 * @param mixed $default
-	 */
-	public function getMountOption($name, $default = null): mixed {
+	public function getMountOption(string $name, mixed $default = null): mixed {
 		return $this->mountOptions[$name] ?? $default;
 	}
 
-	/**
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @param bool $preserveMtime
-	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool {
 		if ($sourceStorage === $this) {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
@@ -563,11 +545,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $storage === $this;
 	}
 
-	/**
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($this->isSameStorage($sourceStorage)) {
 			// resolve any jailed paths
 			while ($sourceStorage->instanceOfStorage(Jail::class)) {
@@ -607,7 +585,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $result;
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		if (Filesystem::isFileBlacklisted($path)) {
 			throw new ForbiddenException('Invalid path: ' . $path, false);
 		}
@@ -637,7 +615,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $data;
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider): void {
+	public function acquireLock(string $path, int $type, ILockingProvider $provider): void {
 		$logger = $this->getLockLogger();
 		if ($logger) {
 			$typeString = ($type === ILockingProvider::LOCK_SHARED) ? 'shared' : 'exclusive';
@@ -664,7 +642,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider): void {
+	public function releaseLock(string $path, int $type, ILockingProvider $provider): void {
 		$logger = $this->getLockLogger();
 		if ($logger) {
 			$typeString = ($type === ILockingProvider::LOCK_SHARED) ? 'shared' : 'exclusive';
@@ -691,7 +669,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		}
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider): void {
+	public function changeLock(string $path, int $type, ILockingProvider $provider): void {
 		$logger = $this->getLockLogger();
 		if ($logger) {
 			$typeString = ($type === ILockingProvider::LOCK_SHARED) ? 'shared' : 'exclusive';
@@ -733,7 +711,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $this->getStorageCache()->getAvailability();
 	}
 
-	public function setAvailability($isAvailable): void {
+	public function setAvailability(bool $isAvailable): void {
 		$this->getStorageCache()->setAvailability($isAvailable);
 	}
 
@@ -762,7 +740,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 		return $count;
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		$dh = $this->opendir($directory);
 
 		if ($dh === false) {

--- a/lib/private/Files/Storage/CommonTest.php
+++ b/lib/private/Files/Storage/CommonTest.php
@@ -21,40 +21,40 @@ class CommonTest extends \OC\Files\Storage\Common {
 	public function getId(): string {
 		return 'test::' . $this->storage->getId();
 	}
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		return $this->storage->mkdir($path);
 	}
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		return $this->storage->rmdir($path);
 	}
-	public function opendir($path) {
+	public function opendir(string $path) {
 		return $this->storage->opendir($path);
 	}
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		return $this->storage->stat($path);
 	}
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		return @$this->storage->filetype($path);
 	}
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		return $this->storage->isReadable($path);
 	}
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return $this->storage->isUpdatable($path);
 	}
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		return $this->storage->file_exists($path);
 	}
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		return $this->storage->unlink($path);
 	}
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		return $this->storage->fopen($path, $mode);
 	}
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		return $this->storage->free_space($path);
 	}
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		return $this->storage->touch($path, $mtime);
 	}
 }

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -194,7 +194,7 @@ class DAV extends Common {
 		return $baseUri;
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		$result = $this->simpleResponse('MKCOL', $path, null, 201);
@@ -204,7 +204,7 @@ class DAV extends Common {
 		return $result;
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		// FIXME: some WebDAV impl return 403 when trying to DELETE
@@ -215,7 +215,7 @@ class DAV extends Common {
 		return $result;
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		$this->init();
 		$path = $this->cleanPath($path);
 		try {
@@ -243,7 +243,7 @@ class DAV extends Common {
 	 *
 	 * @throws ClientHttpException
 	 */
-	protected function propfind($path): array|false {
+	protected function propfind(string $path): array|false {
 		$path = $this->cleanPath($path);
 		$cachedResponse = $this->statCache->get($path);
 		// we either don't know it, or we know it exists but need more details
@@ -271,7 +271,7 @@ class DAV extends Common {
 		return $response;
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		try {
 			$response = $this->propfind($path);
 			if ($response === false) {
@@ -289,7 +289,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		try {
 			$path = $this->cleanPath($path);
 			$cachedState = $this->statCache->get($path);
@@ -307,7 +307,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		$result = $this->simpleResponse('DELETE', $path, null, 204);
@@ -316,7 +316,7 @@ class DAV extends Common {
 		return $result;
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$this->init();
 		$path = $this->cleanPath($path);
 		switch ($mode) {
@@ -390,15 +390,12 @@ class DAV extends Common {
 		}
 	}
 
-	/**
-	 * @param string $tmpFile
-	 */
-	public function writeBack($tmpFile, $path): void {
+	public function writeBack(string $tmpFile, string $path): void {
 		$this->uploadFile($tmpFile, $path);
 		unlink($tmpFile);
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		$this->init();
 		$path = $this->cleanPath($path);
 		try {
@@ -416,7 +413,7 @@ class DAV extends Common {
 		}
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		$this->init();
 		if (is_null($mtime)) {
 			$mtime = time();
@@ -453,23 +450,14 @@ class DAV extends Common {
 		return true;
 	}
 
-	/**
-	 * @param string $path
-	 * @param mixed $data
-	 * @return int|float|false
-	 */
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		$path = $this->cleanPath($path);
 		$result = parent::file_put_contents($path, $data);
 		$this->statCache->remove($path);
 		return $result;
 	}
 
-	/**
-	 * @param string $path
-	 * @param string $target
-	 */
-	protected function uploadFile($path, $target): void {
+	protected function uploadFile(string $path, string $target): void {
 		$this->init();
 
 		// invalidate
@@ -489,7 +477,7 @@ class DAV extends Common {
 		$this->removeCachedFile($target);
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$this->init();
 		$source = $this->cleanPath($source);
 		$target = $this->cleanPath($target);
@@ -520,7 +508,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		$this->init();
 		$source = $this->cleanPath($source);
 		$target = $this->cleanPath($target);
@@ -548,7 +536,7 @@ class DAV extends Common {
 		return false;
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		if (Filesystem::isFileBlacklisted($path)) {
 			throw new ForbiddenException('Invalid path: ' . $path, false);
 		}
@@ -610,18 +598,18 @@ class DAV extends Common {
 		];
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		$meta = $this->getMetaData($path);
 		return $meta ?: false;
 
 	}
 
-	public function getMimeType($path): string|false {
+	public function getMimeType(string $path): string|false {
 		$meta = $this->getMetaData($path);
 		return $meta ? $meta['mimetype'] : false;
 	}
 
-	public function cleanPath($path): string {
+	public function cleanPath(string $path): string {
 		if ($path === '') {
 			return $path;
 		}
@@ -636,21 +624,17 @@ class DAV extends Common {
 	 * @param string $path to encode
 	 * @return string encoded path
 	 */
-	protected function encodePath($path): string {
+	protected function encodePath(string $path): string {
 		// slashes need to stay
 		return str_replace('%2F', '/', rawurlencode($path));
 	}
 
 	/**
-	 * @param string $method
-	 * @param string $path
-	 * @param string|resource|null $body
-	 * @param int $expected
 	 * @return bool
 	 * @throws StorageInvalidException
 	 * @throws StorageNotAvailableException
 	 */
-	protected function simpleResponse($method, $path, $body, $expected): bool {
+	protected function simpleResponse(string $method, string $path, ?string $body, int $expected): bool {
 		$path = $this->cleanPath($path);
 		try {
 			$response = $this->client->request($method, $this->encodePath($path), $body);
@@ -676,33 +660,33 @@ class DAV extends Common {
 		return true;
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_UPDATE);
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_CREATE);
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_SHARE);
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		return (bool)($this->getPermissions($path) & Constants::PERMISSION_DELETE);
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		$stat = $this->getMetaData($path);
 		return $stat ? $stat['permissions'] : 0;
 	}
 
-	public function getETag($path): string|false {
+	public function getETag(string $path): string|false {
 		$meta = $this->getMetaData($path);
 		return $meta ? $meta['etag'] : false;
 	}
 
-	protected function parsePermissions($permissionsString): int {
+	protected function parsePermissions(string $permissionsString): int {
 		$permissions = Constants::PERMISSION_READ;
 		if (str_contains($permissionsString, 'R')) {
 			$permissions |= Constants::PERMISSION_SHARE;
@@ -720,7 +704,7 @@ class DAV extends Common {
 		return $permissions;
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		$this->init();
 		$path = $this->cleanPath($path);
 		try {
@@ -786,7 +770,7 @@ class DAV extends Common {
 	 *                                      which might be temporary
 	 * @throws ForbiddenException if the action is not allowed
 	 */
-	protected function convertException(Exception $e, $path = ''): void {
+	protected function convertException(Exception $e, string $path = ''): void {
 		Server::get(LoggerInterface::class)->debug($e->getMessage(), ['app' => 'files_external', 'exception' => $e]);
 		if ($e instanceof ClientHttpException) {
 			if ($e->getHttpStatus() === Http::STATUS_LOCKED) {
@@ -818,7 +802,7 @@ class DAV extends Common {
 		// TODO: only log for now, but in the future need to wrap/rethrow exception
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		$this->init();
 		$directory = $this->cleanPath($directory);
 		try {

--- a/lib/private/Files/Storage/FailedStorage.php
+++ b/lib/private/Files/Storage/FailedStorage.php
@@ -34,146 +34,146 @@ class FailedStorage extends Common {
 		return 'failedstorage';
 	}
 
-	public function mkdir($path): never {
+	public function mkdir(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function rmdir($path): never {
+	public function rmdir(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function opendir($path): never {
+	public function opendir(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function is_dir($path): never {
+	public function is_dir(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function is_file($path): never {
+	public function is_file(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function stat($path): never {
+	public function stat(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function filetype($path): never {
+	public function filetype(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function filesize($path): never {
+	public function filesize(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isCreatable($path): never {
+	public function isCreatable(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isReadable($path): never {
+	public function isReadable(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isUpdatable($path): never {
+	public function isUpdatable(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isDeletable($path): never {
+	public function isDeletable(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function isSharable($path): never {
+	public function isSharable(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getPermissions($path): never {
+	public function getPermissions(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function file_exists($path): never {
+	public function file_exists(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function filemtime($path): never {
+	public function filemtime(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function file_get_contents($path): never {
+	public function file_get_contents(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function file_put_contents($path, $data): never {
+	public function file_put_contents(string $path, mixed $data): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function unlink($path): never {
+	public function unlink(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function rename($source, $target): never {
+	public function rename(string $source, string $target): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function copy($source, $target): never {
+	public function copy(string $source, string $target): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function fopen($path, $mode): never {
+	public function fopen(string $path, string $mode): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getMimeType($path): never {
+	public function getMimeType(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function hash($type, $path, $raw = false): never {
+	public function hash(string $type, string $path, bool $raw = false): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function free_space($path): never {
+	public function free_space(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function touch($path, $mtime = null): never {
+	public function touch(string $path, ?int $mtime = null): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getLocalFile($path): never {
+	public function getLocalFile(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function hasUpdated($path, $time): never {
+	public function hasUpdated(string $path, int $time): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getETag($path): never {
+	public function getETag(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getDirectDownload($path): never {
+	public function getDirectDownload(string $path): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function verifyPath($path, $fileName): void {
+	public function verifyPath(string $path, string $fileName): void {
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false): never {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): never {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider): never {
+	public function acquireLock(string $path, int $type, ILockingProvider $provider): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider): never {
+	public function releaseLock(string $path, int $type, ILockingProvider $provider): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider): never {
+	public function changeLock(string $path, int $type, ILockingProvider $provider): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
@@ -181,11 +181,11 @@ class FailedStorage extends Common {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function setAvailability($isAvailable): never {
+	public function setAvailability(bool $isAvailable): never {
 		throw new StorageNotAvailableException($this->e->getMessage(), $this->e->getCode(), $this->e);
 	}
 
-	public function getCache($path = '', $storage = null): FailedCache {
+	public function getCache(string $path = '', ?IStorage $storage = null): FailedCache {
 		return new FailedCache();
 	}
 }

--- a/lib/private/Files/Storage/Home.php
+++ b/lib/private/Files/Storage/Home.php
@@ -10,6 +10,7 @@ namespace OC\Files\Storage;
 use OC\Files\Cache\HomePropagator;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\IPropagator;
+use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 
 /**
@@ -44,7 +45,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 		return $this->id;
 	}
 
-	public function getCache($path = '', $storage = null): ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -54,7 +55,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 		return $this->cache;
 	}
 
-	public function getPropagator($storage = null): IPropagator {
+	public function getPropagator(?IStorage $storage = null): IPropagator {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -69,7 +70,7 @@ class Home extends Local implements \OCP\Files\IHomeStorage {
 		return $this->user;
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		return $this->user->getUID();
 	}
 }

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -78,7 +78,7 @@ class Local extends \OC\Files\Storage\Common {
 		return 'local::' . $this->datadir;
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		$sourcePath = $this->getSourcePath($path);
 		$oldMask = umask($this->defUMask);
 		$result = @mkdir($sourcePath, 0777, true);
@@ -86,7 +86,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $result;
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		if (!$this->isDeletable($path)) {
 			return false;
 		}
@@ -125,11 +125,11 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		return opendir($this->getSourcePath($path));
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		if ($this->caseInsensitive && !$this->file_exists($path)) {
 			return false;
 		}
@@ -139,14 +139,14 @@ class Local extends \OC\Files\Storage\Common {
 		return is_dir($this->getSourcePath($path));
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		if ($this->caseInsensitive && !$this->file_exists($path)) {
 			return false;
 		}
 		return is_file($this->getSourcePath($path));
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		$fullPath = $this->getSourcePath($path);
 		clearstatcache(true, $fullPath);
 		if (!file_exists($fullPath)) {
@@ -164,7 +164,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $statResult;
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		try {
 			$stat = $this->stat($path);
 		} catch (ForbiddenException $e) {
@@ -213,7 +213,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $data;
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		$filetype = filetype($this->getSourcePath($path));
 		if ($filetype == 'link') {
 			$filetype = filetype(realpath($this->getSourcePath($path)));
@@ -221,7 +221,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $filetype;
 	}
 
-	public function filesize($path): int|float|false {
+	public function filesize(string $path): int|float|false {
 		if (!$this->is_file($path)) {
 			return 0;
 		}
@@ -233,15 +233,15 @@ class Local extends \OC\Files\Storage\Common {
 		return filesize($fullPath);
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		return is_readable($this->getSourcePath($path));
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return is_writable($this->getSourcePath($path));
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		if ($this->caseInsensitive) {
 			$fullPath = $this->getSourcePath($path);
 			$parentPath = dirname($fullPath);
@@ -255,7 +255,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		$fullPath = $this->getSourcePath($path);
 		clearstatcache(true, $fullPath);
 		if (!$this->file_exists($path)) {
@@ -268,7 +268,7 @@ class Local extends \OC\Files\Storage\Common {
 		return filemtime($fullPath);
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		// sets the modification time of the file to the given value.
 		// If mtime is nil the current time is set.
 		// note that the access time of the file always changes to the current time.
@@ -289,11 +289,11 @@ class Local extends \OC\Files\Storage\Common {
 		return $result;
 	}
 
-	public function file_get_contents($path): string|false {
+	public function file_get_contents(string $path): string|false {
 		return file_get_contents($this->getSourcePath($path));
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		$oldMask = umask($this->defUMask);
 		if ($this->unlinkOnTruncate) {
 			$this->unlink($path);
@@ -303,7 +303,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $result;
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		if ($this->is_dir($path)) {
 			return $this->rmdir($path);
 		} elseif ($this->is_file($path)) {
@@ -323,7 +323,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$srcParent = dirname($source);
 		$dstParent = dirname($target);
 
@@ -364,7 +364,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $this->copy($source, $target) && $this->unlink($source);
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		if ($this->is_dir($source)) {
 			return parent::copy($source, $target);
 		} else {
@@ -383,7 +383,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$sourcePath = $this->getSourcePath($path);
 		if (!file_exists($sourcePath) && $mode === 'r') {
 			return false;
@@ -397,11 +397,11 @@ class Local extends \OC\Files\Storage\Common {
 		return $result;
 	}
 
-	public function hash($type, $path, $raw = false): string|false {
+	public function hash(string $type, string $path, bool $raw = false): string|false {
 		return hash_file($type, $this->getSourcePath($path), $raw);
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		$sourcePath = $this->getSourcePath($path);
 		// using !is_dir because $sourcePath might be a part file or
 		// non-existing file, so we'd still want to use the parent dir
@@ -417,19 +417,15 @@ class Local extends \OC\Files\Storage\Common {
 		return Util::numericToNumber($space);
 	}
 
-	public function search($query): array {
+	public function search(string $query): array {
 		return $this->searchInDir($query);
 	}
 
-	public function getLocalFile($path): string|false {
+	public function getLocalFile(string $path): string|false {
 		return $this->getSourcePath($path);
 	}
 
-	/**
-	 * @param string $query
-	 * @param string $dir
-	 */
-	protected function searchInDir($query, $dir = ''): array {
+	protected function searchInDir(string $query, string $dir = ''): array {
 		$files = [];
 		$physicalDir = $this->getSourcePath($dir);
 		foreach (scandir($physicalDir) as $item) {
@@ -448,7 +444,7 @@ class Local extends \OC\Files\Storage\Common {
 		return $files;
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		if ($this->file_exists($path)) {
 			return $this->filemtime($path) > $time;
 		} else {
@@ -459,10 +455,9 @@ class Local extends \OC\Files\Storage\Common {
 	/**
 	 * Get the source path (on disk) of a given path
 	 *
-	 * @param string $path
 	 * @throws ForbiddenException
 	 */
-	public function getSourcePath($path): string {
+	public function getSourcePath(string $path): string {
 		if (Filesystem::isFileBlacklisted($path)) {
 			throw new ForbiddenException('Invalid path: ' . $path, false);
 		}
@@ -498,7 +493,7 @@ class Local extends \OC\Files\Storage\Common {
 		return true;
 	}
 
-	public function getETag($path): string|false {
+	public function getETag(string $path): string|false {
 		return $this->calculateEtag($path, $this->stat($path));
 	}
 
@@ -529,7 +524,7 @@ class Local extends \OC\Files\Storage\Common {
 	}
 
 	private function canDoCrossStorageMove(IStorage $sourceStorage): bool {
-		/** @psalm-suppress UndefinedClass */
+		/** @psalm-suppress UndefinedClass,InvalidArgument */
 		return $sourceStorage->instanceOfStorage(Local::class)
 			// Don't treat ACLStorageWrapper like local storage where copy can be done directly.
 			// Instead, use the slower recursive copying in php from Common::copyFromStorage with
@@ -541,7 +536,7 @@ class Local extends \OC\Files\Storage\Common {
 			&& !$sourceStorage->instanceOfStorage(Encryption::class);
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool {
 		if ($this->canDoCrossStorageMove($sourceStorage)) {
 			if ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**
@@ -559,13 +554,7 @@ class Local extends \OC\Files\Storage\Common {
 		}
 	}
 
-	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
-	 * @return bool
-	 */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($this->canDoCrossStorageMove($sourceStorage)) {
 			if ($sourceStorage->instanceOfStorage(Jail::class)) {
 				/**

--- a/lib/private/Files/Storage/LocalRootStorage.php
+++ b/lib/private/Files/Storage/LocalRootStorage.php
@@ -10,9 +10,10 @@ namespace OC\Files\Storage;
 
 use OC\Files\Cache\LocalRootScanner;
 use OCP\Files\Cache\IScanner;
+use OCP\Files\Storage\IStorage;
 
 class LocalRootStorage extends Local {
-	public function getScanner($path = '', $storage = null): IScanner {
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}

--- a/lib/private/Files/Storage/LocalTempFileTrait.php
+++ b/lib/private/Files/Storage/LocalTempFileTrait.php
@@ -29,10 +29,7 @@ trait LocalTempFileTrait {
 		return $this->cachedFiles[$path];
 	}
 
-	/**
-	 * @param string $path
-	 */
-	protected function removeCachedFile($path): void {
+	protected function removeCachedFile(string $path): void {
 		unset($this->cachedFiles[$path]);
 	}
 

--- a/lib/private/Files/Storage/PolyFill/CopyDirectory.php
+++ b/lib/private/Files/Storage/PolyFill/CopyDirectory.php
@@ -10,41 +10,32 @@ namespace OC\Files\Storage\PolyFill;
 trait CopyDirectory {
 	/**
 	 * Check if a path is a directory
-	 *
-	 * @param string $path
 	 */
-	abstract public function is_dir($path): bool;
+	abstract public function is_dir(string $path): bool;
 
 	/**
 	 * Check if a file or folder exists
-	 *
-	 * @param string $path
 	 */
-	abstract public function file_exists($path): bool;
+	abstract public function file_exists(string $path): bool;
 
 	/**
 	 * Delete a file or folder
-	 *
-	 * @param string $path
 	 */
-	abstract public function unlink($path): bool;
+	abstract public function unlink(string $path): bool;
 
 	/**
 	 * Open a directory handle for a folder
 	 *
-	 * @param string $path
 	 * @return resource|false
 	 */
-	abstract public function opendir($path);
+	abstract public function opendir(string $path);
 
 	/**
 	 * Create a new folder
-	 *
-	 * @param string $path
 	 */
-	abstract public function mkdir($path): bool;
+	abstract public function mkdir(string $path): bool;
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		if ($this->is_dir($source)) {
 			if ($this->file_exists($target)) {
 				$this->unlink($target);
@@ -59,7 +50,7 @@ trait CopyDirectory {
 	/**
 	 * For adapters that don't support copying folders natively
 	 */
-	protected function copyRecursive($source, $target): bool {
+	protected function copyRecursive(string $source, string $target): bool {
 		$dh = $this->opendir($source);
 		$result = true;
 		while (($file = readdir($dh)) !== false) {

--- a/lib/private/Files/Storage/Storage.php
+++ b/lib/private/Files/Storage/Storage.php
@@ -22,45 +22,22 @@ use OCP\Files\Storage\IStorage;
  * All paths passed to the storage are relative to the storage and should NOT have a leading slash.
  */
 interface Storage extends IStorage, ILockingStorage {
-	/**
-	 * @param string $path
-	 * @param ?IStorage $storage
-	 */
-	public function getCache($path = '', $storage = null): ICache;
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache;
 
-	/**
-	 * @param string $path
-	 * @param ?IStorage $storage
-	 */
-	public function getScanner($path = '', $storage = null): IScanner;
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner;
 
-	/**
-	 * @param string $path
-	 * @param ?IStorage $storage
-	 */
-	public function getWatcher($path = '', $storage = null): IWatcher;
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher;
 
-	/**
-	 * @param ?IStorage $storage
-	 */
-	public function getPropagator($storage = null): IPropagator;
+	public function getPropagator(?IStorage $storage = null): IPropagator;
 
-	/**
-	 * @param ?IStorage $storage
-	 */
-	public function getUpdater($storage = null): IUpdater;
+	public function getUpdater(?IStorage $storage = null): IUpdater;
 
 	public function getStorageCache(): \OC\Files\Cache\Storage;
 
-	/**
-	 * @param string $path
-	 */
-	public function getMetaData($path): ?array;
+	public function getMetaData(string $path): ?array;
 
 	/**
 	 * Get the contents of a directory with metadata
-	 *
-	 * @param string $directory
 	 *
 	 * The metadata array will contain the following fields
 	 *
@@ -72,5 +49,5 @@ interface Storage extends IStorage, ILockingStorage {
 	 * - storage_mtime
 	 * - permissions
 	 */
-	public function getDirectoryContent($directory): \Traversable;
+	public function getDirectoryContent(string $directory): \Traversable;
 }

--- a/lib/private/Files/Storage/StorageFactory.php
+++ b/lib/private/Files/Storage/StorageFactory.php
@@ -19,7 +19,7 @@ class StorageFactory implements IStorageFactory {
 	 */
 	private $storageWrappers = [];
 
-	public function addStorageWrapper($wrapperName, $callback, $priority = 50, $existingMounts = []): bool {
+	public function addStorageWrapper(string $wrapperName, callable $callback, int $priority = 50, array $existingMounts = []): bool {
 		if (isset($this->storageWrappers[$wrapperName])) {
 			return false;
 		}
@@ -37,31 +37,23 @@ class StorageFactory implements IStorageFactory {
 	 * Remove a storage wrapper by name.
 	 * Note: internal method only to be used for cleanup
 	 *
-	 * @param string $wrapperName name of the wrapper
 	 * @internal
 	 */
-	public function removeStorageWrapper($wrapperName): void {
+	public function removeStorageWrapper(string $wrapperName): void {
 		unset($this->storageWrappers[$wrapperName]);
 	}
 
 	/**
 	 * Create an instance of a storage and apply the registered storage wrappers
-	 *
-	 * @param string $class
-	 * @param array $arguments
-	 * @return IStorage
 	 */
-	public function getInstance(IMountPoint $mountPoint, $class, $arguments): IStorage {
+	public function getInstance(IMountPoint $mountPoint, string $class, array $arguments): IStorage {
 		if (!is_a($class, IConstructableStorage::class, true)) {
 			\OCP\Server::get(LoggerInterface::class)->warning('Building a storage not implementing IConstructableStorage is deprecated since 31.0.0', ['class' => $class]);
 		}
 		return $this->wrap($mountPoint, new $class($arguments));
 	}
 
-	/**
-	 * @param IStorage $storage
-	 */
-	public function wrap(IMountPoint $mountPoint, $storage): IStorage {
+	public function wrap(IMountPoint $mountPoint, IStorage $storage): IStorage {
 		$wrappers = array_values($this->storageWrappers);
 		usort($wrappers, function ($a, $b) {
 			return $b['priority'] - $a['priority'];

--- a/lib/private/Files/Storage/Wrapper/Availability.php
+++ b/lib/private/Files/Storage/Wrapper/Availability.php
@@ -70,7 +70,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::mkdir($path);
@@ -80,7 +80,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::rmdir($path);
@@ -90,7 +90,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		$this->checkAvailability();
 		try {
 			return parent::opendir($path);
@@ -100,7 +100,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::is_dir($path);
@@ -110,7 +110,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::is_file($path);
@@ -120,7 +120,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		$this->checkAvailability();
 		try {
 			return parent::stat($path);
@@ -130,7 +130,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::filetype($path);
@@ -140,7 +140,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function filesize($path): int|float|false {
+	public function filesize(string $path): int|float|false {
 		$this->checkAvailability();
 		try {
 			return parent::filesize($path);
@@ -150,7 +150,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isCreatable($path);
@@ -160,7 +160,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isReadable($path);
@@ -170,7 +170,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isUpdatable($path);
@@ -180,7 +180,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isDeletable($path);
@@ -190,7 +190,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::isSharable($path);
@@ -200,7 +200,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		$this->checkAvailability();
 		try {
 			return parent::getPermissions($path);
@@ -210,7 +210,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		if ($path === '') {
 			return true;
 		}
@@ -223,7 +223,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		$this->checkAvailability();
 		try {
 			return parent::filemtime($path);
@@ -233,7 +233,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function file_get_contents($path): string|false {
+	public function file_get_contents(string $path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::file_get_contents($path);
@@ -243,7 +243,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		$this->checkAvailability();
 		try {
 			return parent::file_put_contents($path, $data);
@@ -253,7 +253,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$this->checkAvailability();
 		try {
 			return parent::unlink($path);
@@ -263,7 +263,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$this->checkAvailability();
 		try {
 			return parent::rename($source, $target);
@@ -273,7 +273,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		$this->checkAvailability();
 		try {
 			return parent::copy($source, $target);
@@ -283,7 +283,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$this->checkAvailability();
 		try {
 			return parent::fopen($path, $mode);
@@ -293,7 +293,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function getMimeType($path): string|false {
+	public function getMimeType(string $path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::getMimeType($path);
@@ -303,7 +303,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function hash($type, $path, $raw = false): string|false {
+	public function hash(string $type, string $path, bool $raw = false): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::hash($type, $path, $raw);
@@ -313,7 +313,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		$this->checkAvailability();
 		try {
 			return parent::free_space($path);
@@ -323,7 +323,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		$this->checkAvailability();
 		try {
 			return parent::touch($path, $mtime);
@@ -333,7 +333,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function getLocalFile($path): string|false {
+	public function getLocalFile(string $path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::getLocalFile($path);
@@ -343,7 +343,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		if (!$this->isAvailable()) {
 			return false;
 		}
@@ -356,7 +356,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		try {
 			return parent::getOwner($path);
 		} catch (StorageNotAvailableException $e) {
@@ -365,7 +365,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function getETag($path): string|false {
+	public function getETag(string $path): string|false {
 		$this->checkAvailability();
 		try {
 			return parent::getETag($path);
@@ -375,7 +375,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function getDirectDownload($path): array|false {
+	public function getDirectDownload(string $path): array|false {
 		$this->checkAvailability();
 		try {
 			return parent::getDirectDownload($path);
@@ -385,7 +385,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		$this->checkAvailability();
 		try {
 			return parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
@@ -395,7 +395,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		$this->checkAvailability();
 		try {
 			return parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
@@ -405,7 +405,7 @@ class Availability extends Wrapper {
 		}
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		$this->checkAvailability();
 		try {
 			return parent::getMetaData($path);
@@ -438,7 +438,7 @@ class Availability extends Wrapper {
 
 
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		$this->checkAvailability();
 		try {
 			return parent::getDirectoryContent($directory);

--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -35,10 +35,8 @@ class Encoding extends Wrapper {
 
 	/**
 	 * Returns whether the given string is only made of ASCII characters
-	 *
-	 * @param string $str string
 	 */
-	private function isAscii($str): bool {
+	private function isAscii(string $str): bool {
 		return !preg_match('/[\\x80-\\xff]+/', $str);
 	}
 
@@ -47,11 +45,9 @@ class Encoding extends Wrapper {
 	 * each form for each path section and returns the correct form.
 	 * If no existing path found, returns the path as it was given.
 	 *
-	 * @param string $fullPath path to check
-	 *
 	 * @return string original or converted path
 	 */
-	private function findPathToUse($fullPath): string {
+	private function findPathToUse(string $fullPath): string {
 		$cachedPath = $this->namesCache[$fullPath];
 		if ($cachedPath !== null) {
 			return $cachedPath;
@@ -75,12 +71,11 @@ class Encoding extends Wrapper {
 	 * Checks whether the last path section of the given path exists in NFC or NFD form
 	 * and returns the correct form. If no existing path found, returns null.
 	 *
-	 * @param string $basePath base path to check
 	 * @param string $lastSection last section of the path to check for NFD/NFC variations
 	 *
 	 * @return string|null original or converted path, or null if none of the forms was found
 	 */
-	private function findPathToUseLastSection($basePath, $lastSection): ?string {
+	private function findPathToUseLastSection(string $basePath, string $lastSection): ?string {
 		$fullPath = $basePath . $lastSection;
 		if ($lastSection === '' || $this->isAscii($lastSection) || $this->storage->file_exists($fullPath)) {
 			$this->namesCache[$fullPath] = $fullPath;
@@ -104,7 +99,7 @@ class Encoding extends Wrapper {
 		return null;
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		// note: no conversion here, method should not be called with non-NFC names!
 		$result = $this->storage->mkdir($path);
 		if ($result) {
@@ -113,7 +108,7 @@ class Encoding extends Wrapper {
 		return $result;
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		$result = $this->storage->rmdir($this->findPathToUse($path));
 		if ($result) {
 			unset($this->namesCache[$path]);
@@ -121,72 +116,72 @@ class Encoding extends Wrapper {
 		return $result;
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		$handle = $this->storage->opendir($this->findPathToUse($path));
 		return EncodingDirectoryWrapper::wrap($handle);
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		return $this->storage->is_dir($this->findPathToUse($path));
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		return $this->storage->is_file($this->findPathToUse($path));
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		return $this->storage->stat($this->findPathToUse($path));
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		return $this->storage->filetype($this->findPathToUse($path));
 	}
 
-	public function filesize($path): int|float|false {
+	public function filesize(string $path): int|float|false {
 		return $this->storage->filesize($this->findPathToUse($path));
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		return $this->storage->isCreatable($this->findPathToUse($path));
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		return $this->storage->isReadable($this->findPathToUse($path));
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return $this->storage->isUpdatable($this->findPathToUse($path));
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		return $this->storage->isDeletable($this->findPathToUse($path));
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		return $this->storage->isSharable($this->findPathToUse($path));
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		return $this->storage->getPermissions($this->findPathToUse($path));
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		return $this->storage->file_exists($this->findPathToUse($path));
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		return $this->storage->filemtime($this->findPathToUse($path));
 	}
 
-	public function file_get_contents($path): string|false {
+	public function file_get_contents(string $path): string|false {
 		return $this->storage->file_get_contents($this->findPathToUse($path));
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		return $this->storage->file_put_contents($this->findPathToUse($path), $data);
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$result = $this->storage->unlink($this->findPathToUse($path));
 		if ($result) {
 			unset($this->namesCache[$path]);
@@ -194,16 +189,16 @@ class Encoding extends Wrapper {
 		return $result;
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		// second name always NFC
 		return $this->storage->rename($this->findPathToUse($source), $this->findPathToUse($target));
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		return $this->storage->copy($this->findPathToUse($source), $this->findPathToUse($target));
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$result = $this->storage->fopen($this->findPathToUse($path), $mode);
 		if ($result && $mode !== 'r' && $mode !== 'rb') {
 			unset($this->namesCache[$path]);
@@ -211,49 +206,49 @@ class Encoding extends Wrapper {
 		return $result;
 	}
 
-	public function getMimeType($path): string|false {
+	public function getMimeType(string $path): string|false {
 		return $this->storage->getMimeType($this->findPathToUse($path));
 	}
 
-	public function hash($type, $path, $raw = false): string|false {
+	public function hash(string $type, string $path, bool $raw = false): string|false {
 		return $this->storage->hash($type, $this->findPathToUse($path), $raw);
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		return $this->storage->free_space($this->findPathToUse($path));
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		return $this->storage->touch($this->findPathToUse($path), $mtime);
 	}
 
-	public function getLocalFile($path): string|false {
+	public function getLocalFile(string $path): string|false {
 		return $this->storage->getLocalFile($this->findPathToUse($path));
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		return $this->storage->hasUpdated($this->findPathToUse($path), $time);
 	}
 
-	public function getCache($path = '', $storage = null): \OCP\Files\Cache\ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): \OCP\Files\Cache\ICache {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->storage->getCache($this->findPathToUse($path), $storage);
 	}
 
-	public function getScanner($path = '', $storage = null): IScanner {
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->storage->getScanner($this->findPathToUse($path), $storage);
 	}
 
-	public function getETag($path): string|false {
+	public function getETag(string $path): string|false {
 		return $this->storage->getETag($this->findPathToUse($path));
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->copy($sourceInternalPath, $this->findPathToUse($targetInternalPath));
 		}
@@ -265,7 +260,7 @@ class Encoding extends Wrapper {
 		return $result;
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			$result = $this->rename($sourceInternalPath, $this->findPathToUse($targetInternalPath));
 			if ($result) {
@@ -283,13 +278,13 @@ class Encoding extends Wrapper {
 		return $result;
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		$entry = $this->storage->getMetaData($this->findPathToUse($path));
 		$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');
 		return $entry;
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		$entries = $this->storage->getDirectoryContent($this->findPathToUse($directory));
 		foreach ($entries as $entry) {
 			$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');

--- a/lib/private/Files/Storage/Wrapper/Jail.php
+++ b/lib/private/Files/Storage/Wrapper/Jail.php
@@ -40,7 +40,7 @@ class Jail extends Wrapper {
 		$this->rootPath = $arguments['root'];
 	}
 
-	public function getUnjailedPath($path): string {
+	public function getUnjailedPath(string $path): string {
 		return trim(Filesystem::normalizePath($this->rootPath . '/' . $path), '/');
 	}
 
@@ -52,7 +52,7 @@ class Jail extends Wrapper {
 	}
 
 
-	public function getJailedPath($path): ?string {
+	public function getJailedPath(string $path): ?string {
 		$root = rtrim($this->rootPath, '/') . '/';
 
 		if ($path !== $this->rootPath && !str_starts_with($path, $root)) {
@@ -67,176 +67,174 @@ class Jail extends Wrapper {
 		return parent::getId();
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		return $this->getWrapperStorage()->mkdir($this->getUnjailedPath($path));
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		return $this->getWrapperStorage()->rmdir($this->getUnjailedPath($path));
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		return $this->getWrapperStorage()->opendir($this->getUnjailedPath($path));
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		return $this->getWrapperStorage()->is_dir($this->getUnjailedPath($path));
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		return $this->getWrapperStorage()->is_file($this->getUnjailedPath($path));
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		return $this->getWrapperStorage()->stat($this->getUnjailedPath($path));
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		return $this->getWrapperStorage()->filetype($this->getUnjailedPath($path));
 	}
 
-	public function filesize($path): int|float|false {
+	public function filesize(string $path): int|float|false {
 		return $this->getWrapperStorage()->filesize($this->getUnjailedPath($path));
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		return $this->getWrapperStorage()->isCreatable($this->getUnjailedPath($path));
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		return $this->getWrapperStorage()->isReadable($this->getUnjailedPath($path));
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return $this->getWrapperStorage()->isUpdatable($this->getUnjailedPath($path));
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		return $this->getWrapperStorage()->isDeletable($this->getUnjailedPath($path));
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		return $this->getWrapperStorage()->isSharable($this->getUnjailedPath($path));
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		return $this->getWrapperStorage()->getPermissions($this->getUnjailedPath($path));
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		return $this->getWrapperStorage()->file_exists($this->getUnjailedPath($path));
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		return $this->getWrapperStorage()->filemtime($this->getUnjailedPath($path));
 	}
 
-	public function file_get_contents($path): string|false {
+	public function file_get_contents(string $path): string|false {
 		return $this->getWrapperStorage()->file_get_contents($this->getUnjailedPath($path));
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		return $this->getWrapperStorage()->file_put_contents($this->getUnjailedPath($path), $data);
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		return $this->getWrapperStorage()->unlink($this->getUnjailedPath($path));
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		return $this->getWrapperStorage()->rename($this->getUnjailedPath($source), $this->getUnjailedPath($target));
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		return $this->getWrapperStorage()->copy($this->getUnjailedPath($source), $this->getUnjailedPath($target));
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		return $this->getWrapperStorage()->fopen($this->getUnjailedPath($path), $mode);
 	}
 
-	public function getMimeType($path): string|false {
+	public function getMimeType(string $path): string|false {
 		return $this->getWrapperStorage()->getMimeType($this->getUnjailedPath($path));
 	}
 
-	public function hash($type, $path, $raw = false): string|false {
+	public function hash(string $type, string $path, bool $raw = false): string|false {
 		return $this->getWrapperStorage()->hash($type, $this->getUnjailedPath($path), $raw);
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		return $this->getWrapperStorage()->free_space($this->getUnjailedPath($path));
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		return $this->getWrapperStorage()->touch($this->getUnjailedPath($path), $mtime);
 	}
 
-	public function getLocalFile($path): string|false {
+	public function getLocalFile(string $path): string|false {
 		return $this->getWrapperStorage()->getLocalFile($this->getUnjailedPath($path));
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		return $this->getWrapperStorage()->hasUpdated($this->getUnjailedPath($path), $time);
 	}
 
-	public function getCache($path = '', $storage = null): ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache {
 		$sourceCache = $this->getWrapperStorage()->getCache($this->getUnjailedPath($path));
 		return new CacheJail($sourceCache, $this->rootPath);
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		return $this->getWrapperStorage()->getOwner($this->getUnjailedPath($path));
 	}
 
-	public function getWatcher($path = '', $storage = null): IWatcher {
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher {
 		$sourceWatcher = $this->getWrapperStorage()->getWatcher($this->getUnjailedPath($path), $this->getWrapperStorage());
 		return new JailWatcher($sourceWatcher, $this->rootPath);
 	}
 
-	public function getETag($path): string|false {
+	public function getETag(string $path): string|false {
 		return $this->getWrapperStorage()->getETag($this->getUnjailedPath($path));
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		return $this->getWrapperStorage()->getMetaData($this->getUnjailedPath($path));
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider): void {
+	public function acquireLock(string $path, int $type, ILockingProvider $provider): void {
 		$this->getWrapperStorage()->acquireLock($this->getUnjailedPath($path), $type, $provider);
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider): void {
+	public function releaseLock(string $path, int $type, ILockingProvider $provider): void {
 		$this->getWrapperStorage()->releaseLock($this->getUnjailedPath($path), $type, $provider);
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider): void {
+	public function changeLock(string $path, int $type, ILockingProvider $provider): void {
 		$this->getWrapperStorage()->changeLock($this->getUnjailedPath($path), $type, $provider);
 	}
 
 	/**
 	 * Resolve the path for the source of the share
-	 *
-	 * @param string $path
 	 */
-	public function resolvePath($path): array {
+	public function resolvePath(string $path): array {
 		return [$this->getWrapperStorage(), $this->getUnjailedPath($path)];
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
 		return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $this->getUnjailedPath($targetInternalPath));
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
 		return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $this->getUnjailedPath($targetInternalPath));
 	}
 
-	public function getPropagator($storage = null): IPropagator {
+	public function getPropagator(?IStorage $storage = null): IPropagator {
 		if (isset($this->propagator)) {
 			return $this->propagator;
 		}
@@ -262,7 +260,7 @@ class Jail extends Wrapper {
 		}
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		return $this->getWrapperStorage()->getDirectoryContent($this->getUnjailedPath($directory));
 	}
 }

--- a/lib/private/Files/Storage/Wrapper/KnownMtime.php
+++ b/lib/private/Files/Storage/Wrapper/KnownMtime.php
@@ -26,7 +26,7 @@ class KnownMtime extends Wrapper {
 		$this->clock = $arguments['clock'];
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		$result = parent::file_put_contents($path, $data);
 		if ($result) {
 			$now = $this->clock->now()->getTimestamp();
@@ -35,7 +35,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		$stat = parent::stat($path);
 		if ($stat) {
 			$this->applyKnownMtime($path, $stat);
@@ -43,7 +43,7 @@ class KnownMtime extends Wrapper {
 		return $stat;
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		$stat = parent::getMetaData($path);
 		if ($stat) {
 			$this->applyKnownMtime($path, $stat);
@@ -58,12 +58,12 @@ class KnownMtime extends Wrapper {
 		}
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		$knownMtime = $this->knowMtimes->get($path) ?? 0;
 		return max(parent::filemtime($path), $knownMtime);
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		$result = parent::mkdir($path);
 		if ($result) {
 			$this->knowMtimes->set($path, $this->clock->now()->getTimestamp());
@@ -71,7 +71,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		$result = parent::rmdir($path);
 		if ($result) {
 			$this->knowMtimes->set($path, $this->clock->now()->getTimestamp());
@@ -79,7 +79,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		$result = parent::unlink($path);
 		if ($result) {
 			$this->knowMtimes->set($path, $this->clock->now()->getTimestamp());
@@ -87,7 +87,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		$result = parent::rename($source, $target);
 		if ($result) {
 			$this->knowMtimes->set($target, $this->clock->now()->getTimestamp());
@@ -96,7 +96,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		$result = parent::copy($source, $target);
 		if ($result) {
 			$this->knowMtimes->set($target, $this->clock->now()->getTimestamp());
@@ -104,7 +104,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		$result = parent::fopen($path, $mode);
 		if ($result && $mode === 'w') {
 			$this->knowMtimes->set($path, $this->clock->now()->getTimestamp());
@@ -112,7 +112,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		$result = parent::touch($path, $mtime);
 		if ($result) {
 			$this->knowMtimes->set($path, $mtime ?? $this->clock->now()->getTimestamp());
@@ -120,7 +120,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		$result = parent::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		if ($result) {
 			$this->knowMtimes->set($targetInternalPath, $this->clock->now()->getTimestamp());
@@ -128,7 +128,7 @@ class KnownMtime extends Wrapper {
 		return $result;
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		$result = parent::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		if ($result) {
 			$this->knowMtimes->set($targetInternalPath, $this->clock->now()->getTimestamp());

--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -49,11 +49,7 @@ class Quota extends Wrapper {
 		return $this->getQuota() !== FileInfo::SPACE_UNLIMITED;
 	}
 
-	/**
-	 * @param string $path
-	 * @param IStorage $storage
-	 */
-	protected function getSize($path, $storage = null): int|float {
+	protected function getSize(string $path, ?IStorage $storage = null): int|float {
 		if ($this->quotaIncludeExternalStorage) {
 			$rootInfo = Filesystem::getFileInfo('', 'ext');
 			if ($rootInfo) {
@@ -71,7 +67,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		if (!$this->hasQuota()) {
 			return $this->storage->free_space($path);
 		}
@@ -91,7 +87,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		if (!$this->hasQuota()) {
 			return $this->storage->file_put_contents($path, $data);
 		}
@@ -103,7 +99,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->copy($source, $target);
 		}
@@ -115,7 +111,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		if (!$this->hasQuota()) {
 			return $this->storage->fopen($path, $mode);
 		}
@@ -141,7 +137,7 @@ class Quota extends Wrapper {
 	 * @param string $path Path that may identify a .part file
 	 * @note this is needed for reusing keys
 	 */
-	private function isPartFile($path): bool {
+	private function isPartFile(string $path): bool {
 		$extension = pathinfo($path, PATHINFO_EXTENSION);
 
 		return ($extension === 'part');
@@ -154,7 +150,7 @@ class Quota extends Wrapper {
 		return str_starts_with(ltrim($path, '/'), 'files/');
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
@@ -166,7 +162,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 		}
@@ -178,7 +174,7 @@ class Quota extends Wrapper {
 		}
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->mkdir($path);
 		}
@@ -190,7 +186,7 @@ class Quota extends Wrapper {
 		return parent::mkdir($path);
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		if (!$this->hasQuota()) {
 			return $this->storage->touch($path, $mtime);
 		}

--- a/lib/private/Files/Storage/Wrapper/Wrapper.php
+++ b/lib/private/Files/Storage/Wrapper/Wrapper.php
@@ -54,151 +54,151 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->getId();
 	}
 
-	public function mkdir($path): bool {
+	public function mkdir(string $path): bool {
 		return $this->getWrapperStorage()->mkdir($path);
 	}
 
-	public function rmdir($path): bool {
+	public function rmdir(string $path): bool {
 		return $this->getWrapperStorage()->rmdir($path);
 	}
 
-	public function opendir($path) {
+	public function opendir(string $path) {
 		return $this->getWrapperStorage()->opendir($path);
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		return $this->getWrapperStorage()->is_dir($path);
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		return $this->getWrapperStorage()->is_file($path);
 	}
 
-	public function stat($path): array|false {
+	public function stat(string $path): array|false {
 		return $this->getWrapperStorage()->stat($path);
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		return $this->getWrapperStorage()->filetype($path);
 	}
 
-	public function filesize($path): int|float|false {
+	public function filesize(string $path): int|float|false {
 		return $this->getWrapperStorage()->filesize($path);
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		return $this->getWrapperStorage()->isCreatable($path);
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		return $this->getWrapperStorage()->isReadable($path);
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return $this->getWrapperStorage()->isUpdatable($path);
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		return $this->getWrapperStorage()->isDeletable($path);
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		return $this->getWrapperStorage()->isSharable($path);
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		return $this->getWrapperStorage()->getPermissions($path);
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		return $this->getWrapperStorage()->file_exists($path);
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		return $this->getWrapperStorage()->filemtime($path);
 	}
 
-	public function file_get_contents($path): string|false {
+	public function file_get_contents(string $path): string|false {
 		return $this->getWrapperStorage()->file_get_contents($path);
 	}
 
-	public function file_put_contents($path, $data): int|float|false {
+	public function file_put_contents(string $path, mixed $data): int|float|false {
 		return $this->getWrapperStorage()->file_put_contents($path, $data);
 	}
 
-	public function unlink($path): bool {
+	public function unlink(string $path): bool {
 		return $this->getWrapperStorage()->unlink($path);
 	}
 
-	public function rename($source, $target): bool {
+	public function rename(string $source, string $target): bool {
 		return $this->getWrapperStorage()->rename($source, $target);
 	}
 
-	public function copy($source, $target): bool {
+	public function copy(string $source, string $target): bool {
 		return $this->getWrapperStorage()->copy($source, $target);
 	}
 
-	public function fopen($path, $mode) {
+	public function fopen(string $path, string $mode) {
 		return $this->getWrapperStorage()->fopen($path, $mode);
 	}
 
-	public function getMimeType($path): string|false {
+	public function getMimeType(string $path): string|false {
 		return $this->getWrapperStorage()->getMimeType($path);
 	}
 
-	public function hash($type, $path, $raw = false): string|false {
+	public function hash(string $type, string $path, bool $raw = false): string|false {
 		return $this->getWrapperStorage()->hash($type, $path, $raw);
 	}
 
-	public function free_space($path): int|float|false {
+	public function free_space(string $path): int|float|false {
 		return $this->getWrapperStorage()->free_space($path);
 	}
 
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		return $this->getWrapperStorage()->touch($path, $mtime);
 	}
 
-	public function getLocalFile($path): string|false {
+	public function getLocalFile(string $path): string|false {
 		return $this->getWrapperStorage()->getLocalFile($path);
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		return $this->getWrapperStorage()->hasUpdated($path, $time);
 	}
 
-	public function getCache($path = '', $storage = null): ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getCache($path, $storage);
 	}
 
-	public function getScanner($path = '', $storage = null): IScanner {
+	public function getScanner(string $path = '', ?IStorage $storage = null): IScanner {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getScanner($path, $storage);
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		return $this->getWrapperStorage()->getOwner($path);
 	}
 
-	public function getWatcher($path = '', $storage = null): IWatcher {
+	public function getWatcher(string $path = '', ?IStorage $storage = null): IWatcher {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getWatcher($path, $storage);
 	}
 
-	public function getPropagator($storage = null): IPropagator {
+	public function getPropagator(?IStorage $storage = null): IPropagator {
 		if (!$storage) {
 			$storage = $this;
 		}
 		return $this->getWrapperStorage()->getPropagator($storage);
 	}
 
-	public function getUpdater($storage = null): IUpdater {
+	public function getUpdater(?IStorage $storage = null): IUpdater {
 		if (!$storage) {
 			$storage = $this;
 		}
@@ -209,7 +209,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->getStorageCache();
 	}
 
-	public function getETag($path): string|false {
+	public function getETag(string $path): string|false {
 		return $this->getWrapperStorage()->getETag($path);
 	}
 
@@ -221,7 +221,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->isLocal();
 	}
 
-	public function instanceOfStorage($class): bool {
+	public function instanceOfStorage(string $class): bool {
 		if (ltrim($class, '\\') === 'OC\Files\Storage\Shared') {
 			// FIXME Temporary fix to keep existing checks working
 			$class = '\OCA\Files_Sharing\SharedStorage';
@@ -251,15 +251,13 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 	/**
 	 * Pass any methods custom to specific storage implementations to the wrapped storage
 	 *
-	 * @param string $method
-	 * @param array $args
 	 * @return mixed
 	 */
-	public function __call($method, $args) {
+	public function __call(string $method, array $args) {
 		return call_user_func_array([$this->getWrapperStorage(), $method], $args);
 	}
 
-	public function getDirectDownload($path): array|false {
+	public function getDirectDownload(string $path): array|false {
 		return $this->getWrapperStorage()->getDirectDownload($path);
 	}
 
@@ -267,15 +265,15 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->getAvailability();
 	}
 
-	public function setAvailability($isAvailable): void {
+	public function setAvailability(bool $isAvailable): void {
 		$this->getWrapperStorage()->setAvailability($isAvailable);
 	}
 
-	public function verifyPath($path, $fileName): void {
+	public function verifyPath(string $path, string $fileName): void {
 		$this->getWrapperStorage()->verifyPath($path, $fileName);
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
@@ -283,7 +281,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		if ($sourceStorage === $this) {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
@@ -291,23 +289,23 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		return $this->getWrapperStorage()->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
-	public function getMetaData($path): ?array {
+	public function getMetaData(string $path): ?array {
 		return $this->getWrapperStorage()->getMetaData($path);
 	}
 
-	public function acquireLock($path, $type, ILockingProvider $provider): void {
+	public function acquireLock(string $path, int $type, ILockingProvider $provider): void {
 		if ($this->getWrapperStorage()->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 			$this->getWrapperStorage()->acquireLock($path, $type, $provider);
 		}
 	}
 
-	public function releaseLock($path, $type, ILockingProvider $provider): void {
+	public function releaseLock(string $path, int $type, ILockingProvider $provider): void {
 		if ($this->getWrapperStorage()->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 			$this->getWrapperStorage()->releaseLock($path, $type, $provider);
 		}
 	}
 
-	public function changeLock($path, $type, ILockingProvider $provider): void {
+	public function changeLock(string $path, int $type, ILockingProvider $provider): void {
 		if ($this->getWrapperStorage()->instanceOfStorage('\OCP\Files\Storage\ILockingStorage')) {
 			$this->getWrapperStorage()->changeLock($path, $type, $provider);
 		}
@@ -331,7 +329,7 @@ class Wrapper implements \OC\Files\Storage\Storage, ILockingStorage, IWriteStrea
 		}
 	}
 
-	public function getDirectoryContent($directory): \Traversable {
+	public function getDirectoryContent(string $directory): \Traversable {
 		return $this->getWrapperStorage()->getDirectoryContent($directory);
 	}
 

--- a/lib/private/Lockdown/Filesystem/NullStorage.php
+++ b/lib/private/Lockdown/Filesystem/NullStorage.php
@@ -20,119 +20,119 @@ class NullStorage extends Common {
 		return 'null';
 	}
 
-	public function mkdir($path): never {
+	public function mkdir(string $path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function rmdir($path): never {
+	public function rmdir(string $path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function opendir($path): IteratorDirectory {
+	public function opendir(string $path): IteratorDirectory {
 		return new IteratorDirectory([]);
 	}
 
-	public function is_dir($path): bool {
+	public function is_dir(string $path): bool {
 		return $path === '';
 	}
 
-	public function is_file($path): bool {
+	public function is_file(string $path): bool {
 		return false;
 	}
 
-	public function stat($path): never {
+	public function stat(string $path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function filetype($path): string|false {
+	public function filetype(string $path): string|false {
 		return ($path === '') ? 'dir' : false;
 	}
 
-	public function filesize($path): never {
+	public function filesize(string $path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function isCreatable($path): bool {
+	public function isCreatable(string $path): bool {
 		return false;
 	}
 
-	public function isReadable($path): bool {
+	public function isReadable(string $path): bool {
 		return $path === '';
 	}
 
-	public function isUpdatable($path): bool {
+	public function isUpdatable(string $path): bool {
 		return false;
 	}
 
-	public function isDeletable($path): bool {
+	public function isDeletable(string $path): bool {
 		return false;
 	}
 
-	public function isSharable($path): bool {
+	public function isSharable(string $path): bool {
 		return false;
 	}
 
-	public function getPermissions($path): int {
+	public function getPermissions(string $path): int {
 		return 0;
 	}
 
-	public function file_exists($path): bool {
+	public function file_exists(string $path): bool {
 		return $path === '';
 	}
 
-	public function filemtime($path): int|false {
+	public function filemtime(string $path): int|false {
 		return ($path === '') ? time() : false;
 	}
 
-	public function file_get_contents($path): never {
+	public function file_get_contents(string $path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function file_put_contents($path, $data): never {
+	public function file_put_contents(string $path, mixed $data): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function unlink($path): never {
+	public function unlink(string $path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function rename($source, $target): never {
+	public function rename(string $source, string $target): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function copy($source, $target): never {
+	public function copy(string $source, string $target): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function fopen($path, $mode): never {
+	public function fopen(string $path, string $mode): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function getMimeType($path): never {
+	public function getMimeType(string $path): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function hash($type, $path, $raw = false): never {
+	public function hash(string $type, string $path, bool $raw = false): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function free_space($path): int {
+	public function free_space(string $path): int {
 		return FileInfo::SPACE_UNKNOWN;
 	}
 
-	public function touch($path, $mtime = null): never {
+	public function touch(string $path, ?int $mtime = null): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function getLocalFile($path): string|false {
+	public function getLocalFile(string $path): string|false {
 		return false;
 	}
 
-	public function hasUpdated($path, $time): bool {
+	public function hasUpdated(string $path, int $time): bool {
 		return false;
 	}
 
-	public function getETag($path): string {
+	public function getETag(string $path): string {
 		return '';
 	}
 
@@ -140,15 +140,15 @@ class NullStorage extends Common {
 		return false;
 	}
 
-	public function getDirectDownload($path): array|false {
+	public function getDirectDownload(string $path): array|false {
 		return false;
 	}
 
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = false): never {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): never {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): never {
 		throw new \OC\ForbiddenException('This request is not allowed to access the filesystem');
 	}
 
@@ -156,11 +156,11 @@ class NullStorage extends Common {
 		return true;
 	}
 
-	public function getOwner($path): string|false {
+	public function getOwner(string $path): string|false {
 		return false;
 	}
 
-	public function getCache($path = '', $storage = null): ICache {
+	public function getCache(string $path = '', ?IStorage $storage = null): ICache {
 		return new NullCache();
 	}
 }

--- a/lib/public/Files/Storage/IChunkedFileWrite.php
+++ b/lib/public/Files/Storage/IChunkedFileWrite.php
@@ -24,28 +24,19 @@ interface IChunkedFileWrite extends IStorage {
 	public function startChunkedWrite(string $targetPath): string;
 
 	/**
-	 * @param string $targetPath
-	 * @param string $writeToken
-	 * @param string $chunkId
 	 * @param resource $data
-	 * @param int|null $size
 	 * @throws GenericFileException
 	 * @since 26.0.0
 	 */
 	public function putChunkedWritePart(string $targetPath, string $writeToken, string $chunkId, $data, ?int $size = null): ?array;
 
 	/**
-	 * @param string $targetPath
-	 * @param string $writeToken
-	 * @return int
 	 * @throws GenericFileException
 	 * @since 26.0.0
 	 */
 	public function completeChunkedWrite(string $targetPath, string $writeToken): int;
 
 	/**
-	 * @param string $targetPath
-	 * @param string $writeToken
 	 * @throws GenericFileException
 	 * @since 26.0.0
 	 */

--- a/lib/public/Files/Storage/ILockingStorage.php
+++ b/lib/public/Files/Storage/ILockingStorage.php
@@ -21,27 +21,24 @@ interface ILockingStorage {
 	/**
 	 * @param string $path The path of the file to acquire the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
-	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
 	 * @since 9.0.0
 	 */
-	public function acquireLock($path, $type, ILockingProvider $provider);
+	public function acquireLock(string $path, int $type, ILockingProvider $provider);
 
 	/**
 	 * @param string $path The path of the file to acquire the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
-	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
 	 * @since 9.0.0
 	 */
-	public function releaseLock($path, $type, ILockingProvider $provider);
+	public function releaseLock(string $path, int $type, ILockingProvider $provider);
 
 	/**
 	 * @param string $path The path of the file to change the lock for
 	 * @param int $type \OCP\Lock\ILockingProvider::LOCK_SHARED or \OCP\Lock\ILockingProvider::LOCK_EXCLUSIVE
-	 * @param \OCP\Lock\ILockingProvider $provider
 	 * @throws \OCP\Lock\LockedException
 	 * @since 9.0.0
 	 */
-	public function changeLock($path, $type, ILockingProvider $provider);
+	public function changeLock(string $path, int $type, ILockingProvider $provider);
 }

--- a/lib/public/Files/Storage/INotifyStorage.php
+++ b/lib/public/Files/Storage/INotifyStorage.php
@@ -36,10 +36,9 @@ interface INotifyStorage {
 	/**
 	 * Start the notification handler for this storage
 	 *
-	 * @param $path
 	 * @return INotifyHandler
 	 *
 	 * @since 12.0.0
 	 */
-	public function notify($path);
+	public function notify(string $path);
 }

--- a/lib/public/Files/Storage/ISharedStorage.php
+++ b/lib/public/Files/Storage/ISharedStorage.php
@@ -19,7 +19,6 @@ interface ISharedStorage extends IStorage {
 	/**
 	 * The the associated share
 	 *
-	 * @return IShare
 	 * @since 30.0.0
 	 */
 	public function getShare(): IShare;

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -40,280 +40,243 @@ interface IStorage {
 	 * see https://www.php.net/manual/en/function.mkdir.php
 	 * implementations need to implement a recursive mkdir
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function mkdir($path);
+	public function mkdir(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.rmdir.php
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function rmdir($path);
+	public function rmdir(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.opendir.php
 	 *
-	 * @param string $path
 	 * @return resource|false
 	 * @since 9.0.0
 	 */
-	public function opendir($path);
+	public function opendir(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.is-dir.php
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function is_dir($path);
+	public function is_dir(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.is-file.php
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function is_file($path);
+	public function is_file(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.stat.php
 	 * only the following keys are required in the result: size and mtime
 	 *
-	 * @param string $path
 	 * @return array|false
 	 * @since 9.0.0
 	 */
-	public function stat($path);
+	public function stat(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.filetype.php
 	 *
-	 * @param string $path
 	 * @return string|false
 	 * @since 9.0.0
 	 */
-	public function filetype($path);
+	public function filetype(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.filesize.php
 	 * The result for filesize when called on a folder is required to be 0
 	 *
-	 * @param string $path
 	 * @return int|float|false
 	 * @since 9.0.0
 	 */
-	public function filesize($path);
+	public function filesize(string $path);
 
 	/**
 	 * check if a file can be created in $path
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isCreatable($path);
+	public function isCreatable(string $path);
 
 	/**
 	 * check if a file can be read
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isReadable($path);
+	public function isReadable(string $path);
 
 	/**
 	 * check if a file can be written to
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isUpdatable($path);
+	public function isUpdatable(string $path);
 
 	/**
 	 * check if a file can be deleted
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isDeletable($path);
+	public function isDeletable(string $path);
 
 	/**
 	 * check if a file can be shared
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function isSharable($path);
+	public function isSharable(string $path);
 
 	/**
 	 * get the full permissions of a path.
 	 * Should return a combination of the PERMISSION_ constants defined in lib/public/constants.php
 	 *
-	 * @param string $path
 	 * @return int
 	 * @since 9.0.0
 	 */
-	public function getPermissions($path);
+	public function getPermissions(string $path);
 
 	/**
-	 * see https://www.php.net/manual/en/function.file_exists.php
+	 * see https://www.php.net/manual/en/function.file-exists.php
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function file_exists($path);
+	public function file_exists(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.filemtime.php
 	 *
-	 * @param string $path
 	 * @return int|false
 	 * @since 9.0.0
 	 */
-	public function filemtime($path);
+	public function filemtime(string $path);
 
 	/**
-	 * see https://www.php.net/manual/en/function.file_get_contents.php
+	 * see https://www.php.net/manual/en/function.file-get-contents.php
 	 *
-	 * @param string $path
 	 * @return string|false
 	 * @since 9.0.0
 	 */
-	public function file_get_contents($path);
+	public function file_get_contents(string $path);
 
 	/**
-	 * see https://www.php.net/manual/en/function.file_put_contents.php
+	 * see https://www.php.net/manual/en/function.file-put-contents.php
 	 *
-	 * @param string $path
-	 * @param mixed $data
 	 * @return int|float|false
 	 * @since 9.0.0
 	 */
-	public function file_put_contents($path, $data);
+	public function file_put_contents(string $path, mixed $data);
 
 	/**
 	 * see https://www.php.net/manual/en/function.unlink.php
 	 *
-	 * @param string $path
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function unlink($path);
+	public function unlink(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.rename.php
 	 *
-	 * @param string $source
-	 * @param string $target
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function rename($source, $target);
+	public function rename(string $source, string $target);
 
 	/**
 	 * see https://www.php.net/manual/en/function.copy.php
 	 *
-	 * @param string $source
-	 * @param string $target
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function copy($source, $target);
+	public function copy(string $source, string $target);
 
 	/**
 	 * see https://www.php.net/manual/en/function.fopen.php
 	 *
-	 * @param string $path
-	 * @param string $mode
 	 * @return resource|false
 	 * @since 9.0.0
 	 */
-	public function fopen($path, $mode);
+	public function fopen(string $path, string $mode);
 
 	/**
 	 * get the mimetype for a file or folder
 	 * The mimetype for a folder is required to be "httpd/unix-directory"
 	 *
-	 * @param string $path
 	 * @return string|false
 	 * @since 9.0.0
 	 */
-	public function getMimeType($path);
+	public function getMimeType(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.hash-file.php
 	 *
-	 * @param string $type
-	 * @param string $path
-	 * @param bool $raw
 	 * @return string|false
 	 * @since 9.0.0
 	 */
-	public function hash($type, $path, $raw = false);
+	public function hash(string $type, string $path, bool $raw = false);
 
 	/**
 	 * see https://www.php.net/manual/en/function.disk-free-space.php
 	 *
-	 * @param string $path
 	 * @return int|float|false
 	 * @since 9.0.0
 	 */
-	public function free_space($path);
+	public function free_space(string $path);
 
 	/**
 	 * see https://www.php.net/manual/en/function.touch.php
 	 * If the backend does not support the operation, false should be returned
 	 *
-	 * @param string $path
-	 * @param int $mtime
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function touch($path, $mtime = null);
+	public function touch(string $path, ?int $mtime = null);
 
 	/**
 	 * get the path to a local version of the file.
 	 * The local version of the file can be temporary and doesn't have to be persistent across requests
 	 *
-	 * @param string $path
 	 * @return string|false
 	 * @since 9.0.0
 	 */
-	public function getLocalFile($path);
+	public function getLocalFile(string $path);
 
 	/**
 	 * check if a file or folder has been updated since $time
 	 *
-	 * @param string $path
-	 * @param int $time
 	 * @return bool
 	 * @since 9.0.0
 	 *
 	 * hasUpdated for folders should return at least true if a file inside the folder is add, removed or renamed.
 	 * returning true for other changes in the folder is optional
 	 */
-	public function hasUpdated($path, $time);
+	public function hasUpdated(string $path, int $time);
 
 	/**
 	 * get the ETag for a file or folder
 	 *
-	 * @param string $path
 	 * @return string|false
 	 * @since 9.0.0
 	 */
-	public function getETag($path);
+	public function getETag(string $path);
 
 	/**
 	 * Returns whether the storage is local, which means that files
@@ -331,51 +294,41 @@ interface IStorage {
 	 * Check if the storage is an instance of $class or is a wrapper for a storage that is an instance of $class
 	 *
 	 * @template T of IStorage
-	 * @param string $class
 	 * @psalm-param class-string<T> $class
 	 * @return bool
 	 * @since 9.0.0
 	 * @psalm-assert-if-true T $this
 	 */
-	public function instanceOfStorage($class);
+	public function instanceOfStorage(string $class);
 
 	/**
 	 * A custom storage implementation can return an url for direct download of a give file.
 	 *
 	 * For now the returned array can hold the parameter url - in future more attributes might follow.
 	 *
-	 * @param string $path
 	 * @return array|false
 	 * @since 9.0.0
 	 */
-	public function getDirectDownload($path);
+	public function getDirectDownload(string $path);
 
 	/**
-	 * @param string $path the path of the target folder
-	 * @param string $fileName the name of the file itself
 	 * @return void
 	 * @throws InvalidPathException
 	 * @since 9.0.0
 	 */
-	public function verifyPath($path, $fileName);
+	public function verifyPath(string $path, string $fileName);
 
 	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath);
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath);
 
 	/**
-	 * @param IStorage $sourceStorage
-	 * @param string $sourceInternalPath
-	 * @param string $targetInternalPath
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath);
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath);
 
 	/**
 	 * Test a storage for availability
@@ -393,10 +346,9 @@ interface IStorage {
 
 	/**
 	 * @since 9.0.0
-	 * @param bool $isAvailable
 	 * @return void
 	 */
-	public function setAvailability($isAvailable);
+	public function setAvailability(bool $isAvailable);
 
 	/**
 	 * @since 12.0.0
@@ -406,19 +358,16 @@ interface IStorage {
 	public function needsPartFile();
 
 	/**
-	 * @param string $path path for which to retrieve the owner
 	 * @return string|false
 	 * @since 9.0.0
 	 */
-	public function getOwner($path);
+	public function getOwner(string $path);
 
 	/**
-	 * @param string $path
-	 * @param IStorage|null $storage
 	 * @return ICache
 	 * @since 9.0.0
 	 */
-	public function getCache($path = '', $storage = null);
+	public function getCache(string $path = '', ?IStorage $storage = null);
 
 	/**
 	 * @return IPropagator
@@ -450,7 +399,7 @@ interface IStorage {
 	 * This can be used for storages that do not have a dedicated owner, where we want to
 	 * pass the user that we setup the mountpoint for along to the storage layer
 	 *
-	 * @param string|null $user Owner user id
+	 * @param ?string $user Owner user id
 	 * @return void
 	 * @since 30.0.0
 	 */

--- a/lib/public/Files/Storage/IStorageFactory.php
+++ b/lib/public/Files/Storage/IStorageFactory.php
@@ -19,20 +19,15 @@ interface IStorageFactory {
 	 *
 	 * $callback should be a function of type (string $mountPoint, Storage $storage) => Storage
 	 *
-	 * @param string $wrapperName
-	 * @param callable $callback
 	 * @return bool true if the wrapper was added, false if there was already a wrapper with this
 	 *              name registered
 	 * @since 8.0.0
 	 */
-	public function addStorageWrapper($wrapperName, $callback);
+	public function addStorageWrapper(string $wrapperName, callable $callback);
 
 	/**
-	 * @param IMountPoint $mountPoint
-	 * @param string $class
-	 * @param array $arguments
 	 * @return IStorage
 	 * @since 8.0.0
 	 */
-	public function getInstance(IMountPoint $mountPoint, $class, $arguments);
+	public function getInstance(IMountPoint $mountPoint, string $class, array $arguments);
 }

--- a/lib/public/Files/Storage/IWriteStreamStorage.php
+++ b/lib/public/Files/Storage/IWriteStreamStorage.php
@@ -19,9 +19,8 @@ interface IWriteStreamStorage extends IStorage {
 	/**
 	 * Write the data from a stream to a file
 	 *
-	 * @param string $path
 	 * @param resource $stream
-	 * @param int|null $size the size of the stream if known in advance
+	 * @param ?int $size the size of the stream if known in advance
 	 * @return int the number of bytes written
 	 * @throws GenericFileException
 	 * @since 15.0.0

--- a/tests/lib/Files/Mount/MountPointTest.php
+++ b/tests/lib/Files/Mount/MountPointTest.php
@@ -8,10 +8,8 @@
 namespace Test\Files\Mount;
 
 use OC\Files\Storage\StorageFactory;
+use OC\Lockdown\Filesystem\NullStorage;
 use OCP\Files\Storage\IStorage;
-
-class DummyStorage {
-}
 
 class MountPointTest extends \Test\TestCase {
 	public function testGetStorage(): void {
@@ -27,7 +25,7 @@ class MountPointTest extends \Test\TestCase {
 
 		$mountPoint = new \OC\Files\Mount\MountPoint(
 			// just use this because a real class is needed
-			'\Test\Files\Mount\DummyStorage',
+			NullStorage::class,
 			'/mountpoint',
 			null,
 			$loader
@@ -54,7 +52,7 @@ class MountPointTest extends \Test\TestCase {
 
 		$mountPoint = new \OC\Files\Mount\MountPoint(
 			// just use this because a real class is needed
-			'\Test\Files\Mount\DummyStorage',
+			NullStorage::class,
 			'/mountpoint',
 			null,
 			$loader

--- a/tests/lib/Files/Storage/CopyDirectoryTest.php
+++ b/tests/lib/Files/Storage/CopyDirectoryTest.php
@@ -10,11 +10,11 @@ namespace Test\Files\Storage;
 use OC\Files\Storage\Temporary;
 
 class StorageNoRecursiveCopy extends Temporary {
-	public function copy($path1, $path2): bool {
-		if ($this->is_dir($path1)) {
+	public function copy(string $source, string $target): bool {
+		if ($this->is_dir($source)) {
 			return false;
 		}
-		return copy($this->getSourcePath($path1), $this->getSourcePath($path2));
+		return copy($this->getSourcePath($source), $this->getSourcePath($target));
 	}
 }
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -37,27 +37,27 @@ use Test\TestMoveableMountPoint;
 use Test\Traits\UserTrait;
 
 class TemporaryNoTouch extends Temporary {
-	public function touch($path, $mtime = null): bool {
+	public function touch(string $path, ?int $mtime = null): bool {
 		return false;
 	}
 }
 
 class TemporaryNoCross extends Temporary {
-	public function copyFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime = null): bool {
+	public function copyFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, bool $preserveMtime = false): bool {
 		return Common::copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath, $preserveMtime);
 	}
 
-	public function moveFromStorage(IStorage $sourceStorage, $sourceInternalPath, $targetInternalPath): bool {
+	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath): bool {
 		return Common::moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 }
 
 class TemporaryNoLocal extends Temporary {
-	public function instanceOfStorage($className): bool {
-		if ($className === '\OC\Files\Storage\Local') {
+	public function instanceOfStorage(string $class): bool {
+		if ($class === '\OC\Files\Storage\Local') {
 			return false;
 		} else {
-			return parent::instanceOfStorage($className);
+			return parent::instanceOfStorage($class);
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adding strong types to the interface method parameters is allowed as long as it previously didn't define strong type.
I also added them to all implementations for completeness and readability (but I don't know if this is even necessary safety wise).
Most of it was actually done through IntelliJ refactoring which was able to add the strong type to the interface and to all implementations at the same time.

Based on https://github.com/nextcloud/server/pull/48487 due to necessary fixes for those tests.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
Signed-off-by: provokateurin <kate@provokateurin.de>