### PR TITLE
fix(QueryBuilder): Account for aliases in output columns

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -582,6 +582,9 @@ class QueryBuilder implements IQueryBuilder {
 			if (is_array($column)) {
 				$this->addOutputColumns($column);
 			} elseif (is_string($column) && !str_contains($column, '*')) {
+				if (str_contains(strtolower($column), ' as ')) {
+					[, $column] = preg_split('/ as /i', $column);
+				}
 				if (str_contains($column, '.')) {
 					[, $column] = explode('.', $column);
 				}
@@ -591,14 +594,7 @@ class QueryBuilder implements IQueryBuilder {
 	}
 
 	public function getOutputColumns(): array {
-		return array_unique(array_map(function (string $column) {
-			if (str_contains($column, '.')) {
-				[, $column] = explode('.', $column);
-				return $column;
-			} else {
-				return $column;
-			}
-		}, $this->selectedColumns));
+		return array_unique($this->selectedColumns);
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/48521

## Summary

https://github.com/nextcloud/server/pull/48361 added error logs when the output column is too long. https://github.com/nextcloud/server/issues/48521 shows the output columns weren't extracted correctly as it contained `display_mode as display_mode_default` which is actually fine because `display_mode_default` is only 20 chars.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
