### PR TITLE
fix: do not reduce count for subadmins if they are members of group

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -154,12 +154,6 @@ class UsersController extends Controller {
 				foreach ($groups as $key => $group) {
 					// $userCount += (int)$group['usercount'];
 					$groupsIds[] = $group['id'];
-					// we prevent subadmins from looking up themselves
-					// so we lower the count of the groups he belongs to
-					if (array_key_exists($group['id'], $userGroups)) {
-						$groups[$key]['usercount']--;
-						$userCount -= 1; // we also lower from one the total count
-					}
 				}
 
 				$userCount += $this->userManager->countUsersOfGroups($groupsInfo->getGroups());


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Follow-up to #48437

## Summary

Counter on sidebar doesn't reflect the actual number of group members, if subadmin is a member too.
For each group, counter is reduced by 1, and for 'All accounts', counter is reduced by amount of groups subadmin is in.

There is a comment:
> we prevent subadmins from looking up themselves so we lower the count of the groups he belongs to

but I don't see a point of it, since we fetch and show yourself in the list anyway, so just removing inconsistency

Before | After
-- | --
<img width="395" alt="image" src="https://github.com/user-attachments/assets/cfa7aa13-e5b9-4a09-92d5-0dfe88c9783b"> | <img width="387" alt="image" src="https://github.com/user-attachments/assets/ba6de883-d348-4b04-8d06-0fddd6de3ea3">
_Subadmin: 'alice', member of 'test group' and 'test group 2'_


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
