### PR TITLE
feat(setupchecks): add row format setup check for MySQL databases

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -104,6 +104,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\MaintenanceWindowStart' => $baseDir . '/../lib/SetupChecks/MaintenanceWindowStart.php',
     'OCA\\Settings\\SetupChecks\\MemcacheConfigured' => $baseDir . '/../lib/SetupChecks/MemcacheConfigured.php',
     'OCA\\Settings\\SetupChecks\\MimeTypeMigrationAvailable' => $baseDir . '/../lib/SetupChecks/MimeTypeMigrationAvailable.php',
+    'OCA\\Settings\\SetupChecks\\MysqlRowFormat' => $baseDir . '/../lib/SetupChecks/MysqlRowFormat.php',
     'OCA\\Settings\\SetupChecks\\MysqlUnicodeSupport' => $baseDir . '/../lib/SetupChecks/MysqlUnicodeSupport.php',
     'OCA\\Settings\\SetupChecks\\OcxProviders' => $baseDir . '/../lib/SetupChecks/OcxProviders.php',
     'OCA\\Settings\\SetupChecks\\OverwriteCliUrl' => $baseDir . '/../lib/SetupChecks/OverwriteCliUrl.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -119,6 +119,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\MaintenanceWindowStart' => __DIR__ . '/..' . '/../lib/SetupChecks/MaintenanceWindowStart.php',
         'OCA\\Settings\\SetupChecks\\MemcacheConfigured' => __DIR__ . '/..' . '/../lib/SetupChecks/MemcacheConfigured.php',
         'OCA\\Settings\\SetupChecks\\MimeTypeMigrationAvailable' => __DIR__ . '/..' . '/../lib/SetupChecks/MimeTypeMigrationAvailable.php',
+        'OCA\\Settings\\SetupChecks\\MysqlRowFormat' => __DIR__ . '/..' . '/../lib/SetupChecks/MysqlRowFormat.php',
         'OCA\\Settings\\SetupChecks\\MysqlUnicodeSupport' => __DIR__ . '/..' . '/../lib/SetupChecks/MysqlUnicodeSupport.php',
         'OCA\\Settings\\SetupChecks\\OcxProviders' => __DIR__ . '/..' . '/../lib/SetupChecks/OcxProviders.php',
         'OCA\\Settings\\SetupChecks\\OverwriteCliUrl' => __DIR__ . '/..' . '/../lib/SetupChecks/OverwriteCliUrl.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -47,6 +47,7 @@ use OCA\Settings\SetupChecks\LegacySSEKeyFormat;
 use OCA\Settings\SetupChecks\MaintenanceWindowStart;
 use OCA\Settings\SetupChecks\MemcacheConfigured;
 use OCA\Settings\SetupChecks\MimeTypeMigrationAvailable;
+use OCA\Settings\SetupChecks\MysqlRowFormat;
 use OCA\Settings\SetupChecks\MysqlUnicodeSupport;
 use OCA\Settings\SetupChecks\OcxProviders;
 use OCA\Settings\SetupChecks\OverwriteCliUrl;
@@ -181,6 +182,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(MaintenanceWindowStart::class);
 		$context->registerSetupCheck(MemcacheConfigured::class);
 		$context->registerSetupCheck(MimeTypeMigrationAvailable::class);
+		$context->registerSetupCheck(MysqlRowFormat::class);
 		$context->registerSetupCheck(MysqlUnicodeSupport::class);
 		$context->registerSetupCheck(OcxProviders::class);
 		$context->registerSetupCheck(OverwriteCliUrl::class);

--- a/apps/settings/lib/SetupChecks/MysqlRowFormat.php
+++ b/apps/settings/lib/SetupChecks/MysqlRowFormat.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Settings\SetupChecks;
+
+use Doctrine\DBAL\Platforms\MySQLPlatform;
+use OC\DB\Connection;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class MysqlRowFormat implements ISetupCheck {
+	public function __construct(
+		private IL10N $l10n,
+		private IConfig $config,
+		private Connection $connection,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('MySQL row format');
+	}
+
+	public function getCategory(): string {
+		return 'database';
+	}
+
+	public function run(): SetupResult {
+		if (!$this->connection->getDatabasePlatform() instanceof MySQLPlatform) {
+			return SetupResult::success($this->l10n->t('You are not using MySQL'));
+		}
+
+		$wrongRowFormatTables = $this->getRowNotDynamicTables();
+		if (empty($wrongRowFormatTables)) {
+			return SetupResult::success($this->l10n->t('None of your table use ROW_FORMAT=Compressed'));
+		}
+
+		return SetupResult::warning(
+			$this->l10n->n(
+				'Table %s is not using ROW_FORMAT=Dynamic. This format offers the best database performances for Nextcloud. Please change the row format to Dynamic.',
+				'Some tables are not using ROW_FORMAT=Dynamic. This format offers the best database performances for Nextcloud. Please change the row format to Dynamic on the following tables: %s.',
+				count($wrongRowFormatTables),
+				[implode(', ', $wrongRowFormatTables)],
+			),
+			'https://dev.mysql.com/doc/refman/en/innodb-row-format.html',
+		);
+	}
+
+	/**
+	 * @return string[]
+	 */
+	private function getRowNotDynamicTables(): array {
+		$sql = 'SELECT table_name
+			FROM information_schema.tables
+			WHERE table_schema = ?
+			  AND table_name LIKE "*PREFIX*%"
+			  AND row_format != "Dynamic";';
+
+		return $this->connection->executeQuery(
+			$sql,
+			[$this->config->getSystemValueString('dbname')],
+		)->fetchFirstColumn();
+	}
+}


### PR DESCRIPTION
* Resolves: #34497 

## Summary
Add a setup check to warn about tables using ROW_FORMAT=Compressed
MySQL specific
![Screenshot_2024-10-08_170508](https://github.com/user-attachments/assets/1553f082-a20a-467a-8f3c-3df07833701b)
![Screenshot_2024-10-08_170554](https://github.com/user-attachments/assets/6559f2f9-10f8-4adc-8933-f5db78216831)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
