### PR TITLE
fix(admin_audit): Listen to the right events

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -8,12 +8,11 @@ declare(strict_types=1);
 namespace OCA\AdminAudit\Actions;
 
 use OC\Files\Node\NonExistingFile;
+use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\Events\Node\BeforeNodeReadEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
-use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
 use OCP\Files\Events\Node\NodeCopiedEvent;
 use OCP\Files\Events\Node\NodeCreatedEvent;
-use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\InvalidPathException;
@@ -28,10 +27,9 @@ use Psr\Log\LoggerInterface;
 class Files extends Action {
 
 	private array $renamedNodes = [];
+
 	/**
 	 * Logs file read actions
-	 *
-	 * @param BeforeNodeReadEvent $event
 	 */
 	public function read(BeforeNodeReadEvent $event): void {
 		try {
@@ -55,8 +53,6 @@ class Files extends Action {
 
 	/**
 	 * Logs rename actions of files
-	 *
-	 * @param BeforeNodeRenamedEvent $event
 	 */
 	public function beforeRename(BeforeNodeRenamedEvent $event): void {
 		try {
@@ -72,8 +68,6 @@ class Files extends Action {
 
 	/**
 	 * Logs rename actions of files
-	 *
-	 * @param NodeRenamedEvent $event
 	 */
 	public function afterRename(NodeRenamedEvent $event): void {
 		try {
@@ -101,8 +95,6 @@ class Files extends Action {
 
 	/**
 	 * Logs creation of files
-	 *
-	 * @param NodeCreatedEvent $event
 	 */
 	public function create(NodeCreatedEvent $event): void {
 		try {
@@ -128,8 +120,6 @@ class Files extends Action {
 
 	/**
 	 * Logs copying of files
-	 *
-	 * @param NodeCopiedEvent $event
 	 */
 	public function copy(NodeCopiedEvent $event): void {
 		try {
@@ -154,14 +144,12 @@ class Files extends Action {
 
 	/**
 	 * Logs writing of files
-	 *
-	 * @param BeforeNodeWrittenEvent $event
 	 */
-	public function write(BeforeNodeWrittenEvent $event): void {
+	public function write(NodeWrittenEvent $event): void {
 		$node = $event->getNode();
 		try {
 			$params = [
-				'id' => $node instanceof NonExistingFile ? null : $node->getId(),
+				'id' => $node->getId(),
 				'path' => mb_substr($node->getInternalPath(), 5),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
@@ -182,35 +170,9 @@ class Files extends Action {
 	}
 
 	/**
-	 * Logs update of files
-	 *
-	 * @param NodeWrittenEvent $event
-	 */
-	public function update(NodeWrittenEvent $event): void {
-		try {
-			$params = [
-				'id' => $event->getNode()->getId(),
-				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
-			];
-		} catch (InvalidPathException|NotFoundException $e) {
-			\OCP\Server::get(LoggerInterface::class)->error(
-				'Exception thrown in file update: ' . $e->getMessage(), ['app' => 'admin_audit', 'exception' => $e]
-			);
-			return;
-		}
-		$this->log(
-			'File with id "%s" updated: "%s"',
-			$params,
-			array_keys($params)
-		);
-	}
-
-	/**
 	 * Logs deletions of files
-	 *
-	 * @param NodeDeletedEvent $event
 	 */
-	public function delete(NodeDeletedEvent $event): void {
+	public function delete(BeforeNodeDeletedEvent $event): void {
 		try {
 			$params = [
 				'id' => $event->getNode()->getId(),

--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -38,12 +38,11 @@ use OCP\Authentication\TwoFactorAuth\TwoFactorProviderChallengeFailed;
 use OCP\Authentication\TwoFactorAuth\TwoFactorProviderChallengePassed;
 use OCP\Console\ConsoleEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\Events\Node\BeforeNodeReadEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
-use OCP\Files\Events\Node\BeforeNodeWrittenEvent;
 use OCP\Files\Events\Node\NodeCopiedEvent;
 use OCP\Files\Events\Node\NodeCreatedEvent;
-use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Group\Events\GroupCreatedEvent;
@@ -195,16 +194,9 @@ class Application extends App implements IBootstrap {
 		);
 
 		$eventDispatcher->addListener(
-			BeforeNodeWrittenEvent::class,
-			function (BeforeNodeWrittenEvent $event) use ($fileActions): void {
-				$fileActions->write($event);
-			}
-		);
-
-		$eventDispatcher->addListener(
 			NodeWrittenEvent::class,
 			function (NodeWrittenEvent $event) use ($fileActions): void {
-				$fileActions->update($event);
+				$fileActions->write($event);
 			}
 		);
 
@@ -216,8 +208,8 @@ class Application extends App implements IBootstrap {
 		);
 
 		$eventDispatcher->addListener(
-			NodeDeletedEvent::class,
-			function (NodeDeletedEvent $event) use ($fileActions): void {
+			BeforeNodeDeletedEvent::class,
+			function (BeforeNodeDeletedEvent $event) use ($fileActions): void {
 				$fileActions->delete($event);
 			}
 		);


### PR DESCRIPTION
* Resolves: #47286

## Summary

Fix issues from https://github.com/nextcloud/server/pull/44871 .
We cannot get the id before the write, because the file may not exist yet. On the contrary for delete we need to get it before deletion.
I remove the "update" listener since this hook has no equivalent in the events (and it is not really needed, it’s the same as NodeWrittenEvent, only difference is the update hook was only called for modifications and not for creations).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
