### PR TITLE
fix(users): improve recently active search

### DIFF
--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -168,7 +168,7 @@ class UsersController extends Controller {
 		$recentUsersGroup = [
 			'id' => '__nc_internal_recent',
 			'name' => $this->l10n->t('Recently active'),
-			'usercount' => $userCount,
+			'usercount' => $this->userManager->countSeenUsers(),
 		];
 
 		$disabledUsersGroup = [

--- a/lib/private/DB/QueryBuilder/Sharded/ShardedQueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardedQueryBuilder.php
@@ -277,7 +277,7 @@ class ShardedQueryBuilder extends ExtendedQueryBuilder {
 
 	public function addOrderBy($sort, $order = null) {
 		$this->registerOrder((string)$sort, (string)$order ?? 'ASC');
-		return parent::orderBy($sort, $order);
+		return parent::addOrderBy($sort, $order);
 	}
 
 	public function orderBy($sort, $order = null) {


### PR DESCRIPTION
* Resolves: #46777

## Summary
- Remove DISTINCT clause to fix PgSQL
- Use data from users only if necessary (search)
- Don't show people who never connected in active list
- Add test
- Add hard limit on list (100 users max)

## TODO 
 - [x] badge still count all users instead of actives ones

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
