### PR TITLE
fix(BackgroundJobs): Adjust intervals and time sensitivities

### DIFF
--- a/apps/contactsinteraction/lib/BackgroundJob/CleanupJob.php
+++ b/apps/contactsinteraction/lib/BackgroundJob/CleanupJob.php
@@ -10,7 +10,6 @@ namespace OCA\ContactsInteraction\BackgroundJob;
 
 use OCA\ContactsInteraction\Db\RecentContactMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 
 class CleanupJob extends TimedJob {
@@ -22,7 +21,7 @@ class CleanupJob extends TimedJob {
 		parent::__construct($time);
 
 		$this->setInterval(24 * 60 * 60);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 
 	}
 

--- a/apps/dav/lib/BackgroundJob/UploadCleanup.php
+++ b/apps/dav/lib/BackgroundJob/UploadCleanup.php
@@ -10,7 +10,6 @@ namespace OCA\DAV\BackgroundJob;
 
 use OC\User\NoUserException;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
 use OCP\Files\File;
@@ -32,7 +31,7 @@ class UploadCleanup extends TimedJob {
 
 		// Run once a day
 		$this->setInterval(60 * 60 * 24);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument) {

--- a/apps/federation/lib/SyncJob.php
+++ b/apps/federation/lib/SyncJob.php
@@ -19,6 +19,7 @@ class SyncJob extends TimedJob {
 		parent::__construct($timeFactory);
 		// Run once a day
 		$this->setInterval(24 * 60 * 60);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 		$this->syncService = $syncService;
 		$this->logger = $logger;
 	}

--- a/apps/files/lib/BackgroundJob/CleanupDirectEditingTokens.php
+++ b/apps/files/lib/BackgroundJob/CleanupDirectEditingTokens.php
@@ -13,14 +13,12 @@ use OCP\BackgroundJob\TimedJob;
 use OCP\DirectEditing\IManager;
 
 class CleanupDirectEditingTokens extends TimedJob {
-	private const INTERVAL_MINUTES = 15 * 60;
-
 	private IManager $manager;
 
 	public function __construct(ITimeFactory $time,
 		IManager $manager) {
 		parent::__construct($time);
-		$this->interval = self::INTERVAL_MINUTES;
+		$this->setInterval(15 * 60);
 		$this->manager = $manager;
 	}
 

--- a/apps/files/lib/BackgroundJob/CleanupFileLocks.php
+++ b/apps/files/lib/BackgroundJob/CleanupFileLocks.php
@@ -16,19 +16,11 @@ use OCP\BackgroundJob\TimedJob;
  */
 class CleanupFileLocks extends TimedJob {
 	/**
-	 * Default interval in minutes
-	 *
-	 * @var int $defaultIntervalMin
-	 **/
-	protected $defaultIntervalMin = 5;
-
-	/**
 	 * sets the correct interval for this timed job
 	 */
 	public function __construct(ITimeFactory $time) {
 		parent::__construct($time);
-
-		$this->interval = $this->defaultIntervalMin * 60;
+		$this->setInterval(5 * 60);
 	}
 
 	/**

--- a/apps/files/lib/BackgroundJob/DeleteExpiredOpenLocalEditor.php
+++ b/apps/files/lib/BackgroundJob/DeleteExpiredOpenLocalEditor.php
@@ -11,7 +11,6 @@ namespace OCA\Files\BackgroundJob;
 
 use OCA\Files\Db\OpenLocalEditorMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 
 /**
@@ -29,7 +28,7 @@ class DeleteExpiredOpenLocalEditor extends TimedJob {
 
 		// Run every 12h
 		$this->interval = 12 * 3600;
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/apps/files/lib/BackgroundJob/DeleteOrphanedItems.php
+++ b/apps/files/lib/BackgroundJob/DeleteOrphanedItems.php
@@ -18,7 +18,6 @@ use Psr\Log\LoggerInterface;
  */
 class DeleteOrphanedItems extends TimedJob {
 	public const CHUNK_SIZE = 200;
-	protected $defaultIntervalMin = 60;
 
 	/**
 	 * sets the correct interval for this timed job
@@ -29,7 +28,7 @@ class DeleteOrphanedItems extends TimedJob {
 		protected LoggerInterface $logger,
 	) {
 		parent::__construct($time);
-		$this->interval = $this->defaultIntervalMin * 60;
+		$this->setInterval(60 * 60);
 	}
 
 	/**

--- a/apps/files_external/lib/BackgroundJob/CredentialsCleanup.php
+++ b/apps/files_external/lib/BackgroundJob/CredentialsCleanup.php
@@ -12,7 +12,6 @@ use OCA\Files_External\Lib\Auth\Password\LoginCredentials;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -37,7 +36,7 @@ class CredentialsCleanup extends TimedJob {
 
 		// run every day
 		$this->setInterval(24 * 60 * 60);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument) {

--- a/apps/files_reminders/lib/BackgroundJob/CleanUpReminders.php
+++ b/apps/files_reminders/lib/BackgroundJob/CleanUpReminders.php
@@ -11,7 +11,6 @@ namespace OCA\FilesReminders\BackgroundJob;
 
 use OCA\FilesReminders\Service\ReminderService;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 
 class CleanUpReminders extends TimedJob {
@@ -22,7 +21,7 @@ class CleanUpReminders extends TimedJob {
 		parent::__construct($time);
 
 		$this->setInterval(24 * 60 * 60); // 1 day
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
+++ b/apps/files_sharing/lib/BackgroundJob/FederatedSharesDiscoverJob.php
@@ -26,7 +26,8 @@ class FederatedSharesDiscoverJob extends TimedJob {
 		private LoggerInterface $logger,
 	) {
 		parent::__construct($time);
-		$this->setInterval(86400);
+		$this->setInterval(24 * 60 * 60);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	public function run($argument) {

--- a/apps/files_sharing/lib/ExpireSharesJob.php
+++ b/apps/files_sharing/lib/ExpireSharesJob.php
@@ -7,7 +7,6 @@
 namespace OCA\Files_Sharing;
 
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IDBConnection;
 use OCP\Share\Exceptions\ShareNotFound;
@@ -33,7 +32,7 @@ class ExpireSharesJob extends TimedJob {
 
 		// Run once a day
 		$this->setInterval(24 * 60 * 60);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 

--- a/apps/files_sharing/lib/SharesReminderJob.php
+++ b/apps/files_sharing/lib/SharesReminderJob.php
@@ -33,7 +33,7 @@ use Psr\Log\LoggerInterface;
  * Send a reminder via email to the sharee(s) if the folder is still empty a predefined time before the expiration date
  */
 class SharesReminderJob extends TimedJob {
-	private const SECONDS_BEFORE_REMINDER = 86400;
+	private const SECONDS_BEFORE_REMINDER = 24 * 60 * 60;
 	private const CHUNK_SIZE = 1000;
 	private int $folderMimeTypeId;
 
@@ -50,7 +50,7 @@ class SharesReminderJob extends TimedJob {
 		IMimeTypeLoader                  $mimeTypeLoader,
 	) {
 		parent::__construct($time);
-		$this->setInterval(3600);
+		$this->setInterval(60 * 60);
 		$this->folderMimeTypeId = $mimeTypeLoader->getId(ICacheEntry::DIRECTORY_MIMETYPE);
 	}
 

--- a/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
+++ b/apps/oauth2/lib/BackgroundJob/CleanupExpiredAuthorizationCode.php
@@ -12,7 +12,6 @@ namespace OCA\OAuth2\BackgroundJob;
 
 use OCA\OAuth2\Db\AccessTokenMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
@@ -27,7 +26,7 @@ class CleanupExpiredAuthorizationCode extends TimedJob {
 		parent::__construct($timeFactory);
 		// 30 days
 		$this->setInterval(60 * 60 * 24 * 30);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
+++ b/apps/twofactor_backupcodes/lib/BackgroundJob/RememberBackupCodesJob.php
@@ -10,7 +10,6 @@ namespace OCA\TwoFactorBackupCodes\BackgroundJob;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\IJobList;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IUserManager;
@@ -43,7 +42,7 @@ class RememberBackupCodesJob extends TimedJob {
 		$this->jobList = $jobList;
 
 		$this->setInterval(60 * 60 * 24 * 14);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument) {

--- a/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
+++ b/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
@@ -40,6 +40,7 @@ class UpdateAvailableNotifications extends TimedJob {
 		parent::__construct($timeFactory);
 		// Run once a day
 		$this->setInterval(60 * 60 * 24);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument) {

--- a/apps/user_ldap/lib/Jobs/CleanUp.php
+++ b/apps/user_ldap/lib/Jobs/CleanUp.php
@@ -27,7 +27,7 @@ class CleanUp extends TimedJob {
 	protected $limit;
 
 	/** @var int $defaultIntervalMin default interval in minutes */
-	protected $defaultIntervalMin = 51;
+	protected $defaultIntervalMin = 60;
 
 	/** @var User_LDAP|User_Proxy $userBackend */
 	protected $userBackend;

--- a/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
+++ b/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
@@ -35,7 +35,7 @@ class ClearOldStatusesBackgroundJob extends TimedJob {
 		$this->mapper = $mapper;
 
 		// Run every time the cron is run
-		$this->setInterval(60);
+		$this->setInterval(0);
 	}
 
 	/**

--- a/core/BackgroundJobs/CleanupLoginFlowV2.php
+++ b/core/BackgroundJobs/CleanupLoginFlowV2.php
@@ -19,7 +19,7 @@ class CleanupLoginFlowV2 extends TimedJob {
 	) {
 		parent::__construct($time);
 
-		$this->setInterval(3600);
+		$this->setInterval(60 * 60);
 	}
 
 	protected function run($argument): void {

--- a/core/BackgroundJobs/GenerateMetadataJob.php
+++ b/core/BackgroundJobs/GenerateMetadataJob.php
@@ -36,8 +36,8 @@ class GenerateMetadataJob extends TimedJob {
 	) {
 		parent::__construct($time);
 
-		$this->setTimeSensitivity(\OCP\BackgroundJob\IJob::TIME_INSENSITIVE);
-		$this->setInterval(24 * 3600);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		$this->setInterval(24 * 60 * 60);
 	}
 
 	protected function run(mixed $argument): void {

--- a/lib/private/Preview/BackgroundCleanupJob.php
+++ b/lib/private/Preview/BackgroundCleanupJob.php
@@ -37,7 +37,8 @@ class BackgroundCleanupJob extends TimedJob {
 		bool $isCLI) {
 		parent::__construct($timeFactory);
 		// Run at most once an hour
-		$this->setInterval(3600);
+		$this->setInterval(60 * 60);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 
 		$this->connection = $connection;
 		$this->previewFolder = $previewFolder;

--- a/lib/private/Security/Bruteforce/CleanupJob.php
+++ b/lib/private/Security/Bruteforce/CleanupJob.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace OC\Security\Bruteforce;
 
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -22,8 +21,8 @@ class CleanupJob extends TimedJob {
 		parent::__construct($time);
 
 		// Run once a day
-		$this->setInterval(3600 * 24);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		$this->setInterval(60 * 60 * 24);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	protected function run($argument): void {

--- a/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
+++ b/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
@@ -16,7 +16,7 @@ use OCP\Files\SimpleFS\ISimpleFolder;
 use Psr\Log\LoggerInterface;
 
 class RemoveOldTasksBackgroundJob extends TimedJob {
-	public const MAX_TASK_AGE_SECONDS = 60 * 50 * 24 * 7 * 4; // 4 weeks
+	public const MAX_TASK_AGE_SECONDS = 60 * 60 * 24 * 7 * 4; // 4 weeks
 	private \OCP\Files\IAppData $appData;
 
 	public function __construct(
@@ -28,7 +28,7 @@ class RemoveOldTasksBackgroundJob extends TimedJob {
 		parent::__construct($timeFactory);
 		$this->setInterval(60 * 60 * 24);
 		// can be deferred to maintenance window
-		$this->setTimeSensitivity(TimedJob::TIME_INSENSITIVE);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 		$this->appData = $appDataFactory->get('core');
 	}
 

--- a/lib/private/TextProcessing/RemoveOldTasksBackgroundJob.php
+++ b/lib/private/TextProcessing/RemoveOldTasksBackgroundJob.php
@@ -17,7 +17,7 @@ use OCP\DB\Exception;
 use Psr\Log\LoggerInterface;
 
 class RemoveOldTasksBackgroundJob extends TimedJob {
-	public const MAX_TASK_AGE_SECONDS = 60 * 50 * 24 * 7; // 1 week
+	public const MAX_TASK_AGE_SECONDS = 60 * 60 * 24 * 7; // 1 week
 
 	public function __construct(
 		ITimeFactory $timeFactory,
@@ -26,6 +26,7 @@ class RemoveOldTasksBackgroundJob extends TimedJob {
 	) {
 		parent::__construct($timeFactory);
 		$this->setInterval(60 * 60 * 24);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/lib/private/TextToImage/RemoveOldTasksBackgroundJob.php
+++ b/lib/private/TextToImage/RemoveOldTasksBackgroundJob.php
@@ -21,7 +21,7 @@ use OCP\Files\NotPermittedException;
 use Psr\Log\LoggerInterface;
 
 class RemoveOldTasksBackgroundJob extends TimedJob {
-	public const MAX_TASK_AGE_SECONDS = 60 * 50 * 24 * 7; // 1 week
+	public const MAX_TASK_AGE_SECONDS = 60 * 60 * 24 * 7; // 1 week
 
 	private IAppData $appData;
 
@@ -34,6 +34,7 @@ class RemoveOldTasksBackgroundJob extends TimedJob {
 		parent::__construct($timeFactory);
 		$this->appData = $appDataFactory->get('core');
 		$this->setInterval(60 * 60 * 24);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php
+++ b/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php
@@ -12,7 +12,6 @@ use OC\User\Manager;
 use OC\User\PartiallyDeletedUsersBackend;
 use OC\User\User;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
@@ -26,8 +25,8 @@ class CleanupDeletedUsers extends TimedJob {
 		private LoggerInterface $logger,
 	) {
 		parent::__construct($time);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
-		$this->setInterval(24 * 3600);
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		$this->setInterval(24 * 60 * 60);
 	}
 
 	protected function run($argument): void {

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 namespace OCP\BackgroundJob;
 
 use OCP\ILogger;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 /**
  * Simple base class to extend to run periodic background jobs.
@@ -80,6 +82,9 @@ abstract class TimedJob extends Job {
 	 */
 	final public function start(IJobList $jobList): void {
 		if (($this->time->getTime() - $this->lastRun) > $this->interval) {
+			if ($this->interval >= 12 * 60 * 60 && $this->isTimeSensitive()) {
+				Server::get(LoggerInterface::class)->debug('TimedJob ' . get_class($this) . ' has a configured interval of ' . $this->interval . ' seconds, but is also marked as time sensitive. Please consider marking it as time insensitive to allow more sensitive jobs to run when needed.');
+			}
 			parent::start($jobList);
 		}
 	}

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -52,8 +52,8 @@ abstract class TimedJob extends Job {
 	 * @since 24.0.0
 	 */
 	public function setTimeSensitivity(int $sensitivity): void {
-		if ($sensitivity !== IJob::TIME_SENSITIVE &&
-			$sensitivity !== IJob::TIME_INSENSITIVE) {
+		if ($sensitivity !== self::TIME_SENSITIVE &&
+			$sensitivity !== self::TIME_INSENSITIVE) {
 			throw new \InvalidArgumentException('Invalid sensitivity');
 		}
 


### PR DESCRIPTION
## Summary

Some jobs were running a bit too frequent and some were also marked as time sensitive even though their interval was quite high.
There are some more jobs that could probably run less often, but I wasn't sure about them so I left them for now.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
