### PR TITLE
refactor(files_sharing): Use events for share access

### DIFF
--- a/apps/files_sharing/lib/Event/ShareLinkAccessedEvent.php
+++ b/apps/files_sharing/lib/Event/ShareLinkAccessedEvent.php
@@ -13,24 +13,24 @@ use OCP\EventDispatcher\Event;
 use OCP\Share\IShare;
 
 class ShareLinkAccessedEvent extends Event {
-	/** @var IShare */
-	private $share;
+	
+	/** @since 31.0.0 */
+	public const STEP_ACCESS = 'access';
+	/** @since 31.0.0 */
+	public const STEP_AUTH = 'auth';
+	/** @since 31.0.0 */
+	public const STEP_DOWNLOAD = 'download';
 
-	/** @var string */
-	private $step;
-
-	/** @var int */
-	private $errorCode;
-
-	/** @var string */
-	private $errorMessage;
-
-	public function __construct(IShare $share, string $step = '', int $errorCode = 200, string $errorMessage = '') {
+	/**
+	 * @param ShareLinkAccessedEvent::STEP_* $step
+	 */
+	public function __construct(
+		private IShare $share,
+		private string $step = '',
+		private int $errorCode = 200,
+		private string $errorMessage = '',
+	) {
 		parent::__construct();
-		$this->share = $share;
-		$this->step = $step;
-		$this->errorCode = $errorCode;
-		$this->errorMessage = $errorMessage;
 	}
 
 	public function getShare(): IShare {

--- a/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
+++ b/apps/files_sharing/lib/Listener/BeforeZipCreatedListener.php
@@ -9,12 +9,18 @@ declare(strict_types=1);
 
 namespace OCA\Files_Sharing\Listener;
 
-use OCA\Files_Sharing\ViewOnly;
+use OCA\Files_Sharing\Services\ShareAccessService;
+use OCP\Activity\IManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\BeforeZipCreatedEvent;
+use OCP\Files\File;
+use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use OCP\Files\Storage\ISharedStorage;
+use OCP\IRequest;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 
 /**
  * @template-implements IEventListener<BeforeZipCreatedEvent|Event>
@@ -24,6 +30,10 @@ class BeforeZipCreatedListener implements IEventListener {
 	public function __construct(
 		private IUserSession $userSession,
 		private IRootFolder $rootFolder,
+		private IManager $activityManager,
+		private IRequest $request,
+		private IFactory $l10n,
+		private ShareAccessService $accessService,
 	) {
 	}
 
@@ -32,28 +42,52 @@ class BeforeZipCreatedListener implements IEventListener {
 			return;
 		}
 
-		$dir = $event->getDirectory();
-		$files = $event->getFiles();
+		// The view-only handling is already managed by the DAV plugin
+		// so all we need to do is to ensure that the share is not a "hide-download" share where we also forbid downloading
 
-		$pathsToCheck = [];
-		foreach ($files as $file) {
-			$pathsToCheck[] = $dir . '/' . $file;
+		$folder = $event->getFolder();
+		if ($folder === null) {
+			$user = $this->userSession->getUser();
+			if ($user === null) {
+				return;
+			} else {
+				$folder = $this->rootFolder->getUserFolder($user->getUID())->get($event->getDirectory());
+				assert($folder instanceof Folder, 'Directory is not a folder but a file');
+			}
 		}
 
-		// Check only for user/group shares. Don't restrict e.g. share links
-		$user = $this->userSession->getUser();
-		if ($user) {
-			$viewOnlyHandler = new ViewOnly(
-				$this->rootFolder->getUserFolder($user->getUID())
-			);
-			if (!$viewOnlyHandler->check($pathsToCheck)) {
-				$event->setErrorMessage('Access to this resource or one of its sub-items has been denied.');
-				$event->setSuccessful(false);
-			} else {
-				$event->setSuccessful(true);
-			}
+		$files = $event->getFiles();
+		if (empty($files)) {
+			$files = [$folder];
 		} else {
-			$event->setSuccessful(true);
+			$files = array_map(fn (string $path) => $folder->get($path), $files);
+		}
+
+		$notified = false;
+		foreach ($files as $file) {
+			$storage = $file->getStorage();
+			if ($storage->instanceOfStorage(ISharedStorage::class)) {
+				/** @var ISharedStorage $storage */
+				$share = $storage->getShare();
+				// Check if it is allowed to download this file - if "hide-download" is enabled but a zip file is created
+				// it means the users managed to access the endpoint manually -> block it
+				if ($share->getHideDownload()) {
+					$event->setSuccessful(false);
+					$event->setErrorMessage($this->l10n->get('files_sharing')->t('Download permission of share not granted.'));
+					// we can early return now as the event is set to failed state
+					return;
+				}
+
+				// only notify once for the zip download
+				if ($notified == false) {
+					$this->accessService->shareDownloaded($share);
+					$notified = true;
+				}
+
+				// All we now need to do is log the download
+				$this->accessService->sharedFileDownloaded($share, $file);
+			}
 		}
 	}
+
 }

--- a/apps/files_sharing/lib/Services/ShareAccessService.php
+++ b/apps/files_sharing/lib/Services/ShareAccessService.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files_Sharing\Services;
+
+use OCA\Files_Sharing\Activity\Providers\Downloads;
+use OCA\Files_Sharing\Event\ShareLinkAccessedEvent;
+use OCP\Activity\IManager;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\IRequest;
+use OCP\Share\IShare;
+
+/**
+ * Service to handle activity and event emission for access to shares.
+ */
+class ShareAccessService {
+
+	public const SHARE_ACCESS = 'access';
+	public const SHARE_AUTH = 'auth';
+	public const SHARE_DOWNLOAD = 'download';
+
+	public function __construct(
+		protected IEventDispatcher $eventDispatcher,
+		protected IManager $activityManager,
+		protected IRootFolder $rootFolder,
+		protected ITimeFactory $timeFactory,
+		protected IRequest $request,
+	) {
+	}
+
+	public function shareNotFound(IShare $share): void {
+		$event = new ShareLinkAccessedEvent($share, ShareLinkAccessedEvent::STEP_ACCESS, 404, 'Share not found');
+		$this->eventDispatcher->dispatchTyped($event);
+	}
+
+	public function accessShare(IShare $share): void {
+		$event = new ShareLinkAccessedEvent($share, ShareLinkAccessedEvent::STEP_ACCESS);
+		$this->eventDispatcher->dispatchTyped($event);
+	}
+
+	public function accessWrongPassword(IShare $share): void {
+		$event = new ShareLinkAccessedEvent($share, ShareLinkAccessedEvent::STEP_AUTH, 403, 'Wrong password');
+		$this->eventDispatcher->dispatchTyped($event);
+	}
+
+	public function shareDownloaded(IShare $share): void {
+		$event = new ShareLinkAccessedEvent($share, ShareLinkAccessedEvent::STEP_DOWNLOAD);
+		$this->eventDispatcher->dispatchTyped($event);
+	}
+
+	public function sharedFileDownloaded(IShare $share, Node $node): void {
+		$incognito = \OC_User::isIncognitoMode();
+		\OC_User::setIncognitoMode(true);
+
+		$fileId = $node->getId();
+		$userFolder = $this->rootFolder->getUserFolder($share->getSharedBy());
+		$userNode = $userFolder->getFirstNodeById($fileId);
+		$ownerFolder = $this->rootFolder->getUserFolder($share->getShareOwner());
+		$userPath = $userFolder->getRelativePath($userNode->getPath());
+		$ownerPath = $ownerFolder->getRelativePath($node->getPath());
+
+		@[$subject, $parameters] = $this->getFileDownloadedSubject($share, $node);
+		if ($subject !== null) {
+			$parameters = array_merge([$userPath], $parameters);
+			$this->publishActivity($subject, $parameters, $share->getSharedBy(), $fileId, $userPath);
+
+			if ($share->getShareOwner() !== $share->getSharedBy()) {
+				$parameters[0] = $ownerPath;
+				$this->publishActivity($subject, $parameters, $share->getShareOwner(), $fileId, $ownerPath);
+			}
+		}
+
+		\OC_User::setIncognitoMode($incognito);
+	}
+
+	/**
+	 * Get the subject and parameters for a shared file download.
+	 *
+	 * @return null|array{0: string, 1: array}
+	 */
+	private function getFileDownloadedSubject(IShare $share, Node $node): ?array {
+		$isFile = $node instanceof \OCP\Files\File;
+
+		$parameters = [];
+		switch ($share->getShareType()) {
+			case IShare::TYPE_EMAIL:
+				$subject = match ($isFile) {
+					true => Downloads::SUBJECT_SHARED_FILE_BY_EMAIL_DOWNLOADED,
+					false => Downloads::SUBJECT_SHARED_FOLDER_BY_EMAIL_DOWNLOADED,
+				};
+				$parameters = [$share->getSharedWith()];
+				// no break
+			case IShare::TYPE_LINK:
+				$subject = match ($isFile) {
+					true => Downloads::SUBJECT_PUBLIC_SHARED_FILE_DOWNLOADED,
+					false => Downloads::SUBJECT_PUBLIC_SHARED_FOLDER_DOWNLOADED,
+				};
+				$dateTime = $this->timeFactory
+					->getDateTime()
+					->format('Y-m-d H');
+				$remoteAddress = $this->request->getRemoteAddress();
+				$parameters = [md5($dateTime . '-' . $remoteAddress)];
+				// no break
+			default:
+				// All other types not yet receive download notifications
+		}
+		if (isset($subject)) {
+			return [$subject, $parameters];
+		}
+		return null;
+	}
+
+	/**
+	 * Publish the activity through the activity manager.
+	 */
+	private function publishActivity(
+		string $subject,
+		array $parameters,
+		string $affectedUser,
+		int $fileId,
+		string $filePath,
+	) {
+		$event = $this->activityManager->generateEvent();
+		$event->setApp('files_sharing')
+			->setType('public_links')
+			->setSubject($subject, $parameters)
+			->setAffectedUser($affectedUser)
+			->setObject('files', $fileId, $filePath);
+		$this->activityManager->publish($event);
+	}
+}

--- a/lib/public/Files/Events/BeforeDirectFileDownloadEvent.php
+++ b/lib/public/Files/Events/BeforeDirectFileDownloadEvent.php
@@ -9,24 +9,34 @@ declare(strict_types=1);
 namespace OCP\Files\Events;
 
 use OCP\EventDispatcher\Event;
+use OCP\Files\Node;
 
 /**
- * This event is triggered when a user tries to download a file
- * directly.
+ * This event is triggered when a user tries to download a file directly.
+ * Possible reasons are i.a. using the direct-download endpoint or WebDAV `GET` request.
+ *
+ * By setting `successful` to false the download can be aborted and denied.
  *
  * @since 25.0.0
  */
 class BeforeDirectFileDownloadEvent extends Event {
 	private string $path;
+	private ?Node $node = null;
 	private bool $successful = true;
 	private ?string $errorMessage = null;
 
 	/**
 	 * @since 25.0.0
+	 * @since 31.0.0 support `Node` as parameter for $path - passing a string is deprecated now.
 	 */
-	public function __construct(string $path) {
+	public function __construct(string|Node $path) {
 		parent::__construct();
-		$this->path = $path;
+		if ($path instanceof Node) {
+			$this->node = $path;
+			$this->path = $path->getPath();
+		} else {
+			$this->path = $path;
+		}
 	}
 
 	/**
@@ -34,6 +44,13 @@ class BeforeDirectFileDownloadEvent extends Event {
 	 */
 	public function getPath(): string {
 		return $this->path;
+	}
+
+	/**
+	 * @since 31.0.0
+	 */
+	public function getNode(): ?Node {
+		return $this->node;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

There are multiple ways to access a shared file, so instead of only handle access through one controller just use the events.
This also splits some logic to a service to make it better maintainable.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
