### PR TITLE
fix(appmanager): Fix tainted file path when loading appinfos

### DIFF
--- a/build/psalm-baseline-security.xml
+++ b/build/psalm-baseline-security.xml
@@ -22,11 +22,6 @@
       <code><![CDATA['Location: ' . \OC::$WEBROOT . '/']]></code>
     </TaintedHeader>
   </file>
-  <file src="lib/private/App/InfoParser.php">
-    <TaintedFile>
-      <code><![CDATA[$file]]></code>
-    </TaintedFile>
-  </file>
   <file src="lib/private/AppFramework/Utility/SimpleContainer.php">
     <TaintedCallable>
       <code><![CDATA[$name]]></code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2750,10 +2750,6 @@
     <NullArgument>
       <code><![CDATA[null]]></code>
     </NullArgument>
-    <TypeDoesNotContainNull>
-      <code><![CDATA[$appId === null]]></code>
-      <code><![CDATA[$appId === null]]></code>
-    </TypeDoesNotContainNull>
   </file>
   <file src="lib/private/legacy/OC_Helper.php">
     <InvalidArrayOffset>

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -65,7 +65,7 @@ class Installer {
 		}
 
 		$l = \OCP\Util::getL10N('core');
-		$info = \OCP\Server::get(IAppManager::class)->getAppInfo($basedir . '/appinfo/info.xml', true, $l->getLanguageCode());
+		$info = \OCP\Server::get(IAppManager::class)->getAppInfoByPath($basedir . '/appinfo/info.xml', $l->getLanguageCode());
 
 		if (!is_array($info)) {
 			throw new \Exception(

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -313,7 +313,8 @@ class OC_App {
 	 * @deprecated 11.0.0 use \OCP\Server::get(IAppManager)->getAppPath()
 	 */
 	public static function getAppPath(string $appId, bool $refreshAppPath = false) {
-		if ($appId === null || trim($appId) === '') {
+		$appId = self::cleanAppId($appId);
+		if ($appId === '') {
 			return false;
 		}
 
@@ -346,7 +347,7 @@ class OC_App {
 	 */
 	public static function getAppVersionByPath(string $path): string {
 		$infoFile = $path . '/appinfo/info.xml';
-		$appData = \OC::$server->getAppManager()->getAppInfo($infoFile, true);
+		$appData = \OCP\Server::get(IAppManager::class)->getAppInfoByPath($infoFile);
 		return $appData['version'] ?? '';
 	}
 

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -25,13 +25,21 @@ interface IAppManager {
 	public const BACKEND_CALDAV = 'caldav';
 
 	/**
-	 * Returns the app information from "appinfo/info.xml".
+	 * Returns the app information from "appinfo/info.xml" for an app
 	 *
 	 * @param string|null $lang
 	 * @return array|null
 	 * @since 14.0.0
+	 * @since 31.0.0 Usage of $path is discontinued and throws an \InvalidArgumentException, use {@see self::getAppInfoByPath} instead.
 	 */
 	public function getAppInfo(string $appId, bool $path = false, $lang = null);
+
+	/**
+	 * Returns the app information from a given path ending with "/appinfo/info.xml"
+	 *
+	 * @since 31.0.0
+	 */
+	public function getAppInfoByPath(string $path, ?string $lang = null): ?array;
 
 	/**
 	 * Returns the app information from "appinfo/info.xml".


### PR DESCRIPTION
## Comments

- It's arguable whether killing the `bool $path` parameter is a breaking change and should be done. But I'd say the risk is minimal. The only usage I found is the `\OC\Installer` code.
- The entry is actually a "false positive", as the claimed call is with `$path = false` and therefore
  ```
  $file - lib/private/App/AppManager.php:747:4
			$file = $appId;
  ```
  is never applicable (it's the `if ($path) {` block). But to work around that would mean we need to add many psalm comments in all the places calling it, until upstream fixes it (and I'm not sure they can with reasonable effort).
- So I thought splitting the method in a "tainted" and "path" way is the better solution.

## After

- 1 less baseline entry

## Before

```
TaintedFile - lib/private/App/InfoParser.php:38:50 - Detected tainted file handling (see https://psalm.dev/255)
  oca\updatenotification\controller\changelogcontroller::showchangelog#1 - apps/updatenotification/lib/Controller/ChangelogController.php:41:32
	public function showChangelog(string $app, ?string $version = null): TemplateResponse {

  $app - apps/updatenotification/lib/Controller/ChangelogController.php:41:39
	public function showChangelog(string $app, ?string $version = null): TemplateResponse {

  call to OCP\App\IAppManager::getAppInfo - apps/updatenotification/lib/Controller/ChangelogController.php:43:44
		$appInfo = $this->appManager->getAppInfo($app) ?? [];

  OCP\App\IAppManager::getAppInfo#1 - lib/public/App/IAppManager.php:34:36
	public function getAppInfo(string $appId, bool $path = false, $lang = null);

  OC\App\AppManager::getAppInfo#1 - apps/files_versions/lib/AppInfo/Application.php:118:39
			$appInfo = $appManager->getAppInfo($app);

  $appId - lib/private/App/AppManager.php:745:36
	public function getAppInfo(string $appId, bool $path = false, $lang = null) {

  $file - lib/private/App/AppManager.php:747:4
			$file = $appId;

  call to OC\App\InfoParser::parse - lib/private/App/AppManager.php:761:26
		$data = $parser->parse($file);

  OC\App\InfoParser::parse#1 - lib/private/App/InfoParser.php:25:24
	public function parse($file) {

  $file - lib/private/App/InfoParser.php:25:24
	public function parse($file) {

  call to file_get_contents - lib/private/App/InfoParser.php:38:50
		$xml = simplexml_load_string(file_get_contents($file));
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
