### PR TITLE
fix(UserTrait): Fix backend initialization

### DIFF
--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -8,13 +8,16 @@
 namespace Test\Traits;
 
 use OC\User\User;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
+use OCP\Server;
 
 class DummyUser extends User {
 	private string $uid;
 
 	public function __construct(string $uid) {
 		$this->uid = $uid;
+		parent::__construct($uid, null, Server::get(IEventDispatcher::class));
 	}
 
 	public function getUID(): string {


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/server/pull/47896 broke groupfolders tests with this error:
```
4) OCA\GroupFolders\Tests\Trash\TrashBackendTest::testHideDeletedTrashItemInDeletedParentFolderAcl
Error: Typed property OC\User\User::$backend must not be accessed before initialization

/home/jld3103/src/github.com/nextcloud/server/lib/private/User/User.php:104
/home/jld3103/src/github.com/nextcloud/server/apps/groupfolders/lib/ACL/UserMapping/UserMappingManager.php:27
/home/jld3103/src/github.com/nextcloud/server/apps/groupfolders/lib/ACL/RuleManager.php:112
/home/jld3103/src/github.com/nextcloud/server/apps/groupfolders/lib/ACL/ACLManager.php:227
/home/jld3103/src/github.com/nextcloud/server/apps/groupfolders/lib/Trash/TrashBackend.php:333
/home/jld3103/src/github.com/nextcloud/server/apps/groupfolders/lib/Trash/TrashBackend.php:56
/home/jld3103/src/github.com/nextcloud/server/apps/groupfolders/tests/Trash/TrashBackendTest.php:203
```
It uses the createUser() method of the UserTrait which wasn't properly initializing the parent by calling the parent constructor.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
