### PR TITLE
fix(tryLogin): Cast `$user` to string to prevent unexpected logs due to wrong type

### DIFF
--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -284,6 +284,8 @@ class LoginController extends Controller {
 		?string $redirect_url = null,
 		string $timezone = '',
 		string $timezone_offset = ''): RedirectResponse {
+		/** @psalm-suppress RedundantCast Cast $user to string to prevent unexpected logs due to wrong type */
+		$user = (string)$user;
 		if (!$this->request->passesCSRFCheck()) {
 			if ($this->userSession->isLoggedIn()) {
 				// If the user is already logged in and the CSRF check does not pass then


### PR DESCRIPTION
Reason: I have recently quite a lot of the following entries in the logs of my Nextcloud test instance which spams the logs:
```
[index] Error: OC\Core\Controller\LoginController::tryLogin(): Argument #2 ($user) must be of type string, array given, called in /var/www/html/lib/private/AppFramework/Http/Dispatcher.php on line 232 in file '/var/www/html/core/Controller/LoginController.php' line 307
	POST /login
	from 154.12.231.73 by -- at Oct 1, 2024, 10:43:11 PM
```