### PR TITLE
feat(l10n): Allow to force language with a query parameter

### DIFF
--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -98,7 +98,7 @@ class Factory implements IFactory {
 				$lang = str_replace(['\0', '/', '\\', '..'], '', $lang);
 			}
 
-			$forceLang = $this->config->getSystemValue('force_language', false);
+			$forceLang = $this->request->getParam('forceLanguage') ?? $this->config->getSystemValue('force_language', false);
 			if (is_string($forceLang)) {
 				$lang = $forceLang;
 			}

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -139,7 +139,7 @@ class Factory implements IFactory {
 	 */
 	public function findLanguage(?string $appId = null): string {
 		// Step 1: Forced language always has precedence over anything else
-		$forceLang = $this->config->getSystemValue('force_language', false);
+		$forceLang = $this->request->getParam('forceLanguage') ?? $this->config->getSystemValue('force_language', false);
 		if (is_string($forceLang)) {
 			$this->requestLanguage = $forceLang;
 		}
@@ -196,7 +196,7 @@ class Factory implements IFactory {
 
 	public function findGenericLanguage(?string $appId = null): string {
 		// Step 1: Forced language always has precedence over anything else
-		$forcedLanguage = $this->config->getSystemValue('force_language', false);
+		$forcedLanguage = $this->request->getParam('forceLanguage') ?? $this->config->getSystemValue('force_language', false);
 		if ($forcedLanguage !== false) {
 			return $forcedLanguage;
 		}
@@ -411,6 +411,10 @@ class Factory implements IFactory {
 				return $language;
 			}
 
+			if (($forcedLanguage = $this->request->getParam('forceLanguage')) !== null) {
+				return $forcedLanguage;
+			}
+
 			// Use language from request
 			if ($this->userSession->getUser() instanceof IUser &&
 				$user->getUID() === $this->userSession->getUser()->getUID()) {
@@ -421,7 +425,7 @@ class Factory implements IFactory {
 			}
 		}
 
-		return $this->config->getSystemValueString('default_language', 'en');
+		return $this->request->getParam('forceLanguage') ?? $this->config->getSystemValueString('default_language', 'en');
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

This will be used by support application to always generate the support
 report in english. It may also be used to debug a language, or to
 temporarily show a page in an other language to take a screenshot or to
 share your screen with someone speaking another language.

## TODO

- [ ] Should that be a header instead?
- [ ] Where should that be documented?
- [ ] Can it cause any troubles anywhere? I don’t think so :thinking: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
