### PR TITLE
fix: Fix empty sections appearing in search results

### DIFF
--- a/apps/settings/lib/Search/SectionSearch.php
+++ b/apps/settings/lib/Search/SectionSearch.php
@@ -74,9 +74,25 @@ class SectionSearch implements IProvider {
 	public function search(IUser $user, ISearchQuery $query): SearchResult {
 		$isAdmin = $this->groupManager->isAdmin($user->getUID());
 
+		$personalSections = $this->settingsManager->getPersonalSections();
+		foreach ($personalSections as $priority => $sections) {
+			$personalSections[$priority] = array_values(array_filter(
+				$sections,
+				fn (IIconSection $section) => !empty($this->settingsManager->getPersonalSettings($section->getID())),
+			));
+		}
+
+		$adminSections = $this->settingsManager->getAdminSections();
+		foreach ($adminSections as $priority => $sections) {
+			$adminSections[$priority] = array_values(array_filter(
+				$sections,
+				fn (IIconSection $section) => !empty($this->settingsManager->getAllowedAdminSettings($section->getID(), $user)),
+			));
+		}
+
 		$result = $this->searchSections(
 			$query,
-			$this->settingsManager->getPersonalSections(),
+			$personalSections,
 			$isAdmin ? $this->l->t('Personal') : '',
 			'settings.PersonalSettings.index'
 		);
@@ -84,7 +100,7 @@ class SectionSearch implements IProvider {
 		if ($this->groupManager->isAdmin($user->getUID())) {
 			$result = array_merge($result, $this->searchSections(
 				$query,
-				$this->settingsManager->getAdminSections(),
+				$adminSections,
 				$this->l->t('Administration'),
 				'settings.AdminSettings.index'
 			));


### PR DESCRIPTION
## Summary

Fix https://github.com/nextcloud/server/issues/48591

Fixes empty sections being shown in search results that lead to blank pages

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)