### PR TITLE
fix: Allow overriding shouldApplyQuota check from child classes

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -150,7 +150,7 @@ class Quota extends Wrapper {
 	/**
 	 * Only apply quota for files, not metadata, trash or others
 	 */
-	private function shouldApplyQuota(string $path): bool {
+	protected function shouldApplyQuota(string $path): bool {
 		return str_starts_with(ltrim($path, '/'), 'files/');
 	}
 


### PR DESCRIPTION
While not the cleanest, since it is a private class, groupfolders currently extends from the Quota class, so we need to be able to adjust the behaviour of shouldApplyQuota

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
