### PR TITLE
feat(http client): expose default request timeout constant to be used instead of magic number 30

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -20,6 +20,7 @@ use OCP\Files\ForbiddenException;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
 use OCP\ICertificateManager;
 use OCP\IConfig;
@@ -124,7 +125,7 @@ class DAV extends Common {
 		$this->logger = Server::get(LoggerInterface::class);
 		$this->eventLogger = Server::get(IEventLogger::class);
 		// This timeout value will be used for the download and upload of files
-		$this->timeout = Server::get(IConfig::class)->getSystemValueInt('davstorage.request_timeout', 30);
+		$this->timeout = Server::get(IConfig::class)->getSystemValueInt('davstorage.request_timeout', IClient::DEFAULT_REQUEST_TIMEOUT);
 		$this->mimeTypeDetector = \OC::$server->getMimeTypeDetector();
 	}
 

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -53,7 +53,7 @@ class Client implements IClient {
 
 		$defaults = [
 			RequestOptions::VERIFY => $this->getCertBundle(),
-			RequestOptions::TIMEOUT => 30,
+			RequestOptions::TIMEOUT => IClient::DEFAULT_REQUEST_TIMEOUT,
 		];
 
 		$options['nextcloud']['allow_local_address'] = $this->isLocalAddressAllowed($options);

--- a/lib/public/Http/Client/IClient.php
+++ b/lib/public/Http/Client/IClient.php
@@ -14,6 +14,14 @@ namespace OCP\Http\Client;
  * @since 8.1.0
  */
 interface IClient {
+
+	/**
+	 * Default request timeout for requests
+	 *
+	 * @since 31.0.0
+	 */
+	public const DEFAULT_REQUEST_TIMEOUT = 30;
+
 	/**
 	 * Sends a GET request
 	 * @param string $uri


### PR DESCRIPTION
Will be used to set default where we are able to override the default timeout.

See https://github.com/nextcloud/server/pull/48418

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
