### PR TITLE
fix(files): Correctly copy the cache information during copy operations

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -628,7 +628,6 @@ class Encryption extends Wrapper {
 						$info->getUnencryptedSize()
 					);
 				}
-				$this->updateEncryptedVersion($sourceStorage, $sourceInternalPath, $targetInternalPath, $isRename, true);
 			}
 			return $result;
 		}

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -273,6 +273,12 @@ class View {
 		}
 	}
 
+	protected function copyUpdate(Storage $sourceStorage, Storage $targetStorage, string $sourceInternalPath, string $targetInternalPath): void {
+		if ($this->updaterEnabled) {
+			$targetStorage->getUpdater()->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
+		}
+	}
+
 	/**
 	 * @param string $path
 	 * @return bool|mixed
@@ -898,7 +904,9 @@ class View {
 						$result = $storage2->copyFromStorage($storage1, $internalPath1, $internalPath2);
 					}
 
-					$this->writeUpdate($storage2, $internalPath2);
+					if ($result) {
+						$this->copyUpdate($storage1, $storage2, $internalPath1, $internalPath2);
+					}
 
 					$this->changeLock($target, ILockingProvider::LOCK_SHARED);
 					$lockTypePath2 = ILockingProvider::LOCK_SHARED;

--- a/lib/public/Files/Cache/IUpdater.php
+++ b/lib/public/Files/Cache/IUpdater.php
@@ -58,4 +58,11 @@ interface IUpdater {
 	 * @since 9.0.0
 	 */
 	public function renameFromStorage(IStorage $sourceStorage, $source, $target);
+
+	/**
+	 * Copy a file or folder in the cache and update the size, etag and mtime of the parent folders
+	 *
+	 * @since 31.0.0
+	 */
+	public function copyFromStorage(IStorage $sourceStorage, string $source, string $target): void;
 }

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2831,4 +2831,12 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals('foo.png', $folderData[1]['name']);
 		$this->assertEquals('foo.txt', $folderData[2]['name']);
 	}
+
+	public function testCopyPreservesContent() {
+		$viewUser1 = new View('/' . 'userId' . '/files');
+		$viewUser1->mkdir('');
+		$viewUser1->file_put_contents('foo.txt', 'foo');
+		$viewUser1->copy('foo.txt', 'bar.txt');
+		$this->assertEquals('foo', $viewUser1->file_get_contents('bar.txt'));
+	}
 }

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2386,6 +2386,7 @@ class ViewTest extends \Test\TestCase {
 		Filesystem::mount($storage2, [], $this->user . '/files/substorage');
 		$storage->mkdir('files');
 		$view->file_put_contents($sourcePath, 'meh');
+		$storage2->getUpdater()->update('');
 
 		$storage->expects($this->never())
 			->method($storageOperation);


### PR DESCRIPTION
Needed to copy the `encrypted` flag of encrypted files when those files are two level down in a moved folder.

Reproduction steps of the issue:

- Set up the following folder structure
  - `/A/B/t.txt`
  - `/C`
- Copy `A` in `C`
 - `t.txt` is encrypted but does not have the `encrypted` flag set to `true`, and therefore not readable.

With this PR, `t.txt` is readable.

Note: Open to better ways to share code between the two methods.

Added a test to ensure file content stays the same after a copy.