### PR TITLE
fix: added type to createConnectionParams, removed safeguard [restore db conversions]

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -155,13 +155,6 @@ class ConvertType extends Command implements CompletionAwareInterface {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		// WARNING:
-		// Leave in place until #45257 is addressed to prevent data loss (hopefully in time for the next maintenance release)
-		//
-		throw new \InvalidArgumentException(
-			'This command is temporarily disabled (until the next maintenance release).'
-		);
-
 		$this->validateInput($input, $output);
 		$this->readPassword($input, $output);
 
@@ -229,7 +222,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 
 	protected function getToDBConnection(InputInterface $input, OutputInterface $output) {
 		$type = $input->getArgument('type');
-		$connectionParams = $this->connectionFactory->createConnectionParams();
+		$connectionParams = $this->connectionFactory->createConnectionParams('', [], $type);
 		$connectionParams = array_merge($connectionParams, [
 			'host' => $input->getArgument('hostname'),
 			'user' => $input->getArgument('username'),

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -108,7 +108,7 @@ class ConnectionFactory {
 		$normalizedType = $this->normalizeType($type);
 		$eventManager = new EventManager();
 		$eventManager->addEventSubscriber(new SetTransactionIsolationLevel());
-		$connectionParams = $this->createConnectionParams('', $additionalConnectionParams);
+		$connectionParams = $this->createConnectionParams('', $additionalConnectionParams, $type);
 		switch ($normalizedType) {
 			case 'pgsql':
 				// pg_connect used by Doctrine DBAL does not support URI notation (enclosed in brackets)
@@ -177,10 +177,13 @@ class ConnectionFactory {
 	 * Create the connection parameters for the config
 	 *
 	 * @param string $configPrefix
+	 * @param array $additionalConnectionParams
+	 * @param string $type
 	 * @return array
 	 */
-	public function createConnectionParams(string $configPrefix = '', array $additionalConnectionParams = []) {
-		$type = $this->config->getValue('dbtype', 'sqlite');
+	public function createConnectionParams(string $configPrefix = '', array $additionalConnectionParams = [], ?string $type = null) {
+		// use provided type or if null use type from config
+		$type = $type ?? $this->config->getValue('dbtype', 'sqlite');
 
 		$connectionParams = array_merge($this->getDefaultConnectionParams($type), [
 			'user' => $this->config->getValue($configPrefix . 'dbuser', $this->config->getValue('dbuser', '')),
@@ -212,7 +215,7 @@ class ConnectionFactory {
 			'tablePrefix' => $connectionParams['tablePrefix']
 		];
 
-		if ($this->config->getValue('mysql.utf8mb4', false)) {
+		if ($this->config->getValue('mysql.utf8mb4', false) && $type==="mysql") {
 			$connectionParams['defaultTableOptions'] = [
 				'collate' => 'utf8mb4_bin',
 				'charset' => 'utf8mb4',

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -215,7 +215,7 @@ class ConnectionFactory {
 			'tablePrefix' => $connectionParams['tablePrefix']
 		];
 
-		if ($this->config->getValue('mysql.utf8mb4', false) && $type==="mysql") {
+		if ($this->config->getValue('mysql.utf8mb4', false) && $type === 'mysql') {
 			$connectionParams['defaultTableOptions'] = [
 				'collate' => 'utf8mb4_bin',
 				'charset' => 'utf8mb4',


### PR DESCRIPTION


* Resolves: #45257 

## Summary
This should fix the db conversion bug. $type was added as a parameter to createConnectionParams in the ConnectionFactory.php. There is also a check if the type value is set if not the default is loaded from the config. There is also an additional type check to make sure mysql.utf8mb4 is only used with mysql. The parameters of createConnectionParams in Connection Factory has also been updated, and the safeguard has been removed.  The solution was provided in the issue comments by @Queuecumber, @normen, @lightonflux and me. 

## TODO

- [ ] An error occurs when using group folders because the table 'oc_group_folders_acl' is missing in MariaDB see #45257 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
