### PR TITLE
fix(share): Return empty string if no label is set

### DIFF
--- a/apps/files_sharing/lib/ResponseDefinitions.php
+++ b/apps/files_sharing/lib/ResponseDefinitions.php
@@ -29,7 +29,7 @@ namespace OCA\Files_Sharing;
  *     item_size: float|int,
  *     item_source: int,
  *     item_type: 'file'|'folder',
- *     label: ?string,
+ *     label: string,
  *     mail_send: 0|1,
  *     mimetype: string,
  *     mount-type: string,

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -583,8 +583,7 @@
                         ]
                     },
                     "label": {
-                        "type": "string",
-                        "nullable": true
+                        "type": "string"
                     },
                     "mail_send": {
                         "type": "integer",

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -991,7 +991,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('file')),
 				$qb->expr()->eq('item_type', $qb->createNamedParameter('folder'))
 			))
-			->execute();
+			->executeQuery();
 
 		$data = $cursor->fetch();
 
@@ -1024,7 +1024,7 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 			->setNote((string)$data['note'])
 			->setMailSend((bool)$data['mail_send'])
 			->setStatus((int)$data['accepted'])
-			->setLabel($data['label']);
+			->setLabel($data['label'] ?? '');
 
 		$shareTime = new \DateTime();
 		$shareTime->setTimestamp((int)$data['stime']);

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -884,6 +884,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 				'token' => $qb->expr()->literal('secrettoken'),
+				'label' => $qb->expr()->literal('the label'),
 			]);
 		$qb->execute();
 		$id = $qb->getLastInsertId();
@@ -899,10 +900,43 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertSame('sharedBy', $share->getSharedBy());
 		$this->assertSame('secrettoken', $share->getToken());
 		$this->assertSame('password', $share->getPassword());
+		$this->assertSame('the label', $share->getLabel());
 		$this->assertSame(true, $share->getSendPasswordByTalk());
 		$this->assertSame(null, $share->getSharedWith());
 	}
 
+	/**
+	 * Assert that if no label is provided the label is correctly,
+	 * as types on IShare, a string and not null
+	 */
+	public function testGetShareByTokenNullLabel(): void {
+		$qb = $this->dbConn->getQueryBuilder();
+
+		$qb->insert('share')
+			->values([
+				'share_type' => $qb->expr()->literal(IShare::TYPE_LINK),
+				'password' => $qb->expr()->literal('password'),
+				'password_by_talk' => $qb->expr()->literal(true),
+				'uid_owner' => $qb->expr()->literal('shareOwner'),
+				'uid_initiator' => $qb->expr()->literal('sharedBy'),
+				'item_type' => $qb->expr()->literal('file'),
+				'file_source' => $qb->expr()->literal(42),
+				'file_target' => $qb->expr()->literal('myTarget'),
+				'permissions' => $qb->expr()->literal(13),
+				'token' => $qb->expr()->literal('secrettoken'),
+			]);
+		$qb->executeStatement();
+		$id = $qb->getLastInsertId();
+
+		$file = $this->createMock(File::class);
+
+		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
+		$this->rootFolder->method('getFirstNodeById')->with(42)->willReturn($file);
+
+		$share = $this->provider->getShareByToken('secrettoken');
+		$this->assertEquals($id, $share->getId());
+		$this->assertSame('', $share->getLabel());
+	}
 
 	public function testGetShareByTokenNotFound(): void {
 		$this->expectException(\OCP\Share\Exceptions\ShareNotFound::class);


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/48629

## Summary

While the database supports NULL, the typing has always said it only returns *string*. So to not break any apps that might trust the typings we should return `''` if the database is set to `NULL`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
