### PR TITLE
fix(updater): make clean-up job more robust / easier to debug

### DIFF
--- a/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
+++ b/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
@@ -28,13 +28,13 @@ class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
 	 * @param array $argument
 	 */
 	public function run($argument): void {
-		$this->log->info("Running background job to clean-up outdated updater backups");
+		$this->log->info('Running background job to clean-up outdated updater backups');
 
 		$updateDir = $this->config->getSystemValue('updatedirectory', null) ?? $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
 		$instanceId = $this->config->getSystemValue('instanceid', null);
 
 		if (!is_string($instanceId) || empty($instanceId)) {
-			$this->log->error("Skipping updater backup clean-up - instanceId is missing!");
+			$this->log->error('Skipping updater backup clean-up - instanceId is missing!');
 			return;
 		}
 
@@ -73,7 +73,7 @@ class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
 				$result = \OC_Helper::rmdirr($dir);
 				if (!$result) {
 					$this->log->error('Could not remove updater backup folder $dir');
-				}					
+				}
 			}
 			$this->log->info('Background job to clean-up updater backups has finished');
 		} else {

--- a/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
+++ b/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
@@ -28,17 +28,20 @@ class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
 	 * @param array $argument
 	 */
 	public function run($argument): void {
+		$this->log->info("Running background job to clean-up outdated updater backups");
+
 		$updateDir = $this->config->getSystemValue('updatedirectory', null) ?? $this->config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data');
 		$instanceId = $this->config->getSystemValue('instanceid', null);
 
 		if (!is_string($instanceId) || empty($instanceId)) {
+			$this->log->error("Skipping updater backup clean-up - instanceId is missing!");
 			return;
 		}
 
 		$updaterFolderPath = $updateDir . '/updater-' . $instanceId;
 		$backupFolderPath = $updaterFolderPath . '/backups';
 		if (file_exists($backupFolderPath)) {
-			$this->log->info("$backupFolderPath exists - start to clean it up");
+			$this->log->debug("Updater backup folder detected: $backupFolderPath");
 
 			$dirList = [];
 			$dirs = new \DirectoryIterator($backupFolderPath);
@@ -52,6 +55,8 @@ class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
 				$realPath = $dir->getRealPath();
 
 				if ($realPath === false) {
+					$pathName = $dir->getPathname();
+					$this->log->warning("Skipping updater backup folder: $pathName (not found)");
 					continue;
 				}
 
@@ -61,15 +66,18 @@ class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
 			ksort($dirList);
 			// drop the newest 3 directories
 			$dirList = array_slice($dirList, 0, -3);
-			$this->log->info('List of all directories that will be deleted: ' . json_encode($dirList));
+			$this->log->debug('Updater backup folders that will be deleted: ' . json_encode($dirList));
 
 			foreach ($dirList as $dir) {
 				$this->log->info("Removing $dir ...");
-				\OC_Helper::rmdirr($dir);
+				$result = \OC_Helper::rmdirr($dir);
+				if (!$result) {
+					$this->log->error('Could not remove updater backup folder $dir');
+				}					
 			}
-			$this->log->info('Cleanup finished');
+			$this->log->info('Background job to clean-up updater backups has finished');
 		} else {
-			$this->log->info("Could not find updater directory $backupFolderPath - cleanup step not needed");
+			$this->log->warning("Skipping updater backup clean-up - could not find updater backup folder $backupFolderPath");
 		}
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: n/a <!-- related github issue -->

## Summary

On occasion there have been vague reports about the updater backup folder clean-up job (#9855) seemingly not, well, cleaning up. This adjusts the logging a bit and checks the return value of the deletions to give the admin (or us) a potentially better chance of figuring out what is going on.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
