### PR TITLE
DNS: do not query CNAME if A succeeded already

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -57,17 +57,21 @@ class DnsPinMiddleware {
 
 		$soaDnsEntry = $this->soaRecord($target);
 		$dnsNegativeTtl = $soaDnsEntry['minimum-ttl'] ?? null;
+		$canHaveCnameRecord = true;
 
 		$dnsTypes = \defined('AF_INET6') || @inet_pton('::1')
 			? [DNS_A, DNS_AAAA, DNS_CNAME]
 			: [DNS_A, DNS_CNAME];
 		foreach ($dnsTypes as $dnsType) {
+			if ($canHaveCnameRecord === false && $dnsType === DNS_CNAME) {
+				continue;
+			}
+
 			if ($this->negativeDnsCache->isNegativeCached($target, $dnsType)) {
 				continue;
 			}
 
 			$dnsResponses = $this->dnsGetRecord($target, $dnsType);
-			$canHaveCnameRecord = true;
 			if ($dnsResponses !== false && count($dnsResponses) > 0) {
 				foreach ($dnsResponses as $dnsResponse) {
 					if (isset($dnsResponse['ip'])) {

--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -82,7 +82,6 @@ class DnsPinMiddleware {
 						$canHaveCnameRecord = false;
 					} elseif (isset($dnsResponse['target']) && $canHaveCnameRecord) {
 						$targetIps = array_merge($targetIps, $this->dnsResolve($dnsResponse['target'], $recursionCount));
-						$canHaveCnameRecord = true;
 					}
 				}
 			} elseif ($dnsNegativeTtl !== null) {

--- a/tests/lib/Http/Client/DnsPinMiddlewareTest.php
+++ b/tests/lib/Http/Client/DnsPinMiddlewareTest.php
@@ -537,10 +537,11 @@ class DnsPinMiddlewareTest extends TestCase {
 			['nextcloud' => ['allow_local_address' => false]]
 		);
 
-		$this->assertCount(4, $dnsQueries);
+		$this->assertCount(3, $dnsQueries);
 		$this->assertContains('example.com' . DNS_SOA, $dnsQueries);
 		$this->assertContains('subsubdomain.subdomain.example.com' . DNS_A, $dnsQueries);
 		$this->assertContains('subsubdomain.subdomain.example.com' . DNS_AAAA, $dnsQueries);
-		$this->assertContains('subsubdomain.subdomain.example.com' . DNS_CNAME, $dnsQueries);
+		// CNAME should not be queried if A or AAAA succeeded already
+		$this->assertNotContains('subsubdomain.subdomain.example.com' . DNS_CNAME, $dnsQueries);
 	}
 }


### PR DESCRIPTION
Fixes: #48048

## Summary

When an A query succeeds, querying for CNAME again is

1. useless at best, and
2. creating unnecessary log entries in the DNS server.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
