### PR TITLE
fix(lock): Call the correct getTTL method

### DIFF
--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -151,7 +151,7 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 			$elapsed = $this->timeFactory->getTime() - $saved['time'];
 
 			// old value to compare to when setting ttl in case someone else changes the lock in the middle of this function
-			$value = $this->memcache->get($path);
+			$value = $this->memcache->getTTL($path);
 
 			$currentTtl = $this->getTTL($path);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

We are checking for TTL, not the lock type.

Fix:
```
OC\\Lock\\MemcacheLockingProvider::setTTL(): Argument #3 ($compare) must be of type ?int, string given
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
