### PR TITLE
fix(files_sharing): Fix FileList account filter button translation

### DIFF
--- a/apps/files_sharing/src/components/FileListFilterAccount.vue
+++ b/apps/files_sharing/src/components/FileListFilterAccount.vue
@@ -5,7 +5,7 @@
 <template>
 	<FileListFilter class="file-list-filter-accounts"
 		:is-active="selectedAccounts.length > 0"
-		:filter-name="t('files', 'People')"
+		:filter-name="t('files_sharing', 'People')"
 		@reset-filter="resetFilter">
 		<template #icon>
 			<NcIconSvgWrapper :path="mdiAccountMultiple" />


### PR DESCRIPTION

## Summary
This is a simple fix to FileListFilter translation so it gets the `People` button translation in the file list filter from the correct source. Currently, the files_sharing app tries to get the account filter button from 'files' app but the needed string is added to files_sharing locale files.

Before:
<img width="344" alt="image" src="https://github.com/user-attachments/assets/82c42af8-c4e1-4bd4-aa09-4e7ddac093c8">
After:
<img width="383" alt="image" src="https://github.com/user-attachments/assets/0cd62a36-9c2a-421c-b4d1-b228365019c5">



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ *] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
