### PR TITLE
fix(locking): Accept mixed as value on setTTL

### DIFF
--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -25,7 +25,7 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 		parent::__construct($ttl);
 	}
 
-	private function setTTL(string $path, ?int $ttl = null, ?int $compare = null): void {
+	private function setTTL(string $path, ?int $ttl = null, mixed $compare = null): void {
 		if (is_null($ttl)) {
 			$ttl = $this->ttl;
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fix:

> OC\\Lock\\MemcacheLockingProvider::setTTL(): Argument #3 ($compare) must be of type ?int, string given

Underlying `compareSetTTL` also accepts mixed values.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
