### PR TITLE
[stable28] fix(locking): Accept mixed as value on setTTL

### DIFF
--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -44,7 +44,7 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 		parent::__construct($ttl);
 	}
 
-	private function setTTL(string $path, int $ttl = null, ?int $compare = null): void {
+	private function setTTL(string $path, int $ttl = null, mixed $compare = null): void {
 		if (is_null($ttl)) {
 			$ttl = $this->ttl;
 		}


### PR DESCRIPTION
Manual backport of https://github.com/nextcloud/server/pull/48689