### PR TITLE
[stable28] fix(AppConfig): Add external JWT private key to sensitive keys

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -51,6 +51,7 @@ class AppConfig implements IAppConfig {
 		],
 		'external' => [
 			'/^sites$/',
+			'/^jwt_token_privkey_(.*)$/',
 		],
 		'integration_discourse' => [
 			'/^private_key$/',


### PR DESCRIPTION
## Summary

Manual backport of https://github.com/nextcloud/server/pull/48682

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
