### PR TITLE
fix: Write memcache locking path hash to exception

### DIFF
--- a/lib/private/Lock/MemcacheLockingProvider.php
+++ b/lib/private/Lock/MemcacheLockingProvider.php
@@ -173,9 +173,9 @@ class MemcacheLockingProvider extends AbstractLockingProvider {
 		if (!$existing) {
 			return 'none';
 		} elseif ($existing === 'exclusive') {
-			return $existing;
+			return $existing . ': ' . $path;
 		} else {
-			return $existing . ' shared locks';
+			return $existing . ' shared locks: ' . $path;
 		}
 	}
 }


### PR DESCRIPTION
When trying to investigate stale locks it can be helpful to have the actual hash available for checking in redis. Otherwise one needs to manually construct the has from the storage and path.

Reference on the hashing: https://github.com/nextcloud/server/blob/f28e74b7a8b3df11ba1f2e4a18492b8158528cdf/lib/private/Files/Storage/Common.php#L635


Before:

> "Documents/test.doc" is locked, existing lock on file: 2 shared lock

After:

> "Documents/test.doc" is locked, existing lock on file: 2 shared lock: files/196106b5350a532ce3d8870cac8d466e