### PR TITLE
fix(caldav): duration handling in the event reader class

### DIFF
--- a/apps/dav/lib/CalDAV/EventReader.php
+++ b/apps/dav/lib/CalDAV/EventReader.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAV\CalDAV;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeInterface;
 use DateTimeZone;
 use InvalidArgumentException;
@@ -109,7 +110,7 @@ class EventReader {
 				unset($events[$key]);
 			}
 		}
-		
+
 		// No base event was found. CalDAV does allow cases where only
 		// overridden instances are stored.
 		//
@@ -173,15 +174,17 @@ class EventReader {
 		// evaluate if duration exists
 		// extract duration and calculate end date
 		elseif (isset($this->baseEvent->DURATION)) {
-			$this->baseEventDuration = $this->baseEvent->DURATION->getDateInterval();
-			$this->baseEventEndDate = ((clone $this->baseEventStartDate)->add($this->baseEventDuration));
+			$this->baseEventEndDate = DateTimeImmutable::createFromInterface($this->baseEventStartDate)
+				->add($this->baseEvent->DURATION->getDateInterval());
+			$this->baseEventDuration = $this->baseEventEndDate->getTimestamp() - $this->baseEventStartDate->getTimestamp();
 		}
 		// evaluate if start date is floating
 		// set duration to 24 hours and calculate the end date
 		// according to the rfc any event without a end date or duration is a complete day
 		elseif ($this->baseEventStartDateFloating == true) {
 			$this->baseEventDuration = 86400;
-			$this->baseEventEndDate = ((clone $this->baseEventStartDate)->add($this->baseEventDuration));
+			$this->baseEventEndDate = DateTimeImmutable::createFromInterface($this->baseEventStartDate)
+				->setTimestamp($this->baseEventStartDate->getTimestamp() + $this->baseEventDuration);
 		}
 		// otherwise, set duration to zero this should never happen
 		else {
@@ -220,7 +223,7 @@ class EventReader {
 		foreach ($events as $vevent) {
 			$this->recurrenceModified[$vevent->{'RECURRENCE-ID'}->getDateTime($this->baseEventStartTimeZone)->getTimeStamp()] = $vevent;
 		}
-		
+
 		$this->recurrenceCurrentDate = clone $this->baseEventStartDate;
 	}
 
@@ -375,7 +378,7 @@ class EventReader {
 	 * @return int|null
 	 */
 	public function recurringConcludesAfter(): ?int {
-		
+
 		// construct count place holder
 		$count = 0;
 		// retrieve and add RRULE iterations count


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/48707

## Summary
 
The call to `$this->baseEvent->DURATION->getDateInterval()` returns an instance of `DateInterval` but `$this->baseEventDuration` is an int.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
