### PR TITLE
fix(ci): Use mysql_native_password on MySQL CI tests

### DIFF
--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -77,6 +77,7 @@ jobs:
           MYSQL_PASSWORD: nextcloud
           MYSQL_DATABASE: oc_autotest
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
+        command: --default-auth=mysql_native_password
       shard1:
         image: ghcr.io/nextcloud/continuous-integration-mysql-${{ matrix.mysql-versions }}:latest
         ports:
@@ -87,6 +88,7 @@ jobs:
           MYSQL_PASSWORD: nextcloud
           MYSQL_DATABASE: nextcloud
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
+        command: --default-auth=mysql_native_password
       shard2:
         image: ghcr.io/nextcloud/continuous-integration-mysql-${{ matrix.mysql-versions }}:latest
         ports:
@@ -97,6 +99,7 @@ jobs:
           MYSQL_PASSWORD: nextcloud
           MYSQL_DATABASE: nextcloud
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
+        command: --default-auth=mysql_native_password
       shard3:
         image: ghcr.io/nextcloud/continuous-integration-mysql-${{ matrix.mysql-versions }}:latest
         ports:
@@ -107,6 +110,7 @@ jobs:
           MYSQL_PASSWORD: nextcloud
           MYSQL_DATABASE: nextcloud
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
+        command: --default-auth=mysql_native_password
       shard4:
         image: ghcr.io/nextcloud/continuous-integration-mysql-${{ matrix.mysql-versions }}:latest
         ports:
@@ -117,6 +121,7 @@ jobs:
           MYSQL_PASSWORD: nextcloud
           MYSQL_DATABASE: nextcloud
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
+        command: --default-auth=mysql_native_password
 
     steps:
       - name: Checkout server

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -81,6 +81,7 @@ jobs:
           MYSQL_PASSWORD: nextcloud
           MYSQL_DATABASE: oc_autotest
         options: --health-cmd="mysqladmin ping" --health-interval 5s --health-timeout 2s --health-retries 10
+        command: --default-auth=mysql_native_password
 
     steps:
       - name: Checkout server


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary

Tests print errors like:

```
"reqId":"Y3lZYyDY66erWDDo1YF5","level":3,"time":"2024-10-16T09:18:07+00:00","remoteAddr":"","user":"--","app":"mysql.setup","method":"","url":"--","message":"Database user creation failed.","userAgent":"--","version":"31.0.0.3","exception":{"Exception":"OC\\DB\\Exceptions\\DbalException","Message":"An exception occurred while executing a query: SQLSTATE[HY000]: General error: 1524 Plugin 'mysql_native_password' is not loaded","Code":1524,"Trace":[{"file":"/home/runner/actions-runner/_work/server/server/lib/private/DB/ConnectionAdapter.php","line":61,"function":"wrap","class":"OC\\DB\\Exceptions\\DbalException","type":"::","args":[{"__class__":"Doctrine\\DBAL\\Exception\\DriverException"}]},{"file":"/home/runner/actions-runner/_work/server/server/lib/private/Setup/MySQL.php","line":103,"function":"executeUpdate","class":"OC\\DB\\ConnectionAdapter","type":"->","args":["CREATE USER 'oc_admin'@'localhost' IDENTIFIED WITH mysql_native_password BY 'qn&?HhkmBYt3M&3h*76gL5GzaP?Cc4'"]},
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
