### PR TITLE
fix(caldav): broken activity rich objects

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Base.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Base.php
@@ -52,14 +52,14 @@ abstract class Base implements IProvider {
 			$data['name'] === CalDavBackend::PERSONAL_CALENDAR_NAME) {
 			return [
 				'type' => 'calendar',
-				'id' => $data['id'],
+				'id' => (string)$data['id'],
 				'name' => $l->t('Personal'),
 			];
 		}
 
 		return [
 			'type' => 'calendar',
-			'id' => $data['id'],
+			'id' => (string)$data['id'],
 			'name' => $data['name'],
 		];
 	}
@@ -72,7 +72,7 @@ abstract class Base implements IProvider {
 	protected function generateLegacyCalendarParameter($id, $name) {
 		return [
 			'type' => 'calendar',
-			'id' => $id,
+			'id' => (string)$id,
 			'name' => $name,
 		];
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Follow up to https://github.com/nextcloud/server/pull/47662

## Summary
Fixes the calendar ID so it's a string instead of an int

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
