### PR TITLE
build(autoloader): Remove noisy changes when regenerating

### DIFF
--- a/build/autoloaderchecker.sh
+++ b/build/autoloaderchecker.sh
@@ -45,6 +45,7 @@ for app in ${REPODIR}/apps/*; do
 		echo "Regenerating composer files for ${app}"
 		$COMPOSER_COMMAND i --no-dev -d ${app}/composer || exit 1
 		$COMPOSER_COMMAND dump-autoload -d ${app}/composer || exit 1
+		git checkout ${app}/composer/composer/installed.php
     fi
 done
 


### PR DESCRIPTION
## Summary

When executing the script all the app/*/composer/composer/installed.php files change as they reference the current HEAD commit hash. To avoid having to manually discard the changes, just drop them automatically.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
