### PR TITLE
[stable30] build: Bump symfony/* to 6.4

### DIFF
--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -37,8 +37,7 @@ class CryptTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->logger->expects($this->any())
-			->method('warning')
-			->willReturn(true);
+			->method('warning');
 		$this->userSession = $this->getMockBuilder(IUserSession::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/files_external/lib/Command/Config.php
+++ b/apps/files_external/lib/Command/Config.php
@@ -73,7 +73,7 @@ class Config extends Base {
 		if (!is_string($value) && json_decode(json_encode($value)) === $value) { // show bools and objects correctly
 			$value = json_encode($value);
 		}
-		$output->writeln($value);
+		$output->writeln((string)$value);
 	}
 
 	/**

--- a/apps/files_external/lib/Command/Delete.php
+++ b/apps/files_external/lib/Command/Delete.php
@@ -12,6 +12,7 @@ use OCA\Files_External\Service\GlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -64,6 +65,7 @@ class Delete extends Base {
 			$listInput->setOption('output', $input->getOption('output'));
 			$listCommand->listMounts(null, [$mount], $listInput, $output);
 
+			/** @var QuestionHelper $questionHelper */
 			$questionHelper = $this->getHelper('question');
 			$question = new ConfirmationQuestion('Delete this mount? [y/N] ', false);
 

--- a/apps/files_external/lib/Command/Option.php
+++ b/apps/files_external/lib/Command/Option.php
@@ -38,7 +38,7 @@ class Option extends Config {
 		if (!is_string($value)) { // show bools and objects correctly
 			$value = json_encode($value);
 		}
-		$output->writeln($value);
+		$output->writeln((string)$value);
 	}
 
 	/**

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -44,11 +44,6 @@
       <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
   </file>
-  <file src="3rdparty/symfony/routing/Route.php">
-    <MethodSignatureMustProvideReturnType>
-      <code><![CDATA[unserialize]]></code>
-    </MethodSignatureMustProvideReturnType>
-  </file>
   <file src="apps/dav/appinfo/v1/caldav.php">
     <UndefinedGlobalVariable>
       <code><![CDATA[$baseuri]]></code>

--- a/core/Command/Background/Delete.php
+++ b/core/Command/Background/Delete.php
@@ -10,6 +10,7 @@ namespace OC\Core\Command\Background;
 
 use OC\Core\Command\Base;
 use OCP\BackgroundJob\IJobList;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -51,6 +52,7 @@ class Delete extends Base {
 			'/^(y|Y)/i'
 		);
 
+		/** @var QuestionHelper $helper */
 		$helper = $this->getHelper('question');
 		if (!$helper->ask($input, $output, $question)) {
 			$output->writeln('aborted.');

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -149,7 +149,7 @@ class Base extends Command implements CompletionAwareInterface {
 		$this->interrupted = true;
 	}
 
-	public function run(InputInterface $input, OutputInterface $output) {
+	public function run(InputInterface $input, OutputInterface $output): int {
 		// check if the php pcntl_signal functions are accessible
 		$this->php_pcntl_signal = function_exists('pcntl_signal');
 		if ($this->php_pcntl_signal) {

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -12,6 +12,7 @@ use OC\AppConfig;
 use OCP\Exceptions\AppConfigIncorrectTypeException;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 use OCP\IAppConfig;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -229,6 +230,7 @@ class SetConfig extends Base {
 	}
 
 	private function ask(InputInterface $input, OutputInterface $output, string $request): bool {
+		/** @var QuestionHelper $helper */
 		$helper = $this->getHelper('question');
 		if ($input->getOption('no-interaction')) {
 			return true;

--- a/core/Command/Db/ConvertFilecacheBigInt.php
+++ b/core/Command/Db/ConvertFilecacheBigInt.php
@@ -11,6 +11,7 @@ use OC\DB\SchemaWrapper;
 use OCP\DB\Types;
 use OCP\IDBConnection;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
@@ -89,6 +90,7 @@ class ConvertFilecacheBigInt extends Command {
 		$output->writeln('<comment>This can take up to hours, depending on the number of files in your instance!</comment>');
 
 		if ($input->isInteractive()) {
+			/** @var QuestionHelper $helper */
 			$helper = $this->getHelper('question');
 			$question = new ConfirmationQuestion('Continue with the conversion (y/n)? [n] ', false);
 

--- a/core/Command/Db/Migrations/GenerateCommand.php
+++ b/core/Command/Db/Migrations/GenerateCommand.php
@@ -15,6 +15,7 @@ use Stecman\Component\Symfony\Console\BashCompletion\Completion\CompletionAwareI
 use Stecman\Component\Symfony\Console\BashCompletion\CompletionContext;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -120,6 +121,7 @@ class {{classname}} extends SimpleMigrationStep {
 				$output->writeln('<comment> - Actual:   ' . $version . '</comment>');
 
 				if ($input->isInteractive()) {
+					/** @var QuestionHelper $helper */
 					$helper = $this->getHelper('question');
 					$question = new ConfirmationQuestion('Continue with your given version? (y/n) [n] ', false);
 

--- a/core/Command/Maintenance/RepairShareOwnership.php
+++ b/core/Command/Maintenance/RepairShareOwnership.php
@@ -14,6 +14,7 @@ use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -60,6 +61,7 @@ class RepairShareOwnership extends Command {
 			$output->writeln("");
 
 			if (!$noConfirm) {
+				/** @var QuestionHelper $helper */
 				$helper = $this->getHelper('question');
 				$question = new ConfirmationQuestion('Repair these shares? [y/N]', false);
 

--- a/core/Command/Preview/Repair.php
+++ b/core/Command/Preview/Repair.php
@@ -19,6 +19,7 @@ use OCP\Lock\LockedException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -133,6 +134,7 @@ class Repair extends Command {
 		if ($input->getOption('batch')) {
 			$output->writeln('Batch mode active: migration is started right away.');
 		} else {
+			/** @var QuestionHelper $helper */
 			$helper = $this->getHelper('question');
 			$question = new ConfirmationQuestion('<info>Should the migration be started? (y/[n]) </info>', false);
 

--- a/lib/private/Console/TimestampFormatter.php
+++ b/lib/private/Console/TimestampFormatter.php
@@ -32,7 +32,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 *
 	 * @param bool $decorated Whether to decorate the messages or not
 	 */
-	public function setDecorated($decorated) {
+	public function setDecorated(bool $decorated) {
 		$this->formatter->setDecorated($decorated);
 	}
 
@@ -51,7 +51,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 * @param string $name The style name
 	 * @param OutputFormatterStyleInterface $style The style instance
 	 */
-	public function setStyle($name, OutputFormatterStyleInterface $style) {
+	public function setStyle(string $name, OutputFormatterStyleInterface $style) {
 		$this->formatter->setStyle($name, $style);
 	}
 
@@ -61,7 +61,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 * @param string $name
 	 * @return bool
 	 */
-	public function hasStyle($name): bool {
+	public function hasStyle(string $name): bool {
 		return $this->formatter->hasStyle($name);
 	}
 
@@ -72,7 +72,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 * @return OutputFormatterStyleInterface
 	 * @throws \InvalidArgumentException When style isn't defined
 	 */
-	public function getStyle($name): OutputFormatterStyleInterface {
+	public function getStyle(string $name): OutputFormatterStyleInterface {
 		return $this->formatter->getStyle($name);
 	}
 

--- a/lib/private/Console/TimestampFormatter.php
+++ b/lib/private/Console/TimestampFormatter.php
@@ -41,7 +41,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 *
 	 * @return bool true if the output will decorate messages, false otherwise
 	 */
-	public function isDecorated() {
+	public function isDecorated(): bool {
 		return $this->formatter->isDecorated();
 	}
 
@@ -61,7 +61,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 * @param string $name
 	 * @return bool
 	 */
-	public function hasStyle($name) {
+	public function hasStyle($name): bool {
 		return $this->formatter->hasStyle($name);
 	}
 
@@ -72,7 +72,7 @@ class TimestampFormatter implements OutputFormatterInterface {
 	 * @return OutputFormatterStyleInterface
 	 * @throws \InvalidArgumentException When style isn't defined
 	 */
-	public function getStyle($name) {
+	public function getStyle($name): OutputFormatterStyleInterface {
 		return $this->formatter->getStyle($name);
 	}
 

--- a/tests/Core/Command/User/SettingTest.php
+++ b/tests/Core/Command/User/SettingTest.php
@@ -49,15 +49,14 @@ class SettingTest extends TestCase {
 
 	public function getCommand(array $methods = []) {
 		if (empty($methods)) {
-			return new Setting($this->userManager, $this->config, $this->connection);
+			return new Setting($this->userManager, $this->config);
 		} else {
-			$mock = $this->getMockBuilder('OC\Core\Command\User\Setting')
+			$mock = $this->getMockBuilder(Setting::class)
 				->setConstructorArgs([
 					$this->userManager,
 					$this->config,
-					$this->connection,
 				])
-				->setMethods($methods)
+				->onlyMethods($methods)
 				->getMock();
 			return $mock;
 		}

--- a/tests/lib/Mail/MessageTest.php
+++ b/tests/lib/Mail/MessageTest.php
@@ -91,23 +91,23 @@ class MessageTest extends TestCase {
 		$this->symfonyEmail
 			->expects($this->once())
 			->method('from')
-			->willReturn(new Address('pierres-general-store@stardewvalley.com', 'Pierres General Store'));
+			->with(new Address('pierres-general-store@stardewvalley.com', 'Pierres General Store'));
 		$this->symfonyEmail
 			->expects($this->once())
 			->method('to')
-			->willReturn(new Address('lewis-tent@stardewvalley.com', "Lewis' Tent Life"));
+			->with(new Address('lewis-tent@stardewvalley.com', "Lewis' Tent Life"));
 		$this->symfonyEmail
 			->expects($this->once())
 			->method('replyTo')
-			->willReturn(new Address('penny@stardewvalley-library.co.edu', 'Penny'));
+			->with(new Address('penny@stardewvalley-library.co.edu', 'Penny'));
 		$this->symfonyEmail
 			->expects($this->once())
 			->method('cc')
-			->willReturn(new Address('gunther@stardewvalley-library.co.edu', 'Gunther'));
+			->with(new Address('gunther@stardewvalley-library.co.edu', 'Gunther'));
 		$this->symfonyEmail
 			->expects($this->once())
 			->method('bcc')
-			->willReturn(new Address('pam@stardewvalley-bus.com', 'Pam'));
+			->with(new Address('pam@stardewvalley-bus.com', 'Pam'));
 
 		$this->message->setRecipients();
 	}


### PR DESCRIPTION
- [x] https://github.com/nextcloud/3rdparty/pull/1960

## Summary
| Prod Packages                      | Operation | Base    | Target  |
|------------------------------------|-----------|---------|---------|
| stecman/symfony-console-completion | Upgraded  | 0.11.0  | v0.13.0 |
| symfony/console                    | Upgraded  | v5.4.35 | v6.4.12 |
| symfony/event-dispatcher           | Upgraded  | v5.4.26 | v6.4.8  |
| symfony/http-foundation            | Upgraded  | v5.4.25 | v6.4.12 |
| symfony/mailer                     | Upgraded  | v5.4.22 | v6.4.12 |
| symfony/mime                       | Upgraded  | v5.4.19 | v6.4.12 |
| symfony/polyfill-intl-grapheme     | Upgraded  | v1.29.0 | v1.31.0 |
| symfony/polyfill-intl-idn          | Upgraded  | v1.29.0 | v1.31.0 |
| symfony/polyfill-intl-normalizer   | Upgraded  | v1.29.0 | v1.31.0 |
| symfony/polyfill-php83             | New       | -       | v1.31.0 |
| symfony/process                    | Upgraded  | v5.4.34 | v6.4.12 |
| symfony/routing                    | Upgraded  | v5.4.25 | v6.4.12 |
| symfony/translation                | Upgraded  | v6.4.4  | v6.4.12 |
| symfony/polyfill-php72             | Removed   | v1.29.0 | -       |
| symfony/polyfill-php73             | Removed   | v1.28.0 | -       |


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
