### PR TITLE
Fix incorrect permissions when copying shared files

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -168,6 +168,9 @@ class Cache implements ICache {
 		if ($data['storage_mtime'] == 0) {
 			$data['storage_mtime'] = $data['mtime'];
 		}
+		if (isset($data['f_permissions'])) {
+			$data['scan_permissions'] = $data['f_permissions'];
+		}
 		$data['permissions'] = (int)$data['permissions'];
 		if (isset($data['creation_time'])) {
 			$data['creation_time'] = (int)$data['creation_time'];

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -1186,7 +1186,7 @@ class Cache implements ICache {
 	}
 
 	private function cacheEntryToArray(ICacheEntry $entry): array {
-		return [
+		$data = [
 			'size' => $entry->getSize(),
 			'mtime' => $entry->getMTime(),
 			'storage_mtime' => $entry->getStorageMTime(),
@@ -1199,6 +1199,10 @@ class Cache implements ICache {
 			'upload_time' => $entry->getUploadTime(),
 			'metadata_etag' => $entry->getMetadataEtag(),
 		];
+		if ($entry instanceof CacheEntry && isset($entry['scan_permissions'])) {
+			$data['permissions'] = $entry['scan_permissions'];
+		}
+		return $data;
 	}
 
 	public function getQueryFilterForStorage(): ISearchOperator {


### PR DESCRIPTION
- Save the original permissions of shared files as `scan_permissions`
- Use `scan_permissions` as the target permissions when doing `copyFromCache`

To test:

- setup instance with s3
- Share `F1` from `U1` to `U2`
- As `U2` copy `F1` to another folder
- Check that the copied file has delete permissions