### PR TITLE
fix type if known while using deprecated method

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -732,6 +732,14 @@ class AppConfig implements IAppConfig {
 		}
 
 		if ($this->hasKey($app, $key, $lazy)) {
+			// if current set is using deprecated method (using MIXED) but config is typed in db, we fix the type.
+			if ($this->isTyped(self::VALUE_MIXED, $type)) {
+				$type = $this->getValueType($app, $key, $lazy);
+				if ($sensitive) {
+					$type = $type | self::VALUE_SENSITIVE;
+				}
+			}
+
 			/**
 			 * no update if key is already known with set lazy status and value is
 			 * not different, unless sensitivity is switched from false to true.


### PR DESCRIPTION
This should fix some usecase where part of code is still trying to use deprecated method from `AllConfig` to store a value (as mixed) while the stored value is already set (as string/int/bool/array/float)