### PR TITLE
feat: support migrating an instance to sharding

### DIFF
--- a/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
+++ b/lib/private/DB/QueryBuilder/Sharded/ShardQueryRunner.php
@@ -55,6 +55,9 @@ class ShardQueryRunner {
 	private function getLikelyShards(array $primaryKeys): array {
 		$shards = [];
 		foreach ($primaryKeys as $primaryKey) {
+			if ($primaryKey < $this->shardDefinition->fromFileId && !in_array(ShardDefinition::MIGRATION_SHARD, $shards)) {
+				$shards[] = ShardDefinition::MIGRATION_SHARD;
+			}
 			$encodedShard = $primaryKey & ShardDefinition::PRIMARY_KEY_SHARD_MASK;
 			if ($encodedShard < count($this->shardDefinition->shards) && !in_array($encodedShard, $shards)) {
 				$shards[] = $encodedShard;

--- a/tests/lib/DB/QueryBuilder/Sharded/SharedQueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/Sharded/SharedQueryBuilderTest.php
@@ -39,7 +39,7 @@ class SharedQueryBuilderTest extends TestCase {
 		return new ShardedQueryBuilder(
 			$this->connection->getQueryBuilder(),
 			[
-				new ShardDefinition($table, $primaryColumn, [], $shardColumn, new RoundRobinShardMapper(), $companionTables, []),
+				new ShardDefinition($table, $primaryColumn, [], $shardColumn, new RoundRobinShardMapper(), $companionTables, [], 0, 0),
 			],
 			$this->createMock(ShardConnectionManager::class),
 			$this->autoIncrementHandler,


### PR DESCRIPTION
- [x] requires https://github.com/nextcloud/server/pull/48563
- [x] Fix "File entry could not be inserted but could also not be selected with getId() in order to perform an update. Please try again." issue
- [x] more testing

Support migrating existing instances to sharding.

Enabled by setting the sharding configuration and setting the `from_shard_key` and `from_primary` to the sharding configuration with the **next** storage/file id (so the first storage/file that will be created after sharding is configured).

The schema from the main db will need to be copied to the shard db's before enabling the sharding (having a command to help with this would be a nice stretch-goal)

Any files on the existing storages will still go to the main db, only newly created storages will be sharded.
