### PR TITLE
Fixing markdown parsing on settings

### DIFF
--- a/apps/settings/src/components/Markdown.vue
+++ b/apps/settings/src/components/Markdown.vue
@@ -48,9 +48,9 @@ export default {
 				out += '>' + text + '</a>'
 				return out
 			}
-			renderer.heading = (text, level) => {
-				level = Math.min(6, level + (this.minHeading - 1))
-				return `<h${level}>${text}</h${level}>`
+			renderer.heading = ({ text, depth }) => {
+				depth = Math.min(6, depth + (this.minHeading - 1))
+				return `<h${depth}>${text}</h${depth}>`
 			}
 			renderer.image = function(href, title, text) {
 				if (text) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #48661

## Summary
The custom markdown renderer heading for "marked" used fn(text,level). 

In the docs it's this:
https://marked.js.org/using_pro
	heading({ tokens, depth }: Tokens.Heading): string;

	interface Heading {
		type: "heading";
		raw: string;
		depth: number;
		text: string;
		tokens: Token[];
	}

Before:
<img width="926" alt="image" src="https://github.com/user-attachments/assets/500c3917-8d60-4865-ba1e-6d28a11a672d">


After:
<img width="875" alt="image" src="https://github.com/user-attachments/assets/a0f153d1-f82e-4806-8e1e-9ae220deb839">



## TODO


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
