### PR TITLE
fix: add eol in dav command and use success const as return code

### DIFF
--- a/apps/dav/lib/Command/FixCalendarSyncCommand.php
+++ b/apps/dav/lib/Command/FixCalendarSyncCommand.php
@@ -43,7 +43,7 @@ class FixCalendarSyncCommand extends Command {
 			$user = $this->userManager->get($userArg);
 			if ($user === null) {
 				$output->writeln("<error>User $userArg does not exist</error>");
-				return 1;
+				return self::FAILURE;
 			}
 
 			$this->fixUserCalendars($user);

--- a/apps/dav/lib/Command/FixCalendarSyncCommand.php
+++ b/apps/dav/lib/Command/FixCalendarSyncCommand.php
@@ -54,7 +54,8 @@ class FixCalendarSyncCommand extends Command {
 			});
 			$progress->finish();
 		}
-		return 0;
+		$output->writeln('');
+		return self::SUCCESS;
 	}
 
 	private function fixUserCalendars(IUser $user, ?ProgressBar $progress = null): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: Each CLI commands should return a end-of-line after execution

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
