### PR TITLE
fix(entity): Fix mapping of old/sub-types to actually supported datab…

### DIFF
--- a/lib/public/AppFramework/Db/Entity.php
+++ b/lib/public/AppFramework/Db/Entity.php
@@ -112,6 +112,15 @@ abstract class Entity {
 			}
 
 			switch ($type) {
+				case Types::BIGINT:
+				case Types::SMALLINT:
+					settype($args[0], Types::INTEGER);
+					break;
+				case Types::BINARY:
+				case Types::DECIMAL:
+				case Types::TEXT:
+					settype($args[0], Types::STRING);
+					break;
 				case Types::TIME:
 				case Types::DATE:
 				case Types::DATETIME:
@@ -260,9 +269,22 @@ abstract class Entity {
 	 *
 	 * @param string $fieldName the name of the attribute
 	 * @param \OCP\DB\Types::* $type the type which will be used to match a cast
+	 * @since 31.0.0 Parameter $type is now restricted to {@see \OCP\DB\Types} constants. The formerly accidentally supported types 'int'|'bool'|'double' are mapped to Types::INTEGER|Types::BOOLEAN|Types::FLOAT accordingly.
 	 * @since 7.0.0
 	 */
 	protected function addType(string $fieldName, string $type): void {
+		/** @psalm-suppress TypeDoesNotContainType */
+		if (in_array($type, ['bool', 'double', 'int', 'array', 'object'], true)) {
+			// Mapping legacy strings to the actual types
+			$type = match ($type) {
+				'int' => Types::INTEGER,
+				'bool' => Types::BOOLEAN,
+				'double' => Types::FLOAT,
+				'array',
+				'object' => Types::STRING,
+			};
+		}
+
 		$this->_fieldTypes[$fieldName] = $type;
 	}
 

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -39,20 +39,31 @@ class TestEntity extends Entity {
 	protected $name;
 	protected $email;
 	protected $testId;
+	protected $smallInt;
+	protected $bigInt;
 	protected $preName;
 	protected $trueOrFalse;
 	protected $anotherBool;
+	protected $text;
 	protected $longText;
 	protected $time;
 	protected $datetime;
 
 	public function __construct($name = null) {
 		$this->addType('testId', Types::INTEGER);
-		$this->addType('trueOrFalse', 'bool');
+		$this->addType('smallInt', Types::SMALLINT);
+		$this->addType('bigInt', Types::BIGINT);
 		$this->addType('anotherBool', Types::BOOLEAN);
+		$this->addType('text', Types::TEXT);
 		$this->addType('longText', Types::BLOB);
 		$this->addType('time', Types::TIME);
 		$this->addType('datetime', Types::DATETIME_IMMUTABLE);
+
+		// Legacy types
+		$this->addType('trueOrFalse', 'bool');
+		$this->addType('legacyInt', 'int');
+		$this->addType('doubleNowFloat', 'double');
+
 		$this->name = $name;
 	}
 
@@ -200,10 +211,28 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	public function testSetterCasts(): void {
+	public function dataSetterCasts(): array {
+		return [
+			['Id', '3', 3],
+			['smallInt', '3', 3],
+			['bigInt', '' . PHP_INT_MAX, PHP_INT_MAX],
+			['trueOrFalse', 0, false],
+			['trueOrFalse', 1, true],
+			['anotherBool', 0, false],
+			['anotherBool', 1, true],
+			['text', 33, '33'],
+			['longText', PHP_INT_MAX, '' . PHP_INT_MAX],
+		];
+	}
+
+
+	/**
+	 * @dataProvider dataSetterCasts
+	 */
+	public function testSetterCasts(string $field, mixed $in, mixed $out): void {
 		$entity = new TestEntity();
-		$entity->setId('3');
-		$this->assertSame(3, $entity->getId());
+		$entity->{'set' . $field}($in);
+		$this->assertSame($out, $entity->{'get' . $field}());
 	}
 
 
@@ -248,11 +277,16 @@ class EntityTest extends \Test\TestCase {
 		$this->assertEquals([
 			'id' => Types::INTEGER,
 			'testId' => Types::INTEGER,
-			'trueOrFalse' => 'bool',
+			'smallInt' => Types::SMALLINT,
+			'bigInt' => Types::BIGINT,
 			'anotherBool' => Types::BOOLEAN,
+			'text' => Types::TEXT,
 			'longText' => Types::BLOB,
 			'time' => Types::TIME,
 			'datetime' => Types::DATETIME_IMMUTABLE,
+			'trueOrFalse' => Types::BOOLEAN,
+			'legacyInt' => Types::INTEGER,
+			'doubleNowFloat' => Types::FLOAT,
 		], $entity->getFieldTypes());
 	}
 


### PR DESCRIPTION
…ase types

- Follow-ups from https://github.com/nextcloud/server/pull/47329

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
