### PR TITLE
build: Print RTL limited characters in translation-checker

### DIFF
--- a/build/translation-checker.php
+++ b/build/translation-checker.php
@@ -76,8 +76,8 @@ foreach ($directories as $dir) {
 		$content = file_get_contents($file->getPathname());
 
 		$language = pathinfo($file->getFilename(), PATHINFO_FILENAME);
-		if (!in_array($language, $rtlLanguages, true) && preg_match('/[' . implode('', $rtlCharacters) . ']/u', $content, $matches)) {
-			$errors[] = $file->getPathname() . "\n" . '  ' . 'Contains a RTL limited characters in the translations. Offending Unicode codepoints: ' . implode(', ', array_map(static fn (string $match) => mb_ord($match), $matches)) . "\n";
+		if (!in_array($language, $rtlLanguages, true) && preg_match_all('/^(.+[' . implode('', $rtlCharacters) . '].+)$/mu', $content, $matches)) {
+			$errors[] = $file->getPathname() . "\n" . '  ' . 'Contains a RTL limited characters in the translations. Offending strings:' . "\n" . implode("\n", $matches[0]) . "\n";
 		}
 
 		$json = json_decode($content, true);

--- a/build/translation-checker.php
+++ b/build/translation-checker.php
@@ -76,8 +76,8 @@ foreach ($directories as $dir) {
 		$content = file_get_contents($file->getPathname());
 
 		$language = pathinfo($file->getFilename(), PATHINFO_FILENAME);
-		if (!in_array($language, $rtlLanguages, true) && preg_match('/[' . implode('', $rtlCharacters) . ']/u', $content)) {
-			$errors[] = $file->getPathname() . "\n" . '  ' . 'Contains a RTL limited character in the translations.' . "\n";
+		if (!in_array($language, $rtlLanguages, true) && preg_match('/[' . implode('', $rtlCharacters) . ']/u', $content, $matches)) {
+			$errors[] = $file->getPathname() . "\n" . '  ' . 'Contains a RTL limited characters in the translations. Offending Unicode codepoints: ' . implode(', ', array_map(static fn (string $match) => mb_ord($match), $matches)) . "\n";
 		}
 
 		$json = json_decode($content, true);


### PR DESCRIPTION
## Summary

So we know which characters are causing problems.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
