### PR TITLE
Fix $uid type in Encryption stream

### DIFF
--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -42,7 +42,7 @@ class Encryption extends Wrapper {
 	/**
 	 * user who perform the read/write operation null for public access
 	 */
-	protected string $uid;
+	protected ?string $uid;
 	protected bool $readOnly;
 	protected bool $writeFlag;
 	protected array $expectedContextProperties;


### PR DESCRIPTION
As explained by the comment.

It was also an issue with the `occ encryption:decrypt-all` command.

Follow-up of https://github.com/nextcloud/server/pull/48487