### PR TITLE
fix(settings): Change "setup warnings" -> "setup checks" in Overview

### DIFF
--- a/apps/settings/lib/Settings/Admin/Overview.php
+++ b/apps/settings/lib/Settings/Admin/Overview.php
@@ -50,7 +50,7 @@ class Overview implements IDelegatedSettings {
 	}
 
 	public function getName(): ?string {
-		return $this->l->t('Security & setup warnings');
+		return $this->l->t('Security & setup checks');
 	}
 
 	public function getAuthorizedAppConfig(): array {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Not everything shown in the overview is a warning. We show errors, warnings, and informational messages there. And we color code them. Let's title the section properly.


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
