### PR TITLE
feat(bruteforce): Allow forcing the database throttler

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -342,7 +342,7 @@ $CONFIG = [
 
 /**
  * The timeout in seconds for synchronizing address books, e.g. federated system address books (as run by `occ federation:sync-addressbooks`).
- * 
+ *
  * Defaults to ``30`` seconds
  */
 'carddav_sync_request_timeout' => 30,
@@ -404,6 +404,17 @@ $CONFIG = [
  * Defaults to ``true``
  */
 'auth.bruteforce.protection.enabled' => true,
+
+/**
+ * Whether the brute force protection should write into the database even when a memory cache is available
+ *
+ * Using the database is most likely worse for performance, but makes investigating
+ * issues a lot easier as it's possible to look directly at the table to see all
+ * logged remote addresses and actions.
+ *
+ * Defaults to ``false``
+ */
+'auth.bruteforce.protection.force.database' => false,
 
 /**
  * Whether the brute force protection shipped with Nextcloud should be set to testing mode.

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -846,7 +846,8 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerService(\OC\Security\Bruteforce\Backend\IBackend::class, function ($c) {
 			$config = $c->get(\OCP\IConfig::class);
-			if (ltrim($config->getSystemValueString('memcache.distributed', ''), '\\') === \OC\Memcache\Redis::class) {
+			if (!$config->getSystemValueBool('auth.bruteforce.protection.force.database', false)
+				&& ltrim($config->getSystemValueString('memcache.distributed', ''), '\\') === \OC\Memcache\Redis::class) {
 				$backend = $c->get(\OC\Security\Bruteforce\Backend\MemoryCacheBackend::class);
 			} else {
 				$backend = $c->get(\OC\Security\Bruteforce\Backend\DatabaseBackend::class);


### PR DESCRIPTION
> Using the database is most likely worse for performance, but makes investigating issues a lot easier as it's possible to look directly at the table to see all logged remote addresses and actions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
