### PR TITLE
[RFC] Setting NCU\ for unstable/work-in-progress API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 			"": "lib/private/legacy",
 			"OC\\": "lib/private",
 			"OC\\Core\\": "core/",
-			"OCP\\": "lib/public"
+			"OCP\\": "lib/public",
+			"NCU\\": "lib/unstable"
 		}
 	},
 	"require": {

--- a/lib/composer/composer/autoload_psr4.php
+++ b/lib/composer/composer/autoload_psr4.php
@@ -9,5 +9,6 @@ return array(
     'OC\\Core\\' => array($baseDir . '/core'),
     'OC\\' => array($baseDir . '/lib/private'),
     'OCP\\' => array($baseDir . '/lib/public'),
+    'NCU\\' => array($baseDir . '/lib/unstable'),
     '' => array($baseDir . '/lib/private/legacy'),
 );

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -17,6 +17,10 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
             'OC\\' => 3,
             'OCP\\' => 4,
         ),
+        'N' => 
+        array (
+            'NCU\\' => 4,
+        ),
     );
 
     public static $prefixDirsPsr4 = array (
@@ -31,6 +35,10 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\' => 
         array (
             0 => __DIR__ . '/../../..' . '/lib/public',
+        ),
+        'NCU\\' =>
+        array (
+            0 => __DIR__ . '/../../..' . '/lib/unstable',
         ),
     );
 

--- a/psalm-ocp.xml
+++ b/psalm-ocp.xml
@@ -19,6 +19,7 @@
 	</plugins>
 	<projectFiles>
 		<directory name="lib/public"/>
+		<directory name="lib/unstable"/>
 		<ignoreFiles>
 			<directory name="lib/composer/bin"/>
 		</ignoreFiles>


### PR DESCRIPTION
This comes after some discussions regarding the implementation of [IUserPreferences](https://github.com/nextcloud/server/pull/47658) directly in `public` or in `private` first. 
During the discussion we established that keeping the API in `private` helps future unexpected fix and modification that might occurs in the near future; however, it will also block people to test it from their apps.

The conclusion was to provide a namespace for in-progress API with rules between `public` and `private`

- by not using `private` API, developers are still encouraged to use and test the API in theirs apps
- by not using `public` API, developers stays alert that the API can change at any moment.
- once the `testing` API is set as stable, code is copied to `OCP\` and previous code within `NCT\` is marked as deprecated 
