### PR TITLE
chore: don't remove needs info label when commenting on a stale issue

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,6 @@ jobs:
           for your contributions.
         stale-issue-label: 'stale'
         only-labels: 'needs info'
-        labels-to-remove-when-unstale: 'needs info,stale'
         exempt-issue-labels: '1. to develop,2. developing,3. to review,4. to release,security'
         days-before-stale: 30
         days-before-close: 14


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

1) Removing the "needs info" label when someone comments on a stale issue seems incorrect. 

2) By default, the stale action removes the "stale" label upon commenting. However, the labels-to-remove-when-unstale option triggers an additional API request to remove the "stale" label, which was already removed in the previous API call.

Test issue:
https://github.com/nextcloud/server/issues/38495 (to see that needs info and stale are removed with the current configuration)

Workflow log:
![Screenshot From 2024-10-25 14-13-27](https://github.com/user-attachments/assets/41a63c89-f5d5-4f2b-8fd8-79c30ea4ce68)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
