### PR TITLE
chore: Clarify log entry requirements in bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -168,7 +168,7 @@ body:
         ./occ config:list system
         ```
         > NOTE: This will be automatically formatted into code for better readability.
-      render: shell
+      render: json
   - type: textarea
     id: apps
     attributes:
@@ -200,10 +200,10 @@ body:
     attributes:
       label: Nextcloud Logs
       description: |
-        Provide Nextcloud logs lines.
-        Copy all contents from `data/nextcloud.log` or a RAW from `/settings/admin/logging` section:
+        Provide relevant Nextcloud log entries (e.g. from the time period you reproduced the problem).
+        Copy full individual entries from `data/nextcloud.log` or use `Copy raw entry` from `/settings/admin/logging` section:
         > NOTE: This will be automatically formatted into code for better readability.
-      render: shell
+      render: json
   - type: textarea
     id: additional-info
     attributes:


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

* We don't want (or need) to the entire log file
  - GitHub will reject it anyhow
  - Reporters get annoyed/confused
  - Wading through days/weeks/months/years of log entries isn't conducive to efficient triaging / bug analysis :)
* Also adjust automatic rendering to `json` (note: I think the automated adding of codeblocks via Issue templates automatically is broken right now on GitHub; I've noticed more Issues coming in that are missing codeblock markers but that's a GH bug... I don't think it's us).

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
