### PR TITLE
feat: Add `allowed_view_extensions` config node

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -131,6 +131,7 @@ class ServerFactory {
 			// Allow view-only plugin for webdav requests
 			$server->addPlugin(new ViewOnlyPlugin(
 				$userFolder,
+				$this->config,
 			));
 
 			if ($this->userSession->isLoggedIn()) {

--- a/apps/dav/lib/DAV/ViewOnlyPlugin.php
+++ b/apps/dav/lib/DAV/ViewOnlyPlugin.php
@@ -14,6 +14,7 @@ use OCA\Files_Versions\Sabre\VersionFile;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\ISharedStorage;
+use OCP\IConfig;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
@@ -27,6 +28,7 @@ class ViewOnlyPlugin extends ServerPlugin {
 
 	public function __construct(
 		private ?Folder $userFolder,
+		private IConfig $config,
 	) {
 	}
 
@@ -89,6 +91,11 @@ class ViewOnlyPlugin extends ServerPlugin {
 
 			$attributes = $share->getAttributes();
 			if ($attributes === null) {
+				return true;
+			}
+
+			$allowedFileExtensions = $this->config->getSystemValue('allowed_view_extensions', []);
+			if ($allowedFileExtensions && in_array($node->getExtension(), $allowedFileExtensions, true)) {
 				return true;
 			}
 

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -253,6 +253,7 @@ class Server {
 			// Allow view-only plugin for webdav requests
 			$this->server->addPlugin(new ViewOnlyPlugin(
 				\OC::$server->getUserFolder(),
+				\OCP\Server::get(IConfig::class),
 			));
 
 			// custom properties plugin must be the last one

--- a/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
@@ -17,6 +17,7 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\Storage\ISharedStorage;
 use OCP\Files\Storage\IStorage;
+use OCP\IConfig;
 use OCP\IUser;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
@@ -39,6 +40,7 @@ class ViewOnlyPluginTest extends TestCase {
 		$this->userFolder = $this->createMock(Folder::class);
 		$this->plugin = new ViewOnlyPlugin(
 			$this->userFolder,
+			$this->createMock(IConfig::class),
 		);
 		$this->request = $this->createMock(RequestInterface::class);
 		$this->tree = $this->createMock(Tree::class);

--- a/tests/Core/Controller/PreviewControllerTest.php
+++ b/tests/Core/Controller/PreviewControllerTest.php
@@ -15,6 +15,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\Storage\IStorage;
+use OCP\IConfig;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\Preview\IMimeIconProvider;
@@ -45,7 +46,8 @@ class PreviewControllerTest extends \Test\TestCase {
 			$this->previewManager,
 			$this->rootFolder,
 			$this->userId,
-			$this->createMock(IMimeIconProvider::class)
+			$this->createMock(IMimeIconProvider::class),
+			$this->createMock(IConfig::class),
 		);
 	}
 


### PR DESCRIPTION
## Summary
It isn't possible to view jpg files if they were shared without allow downloading. Related to https://github.com/nextcloud/text/pull/6564

<details><summary>:mag: Reproducer</summary>
<p>
Share file without download possibility

![image](https://github.com/user-attachments/assets/ec480e7e-1e81-4700-ac06-c4d289621f50)

Try to view file as share recipient
![image](https://github.com/user-attachments/assets/a5914e26-940a-4235-92ae-02f1164574a8)
</p>
</details> 

To fix that we can introduce a new `allowed_view_extensions` config node.

```php
  'allowed_view_extensions' => [
    'jpg',
    'jpeg',
    'png',
    // ...
  ]
```

## TODO

- [ ] ...

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
