### PR TITLE
fix(apps-store): Fix exception on generating preview url for installed app screenshot

### DIFF
--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -245,9 +245,15 @@ class AppSettingsController extends Controller {
 		$apps = $appClass->listAllApps();
 		foreach ($apps as $app) {
 			$app['installed'] = true;
-			// locally installed apps have a flatted screenshot property
+
 			if (isset($app['screenshot'][0])) {
-				$app['screenshot'] = $this->createProxyPreviewUrl($app['screenshot'][0]);
+				$appScreenshot = $app['screenshot'][0] ?? null;
+				if (is_array($appScreenshot)) {
+					// Screenshot with thumbnail
+					$appScreenshot = $appScreenshot['@value'];
+				}
+
+				$app['screenshot'] = $this->createProxyPreviewUrl($appScreenshot);
 			}
 			$this->allApps[$app['id']] = $app;
 		}

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -190,6 +190,17 @@ class InfoParser {
 			$array['dependencies']['backend'] = [$array['dependencies']['backend']];
 		}
 
+		// Ensure some fields are always arrays
+		if (isset($array['screenshot']) && !is_array($array['screenshot'])) {
+			$array['screenshot'] = [$array['screenshot']];
+		}
+		if (isset($array['author']) && !is_array($array['author'])) {
+			$array['author'] = [$array['author']];
+		}
+		if (isset($array['category']) && !is_array($array['category'])) {
+			$array['category'] = [$array['category']];
+		}
+
 		if ($this->cache !== null) {
 			$this->cache->set($fileCacheKey, json_encode($array));
 		}

--- a/tests/data/app/expected-info.json
+++ b/tests/data/app/expected-info.json
@@ -6,7 +6,9 @@
 	"name": "Server-side Encryption",
 	"description": "\n\tThis application encrypts all files accessed by ownCloud at rest, wherever they are stored. As an example, with this application enabled, external cloud based Amazon S3 storage will be encrypted, protecting this data on storage outside of the control of the Admin. When this application is enabled for the first time, all files are encrypted as users log in and are prompted for their password. The recommended recovery key option enables recovery of files in case the key is lost. \n\tNote that this app encrypts all files that are touched by ownCloud, so external storage providers and applications such as SharePoint will see new files encrypted when they are accessed. Encryption is based on AES 128 or 256 bit keys. More information is available in the Encryption documentation \n\t",
 	"licence": "AGPL",
-	"author": "Sam Tuke, Bjoern Schiessle, Florin Peter",
+	"author": [
+		"Sam Tuke, Bjoern Schiessle, Florin Peter"
+	],
 	"requiremin": "4",
 	"shipped": "true",
 	"documentation": {

--- a/tests/data/app/various-single-item.json
+++ b/tests/data/app/various-single-item.json
@@ -1,0 +1,50 @@
+{
+	"id": "notifications",
+	"name": "Notifications",
+	"description": "A single screenshot should be an array",
+	"version": "1.0.0",
+	"licence": "agpl",
+	"author": [
+		"Joas Schilling"
+	],
+	"dependencies": {
+		"nextcloud": {
+			"@attributes": {
+				"min-version": "16",
+				"max-version": "16"
+			}
+		},
+		"backend": []
+	},
+	"screenshot": [
+		"https://raw.githubusercontent.com/nextcloud/notifications/refs/heads/master/docs/screenshot.png"
+	],
+	"category": [
+		"monitoring"
+	],
+	"info": [],
+	"background-jobs": [],
+	"activity": {
+		"filters": [],
+		"settings": [],
+		"providers": []
+	},
+	"commands": [],
+	"remote": [],
+	"public": [],
+	"repair-steps": {
+		"install": [],
+		"pre-migration": [],
+		"post-migration": [],
+		"live-migration": [],
+		"uninstall": []
+	},
+	"settings": {
+		"admin": [],
+		"admin-section": [],
+		"personal": [],
+		"personal-section": []
+	},
+	"two-factor-providers": [],
+	"types": []
+}

--- a/tests/data/app/various-single-item.json.license
+++ b/tests/data/app/various-single-item.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/tests/data/app/various-single-item.xml
+++ b/tests/data/app/various-single-item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+ - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
+	  xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
+	<id>notifications</id>
+	<name>Notifications</name>
+	<description>A single screenshot should be an array</description>
+	<version>1.0.0</version>
+	<licence>agpl</licence>
+	<author>Joas Schilling</author>
+
+	<category>monitoring</category>
+
+	<screenshot>https://raw.githubusercontent.com/nextcloud/notifications/refs/heads/master/docs/screenshot.png</screenshot>
+
+	<dependencies>
+		<nextcloud min-version="16" max-version="16"/>
+	</dependencies>
+</info>

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -53,6 +53,7 @@ class InfoParserTest extends TestCase {
 			[null, 'invalid-info.xml'],
 			['navigation-one-item.json', 'navigation-one-item.xml'],
 			['navigation-two-items.json', 'navigation-two-items.xml'],
+			['various-single-item.json', 'various-single-item.xml'],
 		];
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Some installed apps meant for older server versions might unexpectedly offer up screenshot values in a non-string format (e.g. health). Avoid an exception by checking first if the first app screenshot is indeed a string and only then trying to create the $proxyPreviewUrl

Example error:

```
{"reqId":"HMJg7Rkp0hOomzjCuXPs","level":3,"time":"2024-10-27T11:40:53+00:00","remoteAddr":"192.168.21.3","user":"admin","app":"index","method":"GET","url":"/index.php/settings/apps/list","message":"OCA\\Settings\\Controller\\AppSettingsController::createProxyPreviewUrl(): Argument #1 ($url) must be of type string, array given, called in /var/www/html/apps/settings/lib/Controller/AppSettingsController.php on line 250 in file '/var/www/html/apps/settings/lib/Controller/AppSettingsController.php' line 236","userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15","version":"31.0.0.3","exception":{"Exception":"Exception","Message":"OCA\\Settings\\Controller\\AppSettingsController::createProxyPreviewUrl(): Argument #1 ($url) must be of type string, array given, called in /var/www/html/apps/settings/lib/Controller/AppSettingsController.php on line 250 in file '/var/www/html/apps/settings/lib/Controller/AppSettingsController.php' line 236","Code":0,"Trace":[{"file":"/var/www/html/lib/private/AppFramework/App.php","line":161,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OCA\\Settings\\Controller\\AppSettingsController"},"listApps"]},{"file":"/var/www/html/lib/private/Route/Router.php","line":306,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Settings\\Controller\\AppSettingsController","listApps",{"__class__":"OC\\AppFramework\\DependencyInjection\\DIContainer"},{"_route":"settings.appsettings.listapps"}]},{"file":"/var/www/html/lib/base.php","line":1010,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/settings/apps/list"]},{"file":"/var/www/html/index.php","line":24,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","Line":146,"Previous":{"Exception":"TypeError","Message":"OCA\\Settings\\Controller\\AppSettingsController::createProxyPreviewUrl(): Argument #1 ($url) must be of type string, array given, called in /var/www/html/apps/settings/lib/Controller/AppSettingsController.php on line 250","Code":0,"Trace":[{"file":"/var/www/html/apps/settings/lib/Controller/AppSettingsController.php","line":250,"function":"createProxyPreviewUrl","class":"OCA\\Settings\\Controller\\AppSettingsController","type":"->","args":["*** sensitive parameters replaced ***"]},{"file":"/var/www/html/apps/settings/lib/Controller/AppSettingsController.php","line":295,"function":"fetchApps","class":"OCA\\Settings\\Controller\\AppSettingsController","type":"->","args":[]},{"file":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","line":208,"function":"listApps","class":"OCA\\Settings\\Controller\\AppSettingsController","type":"->","args":[]},{"file":"/var/www/html/lib/private/AppFramework/Http/Dispatcher.php","line":114,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OCA\\Settings\\Controller\\AppSettingsController"},"listApps"]},{"file":"/var/www/html/lib/private/AppFramework/App.php","line":161,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->","args":[{"__class__":"OCA\\Settings\\Controller\\AppSettingsController"},"listApps"]},{"file":"/var/www/html/lib/private/Route/Router.php","line":306,"function":"main","class":"OC\\AppFramework\\App","type":"::","args":["OCA\\Settings\\Controller\\AppSettingsController","listApps",{"__class__":"OC\\AppFramework\\DependencyInjection\\DIContainer"},{"_route":"settings.appsettings.listapps"}]},{"file":"/var/www/html/lib/base.php","line":1010,"function":"match","class":"OC\\Route\\Router","type":"->","args":["/settings/apps/list"]},{"file":"/var/www/html/index.php","line":24,"function":"handleRequest","class":"OC","type":"::","args":[]}],"File":"/var/www/html/apps/settings/lib/Controller/AppSettingsController.php","Line":236},"message":"OCA\\Settings\\Controller\\AppSettingsController::createProxyPreviewUrl(): Argument #1 ($url) must be of type string, array given, called in /var/www/html/apps/settings/lib/Controller/AppSettingsController.php on line 250 in file '/var/www/html/apps/settings/lib/Controller/AppSettingsController.php' line 236","exception":{},"CustomMessage":"OCA\\Settings\\Controller\\AppSettingsController::createProxyPreviewUrl(): Argument #1 ($url) must be of type string, array given, called in /var/www/html/apps/settings/lib/Controller/AppSettingsController.php on line 250 in file '/var/www/html/apps/settings/lib/Controller/AppSettingsController.php' line 236"}}
```

## TODO

This is my first server PR so apologies if I messed something up

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
