### PR TITLE
fix: encrypt and store password, decrypt and retrieve the same

### DIFF
--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OC\Authentication\LoginCredentials;
 
+use Exception;
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
@@ -30,17 +31,13 @@ class Store implements IStore {
 	/** @var IProvider|null */
 	private $tokenProvider;
 
-	/** @var ICrypto */
-	private $crypto;
-
 	public function __construct(ISession $session,
 		LoggerInterface $logger,
-		ICrypto $crypto,
+		private readonly ICrypto $crypto,
 		?IProvider $tokenProvider = null) {
 		$this->session = $session;
 		$this->logger = $logger;
 		$this->tokenProvider = $tokenProvider;
-		$this->crypto = $crypto;
 
 		Util::connectHook('OC_User', 'post_login', $this, 'authenticate');
 	}
@@ -98,7 +95,11 @@ class Store implements IStore {
 		if ($trySession && $this->session->exists('login_credentials')) {
 			/** @var array $creds */
 			$creds = json_decode($this->session->get('login_credentials'), true);
-			$creds['password'] = $this->crypto->decrypt($creds['password']);
+			try {
+				$creds['password'] = $this->crypto->decrypt($creds['password']);
+			} catch (Exception $e) {
+				//decryption failed, continue with old password as it is
+			}
 			return new Credentials(
 				$creds['uid'],
 				$creds['loginName'] ?? $this->session->get('loginname') ?? $creds['uid'], // Pre 20 didn't have a loginName property, hence fall back to the session value and then to the UID

--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -10,12 +10,12 @@ namespace OC\Authentication\LoginCredentials;
 
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
-use OC\Security\Crypto;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\LoginCredentials\ICredentials;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\ISession;
+use OCP\Security\ICrypto;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -30,12 +30,12 @@ class Store implements IStore {
 	/** @var IProvider|null */
 	private $tokenProvider;
 
-	/** @var Crypto */
+	/** @var ICrypto */
 	private $crypto;
 
 	public function __construct(ISession $session,
 		LoggerInterface $logger,
-		Crypto $crypto,
+		ICrypto $crypto,
 		?IProvider $tokenProvider = null) {
 		$this->session = $session;
 		$this->logger = $logger;

--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -10,6 +10,7 @@ namespace OC\Authentication\LoginCredentials;
 
 use OC\Authentication\Exceptions\PasswordlessTokenException;
 use OC\Authentication\Token\IProvider;
+use OC\Security\Crypto;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\LoginCredentials\ICredentials;
@@ -29,12 +30,17 @@ class Store implements IStore {
 	/** @var IProvider|null */
 	private $tokenProvider;
 
+	/** @var Crypto|null */
+	private $crypto;
+
 	public function __construct(ISession $session,
 		LoggerInterface $logger,
-		?IProvider $tokenProvider = null) {
+		?IProvider $tokenProvider = null,
+		?Crypto $crypto = null) {
 		$this->session = $session;
 		$this->logger = $logger;
 		$this->tokenProvider = $tokenProvider;
+		$this->crypto = $crypto;
 
 		Util::connectHook('OC_User', 'post_login', $this, 'authenticate');
 	}
@@ -45,6 +51,7 @@ class Store implements IStore {
 	 * @param array $params
 	 */
 	public function authenticate(array $params) {
+		$params['password'] = $this->crypto->encrypt((string)$params['password']);
 		$this->session->set('login_credentials', json_encode($params));
 	}
 
@@ -91,6 +98,7 @@ class Store implements IStore {
 		if ($trySession && $this->session->exists('login_credentials')) {
 			/** @var array $creds */
 			$creds = json_decode($this->session->get('login_credentials'), true);
+			$creds['password'] = $this->crypto->decrypt($creds['password']);
 			return new Credentials(
 				$creds['uid'],
 				$creds['loginName'] ?? $this->session->get('loginname') ?? $creds['uid'], // Pre 20 didn't have a loginName property, hence fall back to the session value and then to the UID

--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -31,10 +31,12 @@ class Store implements IStore {
 	/** @var IProvider|null */
 	private $tokenProvider;
 
-	public function __construct(ISession $session,
+	public function __construct(
+		ISession $session,
 		LoggerInterface $logger,
 		private readonly ICrypto $crypto,
-		?IProvider $tokenProvider = null) {
+		?IProvider $tokenProvider = null,
+	) {
 		$this->session = $session;
 		$this->logger = $logger;
 		$this->tokenProvider = $tokenProvider;

--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -30,13 +30,13 @@ class Store implements IStore {
 	/** @var IProvider|null */
 	private $tokenProvider;
 
-	/** @var Crypto|null */
+	/** @var Crypto */
 	private $crypto;
 
 	public function __construct(ISession $session,
 		LoggerInterface $logger,
-		?IProvider $tokenProvider = null,
-		?Crypto $crypto = null) {
+		Crypto $crypto,
+		?IProvider $tokenProvider = null) {
 		$this->session = $session;
 		$this->logger = $logger;
 		$this->tokenProvider = $tokenProvider;

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -452,7 +452,7 @@ class Server extends ServerContainer implements IServerContainer {
 			}
 			$logger = $c->get(LoggerInterface::class);
 			$crypto = $c->get(Crypto::class);
-			return new Store($session, $logger, $tokenProvider, $crypto);
+			return new Store($session, $logger, $crypto, $tokenProvider);
 		});
 		$this->registerAlias(IStore::class, Store::class);
 		$this->registerAlias(IProvider::class, Authentication\Token\Manager::class);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -451,7 +451,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$tokenProvider = null;
 			}
 			$logger = $c->get(LoggerInterface::class);
-			$crypto = $c->get(Crypto::class);
+			$crypto = $c->get(ICrypto::class);
 			return new Store($session, $logger, $crypto, $tokenProvider);
 		});
 		$this->registerAlias(IStore::class, Store::class);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -451,7 +451,8 @@ class Server extends ServerContainer implements IServerContainer {
 				$tokenProvider = null;
 			}
 			$logger = $c->get(LoggerInterface::class);
-			return new Store($session, $logger, $tokenProvider);
+			$crypto = $c->get(Crypto::class);
+			return new Store($session, $logger, $tokenProvider, $crypto);
 		});
 		$this->registerAlias(IStore::class, Store::class);
 		$this->registerAlias(IProvider::class, Authentication\Token\Manager::class);

--- a/tests/lib/Authentication/LoginCredentials/StoreTest.php
+++ b/tests/lib/Authentication/LoginCredentials/StoreTest.php
@@ -13,8 +13,10 @@ use OC\Authentication\LoginCredentials\Credentials;
 use OC\Authentication\LoginCredentials\Store;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
+use OC\Security\Crypto;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\ISession;
+use OCP\Security\ICrypto;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -29,6 +31,8 @@ class StoreTest extends TestCase {
 
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
+	/** @var ICrypto|\PHPUnit\Framework\MockObject\MockObject */
+	private $crypto;
 
 	/** @var Store */
 	private $store;
@@ -39,20 +43,24 @@ class StoreTest extends TestCase {
 		$this->session = $this->createMock(ISession::class);
 		$this->tokenProvider = $this->createMock(IProvider::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->crypto = $this->createMock(Crypto::class);
 
-		$this->store = new Store($this->session, $this->logger, $this->tokenProvider);
+		$this->store = new Store($this->session, $this->logger, $this->tokenProvider, $this->crypto);
 	}
 
 	public function testAuthenticate(): void {
 		$params = [
 			'run' => true,
 			'uid' => 'user123',
-			'password' => 123456,
+			'password' => '123456',
 		];
 
 		$this->session->expects($this->once())
 			->method('set')
 			->with($this->equalTo('login_credentials'), $this->equalTo(json_encode($params)));
+		$this->crypto->expects($this->once())
+			->method('encrypt')
+			->willReturn($params['password']);
 
 		$this->store->authenticate($params);
 	}
@@ -65,7 +73,7 @@ class StoreTest extends TestCase {
 	}
 
 	public function testGetLoginCredentialsNoTokenProvider(): void {
-		$this->store = new Store($this->session, $this->logger, null);
+		$this->store = new Store($this->session, $this->logger, null, $this->crypto);
 
 		$this->expectException(CredentialsUnavailableException::class);
 
@@ -139,6 +147,9 @@ class StoreTest extends TestCase {
 			->method('exists')
 			->with($this->equalTo('login_credentials'))
 			->willReturn(true);
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->willReturn($password);
 		$this->session->expects($this->exactly(2))
 			->method('get')
 			->willReturnMap([
@@ -176,6 +187,9 @@ class StoreTest extends TestCase {
 			->method('exists')
 			->with($this->equalTo('login_credentials'))
 			->willReturn(true);
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->willReturn($password);
 		$this->session->expects($this->exactly(2))
 			->method('get')
 			->willReturnMap([
@@ -214,6 +228,9 @@ class StoreTest extends TestCase {
 			->method('exists')
 			->with($this->equalTo('login_credentials'))
 			->willReturn(true);
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->willReturn($password);
 		$this->session->expects($this->once())
 			->method('get')
 			->with($this->equalTo('login_credentials'))

--- a/tests/lib/Authentication/LoginCredentials/StoreTest.php
+++ b/tests/lib/Authentication/LoginCredentials/StoreTest.php
@@ -13,7 +13,6 @@ use OC\Authentication\LoginCredentials\Credentials;
 use OC\Authentication\LoginCredentials\Store;
 use OC\Authentication\Token\IProvider;
 use OC\Authentication\Token\IToken;
-use OC\Security\Crypto;
 use OCP\Authentication\Exceptions\CredentialsUnavailableException;
 use OCP\ISession;
 use OCP\Security\ICrypto;
@@ -43,9 +42,9 @@ class StoreTest extends TestCase {
 		$this->session = $this->createMock(ISession::class);
 		$this->tokenProvider = $this->createMock(IProvider::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->crypto = $this->createMock(Crypto::class);
+		$this->crypto = $this->createMock(ICrypto::class);
 
-		$this->store = new Store($this->session, $this->logger, $this->tokenProvider, $this->crypto);
+		$this->store = new Store($this->session, $this->logger, $this->crypto, $this->tokenProvider);
 	}
 
 	public function testAuthenticate(): void {
@@ -60,7 +59,7 @@ class StoreTest extends TestCase {
 			->with($this->equalTo('login_credentials'), $this->equalTo(json_encode($params)));
 		$this->crypto->expects($this->once())
 			->method('encrypt')
-			->willReturn($params['password']);
+			->willReturn('123456');
 
 		$this->store->authenticate($params);
 	}
@@ -73,7 +72,7 @@ class StoreTest extends TestCase {
 	}
 
 	public function testGetLoginCredentialsNoTokenProvider(): void {
-		$this->store = new Store($this->session, $this->logger, null, $this->crypto);
+		$this->store = new Store($this->session, $this->logger, $this->crypto, null);
 
 		$this->expectException(CredentialsUnavailableException::class);
 


### PR DESCRIPTION
fix: encrypt and store password, decrypt and retrieve the same
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
