### PR TITLE
Clear pending two factor tokens also from configuration

### DIFF
--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -366,6 +366,8 @@ class Manager {
 		$tokensNeeding2FA = $this->config->getUserKeys($userId, 'login_token_2fa');
 
 		foreach ($tokensNeeding2FA as $tokenId) {
+			$this->config->deleteUserValue($userId, 'login_token_2fa', $tokenId);
+
 			$this->tokenProvider->invalidateTokenById($userId, (int)$tokenId);
 		}
 	}

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -12,6 +12,7 @@ use BadMethodCallException;
 use Exception;
 use OC\Authentication\Token\IProvider as TokenProvider;
 use OCP\Activity\IManager;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\TwoFactorAuth\IActivatableAtLogin;
@@ -368,7 +369,10 @@ class Manager {
 		foreach ($tokensNeeding2FA as $tokenId) {
 			$this->config->deleteUserValue($userId, 'login_token_2fa', $tokenId);
 
-			$this->tokenProvider->invalidateTokenById($userId, (int)$tokenId);
+			try {
+				$this->tokenProvider->invalidateTokenById($userId, (int)$tokenId);
+			} catch (DoesNotExistException $e) {
+			}
 		}
 	}
 }

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -701,4 +701,30 @@ class ManagerTest extends TestCase {
 
 		$this->assertFalse($this->manager->needsSecondFactor($user));
 	}
+
+	public function testClearTwoFactorPending() {
+		$this->config->method('getUserKeys')
+			->with('theUserId', 'login_token_2fa')
+			->willReturn([
+				'42', '43', '44'
+			]);
+
+		$this->config->expects($this->exactly(3))
+			->method('deleteUserValue')
+			->withConsecutive(
+				['theUserId', 'login_token_2fa', '42'],
+				['theUserId', 'login_token_2fa', '43'],
+				['theUserId', 'login_token_2fa', '44'],
+			);
+
+		$this->tokenProvider->expects($this->exactly(3))
+			->method('invalidateTokenById')
+			->withConsecutive(
+				['theUserId', 42],
+				['theUserId', 43],
+				['theUserId', 44],
+			);
+
+		$this->manager->clearTwoFactorPending('theUserId');
+	}
 }

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -15,6 +15,7 @@ use OC\Authentication\TwoFactorAuth\MandatoryTwoFactor;
 use OC\Authentication\TwoFactorAuth\ProviderLoader;
 use OCP\Activity\IEvent;
 use OCP\Activity\IManager;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\TwoFactorAuth\IActivatableAtLogin;
 use OCP\Authentication\TwoFactorAuth\IProvider;
@@ -724,6 +725,37 @@ class ManagerTest extends TestCase {
 				['theUserId', 43],
 				['theUserId', 44],
 			);
+
+		$this->manager->clearTwoFactorPending('theUserId');
+	}
+
+	public function testClearTwoFactorPendingTokenDoesNotExist() {
+		$this->config->method('getUserKeys')
+			->with('theUserId', 'login_token_2fa')
+			->willReturn([
+				'42', '43', '44'
+			]);
+
+		$this->config->expects($this->exactly(3))
+			->method('deleteUserValue')
+			->withConsecutive(
+				['theUserId', 'login_token_2fa', '42'],
+				['theUserId', 'login_token_2fa', '43'],
+				['theUserId', 'login_token_2fa', '44'],
+			);
+
+		$this->tokenProvider->expects($this->exactly(3))
+			->method('invalidateTokenById')
+			->withConsecutive(
+				['theUserId', 42],
+				['theUserId', 43],
+				['theUserId', 44],
+			)
+			->willReturnCallback(function ($user, $tokenId) {
+				if ($tokenId === 43) {
+					throw new DoesNotExistException('token does not exist');
+				}
+			});
 
 		$this->manager->clearTwoFactorPending('theUserId');
 	}


### PR DESCRIPTION
Clearing pending two factor tokens removed them from the database, but not from the configuration. Due to that, if the password was reset again, the pending tokens were got again from the configuration and tried to be cleared again from the database, which caused an exception to be thrown.

The fix is split in two commits. The first one removes the token from the configuration as well as from the database, and the second commits handles the exception thrown if a token was already removed from the database but not from the configuration, as it could be the case on an existing instance.

Note that [`invalidateTokenById` does not declare any exception to be thrown](https://github.com/nextcloud/server/blob/99182aac37c0757f8aab65b0a93a2ddb87348dbe/lib/private/Authentication/Token/IProvider.php#L82-L88), and [the `DoesNotExistException` comes from the `PublicKeyTokenMapper`](https://github.com/nextcloud/server/blob/c254855222ca2776ccaa9c362b84295391cdd208/lib/private/Authentication/Token/PublicKeyTokenMapper.php#L103). Therefore rather than catching the exception in `clearTwoFactorPending` it might be better to [catch it in `invalidateTokenById`](https://github.com/nextcloud/server/blob/a8f46af20f4fccac0257eba950e70d0da96c4a5a/lib/private/Authentication/Token/PublicKeyTokenProvider.php#L272) (or to transform it into another exception, as right now a database exception is being exposed to the upper layers). However I am not familiar at all with this code and any possible side effect of doing that, so I just went the safe route (specially given that this should be backported) and caught it in `clearTwoFactorPending`.

## How to test:
- Install and enable _twofactor_nextcloud_notification_ (any two factor authentication app would be probably enough, but this is a convenient one)
- Log errors when reseting the password adding the following to [`LostController::setException`](https://github.com/nextcloud/server/blob/af6de04e9e141466dc229e444ff3f146f4a34765/core/Controller/LostController.php#L225):
```
$this->logger->error('Password could not be reset', ['app' => 'core', 'exception' => $e]);
```
- In a private window, log in as a user
- Open the settings
- Set an e-mail address
- Open security section
- Enable two factor authentication with notifications
- Log out
- Log in again
- When the two factor authentication challenge appears, close the private window
- Open a private window again
- Open Nextcloud login page
- Request a lost password
- Open the link sent by e-mail
- Set the new password
- Instead of login, open Nextcloud login page again
- Request a lost password
- Open the link sent by e-mail
- Set the new password

### Result with this pull request:
The password is reset and the login page is shown again

### Result without this pull request:
_token does not exist_ is shown below the request password form. However, if the login page is open and the new password is used it works. In the logs it can be seen that the exception was thrown by `PublicKeyTokenMapper::getTokenById`, which was called by `TwoFactorAuth\Manager::clearTwoFactorPending`, so at that point the password was already changed.
