### PR TITLE
feat: Allow WebP content type in PhotoCache

### DIFF
--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -26,6 +26,7 @@ class PhotoCache {
 		'image/jpeg' => 'jpg',
 		'image/gif' => 'gif',
 		'image/vnd.microsoft.icon' => 'ico',
+		'image/webp' => 'webp',
 	];
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/contacts/issues/4190
* Closes https://github.com/nextcloud/server/pull/48842

## Summary

I recreated the PR in the repository to get green CI. I also tested it locally and it works fine.

> It seems like CardDAV's PhotoCache is currently only supporting PNG, JPEG, GIF and ICO images.
>
> Nextcloud intercepts GET requests on addressbook URLs ending with `?photo`, and [uses `ALLOWED_CONTENT_TYPES` to set the type name](https://github.com/nextcloud/server/blob/8e4ac51110715baf6c59c0eb9ecf349d3bcd8e6e/apps/dav/lib/CardDAV/ImageExportPlugin.php#L84-L94), returning 404 if the content type is not supported (not part of the allowed content types struct).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
