### PR TITLE
Fix a typo (`a` -> `an` in front of `additional`)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,7 +48,7 @@ In some areas unit testing is hard (aka almost impossible) as of today - in thes
 
 ### Sign your work
 
-We use the Developer Certificate of Origin (DCO) as a additional safeguard
+We use the Developer Certificate of Origin (DCO) as an additional safeguard
 for the Nextcloud project. This is a well established and widely used
 mechanism to assure contributors have confirmed their right to license
 their contribution under the project's license.


### PR DESCRIPTION
see title.