### PR TITLE
feat: add "null" SMTP transport mode

### DIFF
--- a/apps/settings/templates/settings/admin/additional-mail.php
+++ b/apps/settings/templates/settings/admin/additional-mail.php
@@ -34,6 +34,13 @@ $mail_sendmailmode = [
 ?>
 
 <div class="section" id="mail_general_settings">
+<?php if ($_['mail_smtpmode'] === 'null') { ?>
+	<h2><?php p($l->t('Email server'));?></h2>
+
+	<p>
+	 <?php p($l->t('Mail delivery is disabled by instance config "%s".', ['mail_smtpmode'])); ?>
+	</p>
+<?php } else { ?>
 	<form id="mail_general_settings_form" class="mail_settings">
 		<h2><?php p($l->t('Email server'));?></h2>
 		<a 	target="_blank"
@@ -143,4 +150,5 @@ $mail_sendmailmode = [
 	<em><?php p($l->t('Test and verify email settings')); ?></em>
 	<input type="submit" name="sendtestemail" id="sendtestemail" value="<?php p($l->t('Send email')); ?>"/>
 	<span id="sendtestmail_msg" class="msg"></span>
+<?php } ?>
 </div>

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -521,7 +521,7 @@ $CONFIG = [
 'mail_smtpdebug' => false,
 
 /**
- * Which mode to use for sending mail: ``sendmail``, ``smtp`` or ``qmail``.
+ * Which mode to use for sending mail: ``sendmail``, ``smtp``, ``qmail`` or ``null``.
  *
  * If you are using local or remote SMTP, set this to ``smtp``.
  *
@@ -530,6 +530,9 @@ $CONFIG = [
  *
  * For ``qmail`` the binary is /var/qmail/bin/sendmail, and it must be installed
  * on your Unix system.
+ *
+ * Use the string ``null`` to send no mails (disable mail delivery). This can be
+ * useful if mails should be sent via APIs and rendering messages is not necessary.
  *
  * Defaults to ``smtp``
  */

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -27,6 +27,7 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Mailer as SymfonyMailer;
 use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mailer\Transport\NullTransport;
 use Symfony\Component\Mailer\Transport\SendmailTransport;
 use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
 use Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream;
@@ -256,6 +257,9 @@ class Mailer implements IMailer {
 		}
 
 		switch ($this->config->getSystemValueString('mail_smtpmode', 'smtp')) {
+			case 'null':
+				$transport = new NullTransport();
+				break;
 			case 'sendmail':
 				$transport = $this->getSendMailInstance();
 				break;

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -255,8 +255,6 @@ class Mailer implements IMailer {
 			return $this->instance;
 		}
 
-		$transport = null;
-
 		switch ($this->config->getSystemValueString('mail_smtpmode', 'smtp')) {
 			case 'sendmail':
 				$transport = $this->getSendMailInstance();

--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -267,7 +267,9 @@ class Mailer implements IMailer {
 				break;
 		}
 
-		return new SymfonyMailer($transport);
+		$this->instance = new SymfonyMailer($transport);
+
+		return $this->instance;
 	}
 
 	/**

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -337,4 +337,10 @@ class MailerTest extends TestCase {
 		self::assertInstanceOf(EsmtpTransport::class, $transport);
 		self::assertEquals('[127.0.0.1]', $transport->getLocalDomain());
 	}
+
+	public function testCaching(): void {
+		$symfonyMailer1 = self::invokePrivate($this->mailer, 'getInstance');
+		$symfonyMailer2 = self::invokePrivate($this->mailer, 'getInstance');
+		self::assertSame($symfonyMailer1, $symfonyMailer2);
+	}
 }

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -114,6 +114,26 @@ class MailerTest extends TestCase {
 		$this->assertEquals($sendmail, self::invokePrivate($this->mailer, 'getSendMailInstance'));
 	}
 
+	public function testEventForNullTransport(): void {
+		$this->config
+			->expects($this->exactly(1))
+			->method('getSystemValueString')
+			->with('mail_smtpmode', 'smtp')
+			->willReturn('null');
+
+		$message = $this->createMock(Message::class);
+		$message->expects($this->once())
+			->method('getSymfonyEmail')
+			->willReturn((new Email())->to('foo@bar.com')->from('bar@foo.com')->text(''));
+
+		$event = new BeforeMessageSent($message);
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->with($this->equalTo($event));
+
+		$this->mailer->send($message);
+	}
+
 	public function testGetInstanceDefault(): void {
 		$this->config
 			->method('getSystemValue')


### PR DESCRIPTION
## Summary

If mails ought to be send by other means than rendering messages from
templates and sending them via SMTP-like protocols.


### Use-case example

Listening to specific Nextcloud events and pass parameters to a centralized (i.e. REST-based) API that sends e-mails.


### Background why not ...

* **customize mail templates:** mails should not be delivered by SMTP-like protocols and rendering messages that will never be send is unneeded overhead
* **implement template class and set `mail_template_class`:** same as before
* **listen for `BeforeMessageSent` and act upon that**: would be an option, but it would still render messages that will never be sent and the template data might also have to be enriched with custom information (i.e. in our case the sender's _user ID_, not their e-mail address)

_(Short list of internal reasoning we had before making this pull request.)_


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- ~Screenshots before/after for front-end changes~
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- ~[Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)~