### PR TITLE
fix(ShareApiController): Set hideDownload to inverse of allow download attribute

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -637,6 +637,10 @@ class ShareAPIController extends OCSController {
 
 		if ($attributes !== null) {
 			$share = $this->setShareAttributes($share, $attributes);
+			if ($shareAttributes = $share->getAttributes()) {
+				$downloadPermission = (bool) $shareAttributes->getAttribute('permissions', 'download');
+				$share->setHideDownload(!$downloadPermission);
+			}
 		}
 
 		// Expire date


### PR DESCRIPTION
If the download attribute is set to false, then we should set hideDownload to true (essentially hiding the download button from the UI) and vice versa

Resolves: https://github.com/nextcloud/server/issues/46920