### PR TITLE
fix: add PasswordConfirmationRequired to saveGlobalCredentials

### DIFF
--- a/apps/files_external/js/settings.js
+++ b/apps/files_external/js/settings.js
@@ -1488,30 +1488,37 @@ window.addEventListener('DOMContentLoaded', function() {
 		}
 	});
 
-	$('#global_credentials').on('submit', function() {
-		var $form = $(this);
+	function _submitCredentials(success) {
 		var uid = $form.find('[name=uid]').val();
 		var user = $form.find('[name=username]').val();
 		var password = $form.find('[name=password]').val();
-		var $submit = $form.find('[type=submit]');
-		$submit.val(t('files_external', 'Saving …'));
 		$.ajax({
 			type: 'POST',
 			contentType: 'application/json',
 			data: JSON.stringify({
-					uid: uid,
-					user: user,
-				password: password
+				uid,
+				user,
+				password,
 			}),
 				url: OC.generateUrl('apps/files_external/globalcredentials'),
 				dataType: 'json',
-			success: function() {
+				success,
+		});
+	}
+
+	$('#global_credentials').on('submit', function() {
+		var $form = $(this);
+		var $submit = $form.find('[type=submit]');
+		$submit.val(t('files_external', 'Saving …'));
+
+		window.OC.PasswordConfirmation
+			.requirePasswordConfirmation(() => _submitCredentials(function() {
 				$submit.val(t('files_external', 'Saved'));
 				setTimeout(function(){
 					$submit.val(t('files_external', 'Save'));
 				}, 2500);
-			}
-		});
+			}));
+
 		return false;
 	});
 

--- a/apps/files_external/lib/Controller/AjaxController.php
+++ b/apps/files_external/lib/Controller/AjaxController.php
@@ -10,6 +10,7 @@ use OCA\Files_External\Lib\Auth\Password\GlobalAuth;
 use OCA\Files_External\Lib\Auth\PublicKey\RSA;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\Attribute\PasswordConfirmationRequired;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IGroupManager;
 use OCP\IRequest;
@@ -71,6 +72,7 @@ class AjaxController extends Controller {
 	 * @return bool
 	 */
 	#[NoAdminRequired]
+	#[PasswordConfirmationRequired]
 	public function saveGlobalCredentials($uid, $user, $password) {
 		$currentUser = $this->userSession->getUser();
 		if ($currentUser === null) {


### PR DESCRIPTION
fix: add PasswordConfirmationRequired to saveGlobalCredentials

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
