### PR TITLE
Add the option to provide a groupname and only see its' members in occ group:list

### DIFF
--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -25,9 +25,9 @@ class ListCommand extends Base {
 			->setName('group:list')
 			->setDescription('list configured groups')
 			->addArgument(
-				'groupid',
+				'searchstring',
 				InputArgument::OPTIONAL,
-				'Group id to show only the members of that group',
+				'Filter the groups to only those matching the search string',
 				''
 			)
 			->addOption(
@@ -57,7 +57,7 @@ class ListCommand extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$groups = $this->groupManager->search((string)$input->getArgument('groupid'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
+		$groups = $this->groupManager->search((string)$input->getArgument('searchstring'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
 		$this->writeArrayInOutputFormat($input, $output, $this->formatGroups($groups, (bool)$input->getOption('info')));
 		return 0;
 	}

--- a/core/Command/Group/ListCommand.php
+++ b/core/Command/Group/ListCommand.php
@@ -8,6 +8,7 @@ namespace OC\Core\Command\Group;
 use OC\Core\Command\Base;
 use OCP\IGroup;
 use OCP\IGroupManager;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,6 +24,12 @@ class ListCommand extends Base {
 		$this
 			->setName('group:list')
 			->setDescription('list configured groups')
+			->addArgument(
+				'groupid',
+				InputArgument::OPTIONAL,
+				'Group id to show only the members of that group',
+				''
+			)
 			->addOption(
 				'limit',
 				'l',
@@ -50,7 +57,7 @@ class ListCommand extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$groups = $this->groupManager->search('', (int)$input->getOption('limit'), (int)$input->getOption('offset'));
+		$groups = $this->groupManager->search((string)$input->getArgument('groupid'), (int)$input->getOption('limit'), (int)$input->getOption('offset'));
 		$this->writeArrayInOutputFormat($input, $output, $this->formatGroups($groups, (bool)$input->getOption('info')));
 		return 0;
 	}


### PR DESCRIPTION
## Summary
As the title states this adds an optional groupname argument to `occ group:list` so you can see the members of just that group.

Now you can do `occ group:list groupname`

If the change is welcome I can work on the further needed steps to get it in.

## TODO
1. Fail/return error if group doesn't exist
2. Only print the members and not the groupname

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
~~- [ ] Screenshots before/after for front-end changes~~
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
