### PR TITLE
feat(workflows): auto-lock closed issues and PRs older than X days

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,4 +1,6 @@
-name: 'Lock Threads olders than 120 days'
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+name: 'Lock threads older than 120 days'
 
 on:
   schedule:

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
+
 name: 'Lock threads older than 120 days'
 
 on:
@@ -21,7 +22,13 @@ jobs:
       - uses: dessant/lock-threads@v5
         with:
           issue-inactive-days: '120'
-          issue-comment: 'This issue has been inactive for 120 days, we're locking it to keep discussions tidy and focused. If this issue is still relevant, we encourage you to update Nextcloud to the latest supported version first. If needed, feel free to create a new issue, and we'll be happy to help.'
           issue-lock-reason: 'resolved'
+          issue-comment: >
+            This issue has been inactive for 120 days, we're locking it to keep discussions tidy and focused.
+            If you believe this issue is still relevant, we encourage you to update Nextcloud to the latest supported version first.
+            If needed, feel free to create a new issue, and we'll be happy to help.
           pr-inactive-days: '120'
-          pr-comment: 'This PR has been inactive for 120 days, we're locking it to keep discussions tidy and focused. If this PR is causing any issues, feel free to create a new issue, and we'll be happy to help.'
+          pr-lock-reason: 'resolved'
+          pr-comment: >
+            This PR has been inactive for 120 days, we're locking it to keep discussions tidy and focused.
+            If this PR is causing any issues, feel free to create a new issue, and we'll be happy to help.

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,25 @@
+name: 'Lock Threads olders than 120 days'
+
+on:
+  schedule:
+    - cron: '17 3 * * 7'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock-threads
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          issue-inactive-days: '120'
+          issue-comment: 'This issue has been inactive for 120 days, we're locking it to keep discussions tidy and focused. If this issue is still relevant, we encourage you to update Nextcloud to the latest supported version first. If needed, feel free to create a new issue, and we'll be happy to help.'
+          issue-lock-reason: 'resolved'
+          pr-inactive-days: '120'
+          pr-comment: 'This PR has been inactive for 120 days, we're locking it to keep discussions tidy and focused. If this PR is causing any issues, feel free to create a new issue, and we'll be happy to help.'


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Lock Threads is a GitHub Action that locks **closed** threads (issues, PRs) after a certain (configurable) period of inactivity.

The proposed workflow will search once a week (on sunday) for **closed** issues and pull requests that have not had any activity in the past 120 days, and lock them to Nextcloud collaborators only (whose can unlock/reopen/comment on them if needed).

This should prevent regular users to comment on old (out-of-date) threads and invite them to open a new issue instead, with up-to-date material.

More info at https://github.com/dessant/lock-threads

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
