### PR TITLE
Fix parsing of IPv6 addresses with zoneid (e.g %host0)

### DIFF
--- a/lib/private/Net/IpAddressClassifier.php
+++ b/lib/private/Net/IpAddressClassifier.php
@@ -34,7 +34,7 @@ class IpAddressClassifier {
 	public function isLocalAddress(string $ip): bool {
 		$parsedIp = Factory::parseAddressString(
 			$ip,
-			ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED
+			ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED | ParseStringFlag::MAY_INCLUDE_ZONEID
 		);
 		if ($parsedIp === null) {
 			/* Not an IP */

--- a/lib/private/Security/Ip/Address.php
+++ b/lib/private/Security/Ip/Address.php
@@ -11,6 +11,7 @@ namespace OC\Security\Ip;
 use InvalidArgumentException;
 use IPLib\Address\AddressInterface;
 use IPLib\Factory;
+use IPLib\ParseStringFlag;
 use OCP\Security\Ip\IAddress;
 use OCP\Security\Ip\IRange;
 
@@ -21,7 +22,7 @@ class Address implements IAddress {
 	private readonly AddressInterface $ip;
 
 	public function __construct(string $ip) {
-		$ip = Factory::parseAddressString($ip);
+		$ip = Factory::parseAddressString($ip, ParseStringFlag::MAY_INCLUDE_ZONEID);
 		if ($ip === null) {
 			throw new InvalidArgumentException('Given IP address can’t be parsed');
 		}
@@ -29,7 +30,7 @@ class Address implements IAddress {
 	}
 
 	public static function isValid(string $ip): bool {
-		return Factory::parseAddressString($ip) !== null;
+		return Factory::parseAddressString($ip, ParseStringFlag::MAY_INCLUDE_ZONEID) !== null;
 	}
 
 	public function matches(IRange ... $ranges): bool {

--- a/lib/private/Security/Ip/Range.php
+++ b/lib/private/Security/Ip/Range.php
@@ -10,6 +10,7 @@ namespace OC\Security\Ip;
 
 use InvalidArgumentException;
 use IPLib\Factory;
+use IPLib\ParseStringFlag;
 use IPLib\Range\RangeInterface;
 use OCP\Security\Ip\IAddress;
 use OCP\Security\Ip\IRange;
@@ -30,7 +31,7 @@ class Range implements IRange {
 	}
 
 	public function contains(IAddress $address): bool {
-		return $this->range->contains(Factory::parseAddressString((string)$address));
+		return $this->range->contains(Factory::parseAddressString((string)$address, ParseStringFlag::MAY_INCLUDE_ZONEID));
 	}
 
 	public function __toString(): string {


### PR DESCRIPTION
Related Issue: https://help.nextcloud.com/t/invalidargumentexception-given-ip-address-cant-be-parsed-with-link-local-address-after-update-to-30-0-1-2/207968/2

Feel free to use this commit, or re-engineer it with a better solution.
Just created as a quick fix for my installation.