### PR TITLE
fix(net/security): Handle IPv6 zone IDs in link-local addresses

### DIFF
--- a/lib/private/Net/IpAddressClassifier.php
+++ b/lib/private/Net/IpAddressClassifier.php
@@ -34,7 +34,7 @@ class IpAddressClassifier {
 	public function isLocalAddress(string $ip): bool {
 		$parsedIp = Factory::parseAddressString(
 			$ip,
-			ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED
+			ParseStringFlag::IPV4_MAYBE_NON_DECIMAL | ParseStringFlag::IPV4ADDRESS_MAYBE_NON_QUAD_DOTTED | ParseStringFlag::MAY_INCLUDE_ZONEID
 		);
 		if ($parsedIp === null) {
 			/* Not an IP */

--- a/lib/private/Security/Ip/Address.php
+++ b/lib/private/Security/Ip/Address.php
@@ -11,6 +11,7 @@ namespace OC\Security\Ip;
 use InvalidArgumentException;
 use IPLib\Address\AddressInterface;
 use IPLib\Factory;
+use IPLib\ParseStringFlag;
 use OCP\Security\Ip\IAddress;
 use OCP\Security\Ip\IRange;
 
@@ -21,7 +22,7 @@ class Address implements IAddress {
 	private readonly AddressInterface $ip;
 
 	public function __construct(string $ip) {
-		$ip = Factory::parseAddressString($ip);
+		$ip = Factory::parseAddressString($ip, ParseStringFlag::MAY_INCLUDE_ZONEID);
 		if ($ip === null) {
 			throw new InvalidArgumentException('Given IP address can’t be parsed');
 		}
@@ -29,7 +30,7 @@ class Address implements IAddress {
 	}
 
 	public static function isValid(string $ip): bool {
-		return Factory::parseAddressString($ip) !== null;
+		return Factory::parseAddressString($ip, ParseStringFlag::MAY_INCLUDE_ZONEID) !== null;
 	}
 
 	public function matches(IRange ... $ranges): bool {

--- a/lib/private/Security/Ip/Range.php
+++ b/lib/private/Security/Ip/Range.php
@@ -10,6 +10,7 @@ namespace OC\Security\Ip;
 
 use InvalidArgumentException;
 use IPLib\Factory;
+use IPLib\ParseStringFlag;
 use IPLib\Range\RangeInterface;
 use OCP\Security\Ip\IAddress;
 use OCP\Security\Ip\IRange;
@@ -30,7 +31,7 @@ class Range implements IRange {
 	}
 
 	public function contains(IAddress $address): bool {
-		return $this->range->contains(Factory::parseAddressString((string)$address));
+		return $this->range->contains(Factory::parseAddressString((string)$address, ParseStringFlag::MAY_INCLUDE_ZONEID));
 	}
 
 	public function __toString(): string {

--- a/tests/lib/Net/IpAddressClassifierTest.php
+++ b/tests/lib/Net/IpAddressClassifierTest.php
@@ -43,6 +43,7 @@ class IpAddressClassifierTest extends TestCase {
 		return [
 			['192.168.0.1'],
 			['fe80::200:5aee:feaa:20a2'],
+			['fe80::1fc4:15d8:78db:2319%enp4s0'], // v6 zone ID
 			['0:0:0:0:0:ffff:10.0.0.1'],
 			['0:0:0:0:0:ffff:127.0.0.0'],
 			['10.0.0.1'],

--- a/tests/lib/Security/Ip/RemoteAddressTest.php
+++ b/tests/lib/Security/Ip/RemoteAddressTest.php
@@ -52,6 +52,8 @@ class RemoteAddressTest extends \Test\TestCase {
 			// No configuration
 			['1.2.3.4', false, true],
 			['1234:4567:8910::', false, true],
+			// v6 Zone ID
+			['fe80::1fc4:15d8:78db:2319%enp4s0', false, true],
 			// Empty configuration
 			['1.2.3.4', [], true],
 			['1234:4567:8910::', [], true],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Problem reported here: https://help.nextcloud.com/t/invalidargumentexception-given-ip-address-cant-be-parsed-with-link-local-address-after-update-to-30-0-1-2/207968

## Summary

Link-Local Addresses in IPv6 may contain Zone indexes/IDs (e.g. `fe80::1fc4:15d8:78db:2319%enp4s0`). Parsing was failing and throwing. This PR fixes that by enabling the handling in our existing IP handling library.

Docs for the library we use: https://github.com/mlocati/ip-lib?tab=readme-ov-file#accepting-ipv6-zone-ids

Wikipedia for the curious: https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses_(with_zone_index)

## TODO

- [x] Add tests ideally

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
