### PR TITLE
getting default timezone for local time

### DIFF
--- a/lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php
+++ b/lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php
@@ -35,7 +35,7 @@ class LocalTimeProvider implements IProvider {
 		$targetUserId = $entry->getProperty('UID');
 		$targetUser = $this->userManager->get($targetUserId);
 		if (!empty($targetUser)) {
-			$timezone = $this->config->getUserValue($targetUser->getUID(), 'core', 'timezone') ?: date_default_timezone_get();
+			$timezone = $this->config->getUserValue($targetUser->getUID(), 'core', 'timezone') ?: $this->config->getSystemValueString('default_timezone', 'UTC');
 			$dateTimeZone = new \DateTimeZone($timezone);
 			$localTime = $this->dateTimeFormatter->formatTime($this->timeFactory->getDateTime(), 'short', $dateTimeZone);
 


### PR DESCRIPTION
## Summary

In the server/lib/base.php file of the Nextcloud server, UTC is always set as the default timezone:

https://github.com/nextcloud/server/blob/4a44d6a6774d79a8c91cab5f94acafa271b6d4d6/lib/base.php#L609

The main argument for this choice seems to be to simplify log reading, as discussed in this issue: https://github.com/nextcloud/server/issues/3553.

However, this hardcoding of UTC affects all instances where date_default_timezone_get is used, resulting in UTC even when it would be more intuitive to use the server's timezone or the one set in config.php under default_timezone.

This pull request resolves an issue in the contact menu where the timezone was unexpectedly set to UTC. The fix aligns with other parts of the system that correctly retrieve the default timezone by leveraging similar logic:

https://github.com/search?q=org%3Anextcloud+%22%3EgetDefaultTimeZone%28%22&type=code

![image](https://github.com/user-attachments/assets/3f024f26-29f0-481c-b14d-347e3efc4a91)


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
