### PR TITLE
fix(db): Stop writing unused `dbport` to config at install time

### DIFF
--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -77,7 +77,6 @@ abstract class AbstractDatabase {
 		$this->config->setValues([
 			'dbname' => $dbName,
 			'dbhost' => $dbHost,
-			'dbport' => $dbPort,
 			'dbtableprefix' => $dbTablePrefix,
 		]);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

We already have handling for specifying a port at install time or later on (which work just fine). Yet we write out a bogus parameter `dbport` to the initial config.

This value is neither supported nor used (even at install time). Yet we save this bogus parameter in the initial config. Since it's in the config, people end up assuming it does something and wondering why it doesn't work.

It either ends up  being:

```
        "dbport": "",
```

Or, if a specific port was explicitly specified via `maintenance:install --database-port` than that port ends up there. It gets populated with the correct value, but it's still not actually used so :shrug: 

```
        "dbport": "3306",
```

Let's not write it to the config at install time since it's a no-op and avoid all this confusion.

Additional historical context:

- #15560
- d367318
- #19303

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
