### PR TITLE
fix(theming): Return default theme if the user never selected a theme

### DIFF
--- a/apps/theming/lib/Service/ThemesService.php
+++ b/apps/theming/lib/Service/ThemesService.php
@@ -127,7 +127,7 @@ class ThemesService {
 			$this->setEnabledThemes($enabledThemes);
 			return $enabledThemes;
 		}
-		
+
 		return $themesIds;
 	}
 
@@ -160,7 +160,7 @@ class ThemesService {
 		}
 
 		$enforcedTheme = $this->config->getSystemValueString('enforce_theme', '');
-		$enabledThemes = json_decode($this->config->getUserValue($user->getUID(), Application::APP_ID, 'enabled-themes', '[]'));
+		$enabledThemes = json_decode($this->config->getUserValue($user->getUID(), Application::APP_ID, 'enabled-themes', '["default"]'));
 		if ($enforcedTheme !== '') {
 			return array_merge([$enforcedTheme], $enabledThemes);
 		}

--- a/apps/theming/tests/Service/ThemesServiceTest.php
+++ b/apps/theming/tests/Service/ThemesServiceTest.php
@@ -121,8 +121,8 @@ class ThemesServiceTest extends TestCase {
 
 	public function dataTestEnableTheme() {
 		return [
-			['default', [], ['default']],
-			['dark', [], ['dark']],
+			['default', ['default'], ['default']],
+			['dark', ['default'], ['dark']],
 			['dark', ['dark'], ['dark']],
 			['opendyslexic', ['dark'], ['dark', 'opendyslexic']],
 			['dark', ['light-highcontrast', 'opendyslexic'], ['opendyslexic', 'dark']],
@@ -147,7 +147,7 @@ class ThemesServiceTest extends TestCase {
 
 		$this->config->expects($this->once())
 			->method('getUserValue')
-			->with('user', Application::APP_ID, 'enabled-themes', '[]')
+			->with('user', Application::APP_ID, 'enabled-themes', '["default"]')
 			->willReturn(json_encode($enabledThemes));
 
 		$this->assertEquals($expectedEnabled, $this->themesService->enableTheme($this->themes[$toEnable]));
@@ -156,7 +156,7 @@ class ThemesServiceTest extends TestCase {
 
 	public function dataTestDisableTheme() {
 		return [
-			['dark', [], []],
+			['dark', ['default'], ['default']],
 			['dark', ['dark'], []],
 			['opendyslexic', ['dark', 'opendyslexic'], ['dark'], ],
 			['light-highcontrast', ['opendyslexic'], ['opendyslexic']],
@@ -181,7 +181,7 @@ class ThemesServiceTest extends TestCase {
 
 		$this->config->expects($this->once())
 			->method('getUserValue')
-			->with('user', Application::APP_ID, 'enabled-themes', '[]')
+			->with('user', Application::APP_ID, 'enabled-themes', '["default"]')
 			->willReturn(json_encode($enabledThemes));
 
 
@@ -215,7 +215,7 @@ class ThemesServiceTest extends TestCase {
 
 		$this->config->expects($this->once())
 			->method('getUserValue')
-			->with('user', Application::APP_ID, 'enabled-themes', '[]')
+			->with('user', Application::APP_ID, 'enabled-themes', '["default"]')
 			->willReturn(json_encode($enabledThemes));
 
 
@@ -234,14 +234,14 @@ class ThemesServiceTest extends TestCase {
 
 		$this->config->expects($this->once())
 			->method('getUserValue')
-			->with('user', Application::APP_ID, 'enabled-themes', '[]')
-			->willReturn(json_encode([]));
+			->with('user', Application::APP_ID, 'enabled-themes', '["default"]')
+			->willReturn(json_encode(['default']));
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
 			->with('enforce_theme', '')
 			->willReturn('');
 
-		$this->assertEquals([], $this->themesService->getEnabledThemes());
+		$this->assertEquals(['default'], $this->themesService->getEnabledThemes());
 	}
 
 	public function testGetEnabledThemesEnforced(): void {
@@ -256,7 +256,7 @@ class ThemesServiceTest extends TestCase {
 
 		$this->config->expects($this->once())
 			->method('getUserValue')
-			->with('user', Application::APP_ID, 'enabled-themes', '[]')
+			->with('user', Application::APP_ID, 'enabled-themes', '["default"]')
 			->willReturn(json_encode([]));
 		$this->config->expects($this->once())
 			->method('getSystemValueString')


### PR DESCRIPTION
## Summary

While working on https://github.com/nextcloud/ocs_api_viewer/pull/36 I found that if the user never selected a theme the `data-themes` attribute would only be an empty string instead of containing the `default` theme.
I'm not sure if the fallback also needs to be changed in other places, but this at least fixes the attribute problem.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
