### PR TITLE
fix(QBMapper): Fix findEntities() return type to be list<T>

### DIFF
--- a/lib/private/TaskProcessing/Db/TaskMapper.php
+++ b/lib/private/TaskProcessing/Db/TaskMapper.php
@@ -114,7 +114,7 @@ class TaskMapper extends QBMapper {
 		if ($customId !== null) {
 			$qb->andWhere($qb->expr()->eq('custom_id', $qb->createPositionalParameter($customId)));
 		}
-		return array_values($this->findEntities($qb));
+		return $this->findEntities($qb);
 	}
 
 	/**
@@ -133,7 +133,7 @@ class TaskMapper extends QBMapper {
 		if ($customId !== null) {
 			$qb->andWhere($qb->expr()->eq('custom_id', $qb->createPositionalParameter($customId)));
 		}
-		return array_values($this->findEntities($qb));
+		return $this->findEntities($qb);
 	}
 
 	/**
@@ -178,7 +178,7 @@ class TaskMapper extends QBMapper {
 			$qb->andWhere($qb->expr()->isNotNull('ended_at'));
 			$qb->andWhere($qb->expr()->lt('ended_at', $qb->createPositionalParameter($endedBefore, IQueryBuilder::PARAM_INT)));
 		}
-		return array_values($this->findEntities($qb));
+		return $this->findEntities($qb);
 	}
 
 	/**

--- a/lib/public/AppFramework/Db/QBMapper.php
+++ b/lib/public/AppFramework/Db/QBMapper.php
@@ -320,8 +320,8 @@ abstract class QBMapper {
 	 * Runs a sql query and returns an array of entities
 	 *
 	 * @param IQueryBuilder $query
-	 * @return Entity[] all fetched entities
-	 * @psalm-return T[] all fetched entities
+	 * @return list<Entity> all fetched entities
+	 * @psalm-return list<T> all fetched entities
 	 * @throws Exception
 	 * @since 14.0.0
 	 */


### PR DESCRIPTION
## Summary

Found in https://github.com/nextcloud/spreed/pull/13711.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
