### PR TITLE
feat(files_sharing): use share node or label as page title

### DIFF
--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -130,12 +130,16 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 			'index',
 		);
 		$response->setContentSecurityPolicy($csp);
+
 		// If the share has a label, use it as the title
 		if ($share->getLabel() !== '') {
 			$response->setHeaderTitle($share->getLabel());
+			$response->setParams(['pageTitle' => $share->getLabel()]);
 		} else {
 			$response->setHeaderTitle($shareNode->getName());
+			$response->setParams(['pageTitle' => $shareNode->getName()]);
 		}
+
 		if ($ownerName !== '') {
 			$response->setHeaderDetails($this->l10n->t('shared by %s', [$ownerName]));
 		}

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -338,6 +338,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$expectedResponse = new PublicTemplateResponse('files', 'index');
+		$expectedResponse->setParams(['pageTitle' => $filename]);
 		$expectedResponse->setContentSecurityPolicy($csp);
 		$expectedResponse->setHeaderTitle($filename);
 		$expectedResponse->setHeaderDetails('shared by ownerDisplay');
@@ -477,6 +478,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$expectedResponse = new PublicTemplateResponse('files', 'index');
+		$expectedResponse->setParams(['pageTitle' => $filename]);
 		$expectedResponse->setContentSecurityPolicy($csp);
 		$expectedResponse->setHeaderTitle($filename);
 		$expectedResponse->setHeaderDetails('shared by ownerDisplay');
@@ -604,6 +606,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$csp = new ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');
 		$expectedResponse = new PublicTemplateResponse('files', 'index');
+		$expectedResponse->setParams(['pageTitle' => $filename]);
 		$expectedResponse->setContentSecurityPolicy($csp);
 		$expectedResponse->setHeaderTitle($filename);
 		$expectedResponse->setHeaderDetails('');

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -9,8 +9,9 @@
 <head data-requesttoken="<?php p($_['requesttoken']); ?>">
 	<meta charset="utf-8">
 	<title>
-		<?php
-			p(!empty($_['application']) ? $_['application'] . ' - ' : '');
+	<?php
+				p(!empty($_['pageTitle']) && $_['pageTitle'] !== $_['application'] ? $_['pageTitle'] . ' - ' : '');
+p(!empty($_['application']) ? $_['application'] . ' - ' : '');
 p($theme->getTitle());
 ?>
 	</title>


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/11506

![image](https://github.com/user-attachments/assets/c9d5d345-9595-4ac5-a886-21cb8dda7ab4)
