### PR TITLE
PHP 8.4 external storages support

### DIFF
--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1']
+        php-versions: ['8.1', '8.4']
         include:
           - php-versions: '8.1'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.4']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.4']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.4']
         include:
           - php-versions: '8.3'
             coverage: true

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -55,10 +55,6 @@ class FileSearchBackendTest extends TestCase {
 	private $davFolder;
 
 	protected function setUp(): void {
-		if (PHP_VERSION_ID >= 80400) {
-			$this->markTestSkipped('SearchDAV is not yet PHP 8.4 compatible');
-		}
-
 		parent::setUp();
 
 		$this->user = $this->createMock(IUser::class);


### PR DESCRIPTION
- [x] Based on #49145 reverting the last commit

## Follow ups for external storages
- [x] https://github.com/icewind1991/SMB/pull/131
    - [x] Merge and release
    - [x] Bump in apps/files_external/3rdparty/ https://github.com/nextcloud/server/pull/50284
- [x] https://github.com/icewind1991/SearchDAV/pull/14
    - [x] Merge and release
    - [x] Bump in 3rdparty/ https://github.com/nextcloud/3rdparty/pull/1980
- [x] https://github.com/php-opencloud/openstack/pull/415
    - [x] Wait for upstream release or patch in the meantime following the pattern of https://github.com/nextcloud/3rdparty/commit/b3cc57b68388b68e4d4dcf0ddcd8c7ba455dd840
    - [x] Bump in 3rdparty/ ( https://github.com/nextcloud/3rdparty/pull/2024 )
- [ ] https://github.com/Azure/azure-storage-blob-php is deprecated
    - [x] Fork into https://github.com/nextcloud-deps/azure-storage-blob-php & https://github.com/nextcloud-deps/azure-storage-php
    - [ ] Patch and release
    - [ ] Bump in 3rdparty/
