### PR TITLE
fix: skip inaccessible shares in ownership transfer

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -340,10 +340,23 @@ class OwnershipTransferService {
 		$progress->finish();
 		$output->writeln('');
 
-		return array_map(fn (IShare $share) => [
-			'share' => $share,
-			'suffix' => substr(Filesystem::normalizePath($view->getPath($share->getNodeId())), strlen($normalizedPath)),
-		], $shares);
+		$accessibleShares = [];
+
+		foreach ($shares as $share) {
+			try {
+				$normalizedSharePath = Filesystem::normalizePath($view->getPath($share->getNodeId()));
+			} catch (NotFoundException $e) {
+				$output->writeln(sprintf('Unable to transfer share "%s" with error "%s"', $share->getId(), $e->getMessage()));
+				continue;
+			}
+
+			$accessibleShares[] = [
+				'share' => $share,
+				'suffix' => substr($normalizedSharePath, strlen($normalizedPath)),
+			];
+		}
+
+		return $accessibleShares;
 	}
 
 	private function collectIncomingShares(string $sourceUid,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

My experience with transfer ownership is limited, so I’m open to feedback on whether this approach makes sense or if there’s a better way to handle this issue.

How to reproduce: 

- Share a file from alice to bob
- Delete the record in oc_filecache for the file
- Trigger the transfer ownership from alice to admin
- See the stack trace below

Why should we not merge this patch:

Deleting the row in oc_filecache was my workaround to trigger the exception, however that's not the case for the customer case. The row and file do exist. 

```
occ files:transfer-ownership bob admin -vvv

Validating quota
Analysing files of bob ...
    0 [->--------------------------] < 1 sec 50.5 MiB
Collecting all share information for files and folders of bob ...
    1 [============================] < 1 sec 50.5 MiB

In View.php line 1777:

  [OCP\Files\NotFoundException]
  File with id "222702" has not been found.

Exception trace:
  at lib/private/Files/View.php:1777
 OC\Files\View->getPath() at apps/files/lib/Service/OwnershipTransferService.php:345
 OCA\Files\Service\OwnershipTransferService->{closure:OCA\Files\Service\OwnershipTransferService::collectUsersShares():343}() at n/a:n/a
 array_map() at apps/files/lib/Service/OwnershipTransferService.php:343
 OCA\Files\Service\OwnershipTransferService->collectUsersShares() at apps/files/lib/Service/OwnershipTransferService.php:137
 OCA\Files\Service\OwnershipTransferService->transfer() at apps/files/lib/Command/TransferOwnership.php:112
 OCA\Files\Command\TransferOwnership->execute() at 3rdparty/symfony/console/Command/Command.php:326
 Symfony\Component\Console\Command\Command->run() at 3rdparty/symfony/console/Application.php:1078
 Symfony\Component\Console\Application->doRunCommand() at 3rdparty/symfony/console/Application.php:324
 Symfony\Component\Console\Application->doRun() at 3rdparty/symfony/console/Application.php:175
 Symfony\Component\Console\Application->run() at lib/private/Console/Application.php:187
 OC\Console\Application->run() at console.php:87
 require_once() at occ:11
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
