### PR TITLE
feat(testing): Add a fake summary task provider

### DIFF
--- a/apps/testing/composer/composer/autoload_classmap.php
+++ b/apps/testing/composer/composer/autoload_classmap.php
@@ -25,6 +25,7 @@ return array(
     'OCA\\Testing\\TaskProcessing\\FakeContextWriteProvider' => $baseDir . '/../lib/TaskProcessing/FakeContextWriteProvider.php',
     'OCA\\Testing\\TaskProcessing\\FakeTextToImageProvider' => $baseDir . '/../lib/TaskProcessing/FakeTextToImageProvider.php',
     'OCA\\Testing\\TaskProcessing\\FakeTextToTextProvider' => $baseDir . '/../lib/TaskProcessing/FakeTextToTextProvider.php',
+    'OCA\\Testing\\TaskProcessing\\FakeTextToTextSummaryProvider' => $baseDir . '/../lib/TaskProcessing/FakeTextToTextSummaryProvider.php',
     'OCA\\Testing\\TaskProcessing\\FakeTranscribeProvider' => $baseDir . '/../lib/TaskProcessing/FakeTranscribeProvider.php',
     'OCA\\Testing\\TaskProcessing\\FakeTranslateProvider' => $baseDir . '/../lib/TaskProcessing/FakeTranslateProvider.php',
 );

--- a/apps/testing/composer/composer/autoload_static.php
+++ b/apps/testing/composer/composer/autoload_static.php
@@ -40,6 +40,7 @@ class ComposerStaticInitTesting
         'OCA\\Testing\\TaskProcessing\\FakeContextWriteProvider' => __DIR__ . '/..' . '/../lib/TaskProcessing/FakeContextWriteProvider.php',
         'OCA\\Testing\\TaskProcessing\\FakeTextToImageProvider' => __DIR__ . '/..' . '/../lib/TaskProcessing/FakeTextToImageProvider.php',
         'OCA\\Testing\\TaskProcessing\\FakeTextToTextProvider' => __DIR__ . '/..' . '/../lib/TaskProcessing/FakeTextToTextProvider.php',
+        'OCA\\Testing\\TaskProcessing\\FakeTextToTextSummaryProvider' => __DIR__ . '/..' . '/../lib/TaskProcessing/FakeTextToTextSummaryProvider.php',
         'OCA\\Testing\\TaskProcessing\\FakeTranscribeProvider' => __DIR__ . '/..' . '/../lib/TaskProcessing/FakeTranscribeProvider.php',
         'OCA\\Testing\\TaskProcessing\\FakeTranslateProvider' => __DIR__ . '/..' . '/../lib/TaskProcessing/FakeTranslateProvider.php',
     );

--- a/apps/testing/lib/AppInfo/Application.php
+++ b/apps/testing/lib/AppInfo/Application.php
@@ -18,6 +18,7 @@ use OCA\Testing\Settings\DeclarativeSettingsForm;
 use OCA\Testing\TaskProcessing\FakeContextWriteProvider;
 use OCA\Testing\TaskProcessing\FakeTextToImageProvider;
 use OCA\Testing\TaskProcessing\FakeTextToTextProvider;
+use OCA\Testing\TaskProcessing\FakeTextToTextSummaryProvider;
 use OCA\Testing\TaskProcessing\FakeTranscribeProvider;
 use OCA\Testing\TaskProcessing\FakeTranslateProvider;
 use OCP\AppFramework\App;
@@ -42,6 +43,7 @@ class Application extends App implements IBootstrap {
 		$context->registerTextToImageProvider(FakeText2ImageProvider::class);
 
 		$context->registerTaskProcessingProvider(FakeTextToTextProvider::class);
+		$context->registerTaskProcessingProvider(FakeTextToTextSummaryProvider::class);
 		$context->registerTaskProcessingProvider(FakeTextToImageProvider::class);
 		$context->registerTaskProcessingProvider(FakeTranslateProvider::class);
 		$context->registerTaskProcessingProvider(FakeTranscribeProvider::class);

--- a/apps/testing/lib/TaskProcessing/FakeTextToTextSummaryProvider.php
+++ b/apps/testing/lib/TaskProcessing/FakeTextToTextSummaryProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+
+namespace OCA\Testing\TaskProcessing;
+
+use OCA\Testing\AppInfo\Application;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\ISynchronousProvider;
+use OCP\TaskProcessing\ShapeDescriptor;
+use OCP\TaskProcessing\ShapeEnumValue;
+use OCP\TaskProcessing\TaskTypes\TextToTextSummary;
+use RuntimeException;
+
+class FakeTextToTextSummaryProvider implements ISynchronousProvider {
+
+	public function __construct() {
+	}
+
+	public function getId(): string {
+		return Application::APP_ID . '-text2text-summary';
+	}
+
+	public function getName(): string {
+		return 'Fake text2text summary task processing provider';
+	}
+
+	public function getTaskTypeId(): string {
+		return TextToTextSummary::ID;
+	}
+
+	public function getExpectedRuntime(): int {
+		return 1;
+	}
+
+	public function getInputShapeEnumValues(): array {
+		return [];
+	}
+
+	public function getInputShapeDefaults(): array {
+		return [];
+	}
+
+	public function getOptionalInputShape(): array {
+		return [
+			'max_tokens' => new ShapeDescriptor(
+				'Maximum output words',
+				'The maximum number of words/tokens that can be generated in the completion.',
+				EShapeType::Number
+			),
+			'model' => new ShapeDescriptor(
+				'Model',
+				'The model used to generate the completion',
+				EShapeType::Enum
+			),
+		];
+	}
+
+	public function getOptionalInputShapeEnumValues(): array {
+		return [
+			'model' => [
+				new ShapeEnumValue('Model 1', 'model_1'),
+				new ShapeEnumValue('Model 2', 'model_2'),
+				new ShapeEnumValue('Model 3', 'model_3'),
+			],
+		];
+	}
+
+	public function getOptionalInputShapeDefaults(): array {
+		return [
+			'max_tokens' => 1234,
+			'model' => 'model_2',
+		];
+	}
+
+	public function getOptionalOutputShape(): array {
+		return [];
+	}
+
+	public function getOutputShapeEnumValues(): array {
+		return [];
+	}
+
+	public function getOptionalOutputShapeEnumValues(): array {
+		return [];
+	}
+
+	public function process(?string $userId, array $input, callable $reportProgress): array {
+		if (isset($input['model']) && is_string($input['model'])) {
+			$model = $input['model'];
+		} else {
+			$model = 'unknown model';
+		}
+
+		if (!isset($input['input']) || !is_string($input['input'])) {
+			throw new RuntimeException('Invalid prompt');
+		}
+		$prompt = $input['input'];
+
+		$maxTokens = null;
+		if (isset($input['max_tokens']) && is_int($input['max_tokens'])) {
+			$maxTokens = $input['max_tokens'];
+		}
+
+		return [
+			'output' => 'This is a fake summary: ',// . "\n\n- Prompt: " . $prompt . "\n- Model: " . $model . "\n- Maximum number of words: " . $maxTokens,
+		];
+	}
+}


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
