### PR TITLE
fix(ros): Copy better typing information from Notifications/Spreed app

### DIFF
--- a/lib/private/RichObjectStrings/Validator.php
+++ b/lib/private/RichObjectStrings/Validator.php
@@ -14,6 +14,7 @@ use OCP\RichObjectStrings\IValidator;
 /**
  * Class Validator
  *
+ * @psalm-import-type RichObjectParameter from IValidator
  * @package OCP\RichObjectStrings
  * @since 11.0.0
  */
@@ -27,7 +28,7 @@ class Validator implements IValidator {
 
 	/**
 	 * @param string $subject
-	 * @param array<non-empty-string, array<non-empty-string, string>> $parameters
+	 * @param array<non-empty-string, RichObjectParameter> $parameters
 	 * @throws InvalidObjectExeption
 	 * @since 11.0.0
 	 */

--- a/lib/public/RichObjectStrings/IValidator.php
+++ b/lib/public/RichObjectStrings/IValidator.php
@@ -11,6 +11,36 @@ namespace OCP\RichObjectStrings;
 /**
  * Class Validator
  *
+ * @psalm-type RichObjectParameter = array{
+ *     type: string,
+ *     id: string,
+ *     name: string,
+ *     server?: string,
+ *     link?: string,
+ *     'call-type'?: 'one2one'|'group'|'public',
+ *     'icon-url'?: string,
+ *     'message-id'?: string,
+ *     boardname?: string,
+ *     stackname?: string,
+ *     size?: string,
+ *     path?: string,
+ *     mimetype?: string,
+ *     'preview-available'?: 'yes'|'no',
+ *     mtime?: string,
+ *     latitude?: string,
+ *     longitude?: string,
+ *     description?: string,
+ *     thumb?: string,
+ *     website?: string,
+ *     visibility?: '0'|'1',
+ *     assignable?: '0'|'1',
+ *     conversation?: string,
+ *     etag?: string,
+ *     permissions?: string,
+ *     width?: string,
+ *     height?: string,
+ * }
+ *
  * @since 11.0.0
  */
 interface IValidator {
@@ -22,7 +52,7 @@ interface IValidator {
 
 	/**
 	 * @param string $subject
-	 * @param array<non-empty-string, array<non-empty-string, string>> $parameters
+	 * @param array<non-empty-string, RichObjectParameter> $parameters
 	 * @throws InvalidObjectExeption
 	 * @since 11.0.0
 	 */


### PR DESCRIPTION
Fixes failing Talk and Notification psalm in a better way than https://github.com/nextcloud/notifications/pull/2095/commits/5cf07bd1c90ac6242b61f49a4e0aa191782e84d8

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
