### PR TITLE
fix(settings): Provide visual feedback 4 encryption toggle

### DIFF
--- a/apps/settings/src/components/Encryption.vue
+++ b/apps/settings/src/components/Encryption.vue
@@ -14,6 +14,10 @@
 			{{ t('settings', 'Enable server-side encryption') }}
 		</NcCheckboxRadioSwitch>
 
+		<div v-if="!hasEncryptionModules || !encryptionReady" class="notecard warning" role="alert">
+			<p>{{ t('settings', 'Encryption is not available. Please enable the Encryption app or an encryption module.') }}</p>
+		</div>
+
 		<div v-if="shouldDisplayWarning && !encryptionEnabled" class="notecard warning" role="alert">
 			<p>{{ t('settings', 'Please read carefully before activating server-side encryption:') }}</p>
 			<ul>
@@ -34,7 +38,7 @@
 
 		<div v-if="encryptionEnabled">
 			<div v-if="encryptionReady">
-				<p v-if="encryptionModules.length === 0">
+				<p v-if="!hasEncryptionModules">
 					{{ t('settings', 'No encryption module loaded, please enable an encryption module in the app menu.') }}
 				</p>
 				<template v-else>
@@ -89,8 +93,9 @@ export default {
 	},
 	data() {
 		const encryptionModules = loadState('settings', 'encryption-modules')
+		const hasEncryptionModules = encryptionModules instanceof Array && encryptionModules.length > 0
 		let defaultCheckedModule = ''
-		if (encryptionModules instanceof Array && encryptionModules.length > 0) {
+		if (hasEncryptionModules) {
 			const defaultModule = Object.entries(encryptionModules).find((module) => module[1].default)
 			if (defaultModule) {
 				defaultCheckedModule = foundModule[0]
@@ -107,6 +112,7 @@ export default {
 			shouldDisplayWarning: false,
 			migrating: false,
 			defaultCheckedModule,
+			hasEncryptionModules,
 		}
 	},
 	methods: {

--- a/apps/settings/src/components/Encryption.vue
+++ b/apps/settings/src/components/Encryption.vue
@@ -89,15 +89,24 @@ export default {
 	},
 	data() {
 		const encryptionModules = loadState('settings', 'encryption-modules')
+		let defaultCheckedModule = ''
+		if (encryptionModules instanceof Array && encryptionModules.length > 0) {
+			const defaultModule = Object.entries(encryptionModules).find((module) => module[1].default)
+			if (defaultModule) {
+				defaultCheckedModule = foundModule[0]
+			}
+		} else {
+			logger.debug('No encryption module loaded or enabled')
+		}
 		return {
-			encryptionReady: loadState('settings', 'encryption-ready'),
-			encryptionEnabled: loadState('settings', 'encryption-enabled'),
+			encryptionReady: loadState('settings', 'encryption-ready', false),
+			encryptionEnabled: loadState('settings', 'encryption-enabled', false),
 			externalBackendsEnabled: loadState('settings', 'external-backends-enabled'),
 			encryptionAdminDoc: loadState('settings', 'encryption-admin-doc'),
 			encryptionModules,
 			shouldDisplayWarning: false,
 			migrating: false,
-			defaultCheckedModule: Object.entries(encryptionModules).find((module) => module[1].default)[0],
+			defaultCheckedModule,
 		}
 	},
 	methods: {


### PR DESCRIPTION
Show visual feedback if user clicks on encryption toggle when it cannot be activated.

### Demo

[feedback-no-encryption-module.webm](https://github.com/user-attachments/assets/89b346de-1971-4e8f-8e2c-affd9d8b2702)

### Other improvement

- `Object.entries([])` would return an empty array, that leads to the `find`
- return undefined.
- `encryptionReady` and `encryptionEnabled` also returns undefined when no encryption module is available or functional (I guess).

Resolves : https://github.com/nextcloud/server/issues/48829