### PR TITLE
feat(config): Add sysadmin level encription.available config 

### DIFF
--- a/apps/settings/lib/Settings/Admin/Security.php
+++ b/apps/settings/lib/Settings/Admin/Security.php
@@ -9,6 +9,7 @@ use OC\Authentication\TwoFactorAuth\MandatoryTwoFactor;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\Encryption\IManager;
+use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Settings\ISettings;
@@ -22,6 +23,7 @@ class Security implements ISettings {
 		MandatoryTwoFactor $mandatoryTwoFactor,
 		private IInitialState $initialState,
 		private IURLGenerator $urlGenerator,
+		private IConfig $config,
 	) {
 		$this->mandatoryTwoFactor = $mandatoryTwoFactor;
 	}
@@ -43,6 +45,7 @@ class Security implements ISettings {
 
 		$this->initialState->provideInitialState('mandatory2FAState', $this->mandatoryTwoFactor->getState());
 		$this->initialState->provideInitialState('two-factor-admin-doc', $this->urlGenerator->linkToDocs('admin-2fa'));
+		$this->initialState->provideInitialState('encryption-available', $this->config->getSystemValue('encryption.available', true));
 		$this->initialState->provideInitialState('encryption-enabled', $this->manager->isEnabled());
 		$this->initialState->provideInitialState('encryption-ready', $this->manager->isReady());
 		$this->initialState->provideInitialState('external-backends-enabled', count($this->userManager->getBackends()) > 1);

--- a/apps/settings/src/components/Encryption.vue
+++ b/apps/settings/src/components/Encryption.vue
@@ -89,15 +89,24 @@ export default {
 	},
 	data() {
 		const encryptionModules = loadState('settings', 'encryption-modules')
+		let defaultCheckedModule = ''
+		if (encryptionModules instanceof Array && encryptionModules.length > 0) {
+			const defaultModule = Object.entries(encryptionModules).find((module) => module[1].default)
+			if (defaultModule) {
+				defaultCheckedModule = foundModule[0]
+			}
+		} else {
+			logger.debug('No encryption module loaded or enabled')
+		}
 		return {
-			encryptionReady: loadState('settings', 'encryption-ready'),
-			encryptionEnabled: loadState('settings', 'encryption-enabled'),
+			encryptionReady: loadState('settings', 'encryption-ready', false),
+			encryptionEnabled: loadState('settings', 'encryption-enabled', false),
 			externalBackendsEnabled: loadState('settings', 'external-backends-enabled'),
 			encryptionAdminDoc: loadState('settings', 'encryption-admin-doc'),
 			encryptionModules,
 			shouldDisplayWarning: false,
 			migrating: false,
-			defaultCheckedModule: Object.entries(encryptionModules).find((module) => module[1].default)[0],
+			defaultCheckedModule,
 		}
 	},
 	methods: {

--- a/apps/settings/src/components/Encryption.vue
+++ b/apps/settings/src/components/Encryption.vue
@@ -99,6 +99,7 @@ export default {
 			logger.debug('No encryption module loaded or enabled')
 		}
 		return {
+			encryptionIsAvailable: loadState('settings', 'encryption-available', false),
 			encryptionReady: loadState('settings', 'encryption-ready', false),
 			encryptionEnabled: loadState('settings', 'encryption-enabled', false),
 			externalBackendsEnabled: loadState('settings', 'external-backends-enabled'),
@@ -112,12 +113,15 @@ export default {
 	},
 	methods: {
 		displayWarning() {
+			if (encryptionIsAvailable) {
+				this.encryptionEnabledToggleEffect()
+				showError(t('settings', 'File encryption is not allowed by system administrator.'))
+				logger.debug('File encryption is not allowed by system administrator.')
+				return
+			}
 			if (!this.hasEncryptionModules || !this.encryptionReady) {
-				this.encryptionEnabled = true
+				this.encryptionEnabledToggleEffect()
 				showError(t('settings', 'Encryption is not ready, please enable an encryption module/app.'))
-				setTimeout(() => {
-					this.encryptionEnabled = false
-				}, 1000)
 				return
 			}
 			if (!this.encryptionEnabled) {
@@ -126,6 +130,12 @@ export default {
 				this.encryptionEnabled = false
 				this.shouldDisplayWarning = false
 			}
+		},
+		encryptionEnabledToggleEffect() {
+			this.encryptionEnabled = true
+			setTimeout(() => {
+				this.encryptionEnabled = false
+			}, 1000)
 		},
 		async update(key, value) {
 			await confirmPassword()

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2589,4 +2589,11 @@ $CONFIG = [
  * Defaults to 5.
  */
 'files.chunked_upload.max_parallel_count' => 5,
+
+/**
+ * Allow server-side encryption.
+ * 
+ * Default is true, indicating that encryption is available or permitted by the system administrator.
+ */
+'encryption.available' => true,
 ];


### PR DESCRIPTION
This is important because a user who has admin permissions who is not a sysadmin might enable encryption without knowing the full implications, the sysadmin should be able to prevent this.

Originally from 

> I know this is not 100% directly related, but in some cases, (sys)admin shoudl be able to completely disable encryption and its activation with config param like 'encryption_available' => false. If this was set to false (default as true) encryption (and its modules) could not be installed (or, at very least, activated) trough the WebUI or the CLI.
> 
> In this case, a message should also inform the user that encryption modules can't be installed or enabled because of that flag set.

https://github.com/nextcloud/server/issues/48829#issuecomment-2429202836 by @solracsf 
