### PR TITLE
fix(files_external): cast storage id int

### DIFF
--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -271,7 +271,7 @@ abstract class StoragesController extends Controller {
 	 *
 	 * @return DataResponse
 	 */
-	public function show($id, $testOnly = true) {
+	public function show(int $id, $testOnly = true) {
 		try {
 			$storage = $this->service->getStorage($id);
 
@@ -303,7 +303,7 @@ abstract class StoragesController extends Controller {
 	 * @return DataResponse
 	 */
 	#[PasswordConfirmationRequired]
-	public function destroy($id) {
+	public function destroy(int $id) {
 		try {
 			$this->service->removeStorage($id);
 		} catch (NotFoundException $e) {


### PR DESCRIPTION
Fix `"OCA\\Files_External\\Service\\DBConfigService::getMountById(): Argument #1 ($mountId) must be of type int, string given`

Do we need strict typing on this? :thinking: 

```json
{
      "Exception": "TypeError",
      "Message": "OCA\\Files_External\\Service\\DBConfigService::getMountById(): Argument #1 ($mountId) must be of type int, string given, called in /var/www/html/nextcloud_test1/apps/files_external/lib/Service/StoragesService.php on line 164",
      "Code": 0,
      "Trace": [
        {
          "file": "/var/www/html/nextcloud_test1/apps/files_external/lib/Service/StoragesService.php",
          "line": 164,
          "function": "getMountById",
          "class": "OCA\\Files_External\\Service\\DBConfigService",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud_test1/apps/files_external/lib/Controller/StoragesController.php",
          "line": 296,
          "function": "getStorage",
          "class": "OCA\\Files_External\\Service\\StoragesService",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud_test1/apps/files_external/lib/Controller/UserStoragesController.php",
          "line": 110,
          "function": "show",
          "class": "OCA\\Files_External\\Controller\\StoragesController",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud_test1/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 230,
          "function": "show",
          "class": "OCA\\Files_External\\Controller\\UserStoragesController",
          "type": "->"
        },
        {...}
}