### PR TITLE
Add an error log message that notifications app isn't enabled at file…

### DIFF
--- a/apps/files_reminders/appinfo/info.xml
+++ b/apps/files_reminders/appinfo/info.xml
@@ -11,6 +11,9 @@
 	<description><![CDATA[**📣 File reminders**
 
 Set file reminders.
+
+Note: to use the `File reminders` app, ensure that the `Notifications` app is installed and enabled. The `Notifications` app provides the necessary APIs for the `File reminders` app to work correctly.
+
 	]]></description>
 	<version>1.4.0</version>
 	<licence>agpl</licence>

--- a/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
@@ -15,11 +15,13 @@ use OCP\App\IAppManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 
 /** @template-implements IEventListener<LoadAdditionalScriptsEvent> */
 class LoadAdditionalScriptsListener implements IEventListener {
 	public function __construct(
 		private IAppManager $appManager,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -29,6 +31,7 @@ class LoadAdditionalScriptsListener implements IEventListener {
 		}
 
 		if (!$this->appManager->isEnabledForUser('notifications')) {
+			$this->logger->error('Failed to register the `files_reminders` app. This could happen due to the `notifications` app being disabled.', ['app' => 'files_reminders']);
 			return;
 		}
 


### PR DESCRIPTION
* Resolves: #49231 

## Summary
This PR adds an error log message telling admin that the notifications app is not enabled at the files_reminders app loading. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
