### PR TITLE
add .HIF file support

### DIFF
--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -75,6 +75,7 @@
 	"h": ["text/x-h"],
 	"heic": ["image/heic"],
 	"heif": ["image/heif"],
+	"hif": ["image/heic"],
 	"hh": ["text/x-h"],
 	"hpp": ["text/x-h"],
 	"htaccess": ["text/plain"],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #46408 
## Summary

I added `hif` as a supported file extension to the [resources/config/mimetypemapping.dist.json](https://github.com/nextcloud/server/compare/master...mayonnaisehypernova:nextcloud-server:bugfix/hif-file-support?expand=1#diff-8896034d1111a779b0aede10c6f28ae19f241211e37a9aaaeb54237528016ba9) to support .HIF files in nextcloud, especially for the preview generation and display of image files.

## TODO

- [ ] Review and resolve any conflicts