### PR TITLE
[textprocessing] Fix: Accept scheduling a task if there are equivalent taskprocessing providers only

### DIFF
--- a/lib/private/TextProcessing/Manager.php
+++ b/lib/private/TextProcessing/Manager.php
@@ -221,7 +221,11 @@ class Manager implements IManager {
 		}
 		$task->setStatus(OCPTask::STATUS_SCHEDULED);
 		$providers = $this->getPreferredProviders($task);
-		if (count($providers) === 0) {
+		$equivalentTaskProcessingTypeAvailable = (
+			isset(self::$taskProcessingCompatibleTaskTypes[$task->getType()])
+			&& isset($this->taskProcessingManager->getAvailableTaskTypes()[self::$taskProcessingCompatibleTaskTypes[$task->getType()]])
+		);
+		if (count($providers) === 0 && !$equivalentTaskProcessingTypeAvailable) {
 			throw new PreConditionNotMetException('No LanguageModel provider is installed that can handle this task');
 		}
 		[$provider,] = $providers;


### PR DESCRIPTION
Runtask and RunOrSchedule are not affected.

Should be backported to stable30.

To reproduce the issue:
``` bash
curl -H "ocs-apirequest: true" -u admin:admin \
    http://nextcloud.local/ocs/v2.php/textprocessing/schedule \
    -X POST \
    -d '{"input":"bla and bla but bla","type":"OCP\\TextProcessing\\SummaryTaskType","appId":"plopapp"}' \
    -H "Content-Type: application/json"
```
while having no text processing providers but only task processing `core:text2text:summary` providers.
