### PR TITLE
feat(trashbin): Add backend dav property

### DIFF
--- a/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Files_Trashbin\Sabre;
 
 use OCA\DAV\Connector\Sabre\FilesPlugin;
+use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCP\IPreview;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
@@ -24,6 +25,7 @@ class TrashbinPlugin extends ServerPlugin {
 	public const TRASHBIN_TITLE = '{http://nextcloud.org/ns}trashbin-title';
 	public const TRASHBIN_DELETED_BY_ID = '{http://nextcloud.org/ns}trashbin-deleted-by-id';
 	public const TRASHBIN_DELETED_BY_DISPLAY_NAME = '{http://nextcloud.org/ns}trashbin-deleted-by-display-name';
+	public const TRASHBIN_BACKEND = '{http://nextcloud.org/ns}trashbin-backend';
 
 	/** @var Server */
 	private $server;
@@ -103,6 +105,14 @@ class TrashbinPlugin extends ServerPlugin {
 
 		$propFind->handle(FilesPlugin::MOUNT_TYPE_PROPERTYNAME, function () {
 			return '';
+		});
+
+		$propFind->handle(self::TRASHBIN_BACKEND, function () use ($node) {
+			$fileInfo = $node->getFileInfo();
+			if (!($fileInfo instanceof ITrashItem)) {
+				return '';
+			}
+			return $fileInfo->getTrashBackend()::class;
 		});
 	}
 


### PR DESCRIPTION
## Summary

Allow requesting the backend for trash items

```json
[
  {
    "fileid": "195",
    "displayname": "Folder",
    "trashbin-deletion-time": "1731537993",
    "trashbin-backend": "OCA\\Files_Trashbin\\Trash\\LegacyTrashBackend"
  },
  {
    "fileid": "148",
    "displayname": "Group folder",
    "trashbin-deletion-time": "1731538002",
    "trashbin-backend": "OCA\\GroupFolders\\Trash\\TrashBackend"
  }
]
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)