### PR TITLE
Remove Application::registerRoutes() usage

### DIFF
--- a/apps/files_versions/appinfo/routes.php
+++ b/apps/files_versions/appinfo/routes.php
@@ -8,18 +8,6 @@ namespace OCA\Files_Versions\AppInfo;
 
 use OCP\Route\IRouter;
 
-/** @var Application $application */
-$application = \OC::$server->query(Application::class);
-$application->registerRoutes($this, [
-	'routes' => [
-		[
-			'name' => 'Preview#getPreview',
-			'url' => '/preview',
-			'verb' => 'GET',
-		],
-	],
-]);
-
 /** @var IRouter $this */
 $this->create('files_versions_download', 'apps/files_versions/download.php')
 	->actionInclude('files_versions/download.php');
@@ -27,3 +15,13 @@ $this->create('files_versions_ajax_getVersions', 'apps/files_versions/ajax/getVe
 	->actionInclude('files_versions/ajax/getVersions.php');
 $this->create('files_versions_ajax_rollbackVersion', 'apps/files_versions/ajax/rollbackVersion.php')
 	->actionInclude('files_versions/ajax/rollbackVersion.php');
+
+return [
+	'routes' => [
+		[
+			'name' => 'Preview#getPreview',
+			'url' => '/preview',
+			'verb' => 'GET',
+		],
+	],
+];

--- a/apps/user_ldap/appinfo/routes.php
+++ b/apps/user_ldap/appinfo/routes.php
@@ -2,9 +2,6 @@
 
 declare(strict_types=1);
 
-use OCA\User_LDAP\AppInfo\Application;
-use OCP\AppFramework\App;
-
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -25,23 +22,17 @@ $this->create('user_ldap_ajax_testConfiguration', 'apps/user_ldap/ajax/testConfi
 $this->create('user_ldap_ajax_wizard', 'apps/user_ldap/ajax/wizard.php')
 	->actionInclude('user_ldap/ajax/wizard.php');
 
-$application = new App('user_ldap');
-$application->registerRoutes($this, [
+return [
 	'ocs' => [
 		['name' => 'ConfigAPI#create', 'url' => '/api/v1/config', 'verb' => 'POST'],
 		['name' => 'ConfigAPI#show',   'url' => '/api/v1/config/{configID}', 'verb' => 'GET'],
 		['name' => 'ConfigAPI#modify', 'url' => '/api/v1/config/{configID}', 'verb' => 'PUT'],
 		['name' => 'ConfigAPI#delete', 'url' => '/api/v1/config/{configID}', 'verb' => 'DELETE'],
-	]
-]);
-
-/** @var Application $application */
-$application = \OC::$server->query(Application::class);
-$application->registerRoutes($this, [
+	],
 	'routes' => [
 		['name' => 'renewPassword#tryRenewPassword', 'url' => '/renewpassword', 'verb' => 'POST'],
 		['name' => 'renewPassword#showRenewPasswordForm', 'url' => '/renewpassword/{user}', 'verb' => 'GET'],
 		['name' => 'renewPassword#cancel', 'url' => '/renewpassword/cancel', 'verb' => 'GET'],
 		['name' => 'renewPassword#showLoginFormInvalidPassword', 'url' => '/renewpassword/invalidlogin/{user}', 'verb' => 'GET'],
-	]
-]);
+	],
+];

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -978,7 +978,6 @@
   </file>
   <file src="apps/files_versions/appinfo/routes.php">
     <InvalidScope>
-      <code><![CDATA[$this]]></code>
       <code><![CDATA[$this->create('files_versions_download', 'apps/files_versions/download.php')]]></code>
     </InvalidScope>
   </file>


### PR DESCRIPTION
## Summary

Small part extracted from https://github.com/nextcloud/server/pull/42678

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
