### PR TITLE
fix: smb: don't fail hard if we can't load acls for a file

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -193,7 +193,12 @@ class SMB extends Common implements INotifyStorage {
 	 * get the acl from fileinfo that is relevant for the configured user
 	 */
 	private function getACL(IFileInfo $file): ?ACL {
-		$acls = $file->getAcls();
+		try {
+			$acls = $file->getAcls();
+		} catch (Exception $e) {
+			$this->logger->error('Error while getting file acls', ['exception' => $e]);
+			return null;
+		}
 		foreach ($acls as $user => $acl) {
 			[, $user] = $this->splitUser($user); // strip domain
 			if ($user === $this->server->getAuth()->getUsername()) {


### PR DESCRIPTION
Instead we log the error and behave as if no ACL was found.