### PR TITLE
fix: don't set 'name' on null metadata

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -280,7 +280,9 @@ class Encoding extends Wrapper {
 
 	public function getMetaData(string $path): ?array {
 		$entry = $this->storage->getMetaData($this->findPathToUse($path));
-		$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');
+		if ($entry !== null) {
+			$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');
+		}
 		return $entry;
 	}
 


### PR DESCRIPTION
Otherwise the metadata ends up being an array with just the name set.