### PR TITLE
feat(Dispatcher): Add debug log for controller methods returning raw data not wrapped in Response

### DIFF
--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -208,6 +208,10 @@ class Dispatcher {
 		$response = \call_user_func_array([$controller, $methodName], $arguments);
 		$this->eventLogger->end('controller:' . get_class($controller) . '::' . $methodName);
 
+		if (!($response instanceof Response)) {
+			$this->logger->debug($controller::class . '::' . $methodName . ' returned raw data. Please wrap it in a Response or one of it\'s inheritors.');
+		}
+
 		// format response
 		if ($response instanceof DataResponse || !($response instanceof Response)) {
 			// get format from the url format or request format parameter


### PR DESCRIPTION
## Summary

Returning plain data is allowed and some legacy code still does it.
Wrapping with Response or one of it's inheritors is preferred, as it gives better control over the entire response and also allows OpenAPI to work with it (openapi-extractor doesn't allow returning raw data for a good reason).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
