### PR TITLE
fix(OCMDiscoveryService): Also cache error results during discovery

### DIFF
--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -55,7 +55,12 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 
 		if (!$skipCache) {
 			try {
-				$this->provider->import(json_decode($this->cache->get($remote) ?? '', true, 8, JSON_THROW_ON_ERROR) ?? []);
+				$cached = $this->cache->get($remote);
+				if ($cached === false) {
+					throw new OCMProviderException('Previous discovery failed.');
+				}
+
+				$this->provider->import(json_decode($cached ?? '', true, 8, JSON_THROW_ON_ERROR) ?? []);
 				if ($this->supportedAPIVersion($this->provider->getApiVersion())) {
 					return $this->provider; // if cache looks valid, we use it
 				}
@@ -85,8 +90,10 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 				$this->cache->set($remote, $body, 60 * 60 * 24);
 			}
 		} catch (JsonException|OCMProviderException $e) {
+			$this->cache->set($remote, false, 5 * 60);
 			throw new OCMProviderException('data returned by remote seems invalid - ' . ($body ?? ''));
 		} catch (\Exception $e) {
+			$this->cache->set($remote, false, 5 * 60);
 			$this->logger->warning('error while discovering ocm provider', [
 				'exception' => $e,
 				'remote' => $remote
@@ -95,6 +102,7 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 		}
 
 		if (!$this->supportedAPIVersion($this->provider->getApiVersion())) {
+			$this->cache->set($remote, false, 5 * 60);
 			throw new OCMProviderException('API version not supported');
 		}
 


### PR DESCRIPTION
## Summary

On my personal instance I'm currently facing the problem that a folder shared from another instance is no longer available, as the server went down. Unfortunately the remote server doesn't terminate the connection instantly, but it only gets stopped by the client timeout.
This makes literally every request to my own Nextcloud server 10 seconds longer, as the timeout happens every time.

Decreasing the timeout would help a little bit, but then in other scenarios it might also lead to unintended consequences, so it isn't a good way to workaround the problem.
When the remote server has a problem we must also cache the result, but for a much shorter duration (e.g. 1h), just to prevent that every request tries to contact the remote server again.
Now we still check once in a while if the server is still there, but not on every request that uses the Filesystem which was slowing down everything dramatically.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
