### PR TITLE
fix(storage): Try to delete existing target

### DIFF
--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -69,13 +69,16 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 	}
 
 	protected function remove(string $path): bool {
-		if ($this->is_dir($path)) {
-			return $this->rmdir($path);
-		} elseif ($this->is_file($path)) {
-			return $this->unlink($path);
-		} else {
-			return false;
+		if ($this->file_exists($path)) {
+			if ($this->is_dir($path)) {
+				return $this->rmdir($path);
+			} elseif ($this->is_file($path)) {
+				return $this->unlink($path);
+			} else {
+				return false;
+			}
 		}
+		return false;
 	}
 
 	public function is_dir(string $path): bool {

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -342,10 +342,12 @@ class Local extends \OC\Files\Storage\Common {
 			return false;
 		}
 
-		if ($this->is_dir($target)) {
-			$this->rmdir($target);
-		} elseif ($this->is_file($target)) {
-			$this->unlink($target);
+		if ($this->file_exists($target)) {
+			if ($this->is_dir($target)) {
+				$this->rmdir($target);
+			} elseif ($this->is_file($target)) {
+				$this->unlink($target);
+			}
 		}
 
 		if ($this->is_dir($source)) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Should get rid of logs like:

```
{
  "reqId": "iq8oEiCJ1Uc7WrCf9uNP",
  "level": 3,
  "app": "PHP",
  "method": "GET",
  "url": "/index.php/apps/files/api/v1/thumbnail/256/256/00_COMMUN/ORGAN/EST-LES/File.pdf",
  "message": "unlink(/var/www/data/appdata_ocwfs52oscxg/preview/d/a/d/3/f/6/3/4158280/256-256-crop.webp): No such file or directory at /var/www/nextcloud/lib/private/Files/Storage/Local.php#348",
  "userAgent": "Mozilla/5.0 (Android) Nextcloud-android/3.29.2",
  "version": "29.0.9.2",
  "data": {
    "app": "PHP"
  },
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
