### PR TITLE
Revert "build(deps): bump nextcloud/openapi-extractor"

### DIFF
--- a/vendor-bin/openapi-extractor/composer.lock
+++ b/vendor-bin/openapi-extractor/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "adhocore/cli",
-            "version": "v1.8.0",
+            "version": "v1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/adhocore/php-cli.git",
-                "reference": "6092763ab212038de64c44545574cedb7ef86269"
+                "reference": "57834cbaa4fb68cda849417ab86577fba2b15298"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adhocore/php-cli/zipball/6092763ab212038de64c44545574cedb7ef86269",
-                "reference": "6092763ab212038de64c44545574cedb7ef86269",
+                "url": "https://api.github.com/repos/adhocore/php-cli/zipball/57834cbaa4fb68cda849417ab86577fba2b15298",
+                "reference": "57834cbaa4fb68cda849417ab86577fba2b15298",
                 "shasum": ""
             },
             "require": {
@@ -62,7 +62,7 @@
             ],
             "support": {
                 "issues": "https://github.com/adhocore/php-cli/issues",
-                "source": "https://github.com/adhocore/php-cli/tree/v1.8.0"
+                "source": "https://github.com/adhocore/php-cli/tree/v1.7.2"
             },
             "funding": [
                 {
@@ -74,20 +74,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-11-15T08:55:32+00:00"
+            "time": "2024-09-05T00:08:47+00:00"
         },
         {
             "name": "nextcloud/openapi-extractor",
-            "version": "v1.2.2",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-releases/openapi-extractor.git",
-                "reference": "fb177110c9d182dd9c6c5c19d20f1275f2b7f6af"
+                "reference": "d7c135e819d2297e7e9414a3f80464d68f164c94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-releases/openapi-extractor/zipball/fb177110c9d182dd9c6c5c19d20f1275f2b7f6af",
-                "reference": "fb177110c9d182dd9c6c5c19d20f1275f2b7f6af",
+                "url": "https://api.github.com/repos/nextcloud-releases/openapi-extractor/zipball/d7c135e819d2297e7e9414a3f80464d68f164c94",
+                "reference": "d7c135e819d2297e7e9414a3f80464d68f164c94",
                 "shasum": ""
             },
             "require": {
@@ -118,9 +118,9 @@
             "description": "A tool for extracting OpenAPI specifications from Nextcloud source code",
             "support": {
                 "issues": "https://github.com/nextcloud-releases/openapi-extractor/issues",
-                "source": "https://github.com/nextcloud-releases/openapi-extractor/tree/v1.2.2"
+                "source": "https://github.com/nextcloud-releases/openapi-extractor/tree/v1.1.0"
             },
-            "time": "2024-11-13T10:36:57+00:00"
+            "time": "2024-11-06T11:50:20+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
## Summary

Reverts https://github.com/nextcloud/server/pull/49322 which was merged with red CI.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
