### PR TITLE
fix(IURLGenerator): Allow markdown parenthesis in URL_REGEX_NO_MODIFIERS

### DIFF
--- a/lib/public/IURLGenerator.php
+++ b/lib/public/IURLGenerator.php
@@ -30,8 +30,9 @@ interface IURLGenerator {
 	 *
 	 * @since 25.0.0
 	 * @since 29.0.0 changed to match localhost and hostnames with ports
+	 * @since 31.0.0 changed to match markdown embedded links with parenthesis
 	 */
-	public const URL_REGEX_NO_MODIFIERS = '(\s|\n|^)(https?:\/\/)([-A-Z0-9+_.]+(?::[0-9]+)?(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|\n|$)';
+	public const URL_REGEX_NO_MODIFIERS = '(\s|\n|\(|^)(https?:\/\/)([-A-Z0-9+_.]+(?::[0-9]+)?(?:\/[-A-Z0-9+&@#%?=~_|!:,.;()]*)*)(\s|\n|\)|$)';
 
 	/**
 	 * Returns the URL for a route


### PR DESCRIPTION
## Summary

Related to https://github.com/nextcloud/spreed/issues/13756.
Apparently the web UI doesn't use this regex but a hardcoded one, but I fixed it there as well: https://github.com/nextcloud-libraries/nextcloud-vue/pull/6224
Clients should be using this regex, so it also needs to work with the parenthesis from embedded markdown links.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
