### PR TITLE
fix(richtextvalidator): Add missing blurhash

### DIFF
--- a/lib/public/RichObjectStrings/IValidator.php
+++ b/lib/public/RichObjectStrings/IValidator.php
@@ -39,6 +39,7 @@ namespace OCP\RichObjectStrings;
  *     permissions?: string,
  *     width?: string,
  *     height?: string,
+ *     blurhash?: string,
  * }
  *
  * @since 11.0.0


### PR DESCRIPTION
- Missed in #49192

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
