### PR TITLE
Fix integer casting on Sqlite databases

### DIFF
--- a/lib/private/DB/QueryBuilder/ExpressionBuilder/SqliteExpressionBuilder.php
+++ b/lib/private/DB/QueryBuilder/ExpressionBuilder/SqliteExpressionBuilder.php
@@ -63,6 +63,9 @@ class SqliteExpressionBuilder extends ExpressionBuilder {
 			case IQueryBuilder::PARAM_TIME_IMMUTABLE:
 				$column = $this->helper->quoteColumnName($column);
 				return new QueryFunction('TIME(' . $column . ')');
+			case IQueryBuilder::PARAM_INT:
+				$column = $this->helper->quoteColumnName($column);
+				return new QueryFunction('CAST(' . $column . ' AS INTEGER)');
 		}
 
 		return parent::castColumn($column, $type);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

- feat: Add test for casting to int in expression builder
- fix: Fix integer casting on Sqlite

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
