### PR TITLE
improve handling of large single-part s3 uploads

### DIFF
--- a/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
@@ -25,12 +25,16 @@ class AssemblyStreamTest extends \Test\TestCase {
 	/**
 	 * @dataProvider providesNodes()
 	 */
-	public function testGetContentsFread($expected, $nodes): void {
+	public function testGetContentsFread($expected, $nodes, $chunkLength = 3): void {
 		$stream = AssemblyStream::wrap($nodes);
 
 		$content = '';
 		while (!feof($stream)) {
-			$content .= fread($stream, 3);
+			$chunk = fread($stream, $chunkLength);
+			$content .= $chunk;
+			if ($chunkLength !== 3) {
+				$this->assertEquals($chunkLength, strlen($chunk));
+			}
 		}
 
 		$this->assertEquals($expected, $content);
@@ -103,7 +107,19 @@ class AssemblyStreamTest extends \Test\TestCase {
 				]],
 			'a ton of nodes' => [
 				$tonofdata, $tonofnodes
-			]
+			],
+			'one read over multiple nodes' => [
+				'1234567890', [
+					$this->buildNode('0', '1234'),
+					$this->buildNode('1', '5678'),
+					$this->buildNode('2', '90'),
+				], 10],
+			'two reads over multiple nodes' => [
+				'1234567890', [
+					$this->buildNode('0', '1234'),
+					$this->buildNode('1', '5678'),
+					$this->buildNode('2', '90'),
+				], 5],
 		];
 	}
 

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -457,6 +457,14 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 	}
 
 	public function writeStream(string $path, $stream, ?int $size = null): int {
+		if ($size === null) {
+			$stats = fstat($stream);
+			if (is_array($stats) && isset($stats['size'])) {
+				$size = $stats['size'];
+				$this->logger->warning("stream size $size");
+			}
+		}
+
 		$stat = $this->stat($path);
 		if (empty($stat)) {
 			// create new file

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -144,7 +144,7 @@ trait S3ObjectTrait {
 
 		// ($psrStream->isSeekable() && $psrStream->getSize() !== null) evaluates to true for a On-Seekable stream
 		// so the optimisation does not apply
-		$buffer = new Psr7\Stream(fopen('php://memory', 'rwb+'));
+		$buffer = new Psr7\Stream(fopen('php://temp', 'rwb+'));
 		Utils::copyToStream($psrStream, $buffer, $this->putSizeLimit);
 		$buffer->seek(0);
 		if ($buffer->getSize() < $this->putSizeLimit) {


### PR DESCRIPTION
- [use php://temp instead of php://memory for multi-part upload buffer](https://github.com/nextcloud/server/commit/573825cec2207e0b58ff0410b03cfb1adb88d8a8)
- [don't perform the extra buffering in s3 stream write when the stream size is known](https://github.com/nextcloud/server/commit/9b842fe4914bb281d0aa6f804cc9ea1ed375dc9e)
- [don't perform unneeded seeks in assemblystream](https://github.com/nextcloud/server/commit/e4d0882b312923ee9021312c5272df4884276961)
- [try to read the full requested size in assemblystream even if the chunks are smaller](https://github.com/nextcloud/server/commit/e4d0882b312923ee9021312c5272df4884276961)
- [use the size from the stream when writing objects when possible](https://github.com/nextcloud/server/commit/6cf66f95ce9dadffd9fa25203e737917cef0cd8c)

This removes the risk of the memory size ballooning in cases where `putSizeLimit` has been made very high (because the setup doesn't have a working multi-part upload for example)