### PR TITLE
fix(files_sharing): Do not wrap password policy exception into a generic one

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -99,7 +99,7 @@ class Manager implements IManager {
 	 * Verify if a password meets all requirements
 	 *
 	 * @param string $password
-	 * @throws \Exception
+	 * @throws HintException
 	 */
 	protected function verifyPassword($password) {
 		if ($password === null) {
@@ -112,11 +112,7 @@ class Manager implements IManager {
 		}
 
 		// Let others verify the password
-		try {
-			$this->dispatcher->dispatchTyped(new ValidatePasswordPolicyEvent($password));
-		} catch (HintException $e) {
-			throw new \Exception($e->getHint());
-		}
+		$this->dispatcher->dispatchTyped(new ValidatePasswordPolicyEvent($password));
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -112,7 +112,12 @@ class Manager implements IManager {
 		}
 
 		// Let others verify the password
-		$this->dispatcher->dispatchTyped(new ValidatePasswordPolicyEvent($password));
+		try {
+			$this->dispatcher->dispatchTyped(new ValidatePasswordPolicyEvent($password));
+		} catch (HintException $e) {
+			/* Wrap in a 400 bad request error */
+			throw new HintException($e->getMessage(), $e->getHint(), 400, $e);
+		}
 	}
 
 	/**
@@ -780,7 +785,7 @@ class Manager implements IManager {
 	 * @param IShare $share
 	 * @return IShare The share object
 	 * @throws \InvalidArgumentException
-	 * @throws GenericShareException
+	 * @throws HintException
 	 */
 	public function updateShare(IShare $share, bool $onlyValid = true) {
 		$expirationDateUpdated = false;

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -798,7 +798,7 @@ class ManagerTest extends \Test\TestCase {
 				$this->assertInstanceOf(ValidatePasswordPolicyEvent::class, $event);
 				/** @var ValidatePasswordPolicyEvent $event */
 				$this->assertSame('password', $event->getPassword());
-				throw new HintException('message', 'password not accepted');
+				throw new HintException('password not accepted');
 			}
 			);
 


### PR DESCRIPTION
Follow-up of https://github.com/nextcloud/server/pull/49361

## Summary

Let the controller access the HintException and show the error to the user.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
