### PR TITLE
fix(SetupChecks): Make sure array key is set

### DIFF
--- a/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
+++ b/apps/settings/lib/SetupChecks/CheckServerResponseTrait.php
@@ -93,6 +93,10 @@ trait CheckServerResponseTrait {
 	protected function normalizeUrl(string $url, bool $removeWebroot): string {
 		if ($removeWebroot) {
 			$segments = parse_url($url);
+			if (!isset($segments['scheme']) || !isset($segments['host'])) {
+				throw new \InvalidArgumentException('URL is missing scheme or host');
+			}
+
 			$port = isset($segments['port']) ? (':' . $segments['port']) : '';
 			return $segments['scheme'] . '://' . $segments['host'] . $port;
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/49370

## Summary

Backporting a portion of https://github.com/nextcloud/server/pull/47947 to fix an error. This targets `stable30` on purpose.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
