### PR TITLE
fix(SetupChecks): Validate URL before parsing

### DIFF
--- a/lib/public/SetupCheck/CheckServerResponseTrait.php
+++ b/lib/public/SetupCheck/CheckServerResponseTrait.php
@@ -148,15 +148,17 @@ trait CheckServerResponseTrait {
 	 * @since 31.0.0
 	 */
 	private function normalizeUrl(string $url, bool $removeWebroot): string {
-		if ($removeWebroot) {
-			$segments = parse_url($url);
-			if (!isset($segments['scheme']) || !isset($segments['host'])) {
-				throw new \InvalidArgumentException('URL is missing scheme or host');
+		if (filter_var($url, FILTER_VALIDATE_URL)) { // reasonable URL?
+			if (!$removeWebroot) { // no need to do anything else
+				return rtrim($url, '/');
+			} else {
+				$segments = parse_url($url); // parse the url
+				if (is_array($segments) && isset($segments['scheme']) && isset($segments['host'])) { // if we have the minimum required
+					$port = isset($segments['port']) ? (':' . $segments['port']) : '';
+					return $segments['scheme'] . '://' . $segments['host'] . $port;
+				}
 			}
-
-			$port = isset($segments['port']) ? (':' . $segments['port']) : '';
-			return $segments['scheme'] . '://' . $segments['host'] . $port;
 		}
-		return rtrim($url, '/');
+		throw new \InvalidArgumentException("URL ($url) is invalid - Please verify syntax of all URLs / domains / IP addresses in your config");
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Came up while looking at #49373 / #49370 in `stable30`.

## Summary

Using `filter_var()` should be [safer / more likely to catch edge cases](https://www.php.net/manual/en/function.parse-url.php).

Also adds the url in the error output to help the operator track down the culprit faster.

## TODO

- [ ] If this gets merged, make a similar change in #49373 (we can't directly backport this PR due to code restructuring)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
