### PR TITLE
fix(userconfig): Don't fail the precondition if the value is not set at all

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -246,7 +246,7 @@ class AllConfig implements IConfig {
 		$userPreferences = \OCP\Server::get(IUserConfig::class);
 		if ($preCondition !== null) {
 			try {
-				if ($userPreferences->getValueMixed($userId, $appName, $key) !== (string)$preCondition) {
+				if ($userPreferences->hasKey($userId, $appName, $key) && $userPreferences->getValueMixed($userId, $appName, $key) !== (string)$preCondition) {
 					throw new PreConditionNotMetException();
 				}
 			} catch (TypeConflictException) {


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Restoring Nextcloud 30 behaviour, fixing Talk's integration tests:
https://github.com/nextcloud/spreed/actions/runs/11911817197/job/33195693787?pr=13750#step:15:2194

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
