### PR TITLE
feat(dav): increase default calendar subscription refresh rate to one day

### DIFF
--- a/apps/dav/lib/BackgroundJob/RefreshWebcalJob.php
+++ b/apps/dav/lib/BackgroundJob/RefreshWebcalJob.php
@@ -41,8 +41,8 @@ class RefreshWebcalJob extends Job {
 
 		$this->fixSubscriptionRowTyping($subscription);
 
-		// if no refresh rate was configured, just refresh once a week
-		$defaultRefreshRate = $this->config->getAppValue('dav', 'calendarSubscriptionRefreshRate', 'P1W');
+		// if no refresh rate was configured, just refresh once a day
+		$defaultRefreshRate = $this->config->getAppValue('dav', 'calendarSubscriptionRefreshRate', 'P1D');
 		$refreshRate = $subscription[RefreshWebcalService::REFRESH_RATE] ?? $defaultRefreshRate;
 
 		$subscriptionId = $subscription['id'];

--- a/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
@@ -78,7 +78,7 @@ class RefreshWebcalJobTest extends TestCase {
 
 		$this->config->expects($this->once())
 			->method('getAppValue')
-			->with('dav', 'calendarSubscriptionRefreshRate', 'P1W')
+			->with('dav', 'calendarSubscriptionRefreshRate', 'P1D')
 			->willReturn('P1W');
 
 		$this->timeFactory->method('getTime')


### PR DESCRIPTION
## Summary

With the performance benefits from #43541 it makes sense

Reference https://github.com/nextcloud/server/issues/46171#issuecomment-2487910923

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
