### PR TITLE
fix(user_ldap): retrieve from LDAP first "email shaped" value instead…

### DIFF
--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -154,7 +154,14 @@ class User {
 		//change event that will trigger fetching the display name again
 		$attr = strtolower($this->connection->ldapEmailAttribute);
 		if (isset($ldapEntry[$attr])) {
-			$this->updateEmail($ldapEntry[$attr][0]);
+			$mailValue = 0;
+			for ($x = 0; $x < count($ldapEntry[$attr]); $x++) {
+				if (filter_var($ldapEntry[$attr][$x], FILTER_VALIDATE_EMAIL)) {
+					$mailValue = $x;
+					break;
+				}
+			}
+			$this->updateEmail($ldapEntry[$attr][$mailValue]);
 		}
 		unset($attr);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/49177

## Summary

Retrieve from LDAP first "email shaped" value instead of first value

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
