### PR TITLE
feat(files): Add help to / update description of `files:cleanup`

### DIFF
--- a/apps/files/lib/Command/DeleteOrphanedFiles.php
+++ b/apps/files/lib/Command/DeleteOrphanedFiles.php
@@ -29,7 +29,8 @@ class DeleteOrphanedFiles extends Command {
 	protected function configure(): void {
 		$this
 			->setName('files:cleanup')
-			->setDescription('cleanup filecache')
+			->setDescription('Clean up orphaned filecache and mount entries')
+			->setHelp('Deletes orphaned filecache and mount entries (those without an existing storage).')
 			->addOption('skip-filecache-extended', null, InputOption::VALUE_NONE, 'don\'t remove orphaned entries from filecache_extended');
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

### After:

Output of `occ files`:

```
[...]
Available commands for the "files" namespace:
  files:cleanup                    Clean up orphaned filecache and mount entries
  files:copy                       Copy a file or folder
  [...]
```

Output of `files:cleanup --help`:

```
Description:
  Clean up orphaned filecache and mount entries

Usage:
  files:cleanup [options]

Options:
      --skip-filecache-extended  don't remove orphaned entries from filecache_extended
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
  -n, --no-interaction           Do not ask any interactive question
      --no-warnings              Skip global warnings, show command output only
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  Deletes orphaned filecache and mount entries (those without an existing storage).
```

### Before:

Output of `occ files`:

```
[...]
Available commands for the "files" namespace:
  files:cleanup                    cleanup filecache
  files:copy                       Copy a file or folder
[...]
```

Output of `files:cleanup --help`:

```
Description:
  cleanup filecache

Usage:
  files:cleanup [options]

Options:
      --skip-filecache-extended  don't remove orphaned entries from filecache_extended
  -h, --help                     Display help for the given command. When no command is given display help for the list command
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
  -n, --no-interaction           Do not ask any interactive question
      --no-warnings              Skip global warnings, show command output only
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

Historical context:

- cefdcea02171672d6340d9db57a54ffac78c5ab8
- #38933
- #21729

## TODO


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
