### PR TITLE
fix(cache): etag constraint violation

### DIFF
--- a/lib/private/Files/Cache/CacheQueryBuilder.php
+++ b/lib/private/Files/Cache/CacheQueryBuilder.php
@@ -48,7 +48,7 @@ class CacheQueryBuilder extends ExtendedQueryBuilder {
 	public function selectFileCache(?string $alias = null, bool $joinExtendedCache = true) {
 		$name = $alias ?: 'filecache';
 		$this->select("$name.fileid", 'storage', 'path', 'path_hash', "$name.parent", "$name.name", 'mimetype', 'mimepart', 'size', 'mtime',
-			'storage_mtime', 'encrypted', 'etag', "$name.permissions", 'checksum', 'unencrypted_size')
+			'storage_mtime', 'encrypted', "$name.etag", "$name.permissions", 'checksum', 'unencrypted_size')
 			->from('filecache', $name);
 
 		if ($joinExtendedCache) {


### PR DESCRIPTION
Fix etag ambiguous query

```json
{
  "level": 3,
  "user": "admin",
  "app": "webdav",
  "method": "REPORT",
  "url": "/remote.php/dav/files/admin/",
  "message": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'etag' in field list is ambiguous",
  "version": "31.0.0.5",
  "exception": {
    "Exception": "OC\\DB\\Exceptions\\DbalException",
    "Message": "An exception occurred while executing a query: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'etag' in field list is ambiguous",
    "Code": 1052,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/DB/ConnectionAdapter.php",
        "line": 53,
        "function": "wrap",
        "class": "OC\\DB\\Exceptions\\DbalException",
        "type": "::",
        "args": [
          {
            "__class__": "Doctrine\\DBAL\\Exception\\NonUniqueFieldNameException"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
        "line": 289,
        "function": "executeQuery",
        "class": "OC\\DB\\ConnectionAdapter",
        "type": "->",
        "args": [
          "SELECT `file`.`fileid`, `storage`, `path`, `path_hash`, `file`.`parent`, `file`.`name`, `mimetype`, `mimepart`, `size`, `mtime`, `storage_mtime`, `encrypted`, `etag`, `file`.`permissions`, `checksum`, `unencrypted_size`, `meta`.`json` AS `meta_json`, `meta`.`sync_token` AS `meta_sync_token` FROM `*PREFIX*filecache` `file` LEFT JOIN `*PREFIX*systemtag_object_mapping` `systemtagmap` ON (`file`.`fileid` = `systemtagmap`.`objectid`) AND (`systemtagmap`.`objecttype` = :dcValue1) LEFT JOIN `*PREFIX*files_metadata` `meta` ON `file`.`fileid` = `meta`.`file_id` LEFT JOIN `*PREFIX*systemtag` `systemtag` ON `systemtag`.`id` = `systemtagmap`.`systemtagid` WHERE (`systemtag`.`name` = :dcValue2) AND (`storage` = :dcValue3) AND ((`path` = :dcValue4) OR (`path` LIKE :dcValue5))",

```