### PR TITLE
fix(user_ldap): Pass `LDAP_ESCAPE_FILTER` for filters to be used with…

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1299,7 +1299,7 @@ class Access extends LDAPUtility {
 
 		do {
 			// Escape the filter before use to avoid issues with special characters
-			$filter = ldap_escape($filter, "", LDAP_ESCAPE_FILTER);
+			$filter = escapeFilterPart($filter);
 			$search = $this->executeSearch($filter, $base, $attr, $limitPerPage, $offset);
 			if ($search === false) {
 				return [];

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1298,6 +1298,8 @@ class Access extends LDAPUtility {
 		$iFoundItems = 0;
 
 		do {
+			// Escape the filter before use to avoid issues with special characters
+			$filter = ldap_escape($filter, "", LDAP_ESCAPE_FILTER);
 			$search = $this->executeSearch($filter, $base, $attr, $limitPerPage, $offset);
 			if ($search === false) {
 				return [];

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -1298,7 +1298,6 @@ class Access extends LDAPUtility {
 		$iFoundItems = 0;
 
 		do {
-			// Escape the filter before use to avoid issues with special characters
 			$filter = escapeFilterPart($filter);
 			$search = $this->executeSearch($filter, $base, $attr, $limitPerPage, $offset);
 			if ($search === false) {

--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -187,6 +187,8 @@ class LDAP implements ILDAPWrapper {
 			return true;
 		});
 		try {
+			// Escape the filter before use to avoid issues with special characters
+			$filter = ldap_escape($filter, "", LDAP_ESCAPE_FILTER);
 			$result = $this->invokeLDAPMethod('search', $link, $baseDN, $filter, $attr, $attrsOnly, $limit, -1, LDAP_DEREF_NEVER, $serverControls);
 
 			restore_error_handler();


### PR DESCRIPTION
… `ldap_search()`

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves:

https://help.nextcloud.com/t/attempt-for-paging-bad-search-filter/185970/2

## Summary

This step ensures that any special characters in the `$filter` (such as parentheses, asterisks, or backslashes) are properly escaped before performing the LDAP search.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
