### PR TITLE
fix: Wrap partial cache entry in CacheEntry

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -249,14 +249,14 @@ class Cache implements ICache {
 		$file = $this->normalize($file);
 
 		if (isset($this->partial[$file])) { //add any saved partial data
-			$data = array_merge($this->partial[$file], $data);
+			$data = array_merge($this->partial[$file]->getData(), $data);
 			unset($this->partial[$file]);
 		}
 
 		$requiredFields = ['size', 'mtime', 'mimetype'];
 		foreach ($requiredFields as $field) {
 			if (!isset($data[$field])) { //data not complete save as partial and return
-				$this->partial[$file] = $data;
+				$this->partial[$file] = new CacheEntry($data);
 				return -1;
 			}
 		}

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -8,6 +8,7 @@
 namespace Test\Files\Cache;
 
 use OC\Files\Cache\Cache;
+use OC\Files\Cache\CacheEntry;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -127,13 +128,13 @@ class CacheTest extends \Test\TestCase {
 		$file1 = 'foo';
 
 		$this->cache->put($file1, ['size' => 10]);
-		$this->assertEquals(['size' => 10], $this->cache->get($file1));
+		$this->assertEquals(new CacheEntry(['size' => 10]), $this->cache->get($file1));
 
 		$this->cache->put($file1, ['mtime' => 15]);
-		$this->assertEquals(['size' => 10, 'mtime' => 15], $this->cache->get($file1));
+		$this->assertEquals(new CacheEntry(['size' => 10, 'mtime' => 15]), $this->cache->get($file1));
 
 		$this->cache->put($file1, ['size' => 12]);
-		$this->assertEquals(['size' => 12, 'mtime' => 15], $this->cache->get($file1));
+		$this->assertEquals(new CacheEntry(['size' => 12, 'mtime' => 15]), $this->cache->get($file1));
 	}
 
 	/**


### PR DESCRIPTION
Because it is returned here: https://github.com/nextcloud/server/blob/7b7d07c5750583ab3a7b29112af475f5c8891143/lib/private/Files/Cache/Cache.php#L136-L137

And some implementation got stricter: https://github.com/nextcloud/groupfolders/blob/df95bf6ba807da5171de91108879b6d8aa9f3611/lib/Mount/RootEntryCache.php#L23-L28
