### PR TITLE
fix(SetupChecks): Pass webfinger if the handler returns 400 too

### DIFF
--- a/apps/settings/lib/SetupChecks/WellKnownUrls.php
+++ b/apps/settings/lib/SetupChecks/WellKnownUrls.php
@@ -45,7 +45,7 @@ class WellKnownUrls implements ISetupCheck {
 		}
 
 		$urls = [
-			['get', '/.well-known/webfinger', [200, 404], true],
+			['get', '/.well-known/webfinger', [200, 400, 404], true], // 400 indicates a handler is installed but (correctly) failed because we didn't specify a resource
 			['get', '/.well-known/nodeinfo', [200, 404], true],
 			['propfind', '/.well-known/caldav', [207], false],
 			['propfind', '/.well-known/carddav', [207], false],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: nextcloud/social#864
* Fixes nextcloud/social#1604

## Summary

When running a check against `/.well-known/webfinger` in a stock install the checks are fine, but when an actual `webfinger` handler is installed (like the `social` app) the return code is going to be 400 per the spec[^1] since the setup check isn't providing a `?resource` value (and we're not going to). 

Semi-related: nextcloud/social#1951 (because we were returning a 500 error since our check doesn't pass a `resource` value and now once merged that'll return a 400 as per the spec; though our checks obviously wouldn't have passed either way).

[^1]: https://datatracker.ietf.org/doc/html/rfc7033#section-4.2

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
