### PR TITLE
fix: invalid usage of IQueryBuilder::createNamedParameter()

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3569,9 +3569,9 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		// delete all links that match object uid's
 		$cmd = $this->db->getQueryBuilder();
 		$cmd->delete($this->dbObjectInvitationsTable)
-			->where($cmd->expr()->in('uid', $cmd->createNamedParameter('uids'), IQueryBuilder::PARAM_STR_ARRAY));
-		foreach (array_chunk($allIds, 1000) as $chunckIds) {
-			$cmd->setParameter('uids', $chunckIds, IQueryBuilder::PARAM_INT_ARRAY);
+			->where($cmd->expr()->in('uid', $cmd->createParameter('uids'), IQueryBuilder::PARAM_STR_ARRAY));
+		foreach (array_chunk($allIds, 1000) as $chunkIds) {
+			$cmd->setParameter('uids', $chunkIds, IQueryBuilder::PARAM_INT_ARRAY);
 			$cmd->executeStatement();
 		}
 	}

--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -3571,7 +3571,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 		$cmd->delete($this->dbObjectInvitationsTable)
 			->where($cmd->expr()->in('uid', $cmd->createParameter('uids'), IQueryBuilder::PARAM_STR_ARRAY));
 		foreach (array_chunk($allIds, 1000) as $chunkIds) {
-			$cmd->setParameter('uids', $chunkIds, IQueryBuilder::PARAM_INT_ARRAY);
+			$cmd->setParameter('uids', $chunkIds, IQueryBuilder::PARAM_STR_ARRAY);
 			$cmd->executeStatement();
 		}
 	}
@@ -3588,7 +3588,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 	protected function purgeObjectInvitations(string $eventId): void {
 		$cmd = $this->db->getQueryBuilder();
 		$cmd->delete($this->dbObjectInvitationsTable)
-			->where($cmd->expr()->eq('uid', $cmd->createNamedParameter($eventId)));
+			->where($cmd->expr()->eq('uid', $cmd->createNamedParameter($eventId, IQueryBuilder::PARAM_STR), IQueryBuilder::PARAM_STR));
 		$cmd->executeStatement();
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Followup to: #47832 

## Summary

I'm sorry, I missed some issues during my code review.

1. Creating a parameter without a value is done via `IQueryBuilder::createParameter()`.
2. Fixed a small typo.
3. Fixed inconsistent and missing types for parameters to improve compatibility with oci.

See also https://github.com/nextcloud/server/pull/49428#discussion_r1853896702

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
