### PR TITLE
fix(CalDav): add support for Microsoft time zones

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -110,6 +110,7 @@ return array(
     'OCA\\DAV\\CalDAV\\Sharing\\Backend' => $baseDir . '/../lib/CalDAV/Sharing/Backend.php',
     'OCA\\DAV\\CalDAV\\Sharing\\Service' => $baseDir . '/../lib/CalDAV/Sharing/Service.php',
     'OCA\\DAV\\CalDAV\\Status\\StatusService' => $baseDir . '/../lib/CalDAV/Status/StatusService.php',
+    'OCA\\DAV\\CalDAV\\TimeZoneFactory' => $baseDir . '/../lib/CalDAV/TimeZoneFactory.php',
     'OCA\\DAV\\CalDAV\\TimezoneService' => $baseDir . '/../lib/CalDAV/TimezoneService.php',
     'OCA\\DAV\\CalDAV\\TipBroker' => $baseDir . '/../lib/CalDAV/TipBroker.php',
     'OCA\\DAV\\CalDAV\\Trashbin\\DeletedCalendarObject' => $baseDir . '/../lib/CalDAV/Trashbin/DeletedCalendarObject.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -125,6 +125,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CalDAV\\Sharing\\Backend' => __DIR__ . '/..' . '/../lib/CalDAV/Sharing/Backend.php',
         'OCA\\DAV\\CalDAV\\Sharing\\Service' => __DIR__ . '/..' . '/../lib/CalDAV/Sharing/Service.php',
         'OCA\\DAV\\CalDAV\\Status\\StatusService' => __DIR__ . '/..' . '/../lib/CalDAV/Status/StatusService.php',
+        'OCA\\DAV\\CalDAV\\TimeZoneFactory' => __DIR__ . '/..' . '/../lib/CalDAV/TimeZoneFactory.php',
         'OCA\\DAV\\CalDAV\\TimezoneService' => __DIR__ . '/..' . '/../lib/CalDAV/TimezoneService.php',
         'OCA\\DAV\\CalDAV\\TipBroker' => __DIR__ . '/..' . '/../lib/CalDAV/TipBroker.php',
         'OCA\\DAV\\CalDAV\\Trashbin\\DeletedCalendarObject' => __DIR__ . '/..' . '/../lib/CalDAV/Trashbin/DeletedCalendarObject.php',

--- a/apps/dav/lib/CalDAV/EventReader.php
+++ b/apps/dav/lib/CalDAV/EventReader.php
@@ -72,6 +72,8 @@ class EventReader {
 	 */
 	public function __construct(VCalendar|VEvent|array|string $input, ?string $uid = null, ?DateTimeZone $timeZone = null) {
 
+		$timeZoneFactory = new TimeZoneFactory();
+
 		// evaluate if the input is a string and convert it to and vobject if required
 		if (is_string($input)) {
 			$input = Reader::read($input);
@@ -94,7 +96,7 @@ class EventReader {
 			}
 			// extract calendar timezone
 			if (isset($input->VTIMEZONE) && isset($input->VTIMEZONE->TZID)) {
-				$calendarTimeZone = new DateTimeZone($input->VTIMEZONE->TZID->getValue());
+				$calendarTimeZone = $timeZoneFactory->fromName($input->VTIMEZONE->TZID->getValue());
 			}
 		}
 		// evaluate if input is a collection of event vobjects
@@ -121,15 +123,15 @@ class EventReader {
 			$this->baseEvent = array_shift($events);
 		}
 
-		// determain the event starting time zone
+		// determine the event starting time zone
 		// we require this to align all other dates times
-		// evaluate if timezone paramater was used (treat this as a override)
+		// evaluate if timezone parameter was used (treat this as a override)
 		if ($timeZone !== null) {
 			$this->baseEventStartTimeZone = $timeZone;
 		}
 		// evaluate if event start date has a timezone parameter
 		elseif (isset($this->baseEvent->DTSTART->parameters['TZID'])) {
-			$this->baseEventStartTimeZone = new DateTimeZone($this->baseEvent->DTSTART->parameters['TZID']->getValue());
+			$this->baseEventStartTimeZone = $timeZoneFactory->fromName($this->baseEvent->DTSTART->parameters['TZID']->getValue()) ?? new DateTimeZone('UTC');
 		}
 		// evaluate if event parent calendar has a time zone
 		elseif (isset($calendarTimeZone)) {
@@ -140,15 +142,15 @@ class EventReader {
 			$this->baseEventStartTimeZone = new DateTimeZone('UTC');
 		}
 
-		// determain the event end time zone
+		// determine the event end time zone
 		// we require this to align all other dates and times
-		// evaluate if timezone paramater was used (treat this as a override)
+		// evaluate if timezone parameter was used (treat this as a override)
 		if ($timeZone !== null) {
 			$this->baseEventEndTimeZone = $timeZone;
 		}
 		// evaluate if event end date has a timezone parameter
 		elseif (isset($this->baseEvent->DTEND->parameters['TZID'])) {
-			$this->baseEventEndTimeZone = new DateTimeZone($this->baseEvent->DTEND->parameters['TZID']->getValue());
+			$this->baseEventEndTimeZone = $timeZoneFactory->fromName($this->baseEvent->DTEND->parameters['TZID']->getValue()) ?? new DateTimeZone('UTC');
 		}
 		// evaluate if event parent calendar has a time zone
 		elseif (isset($calendarTimeZone)) {

--- a/apps/dav/lib/CalDAV/TimeZoneFactory.php
+++ b/apps/dav/lib/CalDAV/TimeZoneFactory.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\CalDAV;
+
+use DateTimeZone;
+
+/**
+ * Class to generate DateTimeZone object with automated Microsoft and IANA handling
+ *
+ * @since 31.0.0
+ */
+class TimeZoneFactory {
+
+	/**
+	 * conversion table of Microsoft time zones to IANA time zones
+	 *
+	 * @var array<string,string> MS2IANA
+	 */
+	private const MS2IANA = [
+		'AUS Central Standard Time' => 'Australia/Darwin',
+		'Aus Central W. Standard Time' => 'Australia/Eucla',
+		'AUS Eastern Standard Time' => 'Australia/Sydney',
+		'Afghanistan Standard Time' => 'Asia/Kabul',
+		'Alaskan Standard Time' => 'America/Anchorage',
+		'Aleutian Standard Time' => 'America/Adak',
+		'Altai Standard Time' => 'Asia/Barnaul',
+		'Arab Standard Time' => 'Asia/Riyadh',
+		'Arabian Standard Time' => 'Asia/Dubai',
+		'Arabic Standard Time' => 'Asia/Baghdad',
+		'Argentina Standard Time' => 'America/Buenos_Aires',
+		'Astrakhan Standard Time' => 'Europe/Astrakhan',
+		'Atlantic Standard Time' => 'America/Halifax',
+		'Azerbaijan Standard Time' => 'Asia/Baku',
+		'Azores Standard Time' => 'Atlantic/Azores',
+		'Bahia Standard Time' => 'America/Bahia',
+		'Bangladesh Standard Time' => 'Asia/Dhaka',
+		'Belarus Standard Time' => 'Europe/Minsk',
+		'Bougainville Standard Time' => 'Pacific/Bougainville',
+		'Cape Verde Standard Time' => 'Atlantic/Cape_Verde',
+		'Canada Central Standard Time' => 'America/Regina',
+		'Caucasus Standard Time' => 'Asia/Yerevan',
+		'Cen. Australia Standard Time' => 'Australia/Adelaide',
+		'Central America Standard Time' => 'America/Guatemala',
+		'Central Asia Standard Time' => 'Asia/Almaty',
+		'Central Brazilian Standard Time' => 'America/Cuiaba',
+		'Central Europe Standard Time' => 'Europe/Budapest',
+		'Central European Standard Time' => 'Europe/Warsaw',
+		'Central Pacific Standard Time' => 'Pacific/Guadalcanal',
+		'Central Standard Time' => 'America/Chicago',
+		'Central Standard Time (Mexico)' => 'America/Mexico_City',
+		'Chatham Islands Standard Time' => 'Pacific/Chatham',
+		'China Standard Time' => 'Asia/Shanghai',
+		'Coordinated Universal Time' => 'UTC',
+		'Cuba Standard Time' => 'America/Havana',
+		'Dateline Standard Time' => 'Etc/GMT+12',
+		'E. Africa Standard Time' => 'Africa/Nairobi',
+		'E. Australia Standard Time' => 'Australia/Brisbane',
+		'E. Europe Standard Time' => 'Europe/Chisinau',
+		'E. South America Standard Time' => 'America/Sao_Paulo',
+		'Easter Island Standard Time' => 'Pacific/Easter',
+		'Eastern Standard Time' => 'America/Toronto',
+		'Eastern Standard Time (Mexico)' => 'America/Cancun',
+		'Egypt Standard Time' => 'Africa/Cairo',
+		'Ekaterinburg Standard Time' => 'Asia/Yekaterinburg',
+		'FLE Standard Time' => 'Europe/Kiev',
+		'Fiji Standard Time' => 'Pacific/Fiji',
+		'GMT Standard Time' => 'Europe/London',
+		'GTB Standard Time' => 'Europe/Bucharest',
+		'Georgian Standard Time' => 'Asia/Tbilisi',
+		'Greenland Standard Time' => 'America/Godthab',
+		'Greenland (Danmarkshavn)' => 'America/Godthab',
+		'Greenwich Standard Time' => 'Atlantic/Reykjavik',
+		'Haiti Standard Time' => 'America/Port-au-Prince',
+		'Hawaiian Standard Time' => 'Pacific/Honolulu',
+		'India Standard Time' => 'Asia/Calcutta',
+		'Iran Standard Time' => 'Asia/Tehran',
+		'Israel Standard Time' => 'Asia/Jerusalem',
+		'Jordan Standard Time' => 'Asia/Amman',
+		'Kaliningrad Standard Time' => 'Europe/Kaliningrad',
+		'Kamchatka Standard Time' => 'Asia/Kamchatka',
+		'Korea Standard Time' => 'Asia/Seoul',
+		'Libya Standard Time' => 'Africa/Tripoli',
+		'Line Islands Standard Time' => 'Pacific/Kiritimati',
+		'Lord Howe Standard Time' => 'Australia/Lord_Howe',
+		'Magadan Standard Time' => 'Asia/Magadan',
+		'Magallanes Standard Time' => 'America/Punta_Arenas',
+		'Malaysia Standard Time' => 'Asia/Kuala_Lumpur',
+		'Marquesas Standard Time' => 'Pacific/Marquesas',
+		'Mauritius Standard Time' => 'Indian/Mauritius',
+		'Mid-Atlantic Standard Time' => 'Atlantic/South_Georgia',
+		'Middle East Standard Time' => 'Asia/Beirut',
+		'Montevideo Standard Time' => 'America/Montevideo',
+		'Morocco Standard Time' => 'Africa/Casablanca',
+		'Mountain Standard Time' => 'America/Denver',
+		'Mountain Standard Time (Mexico)' => 'America/Chihuahua',
+		'Myanmar Standard Time' => 'Asia/Rangoon',
+		'N. Central Asia Standard Time' => 'Asia/Novosibirsk',
+		'Namibia Standard Time' => 'Africa/Windhoek',
+		'Nepal Standard Time' => 'Asia/Katmandu',
+		'New Zealand Standard Time' => 'Pacific/Auckland',
+		'Newfoundland Standard Time' => 'America/St_Johns',
+		'Norfolk Standard Time' => 'Pacific/Norfolk',
+		'North Asia East Standard Time' => 'Asia/Irkutsk',
+		'North Asia Standard Time' => 'Asia/Krasnoyarsk',
+		'North Korea Standard Time' => 'Asia/Pyongyang',
+		'Omsk Standard Time' => 'Asia/Omsk',
+		'Pacific SA Standard Time' => 'America/Santiago',
+		'Pacific Standard Time' => 'America/Los_Angeles',
+		'Pacific Standard Time (Mexico)' => 'America/Tijuana',
+		'Pakistan Standard Time' => 'Asia/Karachi',
+		'Paraguay Standard Time' => 'America/Asuncion',
+		'Qyzylorda Standard Time' => 'Asia/Qyzylorda',
+		'Romance Standard Time' => 'Europe/Paris',
+		'Russian Standard Time' => 'Europe/Moscow',
+		'Russia Time Zone 10' => 'Asia/Srednekolymsk',
+		'Russia Time Zone 3' => 'Europe/Samara',
+		'SA Eastern Standard Time' => 'America/Cayenne',
+		'SA Pacific Standard Time' => 'America/Bogota',
+		'SA Western Standard Time' => 'America/La_Paz',
+		'SE Asia Standard Time' => 'Asia/Bangkok',
+		'Saint Pierre Standard Time' => 'America/Miquelon',
+		'Sakhalin Standard Time' => 'Asia/Sakhalin',
+		'Samoa Standard Time' => 'Pacific/Apia',
+		'Sao Tome Standard Time' => 'Africa/Sao_Tome',
+		'Saratov Standard Time' => 'Europe/Saratov',
+		'Singapore Standard Time' => 'Asia/Singapore',
+		'South Africa Standard Time' => 'Africa/Johannesburg',
+		'South Sudan Standard Time' => 'Africa/Juba',
+		'Sri Lanka Standard Time' => 'Asia/Colombo',
+		'Sudan Standard Time' => 'Africa/Khartoum',
+		'Syria Standard Time' => 'Asia/Damascus',
+		'Taipei Standard Time' => 'Asia/Taipei',
+		'Tasmania Standard Time' => 'Australia/Hobart',
+		'Tocantins Standard Time' => 'America/Araguaina',
+		'Tokyo Standard Time' => 'Asia/Tokyo',
+		'Tomsk Standard Time' => 'Asia/Tomsk',
+		'Tonga Standard Time' => 'Pacific/Tongatapu',
+		'Transbaikal Standard Time' => 'Asia/Chita',
+		'Turkey Standard Time' => 'Europe/Istanbul',
+		'Turks And Caicos Standard Time' => 'America/Grand_Turk',
+		'US Eastern Standard Time' => 'America/Indianapolis',
+		'US Mountain Standard Time' => 'America/Phoenix',
+		'UTC' => 'Etc/GMT',
+		'UTC+13' => 'Etc/GMT-13',
+		'UTC+12' => 'Etc/GMT-12',
+		'UTC-02' => 'Etc/GMT+2',
+		'UTC-09' => 'Etc/GMT+9',
+		'UTC-11' => 'Etc/GMT+11',
+		'Ulaanbaatar Standard Time' => 'Asia/Ulaanbaatar',
+		'Venezuela Standard Time' => 'America/Caracas',
+		'Vladivostok Standard Time' => 'Asia/Vladivostok',
+		'Volgograd Standard Time' => 'Europe/Volgograd',
+		'W. Australia Standard Time' => 'Australia/Perth',
+		'W. Central Africa Standard Time' => 'Africa/Lagos',
+		'W. Europe Standard Time' => 'Europe/Berlin',
+		'W. Mongolia Standard Time' => 'Asia/Hovd',
+		'West Asia Standard Time' => 'Asia/Tashkent',
+		'West Bank Standard Time' => 'Asia/Hebron',
+		'West Pacific Standard Time' => 'Pacific/Port_Moresby',
+		'Yakutsk Standard Time' => 'Asia/Yakutsk',
+		'Yukon Standard Time' => 'America/Whitehorse',
+	];
+
+	/**
+	 * Determines if given time zone name is a Microsoft time zone
+	 *
+	 * @since 31.0.0
+	 *
+	 * @param string $name time zone name
+	 *
+	 * @return bool
+	 */
+	public static function isMS(string $name): bool {
+		return isset(self::MS2IANA[$name]);
+	}
+
+	/**
+	 * Converts Microsoft time zone name to IANA time zone name
+	 *
+	 * @since 31.0.0
+	 *
+	 * @param string $name microsoft time zone
+	 *
+	 * @return string|null valid IANA time zone name on success, or null on failure
+	 */
+	public static function toIANA(string $name): ?string {
+		return isset(self::MS2IANA[$name]) ? self::MS2IANA[$name] : null;
+	}
+
+	/**
+	 * Generates DateTimeZone object for given time zone name
+	 *
+	 * @since 31.0.0
+	 *
+	 * @param string $name time zone name
+	 *
+	 * @return DateTimeZone|null
+	 */
+	public function fromName(string $name): ?DateTimeZone {
+		// if zone name is MS convert to IANA, otherwise just assume the zone is IANA
+		$zone = @timezone_open(self::toIANA($name) ?? $name);
+		return ($zone instanceof DateTimeZone) ? $zone : null;
+	}
+}

--- a/apps/dav/lib/CalDAV/TimeZoneFactory.php
+++ b/apps/dav/lib/CalDAV/TimeZoneFactory.php
@@ -79,7 +79,7 @@ class TimeZoneFactory {
 		'Greenwich Standard Time' => 'Atlantic/Reykjavik',
 		'Haiti Standard Time' => 'America/Port-au-Prince',
 		'Hawaiian Standard Time' => 'Pacific/Honolulu',
-		'India Standard Time' => 'Asia/Calcutta',
+		'India Standard Time' => 'Asia/Kolkata',
 		'Iran Standard Time' => 'Asia/Tehran',
 		'Israel Standard Time' => 'Asia/Jerusalem',
 		'Jordan Standard Time' => 'Asia/Amman',
@@ -103,7 +103,7 @@ class TimeZoneFactory {
 		'Myanmar Standard Time' => 'Asia/Rangoon',
 		'N. Central Asia Standard Time' => 'Asia/Novosibirsk',
 		'Namibia Standard Time' => 'Africa/Windhoek',
-		'Nepal Standard Time' => 'Asia/Katmandu',
+		'Nepal Standard Time' => 'Asia/Kathmandu',
 		'New Zealand Standard Time' => 'Pacific/Auckland',
 		'Newfoundland Standard Time' => 'America/St_Johns',
 		'Norfolk Standard Time' => 'Pacific/Norfolk',
@@ -164,8 +164,10 @@ class TimeZoneFactory {
 		'West Asia Standard Time' => 'Asia/Tashkent',
 		'West Bank Standard Time' => 'Asia/Hebron',
 		'West Pacific Standard Time' => 'Pacific/Port_Moresby',
+		'West Samoa Standard Time' => 'Pacific/Apia',
 		'Yakutsk Standard Time' => 'Asia/Yakutsk',
 		'Yukon Standard Time' => 'America/Whitehorse',
+		'Yekaterinburg Standard Time' => 'Asia/Yekaterinburg',
 	];
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/EventReaderTest.php
+++ b/apps/dav/tests/unit/CalDAV/EventReaderTest.php
@@ -16,18 +16,13 @@ use Test\TestCase;
 
 class EventReaderTest extends TestCase {
 
-	/** @var VCalendar */
-	private $vCalendar1a;
-	/** @var VCalendar */
-	private $vCalendar1b;
-	/** @var VCalendar */
-	private $vCalendar1c;
-	/** @var VCalendar */
-	private $vCalendar1d;
-	/** @var VCalendar */
-	private $vCalendar2;
-	/** @var VCalendar */
-	private $vCalendar3;
+	private VCalendar $vCalendar1a;
+	private VCalendar $vCalendar1b;
+	private VCalendar $vCalendar1c;
+	private VCalendar $vCalendar1d;
+	private VCalendar $vCalendar1e;
+	private VCalendar $vCalendar2;
+	private VCalendar $vCalendar3;
 	
 	protected function setUp(): void {
 
@@ -39,7 +34,7 @@ class EventReaderTest extends TestCase {
 		$vEvent->UID->setValue('96a0e6b1-d886-4a55-a60d-152b31401dcc');
 		$vEvent->add('DTSTART', '20240701T080000', ['TZID' => 'America/Toronto']);
 		$vEvent->add('DTEND', '20240701T090000', ['TZID' => 'America/Toronto']);
-		$vEvent->add('SUMMARY', 'Test Recurrance Event');
+		$vEvent->add('SUMMARY', 'Test Recurrence Event');
 		$vEvent->add('ORGANIZER', 'mailto:organizer@testing.com', ['CN' => 'Organizer']);
 		$vEvent->add('ATTENDEE', 'mailto:attendee1@testing.com', [
 			'CN' => 'Attendee One',
@@ -55,7 +50,7 @@ class EventReaderTest extends TestCase {
 		$vEvent->UID->setValue('96a0e6b1-d886-4a55-a60d-152b31401dcc');
 		$vEvent->add('DTSTART', '20240701T080000', ['TZID' => 'America/Toronto']);
 		$vEvent->add('DTEND', '20240701T090000', ['TZID' => 'America/Vancouver']);
-		$vEvent->add('SUMMARY', 'Test Recurrance Event');
+		$vEvent->add('SUMMARY', 'Test Recurrence Event');
 		$vEvent->add('ORGANIZER', 'mailto:organizer@testing.com', ['CN' => 'Organizer']);
 		$vEvent->add('ATTENDEE', 'mailto:attendee1@testing.com', [
 			'CN' => 'Attendee One',
@@ -75,7 +70,7 @@ class EventReaderTest extends TestCase {
 		$vEvent->UID->setValue('96a0e6b1-d886-4a55-a60d-152b31401dcc');
 		$vEvent->add('DTSTART', '20240701T080000');
 		$vEvent->add('DTEND', '20240701T090000');
-		$vEvent->add('SUMMARY', 'Test Recurrance Event');
+		$vEvent->add('SUMMARY', 'Test Recurrence Event');
 		$vEvent->add('ORGANIZER', 'mailto:organizer@testing.com', ['CN' => 'Organizer']);
 		$vEvent->add('ATTENDEE', 'mailto:attendee1@testing.com', [
 			'CN' => 'Attendee One',
@@ -91,7 +86,23 @@ class EventReaderTest extends TestCase {
 		$vEvent->UID->setValue('96a0e6b1-d886-4a55-a60d-152b31401dcc');
 		$vEvent->add('DTSTART', '20240701T080000');
 		$vEvent->add('DTEND', '20240701T090000');
-		$vEvent->add('SUMMARY', 'Test Recurrance Event');
+		$vEvent->add('SUMMARY', 'Test Recurrence Event');
+		$vEvent->add('ORGANIZER', 'mailto:organizer@testing.com', ['CN' => 'Organizer']);
+		$vEvent->add('ATTENDEE', 'mailto:attendee1@testing.com', [
+			'CN' => 'Attendee One',
+			'CUTYPE' => 'INDIVIDUAL',
+			'PARTSTAT' => 'NEEDS-ACTION',
+			'ROLE' => 'REQ-PARTICIPANT',
+			'RSVP' => 'TRUE'
+		]);
+
+		// construct calendar with a 1 hour event and Microsoft time zone
+		$this->vCalendar1e = new VCalendar();
+		$vEvent = $this->vCalendar1e->add('VEVENT', []);
+		$vEvent->UID->setValue('96a0e6b1-d886-4a55-a60d-152b31401dcc');
+		$vEvent->add('DTSTART', '20240701T080000', ['TZID' => 'Eastern Standard Time']);
+		$vEvent->add('DTEND', '20240701T090000', ['TZID' => 'Eastern Standard Time']);
+		$vEvent->add('SUMMARY', 'Test Recurrence Event');
 		$vEvent->add('ORGANIZER', 'mailto:organizer@testing.com', ['CN' => 'Organizer']);
 		$vEvent->add('ATTENDEE', 'mailto:attendee1@testing.com', [
 			'CN' => 'Attendee One',
@@ -111,7 +122,7 @@ class EventReaderTest extends TestCase {
 		$vEvent->UID->setValue('96a0e6b1-d886-4a55-a60d-152b31401dcc');
 		$vEvent->add('DTSTART', '20240701');
 		$vEvent->add('DTEND', '20240702');
-		$vEvent->add('SUMMARY', 'Test Recurrance Event');
+		$vEvent->add('SUMMARY', 'Test Recurrence Event');
 		$vEvent->add('ORGANIZER', 'mailto:organizer@testing.com', ['CN' => 'Organizer']);
 		$vEvent->add('ATTENDEE', 'mailto:attendee1@testing.com', [
 			'CN' => 'Attendee One',
@@ -131,7 +142,7 @@ class EventReaderTest extends TestCase {
 		$vEvent->UID->setValue('96a0e6b1-d886-4a55-a60d-152b31401dcc');
 		$vEvent->add('DTSTART', '20240701');
 		$vEvent->add('DTEND', '20240706');
-		$vEvent->add('SUMMARY', 'Test Recurrance Event');
+		$vEvent->add('SUMMARY', 'Test Recurrence Event');
 		$vEvent->add('ORGANIZER', 'mailto:organizer@testing.com', ['CN' => 'Organizer']);
 		$vEvent->add('ATTENDEE', 'mailto:attendee1@testing.com', [
 			'CN' => 'Attendee One',
@@ -195,6 +206,12 @@ class EventReaderTest extends TestCase {
 		$er = new EventReader($this->vCalendar1d, $this->vCalendar1d->VEVENT[0]->UID->getValue());
 		// test set by constructor
 		$this->assertEquals((new \DateTime('20240701T080000', (new DateTimeZone('UTC')))), $er->startDateTime());
+
+		/** test day part event with microsoft time zone */
+		// construct event reader
+		$er = new EventReader($this->vCalendar1e, $this->vCalendar1e->VEVENT[0]->UID->getValue());
+		// test set by constructor
+		$this->assertEquals((new \DateTime('20240701T080000', (new DateTimeZone('America/Toronto')))), $er->startDateTime());
 		
 		/** test full day event */
 		// construct event reader
@@ -236,6 +253,12 @@ class EventReaderTest extends TestCase {
 		// test set by constructor
 		$this->assertEquals((new DateTimeZone('UTC')), $er->startTimeZone());
 
+		/** test day part event with microsoft time zone */
+		// construct event reader
+		$er = new EventReader($this->vCalendar1e, $this->vCalendar1e->VEVENT[0]->UID->getValue());
+		// test set by constructor
+		$this->assertEquals((new DateTimeZone('America/Toronto')), $er->startTimeZone());
+
 		/** test full day event */
 		// construct event reader
 		$er = new EventReader($this->vCalendar2, $this->vCalendar2->VEVENT[0]->UID->getValue());
@@ -275,6 +298,12 @@ class EventReaderTest extends TestCase {
 		$er = new EventReader($this->vCalendar1d, $this->vCalendar1d->VEVENT[0]->UID->getValue());
 		// test set by constructor
 		$this->assertEquals((new \DateTime('20240701T090000', (new DateTimeZone('UTC')))), $er->endDateTime());
+
+		/** test day part event with microsoft time zone */
+		// construct event reader
+		$er = new EventReader($this->vCalendar1e, $this->vCalendar1e->VEVENT[0]->UID->getValue());
+		// test set by constructor
+		$this->assertEquals((new \DateTime('20240701T090000', (new DateTimeZone('America/Toronto')))), $er->endDateTime());
 		
 		/** test full day event */
 		// construct event reader
@@ -315,6 +344,12 @@ class EventReaderTest extends TestCase {
 		$er = new EventReader($this->vCalendar1d, $this->vCalendar1d->VEVENT[0]->UID->getValue());
 		// test set by constructor
 		$this->assertEquals((new DateTimeZone('UTC')), $er->endTimeZone());
+
+		/** test day part event with microsoft time zone */
+		// construct event reader
+		$er = new EventReader($this->vCalendar1e, $this->vCalendar1e->VEVENT[0]->UID->getValue());
+		// test set by constructor
+		$this->assertEquals((new DateTimeZone('America/Toronto')), $er->endTimeZone());
 
 		/** test full day event */
 		// construct event reader

--- a/apps/dav/tests/unit/CalDAV/TimeZoneFactoryTest.php
+++ b/apps/dav/tests/unit/CalDAV/TimeZoneFactoryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Tests\unit\CalDAV;
+
+use DateTimeZone;
+use OCA\DAV\CalDAV\TimeZoneFactory;
+use Test\TestCase;
+
+class TimeZoneFactoryTest extends TestCase {
+
+	private TimeZoneFactory $factory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->factory = new TimeZoneFactory();
+	}
+
+	public function testIsMS(): void {
+		// test Microsoft time zone
+		$this->assertTrue(TimeZoneFactory::isMS('Eastern Standard Time'));
+		// test IANA time zone
+		$this->assertFalse(TimeZoneFactory::isMS('America/Toronto'));
+		// test Fake time zone
+		$this->assertFalse(TimeZoneFactory::isMS('Fake Eastern Time'));
+	}
+
+	public function testToIana(): void {
+		// test Microsoft time zone
+		$this->assertEquals('America/Toronto', TimeZoneFactory::toIANA('Eastern Standard Time'));
+		// test IANA time zone
+		$this->assertEquals(null, TimeZoneFactory::toIANA('America/Toronto'));
+		// test Fake time zone
+		$this->assertEquals(null, TimeZoneFactory::toIANA('Fake Eastern Time'));
+	}
+
+	public function testFromName(): void {
+		// test Microsoft time zone
+		$this->assertEquals(new DateTimeZone('America/Toronto'), $this->factory->fromName('Eastern Standard Time'));
+		// test IANA time zone
+		$this->assertEquals(new DateTimeZone('America/Toronto'), $this->factory->fromName('America/Toronto'));
+		// test Fake time zone
+		$this->assertEquals(null, $this->factory->fromName('Fake Eastern Time'));
+	}
+
+}


### PR DESCRIPTION
* Resolves: #https://github.com/nextcloud/server/issues/48079

## Summary
- Adds handling of Microsoft time zones, when generating iMip emails
- Corrects some spelling

## Checklist
- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
