### PR TITLE
fix(Files): use prepare statement for path_hash in propagator

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -80,7 +80,7 @@ class Propagator implements IPropagator {
 		$builder->update('filecache')
 			->set('mtime', $builder->func()->greatest('mtime', $builder->createNamedParameter((int)$time, IQueryBuilder::PARAM_INT)))
 			->where($builder->expr()->eq('storage', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
-			->andWhere($builder->expr()->in('path_hash', $hashParams));
+			->andWhere($builder->expr()->in('path_hash', $builder->createNamedParameter($hashParams, IQueryBuilder::PARAM_STR_ARRAY)));
 		if (!$this->storage->instanceOfStorage(IReliableEtagStorage::class)) {
 			$builder->set('etag', $builder->createNamedParameter($etag, IQueryBuilder::PARAM_STR));
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The other day I had to analyze SQL queries. And in the log I found entries like:

```sql
UPDATE "oc_filecache" SET "mtime" = GREATEST("mtime", $1), "etag" = $2 
WHERE ("storage" = $3) 
    AND ("path_hash" IN ('0123456789abcdef0123456789abcdef', '123456789abcdef0123456789abcdef0', '23456789abcdef0123456789abcdef01', '3456789abcdef0123456789abcdef012', '456789abcdef0123456789abcdef0123', '56789abcdef0123456789abcdef01234', '6789abcdef0123456789abcdef012345', '789abcdef0123456789abcdef0123456')) 
```

As you see, some parameters where having placeholders (originating from use of prepared statements) while the IN list had not. So it was not possible to simply sum up this query, because it contained differing values.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
