### PR TITLE
fix: throw correct exception type when we can't verify if an s3 bucket exists

### DIFF
--- a/.github/workflows/files-external-smb-kerberos.yml
+++ b/.github/workflows/files-external-smb-kerberos.yml
@@ -53,6 +53,12 @@ jobs:
           repository: nextcloud/user_saml
           path: apps/user_saml
 
+      - name: Install user_saml
+        run: |
+          cd apps/user_saml
+          composer i
+          cd ../..
+
       - name: Pull images
         run: |
           docker pull ghcr.io/icewind1991/samba-krb-test-dc

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -13,6 +13,7 @@ use Aws\S3\Exception\S3Exception;
 use Aws\S3\S3Client;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\RejectedPromise;
+use OCP\Files\StorageNotAvailableException;
 use OCP\ICertificateManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
@@ -132,7 +133,7 @@ trait S3ConnectionTrait {
 				try {
 					$logger->info('Bucket "' . $this->bucket . '" does not exist - creating it.', ['app' => 'objectstore']);
 					if (!$this->connection::isBucketDnsCompatible($this->bucket)) {
-						throw new \Exception('The bucket will not be created because the name is not dns compatible, please correct it: ' . $this->bucket);
+						throw new StorageNotAvailableException('The bucket will not be created because the name is not dns compatible, please correct it: ' . $this->bucket);
 					}
 					$this->connection->createBucket(['Bucket' => $this->bucket]);
 					$this->testTimeout();
@@ -142,17 +143,17 @@ trait S3ConnectionTrait {
 						'app' => 'objectstore',
 					]);
 					if ($e->getAwsErrorCode() !== 'BucketAlreadyOwnedByYou') {
-						throw new \Exception('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
+						throw new StorageNotAvailableException('Creation of bucket "' . $this->bucket . '" failed. ' . $e->getMessage());
 					}
 				}
 			}
-	
+
 			// google cloud's s3 compatibility doesn't like the EncodingType parameter
 			if (strpos($base_url, 'storage.googleapis.com')) {
 				$this->connection->getHandlerList()->remove('s3.auto_encode');
 			}
 		} catch (S3Exception $e) {
-			throw new \Exception('S3 service is unable to handle request: ' . $e->getMessage());
+			throw new StorageNotAvailableException('S3 service is unable to handle request: ' . $e->getMessage());
 		}
 
 		return $this->connection;

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -24,7 +24,7 @@ use OC\Share20\ShareDisableChecker;
 use OC_App;
 use OC_Hook;
 use OC_Util;
-use OCA\Files_External\Config\ConfigAdapter;
+use OCA\Files_External\Config\ExternalMountPoint;
 use OCA\Files_Sharing\External\Mount;
 use OCA\Files_Sharing\ISharedMountPoint;
 use OCA\Files_Sharing\SharedMount;
@@ -135,7 +135,7 @@ class SetupManager {
 
 		// install storage availability wrapper, before most other wrappers
 		Filesystem::addStorageWrapper('oc_availability', function ($mountPoint, IStorage $storage, IMountPoint $mount) {
-			$externalMount = $mount instanceof ConfigAdapter || $mount instanceof Mount;
+			$externalMount = $mount instanceof ExternalMountPoint || $mount instanceof Mount;
 			if ($externalMount && !$storage->isLocal()) {
 				return new Availability(['storage' => $storage]);
 			}


### PR DESCRIPTION
Makes sure it can be handled as an unavailable storage.

Includes a bonus fix for the availability wrapper.