### PR TITLE
fix(installer): Label field as username instead of login

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -40,7 +40,7 @@ script('core', 'install');
 	<fieldset id="adminaccount">
 		<legend><?php print_unescaped($l->t('Create an <strong>admin account</strong>')); ?></legend>
 		<p>
-			<label for="adminlogin"><?php p($l->t('Login')); ?></label>
+			<label for="adminlogin"><?php p($l->t('Username')); ?></label>
 			<input type="text" name="adminlogin" id="adminlogin"
 				value="<?php p($_['adminlogin']); ?>"
 				autocomplete="off" autocapitalize="none" spellcheck="false" autofocus required>

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -40,7 +40,7 @@ script('core', 'install');
 	<fieldset id="adminaccount">
 		<legend><?php print_unescaped($l->t('Create an <strong>admin account</strong>')); ?></legend>
 		<p>
-			<label for="adminlogin"><?php p($l->t('Username')); ?></label>
+			<label for="adminlogin"><?php p($l->t('Account name')); ?></label>
 			<input type="text" name="adminlogin" id="adminlogin"
 				value="<?php p($_['adminlogin']); ?>"
 				autocomplete="off" autocapitalize="none" spellcheck="false" autofocus required>


### PR DESCRIPTION


## Summary

The intended username field in the installer is labeled "Login" which translates in many languages in a different meaning. It's better to label it Username. 

Before:

<img width="414" alt="image" src="https://github.com/user-attachments/assets/a6f69605-fa28-463f-b896-3dffcfbfcedc">


After:

<img width="407" alt="image" src="https://github.com/user-attachments/assets/ccdbfdc0-fd93-47fe-aaba-9d2bb05f2a18">



## TODO

Nothing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
