### PR TITLE
fix(CalDAV): disable both iTip and iMip messages

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -97,14 +97,6 @@ class IMipPlugin extends SabreIMipPlugin {
 	 */
 	public function schedule(Message $iTipMessage) {
 
-		// do not send imip messages if external system already did
-		/** @psalm-suppress UndefinedPropertyFetch */
-		if ($iTipMessage->message?->VEVENT?->{'X-NC-DISABLE-SCHEDULING'}?->getValue() === 'true') {
-			if (!$iTipMessage->scheduleStatus) {
-				$iTipMessage->scheduleStatus = '1.0;We got the message, but iMip messages are disabled for this event';
-			}
-			return;
-		}
 		// Not sending any emails if the system considers the update insignificant
 		if (!$iTipMessage->significantChange) {
 			if (!$iTipMessage->scheduleStatus) {

--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -162,10 +163,15 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 
 		try {
 
+			// Do not generate iTip and iMip messages if scheduling is disabled for this message
+			if ($request->getHeader('x-nc-scheduling') === 'false') {
+				return;
+			}
+
 			if (!$this->scheduleReply($this->server->httpRequest)) {
 				return;
 			}
-			
+
 			/** @var Calendar $calendarNode */
 			$calendarNode = $this->server->tree->getNodeForPath($calendarPath);
 			// extract addresses for owner

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipPluginTest.php
@@ -997,23 +997,4 @@ class IMipPluginTest extends TestCase {
 		$this->plugin->schedule($message);
 		$this->assertEquals('1.1', $message->getScheduleStatus());
 	}
-
-	public function testImipDisabledForEvent(): void {
-		// construct iTip message with event and attendees
-		$calendar = new VCalendar();
-		$calendar->add('VEVENT', ['UID' => 'uid-1234']);
-		$event = $calendar->VEVENT;
-		$event->add('ORGANIZER', 'mailto:gandalf@wiz.ard');
-		$event->add('ATTENDEE', 'mailto:' . 'frodo@hobb.it', ['RSVP' => 'TRUE',  'CN' => 'Frodo']);
-		$event->add('X-NC-DISABLE-SCHEDULING', 'true');
-		$message = new Message();
-		$message->method = 'REQUEST';
-		$message->message = $calendar;
-		$message->sender = 'mailto:gandalf@wiz.ard';
-		$message->senderName = 'Mr. Wizard';
-		$message->recipient = 'mailto:' . 'frodo@hobb.it';
-		
-		$this->plugin->schedule($message);
-		$this->assertEquals('1.0;We got the message, but iMip messages are disabled for this event', $message->scheduleStatus);
-	}
 }

--- a/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -738,4 +739,42 @@ class PluginTest extends TestCase {
 
 	}
 
+	/**
+	 * Test Calendar Event Creation with iTip and iMip disabled
+	 *
+	 * Should generate 2 messages for attendees User 2 and User External
+	 */
+	public function testCalendarObjectChangeWithSchedulingDisabled(): void {
+		// construct server request
+		$request = new Request(
+			'PUT',
+			'/remote.php/dav/calendars/user1/personal/B0DC78AE-6DD7-47E3-80BE-89F23E6D5383.ics',
+			['x-nc-scheduling' => 'false']
+		);
+		$request->setBaseUrl('/remote.php/dav/');
+		// construct server response
+		$response = new Response();
+		// construct server tree
+		$tree = $this->createMock(Tree::class);
+		$tree->expects($this->never())
+			->method('getNodeForPath');
+		// construct server properties and returns
+		$this->server->httpRequest = $request;
+		$this->server->tree = $tree;
+		// construct empty calendar event
+		$vCalendar = new VCalendar();
+		$vEvent = $vCalendar->add('VEVENT', []);
+		// define flags
+		$newFlag = true;
+		$modifiedFlag = false;
+		// execute method
+		$this->plugin->calendarObjectChange(
+			$request,
+			$response,
+			$vCalendar,
+			'calendars/user1/personal',
+			$modifiedFlag,
+			$newFlag
+		);
+	}
 }


### PR DESCRIPTION
* Resolves: #https://github.com/nextcloud/server/issues/48528

## Summary
Adjusted logic to disable both iTip and iMip messages

## Checklist
- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
