### PR TITLE
fix(controller): Fix false booleans in multipart/form-data

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1384,9 +1384,6 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/AppFramework/Http/Dispatcher.php">
-    <NoInterfaceProperties>
-      <code><![CDATA[$this->request->method]]></code>
-    </NoInterfaceProperties>
     <NullArgument>
       <code><![CDATA[null]]></code>
     </NullArgument>

--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -183,16 +183,8 @@ class Dispatcher {
 			$value = $this->request->getParam($param, $default);
 			$type = $this->reflector->getType($param);
 
-			// if this is submitted using GET or a POST form, 'false' should be
-			// converted to false
-			if (($type === 'bool' || $type === 'boolean') &&
-				$value === 'false' &&
-				(
-					$this->request->method === 'GET' ||
-					str_contains($this->request->getHeader('Content-Type'),
-						'application/x-www-form-urlencoded')
-				)
-			) {
+			// Converted the string `'false'` to false when the controller wants a boolean
+			if ($value === 'false' && ($type === 'bool' || $type === 'boolean')) {
 				$value = false;
 			} elseif ($value !== null && \in_array($type, $types, true)) {
 				settype($value, $type);

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -328,7 +328,7 @@ class DispatcherTest extends \Test\TestCase {
 		$this->dispatcherPassthrough();
 		$response = $this->dispatcher->dispatch($controller, 'exec');
 
-		$this->assertEquals('[3,true,4,1]', $response[3]);
+		$this->assertEquals('[3,false,4,1]', $response[3]);
 	}
 
 
@@ -361,7 +361,7 @@ class DispatcherTest extends \Test\TestCase {
 		$this->dispatcherPassthrough();
 		$response = $this->dispatcher->dispatch($controller, 'exec');
 
-		$this->assertEquals('[3,true,4,7]', $response[3]);
+		$this->assertEquals('[3,false,4,7]', $response[3]);
 	}
 
 
@@ -471,6 +471,41 @@ class DispatcherTest extends \Test\TestCase {
 		$this->assertEquals('{"text":[3,false,4,1]}', $response[3]);
 	}
 
+	public function testResponseTransformedBySendingMultipartFormData(): void {
+		$this->request = new Request(
+			[
+				'post' => [
+					'int' => '3',
+					'bool' => 'false',
+					'double' => 1.2,
+				],
+				'server' => [
+					'HTTP_ACCEPT' => 'application/text, test',
+					'HTTP_CONTENT_TYPE' => 'multipart/form-data'
+				],
+				'method' => 'POST'
+			],
+			$this->createMock(IRequestId::class),
+			$this->createMock(IConfig::class)
+		);
+		$this->dispatcher = new Dispatcher(
+			$this->http, $this->middlewareDispatcher, $this->reflector,
+			$this->request,
+			$this->config,
+			\OC::$server->getDatabaseConnection(),
+			$this->logger,
+			$this->eventLogger,
+			$this->container
+		);
+		$controller = new TestController('app', $this->request);
+
+		// reflector is supposed to be called once
+		$this->dispatcherPassthrough();
+		$response = $this->dispatcher->dispatch($controller, 'exec');
+
+		$this->assertEquals('{"text":[3,false,4,1]}', $response[3]);
+	}
+
 
 	public function testResponsePrimarilyTransformedByParameterFormat(): void {
 		$this->request = new Request(
@@ -506,7 +541,7 @@ class DispatcherTest extends \Test\TestCase {
 		$this->dispatcherPassthrough();
 		$response = $this->dispatcher->dispatch($controller, 'exec');
 
-		$this->assertEquals('{"text":[3,true,4,1]}', $response[3]);
+		$this->assertEquals('{"text":[3,false,4,1]}', $response[3]);
 	}
 
 


### PR DESCRIPTION
## Summary
I was debugging an issue reported by our frontenders with a new API (ref https://github.com/nextcloud/spreed/pull/13871#discussion_r1858704769)
Turns out sending the boolean false in a post request sees it as `"false"` and therefore evaluates to `true`.
We have some code in place to "sometimes" translate that to `false` (see diff). I now need to extend this to `multipart/form-data`.

But at the same time I wonder why the check is there at all? When the controller requests a `boolean`, shouldn't we always convert `"false"` to `false` independent from request type?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
