### PR TITLE
chore: stricter access to testremote endpoint

### DIFF
--- a/apps/files_sharing/lib/Controller/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controller/ExternalSharesController.php
@@ -100,10 +100,11 @@ class ExternalSharesController extends Controller {
 	 *
 	 * @param string $remote
 	 * @return DataResponse
+	 * @AnonRateThrottle(limit=5, period=120)
 	 */
 	#[PublicPage]
 	public function testRemote($remote) {
-		if (str_contains($remote, '#') || str_contains($remote, '?') || str_contains($remote, ';')) {
+		if (preg_match('%[!#$&\'()*+,;=?@[\]]%', $remote)) {
 			return new DataResponse(false);
 		}
 


### PR DESCRIPTION
## Summary
Add rate limit and stricter checks for testremote endpoint

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
