### PR TITLE
fix: don't propagate future mtimes

### DIFF
--- a/lib/private/Files/Cache/Propagator.php
+++ b/lib/private/Files/Cache/Propagator.php
@@ -13,6 +13,8 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Cache\IPropagator;
 use OCP\Files\Storage\IReliableEtagStorage;
 use OCP\IDBConnection;
+use OCP\Server;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -39,10 +41,13 @@ class Propagator implements IPropagator {
 	 */
 	private $ignore = [];
 
+	private ClockInterface $clock;
+
 	public function __construct(\OC\Files\Storage\Storage $storage, IDBConnection $connection, array $ignore = []) {
 		$this->storage = $storage;
 		$this->connection = $connection;
 		$this->ignore = $ignore;
+		$this->clock = Server::get(ClockInterface::class);
 	}
 
 	/**
@@ -58,7 +63,9 @@ class Propagator implements IPropagator {
 			}
 		}
 
-		$storageId = (int)$this->storage->getStorageCache()->getNumericId();
+		$time = min((int)$time, $this->clock->now()->getTimestamp());
+
+		$storageId = $this->storage->getStorageCache()->getNumericId();
 
 		$parents = $this->getParents($internalPath);
 
@@ -78,7 +85,7 @@ class Propagator implements IPropagator {
 		}, $parentHashes);
 
 		$builder->update('filecache')
-			->set('mtime', $builder->func()->greatest('mtime', $builder->createNamedParameter((int)$time, IQueryBuilder::PARAM_INT)))
+			->set('mtime', $builder->func()->greatest('mtime', $builder->createNamedParameter($time, IQueryBuilder::PARAM_INT)))
 			->where($builder->expr()->eq('storage', $builder->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 			->andWhere($builder->expr()->in('path_hash', $hashParams));
 		if (!$this->storage->instanceOfStorage(IReliableEtagStorage::class)) {


### PR DESCRIPTION
When uploading a file with an mtime in the future the parent folders also get the future timestamp.

This clamps the propagated mtime to the current one to prevent this.

to test:

- create a local file with a timestamp in the future: `touch -d "now +1 year" test.txt`
- Create a folder `test`
- Upload `test.txt` into the `test` folder
- Check the mtime of the `test` folder