### PR TITLE
chore: remove legacy action to test remote endpoint

### DIFF
--- a/apps/files_sharing/appinfo/routes.php
+++ b/apps/files_sharing/appinfo/routes.php
@@ -40,12 +40,6 @@ return [
 			'verb' => 'GET',
 			'root' => '',
 		],
-
-		[
-			'name' => 'externalShares#testRemote',
-			'url' => '/testremote',
-			'verb' => 'GET'
-		],
 		[
 			'name' => 'PublicPreview#getPreview',
 			'url' => '/publicpreview/{token}',

--- a/apps/files_sharing/lib/Controller/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controller/ExternalSharesController.php
@@ -8,11 +8,7 @@ namespace OCA\Files_Sharing\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
-use OCP\AppFramework\Http\Attribute\PublicPage;
-use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\Http\Client\IClientService;
-use OCP\IConfig;
 use OCP\IRequest;
 
 /**
@@ -25,8 +21,6 @@ class ExternalSharesController extends Controller {
 		string $appName,
 		IRequest $request,
 		private \OCA\Files_Sharing\External\Manager $externalManager,
-		private IClientService $clientService,
-		private IConfig $config,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -63,65 +57,5 @@ class ExternalSharesController extends Controller {
 	public function destroy($id) {
 		$this->externalManager->declineShare($id);
 		return new JSONResponse();
-	}
-
-	/**
-	 * Test whether the specified remote is accessible
-	 *
-	 * @param string $remote
-	 * @param bool $checkVersion
-	 * @return bool
-	 */
-	protected function testUrl($remote, $checkVersion = false) {
-		try {
-			$client = $this->clientService->newClient();
-			$response = json_decode($client->get(
-				$remote,
-				[
-					'timeout' => 3,
-					'connect_timeout' => 3,
-					'verify' => !$this->config->getSystemValueBool('sharing.federation.allowSelfSignedCertificates', false),
-				]
-			)->getBody());
-
-			if ($checkVersion) {
-				return !empty($response->version) && version_compare($response->version, '7.0.0', '>=');
-			} else {
-				return is_object($response);
-			}
-		} catch (\Exception $e) {
-			return false;
-		}
-	}
-
-	/**
-	 * @NoOutgoingFederatedSharingRequired
-	 * @NoIncomingFederatedSharingRequired
-	 *
-	 * @param string $remote
-	 * @return DataResponse
-	 * @AnonRateThrottle(limit=5, period=120)
-	 */
-	#[PublicPage]
-	public function testRemote($remote) {
-		if (preg_match('%[!#$&\'()*+,;=?@[\]]%', $remote)) {
-			return new DataResponse(false);
-		}
-
-		if (
-			$this->testUrl('https://' . $remote . '/ocm-provider/') ||
-			$this->testUrl('https://' . $remote . '/ocm-provider/index.php') ||
-			$this->testUrl('https://' . $remote . '/status.php', true)
-		) {
-			return new DataResponse('https');
-		} elseif (
-			$this->testUrl('http://' . $remote . '/ocm-provider/') ||
-			$this->testUrl('http://' . $remote . '/ocm-provider/index.php') ||
-			$this->testUrl('http://' . $remote . '/status.php', true)
-		) {
-			return new DataResponse('http');
-		} else {
-			return new DataResponse(false);
-		}
 	}
 }

--- a/apps/files_sharing/openapi.json
+++ b/apps/files_sharing/openapi.json
@@ -3805,10 +3805,5 @@
             }
         }
     },
-    "tags": [
-        {
-            "name": "external_shares",
-            "description": "Class ExternalSharesController"
-        }
-    ]
+    "tags": []
 }

--- a/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ExternalShareControllerTest.php
@@ -8,11 +8,8 @@ namespace OCA\Files_Sharing\Tests\Controllers;
 
 use OCA\Files_Sharing\Controller\ExternalSharesController;
 use OCA\Files_Sharing\External\Manager;
-use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\Http\Client\IClient;
 use OCP\Http\Client\IClientService;
-use OCP\Http\Client\IResponse;
 use OCP\IConfig;
 use OCP\IRequest;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -78,91 +75,5 @@ class ExternalShareControllerTest extends \Test\TestCase {
 			->with(4);
 
 		$this->assertEquals(new JSONResponse(), $this->getExternalShareController()->destroy(4));
-	}
-
-	public function testRemoteWithValidHttps(): void {
-		$client = $this->createMock(IClient::class);
-		$response = $this->createMock(IResponse::class);
-		$response
-			->expects($this->exactly(2))
-			->method('getBody')
-			->willReturnOnConsecutiveCalls(
-				'Certainly not a JSON string',
-				'{"installed":true,"maintenance":false,"version":"8.1.0.8","versionstring":"8.1.0","edition":""}'
-			);
-		$client
-			->expects($this->any())
-			->method('get')
-			->willReturn($response);
-
-		$this->clientService
-			->expects($this->exactly(2))
-			->method('newClient')
-			->willReturn($client);
-
-		$this->assertEquals(new DataResponse('https'), $this->getExternalShareController()->testRemote('nextcloud.com'));
-	}
-
-	public function testRemoteWithWorkingHttp(): void {
-		$client = $this->createMock(IClient::class);
-		$response = $this->createMock(IResponse::class);
-		$client
-			->method('get')
-			->willReturn($response);
-		$response
-			->expects($this->exactly(5))
-			->method('getBody')
-			->willReturnOnConsecutiveCalls(
-				'Certainly not a JSON string',
-				'Certainly not a JSON string',
-				'Certainly not a JSON string',
-				'Certainly not a JSON string',
-				'{"installed":true,"maintenance":false,"version":"8.1.0.8","versionstring":"8.1.0","edition":""}'
-			);
-		$this->clientService
-			->expects($this->exactly(5))
-			->method('newClient')
-			->willReturn($client);
-
-		$this->assertEquals(new DataResponse('http'), $this->getExternalShareController()->testRemote('nextcloud.com'));
-	}
-
-	public function testRemoteWithInvalidRemote(): void {
-		$client = $this->createMock(IClient::class);
-		$response = $this->createMock(IResponse::class);
-		$client
-			->expects($this->exactly(6))
-			->method('get')
-			->willReturn($response);
-		$response
-			->expects($this->exactly(6))
-			->method('getBody')
-			->willReturn('Certainly not a JSON string');
-		$this->clientService
-			->expects($this->exactly(6))
-			->method('newClient')
-			->willReturn($client);
-
-		$this->assertEquals(new DataResponse(false), $this->getExternalShareController()->testRemote('nextcloud.com'));
-	}
-
-	public function dataRemoteWithInvalidRemoteURLs(): array {
-		return [
-			['nextcloud.com?query'],
-			['nextcloud.com/#anchor'],
-			['nextcloud.com/;tomcat'],
-		];
-	}
-
-	/**
-	 * @dataProvider dataRemoteWithInvalidRemoteURLs
-	 * @param string $remote
-	 */
-	public function testRemoteWithInvalidRemoteURLs(string $remote): void {
-		$this->clientService
-			->expects($this->never())
-			->method('newClient');
-
-		$this->assertEquals(new DataResponse(false), $this->getExternalShareController()->testRemote($remote));
 	}
 }


### PR DESCRIPTION
## Summary

Call to this endpoint was removed in nextcloud/server#47568

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
