### PR TITLE
perf: improve performance of SharedStorage::getWatcher

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -7,6 +7,7 @@
 namespace OCA\Files_Sharing;
 
 use OC\Files\Cache\CacheDependencies;
+use OC\Files\Cache\CacheEntry;
 use OC\Files\Cache\FailedCache;
 use OC\Files\Cache\NullWatcher;
 use OC\Files\ObjectStore\HomeObjectStoreStorage;
@@ -20,14 +21,12 @@ use OC\Files\Storage\Wrapper\Wrapper;
 use OC\Files\View;
 use OC\Share\Share;
 use OC\User\NoUserException;
-use OCA\Files_External\Config\ConfigAdapter;
 use OCA\Files_Sharing\ISharedStorage as LegacyISharedStorage;
 use OCP\Constants;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Cache\IScanner;
 use OCP\Files\Cache\IWatcher;
-use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Folder;
 use OCP\Files\IHomeStorage;
 use OCP\Files\IRootFolder;
@@ -437,17 +436,13 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 
 		// Get node information
 		$node = $this->getShare()->getNodeCacheEntry();
-		if ($node) {
-			/** @var IUserMountCache $userMountCache */
-			$userMountCache = \OC::$server->get(IUserMountCache::class);
-			$mounts = $userMountCache->getMountsForStorageId($node->getStorageId());
-			foreach ($mounts as $mount) {
-				// If the share is originating from an external storage
-				if ($mount->getMountProvider() === ConfigAdapter::class) {
-					// Propagate original storage scan
-					$this->watcher = parent::getWatcher($path, $storage);
-					return $this->watcher;
-				}
+		if ($node instanceof CacheEntry) {
+			$storageId = $node->getData()['storage_string_id'];
+			// for shares from the home storage we can rely on the home storage to keep itself up to date
+			// for other storages we need use the proper watcher
+			if (!(str_starts_with($storageId, 'home::') || str_starts_with($storageId, 'object::user'))) {
+				$this->watcher = parent::getWatcher($path, $storage);
+				return $this->watcher;
 			}
 		}
 


### PR DESCRIPTION
Instead of asking the db, use the storage id we already have.