### PR TITLE
fix(occ): `occ integrity:check-app` and Admin panel "rescan" deliver inconsistent results

### DIFF
--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -47,7 +47,10 @@ class CheckApp extends Base {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appid = $input->getArgument('appid');
-		$path = (string)$input->getOption('path') ?? $this->appLocator->getAppPath($appid);
+		$path = (string)$input->getOption('path');
+		if ($path === '') {
+			$path = $this->appLocator->getAppPath($appid);
+		}
 		if ($this->fileAccessHelper->file_exists($path . '/appinfo/signature.json')) {
 			// Only verify if the application explicitly ships a signature.json file
 			$result = $this->checker->verifyAppSignature($appid, $path, true);

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -25,9 +25,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CheckApp extends Base {
 	public function __construct(
 		private Checker $checker,
-		private IAppManager $appManager,
 		private AppLocator $appLocator,
 		private FileAccessHelper $fileAccessHelper,
+		private IAppManager $appManager,
 	) {
 		parent::__construct();
 	}

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -9,6 +9,8 @@ namespace OC\Core\Command\Integrity;
 
 use OC\Core\Command\Base;
 use OC\IntegrityCheck\Checker;
+use OC\IntegrityCheck\Helpers\AppLocator;
+use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -22,6 +24,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CheckApp extends Base {
 	public function __construct(
 		private Checker $checker,
+		private AppLocator $appLocator,
+		private FileAccessHelper $fileAccessHelper,
 	) {
 		parent::__construct();
 	}
@@ -43,14 +47,19 @@ class CheckApp extends Base {
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appid = $input->getArgument('appid');
-		$path = (string)$input->getOption('path');
-		$result = $this->checker->verifyAppSignature($appid, $path, true);
-		$this->writeArrayInOutputFormat($input, $output, $result);
-		if (count($result) > 0) {
-			$output->writeln('<error>' . count($result) . ' errors found</error>', OutputInterface::VERBOSITY_VERBOSE);
-			return 1;
+		$path = (string)$input->getOption('path') ?? $this->appLocator->getAppPath($appid);
+		if ($this->fileAccessHelper->file_exists($path . '/appinfo/signature.json')) {
+			// Only verify if the application explicitly ships a signature.json file
+			$result = $this->checker->verifyAppSignature($appid, $path, true);
+			$this->writeArrayInOutputFormat($input, $output, $result);
+			if (count($result) > 0) {
+				$output->writeln('<error>' . count($result) . ' errors found</error>', OutputInterface::VERBOSITY_VERBOSE);
+				return 1;
+			}
+			$output->writeln('<info>No errors found</info>', OutputInterface::VERBOSITY_VERBOSE);
+		} else {
+			$output->writeln('<info>App signature not found, skipping app integrity check</info>', OutputInterface::VERBOSITY_VERBOSE);
 		}
-		$output->writeln('<info>No errors found</info>', OutputInterface::VERBOSITY_VERBOSE);
 		return 0;
 	}
 }

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -63,7 +63,7 @@ class CheckApp extends Base {
 			}
 			$output->writeln('<info>No errors found</info>', OutputInterface::VERBOSITY_VERBOSE);
 		} else {
-			$output->writeln('<info>App signature not found, skipping app integrity check</info>', OutputInterface::VERBOSITY_VERBOSE);
+			$output->writeln('<comment>App signature not found, skipping app integrity check</comment>');
 		}
 		return 0;
 	}

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -11,6 +11,7 @@ use OC\Core\Command\Base;
 use OC\IntegrityCheck\Checker;
 use OC\IntegrityCheck\Helpers\AppLocator;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
+use OCP\App\IAppManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -24,6 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CheckApp extends Base {
 	public function __construct(
 		private Checker $checker,
+		private ?IAppManager $appManager,
 		private AppLocator $appLocator,
 		private FileAccessHelper $fileAccessHelper,
 	) {
@@ -51,7 +53,7 @@ class CheckApp extends Base {
 		if ($path === '') {
 			$path = $this->appLocator->getAppPath($appid);
 		}
-		if ($this->fileAccessHelper->file_exists($path . '/appinfo/signature.json')) {
+		if ($this->appManager->isShipped($appid) || $this->fileAccessHelper->file_exists($path . '/appinfo/signature.json')) {
 			// Only verify if the application explicitly ships a signature.json file
 			$result = $this->checker->verifyAppSignature($appid, $path, true);
 			$this->writeArrayInOutputFormat($input, $output, $result);

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CheckApp extends Base {
 	public function __construct(
 		private Checker $checker,
-		private ?IAppManager $appManager,
+		private IAppManager $appManager,
 		private AppLocator $appLocator,
 		private FileAccessHelper $fileAccessHelper,
 	) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #17801 <!-- related github issue -->

## Summary

This issue fixes the behavior discrepancy between the `occ integrity:check-app` command and the Admin panel "rescan" button.
The fix allows `occ integrity:check-app` to gracefully skip the signature check of the app instead of throwing an exception, as instructed in https://github.com/nextcloud/server/issues/17801#issuecomment-2326854333.

## TODO

- [x] Independent validation by a reviewer. Check the below `custom_apps` apps (open the dropdown) that do not ship with signatures. `bookmarks` is a good example (https://github.com/nextcloud/bookmarks/issues/1941).

<details>

```
Technical information
=====================
The following list covers which files have failed the integrity check. Please read
the previous linked documentation to learn more about the errors and how to fix
them.

Results
=======
- apporder
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- bookmarks
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- bruteforcesettings
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- calendar
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- drawio
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- event_update_notification
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- impersonate
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- metadata
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- previewgenerator
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- twofactor_admin
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- twofactor_totp
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.
- twofactor_u2f
	- EXCEPTION
		- OC\IntegrityCheck\Exceptions\InvalidSignatureException
		- Signature data not found.

Raw output
==========
Array
(
    [apporder] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [bookmarks] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [bruteforcesettings] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [calendar] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [drawio] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [event_update_notification] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [impersonate] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [metadata] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [previewgenerator] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [twofactor_admin] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [twofactor_totp] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

    [twofactor_u2f] => Array
        (
            [EXCEPTION] => Array
                (
                    [class] => OC\IntegrityCheck\Exceptions\InvalidSignatureException
                    [message] => Signature data not found.
                )

        )

)
```

</details>

- [ ] Identify unit testing requirements.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting) - **Correct if workflow passes**
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits - **Done**
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes - **Not applicable**
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required - **Not required**
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes) - **Not required because this is annoying but not critical, but may be nonetheless preferred, based on reviewer discretion**

CC @joshtrichards @simonspa @szaimen 