### PR TITLE
fix(updater): Stop expiring secret prematurely

### DIFF
--- a/apps/updatenotification/lib/BackgroundJob/ResetToken.php
+++ b/apps/updatenotification/lib/BackgroundJob/ResetToken.php
@@ -43,8 +43,8 @@ class ResetToken extends TimedJob {
 			return;
 		}
 
-		$secretCreated = $this->appConfig->getValueInt('core', 'updater.secret.created', $this->time->getTime());
-		// Delete old tokens after 2 days
+		$secretCreated = $this->appConfig->getValueInt('core', 'updater.secret.created');
+		// Delete old tokens after 2 days and also tokens without any created date
 		$secretCreatedDiff = $this->time->getTime() - $secretCreated;
 		if ($secretCreatedDiff >= 172800) {
 			$this->config->deleteSystemValue('updater.secret');

--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -21,6 +21,7 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Security\ISecureRandom;
 use OCP\Util;
+use Psr\Log\LoggerInterface;
 
 class AdminController extends Controller {
 
@@ -33,12 +34,9 @@ class AdminController extends Controller {
 		private IAppConfig $appConfig,
 		private ITimeFactory $timeFactory,
 		private IL10N $l10n,
+		private LoggerInterface $logger,
 	) {
 		parent::__construct($appName, $request);
-	}
-
-	private function isUpdaterEnabled(): bool {
-		return !$this->config->getSystemValueBool('upgrade.disable-web');
 	}
 
 	/**
@@ -55,8 +53,12 @@ class AdminController extends Controller {
 	 * @return DataResponse
 	 */
 	public function createCredentials(): DataResponse {
-		if (!$this->isUpdaterEnabled()) {
+		if ($this->config->getSystemValueBool('upgrade.disable-web')) {
 			return new DataResponse(['status' => 'error', 'message' => $this->l10n->t('Web updater is disabled')], Http::STATUS_FORBIDDEN);
+		}
+
+		if ($this->config->getSystemValueBool('config_is_read_only')) {
+			return new DataResponse(['status' => 'error', 'message' => $this->l10n->t('Configuration is read-only')], Http::STATUS_FORBIDDEN);
 		}
 
 		// Create a new job and store the creation date
@@ -66,6 +68,8 @@ class AdminController extends Controller {
 		// Create a new token
 		$newToken = $this->secureRandom->generate(64);
 		$this->config->setSystemValue('updater.secret', password_hash($newToken, PASSWORD_DEFAULT));
+
+		$this->logger->warning('Created new `updater.secret`', ['app' => 'updatenotification']);
 
 		return new DataResponse($newToken);
 	}

--- a/apps/updatenotification/tests/BackgroundJob/ResetTokenTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/ResetTokenTest.php
@@ -38,7 +38,10 @@ class ResetTokenTest extends TestCase {
 		);
 	}
 
-	public function testRunWithNotExpiredToken(): void { // Affirm if updater.secret.created <48 hours ago then `updater.secret` is left alone
+	/**
+	 * Affirm if updater.secret.created <48 hours ago then `updater.secret` is left alone.
+	 */
+	public function testKeepSecretWhenCreatedRecently(): void {
 		$this->timeFactory
 			->expects($this->atLeastOnce())
 			->method('getTime')
@@ -46,7 +49,7 @@ class ResetTokenTest extends TestCase {
 		$this->appConfig
 			->expects($this->once())
 			->method('getValueInt')
-			->with('core', 'updater.secret.created', 1733069649)
+			->with('core', 'updater.secret.created')
 			->willReturn(1733069649 - 1 * 24 * 60 * 60); // 24h prior: "Sat, 30 Nov 2024 16:14:09 +0000"
 		$this->config
 			->expects($this->once())
@@ -66,10 +69,13 @@ class ResetTokenTest extends TestCase {
 			->expects($this->once())
 			->method('debug');
 
-		$this->invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
+		static::invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
 	}
 
-	public function testRunWithExpiredToken(): void { // Affirm if updater.secret.created >48 hours ago then `updater.secret` is removed
+	/**
+	 * Affirm if updater.secret.created >48 hours ago then `updater.secret` is removed
+	 */
+	public function testSecretIsRemovedWhenOutdated(): void {
 		$this->timeFactory
 			->expects($this->atLeastOnce())
 			->method('getTime')
@@ -77,7 +83,7 @@ class ResetTokenTest extends TestCase {
 		$this->appConfig
 			->expects($this->once())
 			->method('getValueInt')
-			->with('core', 'updater.secret.created', 1455045234)
+			->with('core', 'updater.secret.created')
 			->willReturn(1455045234 - 3 * 24 * 60 * 60); // 72h prior: "Sat, 06 Feb 2016 19:13:54 +0000"
 		$this->config
 			->expects($this->once())
@@ -104,8 +110,8 @@ class ResetTokenTest extends TestCase {
 
 	public function testRunWithExpiredTokenAndReadOnlyConfigFile(): void { // Affirm if config_is_read_only is set that the secret is never reset
 		$this->timeFactory
-			->expects($this->never())
-			->method('getTime');
+				->expects($this->never())
+				->method('getTime');
 		$this->appConfig
 			->expects($this->never())
 			->method('getValueInt');

--- a/apps/updatenotification/tests/BackgroundJob/ResetTokenTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/ResetTokenTest.php
@@ -13,35 +13,41 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ResetTokenTest extends TestCase {
-	private IConfig&MockObject $config;
-	private IAppConfig&MockObject $appConfig;
-	private ITimeFactory&MockObject $timeFactory;
-	private BackgroundJobResetToken $resetTokenBackgroundJob;
+	protected BackgroundJobResetToken $resetTokenBackgroundJob;
+
+	protected IConfig&MockObject $config;
+	protected IAppConfig&MockObject $appConfig;
+	protected ITimeFactory&MockObject $timeFactory;
+	protected LoggerInterface&MockObject $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->appConfig = $this->createMock(IAppConfig::class);
-		$this->config = $this->createMock(IConfig::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->resetTokenBackgroundJob = new BackgroundJobResetToken(
 			$this->timeFactory,
 			$this->config,
 			$this->appConfig,
+			$this->logger,
 		);
 	}
 
-	public function testRunWithNotExpiredToken(): void {
+	public function testRunWithNotExpiredToken(): void { // Affirm if updater.secret.created <48 hours ago then `updater.secret` is left alone
 		$this->timeFactory
 			->expects($this->atLeastOnce())
 			->method('getTime')
-			->willReturn(123);
+			->willReturn(1733069649); // "Sun, 01 Dec 2024 16:14:09 +0000"
 		$this->appConfig
 			->expects($this->once())
 			->method('getValueInt')
-			->with('core', 'updater.secret.created', 123);
+			->with('core', 'updater.secret.created', 1733069649)
+			->willReturn(1733069649 - 1 * 24 * 60 * 60); // 24h prior: "Sat, 30 Nov 2024 16:14:09 +0000"
 		$this->config
 			->expects($this->once())
 			->method('getSystemValueBool')
@@ -50,29 +56,53 @@ class ResetTokenTest extends TestCase {
 		$this->config
 			->expects($this->never())
 			->method('deleteSystemValue');
+		$this->appConfig
+			->expects($this->never())
+			->method('deleteKey');
+		$this->logger
+			->expects($this->never())
+			->method('warning');
+		$this->logger
+			->expects($this->once())
+			->method('debug');
 
-		static::invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
+		$this->invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
 	}
 
-	public function testRunWithExpiredToken(): void {
+	public function testRunWithExpiredToken(): void { // Affirm if updater.secret.created >48 hours ago then `updater.secret` is removed
 		$this->timeFactory
-			->expects($this->once())
+			->expects($this->atLeastOnce())
 			->method('getTime')
-			->willReturn(1455045234);
+			->willReturn(1455045234); // "Tue, 09 Feb 2016 19:13:54 +0000"
 		$this->appConfig
 			->expects($this->once())
 			->method('getValueInt')
 			->with('core', 'updater.secret.created', 1455045234)
-			->willReturn(2 * 24 * 60 * 60 + 1); // over 2 days
+			->willReturn(1455045234 - 3 * 24 * 60 * 60); // 72h prior: "Sat, 06 Feb 2016 19:13:54 +0000"
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('config_is_read_only')
+			->willReturn(false);
 		$this->config
 			->expects($this->once())
 			->method('deleteSystemValue')
 			->with('updater.secret');
+		$this->appConfig
+			->expects($this->once())
+			->method('deleteKey')
+			->with('core', 'updater.secret.created');
+		$this->logger
+			->expects($this->once())
+			->method('warning');
+		$this->logger
+			->expects($this->never())
+			->method('debug');
 
-		static::invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
+		$this->invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
 	}
 
-	public function testRunWithExpiredTokenAndReadOnlyConfigFile(): void {
+	public function testRunWithExpiredTokenAndReadOnlyConfigFile(): void { // Affirm if config_is_read_only is set that the secret is never reset
 		$this->timeFactory
 			->expects($this->never())
 			->method('getTime');
@@ -87,7 +117,16 @@ class ResetTokenTest extends TestCase {
 		$this->config
 			->expects($this->never())
 			->method('deleteSystemValue');
+		$this->appConfig
+			->expects($this->never())
+			->method('deleteKey');
+		$this->logger
+			->expects($this->never())
+			->method('warning');
+		$this->logger
+			->expects($this->once())
+			->method('debug');
 
-		static::invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
+		$this->invokePrivate($this->resetTokenBackgroundJob, 'run', [null]);
 	}
 }

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -19,18 +19,20 @@ use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Security\ISecureRandom;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class AdminControllerTest extends TestCase {
-	private IRequest&MockObject $request;
-	private IJobList&MockObject $jobList;
-	private ISecureRandom&MockObject $secureRandom;
-	private IConfig&MockObject $config;
-	private ITimeFactory&MockObject $timeFactory;
-	private IL10N&MockObject $l10n;
-	private IAppConfig&MockObject $appConfig;
+	protected IRequest&MockObject $request;
+	protected IJobList&MockObject $jobList;
+	protected ISecureRandom&MockObject $secureRandom;
+	protected IConfig&MockObject $config;
+	protected ITimeFactory&MockObject $timeFactory;
+	protected IL10N&MockObject $l10n;
+	protected IAppConfig&MockObject $appConfig;
+	protected LoggerInterface&MockObject $logger;
 
-	private AdminController $adminController;
+	protected AdminController $adminController;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -42,6 +44,7 @@ class AdminControllerTest extends TestCase {
 		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
 		$this->l10n = $this->createMock(IL10N::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->adminController = new AdminController(
 			'updatenotification',
@@ -51,7 +54,8 @@ class AdminControllerTest extends TestCase {
 			$this->config,
 			$this->appConfig,
 			$this->timeFactory,
-			$this->l10n
+			$this->l10n,
+			$this->logger,
 		);
 	}
 
@@ -80,5 +84,30 @@ class AdminControllerTest extends TestCase {
 
 		$expected = new DataResponse('MyGeneratedToken');
 		$this->assertEquals($expected, $this->adminController->createCredentials());
+	}
+
+	public function testCreateCredentialsAndWebUpdaterDisabled(): void {
+		$this->config
+			->expects($this->once())
+			->method('getSystemValueBool')
+			->with('upgrade.disable-web')
+			->willReturn(true);
+		$this->jobList
+			->expects($this->never())
+			->method('add');
+		$this->secureRandom
+			->expects($this->never())
+			->method('generate');
+		$this->config
+			->expects($this->never())
+			->method('setSystemValue');
+		$this->timeFactory
+			->expects($this->never())
+			->method('getTime');
+		$this->appConfig
+			->expects($this->never())
+			->method('setValueInt');
+
+		$this->adminController->createCredentials();
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: nextcloud/updater#574 <!-- related github issue -->
* Resolves: #45714

## Summary

#43967 introduced a regression in the handling of the expiration of `updater.secret`. The result is that `updater.secret` is expired at the next job interval (~10 minutes). If the web Updater takes >10 minutes this prevents it from continuing. 

* Fixed expiration handling
* Added logging when we expire the secret
* Added cleanup of the `updater.secret.created` value when we expire a secret
* Added handling for `config_is_read_only` in the `AdminController`
* Changed `ResetToken` background job unit tests to catch the scenario addressed by this PR
* Expanded `ResetToken` background job unit test coverage in general
* Expanded `AdminController` unit test coverage in general

## TODO

- [ ] Tests: Confirm new tests are working (I eliminated the `static` used in the `ResetToken` test since it didn't seem to serve a purpose but I may have broken it so may require another look)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
