### PR TITLE
chore(absence): Add capability

### DIFF
--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -7,15 +7,17 @@ namespace OCA\DAV;
 
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
+use OCP\User\IAvailabilityCoordinator;
 
 class Capabilities implements ICapability {
 	public function __construct(
 		private IConfig $config,
+		private IAvailabilityCoordinator $coordinator,
 	) {
 	}
 
 	/**
-	 * @return array{dav: array{chunking: string, bulkupload?: string}}
+	 * @return array{dav: array{chunking: string, bulkupload?: string, absence-supported?: bool}}
 	 */
 	public function getCapabilities() {
 		$capabilities = [
@@ -25,6 +27,9 @@ class Capabilities implements ICapability {
 		];
 		if ($this->config->getSystemValueBool('bulkupload.enabled', true)) {
 			$capabilities['dav']['bulkupload'] = '1.0';
+		}
+		if ($this->coordinator->isEnabled()) {
+			$capabilities['dav']['absence-supported'] = true;
 		}
 		return $capabilities;
 	}

--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -17,7 +17,7 @@ class Capabilities implements ICapability {
 	}
 
 	/**
-	 * @return array{dav: array{chunking: string, bulkupload?: string, absence-supported?: bool}}
+	 * @return array{dav: array{chunking: string, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
 	 */
 	public function getCapabilities() {
 		$capabilities = [
@@ -30,6 +30,7 @@ class Capabilities implements ICapability {
 		}
 		if ($this->coordinator->isEnabled()) {
 			$capabilities['dav']['absence-supported'] = true;
+			$capabilities['dav']['absence-replacement'] = true;
 		}
 		return $capabilities;
 	}

--- a/apps/dav/openapi.json
+++ b/apps/dav/openapi.json
@@ -40,6 +40,9 @@
                             },
                             "absence-supported": {
                                 "type": "boolean"
+                            },
+                            "absence-replacement": {
+                                "type": "boolean"
                             }
                         }
                     }

--- a/apps/dav/openapi.json
+++ b/apps/dav/openapi.json
@@ -37,6 +37,9 @@
                             },
                             "bulkupload": {
                                 "type": "string"
+                            },
+                            "absence-supported": {
+                                "type": "boolean"
                             }
                         }
                     }

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProviderManagerTest.php
@@ -17,6 +17,9 @@ use OCA\DAV\Capabilities;
 use OCP\AppFramework\QueryException;
 use Test\TestCase;
 
+/**
+ * @group DB
+ */
 class NotificationProviderManagerTest extends TestCase {
 
 	/** @var NotificationProviderManager|\PHPUnit\Framework\MockObject\MockObject */

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -68,6 +68,7 @@ class CapabilitiesTest extends TestCase {
 			'dav' => [
 				'chunking' => '1.0',
 				'absence-supported' => true,
+				'absence-replacement' => true,
 			],
 		];
 		$this->assertSame($expected, $capabilities->getCapabilities());

--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -7,6 +7,7 @@ namespace OCA\DAV\Tests\unit;
 
 use OCA\DAV\Capabilities;
 use OCP\IConfig;
+use OCP\User\IAvailabilityCoordinator;
 use Test\TestCase;
 
 /**
@@ -19,7 +20,11 @@ class CapabilitiesTest extends TestCase {
 			->method('getSystemValueBool')
 			->with('bulkupload.enabled', $this->isType('bool'))
 			->willReturn(false);
-		$capabilities = new Capabilities($config);
+		$coordinator = $this->createMock(IAvailabilityCoordinator::class);
+		$coordinator->expects($this->once())
+			->method('isEnabled')
+			->willReturn(false);
+		$capabilities = new Capabilities($config, $coordinator);
 		$expected = [
 			'dav' => [
 				'chunking' => '1.0',
@@ -34,11 +39,35 @@ class CapabilitiesTest extends TestCase {
 			->method('getSystemValueBool')
 			->with('bulkupload.enabled', $this->isType('bool'))
 			->willReturn(true);
-		$capabilities = new Capabilities($config);
+		$coordinator = $this->createMock(IAvailabilityCoordinator::class);
+		$coordinator->expects($this->once())
+			->method('isEnabled')
+			->willReturn(false);
+		$capabilities = new Capabilities($config, $coordinator);
 		$expected = [
 			'dav' => [
 				'chunking' => '1.0',
 				'bulkupload' => '1.0',
+			],
+		];
+		$this->assertSame($expected, $capabilities->getCapabilities());
+	}
+
+	public function testGetCapabilitiesWithAbsence(): void {
+		$config = $this->createMock(IConfig::class);
+		$config->expects($this->once())
+			->method('getSystemValueBool')
+			->with('bulkupload.enabled', $this->isType('bool'))
+			->willReturn(false);
+		$coordinator = $this->createMock(IAvailabilityCoordinator::class);
+		$coordinator->expects($this->once())
+			->method('isEnabled')
+			->willReturn(true);
+		$capabilities = new Capabilities($config, $coordinator);
+		$expected = [
+			'dav' => [
+				'chunking' => '1.0',
+				'absence-supported' => true,
 			],
 		];
 		$this->assertSame($expected, $capabilities->getCapabilities());


### PR DESCRIPTION
* Related: https://github.com/nextcloud/talk-ios/pull/1890

## Summary

We started using the absence / out-of-office api in talk-ios recently, but there's no capability for us to check if a server supports the absence api (NC 28) and setting a replacement (NC 30).

## TODO

- [ ] Trigger backports
- [ ] Update documentation to include the capabilities

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
