### PR TITLE
fix(maintenance): Show a success message on data-fingerprint command

### DIFF
--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -28,7 +28,9 @@ class DataFingerprint extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$this->config->setSystemValue('data-fingerprint', md5($this->timeFactory->getTime()));
+		$fingerPrint = md5($this->timeFactory->getTime());
+		$this->config->setSystemValue('data-fingerprint', $fingerPrint);
+		$output->writeln('<info>Updated data-fingerprint to ' . $fingerPrint . '</info>');
 		return 0;
 	}
 }


### PR DESCRIPTION
## Summary

1. Enable maintenance mode
2. (optional: restore a backup)
3. Run `occ maintenance:data-fingerprint`
4. Be unsure if the command worked as you only read something about maintenance mode.
5. Wonder if you need to allow clients to sync again before being able updating the fingerprint

Before | After
---|---
![Bildschirmfoto vom 2024-12-02 08-41-08](https://github.com/user-attachments/assets/158b1eeb-5931-4d41-9844-e9e0734da8d4) | ![Bildschirmfoto vom 2024-12-02 08-39-27](https://github.com/user-attachments/assets/da37ff15-e23c-4cb9-adf8-5fd4a4009fd2)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
