### PR TITLE
fix(setupcheck): Make the Memcache setupcheck use the cache

### DIFF
--- a/apps/settings/lib/SetupChecks/MemcacheConfigured.php
+++ b/apps/settings/lib/SetupChecks/MemcacheConfigured.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Settings\SetupChecks;
 
 use OC\Memcache\Memcached;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -20,6 +21,7 @@ class MemcacheConfigured implements ISetupCheck {
 		private IL10N $l10n,
 		private IConfig $config,
 		private IURLGenerator $urlGenerator,
+		private ICacheFactory $cacheFactory,
 	) {
 	}
 
@@ -56,6 +58,41 @@ class MemcacheConfigured implements ISetupCheck {
 				$this->urlGenerator->linkToDocs('admin-performance')
 			);
 		}
+
+		if ($this->cacheFactory->isLocalCacheAvailable()) {
+			$random = random_bytes(64);
+			$local = $this->cacheFactory->createLocal('setupcheck.local');
+			try {
+				$local->set('test', $random);
+				$local2 = $this->cacheFactory->createLocal('setupcheck.local');
+				$actual = $local2->get('test');
+				$local->remove('test');
+			} catch (\Throwable) {
+				$actual = null;
+			}
+
+			if ($actual !== $random) {
+				return SetupResult::error($this->l10n->t('Failed to write and read a value from local cache.'));
+			}
+		}
+
+		if ($this->cacheFactory->isAvailable()) {
+			$random = random_bytes(64);
+			$distributed = $this->cacheFactory->createDistributed('setupcheck');
+			try {
+				$distributed->set('test', $random);
+				$distributed2 = $this->cacheFactory->createDistributed('setupcheck');
+				$actual = $distributed2->get('test');
+				$distributed->remove('test');
+			} catch (\Throwable) {
+				$actual = null;
+			}
+
+			if ($actual !== $random) {
+				return SetupResult::error($this->l10n->t('Failed to write and read a value from distributed cache.'));
+			}
+		}
+
 		return SetupResult::success($this->l10n->t('Configured'));
 	}
 }


### PR DESCRIPTION
## Summary

I made a typo in the host url of the redis, but the setupcheck worked and only later on once someone that used external storage accessed the instance, it failed and errored.

Steps:
1. Install php redis
2. Setup the following Nextcloud config

```
  'memcache.local' => '\\OC\\Memcache\\Redis',
  'memcache.distributed' => '\\OC\\Memcache\\Redis',
  'memcache.locking' => '\\OC\\Memcache\\Redis',
  'redis' => 
  array (
    'host' => '127.0.213.1',
    'port' => 6379,
  ),
```

Before | After
---|---
![grafik](https://github.com/user-attachments/assets/56b40344-f8d5-4efc-91e8-c48e05ff033d) | ![Bildschirmfoto vom 2024-12-02 09-01-40](https://github.com/user-attachments/assets/79af1367-e582-446e-83c1-b2040ac1ca42)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
