### PR TITLE
[stable29] fix(share_api): Respect requested permissions or error out

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -645,9 +645,6 @@ class ShareAPIController extends OCSController {
 			throw new OCSNotFoundException($this->l->t('Invalid permissions'));
 		}
 
-		// Shares always require read permissions
-		$permissions |= Constants::PERMISSION_READ;
-
 		if ($node instanceof \OCP\Files\File) {
 			// Single file shares should never have delete or create permissions
 			$permissions &= ~Constants::PERMISSION_DELETE;
@@ -727,11 +724,6 @@ class ShareAPIController extends OCSController {
 					Constants::PERMISSION_CREATE |
 					Constants::PERMISSION_UPDATE |
 					Constants::PERMISSION_DELETE;
-			}
-
-			// TODO: It might make sense to have a dedicated setting to allow/deny converting link shares into federated ones
-			if ($this->shareManager->outgoingServer2ServerSharesAllowed()) {
-				$permissions |= Constants::PERMISSION_SHARE;
 			}
 
 			$share->setPermissions($permissions);

--- a/build/integration/sharing_features/sharing-v1.feature
+++ b/build/integration/sharing_features/sharing-v1.feature
@@ -216,7 +216,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 17 |
+      | permissions | 1 |
       | stime | A_NUMBER |
       | expiration | +3 days |
       | token | A_TOKEN |
@@ -267,7 +267,7 @@ Feature: sharing
       | share_type | 3 |
       | file_source | A_NUMBER |
       | file_target | /FOLDER |
-      | permissions | 17 |
+      | permissions | 1 |
       | stime | A_NUMBER |
       | token | A_TOKEN |
       | storage | A_NUMBER |


### PR DESCRIPTION
The share API currently always adds read permissions sent in share request with the argument that all shares must have read permissions. That this not true as link and email shares allowed not to.

In addition to the above, there is a check that ensures any share which is not a link or email share must have read permissions. There is also protection for legacy integrations where if no permissions are sent at all default permissions are set.

So it does not make sense to make any sort of additions to the permissions that a client has sent, as the response would be different from what the client expects.

