### PR TITLE
fix: Correct wording when attempting to remove a disabled app

### DIFF
--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -49,9 +49,9 @@ class Remove extends Command implements CompletionAwareInterface {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
 
-		// Check if the app is installed
+		// Check if the app is enabled
 		if (!$this->manager->isInstalled($appId)) {
-			$output->writeln($appId . ' is not installed');
+			$output->writeln($appId . ' is not enabled');
 			return 1;
 		}
 


### PR DESCRIPTION
## Summary

Fixes the confusing wording due to the mismatch between method name vs what the method actually does

https://github.com/nextcloud/server/blob/0729e264f53c2d35e6ea7ec9126216056ff58dce/lib/private/App/AppManager.php#L391

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)