### PR TITLE
fix: adjust url for task links

### DIFF
--- a/apps/dav/lib/Search/TasksSearchProvider.php
+++ b/apps/dav/lib/Search/TasksSearchProvider.php
@@ -121,7 +121,7 @@ class TasksSearchProvider extends ACalendarSearchProvider {
 	): string {
 		return $this->urlGenerator->getAbsoluteURL(
 			$this->urlGenerator->linkToRoute('tasks.page.index')
-			. '#/calendars/'
+			. 'calendars/'
 			. $calendarUri
 			. '/tasks/'
 			. $taskUri

--- a/apps/dav/tests/unit/Search/TasksSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/TasksSearchProviderTest.php
@@ -292,11 +292,11 @@ class TasksSearchProviderTest extends TestCase {
 			->willReturn('link-to-route-tasks.index');
 		$this->urlGenerator->expects($this->once())
 			->method('getAbsoluteURL')
-			->with('link-to-route-tasks.index#/calendars/uri-john.doe/tasks/task-uri.ics')
-			->willReturn('absolute-url-link-to-route-tasks.index#/calendars/uri-john.doe/tasks/task-uri.ics');
+			->with('link-to-route-tasks.indexcalendars/uri-john.doe/tasks/task-uri.ics')
+			->willReturn('absolute-url-link-to-route-tasks.indexcalendars/uri-john.doe/tasks/task-uri.ics');
 
 		$actual = self::invokePrivate($this->provider, 'getDeepLinkToTasksApp', ['uri-john.doe', 'task-uri.ics']);
-		$this->assertEquals('absolute-url-link-to-route-tasks.index#/calendars/uri-john.doe/tasks/task-uri.ics', $actual);
+		$this->assertEquals('absolute-url-link-to-route-tasks.indexcalendars/uri-john.doe/tasks/task-uri.ics', $actual);
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: #49473 

## Summary

The URL to tasks in the Task app changed with https://github.com/nextcloud/tasks/pull/2480 which was released with Tasks 0.16.0. This fix should be backported to Nextcloud 28 which is the oldest server version supported by Tasks 0.16.0.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
