### PR TITLE
Clarify app manager method names

### DIFF
--- a/apps/comments/lib/Activity/Listener.php
+++ b/apps/comments/lib/Activity/Listener.php
@@ -31,7 +31,7 @@ class Listener {
 	public function commentEvent(CommentsEvent $event): void {
 		if ($event->getComment()->getObjectType() !== 'files'
 			|| $event->getEvent() !== CommentsEvent::EVENT_ADD
-			|| !$this->appManager->isInstalled('activity')) {
+			|| !$this->appManager->isEnabledForAnyone('activity')) {
 			// Comment not for file, not adding a comment or no activity-app enabled (save the energy)
 			return;
 		}

--- a/apps/comments/tests/Unit/Activity/ListenerTest.php
+++ b/apps/comments/tests/Unit/Activity/ListenerTest.php
@@ -67,7 +67,7 @@ class ListenerTest extends TestCase {
 
 	public function testCommentEvent(): void {
 		$this->appManager->expects($this->any())
-			->method('isInstalled')
+			->method('isEnabledForAnyone')
 			->with('activity')
 			->willReturn(true);
 

--- a/apps/dav/lib/AppInfo/PluginManager.php
+++ b/apps/dav/lib/AppInfo/PluginManager.php
@@ -119,7 +119,7 @@ class PluginManager {
 
 		$this->calendarPlugins[] = $this->container->get(AppCalendarPlugin::class);
 
-		foreach ($this->appManager->getInstalledApps() as $app) {
+		foreach ($this->appManager->getEnabledApps() as $app) {
 			// load plugins and collections from info.xml
 			$info = $this->appManager->getAppInfo($app);
 			if (!isset($info['types']) || !in_array('dav', $info['types'], true)) {

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -220,7 +220,7 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 			if (!$this->info->isReadable()) {
 				// return 403 instead of 404 because a 404 would make
 				// the caller believe that the collection itself does not exist
-				if (Server::get(IAppManager::class)->isInstalled('files_accesscontrol')) {
+				if (Server::get(IAppManager::class)->isEnabledForAnyone('files_accesscontrol')) {
 					throw new Forbidden('No read permissions. This might be caused by files_accesscontrol, check your configured rules');
 				} else {
 					throw new Forbidden('No read permissions');

--- a/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
+++ b/apps/dav/tests/unit/AppInfo/PluginManagerTest.php
@@ -24,7 +24,7 @@ class PluginManagerTest extends TestCase {
 		$server = $this->createMock(ServerContainer::class);
 
 		$appManager = $this->createMock(AppManager::class);
-		$appManager->method('getInstalledApps')
+		$appManager->method('getEnabledApps')
 			->willReturn(['adavapp', 'adavapp2']);
 
 		$appInfo1 = [

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -746,7 +746,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 
 	public function getUserDisplayName(string $userId): string {
 		// check if gss is enabled and available
-		if (!$this->appManager->isInstalled('globalsiteselector')
+		if (!$this->appManager->isEnabledForAnyone('globalsiteselector')
 			|| !class_exists('\OCA\GlobalSiteSelector\Service\SlaveService')) {
 			return '';
 		}

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -408,7 +408,7 @@ class ShareAPIController extends OCSController {
 	private function retrieveFederatedDisplayName(array $userIds, bool $cacheOnly = false): array {
 		// check if gss is enabled and available
 		if (count($userIds) === 0
-			|| !$this->appManager->isInstalled('globalsiteselector')
+			|| !$this->appManager->isEnabledForAnyone('globalsiteselector')
 			|| !class_exists('\OCA\GlobalSiteSelector\Service\SlaveService')) {
 			return [];
 		}

--- a/apps/files_trashbin/lib/AppInfo/Application.php
+++ b/apps/files_trashbin/lib/AppInfo/Application.php
@@ -74,7 +74,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function registerTrashBackends(ContainerInterface $serverContainer, LoggerInterface $logger, IAppManager $appManager, ITrashManager $trashManager): void {
-		foreach ($appManager->getInstalledApps() as $app) {
+		foreach ($appManager->getEnabledApps() as $app) {
 			$appInfo = $appManager->getAppInfo($app);
 			if (isset($appInfo['trash'])) {
 				$backends = $appInfo['trash'];

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -114,7 +114,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function registerVersionBackends(ContainerInterface $container, IAppManager $appManager, LoggerInterface $logger): void {
-		foreach ($appManager->getInstalledApps() as $app) {
+		foreach ($appManager->getEnabledApps() as $app) {
 			$appInfo = $appManager->getAppInfo($app);
 			if (isset($appInfo['versions'])) {
 				$backends = $appInfo['versions'];

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -92,7 +92,7 @@ class AppSettingsController extends Controller {
 		$this->initialState->provideInitialState('appstoreDeveloperDocs', $this->urlGenerator->linkToDocs('developer-manual'));
 		$this->initialState->provideInitialState('appstoreUpdateCount', count($this->getAppsWithUpdates()));
 
-		if ($this->appManager->isInstalled('app_api')) {
+		if ($this->appManager->isEnabledForAnyone('app_api')) {
 			try {
 				Server::get(\OCA\AppAPI\Service\ExAppsPageService::class)->provideAppApiState($this->initialState);
 			} catch (\Psr\Container\NotFoundExceptionInterface|\Psr\Container\ContainerExceptionInterface $e) {
@@ -440,7 +440,7 @@ class AppSettingsController extends Controller {
 			}
 
 			$currentVersion = '';
-			if ($this->appManager->isInstalled($app['id'])) {
+			if ($this->appManager->isEnabledForAnyone($app['id'])) {
 				$currentVersion = $this->appManager->getAppVersion($app['id']);
 			} else {
 				$currentVersion = $app['releases'][0]['version'];

--- a/apps/systemtags/lib/Activity/Listener.php
+++ b/apps/systemtags/lib/Activity/Listener.php
@@ -109,7 +109,7 @@ class Listener {
 		$tagIds = $event->getTags();
 		if ($event->getObjectType() !== 'files' || empty($tagIds)
 			|| !in_array($event->getEvent(), [MapperEvent::EVENT_ASSIGN, MapperEvent::EVENT_UNASSIGN])
-			|| !$this->appManager->isInstalled('activity')) {
+			|| !$this->appManager->isEnabledForAnyone('activity')) {
 			// System tags not for files, no tags, not (un-)assigning or no activity-app enabled (save the energy)
 			return;
 		}

--- a/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
+++ b/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
@@ -132,7 +132,7 @@ class UpdateAvailableNotifications extends TimedJob {
 	 * Check all installed apps for updates
 	 */
 	protected function checkAppUpdates() {
-		$apps = $this->appManager->getInstalledApps();
+		$apps = $this->appManager->getEnabledApps();
 		foreach ($apps as $app) {
 			$update = $this->isUpdateAvailable($app);
 			if ($update !== false) {

--- a/apps/updatenotification/lib/Command/Check.php
+++ b/apps/updatenotification/lib/Command/Check.php
@@ -56,7 +56,7 @@ class Check extends Command {
 
 
 		// Apps
-		$apps = $this->appManager->getInstalledApps();
+		$apps = $this->appManager->getEnabledApps();
 		foreach ($apps as $app) {
 			$update = $this->installer->isUpdateAvailable($app);
 			if ($update !== false) {

--- a/apps/updatenotification/lib/Controller/APIController.php
+++ b/apps/updatenotification/lib/Controller/APIController.php
@@ -75,7 +75,7 @@ class APIController extends OCSController {
 		}
 
 		// Get list of installed custom apps
-		$installedApps = $this->appManager->getInstalledApps();
+		$installedApps = $this->appManager->getEnabledApps();
 		$installedApps = array_filter($installedApps, function ($app) {
 			try {
 				$this->appManager->getAppPath($app);

--- a/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
@@ -244,7 +244,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		]);
 
 		$this->appManager->expects($this->once())
-			->method('getInstalledApps')
+			->method('getEnabledApps')
 			->willReturn($apps);
 
 		$job->expects($this->exactly(\count($apps)))

--- a/apps/webhook_listeners/lib/BackgroundJobs/WebhookCall.php
+++ b/apps/webhook_listeners/lib/BackgroundJobs/WebhookCall.php
@@ -60,7 +60,7 @@ class WebhookCall extends QueuedJob {
 			$exAppId = $webhookListener->getAppId();
 			if ($exAppId !== null && str_starts_with($webhookUri, '/')) {
 				// ExApp is awaiting a direct request to itself using AppAPI
-				if (!$this->appManager->isInstalled('app_api')) {
+				if (!$this->appManager->isEnabledForAnyone('app_api')) {
 					throw new RuntimeException('AppAPI is disabled or not installed.');
 				}
 				try {

--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -44,7 +44,7 @@ class Disable extends Command implements CompletionAwareInterface {
 	}
 
 	private function disableApp(string $appId, OutputInterface $output): void {
-		if ($this->appManager->isInstalled($appId) === false) {
+		if ($this->appManager->isEnabledForAnyone($appId) === false) {
 			$output->writeln('No such app enabled: ' . $appId);
 			return;
 		}

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -27,6 +27,7 @@ class Enable extends Command implements CompletionAwareInterface {
 	public function __construct(
 		protected IAppManager $appManager,
 		protected IGroupManager $groupManager,
+		private Installer $installer,
 	) {
 		parent::__construct();
 	}
@@ -77,20 +78,17 @@ class Enable extends Command implements CompletionAwareInterface {
 			return $group->getDisplayName();
 		}, $groupIds);
 
-		if ($this->appManager->isInstalled($appId) && $groupIds === []) {
+		if ($this->appManager->isEnabledForUser($appId) && $groupIds === []) {
 			$output->writeln($appId . ' already enabled');
 			return;
 		}
 
 		try {
-			/** @var Installer $installer */
-			$installer = \OC::$server->query(Installer::class);
-
-			if ($installer->isDownloaded($appId) === false) {
-				$installer->downloadApp($appId);
+			if ($this->installer->isDownloaded($appId) === false) {
+				$this->installer->downloadApp($appId);
 			}
 
-			$installer->installApp($appId, $forceEnable);
+			$this->installer->installApp($appId, $forceEnable);
 			$appVersion = $this->appManager->getAppVersion($appId);
 
 			if ($groupIds === []) {

--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -58,7 +58,7 @@ class Install extends Command {
 		$appId = $input->getArgument('app-id');
 		$forceEnable = (bool)$input->getOption('force');
 
-		if ($this->appManager->isInstalled($appId)) {
+		if ($this->appManager->isEnabledForAnyone($appId)) {
 			$output->writeln($appId . ' already installed');
 			return 1;
 		}

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -65,7 +65,7 @@ class ListApps extends Base {
 			if ($shippedFilter !== null && $this->manager->isShipped($app) !== $shippedFilter) {
 				continue;
 			}
-			if ($this->manager->isInstalled($app)) {
+			if ($this->manager->isEnabledForAnyone($app)) {
 				$enabledApps[] = $app;
 			} else {
 				$disabledApps[] = $app;

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -117,7 +117,7 @@ class Remove extends Command implements CompletionAwareInterface {
 	 */
 	public function completeArgumentValues($argumentName, CompletionContext $context): array {
 		if ($argumentName === 'app-id') {
-			return $this->manager->getInstalledApps();
+			return $this->manager->getEnabledApps();
 		}
 		return [];
 	}

--- a/core/Command/App/Remove.php
+++ b/core/Command/App/Remove.php
@@ -50,7 +50,7 @@ class Remove extends Command implements CompletionAwareInterface {
 		$appId = $input->getArgument('app-id');
 
 		// Check if the app is enabled
-		if (!$this->manager->isInstalled($appId)) {
+		if (!$this->manager->isEnabledForAnyone($appId)) {
 			$output->writeln($appId . ' is not enabled');
 			return 1;
 		}

--- a/core/Command/Db/Migrations/GenerateMetadataCommand.php
+++ b/core/Command/Db/Migrations/GenerateMetadataCommand.php
@@ -68,15 +68,11 @@ class GenerateMetadataCommand extends Command {
 		$metadata = [];
 		foreach ($allApps as $appId) {
 			// We need to load app before being able to extract Migrations
-			// If app was not enabled before, we will disable it afterward.
-			$alreadyLoaded = $this->appManager->isInstalled($appId);
+			$alreadyLoaded = $this->appManager->isAppLoaded($appId);
 			if (!$alreadyLoaded) {
 				$this->appManager->loadApp($appId);
 			}
 			$metadata[$appId] = $this->metadataManager->extractMigrationAttributes($appId);
-			if (!$alreadyLoaded) {
-				$this->appManager->disableApp($appId);
-			}
 		}
 		return $metadata;
 	}

--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -61,7 +61,7 @@ class Repair extends Command {
 			$this->repair->addStep($step);
 		}
 
-		$apps = $this->appManager->getInstalledApps();
+		$apps = $this->appManager->getEnabledApps();
 		foreach ($apps as $app) {
 			if (!$this->appManager->isEnabledForUser($app)) {
 				continue;

--- a/lib/base.php
+++ b/lib/base.php
@@ -255,7 +255,7 @@ class OC {
 		$tooBig = false;
 		if (!$disableWebUpdater) {
 			$apps = Server::get(\OCP\App\IAppManager::class);
-			if ($apps->isInstalled('user_ldap')) {
+			if ($apps->isEnabledForAnyone('user_ldap')) {
 				$qb = Server::get(\OCP\IDBConnection::class)->getQueryBuilder();
 
 				$result = $qb->select($qb->func()->count('*', 'user_count'))
@@ -266,7 +266,7 @@ class OC {
 
 				$tooBig = ($row['user_count'] > 50);
 			}
-			if (!$tooBig && $apps->isInstalled('user_saml')) {
+			if (!$tooBig && $apps->isEnabledForAnyone('user_saml')) {
 				$qb = Server::get(\OCP\IDBConnection::class)->getQueryBuilder();
 
 				$result = $qb->select($qb->func()->count('*', 'user_count'))
@@ -1130,11 +1130,11 @@ class OC {
 	}
 
 	protected static function tryAppAPILogin(OCP\IRequest $request): bool {
-		$appManager = Server::get(OCP\App\IAppManager::class);
 		if (!$request->getHeader('AUTHORIZATION-APP-API')) {
 			return false;
 		}
-		if (!$appManager->isInstalled('app_api')) {
+		$appManager = Server::get(OCP\App\IAppManager::class);
+		if (!$appManager->isEnabledForAnyone('app_api')) {
 			return false;
 		}
 		try {

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -395,10 +395,12 @@ class AppManager implements IAppManager {
 	 * Notice: This actually checks if the app is enabled and not only if it is installed.
 	 *
 	 * @param string $appId
-	 * @param IGroup[]|String[] $groups
-	 * @return bool
 	 */
-	public function isInstalled($appId) {
+	public function isInstalled($appId): bool {
+		return $this->isEnabledForAnyone($appId);
+	}
+
+	public function isEnabledForAnyone(string $appId): bool {
 		$installedApps = $this->getInstalledAppsValues();
 		return isset($installedApps[$appId]);
 	}

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -149,11 +149,20 @@ class AppManager implements IAppManager {
 	}
 
 	/**
-	 * List all installed apps
+	 * Deprecated alias
 	 *
 	 * @return string[]
 	 */
 	public function getInstalledApps() {
+		return $this->getEnabledApps();
+	}
+
+	/**
+	 * List all enabled apps, either for everyone or for some groups
+	 *
+	 * @return list<string>
+	 */
+	public function getEnabledApps(): array {
 		return array_keys($this->getInstalledAppsValues());
 	}
 

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -88,7 +88,7 @@ class Application {
 					$this->writeMaintenanceModeInfo($input, $output);
 				} else {
 					$this->appManager->loadApps();
-					foreach ($this->appManager->getInstalledApps() as $app) {
+					foreach ($this->appManager->getEnabledApps() as $app) {
 						try {
 							$appPath = $this->appManager->getAppPath($app);
 						} catch (AppPathNotFoundException) {

--- a/lib/private/Migration/MetadataManager.php
+++ b/lib/private/Migration/MetadataManager.php
@@ -97,7 +97,7 @@ class MetadataManager {
 	 * @since 30.0.0
 	 */
 	public function getUnsupportedApps(array $metadata): array {
-		return array_values(array_diff($this->appManager->getInstalledApps(), array_keys($metadata['apps'])));
+		return array_values(array_diff($this->appManager->getEnabledApps(), array_keys($metadata['apps'])));
 	}
 
 	/**

--- a/lib/private/Migration/MetadataManager.php
+++ b/lib/private/Migration/MetadataManager.php
@@ -73,7 +73,7 @@ class MetadataManager {
 	): array {
 		$appsAttributes = [];
 		foreach (array_keys($metadata['apps']) as $appId) {
-			if ($filterKnownMigrations && !$this->appManager->isInstalled($appId)) {
+			if ($filterKnownMigrations && !$this->appManager->isEnabledForAnyone($appId)) {
 				continue; // if not interested and app is not installed
 			}
 

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -328,7 +328,7 @@ class NavigationManager implements INavigationManager {
 			$apps = $this->appManager->getEnabledAppsForUser($user);
 			$this->customAppOrder = json_decode($this->config->getUserValue($user->getUID(), 'core', 'apporder', '[]'), true, flags:JSON_THROW_ON_ERROR);
 		} else {
-			$apps = $this->appManager->getInstalledApps();
+			$apps = $this->appManager->getEnabledApps();
 			$this->customAppOrder = [];
 		}
 

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -837,7 +837,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$busClass = $c->get(\OCP\IConfig::class)->getSystemValueString('commandbus');
 			if ($busClass) {
 				[$app, $class] = explode('::', $busClass, 2);
-				if ($c->get(IAppManager::class)->isInstalled($app)) {
+				if ($c->get(IAppManager::class)->isEnabledForUser($app)) {
 					\OC_App::loadApp($app);
 					return $c->get($class);
 				} else {
@@ -1046,7 +1046,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$classExists = false;
 			}
 
-			if ($classExists && $c->get(\OCP\IConfig::class)->getSystemValueBool('installed', false) && $c->get(IAppManager::class)->isInstalled('theming') && $c->get(TrustedDomainHelper::class)->isTrustedDomain($c->getRequest()->getInsecureServerHost())) {
+			if ($classExists && $c->get(\OCP\IConfig::class)->getSystemValueBool('installed', false) && $c->get(IAppManager::class)->isEnabledForAnyone('theming') && $c->get(TrustedDomainHelper::class)->isTrustedDomain($c->getRequest()->getInsecureServerHost())) {
 				$backgroundService = new BackgroundService(
 					$c->get(IRootFolder::class),
 					$c->getAppDataDir('theming'),

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -1396,7 +1396,7 @@ class Manager implements IManager {
 				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. Invalid method: ' . $method);
 			}
 			[, $exAppId, $httpMethod] = $parsedMethod;
-			if (!$this->appManager->isInstalled('app_api')) {
+			if (!$this->appManager->isEnabledForAnyone('app_api')) {
 				$this->logger->warning('Task processing AppAPI webhook failed for task ' . $task->getId() . '. AppAPI is disabled or not installed.');
 				return;
 			}

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -78,7 +78,7 @@ class JSConfigHelper {
 		$apps_paths = [];
 
 		if ($this->currentUser === null) {
-			$apps = $this->appManager->getInstalledApps();
+			$apps = $this->appManager->getEnabledApps();
 		} else {
 			$apps = $this->appManager->getEnabledAppsForUser($this->currentUser);
 		}

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -242,7 +242,7 @@ class Updater extends BasicEmitter {
 		$appManager = \OC::$server->getAppManager();
 
 		// upgrade appstore apps
-		$this->upgradeAppStoreApps($appManager->getInstalledApps());
+		$this->upgradeAppStoreApps($appManager->getEnabledApps());
 		$autoDisabledApps = $appManager->getAutoDisabledApps();
 		if (!empty($autoDisabledApps)) {
 			$this->upgradeAppStoreApps(array_keys($autoDisabledApps), $autoDisabledApps);

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -185,7 +185,7 @@ class OC_App {
 		}
 
 		if (is_null($user)) {
-			$apps = $appManager->getInstalledApps();
+			$apps = $appManager->getEnabledApps();
 		} else {
 			$apps = $appManager->getEnabledAppsForUser($user);
 		}

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -79,8 +79,16 @@ interface IAppManager {
 	 * @param string $appId
 	 * @return bool
 	 * @since 8.0.0
+	 * @deprecated 31.0.0 Use either {@see self::isEnabledForUser} or {@see self::isEnabledForAnyone}
 	 */
 	public function isInstalled($appId);
+
+	/**
+	 * Check if an app is enabled in the instance, either for everyone or for specific groups
+	 *
+	 * @since 31.0.0
+	 */
+	public function isEnabledForAnyone(string $appId): bool;
 
 	/**
 	 * Check if an app should be enabled by default

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -79,14 +79,14 @@ interface IAppManager {
 	 * @param string $appId
 	 * @return bool
 	 * @since 8.0.0
-	 * @deprecated 31.0.0 Use either {@see self::isEnabledForUser} or {@see self::isEnabledForAnyone}
+	 * @deprecated 32.0.0 Use either {@see self::isEnabledForUser} or {@see self::isEnabledForAnyone}
 	 */
 	public function isInstalled($appId);
 
 	/**
 	 * Check if an app is enabled in the instance, either for everyone or for specific groups
 	 *
-	 * @since 31.0.0
+	 * @since 32.0.0
 	 */
 	public function isEnabledForAnyone(string $appId): bool;
 
@@ -186,8 +186,17 @@ interface IAppManager {
 	 *
 	 * @return string[]
 	 * @since 8.1.0
+	 * @deprecated 32.0.0 Use either {@see self::getEnabledApps} or {@see self::getEnabledAppsForUser}
 	 */
 	public function getInstalledApps();
+
+	/**
+	 * List all apps enabled, either for everyone or for specific groups only
+	 *
+	 * @return list<string>
+	 * @since 32.0.0
+	 */
+	public function getEnabledApps(): array;
 
 	/**
 	 * Clear the cached list of apps when enabling/disabling an app

--- a/public.php
+++ b/public.php
@@ -70,7 +70,7 @@ try {
 	OC_App::loadApps(['filesystem', 'logging']);
 
 	// Check if the app is enabled
-	if (!\OC::$server->getAppManager()->isInstalled($app)) {
+	if (!\OC::$server->getAppManager()->isEnabledForUser($app)) {
 		throw new \Exception('App not installed: ' . $app);
 	}
 

--- a/remote.php
+++ b/remote.php
@@ -134,7 +134,7 @@ try {
 			$file = OC::$SERVERROOT . '/' . $file;
 			break;
 		default:
-			if (!$appManager->isInstalled($app)) {
+			if (!$appManager->isEnabledForUser($app)) {
 				throw new RemoteException('App not installed: ' . $app);
 			}
 			$appManager->loadApp($app);

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Tests\Core\Command\Config;
 
 use OC\Core\Command\App\Enable;
+use OC\Installer;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -26,7 +27,8 @@ class AppsEnableTest extends TestCase {
 
 		$command = new Enable(
 			\OC::$server->getAppManager(),
-			\OC::$server->getGroupManager()
+			\OC::$server->getGroupManager(),
+			\OC::$server->get(Installer::class),
 		);
 
 		$this->commandTester = new CommandTester($command);

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -539,7 +539,7 @@ class AppManagerTest extends TestCase {
 		$this->assertTrue($this->manager->isEnabledForUser('test'));
 	}
 
-	public function testGetInstalledApps(): void {
+	public function testGetEnabledApps(): void {
 		$this->appConfig->setValue('test1', 'enabled', 'yes');
 		$this->appConfig->setValue('test2', 'enabled', 'no');
 		$this->appConfig->setValue('test3', 'enabled', '["foo"]');
@@ -560,7 +560,7 @@ class AppManagerTest extends TestCase {
 			'viewer',
 			'workflowengine',
 		];
-		$this->assertEquals($apps, $this->manager->getInstalledApps());
+		$this->assertEquals($apps, $this->manager->getEnabledApps());
 	}
 
 	public function testGetAppsForUser(): void {

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -426,17 +426,17 @@ class AppManagerTest extends TestCase {
 
 	public function testIsInstalledEnabled(): void {
 		$this->appConfig->setValue('test', 'enabled', 'yes');
-		$this->assertTrue($this->manager->isInstalled('test'));
+		$this->assertTrue($this->manager->isEnabledForAnyone('test'));
 	}
 
 	public function testIsInstalledDisabled(): void {
 		$this->appConfig->setValue('test', 'enabled', 'no');
-		$this->assertFalse($this->manager->isInstalled('test'));
+		$this->assertFalse($this->manager->isEnabledForAnyone('test'));
 	}
 
 	public function testIsInstalledEnabledForGroups(): void {
 		$this->appConfig->setValue('test', 'enabled', '["foo"]');
-		$this->assertTrue($this->manager->isInstalled('test'));
+		$this->assertTrue($this->manager->isEnabledForAnyone('test'));
 	}
 
 	private function newUser($uid) {

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -718,7 +718,7 @@ class NavigationManagerTest extends TestCase {
 			'id' => 'settings',
 		]);
 
-		$this->appManager->method('getInstalledApps')->willReturn([]);
+		$this->appManager->method('getEnabledApps')->willReturn([]);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user1');
@@ -743,7 +743,7 @@ class NavigationManagerTest extends TestCase {
 	}
 
 	public function testDefaultEntryUpdated(): void {
-		$this->appManager->method('getInstalledApps')->willReturn([]);
+		$this->appManager->method('getEnabledApps')->willReturn([]);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user1');


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Renames isInstalled -> isEnabledForAnyone, and getInstalledApps -> getEnabledApps.

There is a weird situation for apps which are enabled only for some groups of users:
- They are in the return of getInstalledApps/getEnabledApps
- They return true for isInstalled/isEnabledForAnyone (which is why I named it that way)
For isEnabled*, one can use isEnabledForUser($app, null), to check if the app is enabled for everyone.
But for getEnabled*, there is no equivalent, as getEnabledForUser parameter is mandatory.
Because of that, in NavigationManager, isEnabledForUser is called on each app returned by getInstalledApps.

We could consider that when there is no user in session we should always exclude apps enabled only for some groups, and I think for public pages it makes sense (does it?).
But the issue is for `occ` cli tool, there there is no user in session but we do want to consider app enabled for some groups only as enabled.

So basically for each getInstalledApps call, we should ask ourselves whether the list should include partially-enabled apps or not, and replace with the appropriate method call.
We may want to rename getEnabledApps with a more precise name, but getEnableAppsForAnyone is ugly, no?
We may want to add a way to get apps enabled for everyone, either as a new method or by making the parameter nullable in getEnabledAppsForUser.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
