### PR TITLE
Handle tags with the same name gracefully

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1994,6 +1994,8 @@ return array(
     'OC\\TagManager' => $baseDir . '/lib/private/TagManager.php',
     'OC\\Tagging\\Tag' => $baseDir . '/lib/private/Tagging/Tag.php',
     'OC\\Tagging\\TagMapper' => $baseDir . '/lib/private/Tagging/TagMapper.php',
+    'OC\\Tagging\\TagRelation' => $baseDir . '/lib/private/Tagging/TagRelation.php',
+    'OC\\Tagging\\TagRelationMapper' => $baseDir . '/lib/private/Tagging/TagRelationMapper.php',
     'OC\\Tags' => $baseDir . '/lib/private/Tags.php',
     'OC\\Talk\\Broker' => $baseDir . '/lib/private/Talk/Broker.php',
     'OC\\Talk\\ConversationOptions' => $baseDir . '/lib/private/Talk/ConversationOptions.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -2035,6 +2035,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\TagManager' => __DIR__ . '/../../..' . '/lib/private/TagManager.php',
         'OC\\Tagging\\Tag' => __DIR__ . '/../../..' . '/lib/private/Tagging/Tag.php',
         'OC\\Tagging\\TagMapper' => __DIR__ . '/../../..' . '/lib/private/Tagging/TagMapper.php',
+        'OC\\Tagging\\TagRelation' => __DIR__ . '/../../..' . '/lib/private/Tagging/TagRelation.php',
+        'OC\\Tagging\\TagRelationMapper' => __DIR__ . '/../../..' . '/lib/private/Tagging/TagRelationMapper.php',
         'OC\\Tags' => __DIR__ . '/../../..' . '/lib/private/Tags.php',
         'OC\\Talk\\Broker' => __DIR__ . '/../../..' . '/lib/private/Talk/Broker.php',
         'OC\\Talk\\ConversationOptions' => __DIR__ . '/../../..' . '/lib/private/Talk/ConversationOptions.php',

--- a/lib/private/Tagging/TagRelation.php
+++ b/lib/private/Tagging/TagRelation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Tagging;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ *
+ * @method int getObjid()
+ * @method void setObjid(int $objid)
+ * @method int getCategoryid()
+ * @method void setCategoryid(int $categoryid)
+ * @method string getType()
+ * @method void setType(string $type)
+ */
+class TagRelation extends Entity {
+	public function __construct(
+		protected int $objid,
+		protected int $categoryid,
+		protected string $type,
+	) {
+		$this->addType('objid', 'integer');
+		$this->addType('categoryid', 'integer');
+		$this->addType('type', 'string');
+	}
+}

--- a/lib/private/Tagging/TagRelationMapper.php
+++ b/lib/private/Tagging/TagRelationMapper.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Tagging;
+
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<TagRelation>
+ */
+class TagRelationMapper extends QBMapper {
+
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'vcategory_to_object', TagRelation::class);
+	}
+
+	public function deleteByObjidAndTagIds(int $objid, array $tagIds): void {
+		$qb = $this->db->getQueryBuilder();
+		$qb->delete($this->getTableName())
+			->where($qb->expr()->eq('objid', $qb->createNamedParameter($objid, IQueryBuilder::PARAM_INT), IQueryBuilder::PARAM_INT))
+			->andWhere($qb->expr()->in('categoryid', $qb->createNamedParameter($tagIds, IQueryBuilder::PARAM_INT_ARRAY)), IQueryBuilder::PARAM_INT_ARRAY);
+
+		$qb->executeStatement();
+	}
+}


### PR DESCRIPTION
## Summary

We received a report that some files marked as favorites are not displayed in the "Favorites" view. Additionally, users cannot remove the favorite state from these files. This issue is similar to https://github.com/nextcloud/server/issues/49395.

**Root Cause** 
- The lib/private/Tags.php implementation does not properly verify if a given tag already exists. Although a check exists, the list of tags is loaded only once and never updated.
- The database table lacks a unique constraint, allowing multiple identical tags for the same user.


**Proposed Solution**

To avoid requiring a migration path for existing tags, I adjusted the code to handle tags with the same name gracefully.

Commit: "vobjects may contain the same tag with different ids"
  - Resolves the display issue by using a subselect to find all tag IDs associated with a name and fetching the relevant objects.

Commit: "add mapper for vcategory_to_object"
  - Introduces a TagRelation and TagRelationMapper to clean up the codebase and address the deletion issue.
  - This makes it possible to delete mappings for multiple categorieid values, which previously only targeted the first ID.

**Current Status**

The implementation requires additional work to fully resolve the deletion issue. However, due to higher-priority tickets, we are unable to allocate further time to this effort at the moment.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
