### PR TITLE
fix(activity): make emails for link share uploads true by default

### DIFF
--- a/apps/files_sharing/lib/Activity/Settings/PublicLinksUpload.php
+++ b/apps/files_sharing/lib/Activity/Settings/PublicLinksUpload.php
@@ -61,6 +61,6 @@ class PublicLinksUpload extends ShareActivitySettings {
 	 * @since 11.0.0
 	 */
 	public function isDefaultEnabledMail() {
-		return false;
+		return true;
 	}
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/49133

Setting is new by default since Nc 30

BTW, Wouldn't it make sense to reset the `'activity', 'configured'` user config, so that we can set defaults again?
https://github.com/nextcloud/activity/blob/4044007b25aae32ae423f85b9d2f51c8c8cf780e/lib/Listener/SetUserDefaults.php