### PR TITLE
fix: only do cache copy in updater if the parent folder should be in cache

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -185,7 +185,15 @@ class Updater implements IUpdater {
 	 */
 	public function copyFromStorage(IStorage $sourceStorage, string $source, string $target): void {
 		$this->copyOrRenameFromStorage($sourceStorage, $source, $target, function (ICache $sourceCache, ICacheEntry $sourceInfo) use ($target) {
-			$this->cache->copyFromCache($sourceCache, $sourceInfo, $target);
+			$parent = dirname($target);
+			$parentInCache = $this->cache->inCache($parent);
+			if (!$parentInCache) {
+				$parentData = $this->scanner->scan($parent, Scanner::SCAN_SHALLOW, -1, false);
+				$parentInCache = $parentData !== null;
+			}
+			if ($parentInCache) {
+				$this->cache->copyFromCache($sourceCache, $sourceInfo, $target);
+			}
 		});
 	}
 


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/48651 broke moving encrypted files to encrypted groupfolders when not using object store (see [the failing cypress run](https://github.com/nextcloud/groupfolders/actions/runs/12200625501/job/34037815580?pr=3425)) because the `/files_encryption/...` folders are [intentionally excluded](https://github.com/nextcloud/server/blob/dae7c159f728a90ffa53247d6e033abdae5d2bd6/lib/private/Files/Cache/LocalRootScanner.php#L30) from the cache. So that parent folder of the target of the copy is not in cache, making `copyFromCache` fail.

This change makes the updater match the old behavior[1] by not updating the cache if the parent folder isn't in the cache (and is excluded from scanning).

[1]: the cache updates for copies where previously handled by `Updater::update` which just calls `scan` and thus ignores such excluded paths