### PR TITLE
feat(occ): Better handling of disabled or unreacheable App store

### DIFF
--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -10,6 +10,7 @@ namespace OC\Core\Command\App;
 
 use OC\Installer;
 use OCP\App\IAppManager;
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,8 +19,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Update extends Command {
+	public const APP_STORE_URL = 'https://apps.nextcloud.com/api/v1';
+
 	public function __construct(
 		protected IAppManager $manager,
+		protected IConfig $config,
 		private Installer $installer,
 		private LoggerInterface $logger,
 	) {
@@ -57,6 +61,19 @@ class Update extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$appStoreEnabled = $this->config->getSystemValueBool('appstoreenabled', true);
+		if ($appStoreEnabled === false) {
+			$output->writeln('App store access is disabled');
+			return 1;
+		}
+
+		$internetAvailable = $this->config->getSystemValueBool('has_internet_connection', true);
+		$isDefaultAppStore = $this->config->getSystemValueString('appstoreurl', self::APP_STORE_URL) === self::APP_STORE_URL;
+		if ($internetAvailable === false && $isDefaultAppStore === true) {
+			$output->writeln('Internet connection is disabled, and therefore the default public App store is not reachable');
+			return 1;
+		}
+
 		$singleAppId = $input->getArgument('app-id');
 		$updateFound = false;
 

--- a/core/Command/App/Update.php
+++ b/core/Command/App/Update.php
@@ -12,6 +12,7 @@ namespace OC\Core\Command\App;
 use OC\Installer;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
+use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -20,8 +21,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Update extends Command {
+	public const APP_STORE_URL = 'https://apps.nextcloud.com/api/v1';
+
 	public function __construct(
 		protected IAppManager $manager,
+		protected IConfig $config,
 		private Installer $installer,
 		private LoggerInterface $logger,
 	) {
@@ -67,6 +71,19 @@ class Update extends Command {
 
 	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$appStoreEnabled = $this->config->getSystemValueBool('appstoreenabled', true);
+		if ($appStoreEnabled === false) {
+			$output->writeln('App store access is disabled');
+			return 1;
+		}
+
+		$internetAvailable = $this->config->getSystemValueBool('has_internet_connection', true);
+		$isDefaultAppStore = $this->config->getSystemValueString('appstoreurl', self::APP_STORE_URL) === self::APP_STORE_URL;
+		if ($internetAvailable === false && $isDefaultAppStore === true) {
+			$output->writeln('Internet connection is disabled, and therefore the default public App store is not reachable');
+			return 1;
+		}
+
 		$singleAppId = $input->getArgument('app-id');
 		$updateFound = false;
 		$showOnly = $input->getOption('showonly') || $input->getOption('showcurrent');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
Set either `appstoreenabled` or `has_internet_connection` to `false` on `config.php` file.

Previously in all cases:

```
# occ app:update previewgenerator
previewgenerator is up-to-date or no updates could be found
```

After:

```
# occ app:update previewgenerator
App store access is disabled
```
or
```
# occ app:update previewgenerator
Internet connection is disabled, and therefore the default public App store is not reachable
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
