### PR TITLE
enh: Improving ShareEntryLink

### DIFF
--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -696,9 +696,8 @@ export default {
 		 * accordingly
 		 *
 		 * @param {Share} share the new share
-		 * @param {boolean} [update] do we update the current share ?
 		 */
-		async pushNewLinkShare(share, update) {
+		async pushNewLinkShare(share) {
 			try {
 				// do nothing if we're already pending creation
 				if (this.loading) {
@@ -728,20 +727,13 @@ export default {
 				this.open = false
 				this.shareCreationComplete = true
 				console.debug('Link share created', newShare)
-				// if share already exists, copy link directly on next tick
-				let component
-				if (update) {
-					component = await new Promise(resolve => {
-						this.$emit('update:share', newShare, resolve)
-					})
-				} else {
-					// adding new share to the array and copying link to clipboard
-					// using promise so that we can copy link in the same click function
-					// and avoid firefox copy permissions issue
-					component = await new Promise(resolve => {
-						this.$emit('add:share', newShare, resolve)
-					})
-				}
+
+				// adding new share to the array and copying link to clipboard
+				// using promise so that we can copy link in the same click function
+				// and avoid firefox copy permissions issue
+				const component = await new Promise(resolve => {
+					this.$emit('add:share', newShare, resolve)
+				})
 
 				await this.getNode()
 				emit('files:node:updated', this.node)


### PR DESCRIPTION
Since Nexcloud27, all share edits can only be done from the `SharingDetailsTab` or the `QuickShareSelect` so this concerned component does not need to handle updates.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
