### PR TITLE
fix(federation): Restore compatibility with Nextcloud 30 servers

### DIFF
--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -182,12 +182,14 @@ class OCMProvider implements IOCMProvider {
 		}
 		$this->setResourceTypes($resources);
 
-		// import details about the remote request signing public key, if available
-		$signatory = new Signatory();
-		$signatory->setKeyId($data['publicKey']['keyId'] ?? '');
-		$signatory->setPublicKey($data['publicKey']['publicKeyPem'] ?? '');
-		if ($signatory->getKeyId() !== '' && $signatory->getPublicKey() !== '') {
-			$this->setSignatory($signatory);
+		if (isset($data['publicKey'])) {
+			// import details about the remote request signing public key, if available
+			$signatory = new Signatory();
+			$signatory->setKeyId($data['publicKey']['keyId'] ?? '');
+			$signatory->setPublicKey($data['publicKey']['publicKeyPem'] ?? '');
+			if ($signatory->getKeyId() !== '' && $signatory->getPublicKey() !== '') {
+				$this->setSignatory($signatory);
+			}
 		}
 
 		if (!$this->looksValid()) {

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -172,7 +172,8 @@ class OCMProvider implements IOCMProvider {
 	 */
 	public function import(array $data): static {
 		$this->setEnabled(is_bool($data['enabled'] ?? '') ? $data['enabled'] : false)
-			->setApiVersion((string)($data['version'] ?? ''))
+			// Fall back to old apiVersion for Nextcloud 30 compatibility
+			->setApiVersion((string)($data['version'] ?? $data['apiVersion'] ?? ''))
 			->setEndPoint($data['endPoint'] ?? '');
 
 		$resources = [];


### PR DESCRIPTION
## Summary

- [x] Federation from 31 to a 30 server did no longer work, because it only allowed the new version parameter and did not fall back to the old one
- [x] Also it broke when the public key was missing from the response, which is always the case from old instances

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
