### PR TITLE
fix(share): Don't print twice the same text on emails

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -333,7 +333,6 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		$emailTemplate->setSubject($this->l->t('%1$s shared %2$s with you', [$initiatorDisplayName, $filename]));
 		$emailTemplate->addHeader();
 		$emailTemplate->addHeading($this->l->t('%1$s shared %2$s with you', [$initiatorDisplayName, $filename]), false);
-		$text = $this->l->t('%1$s shared %2$s with you.', [$initiatorDisplayName, $filename]);
 
 		if ($note !== '') {
 			$emailTemplate->addBodyListItem(
@@ -354,8 +353,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		}
 
 		$emailTemplate->addBodyText(
-			htmlspecialchars($text . ' ' . $this->l->t('Click the button below to open it.')),
-			$text
+			$this->l->t('Click the button below to open it.')
 		);
 
 		$emailTemplate->addBodyButton(

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -1292,10 +1292,7 @@ class ShareByMailProviderTest extends TestCase {
 		$template
 			->expects($this->once())
 			->method('addBodyText')
-			->with(
-				'Mrs. Owner User shared file.txt with you. Click the button below to open it.',
-				'Mrs. Owner User shared file.txt with you.'
-			);
+			->with('Click the button below to open it.');
 		$template
 			->expects($this->once())
 			->method('addBodyButton')
@@ -1405,7 +1402,7 @@ class ShareByMailProviderTest extends TestCase {
 		$template
 			->expects($this->once())
 			->method('addBodyText')
-			->with('Mrs. Owner User shared file.txt with you. Click the button below to open it.', 'Mrs. Owner User shared file.txt with you.');
+			->with('Click the button below to open it.');
 
 		$this->urlGenerator->expects($this->once())->method('imagePath')
 			->with('core', 'caldav/description.png')
@@ -1531,7 +1528,7 @@ class ShareByMailProviderTest extends TestCase {
 		$template
 			->expects($this->once())
 			->method('addBodyText')
-			->with('Mrs. Owner User shared file.txt with you. Click the button below to open it.', 'Mrs. Owner User shared file.txt with you.');
+			->with('Click the button below to open it.');
 
 		$expiration = new DateTime('2001-01-01');
 		$this->l->expects($this->once())
@@ -1663,10 +1660,7 @@ class ShareByMailProviderTest extends TestCase {
 		$template
 			->expects($this->once())
 			->method('addBodyText')
-			->with(
-				'Mr. Initiator User shared file.txt with you. Click the button below to open it.',
-				'Mr. Initiator User shared file.txt with you.'
-			);
+			->with('Click the button below to open it.');
 		$template
 			->expects($this->once())
 			->method('addBodyButton')
@@ -1767,10 +1761,7 @@ class ShareByMailProviderTest extends TestCase {
 		$template
 			->expects($this->once())
 			->method('addBodyText')
-			->with(
-				'Mrs. Owner User shared file.txt with you. Click the button below to open it.',
-				'Mrs. Owner User shared file.txt with you.'
-			);
+			->with('Click the button below to open it.');
 		$template
 			->expects($this->once())
 			->method('addBodyButton')
@@ -1875,10 +1866,7 @@ class ShareByMailProviderTest extends TestCase {
 		$template
 			->expects($this->once())
 			->method('addBodyText')
-			->with(
-				'Mr. Initiator User shared file.txt with you. Click the button below to open it.',
-				'Mr. Initiator User shared file.txt with you.'
-			);
+			->with('Click the button below to open it.');
 		$template
 			->expects($this->once())
 			->method('addBodyButton')

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -1512,21 +1512,20 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 			'shareWith' => $shareWith,
 		]);
 
-		$emailTemplate->setSubject($l->t('%1$s shared »%2$s« with you', [$initiatorDisplayName, $filename]));
+		$emailTemplate->setSubject($l->t('%1$s shared %2$s with you', [$initiatorDisplayName, $filename]));
 		$emailTemplate->addHeader();
-		$emailTemplate->addHeading($l->t('%1$s shared »%2$s« with you', [$initiatorDisplayName, $filename]), false);
-		$text = $l->t('%1$s shared »%2$s« with you.', [$initiatorDisplayName, $filename]);
+		$emailTemplate->addHeading($l->t('%1$s shared %2$s with you', [$initiatorDisplayName, $filename]), false);
 
 		if ($note !== '') {
 			$emailTemplate->addBodyText(htmlspecialchars($note), $note);
 		}
 
 		$emailTemplate->addBodyText(
-			htmlspecialchars($text . ' ' . $l->t('Click the button below to open it.')),
-			$text
+			$l->t('Click the button below to open it.')
 		);
+
 		$emailTemplate->addBodyButton(
-			$l->t('Open »%s«', [$filename]),
+			$l->t('Open %s', [$filename]),
 			$link
 		);
 
@@ -1601,20 +1600,20 @@ class DefaultShareProvider implements IShareProviderWithNotification, IShareProv
 			$initiatorUser = $this->userManager->get($initiator);
 			$initiatorDisplayName = ($initiatorUser instanceof IUser) ? $initiatorUser->getDisplayName() : $initiator;
 			$initiatorEmailAddress = ($initiatorUser instanceof IUser) ? $initiatorUser->getEMailAddress() : null;
-			$plainHeading = $l->t('%1$s shared »%2$s« with you and wants to add:', [$initiatorDisplayName, $filename]);
-			$htmlHeading = $l->t('%1$s shared »%2$s« with you and wants to add', [$initiatorDisplayName, $filename]);
+			$plainHeading = $l->t('%1$s shared %2$s with you and wants to add:', [$initiatorDisplayName, $filename]);
+			$htmlHeading = $l->t('%1$s shared %2$s with you and wants to add', [$initiatorDisplayName, $filename]);
 			$message = $this->mailer->createMessage();
 
 			$emailTemplate = $this->mailer->createEMailTemplate('defaultShareProvider.sendNote');
 
-			$emailTemplate->setSubject($l->t('»%s« added a note to a file shared with you', [$initiatorDisplayName]));
+			$emailTemplate->setSubject($l->t('%s added a note to a file shared with you', [$initiatorDisplayName]));
 			$emailTemplate->addHeader();
 			$emailTemplate->addHeading($htmlHeading, $plainHeading);
 			$emailTemplate->addBodyText(htmlspecialchars($note), $note);
 
 			$link = $this->urlGenerator->linkToRouteAbsolute('files.viewcontroller.showFile', ['fileid' => $share->getNode()->getId()]);
 			$emailTemplate->addBodyButton(
-				$l->t('Open »%s«', [$filename]),
+				$l->t('Open %s', [$filename]),
 				$link
 			);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Don't print twice the same text on email.

Also removed those `» «` From `DefaultShare` as they are not printed on `ShareByMail` for consistency.

### Before

![image](https://github.com/user-attachments/assets/2bd6da9b-d79b-4053-9e5e-3b4e13ced9b0)

### After

![image](https://github.com/user-attachments/assets/5d9bcc28-b8ef-45db-8625-eed946d72755)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
