### PR TITLE
fix(federation): Allow Oracles empty strings

### DIFF
--- a/lib/unstable/Security/Signature/Model/Signatory.php
+++ b/lib/unstable/Security/Signature/Model/Signatory.php
@@ -39,8 +39,7 @@ use OCP\AppFramework\Db\Entity;
  * @method void setType(int $type)
  * @method int getStatus()
  * @method void setStatus(int $status)
- * @method void setAccount(string $account)
- * @method string getAccount()
+ * @method void setAccount(?string $account)
  * @method void setMetadata(array $metadata)
  * @method ?array getMetadata()
  * @method void setCreation(int $creation)
@@ -56,7 +55,7 @@ class Signatory extends Entity implements JsonSerializable {
 	protected string $host = '';
 	protected string $publicKey = '';
 	protected string $privateKey = '';
-	protected string $account = '';
+	protected ?string $account = '';
 	protected int $type = 9;
 	protected int $status = 1;
 	protected ?array $metadata = null;
@@ -143,6 +142,13 @@ class Signatory extends Entity implements JsonSerializable {
 	 */
 	public function getSignatoryStatus(): SignatoryStatus {
 		return SignatoryStatus::from($this->getStatus());
+	}
+
+	/**
+	 * @experimental 31.0.0
+	 */
+	public function getAccount(): string {
+		return $this->account ?? '';
 	}
 
 	/**


### PR DESCRIPTION
* Resolves: `Cannot assign null to property NCU\\Security\\Signature\\Model\\Signatory::$account of type string in file '/home/runner/actions-runner/_work/spreed/spreed/host/lib/public/AppFramework/Db/Entity.php' line 149`
* Before https://github.com/nextcloud/spreed/actions/runs/12251789635/job/34177104152?pr=13967
* After https://github.com/nextcloud/spreed/actions/runs/12254262324/job/34184792486?pr=13967

## Summary

- Since this is a general problem I wonder if we should fix it in a better way. Basically we need `$this->addType('account', 'string');` to specify if they are "nullable" and if not "heal oracle" by converting null to empty string?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
