### PR TITLE
Make files settings admin configurable

### DIFF
--- a/apps/files/lib/Service/UserConfig.php
+++ b/apps/files/lib/Service/UserConfig.php
@@ -115,7 +115,12 @@ class UserConfig {
 			throw new \InvalidArgumentException('Unknown config key');
 		}
 
-		if (!in_array($value, $this->getAllowedConfigValues($key))) {
+		$isBoolValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($isBoolValue !== null) {
+            $value = $isBoolValue;
+        }
+
+		if (!in_array($value, $this->getAllowedConfigValues($key), true)) {
 			throw new \InvalidArgumentException('Invalid config value');
 		}
 

--- a/apps/files/lib/Service/UserConfig.php
+++ b/apps/files/lib/Service/UserConfig.php
@@ -6,6 +6,7 @@
 namespace OCA\Files\Service;
 
 use OCA\Files\AppInfo\Application;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -54,6 +55,7 @@ class UserConfig {
 	public function __construct(
 		protected IConfig $config,
 		IUserSession $userSession,
+		protected IAppConfig $appConfig,
 	) {
 		$this->user = $userSession->getUser();
 	}
@@ -143,9 +145,11 @@ class UserConfig {
 
 		$userId = $this->user->getUID();
 		$userConfigs = array_map(function (string $key) use ($userId) {
-			$value = $this->config->getUserValue($userId, Application::APP_ID, $key, $this->getDefaultConfigValue($key));
-			// If the default is expected to be a boolean, we need to cast the value
-			if (is_bool($this->getDefaultConfigValue($key)) && is_string($value)) {
+			$value = $this->config->getUserValue($userId, Application::APP_ID, $key, null);
+			if ($value === null) {
+				$value = $this->appConfig->getAppValueBool($key, $this->getDefaultConfigValue($key));
+			} else if (is_bool($this->getDefaultConfigValue($key)) && is_string($value)) {
+				// If the default value is expected to be a boolean, we need to cast the value
 				return $value === '1';
 			}
 			return $value;

--- a/apps/files/tests/Service/UserConfigTest.php
+++ b/apps/files/tests/Service/UserConfigTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2024 STRATO AG
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\Files\Tests\Service;
+
+use OCA\Files\AppInfo\Application;
+use OCA\Files\Service\UserConfig;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserSession;
+
+/**
+ * Class UserConfigTest
+ *
+ * @group DB
+ *
+ * @package OCA\Files
+ */
+class UserConfigTest extends \Test\TestCase {
+	/**
+	 * @var string
+	 */
+	private $userUID;
+
+	private $userMock;
+
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	private $configMock;
+
+	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
+	private $userSessionMock;
+
+	/**
+	 * @var UserConfig|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private $userConfigService;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->configMock = $this->createMock(IConfig::class);
+
+		$this->userUID = static::getUniqueID('user_id-');
+		\OC::$server->getUserManager()->createUser($this->userUID, 'test');
+		\OC_User::setUserId($this->userUID);
+		\OC_Util::setupFS($this->userUID);
+		$this->userMock = $this->getUserMock($this->userUID);
+
+		$this->userSessionMock = $this->createMock(IUserSession::class);
+		$this->userSessionMock->expects($this->any())
+			->method('getUser')
+			->withAnyParameters()
+			->willReturn($this->userMock);
+
+		$this->userConfigService = $this->getUserConfigService(['addActivity']);
+	}
+
+	/**
+	 * @param array $methods
+	 * @return UserConfig|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	protected function getUserConfigService(array $methods = []) {
+		return $this->getMockBuilder(UserConfig::class)
+			->setConstructorArgs([
+				$this->configMock,
+				$this->userSessionMock,
+			])
+			->setMethods($methods)
+			->getMock();
+	}
+
+	/**
+	 * @param string $uid
+	 * @return IUser|MockObject
+	 */
+	protected function getUserMock($uid) {
+		$user = $this->createMock(IUser::class);
+		$user->expects($this->any())
+			->method('getUID')
+			->willReturn($uid);
+		return $user;
+	}
+	protected function tearDown(): void {
+		\OC_User::setUserId('');
+		$user = \OC::$server->getUserManager()->get($this->userUID);
+		if ($user !== null) {
+			$user->delete();
+		}
+	}
+	public function testThrowsExceptionWhenNoUserLoggedInForSetConfig(): void {
+		$this->userSessionMock = $this->createMock(IUserSession::class);
+		$this->userSessionMock->expects($this->any())
+			->method('getUser')
+			->withAnyParameters()
+			->willReturn(null);
+
+		$this->expectException(\Exception::class);
+		$this->expectExceptionMessage('No user logged in');
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		$userConfig->setConfig('crop_image_previews', true);
+	}
+
+	public function testThrowsInvalidArgumentExceptionForUnknownConfigKey(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Unknown config key');
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		$userConfig->setConfig('unknown_key', true);
+	}
+
+	public function testSetsConfigSuccessfully(): void {
+		$this->configMock->expects($this->once())
+			->method('setUserValue')
+			->with($this->userUID, Application::APP_ID, 'crop_image_previews', '1');
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		$userConfig->setConfig('crop_image_previews', true);
+	}
+
+	public function testGetsConfigsWithDefaultValuesSuccessfully(): void {
+		$this->userSessionMock->method('getUser')->willReturn($this->userMock);
+		$this->configMock->method('getUserValue')
+			->willReturnCallback(function ($userId, $appId, $key, $default) {
+				return $default;
+			});
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		$configs = $userConfig->getConfigs();
+		$this->assertEquals([
+			'crop_image_previews' => true,
+			'show_hidden' => false,
+			'sort_favorites_first' => true,
+			'sort_folders_first' => true,
+			'grid_view' => false,
+			'folder_tree' => true,
+		], $configs);
+	}
+
+	public function testGetsConfigsOverrideWithUserValuesSuccessfully(): void {
+		$this->userSessionMock->method('getUser')->willReturn($this->userMock);
+		$this->configMock->method('getUserValue')
+			->willReturnCallback(function ($userId, $appId, $key, $default) {
+
+				// Override the default values
+				if ($key === 'crop_image_previews') {
+					return !$default;
+				} elseif ($key === 'show_hidden') {
+					return !$default;
+				}
+
+				return $default;
+			});
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		$configs = $userConfig->getConfigs();
+		$this->assertEquals([
+			'crop_image_previews' => false,
+			'show_hidden' => true,
+			'sort_favorites_first' => true,
+			'sort_folders_first' => true,
+			'grid_view' => false,
+			'folder_tree' => true,
+		], $configs);
+	}
+}

--- a/apps/files/tests/Service/UserConfigTest.php
+++ b/apps/files/tests/Service/UserConfigTest.php
@@ -9,6 +9,7 @@ namespace OCA\Files\Tests\Service;
 
 use OCA\Files\AppInfo\Application;
 use OCA\Files\Service\UserConfig;
+use OCP\AppFramework\Services\IAppConfig;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserSession;
@@ -34,6 +35,9 @@ class UserConfigTest extends \Test\TestCase {
 	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
 	private $userSessionMock;
 
+	/** @var IAppConfig|\PHPUnit\Framework\MockObject\MockObject */
+	private $appConfigMock;
+
 	/**
 	 * @var UserConfig|\PHPUnit\Framework\MockObject\MockObject
 	 */
@@ -42,6 +46,7 @@ class UserConfigTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		$this->configMock = $this->createMock(IConfig::class);
+		$this->appConfigMock = $this->createMock(IAppConfig::class);
 
 		$this->userUID = static::getUniqueID('user_id-');
 		\OC::$server->getUserManager()->createUser($this->userUID, 'test');
@@ -67,6 +72,7 @@ class UserConfigTest extends \Test\TestCase {
 			->setConstructorArgs([
 				$this->configMock,
 				$this->userSessionMock,
+				$this->appConfigMock,
 			])
 			->setMethods($methods)
 			->getMock();
@@ -100,7 +106,7 @@ class UserConfigTest extends \Test\TestCase {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('No user logged in');
 
-		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock, $this->appConfigMock);
 		$userConfig->setConfig('crop_image_previews', true);
 	}
 
@@ -108,7 +114,7 @@ class UserConfigTest extends \Test\TestCase {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Unknown config key');
 
-		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock, $this->appConfigMock);
 		$userConfig->setConfig('unknown_key', true);
 	}
 
@@ -123,6 +129,14 @@ class UserConfigTest extends \Test\TestCase {
 			[true, '1'],
 			[false, '0'],
 		];
+	}
+
+	public function testThrowsInvalidArgumentExceptionForInvalidConfigValue(): void {
+		$this->expectException(\InvalidArgumentException::class);
+		$this->expectExceptionMessage('Invalid config value');
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock, $this->appConfigMock);
+		$userConfig->setConfig('crop_image_previews', 'foo');
 	}
 
 	/**
@@ -144,7 +158,13 @@ class UserConfigTest extends \Test\TestCase {
 				return $default;
 			});
 
-		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		// pass the default app settings unchanged
+		$this->appConfigMock->method('getAppValueBool')
+			->willReturnCallback(function ($key, $default) {
+				return $default;
+			});
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock, $this->appConfigMock);
 		$configs = $userConfig->getConfigs();
 		$this->assertEquals([
 			'crop_image_previews' => true,
@@ -171,7 +191,13 @@ class UserConfigTest extends \Test\TestCase {
 				return $default;
 			});
 
-		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
+		// pass the default app settings unchanged
+		$this->appConfigMock->method('getAppValueBool')
+			->willReturnCallback(function ($key, $default) {
+				return $default;
+			});
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock, $this->appConfigMock);
 		$configs = $userConfig->getConfigs();
 		$this->assertEquals([
 			'crop_image_previews' => false,
@@ -179,6 +205,38 @@ class UserConfigTest extends \Test\TestCase {
 			'sort_favorites_first' => true,
 			'sort_folders_first' => true,
 			'grid_view' => false,
+			'folder_tree' => true,
+		], $configs);
+	}
+
+	public function testGetsConfigsOverrideWithAppsValuesSuccessfully(): void {
+		$this->userSessionMock->method('getUser')->willReturn($this->userMock);
+
+		// set all user values to true
+		$this->configMock->method('getUserValue')
+			->willReturnCallback(function () {
+				return true;
+			});
+
+		// emulate override by the app config values
+		$this->appConfigMock->method('getAppValueBool')
+			->willReturnCallback(function ($key, $default) {
+				if ($key === 'crop_image_previews') {
+					return false;
+				} elseif ($key === 'show_hidden') {
+					return false;
+				}
+				return $default;
+			});
+
+		$userConfig = new UserConfig($this->configMock, $this->userSessionMock, $this->appConfigMock);
+		$configs = $userConfig->getConfigs();
+		$this->assertEquals([
+			'crop_image_previews' => false,
+			'show_hidden' => false,
+			'sort_favorites_first' => true,
+			'sort_folders_first' => true,
+			'grid_view' => true,
 			'folder_tree' => true,
 		], $configs);
 	}

--- a/apps/files/tests/Service/UserConfigTest.php
+++ b/apps/files/tests/Service/UserConfigTest.php
@@ -112,12 +112,29 @@ class UserConfigTest extends \Test\TestCase {
 		$userConfig->setConfig('unknown_key', true);
 	}
 
-	public function testSetsConfigSuccessfully(): void {
+	public static function validBoolConfigValues(): array {
+		return [
+			['true', '1'],
+			['false', '0'],
+			['1', '1'],
+			['0', '0'],
+			['yes', '1'],
+			['no', '0'],
+			[true, '1'],
+			[false, '0'],
+		];
+	}
+
+	/**
+	 * @dataProvider validBoolConfigValues
+	 */
+	public function testSetsConfigWithBooleanValuesSuccessfully($boolValue, $expectedValue): void {
 		$this->configMock->expects($this->once())
 			->method('setUserValue')
-			->with($this->userUID, Application::APP_ID, 'crop_image_previews', '1');
+			->with($this->userUID, Application::APP_ID, 'crop_image_previews', $expectedValue);
+
 		$userConfig = new UserConfig($this->configMock, $this->userSessionMock);
-		$userConfig->setConfig('crop_image_previews', true);
+		$userConfig->setConfig('crop_image_previews', $boolValue);
 	}
 
 	public function testGetsConfigsWithDefaultValuesSuccessfully(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- This gives an admin the ability to override user settings for the file app. For example, to always show hidden files.
- Adds unitests for https://github.com/nextcloud/server/blob/master/apps/files/lib/Service/UserConfig.php
- Fixes a bug where the "Invalid config value" exception is never thrown

To set the config run

```shell
ooc config:app:set --value <yes/no> files crop_image_previews
ooc config:app:set --value <yes/no> files show_hidden
ooc config:app:set --value <yes/no> files sort_favorites_first
ooc config:app:set --value <yes/no> files sort_folders_first
ooc config:app:set --value <yes/no> files grid_view
ooc config:app:set --value <yes/no> files folder_tree
``` 
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
