### PR TITLE
fix(ReferenceApiController): Bump rate limit for public resolve endpoint

### DIFF
--- a/core/Controller/ReferenceApiController.php
+++ b/core/Controller/ReferenceApiController.php
@@ -128,7 +128,7 @@ class ReferenceApiController extends \OCP\AppFramework\OCSController {
 	 */
 	#[ApiRoute(verb: 'GET', url: '/resolvePublic', root: '/references')]
 	#[PublicPage]
-	#[AnonRateLimit(limit: 10, period: 120)]
+	#[AnonRateLimit(limit: 25, period: 120)]
 	public function resolveOnePublic(string $reference, string $sharingToken): DataResponse {
 		/** @var ?CoreReference $resolvedReference */
 		$resolvedReference = $this->referenceManager->resolveReference(trim($reference), true, trim($sharingToken))?->jsonSerialize();


### PR DESCRIPTION
E.g. text documents might contain hundreds of links whose previews need to get loaded.

Fixes: nextcloud/collectives#1607

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
