### PR TITLE
chore: ignore vendor-bin for coverage

### DIFF
--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -74,7 +74,7 @@ jobs:
           ./occ app:enable --force files_external
 
       - name: PHPUnit
-        run: composer run test:files_external \
+        run: composer run test:files_external -- \
           ${{ matrix.coverage && ' --coverage-clover ./clover.xml' || '' }}
 
       - name: Upload code coverage

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -30,6 +30,7 @@
 			<directory suffix=".php">../build</directory>
 			<directory suffix=".php">../lib/composer</directory>
 			<directory suffix=".php">../tests</directory>
+			<directory suffix=".php">../vendor-bin</directory>
 		</exclude>
 	</coverage>
 	<listeners>


### PR DESCRIPTION
## Summary

- Otherwise the coverage for *.php files in vendor-bin is also calculated.
- Fix `Error: The "--coverage-clover" option does not exist.` for the external generic workflow.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
