### PR TITLE
fix: return 204 instead of 404

### DIFF
--- a/apps/dav/lib/CardDAV/ImageExportPlugin.php
+++ b/apps/dav/lib/CardDAV/ImageExportPlugin.php
@@ -90,7 +90,7 @@ class ImageExportPlugin extends ServerPlugin {
 
 			$response->setBody($file->getContent());
 		} catch (NotFoundException $e) {
-			$response->setStatus(404);
+			$response->setStatus(\OCP\AppFramework\Http::STATUS_NO_CONTENT);
 		}
 
 		return false;

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -171,7 +171,7 @@ class ImageExportPluginTest extends TestCase {
 				->willThrowException(new NotFoundException());
 			$this->response->expects($this->once())
 				->method('setStatus')
-				->with(404);
+				->with(\OCP\AppFramework\Http::STATUS_NO_CONTENT);
 		}
 
 		$result = $this->plugin->httpGet($this->request, $this->response);


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/contacts/issues/3021
* Related: https://github.com/nextcloud/contacts/pull/4249

## Summary
Changed status return to 204 "no content" instead of 404 when a photo does not exist

204 make more sense as it signals that there was no image, instead that a error occurred.

## Checklist
- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
