### PR TITLE
fix(files_external): wrong type for external mount id

### DIFF
--- a/apps/files_external/lib/Command/StorageAuthBase.php
+++ b/apps/files_external/lib/Command/StorageAuthBase.php
@@ -52,7 +52,7 @@ abstract class StorageAuthBase extends Base {
 	protected function createStorage(InputInterface $input, OutputInterface $output): array {
 		try {
 			/** @var StorageConfig|null $mount */
-			$mount = $this->globalService->getStorage($input->getArgument('mount_id'));
+			$mount = $this->globalService->getStorage((int)$input->getArgument('mount_id'));
 		} catch (NotFoundException $e) {
 			$output->writeln('<error>Mount not found</error>');
 			return [null, null];


### PR DESCRIPTION
## Summary

Fix error: 
```
TypeError: OCA\Files_External\Service\StoragesService::getStorage(): Argument #1 ($id) must be of type int, string given, called in /var/www/html/apps/files_external/lib/Command/StorageAuthBase.php on line 70 and defined in /var/www/html/apps/files_external/lib/Service/StoragesService.php:163
```
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
