### PR TITLE
fix: change translation logic to handle plurals better

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipService.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipService.php
@@ -45,8 +45,9 @@ class IMipService {
 		private L10NFactory $l10nFactory,
 		private ITimeFactory $timeFactory,
 	) {
-		$default = $this->l10nFactory->findGenericLanguage();
-		$this->l10n = $this->l10nFactory->get('dav', $default);
+		$language = $this->l10nFactory->findGenericLanguage();
+		$locale = $this->l10nFactory->findLocale($language);
+		$this->l10n = $this->l10nFactory->get('dav', $language, $locale);
 	}
 
 	/**
@@ -188,6 +189,9 @@ class IMipService {
 	 * @return string
 	 */
 	public function generateWhenStringSingular(EventReader $er): string {
+		// initialize
+		$startTime = null;
+		$endTime = null;
 		// calculate time difference from now to start of event
 		$occurring = $this->minimizeInterval($this->timeFactory->getDateTime()->diff($er->recurrenceDate()));
 		// extract start date
@@ -202,15 +206,91 @@ class IMipService {
 		// TRANSLATORS
 		// Indicates when a calendar event will happen, shown on invitation emails
 		// Output produced in order:
-		// In a day/week/month/year on July 1, 2024 for the entire day
-		// In a day/week/month/year on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)
-		// In 2 days/weeks/months/years on July 1, 2024 for the entire day
-		// In 2 days/weeks/months/years on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)
-		return match ([($occurring[0] > 1), !empty($endTime)]) {
-			[false, false] => $this->l10n->t('In a %1$s on %2$s for the entire day', [$occurring[1], $startDate]),
-			[false, true] => $this->l10n->t('In a %1$s on %2$s between %3$s - %4$s', [$occurring[1], $startDate, $startTime, $endTime]),
-			[true, false] => $this->l10n->t('In %1$s %2$s on %3$s for the entire day', [$occurring[0], $occurring[1], $startDate]),
-			[true, true] => $this->l10n->t('In %1$s %2$s on %3$s between %4$s - %5$s', [$occurring[0], $occurring[1], $startDate, $startTime, $endTime]),
+		// In a minute/hour/day/week/month/year on July 1, 2024 for the entire day
+		// In a minute/hour/day/week/month/year on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)
+		// In 2 minutes/hours/days/weeks/months/years on July 1, 2024 for the entire day
+		// In 2 minutes/hours/days/weeks/months/years on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)
+		return match ([$occurring['scale'], $endTime !== null]) {
+			['past', false] => $this->l10n->t(
+				'In the past on %1$s for the entire day',
+				[$startDate]
+			),
+			['minute', false] => $this->l10n->n(
+				'In a minute on %1$s for the entire day',
+				'In %n minutes on %1$s for the entire day',
+				$occurring['interval'],
+				[$startDate]
+			),
+			['hour', false] => $this->l10n->n(
+				'In a hour on %1$s for the entire day',
+				'In %n hours on %1$s for the entire day',
+				$occurring['interval'],
+				[$startDate]
+			),
+			['day', false] => $this->l10n->n(
+				'In a day on %1$s for the entire day',
+				'In %n days on %1$s for the entire day',
+				$occurring['interval'],
+				[$startDate]
+			),
+			['week', false] => $this->l10n->n(
+				'In a week on %1$s for the entire day',
+				'In %n weeks on %1$s for the entire day',
+				$occurring['interval'],
+				[$startDate]
+			),
+			['month', false] => $this->l10n->n(
+				'In a month on %1$s for the entire day',
+				'In %n months on %1$s for the entire day',
+				$occurring['interval'],
+				[$startDate]
+			),
+			['year', false] => $this->l10n->n(
+				'In a year on %1$s for the entire day',
+				'In %n years on %1$s for the entire day',
+				$occurring['interval'],
+				[$startDate]
+			),
+			['past', true] => $this->l10n->t(
+				'In the past on %1$s between %2$s - %3$s',
+				[$startDate, $startTime, $endTime]
+			),
+			['minute', true] => $this->l10n->n(
+				'In a minute on %1$s between %2$s - %3$s',
+				'In %n minutes on %1$s between %2$s - %3$s',
+				$occurring['interval'],
+				[$startDate, $startTime, $endTime]
+			),
+			['hour', true] => $this->l10n->n(
+				'In a hour on %1$s between %2$s - %3$s',
+				'In %n hours on %1$s between %2$s - %3$s',
+				$occurring['interval'],
+				[$startDate, $startTime, $endTime]
+			),
+			['day', true] => $this->l10n->n(
+				'In a day on %1$s between %2$s - %3$s',
+				'In %n days on %1$s between %2$s - %3$s',
+				$occurring['interval'],
+				[$startDate, $startTime, $endTime]
+			),
+			['week', true] => $this->l10n->n(
+				'In a week on %1$s between %2$s - %3$s',
+				'In %n weeks on %1$s between %2$s - %3$s',
+				$occurring['interval'],
+				[$startDate, $startTime, $endTime]
+			),
+			['month', true] => $this->l10n->n(
+				'In a month on %1$s between %2$s - %3$s',
+				'In %n months on %1$s between %2$s - %3$s',
+				$occurring['interval'],
+				[$startDate, $startTime, $endTime]
+			),
+			['year', true] => $this->l10n->n(
+				'In a year on %1$s between %2$s - %3$s',
+				'In %n years on %1$s between %2$s - %3$s',
+				$occurring['interval'],
+				[$startDate, $startTime, $endTime]
+			),
 			default => $this->l10n->t('Could not generate when statement')
 		};
 	}
@@ -247,9 +327,8 @@ class IMipService {
 		
 		// initialize
 		$interval = (int)$er->recurringInterval();
-		$startTime = '';
-		$endTime = '';
-		$conclusion = '';
+		$startTime = null;
+		$conclusion = null;
 		// time of the day
 		if (!$er->entireDay()) {
 			$startTime = $this->l10n->l('time', $er->startDateTime(), ['width' => 'short']);
@@ -272,7 +351,7 @@ class IMipService {
 		// Every 3 Days for the entire day until July 13, 2024
 		// Every 3 Days between 8:00 AM - 9:00 AM (America/Toronto)
 		// Every 3 Days between 8:00 AM - 9:00 AM (America/Toronto) until July 13, 2024
-		return match ([($interval > 1), !empty($startTime), !empty($conclusion)]) {
+		return match ([($interval > 1), $startTime !== null, $conclusion !== null]) {
 			[false, false, false] => $this->l10n->t('Every Day for the entire day'),
 			[false, false, true] => $this->l10n->t('Every Day for the entire day until %1$s', [$conclusion]),
 			[false, true, false] => $this->l10n->t('Every Day between %1$s - %2$s', [$startTime, $endTime]),
@@ -299,9 +378,8 @@ class IMipService {
 		
 		// initialize
 		$interval = (int)$er->recurringInterval();
-		$startTime = '';
-		$endTime = '';
-		$conclusion = '';
+		$startTime = null;
+		$conclusion = null;
 		// days of the week
 		$days = implode(', ', array_map(function ($value) { return $this->localizeDayName($value); }, $er->recurringDaysOfWeekNamed()));
 		// time of the day
@@ -326,7 +404,7 @@ class IMipService {
 		// Every 2 Weeks on Monday, Wednesday, Friday for the entire day until July 13, 2024
 		// Every 2 Weeks on Monday, Wednesday, Friday between 8:00 AM - 9:00 AM (America/Toronto)
 		// Every 2 Weeks on Monday, Wednesday, Friday between 8:00 AM - 9:00 AM (America/Toronto) until July 13, 2024
-		return match ([($interval > 1), !empty($startTime), !empty($conclusion)]) {
+		return match ([($interval > 1), $startTime !== null, $conclusion !== null]) {
 			[false, false, false] => $this->l10n->t('Every Week on %1$s for the entire day', [$days]),
 			[false, false, true] => $this->l10n->t('Every Week on %1$s for the entire day until %2$s', [$days, $conclusion]),
 			[false, true, false] => $this->l10n->t('Every Week on %1$s between %2$s - %3$s', [$days, $startTime, $endTime]),
@@ -353,9 +431,8 @@ class IMipService {
 		
 		// initialize
 		$interval = (int)$er->recurringInterval();
-		$startTime = '';
-		$endTime = '';
-		$conclusion = '';
+		$startTime = null;
+		$conclusion = null;
 		// days of month
 		if ($er->recurringPattern() === 'R') {
 			$days = implode(', ', array_map(function ($value) { return $this->localizeRelativePositionName($value); }, $er->recurringRelativePositionNamed())) . ' ' .
@@ -393,7 +470,7 @@ class IMipService {
 		// Relative: Every 2 Months on the First Sunday, Saturday between 8:00 AM - 9:00 AM (America/Toronto)
 		// Absolute: Every 2 Months on the 1, 8 between 8:00 AM - 9:00 AM (America/Toronto) until December 31, 2024
 		// Relative: Every 2 Months on the First Sunday, Saturday between 8:00 AM - 9:00 AM (America/Toronto) until December 31, 2024
-		return match ([($interval > 1), !empty($startTime), !empty($conclusion)]) {
+		return match ([($interval > 1), $startTime !== null, $conclusion !== null]) {
 			[false, false, false] => $this->l10n->t('Every Month on the %1$s for the entire day', [$days]),
 			[false, false, true] => $this->l10n->t('Every Month on the %1$s for the entire day until %2$s', [$days, $conclusion]),
 			[false, true, false] => $this->l10n->t('Every Month on the %1$s between %2$s - %3$s', [$days, $startTime, $endTime]),
@@ -419,9 +496,8 @@ class IMipService {
 		
 		// initialize
 		$interval = (int)$er->recurringInterval();
-		$startTime = '';
-		$endTime = '';
-		$conclusion = '';
+		$startTime = null;
+		$conclusion = null;
 		// months of year
 		$months = implode(', ', array_map(function ($value) { return $this->localizeMonthName($value); }, $er->recurringMonthsOfYearNamed()));
 		// days of month
@@ -461,7 +537,7 @@ class IMipService {
 		// Relative: Every 2 Years in July on the First Sunday, Saturday between 8:00 AM - 9:00 AM (America/Toronto)
 		// Absolute: Every 2 Years in July on the 1st between 8:00 AM - 9:00 AM (America/Toronto) until July 31, 2026
 		// Relative: Every 2 Years in July on the First Sunday, Saturday between 8:00 AM - 9:00 AM (America/Toronto) until July 31, 2026
-		return match ([($interval > 1), !empty($startTime), !empty($conclusion)]) {
+		return match ([($interval > 1), $startTime !== null, $conclusion !== null]) {
 			[false, false, false] => $this->l10n->t('Every Year in %1$s on the %2$s for the entire day', [$months, $days]),
 			[false, false, true] => $this->l10n->t('Every Year in %1$s on the %2$s for the entire day until %3$s', [$months, $days, $conclusion]),
 			[false, true, false] => $this->l10n->t('Every Year in %1$s on the %2$s between %3$s - %4$s', [$months, $days, $startTime, $endTime]),
@@ -485,9 +561,8 @@ class IMipService {
 	 */
 	public function generateWhenStringRecurringFixed(EventReader $er): string {
 		// initialize
-		$startTime = '';
-		$endTime = '';
-		$conclusion = '';
+		$startTime = null;
+		$conclusion = null;
 		// time of the day
 		if (!$er->entireDay()) {
 			$startTime = $this->l10n->l('time', $er->startDateTime(), ['width' => 'short']);
@@ -502,7 +577,7 @@ class IMipService {
 		// Output produced in order:
 		// On specific dates for the entire day until July 13, 2024
 		// On specific dates between 8:00 AM - 9:00 AM (America/Toronto) until July 13, 2024
-		return match (!empty($startTime)) {
+		return match ($startTime !== null) {
 			false => $this->l10n->t('On specific dates for the entire day until %1$s', [$conclusion]),
 			true => $this->l10n->t('On specific dates between %1$s - %2$s until %3$s', [$startTime, $endTime, $conclusion]),
 		};
@@ -519,6 +594,10 @@ class IMipService {
 	 */
 	public function generateOccurringString(EventReader $er): string {
 
+		// initialize
+		$occurrence = null;
+		$occurrence2 = null;
+		$occurrence3 = null;
 		// reset to initial occurrence
 		$er->recurrenceRewind();
 		// forward to current date
@@ -545,19 +624,133 @@ class IMipService {
 		// TRANSLATORS
 		// Indicates when a calendar event will happen, shown on invitation emails
 		// Output produced in order:
-		// In a day/week/month/year on July 1, 2024
-		// In a day/week/month/year on July 1, 2024 then on July 3, 2024
-		// In a day/week/month/year on July 1, 2024 then on July 3, 2024 and July 5, 2024
-		// In 2 days/weeks/months/years on July 1, 2024
-		// In 2 days/weeks/months/years on July 1, 2024 then on July 3, 2024
-		// In 2 days/weeks/months/years on July 1, 2024 then on July 3, 2024 and July 5, 2024
-		return match ([($occurrenceIn[0] > 1), !empty($occurrence2), !empty($occurrence3)]) {
-			[false, false, false] => $this->l10n->t('In a %1$s on %2$s', [$occurrenceIn[1], $occurrence]),
-			[false, true, false] => $this->l10n->t('In a %1$s on %2$s then on %3$s', [$occurrenceIn[1], $occurrence, $occurrence2]),
-			[false, true, true] => $this->l10n->t('In a %1$s on %2$s then on %3$s and %4$s', [$occurrenceIn[1], $occurrence, $occurrence2, $occurrence3]),
-			[true, false, false] => $this->l10n->t('In %1$s %2$s on %3$s', [$occurrenceIn[0], $occurrenceIn[1], $occurrence]),
-			[true, true, false] => $this->l10n->t('In %1$s %2$s on %3$s then on %4$s', [$occurrenceIn[0], $occurrenceIn[1], $occurrence, $occurrence2]),
-			[true, true, true] => $this->l10n->t('In %1$s %2$s on %3$s then on %4$s and %5$s', [$occurrenceIn[0], $occurrenceIn[1], $occurrence, $occurrence2, $occurrence3]),
+		// In a minute/hour/day/week/month/year on July 1, 2024
+		// In a minute/hour/day/week/month/year on July 1, 2024 then on July 3, 2024
+		// In a minute/hour/day/week/month/year on July 1, 2024 then on July 3, 2024 and July 5, 2024
+		// In 2 minutes/hours/days/weeks/months/years on July 1, 2024
+		// In 2 minutes/hours/days/weeks/months/years on July 1, 2024 then on July 3, 2024
+		// In 2 minutes/hours/days/weeks/months/years on July 1, 2024 then on July 3, 2024 and July 5, 2024
+		return match ([$occurrenceIn['scale'], $occurrence2 !== null, $occurrence3 !== null]) {
+			['past', false, false] => $this->l10n->t(
+				'In the past on %1$s',
+				[$occurrence]
+			),
+			['minute', false, false] => $this->l10n->n(
+				'In a minute on %1$s',
+				'In %n minutes on %1$s',
+				$occurrenceIn['interval'],
+				[$occurrence]
+			),
+			['hour', false, false] => $this->l10n->n(
+				'In a hour on %1$s',
+				'In %n hours on %1$s',
+				$occurrenceIn['interval'],
+				[$occurrence]
+			),
+			['day', false, false] => $this->l10n->n(
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				$occurrenceIn['interval'],
+				[$occurrence]
+			),
+			['week', false, false] => $this->l10n->n(
+				'In a week on %1$s',
+				'In %n weeks on %1$s',
+				$occurrenceIn['interval'],
+				[$occurrence]
+			),
+			['month', false, false] => $this->l10n->n(
+				'In a month on %1$s',
+				'In %n months on %1$s',
+				$occurrenceIn['interval'],
+				[$occurrence]
+			),
+			['year', false, false] => $this->l10n->n(
+				'In a year on %1$s',
+				'In %n years on %1$s',
+				$occurrenceIn['interval'],
+				[$occurrence]
+			),
+			['past', true, false] => $this->l10n->t(
+				'In the past on %1$s then on %2$s',
+				[$occurrence, $occurrence2]
+			),
+			['minute', true, false] => $this->l10n->n(
+				'In a minute on %1$s then on %2$s',
+				'In %n minutes on %1$s then on %2$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2]
+			),
+			['hour', true, false] => $this->l10n->n(
+				'In a hour on %1$s then on %2$s',
+				'In %n hours on %1$s then on %2$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2]
+			),
+			['day', true, false] => $this->l10n->n(
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2]
+			),
+			['week', true, false] => $this->l10n->n(
+				'In a week on %1$s then on %2$s',
+				'In %n weeks on %1$s then on %2$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2]
+			),
+			['month', true, false] => $this->l10n->n(
+				'In a month on %1$s then on %2$s',
+				'In %n months on %1$s then on %2$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2]
+			),
+			['year', true, false] => $this->l10n->n(
+				'In a year on %1$s then on %2$s',
+				'In %n years on %1$s then on %2$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2]
+			),
+			['past', true, true] => $this->l10n->t(
+				'In the past on %1$s then on %2$s and %3$s',
+				[$occurrence, $occurrence2, $occurrence3]
+			),
+			['minute', true, true] => $this->l10n->n(
+				'In a minute on %1$s then on %2$s and %3$s',
+				'In %n minutes on %1$s then on %2$s and %3$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2, $occurrence3]
+			),
+			['hour', true, true] => $this->l10n->n(
+				'In a hour on %1$s then on %2$s and %3$s',
+				'In %n hours on %1$s then on %2$s and %3$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2, $occurrence3]
+			),
+			['day', true, true] => $this->l10n->n(
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2, $occurrence3]
+			),
+			['week', true, true] => $this->l10n->n(
+				'In a week on %1$s then on %2$s and %3$s',
+				'In %n weeks on %1$s then on %2$s and %3$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2, $occurrence3]
+			),
+			['month', true, true] => $this->l10n->n(
+				'In a month on %1$s then on %2$s and %3$s',
+				'In %n months on %1$s then on %2$s and %3$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2, $occurrence3]
+			),
+			['year', true, true] => $this->l10n->n(
+				'In a year on %1$s then on %2$s and %3$s',
+				'In %n years on %1$s then on %2$s and %3$s',
+				$occurrenceIn['interval'],
+				[$occurrence, $occurrence2, $occurrence3]
+			),
 			default => $this->l10n->t('Could not generate next recurrence statement')
 		};
 
@@ -965,30 +1158,30 @@ class IMipService {
 	public function minimizeInterval(\DateInterval $dateInterval): array {
 		// evaluate if time interval is in the past
 		if ($dateInterval->invert == 1) {
-			return [1, 'the past'];
+			return ['interval' => 1, 'scale' => 'past'];
 		}
 		// evaluate interval parts and return smallest time period
 		if ($dateInterval->y > 0) {
 			$interval = $dateInterval->y;
-			$scale = ($dateInterval->y > 1) ? 'years' : 'year';
+			$scale = 'year';
 		} elseif ($dateInterval->m > 0) {
 			$interval = $dateInterval->m;
-			$scale = ($dateInterval->m > 1) ? 'months' : 'month';
+			$scale = 'month';
 		} elseif ($dateInterval->d >= 7) {
 			$interval = (int)($dateInterval->d / 7);
-			$scale = ((int)($dateInterval->d / 7) > 1) ? 'weeks' : 'week';
+			$scale = 'week';
 		} elseif ($dateInterval->d > 0) {
 			$interval = $dateInterval->d;
-			$scale = ($dateInterval->d > 1) ? 'days' : 'day';
+			$scale = 'day';
 		} elseif ($dateInterval->h > 0) {
 			$interval = $dateInterval->h;
-			$scale = ($dateInterval->h > 1) ? 'hours' : 'hour';
+			$scale = 'hour';
 		} else {
 			$interval = $dateInterval->i;
-			$scale = 'minutes';
+			$scale = 'minute';
 		}
 
-		return [$interval, $scale];
+		return ['interval' => $interval, 'scale' => $scale];
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/IMipServiceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -180,8 +181,14 @@ class IMipServiceTest extends TestCase {
 				};
 			}
 		);
-		$this->l10n->method('t')->willReturnMap([
-			['In a %1$s on %2$s between %3$s - %4$s', ['day', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In a day on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)']
+		$this->l10n->method('n')->willReturnMap([
+			[
+				'In a day on %1$s between %2$s - %3$s',
+				'In %n days on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a day on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			]
 		]);
 		// construct time factory return(s)
 		$this->timeFactory->method('getDateTime')->willReturnCallback(
@@ -222,8 +229,14 @@ class IMipServiceTest extends TestCase {
 				};
 			}
 		);
-		$this->l10n->method('t')->willReturnMap([
-			['In a %1$s on %2$s between %3$s - %4$s', ['day', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In a day on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)']
+		$this->l10n->method('n')->willReturnMap([
+			[
+				'In a day on %1$s between %2$s - %3$s',
+				'In %n days on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a day on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			]
 		]);
 		// construct time factory return(s)
 		$this->timeFactory->method('getDateTime')->willReturnCallback(
@@ -349,42 +362,325 @@ class IMipServiceTest extends TestCase {
 			}
 		);
 		$this->l10n->method('t')->willReturnMap([
-			['In a %1$s on %2$s for the entire day', ['day', 'July 1, 2024'], 'In a day on July 1, 2024 for the entire day'],
-			['In a %1$s on %2$s between %3$s - %4$s', ['day', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In a day on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'],
-			['In %1$s %2$s on %3$s for the entire day', [2, 'days', 'July 1, 2024'], 'In 2 days on July 1, 2024 for the entire day'],
-			['In %1$s %2$s on %3$s between %4$s - %5$s', [2, 'days', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In 2 days on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'],
-			['In a %1$s on %2$s for the entire day', ['week', 'July 1, 2024'], 'In a week on July 1, 2024 for the entire day'],
-			['In a %1$s on %2$s between %3$s - %4$s', ['week', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In a week on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'],
-			['In %1$s %2$s on %3$s for the entire day', [2, 'weeks', 'July 1, 2024'], 'In 2 weeks on July 1, 2024 for the entire day'],
-			['In %1$s %2$s on %3$s between %4$s - %5$s', [2, 'weeks', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In 2 weeks on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'],
-			['In a %1$s on %2$s for the entire day', ['month', 'July 1, 2024'], 'In a month on July 1, 2024 for the entire day'],
-			['In a %1$s on %2$s between %3$s - %4$s', ['month', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In a month on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'],
-			['In %1$s %2$s on %3$s for the entire day', [2, 'months', 'July 1, 2024'], 'In 2 months on July 1, 2024 for the entire day'],
-			['In %1$s %2$s on %3$s between %4$s - %5$s', [2, 'months', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In 2 months on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'],
-			['In a %1$s on %2$s for the entire day', ['year', 'July 1, 2024'], 'In a year on July 1, 2024 for the entire day'],
-			['In a %1$s on %2$s between %3$s - %4$s', ['year', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In a year on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'],
-			['In %1$s %2$s on %3$s for the entire day', [2, 'years', 'July 1, 2024'], 'In 2 years on July 1, 2024 for the entire day'],
-			['In %1$s %2$s on %3$s between %4$s - %5$s', [2, 'years', 'July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'], 'In 2 years on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)']
+			[
+				'In the past on %1$s for the entire day',
+				['July 1, 2024'],
+				'In the past on July 1, 2024 for the entire day'
+			],
+			[
+				'In the past on %1$s between %2$s - %3$s',
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In the past on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+		]);
+		$this->l10n->method('n')->willReturnMap([
+			// singular entire day
+			[
+				'In a minute on %1$s for the entire day',
+				'In %n minutes on %1$s for the entire day',
+				1,
+				['July 1, 2024'],
+				'In a minute on July 1, 2024 for the entire day'
+			],
+			[
+				'In a hour on %1$s for the entire day',
+				'In %n hours on %1$s for the entire day',
+				1,
+				['July 1, 2024'],
+				'In a hour on July 1, 2024 for the entire day'
+			],
+			[
+				'In a day on %1$s for the entire day',
+				'In %n days on %1$s for the entire day',
+				1,
+				['July 1, 2024'],
+				'In a day on July 1, 2024 for the entire day'
+			],
+			[
+				'In a week on %1$s for the entire day',
+				'In %n weeks on %1$s for the entire day',
+				1,
+				['July 1, 2024'],
+				'In a week on July 1, 2024 for the entire day'
+			],
+			[
+				'In a month on %1$s for the entire day',
+				'In %n months on %1$s for the entire day',
+				1,
+				['July 1, 2024'],
+				'In a month on July 1, 2024 for the entire day'
+			],
+			[
+				'In a year on %1$s for the entire day',
+				'In %n years on %1$s for the entire day',
+				1,
+				['July 1, 2024'],
+				'In a year on July 1, 2024 for the entire day'
+			],
+			// plural entire day
+			[
+				'In a minute on %1$s for the entire day',
+				'In %n minutes on %1$s for the entire day',
+				2,
+				['July 1, 2024'],
+				'In 2 minutes on July 1, 2024 for the entire day'
+			],
+			[
+				'In a hour on %1$s for the entire day',
+				'In %n hours on %1$s for the entire day',
+				2,
+				['July 1, 2024'],
+				'In 2 hours on July 1, 2024 for the entire day'
+			],
+			[
+				'In a day on %1$s for the entire day',
+				'In %n days on %1$s for the entire day',
+				2,
+				['July 1, 2024'],
+				'In 2 days on July 1, 2024 for the entire day'
+			],
+			[
+				'In a week on %1$s for the entire day',
+				'In %n weeks on %1$s for the entire day',
+				2,
+				['July 1, 2024'],
+				'In 2 weeks on July 1, 2024 for the entire day'
+			],
+			[
+				'In a month on %1$s for the entire day',
+				'In %n months on %1$s for the entire day',
+				2,
+				['July 1, 2024'],
+				'In 2 months on July 1, 2024 for the entire day'
+			],
+			[
+				'In a year on %1$s for the entire day',
+				'In %n years on %1$s for the entire day',
+				2,
+				['July 1, 2024'],
+				'In 2 years on July 1, 2024 for the entire day'
+			],
+			// singular partial day
+			[
+				'In a minute on %1$s between %2$s - %3$s',
+				'In %n minutes on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a minute on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a hour on %1$s between %2$s - %3$s',
+				'In %n hours on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a hour on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a day on %1$s between %2$s - %3$s',
+				'In %n days on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a day on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a week on %1$s between %2$s - %3$s',
+				'In %n weeks on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a week on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a month on %1$s between %2$s - %3$s',
+				'In %n months on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a month on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a year on %1$s between %2$s - %3$s',
+				'In %n years on %1$s between %2$s - %3$s',
+				1,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In a year on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			// plural partial day
+			[
+				'In a minute on %1$s between %2$s - %3$s',
+				'In %n minutes on %1$s between %2$s - %3$s',
+				2,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In 2 minutes on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a hour on %1$s between %2$s - %3$s',
+				'In %n hours on %1$s between %2$s - %3$s',
+				2,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In 2 hours on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a day on %1$s between %2$s - %3$s',
+				'In %n days on %1$s between %2$s - %3$s',
+				2,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In 2 days on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a week on %1$s between %2$s - %3$s',
+				'In %n weeks on %1$s between %2$s - %3$s',
+				2,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In 2 weeks on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a month on %1$s between %2$s - %3$s',
+				'In %n months on %1$s between %2$s - %3$s',
+				2,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In 2 months on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
+			[
+				'In a year on %1$s between %2$s - %3$s',
+				'In %n years on %1$s between %2$s - %3$s',
+				2,
+				['July 1, 2024', '8:00 AM', '9:00 AM (America/Toronto)'],
+				'In 2 years on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)'
+			],
 		]);
 
 		// construct time factory return(s)
 		$this->timeFactory->method('getDateTime')->willReturnOnConsecutiveCalls(
+			// past interval test dates
+			(new \DateTime('20240702T170000', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240703T170000', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240702T170000', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240703T170000', (new \DateTimeZone('America/Toronto')))),
+			// minute interval test dates
+			(new \DateTime('20240701T075900', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240630T235900', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240701T075800', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240630T235800', (new \DateTimeZone('America/Toronto')))),
+			// hour interval test dates
+			(new \DateTime('20240701T070000', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240630T230000', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240701T060000', (new \DateTimeZone('America/Toronto')))),
+			(new \DateTime('20240630T220000', (new \DateTimeZone('America/Toronto')))),
+			// day interval test dates
 			(new \DateTime('20240629T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240629T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240628T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240628T170000', (new \DateTimeZone('America/Toronto')))),
+			// week interval test dates
 			(new \DateTime('20240621T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240621T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240614T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240614T170000', (new \DateTimeZone('America/Toronto')))),
+			// month interval test dates
 			(new \DateTime('20240530T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240530T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240430T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20240430T170000', (new \DateTimeZone('America/Toronto')))),
+			// year interval test dates
 			(new \DateTime('20230630T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20230630T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20220630T170000', (new \DateTimeZone('America/Toronto')))),
 			(new \DateTime('20220630T170000', (new \DateTimeZone('America/Toronto'))))
+		);
+
+		/** test partial day event in 1 day in the past*/
+		$vCalendar = clone $this->vCalendar1a;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In the past on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test entire day event in 1 day in the past*/
+		$vCalendar = clone $this->vCalendar2;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In the past on July 1, 2024 for the entire day',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test partial day event in 2 days in the past*/
+		$vCalendar = clone $this->vCalendar1a;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In the past on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test entire day event in 2 days in the past*/
+		$vCalendar = clone $this->vCalendar2;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In the past on July 1, 2024 for the entire day',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test partial day event in 1 minute*/
+		$vCalendar = clone $this->vCalendar1a;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In a minute on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test entire day event in 1 minute*/
+		$vCalendar = clone $this->vCalendar2;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In a minute on July 1, 2024 for the entire day',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test partial day event in 2 minutes*/
+		$vCalendar = clone $this->vCalendar1a;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In 2 minutes on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test entire day event in 2 minutes*/
+		$vCalendar = clone $this->vCalendar2;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In 2 minutes on July 1, 2024 for the entire day',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test partial day event in 1 hour*/
+		$vCalendar = clone $this->vCalendar1a;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In a hour on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test entire day event in 1 hour*/
+		$vCalendar = clone $this->vCalendar2;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In a hour on July 1, 2024 for the entire day',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test partial day event in 2 hours*/
+		$vCalendar = clone $this->vCalendar1a;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In 2 hours on July 1, 2024 between 8:00 AM - 9:00 AM (America/Toronto)',
+			$this->service->generateWhenString($eventReader)
+		);
+
+		/** test entire day event in 2 hours*/
+		$vCalendar = clone $this->vCalendar2;
+		$eventReader = new EventReader($vCalendar, $vCalendar->VEVENT[0]->UID->getValue());
+		$this->assertEquals(
+			'In 2 hours on July 1, 2024 for the entire day',
+			$this->service->generateWhenString($eventReader)
 		);
 
 		/** test patrial day event in 1 day*/
@@ -1260,15 +1556,53 @@ class IMipServiceTest extends TestCase {
 				};
 			}
 		);
-		$this->l10n->method('t')->willReturnMap([
-			['In a %1$s on %2$s', ['day', 'July 1, 2024'], 'In a day on July 1, 2024'],
-			['In a %1$s on %2$s then on %3$s', ['day', 'July 1, 2024', 'July 3, 2024'], 'In a day on July 1, 2024 then on July 3, 2024'],
-			['In a %1$s on %2$s then on %3$s and %4$s', ['day', 'July 1, 2024', 'July 3, 2024', 'July 5, 2024'], 'In a day on July 1, 2024 then on July 3, 2024 and July 5, 2024'],
-			['In %1$s %2$s on %3$s', [2, 'days', 'July 1, 2024'], 'In 2 days on July 1, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s', [2, 'days', 'July 1, 2024', 'July 3, 2024'], 'In 2 days on July 1, 2024 then on July 3, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s and %5$s', [2, 'days', 'July 1, 2024', 'July 3, 2024', 'July 5, 2024'], 'In 2 days on July 1, 2024 then on July 3, 2024 and July 5, 2024'],
+		$this->l10n->method('n')->willReturnMap([
+			// singular
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				1,
+				['July 1, 2024'],
+				'In a day on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				1,
+				['July 1, 2024', 'July 3, 2024'],
+				'In a day on July 1, 2024 then on July 3, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				1,
+				['July 1, 2024', 'July 3, 2024', 'July 5, 2024'],
+				'In a day on July 1, 2024 then on July 3, 2024 and July 5, 2024'
+			],
+			// plural
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				2,
+				['July 1, 2024'],
+				'In 2 days on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				2,
+				['July 1, 2024', 'July 3, 2024'],
+				'In 2 days on July 1, 2024 then on July 3, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				2,
+				['July 1, 2024', 'July 3, 2024', 'July 5, 2024'],
+				'In 2 days on July 1, 2024 then on July 3, 2024 and July 5, 2024'
+			],
 		]);
-
+		
 		// construct time factory return(s)
 		$this->timeFactory->method('getDateTime')->willReturnOnConsecutiveCalls(
 			(new \DateTime('20240629T170000', (new \DateTimeZone('America/Toronto')))),
@@ -1364,13 +1698,51 @@ class IMipServiceTest extends TestCase {
 				};
 			}
 		);
-		$this->l10n->method('t')->willReturnMap([
-			['In a %1$s on %2$s', ['day', 'July 1, 2024'], 'In a day on July 1, 2024'],
-			['In a %1$s on %2$s then on %3$s', ['day', 'July 1, 2024', 'July 3, 2024'], 'In a day on July 1, 2024 then on July 3, 2024'],
-			['In a %1$s on %2$s then on %3$s and %4$s', ['day', 'July 1, 2024', 'July 3, 2024', 'July 5, 2024'], 'In a day on July 1, 2024 then on July 3, 2024 and July 5, 2024'],
-			['In %1$s %2$s on %3$s', [2, 'days', 'July 1, 2024'], 'In 2 days on July 1, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s', [2, 'days', 'July 1, 2024', 'July 3, 2024'], 'In 2 days on July 1, 2024 then on July 3, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s and %5$s', [2, 'days', 'July 1, 2024', 'July 3, 2024', 'July 5, 2024'], 'In 2 days on July 1, 2024 then on July 3, 2024 and July 5, 2024'],
+		$this->l10n->method('n')->willReturnMap([
+			// singular
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				1,
+				['July 1, 2024'],
+				'In a day on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				1,
+				['July 1, 2024', 'July 3, 2024'],
+				'In a day on July 1, 2024 then on July 3, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				1,
+				['July 1, 2024', 'July 3, 2024', 'July 5, 2024'],
+				'In a day on July 1, 2024 then on July 3, 2024 and July 5, 2024'
+			],
+			// plural
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				2,
+				['July 1, 2024'],
+				'In 2 days on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				2,
+				['July 1, 2024', 'July 3, 2024'],
+				'In 2 days on July 1, 2024 then on July 3, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				2,
+				['July 1, 2024', 'July 3, 2024', 'July 5, 2024'],
+				'In 2 days on July 1, 2024 then on July 3, 2024 and July 5, 2024'
+			],
 		]);
 
 		// construct time factory return(s)
@@ -1477,13 +1849,51 @@ class IMipServiceTest extends TestCase {
 				};
 			}
 		);
-		$this->l10n->method('t')->willReturnMap([
-			['In a %1$s on %2$s', ['day', 'July 1, 2024'], 'In a day on July 1, 2024'],
-			['In a %1$s on %2$s then on %3$s', ['day', 'July 1, 2024', 'July 5, 2024'], 'In a day on July 1, 2024 then on July 5, 2024'],
-			['In a %1$s on %2$s then on %3$s and %4$s', ['day', 'July 1, 2024', 'July 5, 2024', 'July 7, 2024'], 'In a day on July 1, 2024 then on July 5, 2024 and July 7, 2024'],
-			['In %1$s %2$s on %3$s', [2, 'days', 'July 1, 2024'], 'In 2 days on July 1, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s', [2, 'days', 'July 1, 2024', 'July 5, 2024'], 'In 2 days on July 1, 2024 then on July 5, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s and %5$s', [2, 'days', 'July 1, 2024', 'July 5, 2024', 'July 7, 2024'], 'In 2 days on July 1, 2024 then on July 5, 2024 and July 7, 2024'],
+		$this->l10n->method('n')->willReturnMap([
+			// singular
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				1,
+				['July 1, 2024'],
+				'In a day on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				1,
+				['July 1, 2024', 'July 5, 2024'],
+				'In a day on July 1, 2024 then on July 5, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				1,
+				['July 1, 2024', 'July 5, 2024', 'July 7, 2024'],
+				'In a day on July 1, 2024 then on July 5, 2024 and July 7, 2024'
+			],
+			// plural
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				2,
+				['July 1, 2024'],
+				'In 2 days on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				2,
+				['July 1, 2024', 'July 5, 2024'],
+				'In 2 days on July 1, 2024 then on July 5, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				2,
+				['July 1, 2024', 'July 5, 2024', 'July 7, 2024'],
+				'In 2 days on July 1, 2024 then on July 5, 2024 and July 7, 2024'
+			],
 		]);
 
 		// construct time factory return(s)
@@ -1623,13 +2033,51 @@ class IMipServiceTest extends TestCase {
 				};
 			}
 		);
-		$this->l10n->method('t')->willReturnMap([
-			['In a %1$s on %2$s', ['day', 'July 1, 2024'], 'In a day on July 1, 2024'],
-			['In a %1$s on %2$s then on %3$s', ['day', 'July 1, 2024', 'July 5, 2024'], 'In a day on July 1, 2024 then on July 5, 2024'],
-			['In a %1$s on %2$s then on %3$s and %4$s', ['day', 'July 1, 2024', 'July 5, 2024', 'July 9, 2024'], 'In a day on July 1, 2024 then on July 5, 2024 and July 9, 2024'],
-			['In %1$s %2$s on %3$s', [2, 'days', 'July 1, 2024'], 'In 2 days on July 1, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s', [2, 'days', 'July 1, 2024', 'July 5, 2024'], 'In 2 days on July 1, 2024 then on July 5, 2024'],
-			['In %1$s %2$s on %3$s then on %4$s and %5$s', [2, 'days', 'July 1, 2024', 'July 5, 2024', 'July 9, 2024'], 'In 2 days on July 1, 2024 then on July 5, 2024 and July 9, 2024'],
+		$this->l10n->method('n')->willReturnMap([
+			// singular
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				1,
+				['July 1, 2024'],
+				'In a day on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				1,
+				['July 1, 2024', 'July 5, 2024'],
+				'In a day on July 1, 2024 then on July 5, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				1,
+				['July 1, 2024', 'July 5, 2024', 'July 9, 2024'],
+				'In a day on July 1, 2024 then on July 5, 2024 and July 9, 2024'
+			],
+			// plural
+			[
+				'In a day on %1$s',
+				'In %n days on %1$s',
+				2,
+				['July 1, 2024'],
+				'In 2 days on July 1, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s',
+				'In %n days on %1$s then on %2$s',
+				2,
+				['July 1, 2024', 'July 5, 2024'],
+				'In 2 days on July 1, 2024 then on July 5, 2024'
+			],
+			[
+				'In a day on %1$s then on %2$s and %3$s',
+				'In %n days on %1$s then on %2$s and %3$s',
+				2,
+				['July 1, 2024', 'July 5, 2024', 'July 9, 2024'],
+				'In 2 days on July 1, 2024 then on July 5, 2024 and July 9, 2024'
+			],
 		]);
 
 		// construct time factory return(s)


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/49756

## Summary
- Altered phrase generation logic to work better with plurals and time intervals
- Added more test to cover all possible scenarios 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
