### PR TITLE
Update & Expand Meta Tags

### DIFF
--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -236,8 +236,20 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 		Util::addHeader('meta', ['property' => 'og:description', 'content' => $description]);
 		Util::addHeader('meta', ['property' => 'og:site_name', 'content' => $siteName]);
 		Util::addHeader('meta', ['property' => 'og:url', 'content' => $shareUrl]);
-		Util::addHeader('meta', ['property' => 'og:type', 'content' => 'object']);
-		Util::addHeader('meta', ['property' => 'og:image', 'content' => $ogPreview]);
+		Util::addHeader('meta', ['property' => 'og:type', 'content' => 'website']);
+		Util::addHeader('meta', ['property' => 'og:image', 'content' => $ogPreview]); // recommended to always have the image
+		if ($shareNode->getMimePart() === 'image') {
+			Util::addHeader('meta', ['property' => 'og:image:type', 'content' => $shareNode->getMimeType()]);
+		} elseif ($shareNode->getMimePart() === 'audio') {
+			$audio = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.downloadshare', ['token' => $token]);
+			Util::addHeader('meta', ['property' => 'og:audio', 'content' => $audio]);
+			Util::addHeader('meta', ['property' => 'og:audio:type', 'content' => $shareNode->getMimeType()]);
+		} elseif ($shareNode->getMimePart() === 'video') {
+			$video = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.downloadshare', ['token' => $token]);
+			Util::addHeader('meta', ['property' => 'og:video', 'content' => $video]);
+			Util::addHeader('meta', ['property' => 'og:video:type', 'content' => $shareNode->getMimeType()]);
+		}
+
 
 		// Twitter Support: https://developer.x.com/en/docs/x-for-websites/cards/overview/markup
 		Util::addHeader('meta', ['property' => 'twitter:title', 'content' => $title]);

--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -118,8 +118,7 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 		// Allow external apps to register their scripts
 		$this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($share));
 
-		// OpenGraph Support: http://ogp.me/
-		$this->addOpenGraphHeaders($share);
+		$this->addMetaHeaders($share);
 
 		// CSP to allow office
 		$csp = new ContentSecurityPolicy();
@@ -190,15 +189,17 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 	 * Add OpenGraph headers to response for preview
 	 * @param IShare $share The share for which to add the headers
 	 */
-	protected function addOpenGraphHeaders(IShare $share): void {
+	protected function addMetaHeaders(IShare $share): void {
 		$shareNode = $share->getNode();
 		$token = $share->getToken();
 		$shareUrl = $this->urlGenerator->linkToRouteAbsolute('files_sharing.sharecontroller.showShare', ['token' => $token]);
 
 		// Handle preview generation for OpenGraph
+		$hasImagePreview = false;
 		if ($this->previewManager->isMimeSupported($shareNode->getMimetype())) {
 			// For images we can use direct links
 			if ($shareNode->getMimePart() === 'image') {
+				$hasImagePreview = true;
 				$ogPreview = $this->urlGenerator->linkToRouteAbsolute('files_sharing.publicpreview.directLink', ['token' => $token]);
 				// Whatsapp is kind of picky about their size requirements
 				if ($this->request->isUserAgent(['/^WhatsApp/'])) {
@@ -226,11 +227,22 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 			$ogPreview = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'favicon-fb.png'));
 		}
 
-		Util::addHeader('meta', ['property' => 'og:title', 'content' => $shareNode->getName()]);
-		Util::addHeader('meta', ['property' => 'og:description', 'content' => $this->defaults->getName() . ($this->defaults->getSlogan() !== '' ? ' - ' . $this->defaults->getSlogan() : '')]);
-		Util::addHeader('meta', ['property' => 'og:site_name', 'content' => $this->defaults->getName()]);
+		$title = $shareNode->getName();
+		$siteName = $this->defaults->getName();
+		$description = $siteName . ($this->defaults->getSlogan() !== '' ? ' - ' . $this->defaults->getSlogan() : '');
+
+		// OpenGraph Support: http://ogp.me/
+		Util::addHeader('meta', ['property' => 'og:title', 'content' => $title]);
+		Util::addHeader('meta', ['property' => 'og:description', 'content' => $description]);
+		Util::addHeader('meta', ['property' => 'og:site_name', 'content' => $siteName]);
 		Util::addHeader('meta', ['property' => 'og:url', 'content' => $shareUrl]);
 		Util::addHeader('meta', ['property' => 'og:type', 'content' => 'object']);
 		Util::addHeader('meta', ['property' => 'og:image', 'content' => $ogPreview]);
+
+		// Twitter Support: https://developer.x.com/en/docs/x-for-websites/cards/overview/markup
+		Util::addHeader('meta', ['property' => 'twitter:title', 'content' => $title]);
+		Util::addHeader('meta', ['property' => 'twitter:description', 'content' => $description]);
+		Util::addHeader('meta', ['property' => 'twitter:card', 'content' => $hasImagePreview ? 'summary_large_image' : 'summary']);
+		Util::addHeader('meta', ['property' => 'twitter:image', 'content' => $ogPreview]);
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Improves/expands the meta tags for shared files.

- Adds the following opengraph tags, depending on the file type
  - images:
    - `og:image:type`: the mimetype of the image file (**TODO**: should this be added for all shared files? all files will always have an `og:image` tag with either the preview or the nc logo)
  - audio:
    - `og:audio`: a direct link to the audio file
    - `og:audio:type`: the mimetype of the audio file
  - video:
    - `og:video`: a direct link to the video file
    - `og:video:type`: the mimetype of the video file
- Updates the `og:type` tag from `object` (which is not a type that exists, as far as I can tell) to `website`
- Adds meta tags for twitter
  - `twitter:title`: same as `og:title`
  - `twitter:description`: same as `og:description`
  - `twitter:card`: `summary_large_image` if the shared file is an image & it has a preview, otherwise `summary`
  - `twitter:image`: same as `og:image`

### Before changes

![Image](https://github.com/user-attachments/assets/ca761efc-9966-4481-a479-d6cc7b7f29c7)


### After changes

> [!NOTE]
> I tested this on my personal self-hosted nextcloud, which is running nextcloud `29.0.10`. I did this by just manually editing the `apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php` file.

![image](https://github.com/user-attachments/assets/42dc8993-0594-40f6-9f33-b196521d33a0)


## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
