### PR TITLE
Revert "fix: don't recalculate folder size in Cache::delete if the en…

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1830,6 +1830,11 @@
       <code><![CDATA[self::getGlobalCache()->getStorageInfo($storageId)]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="lib/private/Files/Cache/Updater.php">
+    <RedundantCondition>
+      <code><![CDATA[$this->cache instanceof Cache]]></code>
+    </RedundantCondition>
+  </file>
   <file src="lib/private/Files/Cache/Wrapper/CacheWrapper.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[array]]></code>

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -152,6 +152,9 @@ class Updater implements IUpdater {
 			$this->propagator->propagateChange($path, time(), -$entry->getSize());
 		} else {
 			$this->propagator->propagateChange($path, time());
+			if ($this->cache instanceof Cache) {
+				$this->cache->correctFolderSize($parent);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary


This reverts commit 5ca9d884d78fd4439a74dde02fdcafb3ac7a40f4.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
