### PR TITLE
fix(View): Catch exceptions when executing mkdir for non-existent parents

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1512,10 +1512,17 @@ class View {
 						$entryName = substr($relativePath, 0, $pos);
 
 						// Create parent folders if the mountpoint is inside a subfolder that doesn't exist yet
-						if (!isset($files[$entryName]) && $this->mkdir($path . '/' . $entryName) !== false) {
-							$info = $this->getFileInfo($path . '/' . $entryName);
-							if ($info !== false) {
-								$files[$entryName] = $info;
+						if (!isset($files[$entryName])) {
+							try {
+								if ($this->mkdir($path . '/' . $entryName) !== false) {
+									$info = $this->getFileInfo($path . '/' . $entryName);
+									if ($info !== false) {
+										$files[$entryName] = $info;
+									}
+								}
+							} catch (\Exception $e) {
+								// Creating the parent folder might not be possible, for example due to a lack of permissions.
+								$this->logger->debug('Failed to create non-existent parent', ['exception' => $e, 'path' => $path . '/' . $entryName]);
 							}
 						}
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/nextcloud/server/pull/47417.
We can not simply assume that the user is allowed to create the parent folder, for example groupfolders ACL or files_accesscontrol rules could prevent it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
