### PR TITLE
fix(Http): Only allow valid HTTP status code values via template

### DIFF
--- a/apps/settings/lib/Controller/LogSettingsController.php
+++ b/apps/settings/lib/Controller/LogSettingsController.php
@@ -27,9 +27,7 @@ class LogSettingsController extends Controller {
 	/**
 	 * download logfile
 	 *
-	 * @psalm-suppress MoreSpecificReturnType The value of Content-Disposition is not relevant
-	 * @psalm-suppress LessSpecificReturnStatement The value of Content-Disposition is not relevant
-	 * @return StreamResponse<Http::STATUS_OK, array{Content-Type: 'application/octet-stream', 'Content-Disposition': string}>
+	 * @return StreamResponse<Http::STATUS_OK, array{Content-Type: 'application/octet-stream', 'Content-Disposition': 'attachment; filename="nextcloud.log"'}>
 	 *
 	 * 200: Logfile returned
 	 */
@@ -38,11 +36,13 @@ class LogSettingsController extends Controller {
 		if (!$this->log instanceof Log) {
 			throw new \UnexpectedValueException('Log file not available');
 		}
-		$resp = new StreamResponse($this->log->getLogPath());
-		$resp->setHeaders([
-			'Content-Type' => 'application/octet-stream',
-			'Content-Disposition' => 'attachment; filename="nextcloud.log"',
-		]);
-		return $resp;
+		return new StreamResponse(
+			$this->log->getLogPath(),
+			Http::STATUS_OK,
+			[
+				'Content-Type' => 'application/octet-stream',
+				'Content-Disposition' => 'attachment; filename="nextcloud.log"',
+			],
+		);
 	}
 }

--- a/apps/settings/openapi-administration.json
+++ b/apps/settings/openapi-administration.json
@@ -44,7 +44,10 @@
                         "headers": {
                             "Content-Disposition": {
                                 "schema": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "attachment; filename=\"nextcloud.log\""
+                                    ]
                                 }
                             }
                         },

--- a/apps/settings/openapi-full.json
+++ b/apps/settings/openapi-full.json
@@ -221,7 +221,10 @@
                         "headers": {
                             "Content-Disposition": {
                                 "schema": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "attachment; filename=\"nextcloud.log\""
+                                    ]
                                 }
                             }
                         },

--- a/lib/private/AppFramework/OCS/BaseResponse.php
+++ b/lib/private/AppFramework/OCS/BaseResponse.php
@@ -11,10 +11,10 @@ use OCP\AppFramework\Http\Response;
 
 /**
  * @psalm-import-type DataResponseType from DataResponse
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template-covariant T of DataResponseType
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 abstract class BaseResponse extends Response {
 	/** @var array */

--- a/lib/private/AppFramework/OCS/V1Response.php
+++ b/lib/private/AppFramework/OCS/V1Response.php
@@ -11,17 +11,17 @@ use OCP\AppFramework\OCSController;
 
 /**
  * @psalm-import-type DataResponseType from DataResponse
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template-covariant T of DataResponseType
  * @template H of array<string, mixed>
- * @template-extends BaseResponse<int, DataResponseType, array<string, mixed>>
+ * @template-extends BaseResponse<Http::STATUS_*, DataResponseType, array<string, mixed>>
  */
 class V1Response extends BaseResponse {
 	/**
 	 * The V1 endpoint has very limited http status codes basically everything
 	 * is status 200 except 401
 	 *
-	 * @return int
+	 * @return Http::STATUS_*
 	 */
 	public function getStatus() {
 		$status = parent::getStatus();

--- a/lib/private/AppFramework/OCS/V2Response.php
+++ b/lib/private/AppFramework/OCS/V2Response.php
@@ -11,17 +11,17 @@ use OCP\AppFramework\OCSController;
 
 /**
  * @psalm-import-type DataResponseType from DataResponse
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template-covariant T of DataResponseType
  * @template H of array<string, mixed>
- * @template-extends BaseResponse<int, DataResponseType, array<string, mixed>>
+ * @template-extends BaseResponse<Http::STATUS_*, DataResponseType, array<string, mixed>>
  */
 class V2Response extends BaseResponse {
 	/**
 	 * The V2 endpoint just passes on status codes.
 	 * Of course we have to map the OCS specific codes to proper HTTP status codes
 	 *
-	 * @return int
+	 * @return Http::STATUS_*
 	 */
 	public function getStatus() {
 		$status = parent::getStatus();

--- a/lib/public/AppFramework/Http/DataDisplayResponse.php
+++ b/lib/public/AppFramework/Http/DataDisplayResponse.php
@@ -13,9 +13,9 @@ use OCP\AppFramework\Http;
  * Class DataDisplayResponse
  *
  * @since 8.1.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class DataDisplayResponse extends Response {
 	/**

--- a/lib/public/AppFramework/Http/DataDownloadResponse.php
+++ b/lib/public/AppFramework/Http/DataDownloadResponse.php
@@ -13,10 +13,10 @@ use OCP\AppFramework\Http;
  * Class DataDownloadResponse
  *
  * @since 8.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template C of string
  * @template H of array<string, mixed>
- * @template-extends DownloadResponse<int, string, array<string, mixed>>
+ * @template-extends DownloadResponse<Http::STATUS_*, string, array<string, mixed>>
  */
 class DataDownloadResponse extends DownloadResponse {
 	/**

--- a/lib/public/AppFramework/Http/DataResponse.php
+++ b/lib/public/AppFramework/Http/DataResponse.php
@@ -14,10 +14,10 @@ use OCP\AppFramework\Http;
  * for responders to transform
  * @since 8.0.0
  * @psalm-type DataResponseType = array|int|float|string|bool|object|null|\stdClass|\JsonSerializable
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template-covariant T of DataResponseType
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class DataResponse extends Response {
 	/**

--- a/lib/public/AppFramework/Http/DownloadResponse.php
+++ b/lib/public/AppFramework/Http/DownloadResponse.php
@@ -12,10 +12,10 @@ use OCP\AppFramework\Http;
 /**
  * Prompts the user to download the a file
  * @since 7.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template C of string
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class DownloadResponse extends Response {
 	/**

--- a/lib/public/AppFramework/Http/FileDisplayResponse.php
+++ b/lib/public/AppFramework/Http/FileDisplayResponse.php
@@ -13,9 +13,9 @@ use OCP\Files\SimpleFS\ISimpleFile;
  * Class FileDisplayResponse
  *
  * @since 11.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class FileDisplayResponse extends Response implements ICallbackResponse {
 	/** @var File|ISimpleFile */

--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -12,10 +12,10 @@ use OCP\AppFramework\Http;
 /**
  * A renderer for JSON calls
  * @since 6.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template-covariant T of null|string|int|float|bool|array|\stdClass|\JsonSerializable
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class JSONResponse extends Response {
 	/**

--- a/lib/public/AppFramework/Http/NotFoundResponse.php
+++ b/lib/public/AppFramework/Http/NotFoundResponse.php
@@ -12,9 +12,9 @@ use OCP\AppFramework\Http;
 /**
  * A generic 404 response showing an 404 error page as well to the end-user
  * @since 8.1.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends TemplateResponse<int, array<string, mixed>>
+ * @template-extends TemplateResponse<Http::STATUS_*, array<string, mixed>>
  */
 class NotFoundResponse extends TemplateResponse {
 	/**

--- a/lib/public/AppFramework/Http/RedirectResponse.php
+++ b/lib/public/AppFramework/Http/RedirectResponse.php
@@ -12,9 +12,9 @@ use OCP\AppFramework\Http;
 /**
  * Redirects to a different URL
  * @since 7.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class RedirectResponse extends Response {
 	private $redirectURL;

--- a/lib/public/AppFramework/Http/RedirectToDefaultAppResponse.php
+++ b/lib/public/AppFramework/Http/RedirectToDefaultAppResponse.php
@@ -16,9 +16,9 @@ use OCP\IURLGenerator;
  *
  * @since 16.0.0
  * @deprecated 23.0.0 Use RedirectResponse() with IURLGenerator::linkToDefaultPageUrl() instead
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends RedirectResponse<int, array<string, mixed>>
+ * @template-extends RedirectResponse<Http::STATUS_*, array<string, mixed>>
  */
 class RedirectToDefaultAppResponse extends RedirectResponse {
 	/**

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -18,7 +18,7 @@ use Psr\Log\LoggerInterface;
  *
  * It handles headers, HTTP status code, last modified and ETag.
  * @since 6.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
  */
 class Response {

--- a/lib/public/AppFramework/Http/StandaloneTemplateResponse.php
+++ b/lib/public/AppFramework/Http/StandaloneTemplateResponse.php
@@ -7,6 +7,8 @@ declare(strict_types=1);
  */
 namespace OCP\AppFramework\Http;
 
+use OCP\AppFramework\Http;
+
 /**
  * A template response that does not emit the loadAdditionalScripts events.
  *
@@ -14,9 +16,9 @@ namespace OCP\AppFramework\Http;
  * full nextcloud UI. Like the 2FA page, or the grant page in the login flow.
  *
  * @since 16.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends TemplateResponse<int, array<string, mixed>>
+ * @template-extends TemplateResponse<Http::STATUS_*, array<string, mixed>>
  */
 class StandaloneTemplateResponse extends TemplateResponse {
 }

--- a/lib/public/AppFramework/Http/StreamResponse.php
+++ b/lib/public/AppFramework/Http/StreamResponse.php
@@ -13,9 +13,9 @@ use OCP\AppFramework\Http;
  * Class StreamResponse
  *
  * @since 8.1.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class StreamResponse extends Response implements ICallbackResponse {
 	/** @var string */

--- a/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
+++ b/lib/public/AppFramework/Http/Template/PublicTemplateResponse.php
@@ -15,8 +15,8 @@ use OCP\IInitialStateService;
  *
  * @since 14.0.0
  * @template H of array<string, mixed>
- * @template S of int
- * @template-extends TemplateResponse<int, array<string, mixed>>
+ * @template S of Http::STATUS_*
+ * @template-extends TemplateResponse<Http::STATUS_*, array<string, mixed>>
  */
 class PublicTemplateResponse extends TemplateResponse {
 	private $headerTitle = '';

--- a/lib/public/AppFramework/Http/TemplateResponse.php
+++ b/lib/public/AppFramework/Http/TemplateResponse.php
@@ -13,9 +13,9 @@ use OCP\AppFramework\Http;
  * Response for a normal template
  * @since 6.0.0
  *
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class TemplateResponse extends Response {
 	/**

--- a/lib/public/AppFramework/Http/TextPlainResponse.php
+++ b/lib/public/AppFramework/Http/TextPlainResponse.php
@@ -12,9 +12,9 @@ use OCP\AppFramework\Http;
 /**
  * A renderer for text responses
  * @since 22.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class TextPlainResponse extends Response {
 	/** @var string */

--- a/lib/public/AppFramework/Http/TooManyRequestsResponse.php
+++ b/lib/public/AppFramework/Http/TooManyRequestsResponse.php
@@ -13,9 +13,9 @@ use OCP\Template;
 /**
  * A generic 429 response showing an 404 error page as well to the end-user
  * @since 19.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class TooManyRequestsResponse extends Response {
 	/**

--- a/lib/public/AppFramework/Http/ZipResponse.php
+++ b/lib/public/AppFramework/Http/ZipResponse.php
@@ -15,9 +15,9 @@ use OCP\IRequest;
  * Public library to send several files in one zip archive.
  *
  * @since 15.0.0
- * @template S of int
+ * @template S of Http::STATUS_*
  * @template H of array<string, mixed>
- * @template-extends Response<int, array<string, mixed>>
+ * @template-extends Response<Http::STATUS_*, array<string, mixed>>
  */
 class ZipResponse extends Response implements ICallbackResponse {
 	/** @var array{internalName: string, resource: resource, size: int, time: int}[] Files to be added to the zip response */


### PR DESCRIPTION
## Summary

To prevent anyone from using invalid HTTP status codes.
Ideally it would be possible to re-use the `S` and so on template parameters when extending the parent templates, but psalm doesn't seem to support that.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
