### PR TITLE
fix: don't skip scanner users filesystem if they have a mountpoint at /<user>/files/

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2101,14 +2101,6 @@
       <code><![CDATA[$mimetype]]></code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/private/Files/Utils/Scanner.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$mounts]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[\OC\Files\Mount\MountPoint[]]]></code>
-    </MoreSpecificReturnType>
-  </file>
   <file src="lib/private/Files/View.php">
     <InvalidScalarArgument>
       <code><![CDATA[$mtime]]></code>

--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -23,6 +23,7 @@ use OCP\Files\Events\FileScannedEvent;
 use OCP\Files\Events\FolderScannedEvent;
 use OCP\Files\Events\NodeAddedToCache;
 use OCP\Files\Events\NodeRemovedFromCache;
+use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
@@ -85,7 +86,7 @@ class Scanner extends PublicEmitter {
 	 * get all storages for $dir
 	 *
 	 * @param string $dir
-	 * @return \OC\Files\Mount\MountPoint[]
+	 * @return array<string, IMountPoint>
 	 */
 	protected function getMounts($dir) {
 		//TODO: move to the node based fileapi once that's done
@@ -96,8 +97,9 @@ class Scanner extends PublicEmitter {
 		$mounts = $mountManager->findIn($dir);
 		$mounts[] = $mountManager->find($dir);
 		$mounts = array_reverse($mounts); //start with the mount of $dir
+		$mountPoints = array_map(fn ($mount) => $mount->getMountPoint(), $mounts);
 
-		return $mounts;
+		return array_combine($mountPoints, $mounts);
 	}
 
 	/**
@@ -210,6 +212,9 @@ class Scanner extends PublicEmitter {
 							$owner = $owner['name'] ?? $ownerUid;
 							$permissions = decoct(fileperms($fullPath));
 							throw new ForbiddenException("User folder $fullPath is not writable, folders is owned by $owner and has mode $permissions");
+						} elseif (isset($mounts[$mount->getMountPoint() . $path . '/'])) {
+							// /<user>/files is overwritten by a mountpoint, so this check is irrelevant
+							break;
 						} else {
 							// if the root exists in neither the cache nor the storage the user isn't setup yet
 							break 2;


### PR DESCRIPTION
This currently gives a false positive for the "skip scanning if user isn't setup.