### PR TITLE
refactor(settings): Use parameters explicitly when setting mail settings

### DIFF
--- a/apps/settings/lib/Controller/MailSettingsController.php
+++ b/apps/settings/lib/Controller/MailSettingsController.php
@@ -44,34 +44,37 @@ class MailSettingsController extends Controller {
 
 	/**
 	 * Sets the email settings
-	 *
-	 * @param string $mail_domain
-	 * @param string $mail_from_address
-	 * @param string $mail_smtpmode
-	 * @param string $mail_smtpsecure
-	 * @param string $mail_smtphost
-	 * @param int $mail_smtpauth
-	 * @param string $mail_smtpport
-	 * @return DataResponse
 	 */
 	#[AuthorizedAdminSetting(settings: Overview::class)]
 	#[PasswordConfirmationRequired]
-	public function setMailSettings($mail_domain,
-		$mail_from_address,
-		$mail_smtpmode,
-		$mail_smtpsecure,
-		$mail_smtphost,
-		$mail_smtpauth,
-		$mail_smtpport,
-		$mail_sendmailmode) {
-		$params = get_defined_vars();
-		$configs = [];
-		foreach ($params as $key => $value) {
+	public function setMailSettings(
+		string $mail_domain,
+		string $mail_from_address,
+		string $mail_smtpmode,
+		string $mail_smtpsecure,
+		string $mail_smtphost,
+		?string $mail_smtpauth,
+		string $mail_smtpport,
+		string $mail_sendmailmode,
+	): DataResponse {
+		$mail_smtpauth = $mail_smtpauth == '1';
+
+		$configs = [
+			'mail_domain' => $mail_domain,
+			'mail_from_address' => $mail_from_address,
+			'mail_smtpmode' => $mail_smtpmode,
+			'mail_smtpsecure' => $mail_smtpsecure,
+			'mail_smtphost' => $mail_smtphost,
+			'mail_smtpauth' => $mail_smtpauth,
+			'mail_smtpport' => $mail_smtpport,
+			'mail_sendmailmode' => $mail_sendmailmode,
+		];
+		foreach ($configs as $key => $value) {
 			$configs[$key] = empty($value) ? null : $value;
 		}
 
 		// Delete passwords from config in case no auth is specified
-		if ($params['mail_smtpauth'] !== 1) {
+		if (!$mail_smtpauth) {
 			$configs['mail_smtpname'] = null;
 			$configs['mail_smtppassword'] = null;
 		}

--- a/apps/settings/tests/Controller/MailSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/MailSettingsControllerTest.php
@@ -70,7 +70,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 					'mail_smtphost' => 'mx.nextcloud.org',
 					'mail_smtpauth' => 1,
 					'mail_smtpport' => '25',
-					'mail_sendmailmode' => null,
+					'mail_sendmailmode' => 'smtp',
 				]],
 				[[
 					'mail_domain' => 'nextcloud.com',
@@ -82,7 +82,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 					'mail_smtpport' => '25',
 					'mail_smtpname' => null,
 					'mail_smtppassword' => null,
-					'mail_sendmailmode' => null,
+					'mail_sendmailmode' => 'smtp',
 				]]
 			);
 
@@ -95,7 +95,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'mx.nextcloud.org',
 			1,
 			'25',
-			null
+			'smtp'
 		);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 
@@ -108,7 +108,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'mx.nextcloud.org',
 			0,
 			'25',
-			null
+			'smtp'
 		);
 		$this->assertSame(Http::STATUS_OK, $response->getStatus());
 	}


### PR DESCRIPTION
## Summary

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
