### PR TITLE
fix: Fix copying to the root of another mountpoint

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -186,6 +186,9 @@ class Updater implements IUpdater {
 	public function copyFromStorage(IStorage $sourceStorage, string $source, string $target): void {
 		$this->copyOrRenameFromStorage($sourceStorage, $source, $target, function (ICache $sourceCache, ICacheEntry $sourceInfo) use ($target) {
 			$parent = dirname($target);
+			if ($parent === '.') {
+				$parent = '';
+			}
 			$parentInCache = $this->cache->inCache($parent);
 			if (!$parentInCache) {
 				$parentData = $this->scanner->scan($parent, Scanner::SCAN_SHALLOW, -1, false);


### PR DESCRIPTION
* Resolves: #49883

## Summary

We may want to add a method for this as we have the same call to dirname with special handling of `.` in a lot of places.
But it brings a lot of questions, where to put the method, what to do with `'/'`, and so on, so for now fixing it the known problem first.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
