### PR TITLE
fix(files_trashbin): flaky cypress live photo restore

### DIFF
--- a/apps/files_trashbin/lib/Events/BeforeNodeRestoredEvent.php
+++ b/apps/files_trashbin/lib/Events/BeforeNodeRestoredEvent.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Trashbin\Events;
 
-use Exception;
+use OCP\Exceptions\AbortedEventException;
 use OCP\Files\Events\Node\AbstractNodesEvent;
 use OCP\Files\Node;
 
@@ -30,10 +30,6 @@ class BeforeNodeRestoredEvent extends AbstractNodesEvent {
 	public function abortOperation(?\Throwable $ex = null) {
 		$this->stopPropagation();
 		$this->run = false;
-		if ($ex !== null) {
-			throw $ex;
-		} else {
-			throw new Exception('Operation aborted');
-		}
+		throw new AbortedEventException($ex?->getMessage() ?? 'Operation aborted');
 	}
 }

--- a/cypress/e2e/files/live_photos.cy.ts
+++ b/cypress/e2e/files/live_photos.cy.ts
@@ -142,9 +142,13 @@ describe('Files: Live photos', { testIsolation: true }, () => {
 		it('Restores files when restoring the .jpg', () => {
 			triggerActionForFile(`${randomFileName}.jpg`, 'delete')
 			cy.visit('/apps/files/trashbin')
-			triggerInlineActionForFileId(jpgFileId, 'restore')
-			clickOnBreadcrumbs('Deleted files')
 
+			cy.intercept('MOVE', '/remote.php/dav/trashbin/*/trash/*').as('restoreFile')
+			triggerInlineActionForFileId(jpgFileId, 'restore')
+			cy.wait('@restoreFile')
+			cy.get('@restoreFile').its('response.statusCode').should('equal', 201)
+
+			clickOnBreadcrumbs('Deleted files')
 			getRowForFile(`${randomFileName}.jpg`).should('have.length', 0)
 			getRowForFile(`${randomFileName}.mov`).should('have.length', 0)
 
@@ -157,9 +161,13 @@ describe('Files: Live photos', { testIsolation: true }, () => {
 		it('Blocks restoration when restoring the .mov', () => {
 			triggerActionForFile(`${randomFileName}.jpg`, 'delete')
 			cy.visit('/apps/files/trashbin')
-			triggerInlineActionForFileId(movFileId, 'restore')
-			clickOnBreadcrumbs('Deleted files')
 
+			cy.intercept('MOVE', '/remote.php/dav/trashbin/*/trash/*').as('restoreFile')
+			triggerInlineActionForFileId(movFileId, 'restore')
+			cy.wait('@restoreFile')
+			cy.get('@restoreFile').its('response.statusCode').should('equal', 500)
+
+			clickOnBreadcrumbs('Deleted files')
 			getRowForFileId(jpgFileId).should('have.length', 1)
 			getRowForFileId(movFileId).should('have.length', 1)
 


### PR DESCRIPTION
For some reason, [we throw a 500 error](https://github.com/nextcloud/server/blob/ca3733de234e03e384c7f1de22ff241e21bb1931/apps/dav/lib/Connector/Sabre/Server.php#L104-L111) when the restore gets aborted.
I don't like it, but we should fix it at some point 
![2024-12-17_14-13](https://github.com/user-attachments/assets/d2dc51c9-8adb-4122-8334-343e9f8a5d11)
