### PR TITLE
[stable30] fix: make sure we have a valid scheme when testing ocm urls

### DIFF
--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\OCM;
 
+use GuzzleHttp\Exception\ConnectException;
 use JsonException;
 use OCP\AppFramework\Http;
 use OCP\Http\Client\IClientService;
@@ -52,6 +53,14 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 	 */
 	public function discover(string $remote, bool $skipCache = false): IOCMProvider {
 		$remote = rtrim($remote, '/');
+		if (!str_starts_with($remote, 'http://') && !str_starts_with($remote, 'https://')) {
+			// if scheme not specified, we test both;
+			try {
+				return $this->discover('https://' . $remote, $skipCache);
+			} catch (OCMProviderException|ConnectException) {
+				return $this->discover('http://' . $remote, $skipCache);
+			}
+		}
 
 		if (!$skipCache) {
 			try {


### PR DESCRIPTION
From https://github.com/nextcloud/server/commit/f08d0532905c211d15effdfa1a9fa4f98921e2a9

```json
{
  "reqId": "Z1HCXyNZzFr7XuNp4Tw13QAAAA4",
  "level": 2,
  "time": "2024-12-05T15:10:23+00:00",
  "remoteAddr": "1.2.3.4",
  "user": "admin",
  "app": "no app in context",
  "method": "PROPFIND",
  "url": "/remote.php/dav/files/admin/test-share/",
  "message": "error while discovering ocm provider",
  "userAgent": "",
  "version": "28.0.10.2",
  "exception": {
    "Exception": "OCP\\Http\\Client\\LocalServerException",
    "Message": "Could not detect any host",
    "Code": 0,
    "Trace": [
      {
        "file": "/home/www/nextcloud/lib/private/Http/Client/Client.php",
        "line": 229,
        "function": "preventLocalAddress",
        "class": "OC\\Http\\Client\\Client",
        "type": "->",
        "args": [
          "nextcloud.test.de/ocm-provider/",
          [
            10,
            true,
            10
          ]
        ]
      },