### PR TITLE
fix: restore updated encrypted version when copying versions

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -628,6 +628,7 @@ class Encryption extends Wrapper {
 						$info->getUnencryptedSize()
 					);
 				}
+				$this->updateEncryptedVersion($sourceStorage, $sourceInternalPath, $targetInternalPath, $isRename, true);
 			}
 			return $result;
 		}


### PR DESCRIPTION
This was removed with https://github.com/nextcloud/server/pull/48651 but breaks encrypted versions.

@artonge do you remember why you removed it?