### PR TITLE
feat(Navigation): emit dedicated event for loading additional entries

### DIFF
--- a/apps/files/lib/App.php
+++ b/apps/files/lib/App.php
@@ -10,6 +10,7 @@ namespace OCA\Files;
 use OC\NavigationManager;
 use OCA\Files\Service\ChunkedUploadConfig;
 use OCP\App\IAppManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\INavigationManager;
@@ -36,6 +37,7 @@ class App {
 				Server::get(IGroupManager::class),
 				Server::get(IConfig::class),
 				Server::get(LoggerInterface::class),
+				Server::get(IEventDispatcher::class),
 			);
 			self::$navigationManager->clear(false);
 		}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -640,6 +640,7 @@ return array(
     'OCP\\Migration\\IOutput' => $baseDir . '/lib/public/Migration/IOutput.php',
     'OCP\\Migration\\IRepairStep' => $baseDir . '/lib/public/Migration/IRepairStep.php',
     'OCP\\Migration\\SimpleMigrationStep' => $baseDir . '/lib/public/Migration/SimpleMigrationStep.php',
+    'OCP\\Navigation\\Events\\LoadAdditionalEntriesEvent' => $baseDir . '/lib/public/Navigation/Events/LoadAdditionalEntriesEvent.php',
     'OCP\\Notification\\AlreadyProcessedException' => $baseDir . '/lib/public/Notification/AlreadyProcessedException.php',
     'OCP\\Notification\\IAction' => $baseDir . '/lib/public/Notification/IAction.php',
     'OCP\\Notification\\IApp' => $baseDir . '/lib/public/Notification/IApp.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -681,6 +681,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Migration\\IOutput' => __DIR__ . '/../../..' . '/lib/public/Migration/IOutput.php',
         'OCP\\Migration\\IRepairStep' => __DIR__ . '/../../..' . '/lib/public/Migration/IRepairStep.php',
         'OCP\\Migration\\SimpleMigrationStep' => __DIR__ . '/../../..' . '/lib/public/Migration/SimpleMigrationStep.php',
+        'OCP\\Navigation\\Events\\LoadAdditionalEntriesEvent' => __DIR__ . '/../../..' . '/lib/public/Navigation/Events/LoadAdditionalEntriesEvent.php',
         'OCP\\Notification\\AlreadyProcessedException' => __DIR__ . '/../../..' . '/lib/public/Notification/AlreadyProcessedException.php',
         'OCP\\Notification\\IAction' => __DIR__ . '/../../..' . '/lib/public/Notification/IAction.php',
         'OCP\\Notification\\IApp' => __DIR__ . '/../../..' . '/lib/public/Notification/IApp.php',

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use OC\App\AppManager;
 use OC\Group\Manager;
 use OCP\App\IAppManager;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\INavigationManager;
@@ -18,6 +19,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Navigation\Events\LoadAdditionalEntriesEvent;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -56,6 +58,7 @@ class NavigationManager implements INavigationManager {
 		IGroupManager $groupManager,
 		IConfig $config,
 		LoggerInterface $logger,
+		protected IEventDispatcher $eventDispatcher,
 	) {
 		$this->appManager = $appManager;
 		$this->urlGenerator = $urlGenerator;
@@ -318,6 +321,7 @@ class NavigationManager implements INavigationManager {
 				]);
 			}
 		}
+		$this->eventDispatcher->dispatchTyped(new LoadAdditionalEntriesEvent());
 
 		if ($this->userSession->isLoggedIn()) {
 			$user = $this->userSession->getUser();

--- a/lib/public/Navigation/Events/LoadAdditionalEntriesEvent.php
+++ b/lib/public/Navigation/Events/LoadAdditionalEntriesEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Navigation\Events;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * @since 31.0.0
+ */
+class LoadAdditionalEntriesEvent extends Event {
+}

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -11,6 +11,7 @@ use OC\App\AppManager;
 use OC\Group\Manager;
 use OC\NavigationManager;
 use OC\SubAdmin;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -18,6 +19,8 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Navigation\Events\LoadAdditionalEntriesEvent;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class NavigationManagerTest extends TestCase {
@@ -34,6 +37,8 @@ class NavigationManagerTest extends TestCase {
 	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
+	protected IEVentDispatcher|MockObject $dispatcher;
+
 	/** @var \OC\NavigationManager */
 	protected $navigationManager;
 	protected LoggerInterface $logger;
@@ -48,6 +53,7 @@ class NavigationManagerTest extends TestCase {
 		$this->groupManager = $this->createMock(Manager::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 		$this->navigationManager = new NavigationManager(
 			$this->appManager,
 			$this->urlGenerator,
@@ -56,6 +62,7 @@ class NavigationManagerTest extends TestCase {
 			$this->groupManager,
 			$this->config,
 			$this->logger,
+			$this->dispatcher,
 		);
 
 		$this->navigationManager->clear(false);
@@ -256,6 +263,11 @@ class NavigationManagerTest extends TestCase {
 		$this->groupManager->expects($this->any())->method('getSubAdmin')->willReturn($subadmin);
 
 		$this->navigationManager->clear();
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->willReturnCallback(function ($event) {
+				$this->assertInstanceOf(LoadAdditionalEntriesEvent::class, $event);
+			});
 		$entries = $this->navigationManager->getAll('all');
 		$this->assertEquals($expected, $entries);
 	}
@@ -558,6 +570,11 @@ class NavigationManagerTest extends TestCase {
 		$this->groupManager->expects($this->any())->method('getSubAdmin')->willReturn($subadmin);
 
 		$this->navigationManager->clear();
+		$this->dispatcher->expects($this->once())
+			->method('dispatchTyped')
+			->willReturnCallback(function ($event) {
+				$this->assertInstanceOf(LoadAdditionalEntriesEvent::class, $event);
+			});
 		$entries = $this->navigationManager->getAll();
 		$this->assertEquals($expected, $entries);
 	}


### PR DESCRIPTION
## Summary

Currently, apps that add custom/dynamic entries have to listen to the `BeforeTemplateRenderedEvent` when they intend to add navigation entries. This is already rather a hack and relies on template rendering. 

But there is the endpoint of the NavigationController in core that offers to get the current data of the app navigation. The app management is making use of it, and Tables would like to do so too. But in this code path, the above mentioned Event is not being fired. Hence, fire a dedicated  event. 

This is a grey zone between a feature and a bug. For the other use case in tables we can work around it with an own endpoint, for the app management this can be considered a bug, and solving it would require the change to be backported. It would not be breaking. Since it is nowhere critical I am fine having it for 31 only.

Screenrecording of the problem:

[Screencast_20241217_202733.webm](https://github.com/user-attachments/assets/c9d76985-8255-4c34-9bd5-0ab9dca03871)

With this change and modified tables app:

[Screencast_20241217_202922.webm](https://github.com/user-attachments/assets/7886f051-2b41-4d4c-bdd5-f5b700ee7bd2)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)