### PR TITLE
fix: Create empty file instead of file with a space

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -3030,7 +3030,7 @@
 
 			self.filesClient.putFileContents(
 					targetPath,
-					' ', // dont create empty files which fails on some storage backends
+					'',
 					{
 						contentType: 'text/plain',
 						overwrite: true


### PR DESCRIPTION
This was added in c22776f04abc5133227b8b34171c36086f955da5 but writing empty files was properly fixed in https://github.com/nextcloud/server/pull/14210

It turns out that MS Office Online server requires new files that are opened to be totally empty in some cases.

Ref https://github.com/nextcloud/officeonline/pull/593 which made it work with 1 byte files but this only works for word/excel, not powerpoint.

This PR is against 30 as with 31 this code is no longer in place.