### PR TITLE
fix: when already upgrading, don't instruct to run `occ upgrade`

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -125,7 +125,7 @@ class Application {
 				$errorOutput->writeln('Nextcloud is not installed - only a limited number of commands are available');
 			}
 		} catch (NeedsUpdateException) {
-			if ($input->getArgument('command') !== '_completion') {
+			if ($input->getArgument('command') !== '_completion' && $input->getArgument('command') !== 'upgrade') {
 				$errorOutput = $output->getErrorOutput();
 				$errorOutput->writeln('Nextcloud or one of the apps require upgrade - only a limited number of commands are available');
 				$errorOutput->writeln('You may use your browser or the occ upgrade command to do the upgrade');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #36289 <!-- related github issue -->

## Summary

A usability paper cut fix. 

Misleading and confusing to display this warning when the operator is, in fact, in the midst of running `occ upgrade`.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
