### PR TITLE
Clarify installation wording to be clear that it is about account creation

### DIFF
--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -38,15 +38,15 @@ script('core', 'install');
 	</fieldset>
 	<?php endif; ?>
 	<fieldset id="adminaccount">
-		<legend><?php print_unescaped($l->t('Create an <strong>admin account</strong>')); ?></legend>
+		<legend><?php print_unescaped($l->t('<strong>Create an admin account</strong>')); ?></legend>
 		<p>
-			<label for="adminlogin"><?php p($l->t('Login')); ?></label>
+			<label for="adminlogin"><?php p($l->t('New admin account name')); ?></label>
 			<input type="text" name="adminlogin" id="adminlogin"
 				value="<?php p($_['adminlogin']); ?>"
 				autocomplete="off" autocapitalize="none" spellcheck="false" autofocus required>
 		</p>
 		<p class="groupbottom">
-			<label for="adminpass"><?php p($l->t('Password')); ?></label>
+			<label for="adminpass"><?php p($l->t('New admin password')); ?></label>
 			<input type="password" name="adminpass" data-typetoggle="#show" id="adminpass"
 				value="<?php p($_['adminpass']); ?>"
 				autocomplete="off" autocapitalize="none" spellcheck="false" required>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: Issue reported by @scottjenson via Mastodon: https://mastodon.social/@scottjenson@social.coop/113697131007190957

## Summary
The installation flow does not make it clear enough that these steps are about creating a new admin account, and almost look like a login screen where you are supposed to put in existing credentials.

Before | After
-|-
![Install before](https://github.com/user-attachments/assets/7c8eb3f0-62d7-4c45-88c4-e7c3f976a4c0)|![Install after](https://github.com/user-attachments/assets/485c7fe2-5b1b-4d75-8ea4-6b00862002d7)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
