### PR TITLE
fix: block moving files to it's own parent with dav

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -203,6 +203,11 @@ class FilesPlugin extends ServerPlugin {
 		if (!$sourceNodeFileInfo->isDeletable()) {
 			throw new Forbidden($source . ' cannot be deleted');
 		}
+
+		// The source is not allowed to be the parent of the target
+		if (str_starts_with($source, $target . '/')) {
+			throw new Forbidden($source . ' cannot be moved to it\'s parent');
+		}
 	}
 
 	/**

--- a/build/integration/dav_features/dav-v2.feature
+++ b/build/integration/dav_features/dav-v2.feature
@@ -12,6 +12,16 @@ Feature: dav-v2
 		When User "user0" moves file "/textfile0.txt" to "/FOLDER/textfile0.txt"
 		Then the HTTP status code should be "201"
 
+  Scenario: Moving and overwriting it's parent
+    Given using new dav path
+    And As an "admin"
+    And user "user0" exists
+    And As an "user0"
+    And user "user0" created a folder "/test"
+    And user "user0" created a folder "/test/test"
+    When User "user0" moves file "/test/test" to "/test"
+    Then the HTTP status code should be "403"
+
 	Scenario: download a file with range using new endpoint
 		Given using new dav path
 		And As an "admin"

--- a/build/integration/dav_features/webdav-related.feature
+++ b/build/integration/dav_features/webdav-related.feature
@@ -38,6 +38,16 @@ Feature: webdav-related
 		Then the HTTP status code should be "204"
 		And Downloaded content when downloading file "/textfile0.txt" with range "bytes=0-6" should be "Welcome"
 
+  Scenario: Moving and overwriting it's parent
+    Given using old dav path
+    And As an "admin"
+    And user "user0" exists
+    And As an "user0"
+    And user "user0" created a folder "/test"
+    And user "user0" created a folder "/test/test"
+    When User "user0" moves file "/test/test" to "/test"
+    Then the HTTP status code should be "403"
+
 	Scenario: Moving a file to a folder with no permissions
 		Given using old dav path
 		And As an "admin"


### PR DESCRIPTION
Currently this leads to data loss as sabre will remove the target, and thus also the source, before doing the move

closes #49621