### PR TITLE
perf(settings): Speed up InternetConnectivity setup check

### DIFF
--- a/apps/settings/lib/SetupChecks/InternetConnectivity.php
+++ b/apps/settings/lib/SetupChecks/InternetConnectivity.php
@@ -41,11 +41,12 @@ class InternetConnectivity implements ISetupCheck {
 		}
 
 		$siteArray = $this->config->getSystemValue('connectivity_check_domains', [
-			'www.nextcloud.com', 'www.startpage.com', 'www.eff.org', 'www.edri.org'
+			'https://www.nextcloud.com', 'https://www.startpage.com', 'https://www.eff.org', 'https://www.edri.org'
 		]);
 
 		foreach ($siteArray as $site) {
 			if ($this->isSiteReachable($site)) {
+				// successful as soon as one connection succeeds
 				return SetupResult::success();
 			}
 		}
@@ -55,19 +56,18 @@ class InternetConnectivity implements ISetupCheck {
 	/**
 	 * Checks if the Nextcloud server can connect to a specific URL
 	 * @param string $site site domain or full URL with http/https protocol
+	 * @return bool success/failure
 	 */
 	private function isSiteReachable(string $site): bool {
+		// if there is no protocol specified, test http:// first then, if necessary, https://
+		if (preg_match('/^https?:\/\//', $site) !== 1) {
+			$httpSite = 'http://' . $site . '/';
+			$httpsSite = 'https://' . $site . '/';
+			return $this->isSiteReachable($httpSite) || $this->isSiteReachable($httpsSite);
+		}
 		try {
 			$client = $this->clientService->newClient();
-			// if there is no protocol, test http:// AND https://
-			if (preg_match('/^https?:\/\//', $site) !== 1) {
-				$httpSite = 'http://' . $site . '/';
-				$client->get($httpSite);
-				$httpsSite = 'https://' . $site . '/';
-				$client->get($httpsSite);
-			} else {
-				$client->get($site);
-			}
+			$client->get($site);
 		} catch (\Exception $e) {
 			$this->logger->error('Cannot connect to: ' . $site, [
 				'app' => 'internet_connection_check',

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -936,16 +936,16 @@ $CONFIG = [
  *
  * Defaults to the following domains:
  *
- *  - www.nextcloud.com
- *  - www.startpage.com
- *  - www.eff.org
- *  - www.edri.org
+ *  - https://www.nextcloud.com
+ *  - https://www.startpage.com
+ *  - https://www.eff.org
+ *  - https://www.edri.org
  */
 'connectivity_check_domains' => [
-	'www.nextcloud.com',
-	'www.startpage.com',
-	'www.eff.org',
-	'www.edri.org'
+	'https://www.nextcloud.com',
+	'https://www.startpage.com',
+	'https://www.eff.org',
+	'https://www.edri.org'
 ],
 
 /**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Specify default protocol (https://) for the default domains rather than let default handling trigger both http:// and https:// tests.

Reduces network category check time by >20% (#49978) and overall setup check time by ~16% in my test environment.

## TODO

- n/a

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
