### PR TITLE
feat: Run setup checks by category or class

### DIFF
--- a/core/Command/SetupChecks.php
+++ b/core/Command/SetupChecks.php
@@ -11,6 +11,7 @@ namespace OC\Core\Command;
 
 use OCP\RichObjectStrings\IRichTextFormatter;
 use OCP\SetupCheck\ISetupCheckManager;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -29,12 +30,44 @@ class SetupChecks extends Base {
 		$this
 			->setName('setupchecks')
 			->setDescription('Run setup checks and output the results')
+			->addArgument(
+				'category',
+				InputArgument::OPTIONAL,
+				'Category of setup checks to run ' . "\n" . '(e.g. "network" to run all the network-related checks)',
+				''
+			)
+			->addArgument(
+				'class',
+				InputArgument::OPTIONAL,
+				'Class of setup checks to run ' . "\n" . '(e.g. "OCA\\Settings\\SetupChecks\\InternetConnectivity" to run only the InternetConnectivity check)',
+				''
+			)
 		;
 	}
 
 	#[\Override]
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$results = $this->setupCheckManager->runAll();
+		$filterByCategory = $input->getArgument('category');
+		$filterByClass = $input->getArgument('class');
+
+		if (!is_string($filterByCategory) || !is_string($filterByClass)) {
+			$output->writeln('<error>Invalid type specified</error>');
+			return self::FAILURE;
+		}
+
+		if ($filterByCategory !== '' && $filterByClass !== '') {
+			$output->writeln('<error>Please specify only one of category or class</error>');
+			return self::FAILURE;
+		}
+
+		if ($filterByCategory !== '') {
+			$results = $this->setupCheckManager->runByCategory($filterByCategory);
+		} elseif ($filterByClass !== '') {
+			$results = $this->setupCheckManager->runByClass($filterByClass);
+		} else {
+			$results = $this->setupCheckManager->runAll();
+		}
+
 		switch ($input->getOption('output')) {
 			case self::OUTPUT_FORMAT_JSON:
 			case self::OUTPUT_FORMAT_JSON_PRETTY:

--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -22,13 +22,31 @@ class SetupCheckManager implements ISetupCheckManager {
 		private LoggerInterface $logger,
 	) {
 	}
-
+	
+	public function runClass(): array {
+		if (str_starts_with($limitClass, '\\')) {
+			$limitClass = substr($limitClass, 1);
+		}
+		return $this->run($limitClass);
+	}
+	
+	public function runCategory(): array {
+		return $this->run($limitCategory);
+	}
+	
 	public function runAll(): array {
+		return $this->run();
+	}
+	
+	private function run(?string $limit = null): array {
 		$results = [];
 		$setupChecks = $this->coordinator->getRegistrationContext()->getSetupChecks();
 		foreach ($setupChecks as $setupCheck) {
 			/** @var ISetupCheck $setupCheckObject */
 			$setupCheckObject = Server::get($setupCheck->getService());
+			if (isset($limit) && $limit !== $setupCheckObject->getCategory() && $limit !== get_class($setupCheckObject)) {
+				continue;
+			}
 			$this->logger->debug('Running check ' . get_class($setupCheckObject));
 			try {
 				$setupResult = $setupCheckObject->run();

--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -23,14 +23,14 @@ class SetupCheckManager implements ISetupCheckManager {
 	) {
 	}
 	
-	public function runClass(): array {
+	public function runClass(string $limitClass): array {
 		if (str_starts_with($limitClass, '\\')) {
 			$limitClass = substr($limitClass, 1);
 		}
 		return $this->run($limitClass);
 	}
 	
-	public function runCategory(): array {
+	public function runCategory(string $limitCategory): array {
 		return $this->run($limitCategory);
 	}
 	

--- a/lib/private/SetupCheck/SetupCheckManager.php
+++ b/lib/private/SetupCheck/SetupCheckManager.php
@@ -18,18 +18,43 @@ use Psr\Log\LoggerInterface;
 
 class SetupCheckManager implements ISetupCheckManager {
 	public function __construct(
-		private Coordinator $coordinator,
-		private LoggerInterface $logger,
+		readonly private Coordinator $coordinator,
+		readonly private LoggerInterface $logger,
 	) {
 	}
 
 	#[\Override]
+	public function runByClass(string $filterByClass): array {
+		if (str_starts_with($filterByClass, '\\')) {
+			$filterByClass = substr($filterByClass, 1);
+		}
+		return $this->run(filterByClass: $filterByClass);
+	}
+
+	#[\Override]
+	public function runByCategory(string $filterByCategory): array {
+		return $this->run(filterByCategory: $filterByCategory);
+	}
+
+	#[\Override]
 	public function runAll(): array {
+		return $this->run();
+	}
+
+	private function run(?string $filterByCategory = null, ?string $filterByClass = null): array {
 		$results = [];
 		$setupChecks = $this->coordinator->getRegistrationContext()->getSetupChecks();
 		foreach ($setupChecks as $setupCheck) {
 			/** @var ISetupCheck $setupCheckObject */
 			$setupCheckObject = Server::get($setupCheck->getService());
+			if ($filterByCategory !== null && $filterByCategory !== $setupCheckObject->getCategory()) {
+				continue;
+			}
+
+			if ($filterByClass !== null && $filterByClass !== get_class($setupCheckObject)) {
+				continue;
+			}
+
 			$this->logger->debug('Running check ' . get_class($setupCheckObject));
 			try {
 				$setupResult = $setupCheckObject->run();

--- a/lib/public/SetupCheck/ISetupCheckManager.php
+++ b/lib/public/SetupCheck/ISetupCheckManager.php
@@ -18,4 +18,15 @@ interface ISetupCheckManager {
 	 * @return array<string,array<string,SetupResult>> Result of each check, first level key is category, second level key is title
 	 */
 	public function runAll(): array;
+	/**
+	 * @since 31.0.0
+	 * @return array<string,array<string,SetupResult>> Result of each check, first level key is category, second level key is title
+	 */
+	public function runClass(string $limitClass): array;
+	/**
+	 * @since 31.0.0
+	 * @return array<string,array<string,SetupResult>> Result of each check, first level key is category, second level key is title
+	 */
+	public function runCategory(string $limitCategory): array;
+
 }

--- a/lib/public/SetupCheck/ISetupCheckManager.php
+++ b/lib/public/SetupCheck/ISetupCheckManager.php
@@ -14,8 +14,28 @@ namespace OCP\SetupCheck;
  */
 interface ISetupCheckManager {
 	/**
+	 * Run all setup checks and return the results.
+	 *
 	 * @since 28.0.0
 	 * @return array<string,array<string,SetupResult>> Result of each check, first level key is category, second level key is title
 	 */
 	public function runAll(): array;
+
+	/**
+	 * Run all tests from one specific category and return the results.
+	 *
+	 * @param string $filterByCategory - The id of the category to run.
+	 * @return array<string,array<string,SetupResult>> Result of each check, first level key is category, second level key is title
+	 * @since 35.0.0
+	 */
+	public function runByCategory(string $filterByCategory): array;
+
+	/**
+	 * Run all tests from one specific class and return the results.
+	 *
+	 * @param string $filterByClass - The class to run.
+	 * @return array<string,array<string,SetupResult>> Result of each check, first level key is category, second level key is title
+	 * @since 35.0.0
+	 */
+	public function runByClass(string $filterByClass): array;
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This PR adds the ability to run:

- a specific category of setup checks
- an individual check

Implementation:

- Existing setup check category names are used for running checks in a specific category (e.g. `network`)
- Existing class names are used for running individual checks
- All checks still run otherwise by default so not a breaking change in behavior

Examples:

Run all checks in a specific category - e.g. the `network` related tests:

`./occ setupchecks network`

RESULT:

```
www-data@83e3407f887c:~/html$ ./occ setupchecks network
	network:
		✓ WebDAV endpoint: Your web server is properly set up to allow file synchronization over WebDAV.
		✓ Data directory protected
		✓ Internet connectivity
		✓ JavaScript source map support
		✓ JavaScript modules support
		✓ OCS provider resolving
		✓ .well-known URLs: Your server is correctly configured to serve `.well-known` URLs.
		✓ Font file loading
www-data@83e3407f887c:~/html$ 
```

Run a specific individual check - e.g. the `InternetConnectivity` test:

`./occ setupcheck OCA\\Settings\\SetupChecks\\InternetConnectivity`

RESULT:

```
www-data@83e3407f887c:~/html$ ./occ setupcheck OCA\\Settings\\SetupChecks\\InternetConnectivity
	network:
		✓ Internet connectivity
www-data@83e3407f887c:~/html$ 
```

If an unrecognized category / class is specified inform the user:

```
www-data@83e3407f887c:~/html$ ./occ setupchecks xxx    
Invalid type specified (or no results for that type)
www-data@83e3407f887c:~/html$ 
```

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
