### PR TITLE
feat: Allow AVIF content type in PhotoCache

### DIFF
--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -27,6 +27,7 @@ class PhotoCache {
 		'image/gif' => 'gif',
 		'image/vnd.microsoft.icon' => 'ico',
 		'image/webp' => 'webp',
+		'image/avif' => 'avif',
 	];
 
 	/**


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/49980

## Summary

AVIF is the only [well-supported commonly used format for still images](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types) that is missing in CardDAV's PhotoCache (excluding SVG for [security concerns](https://github.com/nextcloud/server/pull/48842#pullrequestreview-2385937927)).

This patch would be required in order to be able to use AVIF in contact photos.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] (N/A) ~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~
- [x] (N/A) ~Screenshots before/after for front-end changes~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
