### PR TITLE
fix(settings): show the correct initial locale in Personal info

### DIFF
--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -265,8 +265,8 @@ class PersonalInfo implements ISettings {
 		}
 
 		$uid = $user->getUID();
-		$userLocaleString = $this->config->getUserValue($uid, 'core', 'locale', $this->l10nFactory->findLocale());
 		$userLang = $this->config->getUserValue($uid, 'core', 'lang', $this->l10nFactory->findLanguage());
+		$userLocaleString = $this->config->getUserValue($uid, 'core', 'locale', $this->l10nFactory->findLocale($userLang));
 		$localeCodes = $this->l10nFactory->findAvailableLocales();
 		$userLocale = array_filter($localeCodes, fn ($value) => $userLocaleString === $value['code']);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Closes #23486 (+possibly other locale related matters)

## Summary

The initial Locale shown in the *Personal info* page is not the actual locale in-use. Besides being a bug in itself, it likely has resulted in some confusing bug reports about other aspects of Nextcloud not following the apparently active locale within an individual account.

### Details

Given the following sent by the browser:

```
Accept-language: en-US,en;q=0.5
```

Results in our templates returning:

```
<html class="ng-csp" data-placeholder-focus="false" lang="en" data-locale="en" translate="no" >
```

Which is fine I guess, but it does not match what is displayed on the *Personal info* page for this user. The Locale, instead, is shown as "English (United States)" (it should be just "English" given `data-locale="en"`).

Some environments likely work around this by setting the `default_locale` and/or `force_locale` config paremeters (which short circuit the fall back code detailed below).

## Cause

We call `findLocal()` in two different ways, which produces different fallback return values. In our templates we call it with the currently determined language:

https://github.com/nextcloud/server/blob/d8d708e0a8b0bf12590406a4736e46e5d3373d24/lib/private/L10N/Factory.php#L115-L116

...which means if a user doesn't have a locale saved yet we hit this fallback code:

https://github.com/nextcloud/server/blob/d8d708e0a8b0bf12590406a4736e46e5d3373d24/lib/private/L10N/Factory.php#L267-L269

This returns the language (`en` in my test case) as the fallback locale under all circumstances. This is why data-locale is set to en.

But when the user loads up their Personal settings we populate the active locale without providing the language clue to findLocale():

https://github.com/nextcloud/server/blob/d8d708e0a8b0bf12590406a4736e46e5d3373d24/apps/settings/lib/Settings/Personal/PersonalInfo.php#L268

...So we hit a different fallback:

https://github.com/nextcloud/server/blob/d8d708e0a8b0bf12590406a4736e46e5d3373d24/lib/private/L10N/Factory.php#L272-L274

The result is this field **is only accurate if the user changes their locale** since that triggers a save to the preferences table. At best this is confusing, at worst this leads to bug reports about things not being formatted per the locale that is indicated as being active.

This explains why the Personal settings page always shows me the right thing (for an English speaker in the US), but behavior elsewhere in Nextcloud doesn't match it until I toggle it to something else then back which triggers a save (such as in #23486). 

This also [likely] means visitors with a base language other than English sent in their browser `Accept-Language` header get their real fallback locale set to their language (reasonable), but their Personal info page will show "English (United States)" until they toggle it (triggering a save).

This was discovered when looking into #23486 and revisiting my initial quick fix in #49986.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
