### PR TITLE
fix(previews): Make thumbnail generation a bit more robust

### DIFF
--- a/lib/private/Preview/HEIC.php
+++ b/lib/private/Preview/HEIC.php
@@ -12,6 +12,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -44,8 +45,8 @@ class HEIC extends ProviderV2 {
 
 		$tmpPath = $this->getLocalFile($file);
 		if ($tmpPath === false) {
-			\OC::$server->get(LoggerInterface::class)->error(
-				'Failed to get thumbnail for: ' . $file->getPath(),
+			Server::get(LoggerInterface::class)->error(
+				'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
 				['app' => 'core']
 			);
 			return null;

--- a/lib/private/Preview/Image.php
+++ b/lib/private/Preview/Image.php
@@ -9,6 +9,8 @@ namespace OC\Preview;
 
 use OCP\Files\File;
 use OCP\IImage;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 abstract class Image extends ProviderV2 {
 	/**
@@ -25,6 +27,13 @@ abstract class Image extends ProviderV2 {
 		$image = new \OCP\Image();
 
 		$fileName = $this->getLocalFile($file);
+		if ($fileName === false) {
+			Server::get(LoggerInterface::class)->error(
+				'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
+				['app' => 'core']
+			);
+			return null;
+		}
 
 		$image->loadFromFile($fileName);
 		$image->fixOrientation();

--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -9,6 +9,8 @@ namespace OC\Preview;
 
 use OCP\Files\File;
 use OCP\IImage;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
 use wapmorgan\Mp3Info\Mp3Info;
 use function OCP\Log\logger;
 
@@ -25,6 +27,13 @@ class MP3 extends ProviderV2 {
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
 		$tmpPath = $this->getLocalFile($file);
+		if ($tmpPath === false) {
+			Server::get(LoggerInterface::class)->error(
+				'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
+				['app' => 'core']
+			);
+			return null;
+		}
 
 		try {
 			$audio = new Mp3Info($tmpPath, true);

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -10,6 +10,7 @@ namespace OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class Movie extends ProviderV2 {
@@ -75,6 +76,13 @@ class Movie extends ProviderV2 {
 
 		foreach ($sizeAttempts as $size) {
 			$absPath = $this->getLocalFile($file, $size);
+			if ($absPath === false) {
+				Server::get(LoggerInterface::class)->error(
+					'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
+					['app' => 'core']
+				);
+				return null;
+			}
 
 			$result = null;
 			if (is_string($absPath)) {

--- a/lib/private/Preview/Office.php
+++ b/lib/private/Preview/Office.php
@@ -12,6 +12,7 @@ use OCP\Files\FileInfo;
 use OCP\IImage;
 use OCP\ITempManager;
 use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 abstract class Office extends ProviderV2 {
 	/**
@@ -33,6 +34,13 @@ abstract class Office extends ProviderV2 {
 
 		// The file to generate the preview for.
 		$absPath = $this->getLocalFile($file);
+		if ($absPath === false) {
+			Server::get(LoggerInterface::class)->error(
+				'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
+				['app' => 'core']
+			);
+			return null;
+		}
 
 		// The destination for the LibreOffice user profile.
 		// LibreOffice can rune once per user profile and therefore instance id and file id are included.


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: nextcloud/previewgenerator#501

## Summary

Makes thumbnail generation a bit more robust for Office / MP3 / Image / Movie types.

Same thing is already being done for other types e.g. HEIC:

https://github.com/nextcloud/server/blob/c54038cae610a73c9c2165e6d24d84d7c2bb076b/lib/private/Preview/HEIC.php#L45-L52

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
