### PR TITLE
chore(ci): Run kerberos tests on ubuntu-latest

### DIFF
--- a/.github/workflows/files-external-smb-kerberos.yml
+++ b/.github/workflows/files-external-smb-kerberos.yml
@@ -34,7 +34,7 @@ jobs:
               - '**.php'
 
   files-external-smb-kerberos:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: changes
 
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}


### PR DESCRIPTION
## Summary

New images where pushed for https://github.com/icewind1991/samba-krb-test/ that should run on all `ubuntu-latest` runner.

Example run: https://github.com/nextcloud/server/actions/runs/12585726201/job/35078130894?pr=50017

## Checklist

- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
