### PR TITLE
fix(logger): Prevent infinite recursion with log.condition => users or matches

### DIFF
--- a/build/integration/features/log-condition.feature
+++ b/build/integration/features/log-condition.feature
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+Feature: log-condition
+
+  Background:
+    Given invoking occ with "config:system:set log.condition matches 0 users 0 --value admin"
+    Then the command was successful
+
+  Scenario: Accessing /status.php with log.condition
+    When requesting "/status.php" with "GET"
+    Then the HTTP status code should be "200"
+
+  Scenario: Accessing /index.php with log.condition
+    When requesting "/index.php" with "GET"
+    Then the HTTP status code should be "200"
+
+  Scenario: Accessing /remote.php/webdav with log.condition
+    When requesting "/remote.php/webdav" with "GET"
+    Then the HTTP status code should be "401"
+
+  Scenario: Accessing /remote.php/dav with log.condition
+    When requesting "/remote.php/dav" with "GET"
+    Then the HTTP status code should be "401"
+
+  Scenario: Accessing /ocs/v1.php with log.condition
+    When requesting "/ocs/v1.php" with "GET"
+    Then the HTTP status code should be "200"
+
+  Scenario: Accessing /ocs/v2.php with log.condition
+    When requesting "/ocs/v2.php" with "GET"
+    Then the HTTP status code should be "404"
+
+  Scenario: Accessing /public.php/webdav with log.condition
+    When requesting "/public.php/webdav" with "GET"
+    Then the HTTP status code should be "401"
+
+  Scenario: Accessing /public.php/dav with log.condition
+    When requesting "/public.php/dav" with "GET"
+    Then the HTTP status code should be "503"

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -37,6 +37,7 @@ use function strtr;
 class Log implements ILogger, IDataLogger {
 	private ?bool $logConditionSatisfied = null;
 	private ?IEventDispatcher $eventDispatcher = null;
+	private int $nestingLevel = 0;
 
 	public function __construct(
 		private IWriter $logger,
@@ -192,6 +193,11 @@ class Log implements ILogger, IDataLogger {
 	}
 
 	public function getLogLevel(array $context, string $message): int {
+		if ($this->nestingLevel > 1) {
+			return ILogger::WARN;
+		}
+
+		$this->nestingLevel++;
 		/**
 		 * @psalm-var array{
 		 *   shared_secret?: string,
@@ -242,6 +248,7 @@ class Log implements ILogger, IDataLogger {
 
 		// if log condition is satisfied change the required log level to DEBUG
 		if ($this->logConditionSatisfied) {
+			$this->nestingLevel--;
 			return ILogger::DEBUG;
 		}
 
@@ -256,6 +263,7 @@ class Log implements ILogger, IDataLogger {
 			 * once this is met -> change the required log level to debug
 			 */
 			if (in_array($context['app'], $logCondition['apps'] ?? [], true)) {
+				$this->nestingLevel--;
 				return ILogger::DEBUG;
 			}
 		}
@@ -268,6 +276,7 @@ class Log implements ILogger, IDataLogger {
 
 			// Invalid configuration, warn the user and fall back to default level of WARN
 			error_log('Nextcloud configuration: "loglevel" is not a valid integer');
+			$this->nestingLevel--;
 			return ILogger::WARN;
 		}
 
@@ -281,12 +290,15 @@ class Log implements ILogger, IDataLogger {
 				if (!isset($option['apps']) && !isset($option['loglevel']) && !isset($option['message'])) {
 					/* Only user and/or secret are listed as conditions, we can cache the result for the rest of the request */
 					$this->logConditionSatisfied = true;
+					$this->nestingLevel--;
 					return ILogger::DEBUG;
 				}
+				$this->nestingLevel--;
 				return $option['loglevel'] ?? ILogger::DEBUG;
 			}
 		}
 
+		$this->nestingLevel--;
 		return ILogger::WARN;
 	}
 


### PR DESCRIPTION
## Summary

When we need to check the log condition for a user matches, there is a risk that something on the way checks the log level and would result in an infinite loop.
So we simply check if it's a nested call and use the default warning level in that case.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
