### PR TITLE
fix(caldav): rename default calendar to keep it in the trashbin instead of purging it

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/Plugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/Plugin.php
@@ -138,7 +138,7 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 		if ($result === null) {
 			$result = [];
 		}
-		
+
 		// iterate through items and html decode values
 		foreach ($result as $key => $value) {
 			$result[$key] = urldecode($value);
@@ -197,12 +197,12 @@ class Plugin extends \Sabre\CalDAV\Schedule\Plugin {
 			}
 			// process request
 			$this->processICalendarChange($currentObject, $vCal, $addresses, [], $modified);
-	
+
 			if ($currentObject) {
 				// Destroy circular references so PHP will GC the object.
 				$currentObject->destroy();
 			}
-			
+
 		} catch (SameOrganizerForAllComponentsException $e) {
 			$this->handleSameOrganizerException($e, $vCal, $calendarPath);
 		}
@@ -430,12 +430,20 @@ EOF;
 						} else {
 							// Otherwise if we have really nothing, create a new calendar
 							if ($currentCalendarDeleted) {
-								// If the calendar exists but is deleted, we need to purge it first
-								// This may cause some issues in a non synchronous database setup
+								// If the calendar exists but is in the trash bin, we try to rename its uri
+								// so that we can create the new one and still restore the previous one
+								// otherwise we just purge the calendar by removing it before recreating it
 								$calendar = $this->getCalendar($calendarHome, $uri);
 								if ($calendar instanceof Calendar) {
-									$calendar->disableTrashbin();
-									$calendar->delete();
+									$backend = $calendarHome->getCalDAVBackend();
+									if ($backend instanceof CalDavBackend) {
+										// If the CalDAV backend supports moving calendars
+										$this->moveCalendar($backend, $principalUrl, $uri, $uri . '-back-' . time());
+									} else {
+										// Otherwise just purge the calendar
+										$calendar->disableTrashbin();
+										$calendar->delete();
+									}
 								}
 							}
 							$this->createCalendar($calendarHome, $principalUrl, $uri, $displayName);
@@ -572,7 +580,7 @@ EOF;
 		$homePath = $result[0][200]['{' . self::NS_CALDAV . '}calendar-home-set']->getHref();
 		/** @var Calendar $node */
 		foreach ($this->server->tree->getNodeForPath($homePath)->getChildren() as $node) {
-			
+
 			if (!$node instanceof ICalendar) {
 				continue;
 			}
@@ -702,6 +710,10 @@ EOF;
 		$calendarHome->getCalDAVBackend()->createCalendar($principalUri, $uri, [
 			'{DAV:}displayname' => $displayName,
 		]);
+	}
+
+	private function moveCalendar(CalDavBackend $calDavBackend, string $principalUri, string $oldUri, string $newUri): void {
+		$calDavBackend->moveCalendar($oldUri, $principalUri, $principalUri, $newUri);
 	}
 
 	/**

--- a/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
@@ -353,7 +353,7 @@ class PluginTest extends TestCase {
 						'{DAV:}displayname' => $displayName,
 					]);
 
-				$calendarHomeObject->expects($this->once())
+				$calendarHomeObject->expects($this->exactly($deleted ? 2 : 1))
 					->method('getCalDAVBackend')
 					->with()
 					->willReturn($calendarBackend);


### PR DESCRIPTION
## Summary

When doing a PROPFIND on default-calendar-url, if the current default calendar (fallbacking on personal uri) is in the trashbin, it's being purged so that it's recreated.

This leads to loss of data.

We can simply rename the calendar URI and add a suffix so that it doesn't conflict with the new calendar being created.
Shares are fine because they reference the `resourceid` and not the calendar URI.

## TODO

- [x] Add random string or timestamp at the end of the suffix to make sure the new URI is unique
- [x] Find a workaround about `moveCalendar` not in `Sabre\CalDAV\Backend\BackendInterface`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
