### PR TITLE
fix(HTTP): Adjust JSONResponse data type

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -878,11 +878,6 @@
       <code><![CDATA[$cacheData]]></code>
     </MoreSpecificImplementedParamType>
   </file>
-  <file src="apps/files_sharing/lib/Middleware/SharingCheckMiddleware.php">
-    <InvalidArgument>
-      <code><![CDATA[$exception->getMessage()]]></code>
-    </InvalidArgument>
-  </file>
   <file src="apps/files_sharing/lib/MountProvider.php">
     <RedundantFunctionCall>
       <code><![CDATA[array_values]]></code>

--- a/lib/public/AppFramework/Http/JSONResponse.php
+++ b/lib/public/AppFramework/Http/JSONResponse.php
@@ -13,7 +13,7 @@ use OCP\AppFramework\Http;
  * A renderer for JSON calls
  * @since 6.0.0
  * @template S of int
- * @template-covariant T of array|object|\stdClass|\JsonSerializable
+ * @template-covariant T of null|string|int|float|bool|array|\stdClass|\JsonSerializable
  * @template H of array<string, mixed>
  * @template-extends Response<int, array<string, mixed>>
  */


### PR DESCRIPTION
## Summary

Just saw an app return a literal string value in a JSONResponse which is totally valid.
I adjusted the types to match https://json-schema.org/understanding-json-schema/reference/type, as `object` also wasn't correct (and neither is `mixed`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
