### PR TITLE
fix(preview): Do not try to parse M3U files as MP3

### DIFF
--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -343,7 +343,7 @@ class PreviewManager implements IPreview {
 		$this->registerCoreProvider(Preview\XBitmap::class, '/image\/x-xbitmap/');
 		$this->registerCoreProvider(Preview\WebP::class, '/image\/webp/');
 		$this->registerCoreProvider(Preview\Krita::class, '/application\/x-krita/');
-		$this->registerCoreProvider(Preview\MP3::class, '/audio\/mpeg/');
+		$this->registerCoreProvider(Preview\MP3::class, '/audio\/mpeg$/');
 		$this->registerCoreProvider(Preview\OpenDocument::class, '/application\/vnd.oasis.opendocument.*/');
 		$this->registerCoreProvider(Preview\Imaginary::class, Preview\Imaginary::supportedMimeTypes());
 		$this->registerCoreProvider(Preview\ImaginaryPDF::class, Preview\ImaginaryPDF::supportedMimeTypes());


### PR DESCRIPTION
## Summary
By default, the MP3 audio files get the mimetype `audio/mpeg` and the M3U and M3U8 playlist files get the mimetype `audio/mpegurl`. PreviewManager had such a problem that it registered the MP3 preview provider with a regular expression which matched also the M3U files. This caused an error message to be logged on the info (1) level for each M3U file every time a folder with such files was viewed: "Error while getting cover from mp3 file: File /path/to/some/playlist.m3u is not mpeg/audio!".

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
