### PR TITLE
Fix file request dialog keeps asking for upload destination if ignored for the first time

### DIFF
--- a/apps/files_sharing/src/components/NewFileRequestDialog.vue
+++ b/apps/files_sharing/src/components/NewFileRequestDialog.vue
@@ -88,7 +88,7 @@
 			<!-- Next -->
 			<NcButton v-if="currentStep !== STEP.LAST"
 				:aria-label="t('files_sharing', 'Continue')"
-				:disabled="loading"
+				:disabled="loading || (destination === '/' || destination === '')"
 				data-cy-file-request-dialog-controls="next"
 				@click="onPageNext">
 				<template #icon>
@@ -223,14 +223,6 @@ export default defineComponent({
 				return
 			}
 
-			// custom destination validation
-			// cannot share root
-			if (this.destination === '/' || this.destination === '') {
-				const destinationInput = form.querySelector('input[name="destination"]') as HTMLInputElement
-				destinationInput?.setCustomValidity(t('files_sharing', 'Please select a folder, you cannot share the root directory.'))
-				form.reportValidity()
-				return
-			}
 
 			if (this.currentStep === STEP.FIRST) {
 				this.currentStep = STEP.SECOND

--- a/apps/files_sharing/src/components/NewFileRequestDialog/NewFileRequestDialogIntro.vue
+++ b/apps/files_sharing/src/components/NewFileRequestDialog/NewFileRequestDialogIntro.vue
@@ -34,6 +34,10 @@
 				:show-trailing-button="destination !== context.path"
 				:trailing-button-icon="'undo'"
 				:trailing-button-label="t('files_sharing', 'Revert to default')"
+				:error="(destination === '/' || destination === '')"
+				:helper-text="(destination === '/' || destination === '') ? 
+				t('files_sharing', 'Please select a folder, you cannot share the root directory.'):
+				''"
 				name="destination"
 				@click="onPickDestination"
 				@keypress.prevent.stop="/* prevent typing in the input, we use the picker */"


### PR DESCRIPTION
Hello everyone,

* Resolves: #48118 

## Summary
This PR fixes the issue in the validation process of the file request dialog. If you did not enter a destination folder and click next, the dialog fails to clear the first reported validity status. 

This PR resolves an issue in the validation process of the file request dialog. Previously, if no destination folder was entered and the 'Next' button was clicked, the dialog failed to reset the initial validity status, leading to incorrect validation feedback.

What I did was:
- Prevented going to the next step if the destination folder is invalid.
- Added helper text to inform users that selecting the root folder is not allowed.
- Cleared the error message and helper text once a valid path is selected.

@skjnldsv 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
