### PR TITLE
docs(HTTP): Add proper docs for CORS attribute

### DIFF
--- a/lib/public/AppFramework/Http/Attribute/CORS.php
+++ b/lib/public/AppFramework/Http/Attribute/CORS.php
@@ -12,7 +12,9 @@ namespace OCP\AppFramework\Http\Attribute;
 use Attribute;
 
 /**
- * Attribute for controller methods that can also be accessed by not logged-in user
+ * Attribute for controller methods that can also be accessed by other websites.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS for an explanation of the functionality and the security implications.
+ * See https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/rest_apis.html on how to implement it in your controller.
  *
  * @since 27.0.0
  */


### PR DESCRIPTION
## Summary

https://github.com/nextcloud/openapi-extractor/pull/203#pullrequestreview-2534028062

Should this be backported?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
