### PR TITLE
fix: Apply enforce theme config for anonymous users as well

### DIFF
--- a/apps/theming/lib/Service/ThemesService.php
+++ b/apps/theming/lib/Service/ThemesService.php
@@ -154,12 +154,15 @@ class ThemesService {
 	 * @return string[]
 	 */
 	public function getEnabledThemes(): array {
+		$enforcedTheme = $this->config->getSystemValueString('enforce_theme', '');
 		$user = $this->userSession->getUser();
 		if ($user === null) {
+			if ($enforcedTheme !== '') {
+				return [$enforcedTheme];
+			}
 			return [];
 		}
 
-		$enforcedTheme = $this->config->getSystemValueString('enforce_theme', '');
 		$enabledThemes = json_decode($this->config->getUserValue($user->getUID(), Application::APP_ID, 'enabled-themes', '["default"]'));
 		if ($enforcedTheme !== '') {
 			return array_merge([$enforcedTheme], $enabledThemes);

--- a/core/templates/layout.public.php
+++ b/core/templates/layout.public.php
@@ -36,7 +36,9 @@ p($theme->getTitle());
 	<?php emit_script_loading_tags($_); ?>
 	<?php print_unescaped($_['headers']); ?>
 </head>
-<body id="<?php p($_['bodyid']);?>">
+<body id="<?php p($_['bodyid']);?>" <?php foreach ($_['enabledThemes'] as $themeId) {
+	p("data-theme-$themeId ");
+}?> data-themes="<?php p(join(',', $_['enabledThemes'])) ?>">
 	<?php include('layout.noscript.warning.php'); ?>
 	<?php include('layout.initial-state.php'); ?>
 	<div id="skip-actions">
@@ -81,11 +83,11 @@ p($theme->getTitle());
 	<main id="content" class="app-<?php p($_['appid']) ?>">
 		<h1 class="hidden-visually">
 			<?php
-			if (isset($template) && $template->getHeaderTitle() !== '') {
-				p($template->getHeaderTitle());
-			} else {
-				p($theme->getName());
-			} ?>
+		if (isset($template) && $template->getHeaderTitle() !== '') {
+			p($template->getHeaderTitle());
+		} else {
+			p($theme->getName());
+		} ?>
 		</h1>
 		<?php print_unescaped($_['content']); ?>
 	</main>

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -158,6 +158,14 @@ class TemplateLayout extends \OC_Template {
 			$this->assign('appid', $appId);
 			$this->assign('bodyid', 'body-public');
 
+			// Set body data-theme
+			$this->assign('enabledThemes', []);
+			if ($this->appManager->isEnabledForUser('theming') && class_exists('\OCA\Theming\Service\ThemesService')) {
+				/** @var \OCA\Theming\Service\ThemesService $themesService */
+				$themesService = \OC::$server->get(\OCA\Theming\Service\ThemesService::class);
+				$this->assign('enabledThemes', $themesService->getEnabledThemes());
+			}
+
 			// Set logo link target
 			$logoUrl = $this->config->getSystemValueString('logo_url', '');
 			$this->assign('logoUrl', $logoUrl);


### PR DESCRIPTION
Fixes #49086

## Summary
Reproducer:
1. change config to `'enforce_theme' => 'dark',`
2. upload a file and share it to public
3. open public link as anonymous

Expected: dark theme is used.
Actual: default light theme is used.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
