### PR TITLE
fix: Trim tags on adding or editing

### DIFF
--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -145,6 +145,7 @@ class SystemTagManager implements ISystemTagManager {
 	}
 
 	public function createTag(string $tagName, bool $userVisible, bool $userAssignable): ISystemTag {
+		$tagName = trim($tagName);
 		// Length of name column is 64
 		$truncatedTagName = substr($tagName, 0, 64);
 		$query = $this->connection->getQueryBuilder();
@@ -199,6 +200,7 @@ class SystemTagManager implements ISystemTagManager {
 
 		$beforeUpdate = array_shift($tags);
 		// Length of name column is 64
+		$newName = trim($newName);
 		$truncatedNewName = substr($newName, 0, 64);
 		$afterUpdate = new SystemTag(
 			$tagId,


### PR DESCRIPTION
## Summary
It is possible create multiple tags with leading/trailing slashes: `bar`, ` bar`, `bar `, etc. This confuses users and causes usage of wrong tags. Let's trim input.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
