### PR TITLE
Add licenses by SPDX identifier, mark shorthand aliases as deprecated

### DIFF
--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -374,6 +374,15 @@
 
     <xs:simpleType name="licence">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="AGPL-3.0-only"/>
+            <xs:enumeration value="AGPL-3.0-or-later"/>
+            <xs:enumeration value="Apache-2.0"/>
+            <xs:enumeration value="GPL-3.0-only"/>
+            <xs:enumeration value="GPL-3.0-or-later"/>
+            <xs:enumeration value="MIT"/>
+            <xs:enumeration value="MPL-2.0"/>
+
+            <!-- Deprecated -->
             <xs:enumeration value="agpl"/>
             <xs:enumeration value="mpl"/>
             <xs:enumeration value="apache"/>

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -370,6 +370,15 @@
 
     <xs:simpleType name="licence">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="AGPL-3.0-only"/>
+            <xs:enumeration value="AGPL-3.0-or-later"/>
+            <xs:enumeration value="Apache-2.0"/>
+            <xs:enumeration value="GPL-3.0-only"/>
+            <xs:enumeration value="GPL-3.0-or-later"/>
+            <xs:enumeration value="MIT"/>
+            <xs:enumeration value="MPL-2.0"/>
+
+            <!-- Deprecated -->
             <xs:enumeration value="agpl"/>
             <xs:enumeration value="mpl"/>
             <xs:enumeration value="apache"/>


### PR DESCRIPTION
matching the app store change at https://github.com/nextcloud/appstore/pull/1560

What puzzles me a bit is that the app store has:
```
<xs:enumeration value="agpl"/>
<xs:enumeration value="mit"/>
<xs:enumeration value="mpl"/>
<xs:enumeration value="apache"/>
<xs:enumeration value="gpl3"/>
```

While the server has less values:
```
<xs:enumeration value="agpl"/>
<xs:enumeration value="mpl"/>
<xs:enumeration value="apache"/>
```

while the app store list is fine in terms of license compatibility

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/appstore/issues/1274

## Summary


## TODO

- [x] get feedback / review on the change

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
