### PR TITLE
Fix broken taskprocessing api /tasktypes endpoint

### DIFF
--- a/core/Controller/TaskProcessingApiController.php
+++ b/core/Controller/TaskProcessingApiController.php
@@ -39,6 +39,7 @@ use OCP\TaskProcessing\IManager;
 use OCP\TaskProcessing\ShapeEnumValue;
 use OCP\TaskProcessing\Task;
 use RuntimeException;
+use stdClass;
 
 /**
  * @psalm-import-type CoreTaskProcessingTask from ResponseDefinitions
@@ -67,31 +68,70 @@ class TaskProcessingApiController extends \OCP\AppFramework\OCSController {
 	#[PublicPage]
 	#[ApiRoute(verb: 'GET', url: '/tasktypes', root: '/taskprocessing')]
 	public function taskTypes(): DataResponse {
+		/** @var array<string, CoreTaskProcessingTaskType> $taskTypes */
 		$taskTypes = array_map(function (array $tt) {
-			$tt['inputShape'] = array_values(array_map(function ($descriptor) {
+			$tt['inputShape'] = array_map(function ($descriptor) {
 				return $descriptor->jsonSerialize();
-			}, $tt['inputShape']));
-			$tt['outputShape'] = array_values(array_map(function ($descriptor) {
+			}, $tt['inputShape']);
+			if (empty($tt['inputShape'])) {
+				$tt['inputShape'] = new stdClass;
+			}
+
+			$tt['outputShape'] = array_map(function ($descriptor) {
 				return $descriptor->jsonSerialize();
-			}, $tt['outputShape']));
-			$tt['optionalInputShape'] = array_values(array_map(function ($descriptor) {
+			}, $tt['outputShape']);
+			if (empty($tt['outputShape'])) {
+				$tt['outputShape'] = new stdClass;
+			}
+
+			$tt['optionalInputShape'] = array_map(function ($descriptor) {
 				return $descriptor->jsonSerialize();
-			}, $tt['optionalInputShape']));
-			$tt['optionalOutputShape'] = array_values(array_map(function ($descriptor) {
+			}, $tt['optionalInputShape']);
+			if (empty($tt['optionalInputShape'])) {
+				$tt['optionalInputShape'] = new stdClass;
+			}
+
+			$tt['optionalOutputShape'] = array_map(function ($descriptor) {
 				return $descriptor->jsonSerialize();
-			}, $tt['optionalOutputShape']));
-			$tt['inputShapeEnumValues'] = array_values(array_map(function (array $enumValues) {
-				return array_values(array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues));
-			}, $tt['inputShapeEnumValues']));
-			$tt['optionalInputShapeEnumValues'] = array_values(array_map(function (array $enumValues) {
-				return array_values(array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues));
-			}, $tt['optionalInputShapeEnumValues']));
-			$tt['outputShapeEnumValues'] = array_values(array_map(function (array $enumValues) {
-				return array_values(array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues));
-			}, $tt['outputShapeEnumValues']));
-			$tt['optionalOutputShapeEnumValues'] = array_values(array_map(function (array $enumValues) {
-				return array_values(array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues));
-			}, $tt['optionalOutputShapeEnumValues']));
+			}, $tt['optionalOutputShape']);
+			if (empty($tt['optionalOutputShape'])) {
+				$tt['optionalOutputShape'] = new stdClass;
+			}
+
+			$tt['inputShapeEnumValues'] = array_map(function (array $enumValues) {
+				return array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues);
+			}, $tt['inputShapeEnumValues']);
+			if (empty($tt['inputShapeEnumValues'])) {
+				$tt['inputShapeEnumValues'] = new stdClass;
+			}
+
+			$tt['optionalInputShapeEnumValues'] = array_map(function (array $enumValues) {
+				return array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues);
+			}, $tt['optionalInputShapeEnumValues']);
+			if (empty($tt['optionalInputShapeEnumValues'])) {
+				$tt['optionalInputShapeEnumValues'] = new stdClass;
+			}
+
+			$tt['outputShapeEnumValues'] = array_map(function (array $enumValues) {
+				return array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues);
+			}, $tt['outputShapeEnumValues']);
+			if (empty($tt['outputShapeEnumValues'])) {
+				$tt['outputShapeEnumValues'] = new stdClass;
+			}
+
+			$tt['optionalOutputShapeEnumValues'] = array_map(function (array $enumValues) {
+				return array_map(fn (ShapeEnumValue $enumValue) => $enumValue->jsonSerialize(), $enumValues);
+			}, $tt['optionalOutputShapeEnumValues']);
+			if (empty($tt['optionalOutputShapeEnumValues'])) {
+				$tt['optionalOutputShapeEnumValues'] = new stdClass;
+			}
+
+			if (empty($tt['inputShapeDefaults'])) {
+				$tt['inputShapeDefaults'] = new stdClass;
+			}
+			if (empty($tt['optionalInputShapeDefaults'])) {
+				$tt['optionalInputShapeDefaults'] = new stdClass;
+			}
 			return $tt;
 		}, $this->taskProcessingManager->getAvailableTaskTypes());
 		return new DataResponse([

--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -171,16 +171,16 @@ namespace OC\Core;
  * @psalm-type CoreTaskProcessingTaskType = array{
  *     name: string,
  *     description: string,
- *     inputShape: list<CoreTaskProcessingShape>,
- *     inputShapeEnumValues: list<list<array{name: string, value: string}>>,
+ *     inputShape: array<string, CoreTaskProcessingShape>,
+ *     inputShapeEnumValues: array<string, list<array{name: string, value: string}>>,
  *     inputShapeDefaults: array<string, numeric|string>,
- *     optionalInputShape: list<CoreTaskProcessingShape>,
- *     optionalInputShapeEnumValues: list<list<array{name: string, value: string}>>,
+ *     optionalInputShape: array<string, CoreTaskProcessingShape>,
+ *     optionalInputShapeEnumValues: array<string, list<array{name: string, value: string}>>,
  *     optionalInputShapeDefaults: array<string, numeric|string>,
- *     outputShape: list<CoreTaskProcessingShape>,
- *     outputShapeEnumValues: list<list<array{name: string, value: string}>>,
- *     optionalOutputShape: list<CoreTaskProcessingShape>,
- *     optionalOutputShapeEnumValues: list<list<array{name: string, value: string}>>,
+ *     outputShape: array<string, CoreTaskProcessingShape>,
+ *     outputShapeEnumValues: array<string, list<array{name: string, value: string}>>,
+ *     optionalOutputShape: array<string, CoreTaskProcessingShape>,
+ *     optionalOutputShapeEnumValues: array<string, list<array{name: string, value: string}>>,
  * }
  *
  * @psalm-type CoreTaskProcessingIO = array<string, numeric|list<numeric>|string|list<string>>

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -635,14 +635,14 @@
                         "type": "string"
                     },
                     "inputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "inputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",
@@ -675,14 +675,14 @@
                         }
                     },
                     "optionalInputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "optionalInputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",
@@ -715,14 +715,14 @@
                         }
                     },
                     "outputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "outputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",
@@ -742,14 +742,14 @@
                         }
                     },
                     "optionalOutputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "optionalOutputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -635,14 +635,14 @@
                         "type": "string"
                     },
                     "inputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "inputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",
@@ -675,14 +675,14 @@
                         }
                     },
                     "optionalInputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "optionalInputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",
@@ -715,14 +715,14 @@
                         }
                     },
                     "outputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "outputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",
@@ -742,14 +742,14 @@
                         }
                     },
                     "optionalOutputShape": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "$ref": "#/components/schemas/TaskProcessingShape"
                         }
                     },
                     "optionalOutputShapeEnumValues": {
-                        "type": "array",
-                        "items": {
+                        "type": "object",
+                        "additionalProperties": {
                             "type": "array",
                             "items": {
                                 "type": "object",


### PR DESCRIPTION
Reported by @alperozturk96 :blue_heart: 

The `/ocs/v2.php/taskprocessing/tasktypes` was broken by #49015 which changed objects into arrays in the `inputShape`, `outputShape`, `optionalInputShape` etc...

* Those changes have been reverted
* Make sure the serialization of the response gives empty objects instead of empty arrays
* Generate OpenAPI specs

@provokateurin Please put at least @marcelklehr or me as reviewers when making such changes.