### PR TITLE
fix(ocm-discovery): do not use a global model on remote discovery

### DIFF
--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -30,7 +30,7 @@ class OCMProvider implements IOCMProvider {
 	private bool $emittedEvent = false;
 
 	public function __construct(
-		protected IEventDispatcher $dispatcher,
+		protected ?IEventDispatcher $dispatcher,
 	) {
 	}
 
@@ -125,7 +125,7 @@ class OCMProvider implements IOCMProvider {
 		if (!$this->emittedEvent) {
 			$this->emittedEvent = true;
 			$event = new ResourceTypeRegisterEvent($this);
-			$this->dispatcher->dispatchTyped($event);
+			$this->dispatcher?->dispatchTyped($event);
 		}
 
 		return $this->resourceTypes;


### PR DESCRIPTION
This fix an eventual regression from #40885 when discovering remote ocm provider data.

Also, there is no reason for an app to directly interact with the `discovery()` as the method itself should manage last version of the protocol.
