### PR TITLE
fix(SetupChecks): Don't test caches using binary data

### DIFF
--- a/apps/settings/lib/SetupChecks/MemcacheConfigured.php
+++ b/apps/settings/lib/SetupChecks/MemcacheConfigured.php
@@ -60,7 +60,7 @@ class MemcacheConfigured implements ISetupCheck {
 		}
 
 		if ($this->cacheFactory->isLocalCacheAvailable()) {
-			$random = random_bytes(64);
+			$random = bin2hex(random_bytes(64));
 			$local = $this->cacheFactory->createLocal('setupcheck.local');
 			try {
 				$local->set('test', $random);
@@ -77,7 +77,7 @@ class MemcacheConfigured implements ISetupCheck {
 		}
 
 		if ($this->cacheFactory->isAvailable()) {
-			$random = random_bytes(64);
+			$random = bin2hex(random_bytes(64));
 			$distributed = $this->cacheFactory->createDistributed('setupcheck');
 			try {
 				$distributed->set('test', $random);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- Fix https://github.com/nextcloud/server/issues/50110 _(reproduced on my side too using Redis)_.
This shoud be enough for this simple `set` & `get` test, so no serialization/unserialization of data is involved.
- Regression from #49588

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
