### PR TITLE
SimpleFS: Add getFullDirectoryListing for complete directory listing

### DIFF
--- a/lib/private/Files/SimpleFS/SimpleFolder.php
+++ b/lib/private/Files/SimpleFS/SimpleFolder.php
@@ -44,6 +44,21 @@ class SimpleFolder implements ISimpleFolder {
 		return array_values($fileListing);
 	}
 
+	public function getFullDirectoryListing(): array {
+		$listing = $this->folder->getDirectoryListing();
+	
+		$nodeListing = array_map(function (Node $node) {
+			if ($node instanceof File) {
+				return new SimpleFile($node);
+			} elseif ($node instanceof Folder) {
+				return new SimpleFolder($node);
+			}
+			return null;
+		}, $listing);
+	
+		return array_values(array_filter($nodeListing));
+	}
+
 	public function delete(): void {
 		$this->folder->delete();
 	}

--- a/lib/public/Files/SimpleFS/ISimpleFolder.php
+++ b/lib/public/Files/SimpleFS/ISimpleFolder.php
@@ -23,6 +23,14 @@ interface ISimpleFolder {
 	public function getDirectoryListing(): array;
 
 	/**
+	 * Get all the files and folders in a folder
+	 *
+	 * @return array<ISimpleFile|ISimpleFolder>
+	 * @since 32.0.0
+	 */
+	public function getFullDirectoryListing(): array;
+
+	/**
 	 * Check if a file with $name exists
 	 *
 	 * @param string $name


### PR DESCRIPTION
- Adds getFullDirectoryListing to list both files and folders.
- Keeps getDirectoryListing for files only.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
