### PR TITLE
fix: use proper way to get numeric storage id for mountpoint

### DIFF
--- a/lib/private/Files/Mount/MountPoint.php
+++ b/lib/private/Files/Mount/MountPoint.php
@@ -198,7 +198,7 @@ class MountPoint implements IMountPoint {
 			if (is_null($storage)) {
 				return -1;
 			}
-			$this->numericStorageId = $storage->getStorageCache()->getNumericId();
+			$this->numericStorageId = $storage->getCache()->getNumericStorageId();
 		}
 		return $this->numericStorageId;
 	}

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -101,6 +101,8 @@ class UserMountCacheTest extends TestCase {
 		$cache->expects($this->any())
 			->method('getId')
 			->willReturn($rootId);
+		$cache->method('getNumericStorageId')
+			->willReturn($storageId);
 
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()


### PR DESCRIPTION
`getStorageCache()` is not part of a public interface so not all storages might implement it.