### PR TITLE
Limit ldap user count

### DIFF
--- a/apps/dav/lib/Migration/Version1027Date20230504122946.php
+++ b/apps/dav/lib/Migration/Version1027Date20230504122946.php
@@ -33,7 +33,7 @@ class Version1027Date20230504122946 extends SimpleMigrationStep {
 	 * @param array $options
 	 */
 	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
-		if ($this->userManager->countSeenUsers() > 100 || array_sum($this->userManager->countUsers()) > 100) {
+		if ($this->userManager->countSeenUsers() > 100 || $this->userManager->countUsersTotal(100) >= 100) {
 			$this->config->setAppValue('dav', 'needs_system_address_book_sync', 'yes');
 			$output->info('Could not sync system address books during update - too many user records have been found. Please call occ dav:sync-system-addressbook manually.');
 			return;

--- a/apps/updatenotification/lib/Settings/Admin.php
+++ b/apps/updatenotification/lib/Settings/Admin.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
  */
 namespace OCA\UpdateNotification\Settings;
 
-use OC\User\Backend;
 use OCA\UpdateNotification\UpdateChecker;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
@@ -20,7 +19,6 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Settings\ISettings;
 use OCP\Support\Subscription\IRegistry;
-use OCP\User\Backend\ICountUsersBackend;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -141,26 +139,6 @@ class Admin implements ISettings {
 	}
 
 	private function isWebUpdaterRecommended(): bool {
-		return $this->getUserCount() < 100;
-	}
-
-	/**
-	 * @see https://github.com/nextcloud/server/blob/39494fbf794d982f6f6551c984e6ca4c4e947d01/lib/private/Support/Subscription/Registry.php#L188-L216 implementation reference
-	 */
-	private function getUserCount(): int {
-		$userCount = 0;
-		$backends = $this->userManager->getBackends();
-		foreach ($backends as $backend) {
-			// TODO: change below to 'if ($backend instanceof ICountUsersBackend) {'
-			if ($backend->implementsActions(Backend::COUNT_USERS)) {
-				/** @var ICountUsersBackend $backend */
-				$backendUsers = $backend->countUsers();
-				if ($backendUsers !== false) {
-					$userCount += $backendUsers;
-				}
-			}
-		}
-
-		return $userCount;
+		return (int)$this->userManager->countUsersTotal(100) < 100;
 	}
 }

--- a/apps/updatenotification/tests/Settings/AdminTest.php
+++ b/apps/updatenotification/tests/Settings/AdminTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
  */
 namespace OCA\UpdateNotification\Tests\Settings;
 
-use OC\User\Backend;
 use OCA\UpdateNotification\Settings\Admin;
 use OCA\UpdateNotification\UpdateChecker;
 use OCP\AppFramework\Http\TemplateResponse;
@@ -22,8 +21,6 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\L10N\ILanguageIterator;
 use OCP\Support\Subscription\IRegistry;
-use OCP\User\Backend\ICountUsersBackend;
-use OCP\UserInterface;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -81,42 +78,10 @@ class AdminTest extends TestCase {
 	}
 
 	public function testGetFormWithUpdate(): void {
-		$backend1 = $this->createMock(CountUsersBackend::class);
-		$backend2 = $this->createMock(CountUsersBackend::class);
-		$backend3 = $this->createMock(CountUsersBackend::class);
-		$backend1
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(false);
-		$backend2
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(true);
-		$backend3
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(true);
-		$backend1
-			->expects($this->never())
-			->method('countUsers');
-		$backend2
-			->expects($this->once())
-			->method('countUsers')
-			->with()
-			->willReturn(false);
-		$backend3
-			->expects($this->once())
-			->method('countUsers')
-			->with()
-			->willReturn(5);
 		$this->userManager
 			->expects($this->once())
-			->method('getBackends')
-			->with()
-			->willReturn([$backend1, $backend2, $backend3]);
+			->method('countUsersTotal')
+			->willReturn(5);
 		$channels = [
 			'daily',
 			'beta',
@@ -207,42 +172,10 @@ class AdminTest extends TestCase {
 	}
 
 	public function testGetFormWithUpdateAndChangedUpdateServer(): void {
-		$backend1 = $this->createMock(CountUsersBackend::class);
-		$backend2 = $this->createMock(CountUsersBackend::class);
-		$backend3 = $this->createMock(CountUsersBackend::class);
-		$backend1
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(false);
-		$backend2
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(true);
-		$backend3
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(true);
-		$backend1
-			->expects($this->never())
-			->method('countUsers');
-		$backend2
-			->expects($this->once())
-			->method('countUsers')
-			->with()
-			->willReturn(false);
-		$backend3
-			->expects($this->once())
-			->method('countUsers')
-			->with()
-			->willReturn(5);
 		$this->userManager
 			->expects($this->once())
-			->method('getBackends')
-			->with()
-			->willReturn([$backend1, $backend2, $backend3]);
+			->method('countUsersTotal')
+			->willReturn(5);
 		$channels = [
 			'daily',
 			'beta',
@@ -334,42 +267,10 @@ class AdminTest extends TestCase {
 	}
 
 	public function testGetFormWithUpdateAndCustomersUpdateServer(): void {
-		$backend1 = $this->createMock(CountUsersBackend::class);
-		$backend2 = $this->createMock(CountUsersBackend::class);
-		$backend3 = $this->createMock(CountUsersBackend::class);
-		$backend1
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(false);
-		$backend2
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(true);
-		$backend3
-			->expects($this->once())
-			->method('implementsActions')
-			->with(Backend::COUNT_USERS)
-			->willReturn(true);
-		$backend1
-			->expects($this->never())
-			->method('countUsers');
-		$backend2
-			->expects($this->once())
-			->method('countUsers')
-			->with()
-			->willReturn(false);
-		$backend3
-			->expects($this->once())
-			->method('countUsers')
-			->with()
-			->willReturn(5);
 		$this->userManager
 			->expects($this->once())
-			->method('getBackends')
-			->with()
-			->willReturn([$backend1, $backend2, $backend3]);
+			->method('countUsersTotal')
+			->willReturn(5);
 		$channels = [
 			'daily',
 			'beta',
@@ -542,8 +443,4 @@ class AdminTest extends TestCase {
 		$result = $this->invokePrivate($this->admin, 'filterChanges', [$changes]);
 		$this->assertSame($expectation, $result);
 	}
-}
-
-abstract class CountUsersBackend implements UserInterface, ICountUsersBackend {
-
 }

--- a/lib/base.php
+++ b/lib/base.php
@@ -279,8 +279,7 @@ class OC {
 			}
 			if (!$tooBig) {
 				// count users
-				$stats = Server::get(\OCP\IUserManager::class)->countUsers();
-				$totalUsers = array_sum($stats);
+				$totalUsers = Server::get(\OCP\IUserManager::class)->countUsersTotal(51);
 				$tooBig = ($totalUsers > 50);
 			}
 		}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -888,6 +888,7 @@ return array(
     'OCP\\User\\Backend\\IGetDisplayNameBackend' => $baseDir . '/lib/public/User/Backend/IGetDisplayNameBackend.php',
     'OCP\\User\\Backend\\IGetHomeBackend' => $baseDir . '/lib/public/User/Backend/IGetHomeBackend.php',
     'OCP\\User\\Backend\\IGetRealUIDBackend' => $baseDir . '/lib/public/User/Backend/IGetRealUIDBackend.php',
+    'OCP\\User\\Backend\\ILimitAwareCountUsersBackend' => $baseDir . '/lib/public/User/Backend/ILimitAwareCountUsersBackend.php',
     'OCP\\User\\Backend\\IPasswordConfirmationBackend' => $baseDir . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
     'OCP\\User\\Backend\\IPasswordHashBackend' => $baseDir . '/lib/public/User/Backend/IPasswordHashBackend.php',
     'OCP\\User\\Backend\\IProvideAvatarBackend' => $baseDir . '/lib/public/User/Backend/IProvideAvatarBackend.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -929,6 +929,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\User\\Backend\\IGetDisplayNameBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetDisplayNameBackend.php',
         'OCP\\User\\Backend\\IGetHomeBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetHomeBackend.php',
         'OCP\\User\\Backend\\IGetRealUIDBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IGetRealUIDBackend.php',
+        'OCP\\User\\Backend\\ILimitAwareCountUsersBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/ILimitAwareCountUsersBackend.php',
         'OCP\\User\\Backend\\IPasswordConfirmationBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordConfirmationBackend.php',
         'OCP\\User\\Backend\\IPasswordHashBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IPasswordHashBackend.php',
         'OCP\\User\\Backend\\IProvideAvatarBackend' => __DIR__ . '/../../..' . '/lib/public/User/Backend/IProvideAvatarBackend.php',

--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -17,11 +17,11 @@ use OCP\Security\Events\ValidatePasswordPolicyEvent;
 use OCP\Security\IHasher;
 use OCP\User\Backend\ABackend;
 use OCP\User\Backend\ICheckPasswordBackend;
-use OCP\User\Backend\ICountUsersBackend;
 use OCP\User\Backend\ICreateUserBackend;
 use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\IGetHomeBackend;
 use OCP\User\Backend\IGetRealUIDBackend;
+use OCP\User\Backend\ILimitAwareCountUsersBackend;
 use OCP\User\Backend\IPasswordHashBackend;
 use OCP\User\Backend\ISearchKnownUsersBackend;
 use OCP\User\Backend\ISetDisplayNameBackend;
@@ -37,7 +37,7 @@ class Database extends ABackend implements
 	IGetDisplayNameBackend,
 	ICheckPasswordBackend,
 	IGetHomeBackend,
-	ICountUsersBackend,
+	ILimitAwareCountUsersBackend,
 	ISearchKnownUsersBackend,
 	IGetRealUIDBackend,
 	IPasswordHashBackend {
@@ -463,10 +463,8 @@ class Database extends ABackend implements
 
 	/**
 	 * counts the users in the database
-	 *
-	 * @return int|false
 	 */
-	public function countUsers() {
+	public function countUsers(int $limit = 0): int|false {
 		$this->fixDI();
 
 		$query = $this->dbConn->getQueryBuilder();

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -492,6 +492,7 @@ class Manager extends PublicEmitter implements IUserManager {
 
 	public function countUsersTotal(int $limit = 0, bool $onlyMappedUsers = false): int|false {
 		$userCount = false;
+
 		foreach ($this->backends as $backend) {
 			if ($onlyMappedUsers && $backend instanceof ICountMappedUsersBackend) {
 				$backendUsers = $backend->countMappedUsers();
@@ -505,7 +506,7 @@ class Manager extends PublicEmitter implements IUserManager {
 				continue;
 			}
 			if ($backendUsers !== false) {
-				$userCount += $backendUsers;
+				$userCount = (int)$userCount + $backendUsers;
 				if ($limit > 0) {
 					if ($userCount >= $limit) {
 						break;

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -164,6 +164,16 @@ interface IUserManager {
 	public function countUsers();
 
 	/**
+	 * Get how many users exists in total, whithin limit
+	 *
+	 * @param int $limit Limit the count to avoid resource waste. 0 to disable
+	 * @param bool $onlyMappedUsers Count mapped users instead of all users for compatible backends
+	 *
+	 * @since 31.0.0
+	 */
+	public function countUsersTotal(int $limit = 0, bool $onlyMappedUsers = false): int|false;
+
+	/**
 	 * @param \Closure $callback
 	 * @psalm-param \Closure(\OCP\IUser):void $callback
 	 * @param string $search

--- a/lib/public/User/Backend/ICountUsersBackend.php
+++ b/lib/public/User/Backend/ICountUsersBackend.php
@@ -10,6 +10,7 @@ namespace OCP\User\Backend;
 
 /**
  * @since 14.0.0
+ * @deprecated 31.0.0 use and implement ILimitAwareCountUsersBackend instead.
  */
 interface ICountUsersBackend {
 	/**

--- a/lib/public/User/Backend/ILimitAwareCountUsersBackend.php
+++ b/lib/public/User/Backend/ILimitAwareCountUsersBackend.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\User\Backend;
+
+/**
+ * @since 31.0.0
+ */
+interface ILimitAwareCountUsersBackend extends ICountUsersBackend {
+	/**
+	 * @since 31.0.0
+	 *
+	 * @param int $limit Limit to stop counting users if there are more than $limit. 0 to disable limiting.
+	 * @return int|false The number of users (may be limited to $limit) on success false on failure
+	 */
+	public function countUsers(int $limit = 0): int|false;
+}

--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -8,7 +8,6 @@
 namespace Test\Support\Subscription;
 
 use OC\Support\Subscription\Registry;
-use OC\User\Database;
 use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
@@ -17,33 +16,19 @@ use OCP\IUserManager;
 use OCP\Notification\IManager;
 use OCP\Support\Subscription\ISubscription;
 use OCP\Support\Subscription\ISupportedApps;
-use OCP\User\Backend\ICountUsersBackend;
-use OCP\UserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class RegistryTest extends TestCase {
-	/** @var Registry */
-	private $registry;
+	private Registry $registry;
 
-	/** @var MockObject|IConfig */
-	private $config;
-
-	/** @var MockObject|IServerContainer */
-	private $serverContainer;
-
-	/** @var MockObject|IUserManager */
-	private $userManager;
-
-	/** @var MockObject|IGroupManager */
-	private $groupManager;
-
-	/** @var MockObject|LoggerInterface */
-	private $logger;
-
-	/** @var MockObject|IManager */
-	private $notificationManager;
+	private MockObject&IConfig $config;
+	private MockObject&IServerContainer $serverContainer;
+	private MockObject&IUserManager $userManager;
+	private MockObject&IGroupManager $groupManager;
+	private MockObject&LoggerInterface $logger;
+	private MockObject&IManager $notificationManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -198,17 +183,9 @@ class RegistryTest extends TestCase {
 			->method('getUsersForUserValue')
 			->with('core', 'enabled', 'false')
 			->willReturn(array_fill(0, $disabledUsers, ''));
-		/* @var UserInterface|ICountUsersBackend|\PHPUnit\Framework\MockObject\MockObject $dummyBackend */
-		$dummyBackend = $this->createMock(Database::class);
-		$dummyBackend->expects($this->once())
-			->method('implementsActions')
-			->willReturn(true);
-		$dummyBackend->expects($this->once())
-			->method('countUsers')
-			->willReturn($userCount);
 		$this->userManager->expects($this->once())
-			->method('getBackends')
-			->willReturn([$dummyBackend]);
+			->method('countUsersTotal')
+			->willReturn($userCount);
 
 		if ($expectedResult) {
 			$dummyGroup = $this->createMock(IGroup::class);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

This avoids listing all LDAP users only to check if there are more than 100 for the `updatenotification` application. This speeds up opening admin settings a lot on big instances with LDAP backend.
The new user count limit is made so that it can be implemented in other backends if needed, and places calling the user count only to compare against a threshold have been adapted to set a limit.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
