### PR TITLE
test(dashboard): Add regression test for loading unneeded data

### DIFF
--- a/cypress/e2e/dashboard/widget-performance.cy.ts
+++ b/cypress/e2e/dashboard/widget-performance.cy.ts
@@ -1,0 +1,41 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Regression test of https://github.com/nextcloud/server/issues/48403
+ * Ensure that only visible widget data is loaded
+ */
+describe('dashboard: performance', () => {
+	before(() => {
+		cy.createRandomUser().then((user) => {
+			// Enable one widget
+			cy.runOccCommand(`user:setting -- '${user.userId}' dashboard layout files-favorites`)
+			cy.login(user)
+		})
+	})
+
+	it('Only load needed widgets', () => {
+		cy.intercept('**/dashboard/api/v2/widget-items?widgets*').as('loadedWidgets')
+
+		const now = new Date(2025, 0, 14, 15)
+		cy.clock(now)
+
+		// The dashboard is loaded
+		cy.visit('/apps/dashboard')
+		cy.get('#app-dashboard')
+			.should('be.visible')
+			.contains('Good afternoon')
+			.should('be.visible')
+
+		// Wait that one data is loaded (ensure the API works), this should be the favorite files.
+		cy.wait('@loadedWidgets')
+		// Wait and check no requests are made (ensure that the user statuses data is NOT loaded)
+		// eslint-disable-next-line cypress/no-unnecessary-waiting
+		cy.wait(4000, { timeout: 8000 })
+		cy.get('@loadedWidgets.all').then((interceptions) => {
+			expect(interceptions).to.have.length(1)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

* Fails before the PR of @st3iny 
* Succeeds afterwards :heavy_check_mark: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
