### PR TITLE
fix(oauth2): adjust db schemas when migrating from owncloud

### DIFF
--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -7,7 +7,6 @@
  */
 namespace OC;
 
-use OC\DB\Connection;
 use OC\DB\ConnectionAdapter;
 use OC\Repair\AddAppConfigLazyMigration;
 use OC\Repair\AddBruteForceCleanupJob;
@@ -167,7 +166,7 @@ class Repair implements IOutput {
 				\OC::$server->getUserManager(),
 				\OC::$server->getConfig()
 			),
-			new MigrateOauthTables(\OC::$server->get(Connection::class)),
+			\OC::$server->get(MigrateOauthTables::class),
 			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
 			new AddLogRotateJob(\OC::$server->getJobList()),
 			new ClearFrontendCaches(\OC::$server->getMemCacheFactory(), \OCP\Server::get(JSCombiner::class)),

--- a/lib/private/Repair/Owncloud/MigrateOauthTables.php
+++ b/lib/private/Repair/Owncloud/MigrateOauthTables.php
@@ -5,11 +5,18 @@
  */
 namespace OC\Repair\Owncloud;
 
+use OC\Authentication\Token\IProvider as ITokenProvider;
 use OC\DB\Connection;
 use OC\DB\SchemaWrapper;
+use OCA\OAuth2\Db\AccessToken;
+use OCA\OAuth2\Db\AccessTokenMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Token\IToken;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
+use OCP\Security\ICrypto;
+use OCP\Security\ISecureRandom;
 
 class MigrateOauthTables implements IRepairStep {
 	/** @var Connection */
@@ -18,7 +25,14 @@ class MigrateOauthTables implements IRepairStep {
 	/**
 	 * @param Connection $db
 	 */
-	public function __construct(Connection $db) {
+	public function __construct(
+		Connection $db,
+		private AccessTokenMapper $accessTokenMapper,
+		private ITokenProvider $tokenProvider,
+		private ISecureRandom $random,
+		private ITimeFactory $timeFactory,
+		private ICrypto $crypto,
+	) {
 		$this->db = $db;
 	}
 
@@ -36,14 +50,23 @@ class MigrateOauthTables implements IRepairStep {
 			return;
 		}
 
-		$output->info('Update the oauth2_access_tokens table schema.');
+		// Create column and then migrate before handling unique index.
+		// So that we can distinguish between legacy (from oc) and new rows (from nc).
 		$table = $schema->getTable('oauth2_access_tokens');
 		if (!$table->hasColumn('hashed_code')) {
+			$output->info('Prepare the oauth2_access_tokens table schema.');
 			$table->addColumn('hashed_code', 'string', [
 				'notnull' => true,
 				'length' => 128,
 			]);
+
+			// Regenerate schema after migrating to it
+			$this->db->migrateToSchema($schema->getWrappedSchema());
+			$schema = new SchemaWrapper($this->db);
 		}
+
+		$output->info('Update the oauth2_access_tokens table schema.');
+		$table = $schema->getTable('oauth2_access_tokens');
 		if (!$table->hasColumn('encrypted_token')) {
 			$table->addColumn('encrypted_token', 'string', [
 				'notnull' => true,
@@ -51,10 +74,30 @@ class MigrateOauthTables implements IRepairStep {
 			]);
 		}
 		if (!$table->hasIndex('oauth2_access_hash_idx')) {
+			// Drop legacy access codes first to prevent integrity constraint violations
+			$qb = $this->db->getQueryBuilder();
+			$qb->delete('oauth2_access_tokens')
+				->where($qb->expr()->eq('hashed_code', $qb->createNamedParameter('')));
+			$qb->executeStatement();
+
 			$table->addUniqueIndex(['hashed_code'], 'oauth2_access_hash_idx');
 		}
 		if (!$table->hasIndex('oauth2_access_client_id_idx')) {
 			$table->addIndex(['client_id'], 'oauth2_access_client_id_idx');
+		}
+		if (!$table->hasColumn('token_id')) {
+			$table->addColumn('token_id', 'integer', [
+				'notnull' => true,
+			]);
+		}
+		if ($table->hasColumn('expires')) {
+			$table->dropColumn('expires');
+		}
+		if ($table->hasColumn('user_id')) {
+			$table->dropColumn('user_id');
+		}
+		if ($table->hasColumn('token')) {
+			$table->dropColumn('token');
 		}
 
 		$output->info('Update the oauth2_clients table schema.');
@@ -99,10 +142,10 @@ class MigrateOauthTables implements IRepairStep {
 			$table->addIndex(['client_identifier'], 'oauth2_client_id_idx');
 		}
 
-		$this->db->migrateToSchema($schema->getWrappedSchema());
-
 		// Regenerate schema after migrating to it
+		$this->db->migrateToSchema($schema->getWrappedSchema());
 		$schema = new SchemaWrapper($this->db);
+
 		if ($schema->getTable('oauth2_clients')->hasColumn('identifier')) {
 			$output->info("Move identifier column's data to the new client_identifier column.");
 			// 1. Fetch all [id, identifier] couple.
@@ -124,7 +167,10 @@ class MigrateOauthTables implements IRepairStep {
 			$output->info('Drop the identifier column.');
 			$table = $schema->getTable('oauth2_clients');
 			$table->dropColumn('identifier');
+
+			// Regenerate schema after migrating to it
 			$this->db->migrateToSchema($schema->getWrappedSchema());
+			$schema = new SchemaWrapper($this->db);
 		}
 
 		$output->info('Delete clients (and their related access tokens) with the redirect_uri starting with oc:// or ending with *');
@@ -157,5 +203,50 @@ class MigrateOauthTables implements IRepairStep {
 				$qbDeleteClients->expr()->iLike('redirect_uri', $qbDeleteClients->createNamedParameter('%*', IQueryBuilder::PARAM_STR))
 			);
 		$qbDeleteClients->executeStatement();
+
+		// Migrate legacy refresh tokens from oc
+		if ($schema->hasTable('oauth2_refresh_tokens')) {
+			$output->info('Migrate legacy oauth2 refresh tokens.');
+
+			$qbSelect = $this->db->getQueryBuilder();
+			$qbSelect->select('*')
+				->from('oauth2_refresh_tokens');
+			$result = $qbSelect->executeQuery();
+			$now = $this->timeFactory->now()->getTimestamp();
+			$index = 0;
+			while ($row = $result->fetch()) {
+				$clientId = $row['client_id'];
+				$refreshToken = $row['token'];
+
+				// Insert expired token so that it can be rotated on the next refresh
+				$accessToken = $this->random->generate(72, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+				$authToken = $this->tokenProvider->generateToken(
+					$accessToken,
+					$row['user_id'],
+					$row['user_id'],
+					null,
+					"oc_migrated_client${clientId}_t{$now}_i$index",
+					IToken::PERMANENT_TOKEN,
+					IToken::DO_NOT_REMEMBER,
+				);
+				$authToken->setExpires($now - 3600);
+				$this->tokenProvider->updateToken($authToken);
+
+				$accessTokenEntity = new AccessToken();
+				$accessTokenEntity->setTokenId($authToken->getId());
+				$accessTokenEntity->setClientId($clientId);
+				$accessTokenEntity->setHashedCode(hash('sha512', $refreshToken));
+				$accessTokenEntity->setEncryptedToken($this->crypto->encrypt($accessToken, $refreshToken));
+				$accessTokenEntity->setCodeCreatedAt($now);
+				$accessTokenEntity->setTokenCount(1);
+				$this->accessTokenMapper->insert($accessTokenEntity);
+
+				$index++;
+			}
+			$result->closeCursor();
+
+			$schema->dropTable('oauth2_refresh_tokens');
+			$schema->performDropTableCalls();
+		}
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #50186 

## Summary

See also https://github.com/nextcloud/server/pull/49075

This PR fixes two issues:
1. Not being able to create or auth using OAuth2 clients after migrating from ownCloud.
2. Not being able to refresh legacy tokens from ownCloud after migrating to Nextcloud.

It does not aim to migrate legacy access tokens from ownCloud as this incurs a lot of work and tokens are only valid for an hour. So, it does not make sense as the migration window set by admins is probably longer than their lifetime anyway.

### What I tested

1. Install ownCloud (latest) and install/enable the oauth2 app.
4. Add an oauth2 client, use it to generate an access token and refresh it at least once.
5. Dump related tables: `mysqldump owncloud oc_oauth2_access_tokens oc_oauth2_refresh_tokens oc_oauth2_clients`
6. Import dumped tables into Nextcloud.
7. Reset all oauth2 migrations and drop oauth2 tables (`oc_oauth2_access_tokens`, `oc_oauth2_refresh_tokens` and `oc_oauth2_clients`).
8. Import dumped tables.
9. Migrate oauth2 and run repair steps: `occ migrations:migrate oauth2 && occ maintenance:repair`
10. Refresh the token generated in step 2 using your oauth2 client (might be necessary to adjust the token URL if Nextcloud is on another domain).
11. Observe that the refreshed access token can still be used to log into Nextcloud.

## TODO

- [x] Needs to be tested with a live ownCloud instance (see above)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
