### PR TITLE
docs: Use proper return type for custom template listing

### DIFF
--- a/lib/public/Files/Template/ICustomTemplateProvider.php
+++ b/lib/public/Files/Template/ICustomTemplateProvider.php
@@ -17,7 +17,7 @@ interface ICustomTemplateProvider {
 	/**
 	 * Return a list of additional templates that the template provider is offering
 	 *
-	 * @return File[]
+	 * @return Template[]
 	 * @since 21.0.0
 	 */
 	public function getCustomTemplates(string $mimetype): array;


### PR DESCRIPTION
Came up with https://github.com/nextcloud/richdocuments/pull/4386 in psalm

We have the wrong return type annotated, the returned list is using `Template` objects, which is also what all existing implementations do and what the usage expects:

https://github.com/nextcloud/server/blob/efa615bb0149ac77a317f24710a8579d89fa4c34/lib/private/Files/Template/TemplateManager.php#L188-L195
https://github.com/nextcloud/richdocuments/blob/ba9c364e952fed85dd7431f711b57246b9e268f3/lib/Template/CollaboraTemplateProvider.php#L47
https://github.com/ONLYOFFICE/onlyoffice-nextcloud/blob/d20b985948957de6785a5e126aa9d63dd668b453/lib/TemplateProvider.php#L69
