### PR TITLE
test(e2e): copy-move actions with insufficient share permissions

### DIFF
--- a/cypress/e2e/files_sharing/FilesSharingUtils.ts
+++ b/cypress/e2e/files_sharing/FilesSharingUtils.ts
@@ -79,6 +79,17 @@ export function updateShare(fileName: string, index: number, shareSettings: Part
 			}
 		}
 
+		if (shareSettings.create !== undefined) {
+			cy.get('[data-cy-files-sharing-share-permissions-checkbox="create"]').find('input').as('createCheckbox')
+			if (shareSettings.create) {
+				// Force:true because the checkbox is hidden by the pretty UI.
+				cy.get('@createCheckbox').check({ force: true, scrollBehavior: 'nearest' })
+			} else {
+				// Force:true because the checkbox is hidden by the pretty UI.
+				cy.get('@createCheckbox').uncheck({ force: true, scrollBehavior: 'nearest' })
+			}
+		}
+
 		if (shareSettings.delete !== undefined) {
 			cy.get('[data-cy-files-sharing-share-permissions-checkbox="delete"]').find('input').as('deleteCheckbox')
 			if (shareSettings.delete) {

--- a/cypress/e2e/files_sharing/files-copy-move.cy.ts
+++ b/cypress/e2e/files_sharing/files-copy-move.cy.ts
@@ -1,0 +1,151 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+import type { User } from '@nextcloud/cypress'
+import { createShare } from './FilesSharingUtils.ts'
+import {
+	getRowForFile,
+	moveFile,
+	copyFile,
+	navigateToFolder,
+	triggerActionForFile,
+} from '../files/FilesUtils.ts'
+
+export const copyFileForbidden = (fileName: string, dirPath: string) => {
+	getRowForFile(fileName).should('be.visible')
+	triggerActionForFile(fileName, 'move-copy')
+
+	cy.get('.file-picker').within(() => {
+		// intercept the copy so we can wait for it
+		cy.intercept('COPY', /\/(remote|public)\.php\/dav\/files\//).as('copyFile')
+
+		const directories = dirPath.split('/')
+		directories.forEach((directory) => {
+			// select the folder
+			cy.get(`[data-filename="${CSS.escape(directory)}"]`).should('be.visible').click()
+		})
+
+		// check copy button
+		cy.contains('button', `Copy to ${directories.at(-1)}`).should('be.disabled')
+	})
+}
+
+export const moveFileForbidden = (fileName: string, dirPath: string) => {
+	getRowForFile(fileName).should('be.visible')
+	triggerActionForFile(fileName, 'move-copy')
+
+	cy.get('.file-picker').within(() => {
+		// intercept the copy so we can wait for it
+		cy.intercept('MOVE', /\/(remote|public)\.php\/dav\/files\//).as('moveFile')
+
+		// select home folder
+		cy.get('button[title="Home"]').should('be.visible').click()
+
+		const directories = dirPath.split('/')
+		directories.forEach((directory) => {
+			// select the folder
+			cy.get(`[data-filename="${directory}"]`).should('be.visible').click()
+		})
+
+		// click move
+		cy.contains('button', `Move to ${directories.at(-1)}`).should('not.exist')
+	})
+}
+
+describe('files_sharing: Move or copy files', { testIsolation: true }, () => {
+	let user: User
+	let sharee: User
+
+	beforeEach(() => {
+		cy.createRandomUser().then(($user) => {
+			user = $user
+		})
+		cy.createRandomUser().then(($user) => {
+			sharee = $user
+		})
+	})
+
+
+	it('can create a file in a shared folder', () => {
+		// share the folder
+		cy.mkdir(user, '/folder')
+		cy.login(user)
+		cy.visit('/apps/files')
+		createShare('folder', sharee.userId, { read: true, download: true })
+		cy.logout()
+
+		// Now for the sharee
+		cy.uploadContent(sharee, new Blob([]), 'text/plain', '/folder/file.txt')
+		cy.login(sharee)
+		// visit shared files view
+		cy.visit('/apps/files')
+		// see the shared folder
+		getRowForFile('folder').should('be.visible')
+		navigateToFolder('folder')
+		// Content of the shared folder
+		getRowForFile('file.txt').should('be.visible')
+	})
+
+	it('can copy a file to a shared folder', () => {
+		// share the folder
+		cy.mkdir(user, '/folder')
+		cy.login(user)
+		cy.visit('/apps/files')
+		createShare('folder', sharee.userId, { read: true, download: true })
+		cy.logout()
+
+		// Now for the sharee
+		cy.uploadContent(sharee, new Blob([]), 'text/plain', '/file.txt')
+		cy.login(sharee)
+		// visit shared files view
+		cy.visit('/apps/files')
+		// see the shared folder
+		getRowForFile('folder').should('be.visible')
+		// copy file to a shared folder
+		copyFile('file.txt', 'folder')
+		// click on the folder should open it in files
+		navigateToFolder('folder')
+		// Content of the shared folder
+		getRowForFile('file.txt').should('be.visible')
+	})
+
+	it('can not copy a file to a shared folder with no create permissions', () => {
+		// share the folder
+		cy.mkdir(user, '/folder')
+		cy.login(user)
+		cy.visit('/apps/files')
+		createShare('folder', sharee.userId, { read: true, download: true, create: false })
+		cy.logout()
+
+		// Now for the sharee
+		cy.uploadContent(sharee, new Blob([]), 'text/plain', '/file.txt')
+		cy.login(sharee)
+		// visit shared files view
+		cy.visit('/apps/files')
+		// see the shared folder
+		getRowForFile('folder').should('be.visible')
+		copyFileForbidden('file.txt', 'folder')
+	})
+
+	it('can not move a file from a shared folder with no delete permissions', () => {
+		// share the folder
+		cy.mkdir(user, '/folder')
+		cy.uploadContent(user, new Blob([]), 'text/plain', '/folder/file.txt')
+		cy.login(user)
+		cy.visit('/apps/files')
+		createShare('folder', sharee.userId, { read: true, download: true, delete: false })
+		cy.logout()
+
+		// Now for the sharee
+		cy.mkdir(sharee, '/folder-own')
+		cy.login(sharee)
+		// visit shared files view
+		cy.visit('/apps/files')
+		// see the shared folder
+		getRowForFile('folder').should('be.visible')
+		navigateToFolder('folder')
+		getRowForFile('file.txt').should('be.visible')
+		moveFileForbidden('file.txt', 'folder-own')
+	})
+})


### PR DESCRIPTION
* Resolves: follow-up to #50177

## Summary


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
