### PR TITLE
Hide "Create templates folder" option if templates are disabled

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -3,6 +3,7 @@
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-FileCopyrightText: 2025 Informatyka Boguslawski sp. z o.o. sp.k.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 namespace OCA\Files\Controller;
@@ -194,6 +195,7 @@ class ViewController extends Controller {
 			$this->eventDispatcher->dispatchTyped(new LoadViewer());
 		}
 
+		$this->initialState->provideInitialState('templates_enabled', ($this->config->getSystemValueString('skeletondirectory', '') !== '') || ($this->config->getSystemValueString('templatedirectory', '') !== ''));
 		$this->initialState->provideInitialState('templates_path', $this->templateManager->hasTemplateDirectory() ? $this->templateManager->getTemplatePath() : false);
 		$this->initialState->provideInitialState('templates', $this->templateManager->listCreators());
 

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -3,7 +3,6 @@
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
- * SPDX-FileCopyrightText: 2025 Informatyka Boguslawski sp. z o.o. sp.k.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 namespace OCA\Files\Controller;

--- a/apps/files/src/newMenu/newTemplatesFolder.ts
+++ b/apps/files/src/newMenu/newTemplatesFolder.ts
@@ -1,5 +1,6 @@
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2025 Informatyka Boguslawski sp. z o.o. sp.k.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { Entry, Folder, Node } from '@nextcloud/files'
@@ -17,7 +18,9 @@ import PlusSvg from '@mdi/svg/svg/plus.svg?raw'
 import axios from '@nextcloud/axios'
 import logger from '../logger.ts'
 
+let templatesEnabled = loadState<boolean>('files', 'templates_enabled', true)
 let templatesPath = loadState<string|false>('files', 'templates_path', false)
+logger.debug('Templates folder enabled', { templatesEnabled })
 logger.debug('Initial templates folder', { templatesPath })
 
 /**
@@ -57,8 +60,8 @@ export const entry = {
 	iconSvgInline: PlusSvg,
 	order: 30,
 	enabled(context: Folder): boolean {
-		// Templates folder already initialized
-		if (templatesPath) {
+		// Templates disabled or templates folder already initialized
+		if (!templatesEnabled || templatesPath) {
 			return false
 		}
 		// Allow creation on your own folders only

--- a/apps/files/src/newMenu/newTemplatesFolder.ts
+++ b/apps/files/src/newMenu/newTemplatesFolder.ts
@@ -1,6 +1,5 @@
 /**
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
- * SPDX-FileCopyrightText: 2025 Informatyka Boguslawski sp. z o.o. sp.k.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 import type { Entry, Folder, Node } from '@nextcloud/files'
@@ -18,7 +17,7 @@ import PlusSvg from '@mdi/svg/svg/plus.svg?raw'
 import axios from '@nextcloud/axios'
 import logger from '../logger.ts'
 
-let templatesEnabled = loadState<boolean>('files', 'templates_enabled', true)
+const templatesEnabled = loadState<boolean>('files', 'templates_enabled', true)
 let templatesPath = loadState<string|false>('files', 'templates_path', false)
 logger.debug('Templates folder enabled', { templatesEnabled })
 logger.debug('Initial templates folder', { templatesPath })

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -3,6 +3,7 @@
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-FileCopyrightText: 2025 Informatyka Boguslawski sp. z o.o. sp.k.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
@@ -288,8 +289,9 @@ $CONFIG = [
 
 /**
  * The directory where the skeleton files are located. These files will be
- * copied to the data directory of new users. Leave empty to not copy any
- * skeleton files.
+ * copied to the data directory of new users. Set empty string to not copy any
+ * skeleton files. If unset and templatedirectory is empty string, shipped
+ * templates will be used to create a template directory for the user.
  * ``{lang}`` can be used as a placeholder for the language of the user.
  * If the directory does not exist, it falls back to non dialect (from ``de_DE``
  * to ``de``). If that does not exist either, it falls back to ``default``
@@ -298,18 +300,16 @@ $CONFIG = [
  */
 'skeletondirectory' => '/path/to/nextcloud/core/skeleton',
 
-
 /**
  * The directory where the template files are located. These files will be
- * copied to the template directory of new users. Leave empty to not copy any
+ * copied to the template directory of new users. Set empty string to not copy any
  * template files.
  * ``{lang}`` can be used as a placeholder for the language of the user.
  * If the directory does not exist, it falls back to non dialect (from ``de_DE``
  * to ``de``). If that does not exist either, it falls back to ``default``
  *
- * If this is not set creating a template directory will only happen if no custom
- * ``skeletondirectory`` is defined, otherwise the shipped templates will be used
- * to create a template directory for the user.
+ * To disable creating a template directory, set both skeletondirectory and
+ * templatedirectory to empty strings.
  */
 'templatedirectory' => '/path/to/nextcloud/templates',
 

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -3,7 +3,6 @@
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
- * SPDX-FileCopyrightText: 2025 Informatyka Boguslawski sp. z o.o. sp.k.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 


### PR DESCRIPTION
## Summary

When both `skeletondirectory` and `templatedirectory` are set to empty strings in configuration, templates folder creation should be disabled and no Create templates folder option should be present in new folder menu.

Related: https://github.com/nextcloud/server/issues/39266
Related: https://github.com/nextcloud/server/issues/46455
Author-Change-Id: IB#1156403

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
