### PR TITLE
fix(conversion): missing target file extension

### DIFF
--- a/lib/private/Files/Conversion/ConversionManager.php
+++ b/lib/private/Files/Conversion/ConversionManager.php
@@ -11,7 +11,6 @@ namespace OC\Files\Conversion;
 
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\SystemConfig;
-use OCP\Files\Conversion\ConversionMimeProvider;
 use OCP\Files\Conversion\IConversionManager;
 use OCP\Files\Conversion\IConversionProvider;
 use OCP\Files\File;
@@ -59,22 +58,6 @@ class ConversionManager implements IConversionManager {
 			$providers = array_merge($providers, $provider->getSupportedMimeTypes());
 		}
 		return $providers;
-	}
-
-	/**
-	 * @param string $mime
-	 * @return list<ConversionMimeProvider>
-	 */
-	private function getProvidersForMime(string $mime): array {
-		$mimeTypes = $this->getProviders();
-		$filtered = array_filter(
-			$mimeTypes,
-			function (ConversionMimeProvider $mimeProvider) use ($mime) {
-				return $mimeProvider->getFrom() === $mime;
-			}
-		);
-
-		return array_values($filtered);
 	}
 
 	public function convert(File $file, string $targetMimeType, ?string $destination = null): string {

--- a/lib/private/Files/Conversion/ConversionManager.php
+++ b/lib/private/Files/Conversion/ConversionManager.php
@@ -92,16 +92,16 @@ class ConversionManager implements IConversionManager {
 		$fileMimeType = $file->getMimetype();
 		$validProvider = $this->getValidProvider($fileMimeType, $targetMimeType);
 
-		$targetExtension = '';
-		foreach ($this->getProvidersForMime($fileMimeType) as $mimeProvider) {
-			if ($mimeProvider->getTo() === $targetMimeType) {
-				$targetExtension = $mimeProvider->getExtension();
-				break;
-			}
-		}
-
 		if ($validProvider !== null) {
 			$convertedFile = $validProvider->convertFile($file, $targetMimeType);
+			
+			$targetExtension = '';
+			foreach ($validProvider->getSupportedMimeTypes() as $mimeProvider) {
+				if ($mimeProvider->getTo() === $targetMimeType) {
+					$targetExtension = $mimeProvider->getExtension();
+					break;
+				}
+			}
 
 			// If destination not provided, we use the same path
 			// as the original file, but with the new extension
@@ -122,10 +122,6 @@ class ConversionManager implements IConversionManager {
 	 * @return list<IConversionProvider>
 	 */
 	private function getRegisteredProviders(): array {
-		if (count($this->providers) > 0) {
-			return $this->providers;
-		}
-
 		$context = $this->coordinator->getRegistrationContext();
 		foreach ($context->getFileConversionProviders() as $providerRegistration) {
 			$class = $providerRegistration->getService();


### PR DESCRIPTION
## Summary
I discovered that, when working on the richdocuments file conversion provider, not all file conversion providers will be properly detected when searching for the correct file extension to assign the converted file. When no destination is provided, the filename will not include an extension (e.g. `doc.` instead of `doc.pdf`); however, when a destination is provided, we do not append the extension since it is assumed the destination would include it (e.g. `/subfolder/doc.pdf`).

The issue lies with the following bit of code, primarily:

```php
private function getRegisteredProviders(): array {
    if (count($this->providers) > 0) {
        return $this->providers;
    }

    // ...continued
}
```

If this method is called twice, the logic for getting a registration context to peek at the registered file conversion providers is skipped, and the preexisting providers are simply returned. This sounded like a good idea at first, but I ran into an issue where my richdocuments file conversion provider was not being returned in this list on subsequent calls to the method (maybe due to it not being fully registered yet or something?).

Removing the `if` statement seems to work and resolve the issue, but I think we can avoid having to call this method more than once anyway but changing the logic for getting the correct file extension. We already get the valid conversion provider that can do the conversion, so we just get the right extension from its supported ones instead of re-fetching all the registered providers.

The tests implemented already never failed, and my guess for that is because the testing app's conversion providers are being registered first somehow before other the other apps' providers. /shrug

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
