### PR TITLE
Add integration tests for moving a file from and to a shared folder

### DIFF
--- a/build/integration/dav_features/webdav-related.feature
+++ b/build/integration/dav_features/webdav-related.feature
@@ -48,6 +48,33 @@ Feature: webdav-related
     When User "user0" moves file "/test/test" to "/test"
     Then the HTTP status code should be "403"
 
+	Scenario: Moving a file from shared folder to root folder
+		Given using old dav path
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" created a folder "/testshare"
+		And User "user0" copies file "/welcome.txt" to "/testshare/welcome.txt"
+		And as "user0" creating a share with
+			| path | testshare |
+			| shareType | 0 |
+			| shareWith | user1 |
+		When User "user1" moves file "/testshare/welcome.txt" to "/movedwelcome.txt"
+		Then As an "user1"
+		And Downloaded content when downloading file "/movedwelcome.txt" with range "bytes=0-6" should be "Welcome"
+
+	Scenario: Moving a file from root folder to shared folder
+		Given using old dav path
+		And user "user0" exists
+		And user "user1" exists
+		And user "user0" created a folder "/testshare"
+		And as "user0" creating a share with
+			| path | testshare |
+			| shareType | 0 |
+			| shareWith | user1 |
+		When User "user1" moves file "/welcome.txt" to "/testshare/movedwelcome.txt"
+		Then As an "user1"
+		And Downloaded content when downloading file "/testshare/movedwelcome.txt" with range "bytes=0-6" should be "Welcome"
+
 	Scenario: Moving a file to a folder with no permissions
 		Given using old dav path
 		And As an "admin"


### PR DESCRIPTION
(Turns out that back in the day I made the commit, wrote the pull request description in a local file... and then forgot to open the pull request :facepalm: Sorry about that.)

This pull request adds some integration tests that should have exposed the regression introduced in https://github.com/nextcloud/server/commit/bd740ac0b012da697085d4244b890f931a3b1fd2 (and fixed in https://github.com/nextcloud/server/pull/47986#issuecomment-2449791411) when [run on CI](https://github.com/nextcloud/server/actions/runs/10526510822/job/29167666696), as [_dav_features/webdav-related.feature_ are also run with S3 as primary storage](https://github.com/nextcloud/server/blob/0a5bb99345a616843d12b59e4bee4fc5dae6d2ee/.github/workflows/integration-s3-primary.yml#L99).
