### PR TITLE
[stable30] Fix renaming a received share by a user with stale shares

### DIFF
--- a/build/integration/sharing_features/sharing-v1-part2.feature
+++ b/build/integration/sharing_features/sharing-v1-part2.feature
@@ -923,6 +923,34 @@ Feature: sharing
     Then the OCS status code should be "403"
     And the HTTP status code should be "200"
 
+  Scenario: Rename a received share after deleting the source file of a share made by the receiver
+    Given user "user0" exists
+    And user "user1" exists
+    And user "user2" exists
+    And file "textfile0.txt" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
+    And User "user1" deletes file "/textfile0.txt"
+    When file "textfile1.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
+    And User "user1" moves file "/textfile1 (2).txt" to "/shared_file.txt"
+    Then the HTTP status code should be "201"
+    And as "user1" the file "/shared_file.txt" exists
+
+  Scenario: Rename a received share after deleting the source file of a reshare made by the receiver
+    Given user "user0" exists
+    And user "user1" exists
+    And user "user2" exists
+    And file "textfile0.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
+    And file "textfile0 (2).txt" of user "user1" is shared with user "user2"
+    And user "user2" accepts last share
+    And User "user0" deletes file "/textfile0.txt"
+    When file "textfile1.txt" of user "user0" is shared with user "user1"
+    And user "user1" accepts last share
+    And User "user1" moves file "/textfile1 (2).txt" to "/shared_file.txt"
+    Then the HTTP status code should be "201"
+    And as "user1" the file "/shared_file.txt" exists
+
   Scenario: Keep usergroup shares (#22143)
     Given As an "admin"
     And user "user0" exists

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1460,6 +1460,15 @@ class Manager implements IManager {
 			$this->deleteShare($share);
 			throw new ShareNotFound($this->l->t('The requested share does not exist anymore'));
 		}
+
+		try {
+			$share->getNode();
+			// Ignore share, file is still accessible
+		} catch (NotFoundException) {
+			// Access lost, but maybe only temporarily, so don't delete the share right away
+			throw new ShareNotFound($this->l->t('The requested share does not exist anymore'));
+		}
+
 		if ($this->config->getAppValue('files_sharing', 'hide_disabled_user_shares', 'no') === 'yes') {
 			$uids = array_unique([$share->getShareOwner(),$share->getSharedBy()]);
 			foreach ($uids as $uid) {


### PR DESCRIPTION
If a user tries to rename a received share and that user has stale shares (shares where the source file was deleted) an internal server error is triggered.

The problem comes from [checking the existing shares to ensure that the share is not moved inside one of them](https://github.com/nextcloud/server/blob/757076af29469fe919c56dc043e54f33d71e8e2c/lib/private/Files/View.php#L1876-L1908). If the source file of a share made by the user was deleted [when the node is tried to be got](https://github.com/nextcloud/server/blob/757076af29469fe919c56dc043e54f33d71e8e2c/lib/private/Files/View.php#L1898) a `OCP\Files\NotFoundException` is thrown; this is not caught anywhere and causes an internal server error.

In master the problem was fixed by c2ca99e2f641396b6823c1e675afd3ecb486e744. After that change `getSharesBy` filters out shares with a no longer accessible node, so `targetIsNotShared` no longer throws an exception. However, the pull request that the commit belongs to has not been backported to the stable branches (and I assume that it will not be, as it is a new feature), so the issue is still present in the stable versions of Nextcloud.

c2ca99e2f641396b6823c1e675afd3ecb486e744 looks like a sane check independently of the rest of #49073, so I have cherry-picked just that commit (and added integration tests for the issue). But I do not really know if that could have any problematic side effect :shrug: so a careful review is encouraged :-)

## How to test

- Setup Nextcloud
- Add users _admin_ and _user0_
- As _admin_, create a folder (`curl --user admin:admin --request MKCOL --header "OCS-APIRequest: true" "http://127.0.0.1:8000/remote.php/dav/files/admin/folder-to-be-deleted"`)
- Share the folder with _user0_ (`curl --user admin:admin --request POST --header "OCS-APIRequest: true" "http://127.0.0.1:8000/ocs/v1.php/apps/files_sharing/api/v1/shares?path=folder-to-be-deleted&shareType=0&shareWith=user0"`)
- Delete the folder (`curl --user admin:admin --request DELETE --header "OCS-APIRequest: true" "http://127.0.0.1:8000/remote.php/dav/files/admin/folder-to-be-deleted"`)
- As _user0_, create a folder (`curl --user user0:123456 --request MKCOL --header "OCS-APIRequest: true" "http://127.0.0.1:8000/remote.php/dav/files/user0/folder-to-be-renamed"`)
- Share the folder with _admin_ (`curl --user user0:123456 --request POST --header "OCS-APIRequest: true" "http://127.0.0.1:8000/ocs/v1.php/apps/files_sharing/api/v1/shares?path=folder-to-be-renamed&shareType=0&shareWith=admin"`)
- As _admin_, try to rename the received share (`curl --user admin:admin --request MOVE --header "OCS-APIRequest: true" --header "Destination: http://127.0.0.1:8000/remote.php/dav/files/admin/new-folder-name" "http://127.0.0.1:8000/remote.php/dav/files/admin/folder-to-be-renamed"`)

### Result with this pull request

The received share is renamed

### Result without this pull request

Internal server error
