### PR TITLE
fix(updatenotification): Parse pre-release version of apps

### DIFF
--- a/apps/updatenotification/lib/Controller/APIController.php
+++ b/apps/updatenotification/lib/Controller/APIController.php
@@ -153,14 +153,23 @@ class APIController extends OCSController {
 	 * @param string $appId App to search changelog entry for
 	 * @param string|null $version The version to search the changelog entry for (defaults to the latest installed)
 	 *
-	 * @return DataResponse<Http::STATUS_OK, array{appName: string, content: string, version: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{}, array{}>
+	 * @return DataResponse<Http::STATUS_OK, array{appName: string, content: string, version: string}, array{}>|DataResponse<Http::STATUS_NOT_FOUND, array{}, array{}>|DataResponse<Http::STATUS_BAD_REQUEST, array{}, array{}>
 	 *
 	 * 200: Changelog entry returned
+	 * 400: The `version` parameter is not a valid version format
 	 * 404: No changelog found
 	 */
 	public function getAppChangelogEntry(string $appId, ?string $version = null): DataResponse {
 		$version = $version ?? $this->appManager->getAppVersion($appId);
-		$changes = $this->manager->getChangelog($appId, $version);
+		// handle pre-release versions
+		$matches = [];
+		$result = preg_match('/^(\d+\.\d+(\.\d+)?)/', $version, $matches);
+		if ($result === false || $result === 0) {
+			return new DataResponse([], Http::STATUS_BAD_REQUEST);
+		}
+		$shortVersion = $matches[0];
+
+		$changes = $this->manager->getChangelog($appId, $shortVersion);
 
 		if ($changes === null) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);

--- a/apps/updatenotification/openapi.json
+++ b/apps/updatenotification/openapi.json
@@ -338,6 +338,36 @@
                                 }
                             }
                         }
+                    },
+                    "400": {
+                        "description": "The `version` parameter is not a valid version format",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/apps/updatenotification/tests/Controller/APIControllerTest.php
+++ b/apps/updatenotification/tests/Controller/APIControllerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\UpdateNotification\Tests\Controller;
+
+use OC\App\AppStore\Fetcher\AppFetcher;
+use OCA\UpdateNotification\AppInfo\Application;
+use OCA\UpdateNotification\Controller\APIController;
+use OCA\UpdateNotification\Manager;
+use OCP\App\IAppManager;
+use OCP\AppFramework\Http;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\L10N\IFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class APIControllerTest extends TestCase {
+	private IRequest&MockObject $request;
+	private IConfig&MockObject $config;
+	private IAppManager&MockObject $appManager;
+	private AppFetcher&MockObject $appFetcher;
+	private IFactory&MockObject $l10nFactory;
+	private IUserSession&MockObject $userSession;
+	private Manager&MockObject $manager;
+
+	private APIController $apiController;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->request = $this->createMock(IRequest::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->appFetcher = $this->createMock(AppFetcher::class);
+		$this->l10nFactory = $this->createMock(IFactory::class);
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->manager = $this->createMock(Manager::class);
+
+		$this->apiController = new APIController(
+			Application::APP_NAME,
+			$this->request,
+			$this->config,
+			$this->appManager,
+			$this->appFetcher,
+			$this->l10nFactory,
+			$this->userSession,
+			$this->manager,
+		);
+	}
+
+	/**
+	 * @dataProvider dataGetAppChangelog
+	 */
+	public function testGetAppChangelogEntry(
+		array $params,
+		bool $hasChanges,
+		array $appInfo,
+		array $expected,
+	): void {
+		$this->appManager->method('getAppInfo')
+			->with('the-app')
+			->willReturn($appInfo);
+		$this->appManager->method('getAppVersion')
+			->with('the-app')
+			->willReturn($appInfo['version']);
+		$this->manager->method('getChangelog')
+			->with('the-app', self::anything())
+			->willReturnCallback(fn ($app, $version) => $hasChanges ? "$app v$version" : null);
+
+		$result = $this->apiController->getAppChangelogEntry(...$params);
+		$this->assertEquals($result->getStatus(), $expected['status']);
+		$this->assertEquals($result->getData(), $expected['data']);
+	}
+
+	public static function dataGetAppChangelog(): array {
+		return [
+			'no changes found' => [
+				['the-app', null],
+				false,
+				[
+					'name' => 'Localized name',
+					'version' => '1.0.0',
+				],
+				[
+					'status' => Http::STATUS_NOT_FOUND,
+					'data' => [],
+				]
+			],
+			'changes with version parameter' => [
+				['the-app', '1.0.0'],
+				true,
+				[
+					'name' => 'Localized name',
+					'version' => '1.2.0', // installed version
+				],
+				[
+					'status' => Http::STATUS_OK,
+					'data' => [
+						'appName' => 'Localized name',
+						'content' => 'the-app v1.0.0',
+						'version' => '1.0.0',
+					],
+				]
+			],
+			'changes without version parameter' => [
+				['the-app', null],
+				true,
+				[
+					'name' => 'Localized name',
+					'version' => '1.2.0',
+				],
+				[
+					'status' => Http::STATUS_OK,
+					'data' => [
+						'appName' => 'Localized name',
+						'content' => 'the-app v1.2.0',
+						'version' => '1.2.0',
+					],
+				]
+			],
+			'changes of pre-release version' => [
+				['the-app', null],
+				true,
+				[
+					'name' => 'Localized name',
+					'version' => '1.2.0-alpha.1',
+				],
+				[
+					'status' => Http::STATUS_OK,
+					'data' => [
+						'appName' => 'Localized name',
+						'content' => 'the-app v1.2.0',
+						'version' => '1.2.0-alpha.1',
+					],
+				]
+			],
+			'changes of pre-release version as parameter' => [
+				['the-app', '1.2.0-alpha.2'],
+				true,
+				[
+					'name' => 'Localized name',
+					'version' => '1.2.0-beta.3',
+				],
+				[
+					'status' => Http::STATUS_OK,
+					'data' => [
+						'appName' => 'Localized name',
+						'content' => 'the-app v1.2.0',
+						'version' => '1.2.0-alpha.2',
+					],
+				]
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Summary
The notification is correctly created, but the changelog is not show. We need to make sure the version passed to the manager is in the allowed format (major.minor.patch).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
