### PR TITLE
[stable30] fix(files): Add empty alt text to purely decorative icons

### DIFF
--- a/apps/files_sharing/js/templates.js
+++ b/apps/files_sharing/js/templates.js
@@ -21,8 +21,8 @@ templates['files_drop'] = template({"1":function(container,depth0,helpers,partia
 
   return "		<img src=\""
     + alias4(((helper = (helper = lookupProperty(helpers,"iconSrc") || (depth0 != null ? lookupProperty(depth0,"iconSrc") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"iconSrc","hash":{},"data":data,"loc":{"start":{"line":6,"column":12},"end":{"line":6,"column":23}}}) : helper)))
-    + "\"/> "
-    + alias4(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":6,"column":27},"end":{"line":6,"column":35}}}) : helper)))
+    + "\" alt=\"\" /> "
+    + alias4(((helper = (helper = lookupProperty(helpers,"name") || (depth0 != null ? lookupProperty(depth0,"name") : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data,"loc":{"start":{"line":6,"column":35},"end":{"line":6,"column":43}}}) : helper)))
     + "\n";
 },"compiler":[8,">= 4.3.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=container.hooks.helperMissing, alias3="function", alias4=container.escapeExpression, lookupProperty = container.lookupProperty || function(parent, propertyName) {

--- a/apps/files_sharing/js/templates/files_drop.handlebars
+++ b/apps/files_sharing/js/templates/files_drop.handlebars
@@ -3,6 +3,6 @@
 		<div id="drop-upload-name">{{name}}</div><div id="drop-upload-status"></div>
 		<progress id="drop-upload-progress-bar" value="0" max="100"></progress>
 	{{else}}
-		<img src="{{iconSrc}}"/> {{name}}
+		<img src="{{iconSrc}}" alt="" /> {{name}}
 	{{/if}}
 </li>


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/49923

## Summary

Add an empty `alt` text to prevent this decorative image from appearing in the accessibility tree.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
