### PR TITLE
Fix log spamming for shares without label

### DIFF
--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -132,7 +132,7 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 		$response->setContentSecurityPolicy($csp);
 
 		// If the share has a label, use it as the title
-		if ($share->getLabel() !== '') {
+		if (!empty($share->getLabel())) {
 			$response->setHeaderTitle($share->getLabel());
 			$response->setParams(['pageTitle' => $share->getLabel()]);
 		} else {


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/49682

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Database field is null and we should check it with empt() function to prevent error like this: https://github.com/nextcloud/server/issues/49682

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
