### PR TITLE
perf(files_reminders): Reduce db queries on propfind

### DIFF
--- a/apps/files_reminders/composer/composer/autoload_classmap.php
+++ b/apps/files_reminders/composer/composer/autoload_classmap.php
@@ -16,6 +16,7 @@ return array(
     'OCA\\FilesReminders\\Db\\Reminder' => $baseDir . '/../lib/Db/Reminder.php',
     'OCA\\FilesReminders\\Db\\ReminderMapper' => $baseDir . '/../lib/Db/ReminderMapper.php',
     'OCA\\FilesReminders\\Exception\\NodeNotFoundException' => $baseDir . '/../lib/Exception/NodeNotFoundException.php',
+    'OCA\\FilesReminders\\Exception\\ReminderNotFoundException' => $baseDir . '/../lib/Exception/ReminderNotFoundException.php',
     'OCA\\FilesReminders\\Exception\\UserNotFoundException' => $baseDir . '/../lib/Exception/UserNotFoundException.php',
     'OCA\\FilesReminders\\Listener\\LoadAdditionalScriptsListener' => $baseDir . '/../lib/Listener/LoadAdditionalScriptsListener.php',
     'OCA\\FilesReminders\\Listener\\NodeDeletedListener' => $baseDir . '/../lib/Listener/NodeDeletedListener.php',

--- a/apps/files_reminders/composer/composer/autoload_static.php
+++ b/apps/files_reminders/composer/composer/autoload_static.php
@@ -31,6 +31,7 @@ class ComposerStaticInitFilesReminders
         'OCA\\FilesReminders\\Db\\Reminder' => __DIR__ . '/..' . '/../lib/Db/Reminder.php',
         'OCA\\FilesReminders\\Db\\ReminderMapper' => __DIR__ . '/..' . '/../lib/Db/ReminderMapper.php',
         'OCA\\FilesReminders\\Exception\\NodeNotFoundException' => __DIR__ . '/..' . '/../lib/Exception/NodeNotFoundException.php',
+        'OCA\\FilesReminders\\Exception\\ReminderNotFoundException' => __DIR__ . '/..' . '/../lib/Exception/ReminderNotFoundException.php',
         'OCA\\FilesReminders\\Exception\\UserNotFoundException' => __DIR__ . '/..' . '/../lib/Exception/UserNotFoundException.php',
         'OCA\\FilesReminders\\Listener\\LoadAdditionalScriptsListener' => __DIR__ . '/..' . '/../lib/Listener/LoadAdditionalScriptsListener.php',
         'OCA\\FilesReminders\\Listener\\NodeDeletedListener' => __DIR__ . '/..' . '/../lib/Listener/NodeDeletedListener.php',

--- a/apps/files_reminders/lib/Dav/PropFindPlugin.php
+++ b/apps/files_reminders/lib/Dav/PropFindPlugin.php
@@ -12,7 +12,6 @@ namespace OCA\FilesReminders\Dav;
 use DateTimeInterface;
 use OCA\DAV\Connector\Sabre\Node;
 use OCA\FilesReminders\Service\ReminderService;
-use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IUser;
 use OCP\IUserSession;
 use Sabre\DAV\INode;
@@ -52,9 +51,8 @@ class PropFindPlugin extends ServerPlugin {
 				}
 
 				$fileId = $node->getId();
-				try {
-					$reminder = $this->reminderService->getDueForUser($user, $fileId);
-				} catch (DoesNotExistException $e) {
+				$reminder = $this->reminderService->getDueForUser($user, $fileId);
+				if ($reminder === null) {
 					return '';
 				}
 

--- a/apps/files_reminders/lib/Db/ReminderMapper.php
+++ b/apps/files_reminders/lib/Db/ReminderMapper.php
@@ -13,6 +13,7 @@ use DateTime;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IDBConnection;
@@ -128,6 +129,32 @@ class ReminderMapper extends QBMapper {
 			->andWhere($qb->expr()->lt('due_date', $qb->createNamedParameter($buffer, IQueryBuilder::PARAM_DATETIME_MUTABLE)))
 			->orderBy('due_date', 'ASC')
 			->setMaxResults($limit);
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * @return Reminder[]
+	 */
+	public function findAllInFolder(IUser $user, Folder $folder) {
+		$fileIds = array_values(array_filter(array_map(
+			function (Node $node) {
+				try {
+					return $node->getId();
+				} catch (NotFoundException $e) {
+					return null;
+				}
+			},
+			$folder->getDirectoryListing(),
+		)));
+
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('id', 'user_id', 'file_id', 'due_date', 'updated_at', 'created_at', 'notified')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($user->getUID(), IQueryBuilder::PARAM_STR)))
+			->andWhere($qb->expr()->in('file_id', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)))
+			->orderBy('due_date', 'ASC');
 
 		return $this->findEntities($qb);
 	}

--- a/apps/files_reminders/lib/Db/ReminderMapper.php
+++ b/apps/files_reminders/lib/Db/ReminderMapper.php
@@ -39,16 +39,6 @@ class ReminderMapper extends QBMapper {
 		return $this->update($reminderUpdate);
 	}
 
-	public function find(int $id): Reminder {
-		$qb = $this->db->getQueryBuilder();
-
-		$qb->select('id', 'user_id', 'file_id', 'due_date', 'updated_at', 'created_at', 'notified')
-			->from($this->getTableName())
-			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-
-		return $this->findEntity($qb);
-	}
-
 	/**
 	 * @throws DoesNotExistException
 	 */

--- a/apps/files_reminders/lib/Exception/ReminderNotFoundException.php
+++ b/apps/files_reminders/lib/Exception/ReminderNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesReminders\Exception;
+
+use Exception;
+
+class ReminderNotFoundException extends Exception {
+}

--- a/apps/files_reminders/lib/Service/ReminderService.php
+++ b/apps/files_reminders/lib/Service/ReminderService.php
@@ -44,7 +44,7 @@ class ReminderService {
 		protected LoggerInterface $logger,
 		protected ICacheFactory $cacheFactory,
 	) {
-		$this->cache = $this->cacheFactory->createDistributed('files_reminders');
+		$this->cache = $this->cacheFactory->createInMemory();
 	}
 
 	public function cacheFolder(IUser $user, Folder $folder): void {

--- a/apps/files_reminders/lib/Service/ReminderService.php
+++ b/apps/files_reminders/lib/Service/ReminderService.php
@@ -15,11 +15,14 @@ use OCA\FilesReminders\AppInfo\Application;
 use OCA\FilesReminders\Db\Reminder;
 use OCA\FilesReminders\Db\ReminderMapper;
 use OCA\FilesReminders\Exception\NodeNotFoundException;
+use OCA\FilesReminders\Exception\ReminderNotFoundException;
 use OCA\FilesReminders\Exception\UserNotFoundException;
 use OCA\FilesReminders\Model\RichReminder;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Node;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -28,6 +31,9 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 
 class ReminderService {
+
+	private ICache $cache;
+
 	public function __construct(
 		protected IUserManager $userManager,
 		protected IURLGenerator $urlGenerator,
@@ -35,7 +41,9 @@ class ReminderService {
 		protected ReminderMapper $reminderMapper,
 		protected IRootFolder $root,
 		protected LoggerInterface $logger,
+		protected ICacheFactory $cacheFactory,
 	) {
+		$this->cache = $this->cacheFactory->createDistributed('files_reminders');
 	}
 
 	/**
@@ -48,12 +56,26 @@ class ReminderService {
 
 	/**
 	 * @throws NodeNotFoundException
-	 * @throws DoesNotExistException
 	 */
-	public function getDueForUser(IUser $user, int $fileId): RichReminder {
+	public function getDueForUser(IUser $user, int $fileId): ?RichReminder {
 		$this->checkNode($user, $fileId);
-		$reminder = $this->reminderMapper->findDueForUser($user, $fileId);
-		return new RichReminder($reminder, $this->root);
+		/** @var null|false|Reminder $cachedReminder */
+		$cachedReminder = $this->cache->get("{$user->getUID()}-$fileId");
+		if ($cachedReminder === false) {
+			return null;
+		}
+		if ($cachedReminder instanceof Reminder) {
+			return new RichReminder($cachedReminder, $this->root);
+		}
+
+		try {
+			$reminder = $this->reminderMapper->findDueForUser($user, $fileId);
+			$this->cache->set("{$user->getUID()}-$fileId", $reminder);
+			return new RichReminder($reminder, $this->root);
+		} catch (DoesNotExistException $e) {
+			$this->cache->set("{$user->getUID()}-$fileId", false);
+			return null;
+		}
 	}
 
 	/**
@@ -77,14 +99,8 @@ class ReminderService {
 	public function createOrUpdate(IUser $user, int $fileId, DateTime $dueDate): bool {
 		$now = new DateTime('now', new DateTimeZone('UTC'));
 		$this->checkNode($user, $fileId);
-		try {
-			$reminder = $this->reminderMapper->findDueForUser($user, $fileId);
-			$reminder->setDueDate($dueDate);
-			$reminder->setUpdatedAt($now);
-			$this->reminderMapper->update($reminder);
-			return false;
-		} catch (DoesNotExistException $e) {
-			// Create new reminder if no reminder is found
+		$reminder = $this->getDueForUser($user, $fileId);
+		if ($reminder === null) {
 			$reminder = new Reminder();
 			$reminder->setUserId($user->getUID());
 			$reminder->setFileId($fileId);
@@ -92,31 +108,40 @@ class ReminderService {
 			$reminder->setUpdatedAt($now);
 			$reminder->setCreatedAt($now);
 			$this->reminderMapper->insert($reminder);
+			$this->cache->set("{$user->getUID()}-$fileId", $reminder);
 			return true;
 		}
+		$reminder->setDueDate($dueDate);
+		$reminder->setUpdatedAt($now);
+		$this->reminderMapper->update($reminder);
+		$this->cache->set("{$user->getUID()}-$fileId", $reminder);
+		return false;
 	}
 
 	/**
 	 * @throws NodeNotFoundException
-	 * @throws DoesNotExistException
+	 * @throws ReminderNotFoundException
 	 */
 	public function remove(IUser $user, int $fileId): void {
 		$this->checkNode($user, $fileId);
-		$reminder = $this->reminderMapper->findDueForUser($user, $fileId);
-		$this->reminderMapper->delete($reminder);
+		$reminder = $this->getDueForUser($user, $fileId);
+		if ($reminder === null) {
+			throw new ReminderNotFoundException();
+		}
+		$this->deleteReminder($reminder);
 	}
 
 	public function removeAllForNode(Node $node): void {
 		$reminders = $this->reminderMapper->findAllForNode($node);
 		foreach ($reminders as $reminder) {
-			$this->reminderMapper->delete($reminder);
+			$this->deleteReminder($reminder);
 		}
 	}
 
 	public function removeAllForUser(IUser $user): void {
 		$reminders = $this->reminderMapper->findAllForUser($user);
 		foreach ($reminders as $reminder) {
-			$this->reminderMapper->delete($reminder);
+			$this->deleteReminder($reminder);
 		}
 	}
 
@@ -148,6 +173,7 @@ class ReminderService {
 		try {
 			$this->notificationManager->notify($notification);
 			$this->reminderMapper->markNotified($reminder);
+			$this->cache->set("{$user->getUID()}-{$reminder->getFileId()}", $reminder);
 		} catch (Throwable $th) {
 			$this->logger->error($th->getMessage(), $th->getTrace());
 		}
@@ -159,9 +185,15 @@ class ReminderService {
 			->modify('-1 day');
 		$reminders = $this->reminderMapper->findNotified($buffer, $limit);
 		foreach ($reminders as $reminder) {
-			$this->reminderMapper->delete($reminder);
+			$this->deleteReminder($reminder);
 		}
 	}
+
+	private function deleteReminder(Reminder $reminder): void {
+		$this->reminderMapper->delete($reminder);
+		$this->cache->set("{$reminder->getUserId()}-{$reminder->getFileId()}", false);
+	}
+
 
 	/**
 	 * @throws NodeNotFoundException

--- a/apps/files_reminders/lib/Service/ReminderService.php
+++ b/apps/files_reminders/lib/Service/ReminderService.php
@@ -47,14 +47,6 @@ class ReminderService {
 	}
 
 	/**
-	 * @throws DoesNotExistException
-	 */
-	public function get(int $id): RichReminder {
-		$reminder = $this->reminderMapper->find($id);
-		return new RichReminder($reminder, $this->root);
-	}
-
-	/**
 	 * @throws NodeNotFoundException
 	 */
 	public function getDueForUser(IUser $user, int $fileId): ?RichReminder {


### PR DESCRIPTION
## Summary

- Add caching for reminders
- Reduces database queries by n number of nodes in the directory per PROPFIND

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)