### PR TITLE
Fix: Match token login name by UID or e-mail address

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -780,12 +780,15 @@ class Session implements IUserSession, Emitter {
 	 * Check if login names match
 	 */
 	private function validateTokenLoginName(?string $loginName, IToken $token): bool {
-		if ($token->getLoginName() !== $loginName) {
-			// TODO: this makes it impossible to use different login names on browser and client
-			// e.g. login by e-mail 'user@example.com' on browser for generating the token will not
-			//      allow to use the client token with the login name 'user'.
+		$tokenUser = $this->manager->get($token->getUID());
+		if (!is_null($tokenUser)) {
+			$tokenEmail = $tokenUser->getEMailAddress();
+		}
+
+		if ($token->getLoginName() !== $loginName && (is_null($tokenUser) || $tokenEmail !== $loginName)) {
 			$this->logger->error('App token login name does not match', [
 				'tokenLoginName' => $token->getLoginName(),
+				'tokenEmailAddress' => $tokenEmail,
 				'sessionLoginName' => $loginName,
 				'app' => 'core',
 				'user' => $token->getUID(),


### PR DESCRIPTION
## Summary
With this changes the login name gets matched against the token user's e-mail address in addition to the login name.

This fixes the web login flow of the app, where the session is based on the e-mail address but the token uses the UID.

* Resolves: #44164

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes (No front-end changes involved in this PR)
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
