### PR TITLE
fix(TemplateManager): Remove warning message

### DIFF
--- a/lib/private/Files/Template/TemplateManager.php
+++ b/lib/private/Files/Template/TemplateManager.php
@@ -179,7 +179,6 @@ class TemplateManager implements ITemplateManager {
 			if ($path instanceof Folder) {
 				return $path;
 			}
-			$this->logger->warning('Template folder ' . $path . ' not found or invalid', ['app' => 'files_templates']);
 		}
 		throw new NotFoundException();
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Regression from https://github.com/nextcloud/server/pull/49451
Resolves https://github.com/nextcloud/server/issues/50269

## Summary

Since Template folder can be defined globally in config.php, but not used by every single user, logging here is not necessary (would spam the log...) and throwing a NotFound is enough.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
