### PR TITLE
fix(settings): Fix setup check when mail_smptmode is set to "null"

### DIFF
--- a/apps/settings/lib/SetupChecks/EmailTestSuccessful.php
+++ b/apps/settings/lib/SetupChecks/EmailTestSuccessful.php
@@ -46,7 +46,9 @@ class EmailTestSuccessful implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		if ($this->wasEmailTestSuccessful()) {
+		if ($this->config->getSystemValueString('mail_smtpmode', 'smtp') === 'null') {
+			return SetupResult::success($this->l10n->t('Mail delivery is disabled by instance config "%s".', ['mail_smtpmode']));
+		} elseif ($this->wasEmailTestSuccessful()) {
 			return SetupResult::success($this->l10n->t('Email test was successfully sent'));
 		} else {
 			// If setup check could link to settings pages, this one should link to OC.generateUrl('/settings/admin')


### PR DESCRIPTION
Follow-up of https://github.com/nextcloud/server/pull/48977

## Summary

Skip irrelevant setup check when mail_smtpmode is set to "null".

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
