### PR TITLE
fix: detect deleted items as updated for smb storage

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -410,7 +410,7 @@ class SMB extends Common implements INotifyStorage {
 			return true;
 		} else {
 			$actualTime = $this->filemtime($path);
-			return $actualTime > $time;
+			return $actualTime > $time || $actualTime === 0;
 		}
 	}
 


### PR DESCRIPTION
`mtime` is 0 for deleted files