### PR TITLE
fix(files_versions): Update `unencrypted_size` during rollback

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -387,8 +387,6 @@ class Storage {
 			$files_view->touch($file, $revision);
 			Storage::scheduleExpire($user->getUID(), $file);
 
-			$node = $userFolder->get($file);
-
 			return true;
 		} elseif ($versionCreated) {
 			self::deleteVersion($users_view, $version);

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -378,7 +378,8 @@ class Storage {
 			$fileInfo->getId(), [
 				'encrypted' => $oldVersion,
 				'encryptedVersion' => $oldVersion,
-				'size' => $oldFileInfo->getSize()
+				'size' => $oldFileInfo->getData()['size'],
+				'unencrypted_size' => $oldFileInfo->getData()['unencrypted_size'],
 			]
 		);
 


### PR DESCRIPTION
This prevents restored versions of encrypted files from having a wrong reported size. This was blocking download.