### PR TITLE
[stable30] chore(3rdParty): Bump doctrine/dbal from 3.9.1 to 3.9.4

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1729,10 +1729,6 @@
     <InvalidArgument>
       <code><![CDATA[$params]]></code>
     </InvalidArgument>
-    <InvalidArrayOffset>
-      <code><![CDATA[$params['adapter']]]></code>
-      <code><![CDATA[$params['tablePrefix']]]></code>
-    </InvalidArrayOffset>
   </file>
   <file src="lib/private/DB/Exceptions/DbalException.php">
     <RedundantCondition>


### PR DESCRIPTION
* For https://github.com/nextcloud/3rdparty/pull/2029