### PR TITLE
test(group): fix frequent `testSearchGroups` failure

### DIFF
--- a/tests/lib/Group/Backend.php
+++ b/tests/lib/Group/Backend.php
@@ -103,14 +103,14 @@ abstract class Backend extends \Test\TestCase {
 
 	public function testSearchGroups(): void {
 		$name1 = $this->getGroupName('foobarbaz');
-		$name2 = $this->getGroupName('bazbarfoo');
+		$name2 = $this->getGroupName('bazfoobarfoo');
 		$name3 = $this->getGroupName('notme');
 
 		$this->backend->createGroup($name1);
 		$this->backend->createGroup($name2);
 		$this->backend->createGroup($name3);
 
-		$result = $this->backend->getGroups('bar');
+		$result = $this->backend->getGroups('foobar');
 		$this->assertSame(2, count($result));
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fixes one of the causes of us frequently needing to rerun unit tests. Specifically it fixes this test:

```
There was 1 failure:

1) Test\Group\DatabaseTest::testSearchGroups
Failed asserting that 3 is identical to 2.

/home/runner/actions-runner/_work/server/server/tests/lib/Group/Backend.php:133
```

Cause:

The `testSearchGroups()` test shares its group namespace with other tests. These tests often call `getGroupName()` without a parameter. This causes this function to generate a random 13 character group name.

These randomized group names frequently (enough) contain the string sequence `bar` somewhere embedded in them. And `getGroups()` searches all configured groups using `ILIKE`. 

As a result, the `getGroups()` call can return results from other tests that just happen to match on `bar`.

This then leads to search here to return unexpected groups. Obviously then the assert here fails. A "good enough" solution here is to adjust the test to use a longer unique string. In my testing this small adjustment was sufficient. It can still fail in theory but should be fairly unlikely now.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [na] Screenshots before/after for front-end changes
- [na] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
