### PR TITLE
fix: don't use cached root info from shared cache if the watcher has detected an update

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -191,4 +191,8 @@ class Cache extends CacheJail {
 			return null;
 		}
 	}
+
+	public function markRootChanged(): void {
+		$this->rootUnchanged = false;
+	}
 }

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -441,7 +441,12 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 			// for shares from the home storage we can rely on the home storage to keep itself up to date
 			// for other storages we need use the proper watcher
 			if (!(str_starts_with($storageId, 'home::') || str_starts_with($storageId, 'object::user'))) {
+				$cache = $this->getCache();
 				$this->watcher = parent::getWatcher($path, $storage);
+				if ($cache instanceof Cache) {
+					$this->watcher->onUpdate($cache->markRootChanged(...));
+				}
+
 				return $this->watcher;
 			}
 		}

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -14,6 +14,7 @@ use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\View;
 use OCA\Files_Sharing\SharedStorage;
 use OCP\Constants;
+use OCP\Files\Cache\IWatcher;
 use OCP\Share\IShare;
 
 /**
@@ -566,5 +567,39 @@ class CacheTest extends TestCase {
 
 		$results = $sharedStorage->getCache()->search('foo.txt');
 		$this->assertCount(1, $results);
+	}
+
+	public function testWatcherRootChange() {
+		$sourceStorage = new Temporary();
+		$sourceStorage->mkdir('shared');
+		$sourceStorage->file_put_contents('shared/foo.txt', 'foo');
+		$sourceStorage->getScanner()->scan('');
+		$sourceStorage->getWatcher()->setPolicy(IWatcher::CHECK_ALWAYS);
+		$this->registerMount(self::TEST_FILES_SHARING_API_USER1, $sourceStorage, '/' . self::TEST_FILES_SHARING_API_USER1 . '/files/foo');
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
+
+		$rootFolder = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1);
+		$node = $rootFolder->get('foo/shared');
+		$this->assertEquals(3, $node->getSize());
+
+		$share = $this->shareManager->newShare();
+		$share->setNode($node)
+			->setShareType(IShare::TYPE_USER)
+			->setSharedWith(self::TEST_FILES_SHARING_API_USER2)
+			->setSharedBy(self::TEST_FILES_SHARING_API_USER1)
+			->setPermissions(Constants::PERMISSION_ALL);
+		$share = $this->shareManager->createShare($share);
+		$share->setStatus(IShare::STATUS_ACCEPTED);
+		$this->shareManager->updateShare($share);
+		\OC_Util::tearDownFS();
+
+		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
+
+		$view = Filesystem::getView();
+
+		$sourceStorage->rmdir('shared');
+
+		$this->assertFalse($view->getFileInfo('shared'));
 	}
 }

--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -33,6 +33,9 @@ class Watcher implements IWatcher {
 	 */
 	protected $scanner;
 
+	/** @var callable[] */
+	protected $onUpdate = [];
+
 	/**
 	 * @param \OC\Files\Storage\Storage $storage
 	 */
@@ -100,6 +103,9 @@ class Watcher implements IWatcher {
 		if ($this->cache instanceof Cache) {
 			$this->cache->correctFolderSize($path);
 		}
+		foreach ($this->onUpdate as $callback) {
+			$callback($path);
+		}
 	}
 
 	/**
@@ -129,5 +135,12 @@ class Watcher implements IWatcher {
 				$this->cache->remove($entry['path']);
 			}
 		}
+	}
+
+	/**
+	 * register a callback to be called whenever the watcher triggers and update
+	 */
+	public function onUpdate(callable $callback): void {
+		$this->onUpdate[] = $callback;
 	}
 }

--- a/lib/private/Files/Cache/Wrapper/JailWatcher.php
+++ b/lib/private/Files/Cache/Wrapper/JailWatcher.php
@@ -55,4 +55,7 @@ class JailWatcher extends Watcher {
 		$this->watcher->cleanFolder($this->getSourcePath($path));
 	}
 
+	public function onUpdate(callable $callback): void {
+		$this->watcher->onUpdate($callback);
+	}
 }

--- a/lib/public/Files/Cache/IWatcher.php
+++ b/lib/public/Files/Cache/IWatcher.php
@@ -76,4 +76,10 @@ interface IWatcher {
 	 * @since 9.0.0
 	 */
 	public function cleanFolder($path);
+
+	/**
+	 * register a callback to be called whenever the watcher triggers and update
+	 * @since 31.0.0
+	 */
+	public function onUpdate(callable $callback): void;
 }


### PR DESCRIPTION
~~WIP: still want to add some tests~~