### PR TITLE
fix(files): allow triggering a Files reload directly

### DIFF
--- a/apps/files/src/actions/convertAction.ts
+++ b/apps/files/src/actions/convertAction.ts
@@ -11,7 +11,7 @@ import { t } from '@nextcloud/l10n'
 
 import AutoRenewSvg from '@mdi/svg/svg/autorenew.svg?raw'
 
-import { convertFile, convertFiles, getParentFolder } from './convertUtils'
+import { convertFile, convertFiles } from './convertUtils'
 
 type ConversionsProvider = {
 	from: string,
@@ -35,7 +35,7 @@ export const registerConvertActions = () => {
 
 			async exec(node: Node, view: View, dir: string) {
 				// If we're here, we know that the node has a fileid
-				convertFile(node.fileid as number, to, getParentFolder(view, dir))
+				convertFile(node.fileid as number, to)
 
 				// Silently terminate, we'll handle the UI in the background
 				return null
@@ -43,7 +43,7 @@ export const registerConvertActions = () => {
 
 			async execBatch(nodes: Node[], view: View, dir: string) {
 				const fileIds = nodes.map(node => node.fileid).filter(Boolean) as number[]
-				convertFiles(fileIds, to, getParentFolder(view, dir))
+				convertFiles(fileIds, to)
 
 				// Silently terminate, we'll handle the UI in the background
 				return Array(nodes.length).fill(null)

--- a/apps/files/src/views/FilesList.vue
+++ b/apps/files/src/views/FilesList.vue
@@ -533,6 +533,13 @@ export default defineComponent({
 
 		// reload on settings change
 		subscribe('files:config:updated', this.fetchContent)
+
+		// Init the global OCP.Files.App object
+		// OCP.Files is already initialized at this point
+		if (!window?.OCP?.Files?.App) {
+			window.OCP.Files.App = {}
+		}
+		Object.assign(window.OCP.Files.App, { ...window.OCP.Files.App, reload: this.fetchContent })
 	},
 
 	unmounted() {


### PR DESCRIPTION
Should simplify how we interact.
Sometimes it make sense to also just trigger a full reload directly :shrug: 

@susnux, thoughts?
I'm not 100% sire this makes sense :thinking: 

- Typings update https://github.com/nextcloud-libraries/nextcloud-typings/pull/277