### PR TITLE
fix: Properly read updater channel before returning version channel as a fallback

### DIFF
--- a/lib/public/ServerVersion.php
+++ b/lib/public/ServerVersion.php
@@ -77,6 +77,12 @@ class ServerVersion {
 	 * @since 31.0.0
 	 */
 	public function getChannel(): string {
+		$updaterChannel = Server::get(IConfig::class)->getSystemValueString('updater.release.channel', $this->channel);
+
+		if (in_array($updaterChannel, ['beta', 'stable', 'enterprise', 'git'], true)) {
+			return $updaterChannel;
+		}
+
 		return $this->channel;
 	}
 


### PR DESCRIPTION
Signed-off-by: Julius Knorr <jus@bitgrid.net>

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

While doing the upgrade to rc1 we noticed that the app store fetching did not return apps for the 31 release. This is due to a regression from https://github.com/nextcloud/server/commit/606241caebda2e01702c0d08adbc35ace8d01f13 and hasn't shown during beta as the release script will use a different channel for beta releases


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
