### PR TITLE
fix(dav): default calendar and address book not created on first login

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -81,6 +81,7 @@ use OCP\Config\BeforePreferenceDeletedEvent;
 use OCP\Config\BeforePreferenceSetEvent;
 use OCP\Contacts\IManager as IContactsManager;
 use OCP\DB\Events\AddMissingIndicesEvent;
+use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
 use OCP\Files\AppData\IAppDataFactory;
@@ -91,7 +92,6 @@ use OCP\User\Events\OutOfOfficeClearedEvent;
 use OCP\User\Events\OutOfOfficeScheduledEvent;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 use Throwable;
 use function is_null;
 

--- a/build/integration/dav_features/caldav.feature
+++ b/build/integration/dav_features/caldav.feature
@@ -87,3 +87,8 @@ Feature: caldav
     When "user0" requests principal "users/user0" on the endpoint "/remote.php/dav/principals/"
     Then The CalDAV response should be multi status
     And The CalDAV response should contain a property "{urn:ietf:params:xml:ns:caldav}schedule-default-calendar-URL" with a href value "/remote.php/dav/calendars/user0/MyCalendar2/"
+
+  Scenario: Should create default calendar on first login
+    Given user "first-login" exists
+    When "first-login" requests calendar "first-login/personal" on the endpoint "/remote.php/dav/calendars/"
+    Then The CalDAV HTTP status code should be "207"

--- a/build/integration/dav_features/carddav.feature
+++ b/build/integration/dav_features/carddav.feature
@@ -79,3 +79,7 @@ Feature: carddav
     Then The CardDAV HTTP status code should be "404"
     And The CardDAV exception is "Sabre\DAV\Exception\NotFound"
     And The CardDAV error message is "File not found: admin in 'addressbooks'"
+
+  Scenario: Should create default addressbook on first login
+    Given user "first-login" exists
+    Then "first-login" requests addressbook "first-login/contacts" with statuscode "207" on the endpoint "/remote.php/dav/addressbooks/users/"


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

Required for https://github.com/nextcloud/calendar/pull/6648

The first login hook was not triggered because the event was not checked against the correct class via `instanceof`.

Consider the following code snippet further down:
https://github.com/nextcloud/server/blob/a2c59d2c77309befa3b6469cdfd2883c09bbfc34/apps/dav/lib/AppInfo/Application.php#L217-L222

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
