### PR TITLE
Revert "fix(Share20\Manager): Ensure node is still accessible when checking share"

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1464,15 +1464,6 @@ class Manager implements IManager {
 			$this->deleteShare($share);
 			throw new ShareNotFound($this->l->t('The requested share does not exist anymore'));
 		}
-
-		try {
-			$share->getNode();
-			// Ignore share, file is still accessible
-		} catch (NotFoundException) {
-			// Access lost, but maybe only temporarily, so don't delete the share right away
-			throw new ShareNotFound($this->l->t('The requested share does not exist anymore'));
-		}
-
 		if ($this->config->getAppValue('files_sharing', 'hide_disabled_user_shares', 'no') === 'yes') {
 			$uids = array_unique([$share->getShareOwner(),$share->getSharedBy()]);
 			foreach ($uids as $uid) {


### PR DESCRIPTION
## Summary

Reverts part of https://github.com/nextcloud/server/pull/49073, as this leads to the FS being setup for everyone when setting it up for a single user.

In principle we still need some kind of check like this one to hide shares where the owner lost access, but I don't know if that is possible in any other way than basically setting up the FS for all users.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
