### PR TITLE
fix: Apply server version based cache buster to core assets

### DIFF
--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -351,7 +351,7 @@ class TemplateLayout extends \OC_Template {
 
 			$appVersion = $this->appManager->getAppVersion($appId);
 			// For shipped apps the app version is not a single source of truth, we rather also need to consider the Nextcloud version
-			if ($this->appManager->isShipped($appId)) {
+			if ($this->appManager->isShipped($appId) || $appVersion === '0') {
 				$appVersion .= '-' . self::$versionHash;
 			}
 


### PR DESCRIPTION
Should prevent caching issues of frontend assets from core after upgrades