### PR TITLE
fix: Correctly return app id and app version for `core` styles and images

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2576,15 +2576,6 @@
       <code><![CDATA[$script]]></code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/private/TemplateLayout.php">
-    <InvalidParamDefault>
-      <code><![CDATA[string]]></code>
-      <code><![CDATA[string]]></code>
-    </InvalidParamDefault>
-    <InvalidScalarArgument>
-      <code><![CDATA[$appId]]></code>
-    </InvalidScalarArgument>
-  </file>
   <file src="lib/private/URLGenerator.php">
     <InvalidReturnStatement>
       <code><![CDATA[$path]]></code>

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -27,6 +27,7 @@ use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\ServerVersion;
 use OCP\Settings\IManager as ISettingsManager;
 use Psr\Log\LoggerInterface;
 
@@ -80,6 +81,7 @@ class AppManager implements IAppManager {
 		private ICacheFactory $memCacheFactory,
 		private IEventDispatcher $dispatcher,
 		private LoggerInterface $logger,
+		private ServerVersion $serverVersion,
 	) {
 	}
 
@@ -786,8 +788,12 @@ class AppManager implements IAppManager {
 
 	public function getAppVersion(string $appId, bool $useCache = true): string {
 		if (!$useCache || !isset($this->appVersions[$appId])) {
-			$appInfo = $this->getAppInfo($appId);
-			$this->appVersions[$appId] = ($appInfo !== null && isset($appInfo['version'])) ? $appInfo['version'] : '0';
+			if ($appId === 'core') {
+				$this->appVersions[$appId] = $this->serverVersion->getVersionString();
+			} else {
+				$appInfo = $this->getAppInfo($appId);
+				$this->appVersions[$appId] = ($appInfo !== null && isset($appInfo['version'])) ? $appInfo['version'] : '0';
+			}
 		}
 		return $this->appVersions[$appId];
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -791,6 +791,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(ICacheFactory::class),
 				$c->get(IEventDispatcher::class),
 				$c->get(LoggerInterface::class),
+				$c->get(ServerVersion::class),
 			);
 		});
 		$this->registerAlias(IAppManager::class, AppManager::class);

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -344,13 +344,18 @@ class TemplateLayout extends \OC_Template {
 				return false;
 			}
 
-			$appVersion = $this->appManager->getAppVersion($appId);
-			// For shipped apps the app version is not a single source of truth, we rather also need to consider the Nextcloud version
-			if ($this->appManager->isShipped($appId)) {
-				$appVersion .= '-' . self::$versionHash;
-			}
+			if ($appId === 'core') {
+				// core is not a real app but the server itself
+				$hash = self::$versionHash;
+			} else {
+				$appVersion = $this->appManager->getAppVersion($appId);
+				// For shipped apps the app version is not a single source of truth, we rather also need to consider the Nextcloud version
+				if ($this->appManager->isShipped($appId)) {
+					$appVersion .= '-' . self::$versionHash;
+				}
 
-			$hash = substr(md5($appVersion), 0, 8);
+				$hash = substr(md5($appVersion), 0, 8);
+			}
 			self::$cacheBusterCache[$path] = $hash;
 		}
 

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -304,12 +304,7 @@ class TemplateLayout extends \OC_Template {
 		$this->assign('id-app-navigation', $renderAs === TemplateResponse::RENDER_AS_USER ? '#app-navigation' : null);
 	}
 
-	/**
-	 * @param string $path
-	 * @param string $file
-	 * @return string
-	 */
-	protected function getVersionHashSuffix($path = false, $file = false) {
+	protected function getVersionHashSuffix(string $path = '', string $file = ''): string {
 		if ($this->config->getSystemValueBool('debug', false)) {
 			// allows chrome workspace mapping in debug mode
 			return '';
@@ -322,11 +317,11 @@ class TemplateLayout extends \OC_Template {
 
 		$hash = false;
 		// Try the web-root first
-		if (is_string($path) && $path !== '') {
+		if ($path !== '') {
 			$hash = $this->getVersionHashByPath($path);
 		}
 		// If not found try the file
-		if ($hash === false && is_string($file) && $file !== '') {
+		if ($hash === false && $file !== '') {
 			$hash = $this->getVersionHashByPath($file);
 		}
 		// As a last resort we use the server version hash
@@ -376,7 +371,7 @@ class TemplateLayout extends \OC_Template {
 
 	/**
 	 * @param string $path
-	 * @return string|boolean
+	 * @return string|false
 	 */
 	public function getAppNamefromPath($path) {
 		if ($path !== '' && is_string($path)) {
@@ -384,6 +379,8 @@ class TemplateLayout extends \OC_Template {
 			if ($pathParts[0] === 'css') {
 				// This is a scss request
 				return $pathParts[1];
+			} elseif ($pathParts[0] === 'core') {
+				return 'core';
 			}
 			return end($pathParts);
 		}

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -12,7 +12,13 @@ use OC\App\InfoParser;
 use OC\AppConfig;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
-use OCP\IURLGenerator;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\ServerVersion;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
@@ -463,8 +469,8 @@ class AppTest extends \Test\TestCase {
 	 * @dataProvider appConfigValuesProvider
 	 */
 	public function testEnabledApps($user, $expectedApps, $forceAll): void {
-		$userManager = \OC::$server->getUserManager();
-		$groupManager = \OC::$server->getGroupManager();
+		$userManager = \OCP\Server::get(IUserManager::class);
+		$groupManager = \OCP\Server::get(IGroupManager::class);
 		$user1 = $userManager->createUser(self::TEST_USER1, 'NotAnEasyPassword123456+');
 		$user2 = $userManager->createUser(self::TEST_USER2, 'NotAnEasyPassword123456_');
 		$user3 = $userManager->createUser(self::TEST_USER3, 'NotAnEasyPassword123456?');
@@ -512,7 +518,7 @@ class AppTest extends \Test\TestCase {
 	 * enabled apps more than once when a user is set.
 	 */
 	public function testEnabledAppsCache(): void {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = \OCP\Server::get(IUserManager::class);
 		$user1 = $userManager->createUser(self::TEST_USER1, 'NotAnEasyPassword123456+');
 
 		\OC_User::setUserId(self::TEST_USER1);
@@ -544,8 +550,8 @@ class AppTest extends \Test\TestCase {
 	private function setupAppConfigMock() {
 		/** @var AppConfig|MockObject */
 		$appConfig = $this->getMockBuilder(AppConfig::class)
-			->setMethods(['getValues'])
-			->setConstructorArgs([\OC::$server->getDatabaseConnection()])
+			->onlyMethods(['getValues'])
+			->setConstructorArgs([\OCP\Server::get(IDBConnection::class)])
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -561,13 +567,13 @@ class AppTest extends \Test\TestCase {
 	private function registerAppConfig(AppConfig $appConfig) {
 		$this->overwriteService(AppConfig::class, $appConfig);
 		$this->overwriteService(AppManager::class, new AppManager(
-			\OC::$server->getUserSession(),
-			\OC::$server->getConfig(),
-			\OC::$server->getGroupManager(),
-			\OC::$server->getMemCacheFactory(),
-			\OC::$server->get(IEventDispatcher::class),
-			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->get(IURLGenerator::class),
+			\OCP\Server::get(IUserSession::class),
+			\OCP\Server::get(IConfig::class),
+			\OCP\Server::get(IGroupManager::class),
+			\OCP\Server::get(ICacheFactory::class),
+			\OCP\Server::get(IEventDispatcher::class),
+			\OCP\Server::get(LoggerInterface::class),
+			\OCP\Server::get(ServerVersion::class),
 		));
 	}
 


### PR DESCRIPTION
Make sure that assets loaded from `core/css` and `core/img` are correctly assigned the server version.