### PR TITLE
fix: log absolute path for locked exception

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -111,11 +111,11 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 
 			// only allow 1 process to upload a file at once but still allow reading the file while writing the part file
 			$node->acquireLock(ILockingProvider::LOCK_SHARED);
-			$this->fileView->lockFile($path . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
+			$this->fileView->lockFile($node->getPath() . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
 
 			$result = $node->put($data);
 
-			$this->fileView->unlockFile($path . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
+			$this->fileView->unlockFile($node->getPath() . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
 			$node->releaseLock(ILockingProvider::LOCK_SHARED);
 			return $result;
 		} catch (StorageNotAvailableException $e) {

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -273,7 +273,7 @@ class File extends Node implements IFile {
 				}
 			}
 		} catch (\Exception $e) {
-			if ($e instanceof LockedException) {
+			if ($e instanceof FileLocked) {
 				\OC::$server->get(LoggerInterface::class)->debug($e->getMessage(), ['exception' => $e]);
 			} else {
 				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2062,11 +2062,15 @@ class View {
 				);
 			}
 		} catch (LockedException $e) {
-			// rethrow with the a human-readable path
+			$this->logger->debug($e->getMessage(), [
+				'exception' => $e,
+				'fakeRoot' => $this->fakeRoot,
+				'absolutePath' => $absolutePath,
+			]);
 			throw new LockedException(
-				$this->getPathRelativeToFiles($absolutePath),
+				$this->getRelativePath($absolutePath) ?? $e->getPath(),
 				$e,
-				$e->getExistingLock()
+				$e->getExistingLock(),
 			);
 		}
 
@@ -2102,20 +2106,16 @@ class View {
 				);
 			}
 		} catch (LockedException $e) {
-			try {
-				// rethrow with the a human-readable path
-				throw new LockedException(
-					$this->getPathRelativeToFiles($absolutePath),
-					$e,
-					$e->getExistingLock()
-				);
-			} catch (\InvalidArgumentException $ex) {
-				throw new LockedException(
-					$absolutePath,
-					$ex,
-					$e->getExistingLock()
-				);
-			}
+			$this->logger->debug($e->getMessage(), [
+				'exception' => $e,
+				'fakeRoot' => $this->fakeRoot,
+				'absolutePath' => $absolutePath,
+			]);
+			throw new LockedException(
+				$this->getRelativePath($absolutePath) ?? $e->getPath(),
+				$e,
+				$e->getExistingLock(),
+			);
 		}
 
 		return true;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
