### PR TITLE
fix(LDAP): also log why the connection to main server failed

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -614,9 +614,11 @@ class Connection extends LDAPUtility {
 					}
 				}
 				$this->logger->warning(
-					'Main LDAP not reachable, connecting to backup',
+					'Main LDAP not reachable, connecting to backup: {msg}',
 					[
-						'app' => 'user_ldap'
+						'app' => 'user_ldap',
+						'msg' => $e->getMessage(),
+						'exception' => $e,
 					]
 				);
 			}


### PR DESCRIPTION
There are actually a handful of reasons for this, and it makes debugging easier when we now it.