### PR TITLE
fix(occ): hide sensitive data while config:app:set

### DIFF
--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -217,7 +217,7 @@ class SetConfig extends Base {
 					"<info>Config value '%s' for app '%s' is now set to '%s', stored as %s in %s</info>",
 					$configName,
 					$appName,
-					$current['value'],
+					$current['sensitive'] ? '<sensitive>' : $current['value'],
 					$current['typeString'],
 					$current['lazy'] ? 'lazy cache' : 'fast cache'
 				)


### PR DESCRIPTION
local repo copy of **approved** PR #49826 ✅ 

Closes #49826

---

## Summary

Do not display sensitive values in CLI output.

Before:
```shell
./occ config:app:set --value "secret!" --sensitive --type string my_app my_secret_pass        
```
:warning:  my pass is visible in output as plain text
```text
Config value 'my_secret_pass' for app 'my_app' is now set to 'secret!', stored as string in fast cache
```

After:
```shell
./occ config:app:set --value "secret!" --sensitive --type string my_app my_secret_pass             
```
:ballot_box_with_check:  my pass is displayed as `<sensitive>`
```text
Config value 'my_secret_pass' for app 'my_app' is now set to '<sensitive>', stored as string in fast cache
```

---

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
