### PR TITLE
files: harden thumbnail endpoint

### DIFF
--- a/apps/files/lib/Controller/ApiController.php
+++ b/apps/files/lib/Controller/ApiController.php
@@ -75,6 +75,7 @@ class ApiController extends Controller {
 	 * Gets a thumbnail of the specified file
 	 *
 	 * @since API version 1.0
+	 * @deprecated 32.0.0 Use the preview endpoint provided by core instead
 	 *
 	 * @param int $x Width of the thumbnail
 	 * @param int $y Height of the thumbnail

--- a/apps/files/openapi.json
+++ b/apps/files/openapi.json
@@ -429,6 +429,7 @@
             "get": {
                 "operationId": "api-get-thumbnail",
                 "summary": "Gets a thumbnail of the specified file",
+                "deprecated": true,
                 "tags": [
                     "api"
                 ],

--- a/apps/files/tests/Controller/ApiControllerTest.php
+++ b/apps/files/tests/Controller/ApiControllerTest.php
@@ -19,6 +19,8 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Files\Storage\ISharedStorage;
+use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
 use OCP\IL10N;
@@ -26,7 +28,9 @@ use OCP\IPreview;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Share\IAttributes;
 use OCP\Share\IManager;
+use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
@@ -173,8 +177,12 @@ class ApiControllerTest extends TestCase {
 	}
 
 	public function testGetThumbnailInvalidImage(): void {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')->with(ISharedStorage::class)->willReturn(false);
+
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(123);
+		$file->method('getStorage')->willReturn($storage);
 		$this->userFolder->method('get')
 			->with($this->equalTo('unknown.jpg'))
 			->willReturn($file);
@@ -196,9 +204,86 @@ class ApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->apiController->getThumbnail(10, 10, 'unknown.jpg'));
 	}
 
-	public function testGetThumbnail(): void {
+	public function testGetThumbnailSharedNoDownload(): void {
+		$attributes = $this->createMock(IAttributes::class);
+		$attributes->expects(self::once())
+			->method('getAttribute')
+			->with('permissions', 'download')
+			->willReturn(false);
+
+		$share = $this->createMock(IShare::class);
+		$share->expects(self::once())
+			->method('getAttributes')
+			->willReturn($attributes);
+
+		$storage = $this->createMock(ISharedStorage::class);
+		$storage->expects(self::once())
+			->method('instanceOfStorage')
+			->with(ISharedStorage::class)
+			->willReturn(true);
+		$storage->expects(self::once())
+			->method('getShare')
+			->willReturn($share);
+
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(123);
+		$file->method('getStorage')->willReturn($storage);
+
+		$this->userFolder->method('get')
+			->with('unknown.jpg')
+			->willReturn($file);
+
+		$this->preview->expects($this->never())
+			->method('getPreview');
+
+		$expected = new DataResponse(['message' => 'File not found.'], Http::STATUS_NOT_FOUND);
+		$this->assertEquals($expected, $this->apiController->getThumbnail(10, 10, 'unknown.jpg'));
+	}
+
+	public function testGetThumbnailShared(): void {
+		$share = $this->createMock(IShare::class);
+		$share->expects(self::once())
+			->method('getAttributes')
+			->willReturn(null);
+
+		$storage = $this->createMock(ISharedStorage::class);
+		$storage->expects(self::once())
+			->method('instanceOfStorage')
+			->with(ISharedStorage::class)
+			->willReturn(true);
+		$storage->expects(self::once())
+			->method('getShare')
+			->willReturn($share);
+
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(123);
+		$file->method('getStorage')->willReturn($storage);
+
+		$this->userFolder->method('get')
+			->with($this->equalTo('known.jpg'))
+			->willReturn($file);
+		$preview = $this->createMock(ISimpleFile::class);
+		$preview->method('getName')->willReturn('my name');
+		$preview->method('getMTime')->willReturn(42);
+		$this->preview->expects($this->once())
+			->method('getPreview')
+			->with($this->equalTo($file), 10, 10, true)
+			->willReturn($preview);
+
+		$ret = $this->apiController->getThumbnail(10, 10, 'known.jpg');
+
+		$this->assertEquals(Http::STATUS_OK, $ret->getStatus());
+		$this->assertInstanceOf(FileDisplayResponse::class, $ret);
+	}
+
+	public function testGetThumbnail(): void {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('instanceOfStorage')->with(ISharedStorage::class)->willReturn(false);
+
+		$file = $this->createMock(File::class);
+		$file->method('getId')->willReturn(123);
+		$file->method('getStorage')->willReturn($storage);
+
 		$this->userFolder->method('get')
 			->with($this->equalTo('known.jpg'))
 			->willReturn($file);


### PR DESCRIPTION
## Summary

- Catch also "forbidden access" exceptions and return consistent 404
- Do not allow thumbnails of download-forbidden files
- [32 only] deprecate this endpoint - there is no benefit over the existing preview endpoint and it is not used by us anymore
  - https://github.com/nextcloud/documentation/pull/12535

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
