### PR TITLE
[stable30] fix: storage wrapper / files scanner do not array access on null

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -510,7 +510,9 @@ class Encoding extends Wrapper {
 
 	public function getMetaData($path) {
 		$entry = $this->storage->getMetaData($this->findPathToUse($path));
-		$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');
+		if ($entry !== null) {
+			$entry['name'] = trim(Filesystem::normalizePath($entry['name']), '/');
+		}
 		return $entry;
 	}
 

--- a/tests/lib/Files/Storage/Wrapper/EncodingTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncodingTest.php
@@ -240,4 +240,12 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		$entry = $this->instance->getMetaData('/test/' . self::NFD_NAME);
 		$this->assertEquals(self::NFC_NAME, $entry['name']);
 	}
+
+	/**
+	 * Regression test of https://github.com/nextcloud/server/issues/50431
+	 */
+	public function testNoMetadata() {
+		$this->assertNull($this->instance->getMetaData('/test/null'));
+	}
+
 }


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/50431

## Summary

- Do not try to set a value on null
- harden files scanner by checking values correctly and fixing type issues
  - see https://github.com/nextcloud/server/pull/50436

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
