### PR TITLE
fix: Ensure `label` is always a string

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -740,7 +740,10 @@ class ShareAPIController extends OCSController {
 			}
 
 			// If we have a label, use it
-			if (!empty($label)) {
+			if ($label !== '') {
+				if (strlen($label) > 255) {
+					throw new OCSBadRequestException('Maximum label length is 255');
+				}
 				$share->setLabel($label);
 			}
 

--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -1008,7 +1008,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		$share->setPassword($data['password']);
 		$passwordExpirationTime = \DateTime::createFromFormat('Y-m-d H:i:s', $data['password_expiration_time'] ?? '');
 		$share->setPasswordExpirationTime($passwordExpirationTime !== false ? $passwordExpirationTime : null);
-		$share->setLabel($data['label']);
+		$share->setLabel($data['label'] ?? '');
 		$share->setSendPasswordByTalk((bool)$data['password_by_talk']);
 		$share->setHideDownload((bool)$data['hide_download']);
 		$share->setReminderSent((bool)$data['reminder_sent']);

--- a/lib/private/Share20/Share.php
+++ b/lib/private/Share20/Share.php
@@ -66,14 +66,13 @@ class Share implements IShare {
 	private $shareTime;
 	/** @var bool */
 	private $mailSend;
-	/** @var string */
-	private $label = '';
 	/** @var ICacheEntry|null */
 	private $nodeCacheEntry;
 	/** @var bool */
 	private $hideDownload = false;
 	private bool $reminderSent = false;
 
+	private string $label = '';
 	private bool $noExpirationDate = false;
 
 	public function __construct(


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/49548

## Summary

Ensure a string is set also for the mail provider and validate valid length of it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
