### PR TITLE
fix: Check that user actually can validate password for js

### DIFF
--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -67,7 +67,7 @@ class JSConfigHelper {
 
 			$backend = $this->currentUser->getBackend();
 			if ($backend instanceof IPasswordConfirmationBackend) {
-				$userBackendAllowsPasswordConfirmation = $backend->canConfirmPassword($uid);
+				$userBackendAllowsPasswordConfirmation = $backend->canConfirmPassword($uid) && $this->canUserValidatePassword();
 			} elseif (isset($this->excludedUserBackEnds[$this->currentUser->getBackendClassName()])) {
 				$userBackendAllowsPasswordConfirmation = false;
 			}


### PR DESCRIPTION
Add missing check for js template

* Fix https://github.com/zorn-v/nextcloud-social-login/issues/494
* Fix #51919

