### PR TITLE
fix(Collaboration): Deduplicate email shares if remote share with same label exists

### DIFF
--- a/lib/private/Collaboration/Collaborators/SearchResult.php
+++ b/lib/private/Collaboration/Collaborators/SearchResult.php
@@ -78,6 +78,8 @@ class SearchResult implements ISearchResult {
 			foreach ($resultArray as $k => $result) {
 				if ($result['value']['shareWith'] === $collaboratorId) {
 					unset($resultArray[$k]);
+					// Ensure no gaps after removing the result
+					$resultArray = array_values($resultArray);
 					$actionDone = true;
 				}
 			}

--- a/tests/lib/Collaboration/Collaborators/SearchTest.php
+++ b/tests/lib/Collaboration/Collaborators/SearchTest.php
@@ -249,6 +249,42 @@ class SearchTest extends TestCase {
 				],
 				false, // expected more results indicator
 			],
+			// Remove emails if there is a remote with same label even if non exact match
+			[
+				'test@example',
+				[IShare::TYPE_REMOTE, IShare::TYPE_EMAIL],
+				1,
+				10,
+				[],
+				[],
+				[
+					'results' => [
+						['label' => 'remote', 'value' => ['shareType' => IShare::TYPE_REMOTE, 'shareWith' => 'test@example.com']],
+						['label' => 'remote', 'value' => ['shareType' => IShare::TYPE_REMOTE, 'shareWith' => 'alice@example.com']],
+					],
+					'exact' => [],
+					'exactIdMatch' => false,
+				],
+				[
+					['label' => 'email', 'value' => ['shareType' => IShare::TYPE_EMAIL, 'shareWith' => 'test@example.com']],
+					['label' => 'email', 'value' => ['shareType' => IShare::TYPE_EMAIL, 'shareWith' => 'bob@example.com']],
+				],
+				[
+					'exact' => [
+						'remotes' => [],
+						'emails' => [],
+					],
+					'remotes' => [
+						['label' => 'remote', 'value' => ['shareType' => IShare::TYPE_REMOTE, 'shareWith' => 'test@example.com']],
+						['label' => 'remote', 'value' => ['shareType' => IShare::TYPE_REMOTE, 'shareWith' => 'alice@example.com']],
+					],
+					'emails' => [
+						// test@example.com email is not present
+						['label' => 'email', 'value' => ['shareType' => IShare::TYPE_EMAIL, 'shareWith' => 'bob@example.com']],
+					]
+				],
+				false,
+			],
 		];
 	}
 }


### PR DESCRIPTION
## Summary

The current logic only deduplicates based on the `uuid`. This doesn't work in all scenarios, so just deduplicate by the label which would be the email or federated cloud ID.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
