### PR TITLE
[stable31] build(deps): Bump doctrine/dbal from 3.9.1 to 3.9.4

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1620,10 +1620,6 @@
     <InvalidArgument>
       <code><![CDATA[$params]]></code>
     </InvalidArgument>
-    <InvalidArrayOffset>
-      <code><![CDATA[$params['adapter']]]></code>
-      <code><![CDATA[$params['tablePrefix']]]></code>
-    </InvalidArrayOffset>
   </file>
   <file src="lib/private/DB/Exceptions/DbalException.php">
     <RedundantCondition>


### PR DESCRIPTION
* [x] https://github.com/nextcloud/3rdparty/pull/2035

| Production Changes     | From  | To    | Compare                                                                |
|------------------------|-------|-------|------------------------------------------------------------------------|
| doctrine/dbal          | 3.9.1 | 3.9.4 | [...](https://github.com/doctrine/dbal/compare/3.9.1...3.9.4)          |
| doctrine/event-manager | 1.2.0 | 2.0.1 | [...](https://github.com/doctrine/event-manager/compare/1.2.0...2.0.1) |
