### PR TITLE
fix: make early check if users filesystem have a mountpoint at /<user>/files

### DIFF
--- a/lib/private/Files/Utils/Scanner.php
+++ b/lib/private/Files/Utils/Scanner.php
@@ -205,7 +205,10 @@ class Scanner extends PublicEmitter {
 				foreach (['', 'files'] as $path) {
 					if (!$storage->isCreatable($path)) {
 						$fullPath = $storage->getSourcePath($path);
-						if (!$storage->is_dir($path) && $storage->getCache()->inCache($path)) {
+						if (isset($mounts[$mount->getMountPoint() . $path . '/'])) {
+							// /<user>/files is overwritten by a mountpoint, so this check is irrelevant
+							break;
+						} elseif (!$storage->is_dir($path) && $storage->getCache()->inCache($path)) {
 							throw new NotFoundException("User folder $fullPath exists in cache but not on disk");
 						} elseif ($storage->is_dir($path)) {
 							$ownerUid = fileowner($fullPath);
@@ -213,9 +216,6 @@ class Scanner extends PublicEmitter {
 							$owner = $owner['name'] ?? $ownerUid;
 							$permissions = decoct(fileperms($fullPath));
 							throw new ForbiddenException("User folder $fullPath is not writable, folders is owned by $owner and has mode $permissions");
-						} elseif (isset($mounts[$mount->getMountPoint() . $path . '/'])) {
-							// /<user>/files is overwritten by a mountpoint, so this check is irrelevant
-							break;
 						} else {
 							// if the root exists in neither the cache nor the storage the user isn't setup yet
 							break 2;


### PR DESCRIPTION
* Resolves: follow-up to #49887

## Summary

Scanner checks both `/<user>` `/<user>/files` directories:
1. If it exists on cache and on disk
2. If it is writable
3. If by chance path is overwritten with ext mountpoint

1 can still fail, if overwritten path of 3 is cached, and default dir doesn't exist, so 3 should be check first

UPD: another issue appeared while testing, added $relativePath to NotFoundException


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
