### PR TITLE
Improve error detail when saving an incorrect LDAP config

### DIFF
--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -23,11 +23,16 @@ $connection = new \OCA\User_LDAP\Connection($ldapWrapper, $_POST['ldap_servercon
 
 try {
 	$configurationOk = true;
+	$configurationError = '';
 	$conf = $connection->getConfiguration();
 	if ($conf['ldap_configuration_active'] === '0') {
 		//needs to be true, otherwise it will also fail with an irritating message
 		$conf['ldap_configuration_active'] = '1';
-		$configurationOk = $connection->setConfiguration($conf);
+		try {
+			$configurationOk = $connection->setConfiguration($conf, throw:true);
+		} catch (ConfigurationIssueException $e) {
+			$configurationError = $e->getHint();
+		}
 	}
 	if ($configurationOk) {
 		//Configuration is okay
@@ -64,7 +69,7 @@ try {
 		}
 	} else {
 		\OC_JSON::error(['message'
-		=> $l->t('Invalid configuration. Please have a look at the logs for further details.')]);
+		=> $l->t('Invalid configuration: %s', $configurationError)]);
 	}
 } catch (\Exception $e) {
 	\OC_JSON::error(['message' => $e->getMessage()]);

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -23,19 +23,18 @@ $connection = new \OCA\User_LDAP\Connection($ldapWrapper, $_POST['ldap_servercon
 
 
 try {
-	$configurationOk = true;
 	$configurationError = '';
 	$conf = $connection->getConfiguration();
 	if ($conf['ldap_configuration_active'] === '0') {
 		//needs to be true, otherwise it will also fail with an irritating message
 		$conf['ldap_configuration_active'] = '1';
-		try {
-			$configurationOk = $connection->setConfiguration($conf, throw:true);
-		} catch (ConfigurationIssueException $e) {
-			$configurationError = $e->getHint();
-		}
 	}
-	if ($configurationOk) {
+	try {
+		$connection->setConfiguration($conf, throw:true);
+	} catch (ConfigurationIssueException $e) {
+		$configurationError = $e->getHint();
+	}
+	if ($configurationError === '') {
 		//Configuration is okay
 		/*
 		 * Closing the session since it won't be used from this point on. There might be a potential

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -1,5 +1,6 @@
 <?php
 
+use OCA\User_LDAP\Exceptions\ConfigurationIssueException;
 use OCA\User_LDAP\LDAP;
 use OCP\ISession;
 use OCP\Server;

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -30,7 +30,7 @@ try {
 		$conf['ldap_configuration_active'] = '1';
 	}
 	try {
-		$connection->setConfiguration($conf, throw:true);
+		$connection->setConfiguration($conf, throw: true);
 	} catch (ConfigurationIssueException $e) {
 		$configurationError = $e->getHint();
 	}

--- a/apps/user_ldap/composer/composer/autoload_classmap.php
+++ b/apps/user_ldap/composer/composer/autoload_classmap.php
@@ -36,6 +36,7 @@ return array(
     'OCA\\User_LDAP\\Events\\GroupBackendRegistered' => $baseDir . '/../lib/Events/GroupBackendRegistered.php',
     'OCA\\User_LDAP\\Events\\UserBackendRegistered' => $baseDir . '/../lib/Events/UserBackendRegistered.php',
     'OCA\\User_LDAP\\Exceptions\\AttributeNotSet' => $baseDir . '/../lib/Exceptions/AttributeNotSet.php',
+    'OCA\\User_LDAP\\Exceptions\\ConfigurationIssueException' => $baseDir . '/../lib/Exceptions/ConfigurationIssueException.php',
     'OCA\\User_LDAP\\Exceptions\\ConstraintViolationException' => $baseDir . '/../lib/Exceptions/ConstraintViolationException.php',
     'OCA\\User_LDAP\\Exceptions\\NoMoreResults' => $baseDir . '/../lib/Exceptions/NoMoreResults.php',
     'OCA\\User_LDAP\\Exceptions\\NotOnLDAP' => $baseDir . '/../lib/Exceptions/NotOnLDAP.php',

--- a/apps/user_ldap/composer/composer/autoload_static.php
+++ b/apps/user_ldap/composer/composer/autoload_static.php
@@ -51,6 +51,7 @@ class ComposerStaticInitUser_LDAP
         'OCA\\User_LDAP\\Events\\GroupBackendRegistered' => __DIR__ . '/..' . '/../lib/Events/GroupBackendRegistered.php',
         'OCA\\User_LDAP\\Events\\UserBackendRegistered' => __DIR__ . '/..' . '/../lib/Events/UserBackendRegistered.php',
         'OCA\\User_LDAP\\Exceptions\\AttributeNotSet' => __DIR__ . '/..' . '/../lib/Exceptions/AttributeNotSet.php',
+        'OCA\\User_LDAP\\Exceptions\\ConfigurationIssueException' => __DIR__ . '/..' . '/../lib/Exceptions/ConfigurationIssueException.php',
         'OCA\\User_LDAP\\Exceptions\\ConstraintViolationException' => __DIR__ . '/..' . '/../lib/Exceptions/ConstraintViolationException.php',
         'OCA\\User_LDAP\\Exceptions\\NoMoreResults' => __DIR__ . '/..' . '/../lib/Exceptions/NoMoreResults.php',
         'OCA\\User_LDAP\\Exceptions\\NotOnLDAP' => __DIR__ . '/..' . '/../lib/Exceptions/NotOnLDAP.php',

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -15,6 +15,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\Server;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -159,7 +160,7 @@ class Connection extends LDAPUtility {
 		$this->doNotValidate = !in_array($this->configPrefix,
 			$helper->getServerConfigurationPrefixes());
 		$this->logger = Server::get(LoggerInterface::class);
-		$this->l10n = Server::get(IL10N::class);
+		$this->l10n = Util::getL10N('user_ldap');
 	}
 
 	public function __destruct() {

--- a/apps/user_ldap/lib/Exceptions/ConfigurationIssueException.php
+++ b/apps/user_ldap/lib/Exceptions/ConfigurationIssueException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\User_LDAP\Exceptions;
+
+use OCP\HintException;
+
+class ConfigurationIssueException extends HintException {
+}

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -1340,7 +1340,7 @@ class QueryBuilder implements IQueryBuilder {
 	 * Returns the table name with database prefix as needed by the implementation
 	 *
 	 * Was protected until version 30.
-  	 *
+	 *
 	 * @param string $table
 	 * @return string
 	 */


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

- Show what is the error when validating a configuration in the LDAP settings
- [x] Check that user base and group base are under the root base

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
