### PR TITLE
fix(s3): treat empty sse_c_key as not set

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -213,7 +213,7 @@ trait S3ConnectionTrait {
 	}
 
 	protected function getSSECKey(): ?string {
-		if (isset($this->params['sse_c_key'])) {
+		if (isset($this->params['sse_c_key']) && $this->params['sse_c_key'] !== '') {
 			return $this->params['sse_c_key'];
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # _none_

## Summary

Setting the `sse_c_key` to an empty string enables encryption despite no key actually being available.

Have a look at the following usage:
https://github.com/nextcloud/server/blob/abd7958b38034ce67b34d59b8a708db95c1c1a00/lib/private/Files/ObjectStore/S3ConnectionTrait.php#L224-L228

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
