### PR TITLE
fix(performance): use low resolution for blurhash

### DIFF
--- a/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
+++ b/lib/private/Blurhash/Listener/GenerateBlurhashMetadata.php
@@ -27,7 +27,7 @@ use OCP\Lock\LockedException;
  * @template-implements IEventListener<AMetadataEvent>
  */
 class GenerateBlurhashMetadata implements IEventListener {
-	private const RESIZE_BOXSIZE = 300;
+	private const RESIZE_BOXSIZE = 30;
 
 	private const COMPONENTS_X = 4;
 	private const COMPONENTS_Y = 3;


### PR DESCRIPTION
Improve blurhash performance by using a low res image.
The results are hard to destinguish visualy.
It is a **blur** hash after all.

## Performance Impact

89 runs per minute ( up from 26)
Memory footprint of 120 MB instead of 1.1 GB.

## Screenshots

### Before: 300px width source
![Bildschirmfoto vom 2025-01-28 09-53-26](https://github.com/user-attachments/assets/0d12ac42-e10f-49aa-a178-0a16b0a20621)

### After: 30px width source
![Bildschirmfoto vom 2025-01-28 09-56-29](https://github.com/user-attachments/assets/aa43ec13-ce22-4949-b5ef-6c6fe2920b3e)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- No tests - sorry.
- Documentation does not mention blurhash yet - so no update needed.
- [x] Upload Screenshots before/after for front-end changes
- [x] Wait for profiling results to see if this has an impact.
- [x] Request Backports.
