### PR TITLE
Don't rethrow a type error

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -111,11 +111,11 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 
 			// only allow 1 process to upload a file at once but still allow reading the file while writing the part file
 			$node->acquireLock(ILockingProvider::LOCK_SHARED);
-			$this->fileView->lockFile($path . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
+			$this->fileView->lockFile($this->path . '/' . $name . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
 
 			$result = $node->put($data);
 
-			$this->fileView->unlockFile($path . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
+			$this->fileView->unlockFile($this->path . '/' . $name . '.upload.part', ILockingProvider::LOCK_EXCLUSIVE);
 			$node->releaseLock(ILockingProvider::LOCK_SHARED);
 			return $result;
 		} catch (StorageNotAvailableException $e) {

--- a/apps/dav/lib/Connector/Sabre/Server.php
+++ b/apps/dav/lib/Connector/Sabre/Server.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Connector\Sabre;
 
 use Sabre\DAV\Exception;
 use Sabre\DAV\Version;
+use TypeError;
 
 /**
  * Class \OCA\DAV\Connector\Sabre\Server
@@ -47,20 +48,17 @@ class Server extends \Sabre\DAV\Server {
 			$this->httpRequest->setBaseUrl($this->getBaseUri());
 			$this->invokeMethod($this->httpRequest, $this->httpResponse);
 		} catch (\Throwable $e) {
-			if ($e instanceof \TypeError) {
+			try {
+				$this->emit('exception', [$e]);
+			} catch (\Exception) {
+			}
+
+			if ($e instanceof TypeError) {
 				/*
 				 * The TypeError includes the file path where the error occurred,
 				 * potentially revealing the installation directory.
-				 *
-				 * By re-throwing the exception, we ensure that the
-				 * default exception handler processes it.
 				 */
-				throw $e;
-			}
-
-			try {
-				$this->emit('exception', [$e]);
-			} catch (\Exception $ignore) {
+				$e = new TypeError('A type error occurred. For more details, please refer to the logs, which provide additional context about the type error.');
 			}
 
 			$DOM = new \DOMDocument('1.0', 'utf-8');

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -2062,9 +2062,9 @@ class View {
 				);
 			}
 		} catch (LockedException $e) {
-			// rethrow with the a human-readable path
+			// rethrow with the human-readable path
 			throw new LockedException(
-				$this->getPathRelativeToFiles($absolutePath),
+				$path,
 				$e,
 				$e->getExistingLock()
 			);
@@ -2102,20 +2102,12 @@ class View {
 				);
 			}
 		} catch (LockedException $e) {
-			try {
-				// rethrow with the a human-readable path
-				throw new LockedException(
-					$this->getPathRelativeToFiles($absolutePath),
-					$e,
-					$e->getExistingLock()
-				);
-			} catch (\InvalidArgumentException $ex) {
-				throw new LockedException(
-					$absolutePath,
-					$ex,
-					$e->getExistingLock()
-				);
-			}
+			// rethrow with the a human-readable path
+			throw new LockedException(
+				$path,
+				$e,
+				$e->getExistingLock()
+			);
 		}
 
 		return true;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Follow-up for https://github.com/nextcloud/server/pull/49004
Alternative to https://github.com/nextcloud/server/pull/49960

## Summary

Rethrowing may trigger a weird code path in remote.php[^1] and therefore it's better to replace the type error with a generic one. The actual expection is still logged.

Test cases for manual testing:

- https://github.com/nextcloud/server/pull/49004#issuecomment-2505634400
- https://github.com/nextcloud/server/pull/49004#issuecomment-2505645635


[^1]: https://github.com/nextcloud/server/blob/2c773033bcf44268cad1e427fffdb9bbcc6a0327/remote.php#L27-L29

## TODO

- [ ] Review
- [ ] CI
- [ ] Update existing backports for 49004

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
