### PR TITLE
feat(S3): add SSE-C support in S3 External Storage

### DIFF
--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -41,6 +41,9 @@ class AmazonS3 extends Backend {
 				(new DefinitionParameter('useMultipartCopy', $l->t('Enable multipart copy')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
+				(new DefinitionParameter('sse_c_key', $l->t('SSE-C encryption key')))
+					->setType(DefinitionParameter::VALUE_PASSWORD)
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 			])
 			->addAuthScheme(AccessKey::SCHEME_AMAZONS3_ACCESSKEY)
 			->addAuthScheme(AuthMechanism::SCHEME_NULL)

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -113,7 +113,7 @@ class AmazonS3 extends Common {
 				$this->objectCache[$key] = $this->getConnection()->headObject([
 					'Bucket' => $this->bucket,
 					'Key' => $key
-				])->toArray();
+				] + $this->getSSECParameters())->toArray();
 			} catch (S3Exception $e) {
 				if ($e->getStatusCode() >= 500) {
 					throw $e;
@@ -207,7 +207,7 @@ class AmazonS3 extends Common {
 				'Key' => $path . '/',
 				'Body' => '',
 				'ContentType' => FileInfo::MIMETYPE_FOLDER
-			]);
+			] + $this->getSSECParameters());
 			$this->testTimeout();
 		} catch (S3Exception $e) {
 			$this->logger->error($e->getMessage(), [
@@ -507,7 +507,7 @@ class AmazonS3 extends Common {
 				'Body' => '',
 				'ContentType' => $mimeType,
 				'MetadataDirective' => 'REPLACE',
-			]);
+			] + $this->getSSECParameters());
 			$this->testTimeout();
 		} catch (S3Exception $e) {
 			$this->logger->error($e->getMessage(), [

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -213,7 +213,7 @@ trait S3ConnectionTrait {
 	}
 
 	protected function getSSECKey(): ?string {
-		if (isset($this->params['sse_c_key'])) {
+		if (isset($this->params['sse_c_key']) && !empty($this->params['sse_c_key'])) {
 			return $this->params['sse_c_key'];
 		}
 


### PR DESCRIPTION
* Resolves: #33283
* Imported from: https://github.com/nextcloud/server/pull/50326
* Closes: https://github.com/nextcloud/server/pull/50326
* Closes: https://github.com/nextcloud/server/pull/50483

## Summary

Adds missing bits to support SSE-C in S3 external storage.

Just need to add the parameter and fix two calls. All other logic is already implemented and implicitly called through the S3ConnectionTrait

Documentation PR: https://github.com/nextcloud/documentation/pull/12530

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

before: 
<img width="973" alt="Screenshot 2025-01-22 at 23 50 41" src="https://github.com/user-attachments/assets/835be8ed-2088-4ed3-8a77-172550faf61c" />

after:
<img width="970" alt="Screenshot 2025-01-22 at 23 49 44" src="https://github.com/user-attachments/assets/ef272bc6-c0d9-456b-9128-02aa500f19e6" />