### PR TITLE
fix: Show recipient email addresses in share owner notification email

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -567,7 +567,7 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 		$initiator = $this->userManager->get($share->getSharedBy());
 		$initiatorEMailAddress = ($initiator instanceof IUser) ? $initiator->getEMailAddress() : null;
 		$initiatorDisplayName = ($initiator instanceof IUser) ? $initiator->getDisplayName() : $share->getSharedBy();
-		$shareWith = $share->getSharedWith();
+		$shareWith = implode(', ', $this->getSharedWithEmails($share));
 
 		if ($initiatorEMailAddress === null) {
 			throw new \Exception(


### PR DESCRIPTION
Previously, the share owner notification email did not display the recipient email addresses, making it difficult for the owner to know who the share was sent to. This fix ensures that the recipient email addresses are included in the notification email.

| Before | After |
| ---------- | ------- |
| ![image](https://github.com/user-attachments/assets/82f5748d-7de1-4026-9556-b1fb1952b9d5) | ![image](https://github.com/user-attachments/assets/359482fd-d208-4a94-b7e4-34dc73e2b9ec) |

