### PR TITLE
fix: Send password to owner when password sending fails, regardless of enforcement

### DIFF
--- a/apps/sharebymail/lib/ShareByMailProvider.php
+++ b/apps/sharebymail/lib/ShareByMailProvider.php
@@ -272,10 +272,9 @@ class ShareByMailProvider extends DefaultShareProvider implements IShareProvider
 				// Lastly, if the mail to recipient failed, we send the password to the owner as a fallback.
 				// If a password expires, the recipient will still be able to request a new one via talk.
 				$passwordExpire = $this->config->getSystemValue('sharing.enable_mail_link_password_expiration', false);
-				$passwordEnforced = $this->shareManager->shareApiLinkEnforcePassword();
 				if ($passwordExpire === false || $share->getSendPasswordByTalk()) {
 					$send = $this->sendPassword($share, $share->getPassword(), $validEmails);
-					if ($passwordEnforced && $send === false) {
+					if ($send === false) {
 						$this->sendPasswordToOwner($share, $share->getPassword());
 					}
 				}


### PR DESCRIPTION
Previously, the `sendPasswordToOwner` method would only trigger if password enforcement was enabled and sending the password to the recipient failed. This behavior was inconsistent with the intended functionality, as the owner should receive the password whenever sending to the recipient fails, regardless of whether password enforcement is enabled.

This change ensures that the owner is notified of the password whenever sending it to the recipient fails, improving consistency and user experience.

Fixes : https://github.com/nextcloud/server/issues/50512

Uses : https://github.com/nextcloud/server/pull/50515