### PR TITLE
refactor(encoding): Check if strings are valid ASCII

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -37,7 +37,7 @@ class Encoding extends Wrapper {
 	 * Returns whether the given string is only made of ASCII characters
 	 */
 	private function isAscii(string $str): bool {
-		return !preg_match('/[\\x80-\\xff]+/', $str);
+		return mb_check_encoding($str, 'ASCII');
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Encoding.php
+++ b/lib/private/Files/Storage/Wrapper/Encoding.php
@@ -35,7 +35,7 @@ class Encoding extends Wrapper {
 	 * Returns whether the given string is only made of ASCII characters
 	 */
 	private function isAscii(string $str): bool {
-		return !preg_match('/[\\x80-\\xff]+/', $str);
+		return mb_check_encoding($str, 'ASCII');
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

`mb_check_encoding()` should be more explicit.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
