### PR TITLE
fix(ConvertType): Read dbtype in createConnectionParams and remove safeguard

### DIFF
--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -236,7 +236,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 		}
 
 		// parse hostname for unix socket
-		if (preg_match('/^(.+)(:(\d+|[^:]+))?$/', $input->getOption('hostname'), $matches)) {
+		if (preg_match('/^(.+)(:(\d+|[^:]+))?$/', $input->getArgument('hostname'), $matches)) {
 			$connectionParams['host'] = $matches[1];
 			if (isset($matches[3])) {
 				if (is_numeric($matches[3])) {

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -155,13 +155,6 @@ class ConvertType extends Command implements CompletionAwareInterface {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		// WARNING:
-		// Leave in place until #45257 is addressed to prevent data loss (hopefully in time for the next maintenance release)
-		//
-		throw new \InvalidArgumentException(
-			'This command is temporarily disabled (until the next maintenance release).'
-		);
-
 		$this->validateInput($input, $output);
 		$this->readPassword($input, $output);
 
@@ -229,7 +222,7 @@ class ConvertType extends Command implements CompletionAwareInterface {
 
 	protected function getToDBConnection(InputInterface $input, OutputInterface $output) {
 		$type = $input->getArgument('type');
-		$connectionParams = $this->connectionFactory->createConnectionParams();
+		$connectionParams = $this->connectionFactory->createConnectionParams(type: $type);
 		$connectionParams = array_merge($connectionParams, [
 			'host' => $input->getArgument('hostname'),
 			'user' => $input->getArgument('username'),

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -108,7 +108,7 @@ class ConnectionFactory {
 		$normalizedType = $this->normalizeType($type);
 		$eventManager = new EventManager();
 		$eventManager->addEventSubscriber(new SetTransactionIsolationLevel());
-		$connectionParams = $this->createConnectionParams('', $additionalConnectionParams);
+		$connectionParams = $this->createConnectionParams('', $additionalConnectionParams, $type);
 		switch ($normalizedType) {
 			case 'pgsql':
 				// pg_connect used by Doctrine DBAL does not support URI notation (enclosed in brackets)
@@ -175,12 +175,10 @@ class ConnectionFactory {
 
 	/**
 	 * Create the connection parameters for the config
-	 *
-	 * @param string $configPrefix
-	 * @return array
 	 */
-	public function createConnectionParams(string $configPrefix = '', array $additionalConnectionParams = []) {
-		$type = $this->config->getValue('dbtype', 'sqlite');
+	public function createConnectionParams(string $configPrefix = '', array $additionalConnectionParams = [], ?string $type = null) {
+		// use provided type or if null use type from config
+		$type = $type ?? $this->config->getValue('dbtype', 'sqlite');
 
 		$connectionParams = array_merge($this->getDefaultConnectionParams($type), [
 			'user' => $this->config->getValue($configPrefix . 'dbuser', $this->config->getValue('dbuser', '')),
@@ -212,7 +210,7 @@ class ConnectionFactory {
 			'tablePrefix' => $connectionParams['tablePrefix']
 		];
 
-		if ($this->config->getValue('mysql.utf8mb4', false)) {
+		if ($type === 'mysql' && $this->config->getValue('mysql.utf8mb4', false)) {
 			$connectionParams['defaultTableOptions'] = [
 				'collate' => 'utf8mb4_bin',
 				'charset' => 'utf8mb4',


### PR DESCRIPTION
## Summary

Fixes https://github.com/nextcloud/server/issues/45257
Unforked version of https://github.com/nextcloud/server/pull/48666.
While testing I also found that https://github.com/nextcloud/server/pull/39242 read the hostname wrong which never worked.

I tested it successfully like this (make sure to have `pdo_pgsql` enabled):
```
docker run --rm --network=host --env POSTGRES_PASSWORD=postgres postgres:17
./occ maintenance:install --admin-pass admin
./occ db:convert-type --all-apps --password=postgres -- pgsql postgres localhost postgres
rm data/owncloud.db
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)