### PR TITLE
fix(files_sharing): skip expiration notify for invalid share record

### DIFF
--- a/apps/files_sharing/lib/Command/ExiprationNotification.php
+++ b/apps/files_sharing/lib/Command/ExiprationNotification.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Sharing\Command;
 
+use OCA\Files_Sharing\OrphanHelper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IDBConnection;
 use OCP\Notification\IManager as NotificationManager;
@@ -23,6 +24,7 @@ class ExiprationNotification extends Command {
 		private NotificationManager $notificationManager,
 		private IDBConnection $connection,
 		private ShareManager $shareManager,
+		private OrphanHelper $orphanHelper,
 	) {
 		parent::__construct();
 	}
@@ -50,7 +52,8 @@ class ExiprationNotification extends Command {
 		foreach ($shares as $share) {
 			if ($share->getExpirationDate() === null
 				|| $share->getExpirationDate()->getTimestamp() < $minTime->getTimestamp()
-				|| $share->getExpirationDate()->getTimestamp() > $maxTime->getTimestamp()) {
+				|| $share->getExpirationDate()->getTimestamp() > $maxTime->getTimestamp()
+				|| !$this->orphanHelper->isShareValid($share->getSharedBy(), $share->getNodeId())) {
 				continue;
 			}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #50541

## Summary
When the share is expired and the file is no longer present, the expiration notification should be skipped.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
