### PR TITLE
[stable30] fix(OC_Files): Fix error response when `event` was not set

### DIFF
--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -13,6 +13,7 @@ use OCP\Files\Events\BeforeDirectFileDownloadEvent;
 use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\IRootFolder;
 use OCP\Lock\ILockingProvider;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class for file server access
@@ -202,12 +203,15 @@ class OC_Files {
 			die();
 		} catch (\Exception $ex) {
 			self::unlockAllTheFiles($dir, $files, $getType, $view, $filename);
-			OC::$server->getLogger()->logException($ex);
-			$l = \OC::$server->getL10N('lib');
-			$hint = method_exists($ex, 'getHint') ? $ex->getHint() : '';
-			if ($event && $event->getErrorMessage() !== null) {
+			$logger = \OCP\Server::get(LoggerInterface::class);
+			$logger->error($ex->getMessage(), ['exception' => $ex]);
+			$l = \OCP\Server::get(\OCP\L10N\IFactory::class)->get('lib');
+
+			$hint = ($ex instanceof \OCP\HintException) ? $ex->getHint() : '';
+			if (isset($event) && $event->getErrorMessage() !== null) {
 				$hint .= ' ' . $event->getErrorMessage();
 			}
+
 			\OC_Template::printErrorPage($l->t('Cannot download file'), $hint, 200);
 		}
 	}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/50431#issuecomment-2621632812

## Summary

Correctly handle an exception (in this case a db exception) in OC files (30 and below only).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
