### PR TITLE
Add LDAP test settings command

### DIFF
--- a/apps/user_ldap/appinfo/info.xml
+++ b/apps/user_ldap/appinfo/info.xml
@@ -64,6 +64,7 @@ A user logs into Nextcloud with their LDAP or AD credentials, and is granted acc
 		<command>OCA\User_LDAP\Command\ShowConfig</command>
 		<command>OCA\User_LDAP\Command\ShowRemnants</command>
 		<command>OCA\User_LDAP\Command\TestConfig</command>
+		<command>OCA\User_LDAP\Command\TestUserSettings</command>
 		<command>OCA\User_LDAP\Command\UpdateUUID</command>
 	</commands>
 

--- a/apps/user_ldap/composer/composer/autoload_classmap.php
+++ b/apps/user_ldap/composer/composer/autoload_classmap.php
@@ -23,6 +23,7 @@ return array(
     'OCA\\User_LDAP\\Command\\ShowConfig' => $baseDir . '/../lib/Command/ShowConfig.php',
     'OCA\\User_LDAP\\Command\\ShowRemnants' => $baseDir . '/../lib/Command/ShowRemnants.php',
     'OCA\\User_LDAP\\Command\\TestConfig' => $baseDir . '/../lib/Command/TestConfig.php',
+    'OCA\\User_LDAP\\Command\\TestUserSettings' => $baseDir . '/../lib/Command/TestUserSettings.php',
     'OCA\\User_LDAP\\Command\\UpdateUUID' => $baseDir . '/../lib/Command/UpdateUUID.php',
     'OCA\\User_LDAP\\Configuration' => $baseDir . '/../lib/Configuration.php',
     'OCA\\User_LDAP\\Connection' => $baseDir . '/../lib/Connection.php',

--- a/apps/user_ldap/composer/composer/autoload_static.php
+++ b/apps/user_ldap/composer/composer/autoload_static.php
@@ -38,6 +38,7 @@ class ComposerStaticInitUser_LDAP
         'OCA\\User_LDAP\\Command\\ShowConfig' => __DIR__ . '/..' . '/../lib/Command/ShowConfig.php',
         'OCA\\User_LDAP\\Command\\ShowRemnants' => __DIR__ . '/..' . '/../lib/Command/ShowRemnants.php',
         'OCA\\User_LDAP\\Command\\TestConfig' => __DIR__ . '/..' . '/../lib/Command/TestConfig.php',
+        'OCA\\User_LDAP\\Command\\TestUserSettings' => __DIR__ . '/..' . '/../lib/Command/TestUserSettings.php',
         'OCA\\User_LDAP\\Command\\UpdateUUID' => __DIR__ . '/..' . '/../lib/Command/UpdateUUID.php',
         'OCA\\User_LDAP\\Configuration' => __DIR__ . '/..' . '/../lib/Configuration.php',
         'OCA\\User_LDAP\\Connection' => __DIR__ . '/..' . '/../lib/Connection.php',

--- a/apps/user_ldap/lib/Command/TestUserSettings.php
+++ b/apps/user_ldap/lib/Command/TestUserSettings.php
@@ -46,6 +46,12 @@ class TestUserSettings extends Command {
 				InputOption::VALUE_REQUIRED,
 				'A group DN to check if the user is a member or not'
 			)
+			->addOption(
+				'clearcache',
+				null,
+				InputOption::VALUE_NONE,
+				'Clear the cache of the LDAP connection before the beginning of tests'
+			)
 		;
 	}
 
@@ -54,6 +60,9 @@ class TestUserSettings extends Command {
 			$uid = $input->getArgument('user');
 			$access = $this->backend->getLDAPAccess($uid);
 			$connection = $access->getConnection();
+			if ($input->getOption('clearcache')) {
+				$connection->clearCache();
+			}
 			$configPrefix = $connection->getConfigPrefix();
 			$knownDn = '';
 			if ($access->stringResemblesDN($uid)) {

--- a/apps/user_ldap/lib/Command/TestUserSettings.php
+++ b/apps/user_ldap/lib/Command/TestUserSettings.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OCA\User_LDAP\Command;
+
+use OCA\User_LDAP\Group_Proxy;
+use OCA\User_LDAP\Helper;
+use OCA\User_LDAP\Mapping\GroupMapping;
+use OCA\User_LDAP\Mapping\UserMapping;
+use OCA\User_LDAP\User\DeletedUsersIndex;
+use OCA\User_LDAP\User_Proxy;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestUserSettings extends Command {
+	public function __construct(
+		protected User_Proxy $backend,
+		protected Group_Proxy $groupBackend,
+		protected Helper $helper,
+		protected DeletedUsersIndex $dui,
+		protected UserMapping $mapping,
+		protected GroupMapping $groupMapping,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		$this
+			->setName('ldap:test-user-settings')
+			->setDescription('Runs tests and show information about user related LDAP settings')
+			->addArgument(
+				'user',
+				InputArgument::REQUIRED,
+				'the user name as used in Nextcloud, or the LDAP DN'
+			)
+			->addOption(
+				'group',
+				'g',
+				InputOption::VALUE_REQUIRED,
+				'A group DN to check if the user is a member or not'
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		try {
+			$uid = $input->getArgument('user');
+			$access = $this->backend->getLDAPAccess($uid);
+			$connection = $access->getConnection();
+			$configPrefix = $connection->getConfigPrefix();
+			$knownDn = '';
+			if ($access->stringResemblesDN($uid)) {
+				$knownDn = $uid;
+				$username = $access->dn2username($uid);
+				if ($username !== false) {
+					$uid = $username;
+				}
+			}
+
+			$dn = $this->mapping->getDNByName($uid);
+			if ($dn !== false) {
+				$output->writeln("User <info>$dn</info> is mapped with account name <info>$uid</info>.");
+				$uuid = $this->mapping->getUUIDByDN($dn);
+				$output->writeln("Known UUID is <info>$uuid</info>.");
+				if ($knownDn === '') {
+					$knownDn = $dn;
+				}
+			} else {
+				$output->writeln("User <info>$uid</info> is not mapped.");
+			}
+
+			if ($knownDn === '') {
+				return self::SUCCESS;
+			}
+
+			if (!$access->isDNPartOfBase($knownDn, $access->getConnection()->ldapBaseUsers)) {
+				$output->writeln(
+					"User <info>$knownDn</info> is not in one of the configured user bases: <info>" .
+					implode(',', $access->getConnection()->ldapBaseUsers) .
+					'</info>.'
+				);
+			}
+
+			$output->writeln("Configuration prefix is <info>$configPrefix</info>");
+			$output->writeln('');
+
+			$attributeNames = [
+				'ldapExpertUsernameAttr',
+				'ldapUuidUserAttribute',
+				'ldapExpertUUIDUserAttr',
+				'ldapQuotaAttribute',
+				'ldapEmailAttribute',
+				'ldapUserDisplayName',
+				'ldapUserDisplayName2',
+				'ldapExtStorageHomeAttribute',
+				'ldapAttributePhone',
+				'ldapAttributeWebsite',
+				'ldapAttributeAddress',
+				'ldapAttributeTwitter',
+				'ldapAttributeFediverse',
+				'ldapAttributeOrganisation',
+				'ldapAttributeRole',
+				'ldapAttributeHeadline',
+				'ldapAttributeBiography',
+				'ldapAttributeBirthDate',
+				'ldapAttributePronouns',
+			];
+			$output->writeln('Attributes set in configuration:');
+			foreach ($attributeNames as $attributeName) {
+				if ($connection->$attributeName !== '') {
+					$output->writeln("- $attributeName: <info>" . $connection->$attributeName . '</info>');
+				}
+			}
+
+			$filter = $connection->ldapUserFilter;
+			$attrs = $access->userManager->getAttributes(true);
+			$attrs[] = strtolower($connection->ldapExpertUsernameAttr);
+			if ($connection->ldapUuidUserAttribute !== 'auto') {
+				$attrs[] = strtolower($connection->ldapUuidUserAttribute);
+			}
+			$attrs[] = 'memberof';
+			$attrs = array_values(array_unique($attrs));
+			$attributes = $access->readAttributes($knownDn, $attrs, $filter);
+
+			if ($attributes === false) {
+				$output->writeln(
+					"LDAP read on <info>$knownDn</info> with filter <info>$filter</info> failed."
+				);
+				return self::FAILURE;
+			}
+
+			$output->writeln("Attributes fetched from LDAP using filter <info>$filter</info>:");
+			foreach ($attributes as $attribute => $value) {
+				$output->writeln(
+					"- $attribute: <info>" . json_encode($value) . '</info>'
+				);
+			}
+
+			$uuid = $access->getUUID($knownDn);
+			if ($connection->ldapUuidUserAttribute === 'auto') {
+				$output->writeln('<error>Failed to detect UUID attribute</error>');
+			} else {
+				$output->writeln('Detected UUID attribute: <info>' . $connection->ldapUuidUserAttribute . '</info>');
+			}
+			if ($uuid === false) {
+				$output->writeln("<error>Failed to find UUID for $knownDn</error>");
+			} else {
+				$output->writeln("UUID for <info>$knownDn</info>: <info>$uuid</info>");
+			}
+
+			$groupLdapInstance = $this->groupBackend->getBackend($configPrefix);
+
+			$output->writeln('');
+			$output->writeln('Group information:');
+
+			$attributeNames = [
+				'ldapDynamicGroupMemberURL',
+				'ldapGroupFilter',
+				'ldapGroupMemberAssocAttr',
+			];
+			$output->writeln('Configuration:');
+			foreach ($attributeNames as $attributeName) {
+				if ($connection->$attributeName !== '') {
+					$output->writeln("- $attributeName: <info>" . $connection->$attributeName . '</info>');
+				}
+			}
+
+			$primaryGroup = $groupLdapInstance->getUserPrimaryGroup($knownDn);
+			$output->writeln('Primary group: <info>' . ($primaryGroup !== false? $primaryGroup:'') . '</info>');
+
+			$groupByGid = $groupLdapInstance->getUserGroupByGid($knownDn);
+			$output->writeln('Group from gidNumber: <info>' . ($groupByGid !== false? $groupByGid:'') . '</info>');
+
+			$groups = $groupLdapInstance->getUserGroups($uid);
+			$output->writeln('All known groups: <info>' . json_encode($groups) . '</info>');
+
+			$memberOfUsed = ((int)$access->connection->hasMemberOfFilterSupport === 1
+				&& (int)$access->connection->useMemberOfToDetectMembership === 1);
+
+			$output->writeln('MemberOf usage: <info>' . ($memberOfUsed ? 'on' : 'off') . '</info> (' . $access->connection->hasMemberOfFilterSupport . ',' . $access->connection->useMemberOfToDetectMembership . ')');
+
+			$gid = (string)$input->getOption('group');
+			if ($gid === '') {
+				return self::SUCCESS;
+			}
+
+			$output->writeln('');
+			$output->writeln("Group $gid:");
+			$knownGroupDn = '';
+			if ($access->stringResemblesDN($gid)) {
+				$knownGroupDn = $gid;
+				$groupname = $access->dn2groupname($gid);
+				if ($groupname !== false) {
+					$gid = $groupname;
+				}
+			}
+
+			$groupDn = $this->groupMapping->getDNByName($gid);
+			if ($groupDn !== false) {
+				$output->writeln("Group <info>$groupDn</info> is mapped with name <info>$gid</info>.");
+				$groupUuid = $this->groupMapping->getUUIDByDN($groupDn);
+				$output->writeln("Known UUID is <info>$groupUuid</info>.");
+				if ($knownGroupDn === '') {
+					$knownGroupDn = $groupDn;
+				}
+			} else {
+				$output->writeln("Group <info>$gid</info> is not mapped.");
+			}
+
+			$members = $groupLdapInstance->usersInGroup($gid);
+			$output->writeln('Members: <info>' . json_encode($members) . '</info>');
+
+			return self::SUCCESS;
+
+		} catch (\Exception $e) {
+			$output->writeln('<error>' . $e->getMessage() . '</error>');
+			return self::FAILURE;
+		}
+	}
+}

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -131,9 +131,7 @@ class Group_Proxy extends Proxy implements GroupInterface, IGroupLDAP, IGetDispl
 		$groups = [];
 		foreach ($this->backends as $backend) {
 			$backendGroups = $backend->getUserGroups($uid);
-			if (is_array($backendGroups)) {
-				$groups = array_merge($groups, $backendGroups);
-			}
+			$groups = array_merge($groups, $backendGroups);
 		}
 
 		return array_values(array_unique($groups));

--- a/apps/user_ldap/lib/Group_Proxy.php
+++ b/apps/user_ldap/lib/Group_Proxy.php
@@ -18,11 +18,10 @@ use OCP\GroupInterface;
 use OCP\IConfig;
 use OCP\IUserManager;
 
+/**
+ * @template-extends Proxy<Group_LDAP>
+ */
 class Group_Proxy extends Proxy implements GroupInterface, IGroupLDAP, IGetDisplayNameBackend, INamedBackend, IDeleteGroupBackend, IBatchMethodsBackend, IIsAdminBackend {
-	private $backends = [];
-	private ?Group_LDAP $refBackend = null;
-	private bool $isSetUp = false;
-
 	public function __construct(
 		private Helper $helper,
 		ILDAPWrapper $ldap,
@@ -31,24 +30,12 @@ class Group_Proxy extends Proxy implements GroupInterface, IGroupLDAP, IGetDispl
 		private IConfig $config,
 		private IUserManager $ncUserManager,
 	) {
-		parent::__construct($ldap, $accessFactory);
+		parent::__construct($helper, $ldap, $accessFactory);
 	}
 
-	protected function setup(): void {
-		if ($this->isSetUp) {
-			return;
-		}
 
-		$serverConfigPrefixes = $this->helper->getServerConfigurationPrefixes(true);
-		foreach ($serverConfigPrefixes as $configPrefix) {
-			$this->backends[$configPrefix] =
-				new Group_LDAP($this->getAccess($configPrefix), $this->groupPluginManager, $this->config, $this->ncUserManager);
-			if (is_null($this->refBackend)) {
-				$this->refBackend = $this->backends[$configPrefix];
-			}
-		}
-
-		$this->isSetUp = true;
+	protected function newInstance(string $configPrefix): Group_LDAP {
+		return new Group_LDAP($this->getAccess($configPrefix), $this->groupPluginManager, $this->config, $this->ncUserManager);
 	}
 
 	/**

--- a/apps/user_ldap/lib/Proxy.php
+++ b/apps/user_ldap/lib/Proxy.php
@@ -12,13 +12,24 @@ use OCA\User_LDAP\Mapping\UserMapping;
 use OCP\ICache;
 use OCP\Server;
 
+/**
+ * @template T
+ */
 abstract class Proxy {
 	/** @var array<string,Access> */
 	private static array $accesses = [];
 	private ?bool $isSingleBackend = null;
 	private ?ICache $cache = null;
 
+	/** @var T[] */
+	protected array $backends = [];
+	/** @var ?T */
+	protected $refBackend = null;
+
+	protected bool $isSetUp = false;
+
 	public function __construct(
+		private Helper $helper,
 		private ILDAPWrapper $ldap,
 		private AccessFactory $accessFactory,
 	) {
@@ -26,6 +37,36 @@ abstract class Proxy {
 		if ($memcache->isAvailable()) {
 			$this->cache = $memcache->createDistributed();
 		}
+	}
+
+	protected function setup(): void {
+		if ($this->isSetUp) {
+			return;
+		}
+
+		$serverConfigPrefixes = $this->helper->getServerConfigurationPrefixes(true);
+		foreach ($serverConfigPrefixes as $configPrefix) {
+			$this->backends[$configPrefix] = $this->newInstance($configPrefix);
+
+			if (is_null($this->refBackend)) {
+				$this->refBackend = $this->backends[$configPrefix];
+			}
+		}
+
+		$this->isSetUp = true;
+	}
+
+	/**
+	 * @return T
+	 */
+	abstract protected function newInstance(string $configPrefix): object;
+
+	/**
+	 * @return T
+	 */
+	public function getBackend(string $configPrefix): object {
+		$this->setup();
+		return $this->backends[$configPrefix];
 	}
 
 	private function addAccess(string $configPrefix): void {


### PR DESCRIPTION
* Resolves: #44850 

## Summary

To help debugging issues related to LDAP configuration, this command shows how Nextcloud sees a specific LDAP user, and if provided an associated group.
This should help debugging situations where group<>member association is not working as expected, and may also help in any situation where LDAP configuration is involved.

![Copie d'écran_20250130_120330](https://github.com/user-attachments/assets/988ed9d0-6cac-4a0d-9d13-23bfc468016f)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
