### PR TITLE
fix(files): Fix folder preview for favorites widget

### DIFF
--- a/apps/files/lib/Dashboard/FavoriteWidget.php
+++ b/apps/files/lib/Dashboard/FavoriteWidget.php
@@ -18,6 +18,7 @@ use OCP\Dashboard\Model\WidgetButton;
 use OCP\Dashboard\Model\WidgetItem;
 use OCP\Dashboard\Model\WidgetItems;
 use OCP\Dashboard\Model\WidgetOptions;
+use OCP\Files\File;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\IRootFolder;
 use OCP\IL10N;
@@ -88,13 +89,17 @@ class FavoriteWidget implements IIconWidget, IAPIWidgetV2, IButtonWidget, IOptio
 				$url = $this->urlGenerator->linkToRouteAbsolute(
 					'files.view.showFile', ['fileid' => $node->getId()]
 				);
-				$icon = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', [
-					'x' => 256,
-					'y' => 256,
-					'fileId' => $node->getId(),
-					'c' => $node->getEtag(),
-					'mimeFallback' => true,
-				]);
+				if ($node instanceof File) {
+					$icon = $this->urlGenerator->linkToRouteAbsolute('core.Preview.getPreviewByFileId', [
+						'x' => 256,
+						'y' => 256,
+						'fileId' => $node->getId(),
+						'c' => $node->getEtag(),
+						'mimeFallback' => true,
+					]);
+				} else {
+					$icon = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'filetypes/folder.svg'));
+				}
 				$favoriteNodes[] = new WidgetItem(
 					$node->getName(),
 					'',


### PR DESCRIPTION
## Summary

Folders don't have a preview and result in 404.
Alternatively we could change the endpoint to also generate "previews" for folders when mimeFallback=true.
That would make it more robust overall which would be nice.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
