### PR TITLE
Enh/apply rector set to apps

### DIFF
--- a/apps/comments/lib/Search/LegacyProvider.php
+++ b/apps/comments/lib/Search/LegacyProvider.php
@@ -14,7 +14,9 @@ use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IUser;
+use OCP\IUserSession;
 use OCP\Search\Provider;
+use OCP\Server;
 use function count;
 
 class LegacyProvider extends Provider {
@@ -26,8 +28,8 @@ class LegacyProvider extends Provider {
 	 * @since 7.0.0
 	 */
 	public function search($query): array {
-		$cm = \OC::$server->get(ICommentsManager::class);
-		$us = \OC::$server->getUserSession();
+		$cm = Server::get(ICommentsManager::class);
+		$us = Server::get(IUserSession::class);
 
 		$user = $us->getUser();
 		if (!$user instanceof IUser) {

--- a/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
+++ b/apps/comments/tests/Unit/AppInfo/ApplicationTest.php
@@ -9,6 +9,9 @@ namespace OCA\Comments\Tests\Unit\AppInfo;
 
 use OCA\Comments\AppInfo\Application;
 use OCA\Comments\Notification\Notifier;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -21,12 +24,12 @@ use Test\TestCase;
 class ApplicationTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
-		\OC::$server->getUserManager()->createUser('dummy', '456');
-		\OC::$server->getUserSession()->setUser(\OC::$server->getUserManager()->get('dummy'));
+		Server::get(IUserManager::class)->createUser('dummy', '456');
+		Server::get(IUserSession::class)->setUser(Server::get(IUserManager::class)->get('dummy'));
 	}
 
 	protected function tearDown(): void {
-		\OC::$server->getUserManager()->get('dummy')->delete();
+		Server::get(IUserManager::class)->get('dummy')->delete();
 		parent::tearDown();
 	}
 

--- a/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
+++ b/apps/contactsinteraction/tests/Db/RecentContactMapperTest.php
@@ -12,6 +12,7 @@ use OCA\ContactsInteraction\Db\RecentContact;
 use OCA\ContactsInteraction\Db\RecentContactMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IUser;
+use OCP\Server;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\UUIDUtil;
 use Test\TestCase;
@@ -30,8 +31,8 @@ class RecentContactMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->recentContactMapper = \OC::$server->get(RecentContactMapper::class);
-		$this->time = \OC::$server->get(ITimeFactory::class);
+		$this->recentContactMapper = Server::get(RecentContactMapper::class);
+		$this->time = Server::get(ITimeFactory::class);
 	}
 
 	protected function tearDown(): void {

--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -20,38 +20,47 @@ use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
+use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Security\Bruteforce\IThrottler;
+use OCP\Security\ISecureRandom;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 $authBackend = new Auth(
-	\OC::$server->getSession(),
-	\OC::$server->getUserSession(),
-	\OC::$server->getRequest(),
-	\OC::$server->getTwoFactorAuthManager(),
-	\OC::$server->getBruteForceThrottler(),
+	Server::get(ISession::class),
+	Server::get(IUserSession::class),
+	Server::get(IRequest::class),
+	Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
+	Server::get(IThrottler::class),
 	'principals/'
 );
 $principalBackend = new Principal(
-	\OC::$server->getUserManager(),
-	\OC::$server->getGroupManager(),
-	\OC::$server->get(IAccountManager::class),
-	\OC::$server->getShareManager(),
-	\OC::$server->getUserSession(),
-	\OC::$server->getAppManager(),
-	\OC::$server->query(ProxyMapper::class),
-	\OC::$server->get(KnownUserService::class),
-	\OC::$server->getConfig(),
+	Server::get(IUserManager::class),
+	Server::get(IGroupManager::class),
+	Server::get(IAccountManager::class),
+	Server::get(\OCP\Share\IManager::class),
+	Server::get(IUserSession::class),
+	Server::get(IAppManager::class),
+	Server::get(ProxyMapper::class),
+	Server::get(KnownUserService::class),
+	Server::get(IConfig::class),
 	\OC::$server->getL10NFactory(),
 	'principals/'
 );
-$db = \OC::$server->getDatabaseConnection();
-$userManager = \OC::$server->getUserManager();
-$random = \OC::$server->getSecureRandom();
-$logger = \OC::$server->get(LoggerInterface::class);
-$dispatcher = \OC::$server->get(IEventDispatcher::class);
-$config = \OC::$server->get(IConfig::class);
+$db = Server::get(IDBConnection::class);
+$userManager = Server::get(IUserManager::class);
+$random = Server::get(ISecureRandom::class);
+$logger = Server::get(LoggerInterface::class);
+$dispatcher = Server::get(IEventDispatcher::class);
+$config = Server::get(IConfig::class);
 
 $calDavBackend = new CalDavBackend(
 	$db,
@@ -61,12 +70,12 @@ $calDavBackend = new CalDavBackend(
 	$logger,
 	$dispatcher,
 	$config,
-	OC::$server->get(\OCA\DAV\CalDAV\Sharing\Backend::class),
+	Server::get(\OCA\DAV\CalDAV\Sharing\Backend::class),
 	true
 );
 
-$debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
-$sendInvitations = \OC::$server->getConfig()->getAppValue('dav', 'sendInvitations', 'yes') === 'yes';
+$debugging = Server::get(IConfig::class)->getSystemValue('debug', false);
+$sendInvitations = Server::get(IConfig::class)->getAppValue('dav', 'sendInvitations', 'yes') === 'yes';
 
 // Root nodes
 $principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend);
@@ -83,11 +92,11 @@ $nodes = [
 // Fire up server
 $server = new \Sabre\DAV\Server($nodes);
 $server::$exposeVersion = false;
-$server->httpRequest->setUrl(\OC::$server->getRequest()->getRequestUri());
+$server->httpRequest->setUrl(Server::get(IRequest::class)->getRequestUri());
 $server->setBaseUri($baseuri);
 
 // Add plugins
-$server->addPlugin(new MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
+$server->addPlugin(new MaintenancePlugin(Server::get(IConfig::class), \OC::$server->getL10N('dav')));
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend));
 $server->addPlugin(new \Sabre\CalDAV\Plugin());
 
@@ -98,10 +107,10 @@ if ($debugging) {
 
 $server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 $server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
-$server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DefaultCalendarValidator::class)));
+$server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class)));
 
 if ($sendInvitations) {
-	$server->addPlugin(\OC::$server->query(IMipPlugin::class));
+	$server->addPlugin(Server::get(IMipPlugin::class));
 }
 $server->addPlugin(new ExceptionLoggerPlugin('caldav', $logger));
 $server->addPlugin(Server::get(RateLimitingPlugin::class));

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -23,49 +23,57 @@ use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IGroupManager;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Security\Bruteforce\IThrottler;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\CardDAV\Plugin;
 
 $authBackend = new Auth(
-	\OC::$server->getSession(),
-	\OC::$server->getUserSession(),
-	\OC::$server->getRequest(),
-	\OC::$server->getTwoFactorAuthManager(),
-	\OC::$server->getBruteForceThrottler(),
+	Server::get(ISession::class),
+	Server::get(IUserSession::class),
+	Server::get(IRequest::class),
+	Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
+	Server::get(IThrottler::class),
 	'principals/'
 );
 $principalBackend = new Principal(
-	\OC::$server->getUserManager(),
-	\OC::$server->getGroupManager(),
-	\OC::$server->get(IAccountManager::class),
-	\OC::$server->getShareManager(),
-	\OC::$server->getUserSession(),
-	\OC::$server->getAppManager(),
-	\OC::$server->query(ProxyMapper::class),
-	\OC::$server->get(KnownUserService::class),
-	\OC::$server->getConfig(),
+	Server::get(IUserManager::class),
+	Server::get(IGroupManager::class),
+	Server::get(IAccountManager::class),
+	Server::get(\OCP\Share\IManager::class),
+	Server::get(IUserSession::class),
+	Server::get(IAppManager::class),
+	Server::get(ProxyMapper::class),
+	Server::get(KnownUserService::class),
+	Server::get(IConfig::class),
 	\OC::$server->getL10NFactory(),
 	'principals/'
 );
-$db = \OC::$server->getDatabaseConnection();
+$db = Server::get(IDBConnection::class);
 $cardDavBackend = new CardDavBackend(
 	$db,
 	$principalBackend,
-	\OC::$server->getUserManager(),
-	\OC::$server->get(IEventDispatcher::class),
-	\OC::$server->get(\OCA\DAV\CardDAV\Sharing\Backend::class),
+	Server::get(IUserManager::class),
+	Server::get(IEventDispatcher::class),
+	Server::get(\OCA\DAV\CardDAV\Sharing\Backend::class),
 );
 
-$debugging = \OC::$server->getConfig()->getSystemValue('debug', false);
+$debugging = Server::get(IConfig::class)->getSystemValue('debug', false);
 
 // Root nodes
 $principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend);
 $principalCollection->disableListing = !$debugging; // Disable listing
 
-$pluginManager = new PluginManager(\OC::$server, \OC::$server->query(IAppManager::class));
-$addressBookRoot = new AddressBookRoot($principalBackend, $cardDavBackend, $pluginManager, \OC::$server->getUserSession()->getUser(), \OC::$server->get(IGroupManager::class));
+$pluginManager = new PluginManager(\OC::$server, Server::get(IAppManager::class));
+$addressBookRoot = new AddressBookRoot($principalBackend, $cardDavBackend, $pluginManager, Server::get(IUserSession::class)->getUser(), Server::get(IGroupManager::class));
 $addressBookRoot->disableListing = !$debugging; // Disable listing
 
 $nodes = [
@@ -76,10 +84,10 @@ $nodes = [
 // Fire up server
 $server = new \Sabre\DAV\Server($nodes);
 $server::$exposeVersion = false;
-$server->httpRequest->setUrl(\OC::$server->getRequest()->getRequestUri());
+$server->httpRequest->setUrl(Server::get(IRequest::class)->getRequestUri());
 $server->setBaseUri($baseuri);
 // Add plugins
-$server->addPlugin(new MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
+$server->addPlugin(new MaintenancePlugin(Server::get(IConfig::class), \OC::$server->getL10N('dav')));
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend));
 $server->addPlugin(new Plugin());
 
@@ -91,10 +99,10 @@ if ($debugging) {
 $server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 $server->addPlugin(new \Sabre\CardDAV\VCFExportPlugin());
 $server->addPlugin(new ImageExportPlugin(new PhotoCache(
-	\OC::$server->getAppDataDir('dav-photocache'),
-	\OC::$server->get(LoggerInterface::class)
+	Server::get(IAppDataFactory::class)->get('dav-photocache'),
+	Server::get(LoggerInterface::class)
 )));
-$server->addPlugin(new ExceptionLoggerPlugin('carddav', \OC::$server->get(LoggerInterface::class)));
+$server->addPlugin(new ExceptionLoggerPlugin('carddav', Server::get(LoggerInterface::class)));
 $server->addPlugin(Server::get(CardDavRateLimitingPlugin::class));
 $server->addPlugin(Server::get(CardDavValidatePlugin::class));
 

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -11,7 +11,17 @@ use OCA\DAV\Connector\Sabre\BearerAuth;
 use OCA\DAV\Connector\Sabre\ServerFactory;
 use OCA\DAV\Events\SabrePluginAddEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Mount\IMountManager;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IPreview;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\ITagManager;
+use OCP\IUserSession;
 use OCP\SabrePluginEvent;
+use OCP\Security\Bruteforce\IThrottler;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 // no php execution timeout for webdav
@@ -23,39 +33,39 @@ ignore_user_abort(true);
 // Turn off output buffering to prevent memory problems
 \OC_Util::obEnd();
 
-$dispatcher = \OC::$server->get(IEventDispatcher::class);
+$dispatcher = Server::get(IEventDispatcher::class);
 
 $serverFactory = new ServerFactory(
-	\OC::$server->getConfig(),
-	\OC::$server->get(LoggerInterface::class),
-	\OC::$server->getDatabaseConnection(),
-	\OC::$server->getUserSession(),
-	\OC::$server->getMountManager(),
-	\OC::$server->getTagManager(),
-	\OC::$server->getRequest(),
-	\OC::$server->getPreviewManager(),
+	Server::get(IConfig::class),
+	Server::get(LoggerInterface::class),
+	Server::get(IDBConnection::class),
+	Server::get(IUserSession::class),
+	Server::get(IMountManager::class),
+	Server::get(ITagManager::class),
+	Server::get(IRequest::class),
+	Server::get(IPreview::class),
 	$dispatcher,
 	\OC::$server->getL10N('dav')
 );
 
 // Backends
 $authBackend = new Auth(
-	\OC::$server->getSession(),
-	\OC::$server->getUserSession(),
-	\OC::$server->getRequest(),
-	\OC::$server->getTwoFactorAuthManager(),
-	\OC::$server->getBruteForceThrottler(),
+	Server::get(ISession::class),
+	Server::get(IUserSession::class),
+	Server::get(IRequest::class),
+	Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
+	Server::get(IThrottler::class),
 	'principals/'
 );
 $authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);
 $bearerAuthPlugin = new BearerAuth(
-	\OC::$server->getUserSession(),
-	\OC::$server->getSession(),
-	\OC::$server->getRequest()
+	Server::get(IUserSession::class),
+	Server::get(ISession::class),
+	Server::get(IRequest::class)
 );
 $authPlugin->addBackend($bearerAuthPlugin);
 
-$requestUri = \OC::$server->getRequest()->getRequestUri();
+$requestUri = Server::get(IRequest::class)->getRequestUri();
 
 $server = $serverFactory->createServer($baseuri, $requestUri, $authPlugin, function () {
 	// use the view for the logged in user

--- a/apps/dav/appinfo/v2/direct.php
+++ b/apps/dav/appinfo/v2/direct.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 use OCA\DAV\Db\DirectMapper;
 use OCA\DAV\Direct\ServerFactory;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Files\IRootFolder;
+use OCP\IRequest;
+use OCP\Security\Bruteforce\IThrottler;
+use OCP\Server;
 
 // no php execution timeout for webdav
 if (!str_contains(@ini_get('disable_functions'), 'set_time_limit')) {
@@ -19,18 +23,18 @@ ignore_user_abort(true);
 // Turn off output buffering to prevent memory problems
 \OC_Util::obEnd();
 
-$requestUri = \OC::$server->getRequest()->getRequestUri();
+$requestUri = Server::get(IRequest::class)->getRequestUri();
 
 /** @var ServerFactory $serverFactory */
-$serverFactory = \OC::$server->query(ServerFactory::class);
+$serverFactory = Server::get(ServerFactory::class);
 $server = $serverFactory->createServer(
 	$baseuri,
 	$requestUri,
-	\OC::$server->getRootFolder(),
-	\OC::$server->query(DirectMapper::class),
-	\OC::$server->query(ITimeFactory::class),
-	\OC::$server->getBruteForceThrottler(),
-	\OC::$server->getRequest()
+	Server::get(IRootFolder::class),
+	Server::get(DirectMapper::class),
+	Server::get(ITimeFactory::class),
+	Server::get(IThrottler::class),
+	Server::get(IRequest::class)
 );
 
 $server->exec();

--- a/apps/dav/appinfo/v2/remote.php
+++ b/apps/dav/appinfo/v2/remote.php
@@ -1,6 +1,7 @@
 <?php
 
 use OCA\DAV\Server;
+use OCP\IRequest;
 
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
@@ -16,6 +17,6 @@ ignore_user_abort(true);
 // Turn off output buffering to prevent memory problems
 \OC_Util::obEnd();
 
-$request = \OC::$server->getRequest();
+$request = \OCP\Server::get(IRequest::class);
 $server = new Server($request, $baseuri);
 $server->exec();

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -83,6 +83,7 @@ use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\IUserSession;
 use OCP\Server;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\BeforeUserIdUnassignedEvent;
@@ -250,7 +251,7 @@ class Application extends App implements IBootstrap {
 
 	public function registerContactsManager(IContactsManager $cm, IAppContainer $container): void {
 		$cm->register(function () use ($container, $cm): void {
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = Server::get(IUserSession::class)->getUser();
 			if (!is_null($user)) {
 				$this->setupContactsProvider($cm, $container, $user->getUID());
 			} else {
@@ -279,7 +280,7 @@ class Application extends App implements IBootstrap {
 	public function registerCalendarManager(ICalendarManager $calendarManager,
 		IAppContainer $container): void {
 		$calendarManager->register(function () use ($container, $calendarManager): void {
-			$user = \OC::$server->getUserSession()->getUser();
+			$user = Server::get(IUserSession::class)->getUser();
 			if ($user !== null) {
 				$this->setupCalendarProvider($calendarManager, $container, $user->getUID());
 			}

--- a/apps/dav/lib/Avatars/RootCollection.php
+++ b/apps/dav/lib/Avatars/RootCollection.php
@@ -7,6 +7,7 @@
 namespace OCA\DAV\Avatars;
 
 use OCP\IAvatarManager;
+use OCP\Server;
 use Sabre\DAVACL\AbstractPrincipalCollection;
 
 class RootCollection extends AbstractPrincipalCollection {
@@ -22,7 +23,7 @@ class RootCollection extends AbstractPrincipalCollection {
 	 * @return AvatarHome
 	 */
 	public function getChildForPrincipal(array $principalInfo) {
-		$avatarManager = \OC::$server->get(IAvatarManager::class);
+		$avatarManager = Server::get(IAvatarManager::class);
 		return new AvatarHome($principalInfo, $avatarManager);
 	}
 

--- a/apps/dav/lib/CalDAV/CalendarHome.php
+++ b/apps/dav/lib/CalDAV/CalendarHome.php
@@ -11,8 +11,10 @@ use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\Integration\ExternalCalendar;
 use OCA\DAV\CalDAV\Integration\ICalendarProvider;
 use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
+use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IL10N;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Backend\BackendInterface;
 use Sabre\CalDAV\Backend\NotificationSupport;
@@ -45,10 +47,10 @@ class CalendarHome extends \Sabre\CalDAV\CalendarHome {
 	) {
 		parent::__construct($caldavBackend, $principalInfo);
 		$this->l10n = \OC::$server->getL10N('dav');
-		$this->config = \OC::$server->getConfig();
+		$this->config = Server::get(IConfig::class);
 		$this->pluginManager = new PluginManager(
 			\OC::$server,
-			\OC::$server->getAppManager()
+			Server::get(IAppManager::class)
 		);
 	}
 

--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -20,8 +20,10 @@ use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\DAV\RootCollection;
 use OCA\Theming\ThemingDefaults;
+use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
+use OCP\IURLGenerator;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\ITip\Message;
@@ -42,7 +44,7 @@ class InvitationResponseServer {
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
 
 		// Add maintenance plugin
-		$this->server->addPlugin(new MaintenancePlugin(\OC::$server->getConfig(), \OC::$server->getL10N('dav')));
+		$this->server->addPlugin(new MaintenancePlugin(Server::get(IConfig::class), \OC::$server->getL10N('dav')));
 
 		// Set URL explicitly due to reverse-proxy situations
 		$this->server->httpRequest->setUrl($baseUri);
@@ -79,13 +81,13 @@ class InvitationResponseServer {
 		// calendar plugins
 		$this->server->addPlugin(new \OCA\DAV\CalDAV\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\ICSExportPlugin());
-		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(\OC::$server->getConfig(), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DefaultCalendarValidator::class)));
+		$this->server->addPlugin(new \OCA\DAV\CalDAV\Schedule\Plugin(Server::get(IConfig::class), Server::get(LoggerInterface::class), Server::get(DefaultCalendarValidator::class)));
 		$this->server->addPlugin(new \Sabre\CalDAV\Subscriptions\Plugin());
 		$this->server->addPlugin(new \Sabre\CalDAV\Notifications\Plugin());
 		//$this->server->addPlugin(new \OCA\DAV\DAV\Sharing\Plugin($authBackend, \OC::$server->getRequest()));
 		$this->server->addPlugin(new PublishPlugin(
-			\OC::$server->getConfig(),
-			\OC::$server->getURLGenerator()
+			Server::get(IConfig::class),
+			Server::get(IURLGenerator::class)
 		));
 
 		// wait with registering these until auth is handled and the filesystem is setup
@@ -93,7 +95,7 @@ class InvitationResponseServer {
 			// register plugins from apps
 			$pluginManager = new PluginManager(
 				\OC::$server,
-				\OC::$server->getAppManager()
+				Server::get(IAppManager::class)
 			);
 			foreach ($pluginManager->getAppPlugins() as $appPlugin) {
 				$this->server->addPlugin($appPlugin);

--- a/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\CalDAV\Reminder;
 
 use OCA\DAV\CalDAV\Reminder\NotificationProvider\ProviderNotAvailableException;
 use OCP\AppFramework\QueryException;
+use OCP\Server;
 
 /**
  * Class NotificationProviderManager
@@ -57,7 +58,7 @@ class NotificationProviderManager {
 	 * @throws QueryException
 	 */
 	public function registerProvider(string $providerClassName):void {
-		$provider = \OC::$server->query($providerClassName);
+		$provider = Server::get($providerClassName);
 
 		if (!$provider instanceof INotificationProvider) {
 			throw new \InvalidArgumentException('Invalid notification provider registered');

--- a/apps/dav/lib/CardDAV/UserAddressBooks.php
+++ b/apps/dav/lib/CardDAV/UserAddressBooks.php
@@ -56,7 +56,7 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 			$this->l10n = \OC::$server->getL10N('dav');
 		}
 		if ($this->config === null) {
-			$this->config = \OC::$server->getConfig();
+			$this->config = Server::get(IConfig::class);
 		}
 
 		/** @var string|array $principal */
@@ -82,8 +82,8 @@ class UserAddressBooks extends \Sabre\CardDAV\AddressBookHome {
 				$trustedServers = null;
 				$request = null;
 				try {
-					$trustedServers = \OC::$server->get(TrustedServers::class);
-					$request = \OC::$server->get(IRequest::class);
+					$trustedServers = Server::get(TrustedServers::class);
+					$request = Server::get(IRequest::class);
 				} catch (QueryException|NotFoundExceptionInterface|ContainerExceptionInterface $e) {
 					// nothing to do, the request / trusted servers don't exist
 				}

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -13,11 +13,15 @@ use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\CalDAV\Sharing\Backend;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
+use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Security\ISecureRandom;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -53,19 +57,19 @@ class CreateCalendar extends Command {
 		$principalBackend = new Principal(
 			$this->userManager,
 			$this->groupManager,
-			\OC::$server->get(IAccountManager::class),
-			\OC::$server->getShareManager(),
-			\OC::$server->getUserSession(),
-			\OC::$server->getAppManager(),
-			\OC::$server->query(ProxyMapper::class),
-			\OC::$server->get(KnownUserService::class),
-			\OC::$server->getConfig(),
+			Server::get(IAccountManager::class),
+			Server::get(\OCP\Share\IManager::class),
+			Server::get(IUserSession::class),
+			Server::get(IAppManager::class),
+			Server::get(ProxyMapper::class),
+			Server::get(KnownUserService::class),
+			Server::get(IConfig::class),
 			\OC::$server->getL10NFactory(),
 		);
-		$random = \OC::$server->getSecureRandom();
-		$logger = \OC::$server->get(LoggerInterface::class);
-		$dispatcher = \OC::$server->get(IEventDispatcher::class);
-		$config = \OC::$server->get(IConfig::class);
+		$random = Server::get(ISecureRandom::class);
+		$logger = Server::get(LoggerInterface::class);
+		$dispatcher = Server::get(IEventDispatcher::class);
+		$config = Server::get(IConfig::class);
 		$name = $input->getArgument('name');
 		$caldav = new CalDavBackend(
 			$this->dbConnection,
@@ -75,7 +79,7 @@ class CreateCalendar extends Command {
 			$logger,
 			$dispatcher,
 			$config,
-			\OC::$server->get(Backend::class),
+			Server::get(Backend::class),
 		);
 		$caldav->createCalendar("principals/users/$user", $name, []);
 		return self::SUCCESS;

--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -19,6 +19,7 @@ use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\Bruteforce\IThrottler;
 use OCP\Security\Bruteforce\MaxDelayReached;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Auth\Backend\AbstractBasic;
 use Sabre\DAV\Exception\NotAuthenticated;
@@ -108,7 +109,7 @@ class Auth extends AbstractBasic {
 		} catch (Exception $e) {
 			$class = get_class($e);
 			$msg = $e->getMessage();
-			\OCP\Server::get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
+			Server::get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
 			throw new ServiceUnavailable("$class: $msg");
 		}
 	}

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -18,6 +18,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\Folder;
 use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidPathException;
+use OCP\Files\Mount\IMountManager;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\StorageNotAvailableException;
@@ -232,8 +233,8 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 		}
 
 		$nodes = [];
-		$request = \OC::$server->get(IRequest::class);
-		$l10nFactory = \OC::$server->get(IFactory::class);
+		$request = Server::get(IRequest::class);
+		$l10nFactory = Server::get(IFactory::class);
 		$l10n = $l10nFactory->get(Application::APP_ID);
 		foreach ($folderContent as $info) {
 			$node = $this->getChild($info->getName(), $info, $request, $l10n);
@@ -286,7 +287,7 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 	}
 
 	private function getLogger(): LoggerInterface {
-		return \OC::$server->get(LoggerInterface::class);
+		return Server::get(LoggerInterface::class);
 	}
 
 	/**
@@ -380,7 +381,7 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 		$sourcePath = $sourceNode->getPath();
 
 		$isMovableMount = false;
-		$sourceMount = \OC::$server->getMountManager()->find($this->fileView->getAbsolutePath($sourcePath));
+		$sourceMount = Server::get(IMountManager::class)->find($this->fileView->getAbsolutePath($sourcePath));
 		$internalPath = $sourceMount->getInternalPath($this->fileView->getAbsolutePath($sourcePath));
 		if ($sourceMount instanceof MoveableMount && $internalPath === '') {
 			$isMovableMount = true;

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Connector\Sabre;
 use OC\AppFramework\Http\Request;
 use OC\FilesMetadata\Model\FilesMetadata;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\Files_Sharing\External\Mount as SharingExternalMount;
 use OCP\Constants;
 use OCP\Files\ForbiddenException;
 use OCP\Files\IFilenameValidator;
@@ -424,7 +425,7 @@ class FilesPlugin extends ServerPlugin {
 
 			$propFind->handle(self::IS_FEDERATED_PROPERTYNAME, function () use ($node) {
 				return $node->getFileInfo()->getMountPoint()
-					instanceof \OCA\Files_Sharing\External\Mount;
+					instanceof SharingExternalMount;
 			});
 		}
 

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -20,6 +20,7 @@ use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\ISharedStorage;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Server;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 
@@ -60,14 +61,14 @@ abstract class Node implements \Sabre\DAV\INode {
 		if ($shareManager) {
 			$this->shareManager = $shareManager;
 		} else {
-			$this->shareManager = \OC::$server->getShareManager();
+			$this->shareManager = Server::get(\OCP\Share\IManager::class);
 		}
 		if ($info instanceof Folder || $info instanceof File) {
 			$this->node = $info;
 		} else {
 			// The Node API assumes that the view passed doesn't have a fake root
-			$rootView = \OC::$server->get(View::class);
-			$root = \OC::$server->get(IRootFolder::class);
+			$rootView = Server::get(View::class);
+			$root = Server::get(IRootFolder::class);
 			if ($info->getType() === FileInfo::TYPE_FOLDER) {
 				$this->node = new Folder($root, $rootView, $this->fileView->getAbsolutePath($this->path), $info);
 			} else {
@@ -82,8 +83,8 @@ abstract class Node implements \Sabre\DAV\INode {
 			throw new \Sabre\DAV\Exception('Failed to get fileinfo for ' . $this->path);
 		}
 		$this->info = $info;
-		$root = \OC::$server->get(IRootFolder::class);
-		$rootView = \OC::$server->get(View::class);
+		$root = Server::get(IRootFolder::class);
+		$rootView = Server::get(View::class);
 		if ($this->info->getType() === FileInfo::TYPE_FOLDER) {
 			$this->node = new Folder($root, $rootView, $this->path, $this->info);
 		} else {

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -14,18 +14,23 @@ use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCA\DAV\DAV\ViewOnlyPlugin;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\Theming\ThemingDefaults;
+use OCP\App\IAppManager;
+use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Folder;
 use OCP\Files\IFilenameValidator;
 use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IPreview;
 use OCP\IRequest;
 use OCP\ITagManager;
 use OCP\IUserSession;
 use OCP\SabrePluginEvent;
+use OCP\SystemTag\ISystemTagManager;
+use OCP\SystemTag\ISystemTagObjectMapper;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Auth\Plugin;
 
@@ -141,19 +146,19 @@ class ServerFactory {
 					$objectTree,
 					$this->userSession,
 					$userFolder,
-					\OC::$server->getShareManager()
+					\OCP\Server::get(\OCP\Share\IManager::class)
 				));
-				$server->addPlugin(new CommentPropertiesPlugin(\OC::$server->getCommentsManager(), $this->userSession));
+				$server->addPlugin(new CommentPropertiesPlugin(\OCP\Server::get(ICommentsManager::class), $this->userSession));
 				$server->addPlugin(new FilesReportPlugin(
 					$objectTree,
 					$view,
-					\OC::$server->getSystemTagManager(),
-					\OC::$server->getSystemTagObjectMapper(),
-					\OC::$server->getTagManager(),
+					\OCP\Server::get(ISystemTagManager::class),
+					\OCP\Server::get(ISystemTagObjectMapper::class),
+					\OCP\Server::get(ITagManager::class),
 					$this->userSession,
-					\OC::$server->getGroupManager(),
+					\OCP\Server::get(IGroupManager::class),
 					$userFolder,
-					\OC::$server->getAppManager()
+					\OCP\Server::get(IAppManager::class)
 				));
 				// custom properties plugin must be the last one
 				$server->addPlugin(
@@ -163,7 +168,7 @@ class ServerFactory {
 							$objectTree,
 							$this->databaseConnection,
 							$this->userSession->getUser(),
-							\OC::$server->get(DefaultCalendarValidator::class),
+							\OCP\Server::get(DefaultCalendarValidator::class),
 						)
 					)
 				);
@@ -175,7 +180,7 @@ class ServerFactory {
 			$this->eventDispatcher->dispatchTyped($event);
 			$pluginManager = new PluginManager(
 				\OC::$server,
-				\OC::$server->getAppManager()
+				\OCP\Server::get(IAppManager::class)
 			);
 			foreach ($pluginManager->getAppPlugins() as $appPlugin) {
 				$server->addPlugin($appPlugin);

--- a/apps/dav/lib/Files/BrowserErrorPagePlugin.php
+++ b/apps/dav/lib/Files/BrowserErrorPagePlugin.php
@@ -77,7 +77,7 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 	 * @return bool|string
 	 */
 	public function generateBody(int $httpCode) {
-		$request = \OC::$server->getRequest();
+		$request = \OCP\Server::get(IRequest::class);
 
 		$templateName = 'exception';
 		if ($httpCode === 403 || $httpCode === 404) {

--- a/apps/dav/lib/Files/RootCollection.php
+++ b/apps/dav/lib/Files/RootCollection.php
@@ -8,6 +8,8 @@
 namespace OCA\DAV\Files;
 
 use OCP\Files\FileInfo;
+use OCP\IUserSession;
+use OCP\Server;
 use Sabre\DAV\INode;
 use Sabre\DAV\SimpleCollection;
 use Sabre\DAVACL\AbstractPrincipalCollection;
@@ -26,7 +28,7 @@ class RootCollection extends AbstractPrincipalCollection {
 	 */
 	public function getChildForPrincipal(array $principalInfo) {
 		[,$name] = \Sabre\Uri\split($principalInfo['uri']);
-		$user = \OC::$server->getUserSession()->getUser();
+		$user = Server::get(IUserSession::class)->getUser();
 		if (is_null($user) || $name !== $user->getUID()) {
 			// a user is only allowed to see their own home contents, so in case another collection
 			// is accessed, we return a simple empty collection for now

--- a/apps/dav/lib/Listener/UserEventsListener.php
+++ b/apps/dav/lib/Listener/UserEventsListener.php
@@ -17,6 +17,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\BeforeUserIdUnassignedEvent;
 use OCP\User\Events\UserChangedEvent;
@@ -135,7 +136,7 @@ class UserEventsListener implements IEventListener {
 					'components' => 'VEVENT'
 				]);
 			} catch (\Exception $e) {
-				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
+				Server::get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
 			}
 		}
 		if ($this->cardDav->getAddressBooksForUserCount($principal) === 0) {
@@ -144,7 +145,7 @@ class UserEventsListener implements IEventListener {
 					'{DAV:}displayname' => CardDavBackend::PERSONAL_ADDRESSBOOK_NAME,
 				]);
 			} catch (\Exception $e) {
-				\OC::$server->get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
+				Server::get(LoggerInterface::class)->error($e->getMessage(), ['exception' => $e]);
 			}
 		}
 	}

--- a/apps/dav/lib/Upload/UploadFolder.php
+++ b/apps/dav/lib/Upload/UploadFolder.php
@@ -11,6 +11,8 @@ use OC\Files\ObjectStore\ObjectStoreStorage;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
 use OCP\Files\Storage\IStorage;
+use OCP\ICacheFactory;
+use OCP\Server;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\ICollection;
 
@@ -60,7 +62,7 @@ class UploadFolder implements ICollection {
 			/** @var ObjectStoreStorage $storage */
 			$objectStore = $this->storage->getObjectStore();
 			if ($objectStore instanceof IObjectStoreMultiPartUpload) {
-				$cache = \OC::$server->getMemCacheFactory()->createDistributed(ChunkingV2Plugin::CACHE_KEY);
+				$cache = Server::get(ICacheFactory::class)->createDistributed(ChunkingV2Plugin::CACHE_KEY);
 				$uploadSession = $cache->get($this->getName());
 				if ($uploadSession) {
 					$uploadId = $uploadSession[ChunkingV2Plugin::UPLOAD_ID];

--- a/apps/dav/lib/Upload/UploadHome.php
+++ b/apps/dav/lib/Upload/UploadHome.php
@@ -10,6 +10,8 @@ namespace OCA\DAV\Upload;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\DAV\Connector\Sabre\Directory;
+use OCP\IUserSession;
+use OCP\Server;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\ICollection;
 
@@ -73,7 +75,7 @@ class UploadHome implements ICollection {
 
 	private function getView() {
 		$rootView = new View();
-		$user = \OC::$server->getUserSession()->getUser();
+		$user = Server::get(IUserSession::class)->getUser();
 		Filesystem::initMountPoints($user->getUID());
 		if (!$rootView->file_exists('/' . $user->getUID() . '/uploads')) {
 			$rootView->mkdir('/' . $user->getUID() . '/uploads');

--- a/apps/dav/templates/settings-admin-caldav.php
+++ b/apps/dav/templates/settings-admin-caldav.php
@@ -4,7 +4,7 @@
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-script('dav', 'settings-admin-caldav');
+\OCP\Util::addScript('dav', 'settings-admin-caldav', 'core');
 
 ?>
 

--- a/apps/dav/templates/settings-personal-availability.php
+++ b/apps/dav/templates/settings-personal-availability.php
@@ -4,7 +4,7 @@
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-script('dav', 'settings-personal-availability');
+\OCP\Util::addScript('dav', 'settings-personal-availability', 'core');
 
 ?>
 

--- a/apps/dav/tests/integration/Db/PropertyMapperTest.php
+++ b/apps/dav/tests/integration/Db/PropertyMapperTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\integration\Db;
 
 use OCA\DAV\Db\PropertyMapper;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -23,7 +24,7 @@ class PropertyMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->mapper = \OC::$server->get(PropertyMapper::class);
+		$this->mapper = Server::get(PropertyMapper::class);
 	}
 
 	public function testFindNonExistent(): void {

--- a/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
@@ -14,8 +14,10 @@ use OCA\DAV\BackgroundJob\UserStatusAutomation;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
 use OCP\User\IAvailabilityCoordinator;
 use OCP\UserStatus\IManager;
 use OCP\UserStatus\IUserStatus;
@@ -53,7 +55,7 @@ class UserStatusAutomationTest extends TestCase {
 		if (empty($methods)) {
 			return new UserStatusAutomation(
 				$this->time,
-				\OC::$server->getDatabaseConnection(),
+				Server::get(IDBConnection::class),
 				$this->jobList,
 				$this->logger,
 				$this->statusManager,
@@ -66,7 +68,7 @@ class UserStatusAutomationTest extends TestCase {
 		return $this->getMockBuilder(UserStatusAutomation::class)
 			->setConstructorArgs([
 				$this->time,
-				\OC::$server->getDatabaseConnection(),
+				Server::get(IDBConnection::class),
 				$this->jobList,
 				$this->logger,
 				$this->statusManager,

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -25,6 +25,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Security\ISecureRandom;
+use OCP\Server;
 use OCP\Share\IManager as ShareManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -87,8 +88,8 @@ abstract class AbstractCalDavBackend extends TestCase {
 			->withAnyParameters()
 			->willReturn([self::UNIT_TEST_GROUP, self::UNIT_TEST_GROUP2]);
 
-		$this->db = \OC::$server->getDatabaseConnection();
-		$this->random = \OC::$server->getSecureRandom();
+		$this->db = Server::get(IDBConnection::class);
+		$this->random = Server::get(ISecureRandom::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->sharingBackend = new SharingBackend(

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
@@ -8,6 +8,7 @@ namespace OCA\DAV\Tests\unit\CalDAV\Activity\Filter;
 use OCA\DAV\CalDAV\Activity\Filter\Calendar;
 use OCA\DAV\CalDAV\Activity\Filter\Todo;
 use OCP\Activity\IFilter;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -26,7 +27,7 @@ class GenericTest extends TestCase {
 	 * @param string $filterClass
 	 */
 	public function testImplementsInterface($filterClass): void {
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
@@ -36,7 +37,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
@@ -46,7 +47,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
@@ -56,7 +57,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$priority = $filter->getPriority();
 		$this->assertIsInt($filter->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -69,7 +70,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIcon($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIcon());
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
@@ -80,7 +81,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testFilterTypes($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
@@ -90,7 +91,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testAllowedApps($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->allowedApps());
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
@@ -9,6 +9,7 @@ use OCA\DAV\CalDAV\Activity\Setting\Calendar;
 use OCA\DAV\CalDAV\Activity\Setting\Event;
 use OCA\DAV\CalDAV\Activity\Setting\Todo;
 use OCP\Activity\ISetting;
+use OCP\Server;
 use Test\TestCase;
 
 class GenericTest extends TestCase {
@@ -25,7 +26,7 @@ class GenericTest extends TestCase {
 	 * @param string $settingClass
 	 */
 	public function testImplementsInterface($settingClass): void {
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
@@ -35,7 +36,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
@@ -45,7 +46,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
@@ -55,7 +56,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$priority = $setting->getPriority();
 		$this->assertIsInt($setting->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -68,7 +69,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeStream($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
@@ -78,7 +79,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledStream($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
@@ -88,7 +89,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeMail($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
@@ -98,7 +99,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledMail($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledMail());
 	}
 }

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -12,10 +12,12 @@ use OCA\DAV\CalDAV\PublicCalendarRoot;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\Security\ISecureRandom;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
@@ -51,11 +53,11 @@ class PublicCalendarRootTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$db = \OC::$server->getDatabaseConnection();
+		$db = Server::get(IDBConnection::class);
 		$this->principal = $this->createMock('OCA\DAV\Connector\Sabre\Principal');
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
-		$this->random = \OC::$server->getSecureRandom();
+		$this->random = Server::get(ISecureRandom::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$dispatcher = $this->createMock(IEventDispatcher::class);
 		$config = $this->createMock(IConfig::class);

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -27,6 +27,7 @@ use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Server;
 use OCP\Share\IManager as ShareManager;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Exception\BadRequest;
@@ -133,7 +134,7 @@ class CardDavBackendTest extends TestCase {
 			->willReturn([self::UNIT_TEST_GROUP]);
 		$this->dispatcher = $this->createMock(IEventDispatcher::class);
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = Server::get(IDBConnection::class);
 		$this->sharingBackend = new Backend($this->userManager,
 			$this->groupManager,
 			$this->principal,

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Tests\unit\CardDAV;
 use OCA\DAV\CardDAV\AddressBook;
 use OCA\DAV\CardDAV\ImageExportPlugin;
 use OCA\DAV\CardDAV\PhotoCache;
+use OCP\AppFramework\Http;
 use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use Sabre\CardDAV\Card;
@@ -171,7 +172,7 @@ class ImageExportPluginTest extends TestCase {
 				->willThrowException(new NotFoundException());
 			$this->response->expects($this->once())
 				->method('setStatus')
-				->with(\OCP\AppFramework\Http::STATUS_NO_CONTENT);
+				->with(Http::STATUS_NO_CONTENT);
 		}
 
 		$result = $this->plugin->httpGet($this->request, $this->response);

--- a/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
@@ -9,7 +9,9 @@ namespace OCA\DAV\Tests\Unit\Command;
 
 use OCA\DAV\Command\RemoveInvalidShares;
 use OCA\DAV\Connector\Sabre\Principal;
+use OCP\IDBConnection;
 use OCP\Migration\IOutput;
+use OCP\Server;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -23,7 +25,7 @@ use Test\TestCase;
 class RemoveInvalidSharesTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
-		$db = \OC::$server->getDatabaseConnection();
+		$db = Server::get(IDBConnection::class);
 
 		$db->insertIfNotExist('*PREFIX*dav_shares', [
 			'principaluri' => 'principal:unknown',
@@ -34,7 +36,7 @@ class RemoveInvalidSharesTest extends TestCase {
 	}
 
 	public function test(): void {
-		$db = \OC::$server->getDatabaseConnection();
+		$db = Server::get(IDBConnection::class);
 		/** @var Principal | \PHPUnit\Framework\MockObject\MockObject $principal */
 		$principal = $this->createMock(Principal::class);
 

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -11,7 +11,9 @@ use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\DAV\CustomPropertiesBackend;
+use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Tree;
 
@@ -68,14 +70,14 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 		$this->plugin = new CustomPropertiesBackend(
 			$this->server,
 			$this->tree,
-			\OC::$server->getDatabaseConnection(),
+			Server::get(IDBConnection::class),
 			$this->user,
 			$this->defaultCalendarValidator,
 		);
 	}
 
 	protected function tearDown(): void {
-		$connection = \OC::$server->getDatabaseConnection();
+		$connection = Server::get(IDBConnection::class);
 		$deleteStatement = $connection->prepare(
 			'DELETE FROM `*PREFIX*properties`' .
 			' WHERE `userid` = ?'

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/Auth.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/Auth.php
@@ -7,6 +7,8 @@
  */
 namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
+use OCP\IUserSession;
+use OCP\Server;
 use Sabre\DAV\Auth\Backend\BackendInterface;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
@@ -53,7 +55,7 @@ class Auth implements BackendInterface {
 	 * @return array
 	 */
 	public function check(RequestInterface $request, ResponseInterface $response) {
-		$userSession = \OC::$server->getUserSession();
+		$userSession = Server::get(IUserSession::class);
 		$result = $userSession->login($this->user, $this->password);
 		if ($result) {
 			//we need to pass the user name, which may differ from login name

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
@@ -8,6 +8,9 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
 use OC\Files\View;
+use OCP\IConfig;
+use OCP\ITempManager;
+use OCP\Server;
 use Test\Traits\EncryptionTrait;
 
 /**
@@ -22,10 +25,10 @@ class EncryptionMasterKeyUploadTest extends UploadTest {
 
 	protected function setupUser($name, $password) {
 		$this->createUser($name, $password);
-		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
 		// we use the master key
-		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '1');
+		Server::get(IConfig::class)->setAppValue('encryption', 'useMasterKey', '1');
 		$this->setupForUser($name, $password);
 		$this->loginWithEncryption($name);
 		return new View('/' . $name . '/files');

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
@@ -8,6 +8,9 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
 use OC\Files\View;
+use OCP\IConfig;
+use OCP\ITempManager;
+use OCP\Server;
 use Test\Traits\EncryptionTrait;
 
 /**
@@ -22,10 +25,10 @@ class EncryptionUploadTest extends UploadTest {
 
 	protected function setupUser($name, $password) {
 		$this->createUser($name, $password);
-		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
 		// we use per-user keys
-		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '0');
+		Server::get(IConfig::class)->setAppValue('encryption', 'useMasterKey', '0');
 		$this->setupForUser($name, $password);
 		$this->loginWithEncryption($name);
 		return new View('/' . $name . '/files');

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
 use OC\AllConfig;
 use OCP\IConfig;
+use OCP\Server;
 
 /**
  * Class PartFileInRootUploadTest
@@ -19,7 +20,7 @@ use OCP\IConfig;
  */
 class PartFileInRootUploadTest extends UploadTest {
 	protected function setUp(): void {
-		$config = \OC::$server->getConfig();
+		$config = Server::get(IConfig::class);
 		$mockConfig = $this->getMockBuilder(IConfig::class)
 			->disableOriginalConstructor()
 			->getMock();

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -57,7 +57,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->user->method('getUID')
 			->with()
 			->willReturn('dummy_user_42');
-		$this->dbConnection = \OC::$server->getDatabaseConnection();
+		$this->dbConnection = \OCP\Server::get(IDBConnection::class);
 		$this->defaultCalendarValidator = $this->createMock(DefaultCalendarValidator::class);
 
 		$this->backend = new CustomPropertiesBackend(

--- a/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
+++ b/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
@@ -7,7 +7,9 @@ namespace OCA\DAV\Tests\Unit\DAV\Migration;
 
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\Migration\CalDAVRemoveEmptyValue;
+use OCP\IDBConnection;
 use OCP\Migration\IOutput;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\InvalidDataException;
 use Test\TestCase;
@@ -83,7 +85,7 @@ END:VCALENDAR';
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
-				\OC::$server->getDatabaseConnection(),
+				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])
@@ -107,7 +109,7 @@ END:VCALENDAR';
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
-				\OC::$server->getDatabaseConnection(),
+				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])
@@ -150,7 +152,7 @@ END:VCALENDAR';
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
-				\OC::$server->getDatabaseConnection(),
+				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])
@@ -192,7 +194,7 @@ END:VCALENDAR';
 		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
-				\OC::$server->getDatabaseConnection(),
+				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])

--- a/apps/encryption/templates/settings-admin.php
+++ b/apps/encryption/templates/settings-admin.php
@@ -7,7 +7,7 @@
  */
 /** @var array $_ */
 /** @var \OCP\IL10N $l */
-script('encryption', 'settings-admin');
+\OCP\Util::addScript('encryption', 'settings-admin', 'core');
 style('encryption', 'settings-admin');
 ?>
 <form id="ocDefaultEncryptionModule" class="sub-section">

--- a/apps/encryption/templates/settings-personal.php
+++ b/apps/encryption/templates/settings-personal.php
@@ -7,7 +7,7 @@
  */
 /** @var array $_ */
 /** @var \OCP\IL10N $l */
-script('encryption', 'settings-personal');
+\OCP\Util::addScript('encryption', 'settings-personal', 'core');
 ?>
 <form id="ocDefaultEncryptionModule" class="section">
 	<h2 data-anchor-name="basic-encryption-module"><?php p($l->t('Basic encryption module')); ?></h2>

--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -11,6 +11,11 @@ namespace OCA\Encryption\Tests\Command;
 use OC\Files\View;
 use OCA\Encryption\Command\FixEncryptedVersion;
 use OCA\Encryption\Util;
+use OCP\Files\IRootFolder;
+use OCP\IConfig;
+use OCP\ITempManager;
+use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
@@ -43,7 +48,7 @@ class FixEncryptedVersionTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '1');
+		Server::get(IConfig::class)->setAppValue('encryption', 'useMasterKey', '1');
 
 		$this->util = $this->getMockBuilder(Util::class)
 			->disableOriginalConstructor()->getMock();
@@ -51,24 +56,24 @@ class FixEncryptedVersionTest extends TestCase {
 		$this->userId = $this->getUniqueId('user_');
 
 		$this->createUser($this->userId, 'foo12345678');
-		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($this->userId, '\OC\Files\Storage\Local', '/' . $this->userId, ['datadir' => $tmpFolder]);
 		$this->setupForUser($this->userId, 'foo12345678');
 		$this->loginWithEncryption($this->userId);
 
 		$this->fixEncryptedVersion = new FixEncryptedVersion(
-			\OC::$server->getConfig(),
-			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->getRootFolder(),
-			\OC::$server->getUserManager(),
+			Server::get(IConfig::class),
+			Server::get(LoggerInterface::class),
+			Server::get(IRootFolder::class),
+			Server::get(IUserManager::class),
 			$this->util,
 			new View('/')
 		);
 		$this->commandTester = new CommandTester($this->fixEncryptedVersion);
 
-		$this->assertTrue(\OC::$server->getEncryptionManager()->isEnabled());
-		$this->assertTrue(\OC::$server->getEncryptionManager()->isReady());
-		$this->assertTrue(\OC::$server->getEncryptionManager()->isReadyForUser($this->userId));
+		$this->assertTrue(Server::get(\OCP\Encryption\IManager::class)->isEnabled());
+		$this->assertTrue(Server::get(\OCP\Encryption\IManager::class)->isReady());
+		$this->assertTrue(Server::get(\OCP\Encryption\IManager::class)->isReadyForUser($this->userId));
 	}
 
 	/**
@@ -370,7 +375,7 @@ The file \"/$this->userId/files/sub/hello.txt\" is: OK", $output);
 	 * Test commands without master key
 	 */
 	public function testExecuteWithNoMasterKey(): void {
-		\OC::$server->getConfig()->setAppValue('encryption', 'useMasterKey', '0');
+		Server::get(IConfig::class)->setAppValue('encryption', 'useMasterKey', '0');
 		$this->util->expects($this->once())->method('isMasterKeyEnabled')
 			->willReturn(false);
 

--- a/apps/encryption/tests/EncryptedStorageTest.php
+++ b/apps/encryption/tests/EncryptedStorageTest.php
@@ -13,6 +13,7 @@ use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IDisableEncryptionStorage;
+use OCP\Server;
 use Test\TestCase;
 use Test\Traits\EncryptionTrait;
 use Test\Traits\MountProviderTrait;
@@ -44,7 +45,7 @@ class EncryptedStorageTest extends TestCase {
 		$view = new View('/test1/files');
 
 		/** @var IMountManager $mountManager */
-		$mountManager = \OC::$server->get(IMountManager::class);
+		$mountManager = Server::get(IMountManager::class);
 
 		$encryptedMount = $mountManager->find('/test1/files/enc');
 		$unencryptedMount = $mountManager->find('/test1/files/unenc');

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -151,7 +151,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 
 			try {
 				$this->externalShareManager->addShare($remote, $token, '', $name, $owner, $shareType, false, $shareWith, $remoteId);
-				$shareId = \OC::$server->getDatabaseConnection()->lastInsertId('*PREFIX*share_external');
+				$shareId = Server::get(IDBConnection::class)->lastInsertId('*PREFIX*share_external');
 
 				// get DisplayName about the owner of the share
 				$ownerDisplayName = $this->getUserDisplayName($ownerFederatedId);
@@ -163,7 +163,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 						->setSubject(RemoteShares::SUBJECT_REMOTE_SHARE_RECEIVED, [$ownerFederatedId, trim($name, '/'), $ownerDisplayName])
 						->setAffectedUser($shareWith)
 						->setObject('remote_share', $shareId, $name);
-					\OC::$server->getActivityManager()->publish($event);
+					Server::get(IActivityManager::class)->publish($event);
 					$this->notifyAboutNewShare($shareWith, $shareId, $ownerFederatedId, $sharedByFederatedId, $name, $ownerDisplayName);
 
 					// If auto-accept is enabled, accept the share
@@ -179,7 +179,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 							->setSubject(RemoteShares::SUBJECT_REMOTE_SHARE_RECEIVED, [$ownerFederatedId, trim($name, '/'), $ownerDisplayName])
 							->setAffectedUser($user->getUID())
 							->setObject('remote_share', $shareId, $name);
-						\OC::$server->getActivityManager()->publish($event);
+						Server::get(IActivityManager::class)->publish($event);
 						$this->notifyAboutNewShare($user->getUID(), $shareId, $ownerFederatedId, $sharedByFederatedId, $name, $ownerDisplayName);
 
 						// If auto-accept is enabled, accept the share
@@ -515,7 +515,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 					->setSubject(RemoteShares::SUBJECT_REMOTE_SHARE_UNSHARED, [$owner->getId(), $path, $ownerDisplayName])
 					->setAffectedUser($user)
 					->setObject('remote_share', (int)$share['id'], $path);
-				\OC::$server->getActivityManager()->publish($event);
+				Server::get(IActivityManager::class)->publish($event);
 			}
 		}
 

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -25,6 +25,7 @@ use OCP\IDBConnection;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
+use OCP\Server;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -74,7 +75,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = Server::get(IDBConnection::class);
 		$this->notifications = $this->getMockBuilder('OCA\FederatedFileSharing\Notifications')
 			->disableOriginalConstructor()
 			->getMock();
@@ -121,7 +122,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			$this->logger,
 		);
 
-		$this->shareManager = \OC::$server->getShareManager();
+		$this->shareManager = Server::get(\OCP\Share\IManager::class);
 	}
 
 	protected function tearDown(): void {
@@ -870,8 +871,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetSharesInFolder(): void {
-		$userManager = \OC::$server->getUserManager();
-		$rootFolder = \OC::$server->getRootFolder();
+		$userManager = Server::get(IUserManager::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		$u1 = $userManager->createUser('testFed', md5(time()));
 		$u2 = $userManager->createUser('testFed2', md5(time()));
@@ -924,8 +925,8 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	public function testGetAccessList(): void {
-		$userManager = \OC::$server->getUserManager();
-		$rootFolder = \OC::$server->getRootFolder();
+		$userManager = Server::get(IUserManager::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		$u1 = $userManager->createUser('testFed', md5(time()));
 

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -9,6 +9,10 @@ namespace OCA\FederatedFileSharing\Tests;
 
 use OC\Files\Filesystem;
 use OC\Group\Database;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Server;
 
 /**
  * Class Test_Files_Sharing_Base
@@ -26,7 +30,7 @@ abstract class TestCase extends \Test\TestCase {
 
 		// reset backend
 		\OC_User::clearBackends();
-		\OC::$server->getGroupManager()->clearBackends();
+		Server::get(IGroupManager::class)->clearBackends();
 
 		// create users
 		$backend = new \Test\Util\User\Dummy();
@@ -44,11 +48,11 @@ abstract class TestCase extends \Test\TestCase {
 
 	public static function tearDownAfterClass(): void {
 		// cleanup users
-		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER1);
+		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER1);
 		if ($user !== null) {
 			$user->delete();
 		}
-		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER2);
+		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER2);
 		if ($user !== null) {
 			$user->delete();
 		}
@@ -60,8 +64,8 @@ abstract class TestCase extends \Test\TestCase {
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
-		\OC::$server->getGroupManager()->clearBackends();
-		\OC::$server->getGroupManager()->addBackend(new Database());
+		Server::get(IGroupManager::class)->clearBackends();
+		Server::get(IGroupManager::class)->addBackend(new Database());
 
 		parent::tearDownAfterClass();
 	}
@@ -77,8 +81,8 @@ abstract class TestCase extends \Test\TestCase {
 		}
 
 		if ($create) {
-			$userManager = \OC::$server->getUserManager();
-			$groupManager = \OC::$server->getGroupManager();
+			$userManager = Server::get(IUserManager::class);
+			$groupManager = Server::get(IGroupManager::class);
 
 			$userObject = $userManager->createUser($user, $password);
 			$group = $groupManager->createGroup('group');
@@ -89,9 +93,9 @@ abstract class TestCase extends \Test\TestCase {
 		}
 
 		\OC_Util::tearDownFS();
-		\OC::$server->getUserSession()->setUser(null);
+		Server::get(IUserSession::class)->setUser(null);
 		Filesystem::tearDown();
-		\OC::$server->getUserSession()->login($user, $password);
+		Server::get(IUserSession::class)->login($user, $password);
 		\OC::$server->getUserFolder($user);
 
 		\OC_Util::setupFS($user);

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -11,6 +11,7 @@ use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
 use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -33,7 +34,7 @@ class DbHandlerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = Server::get(IDBConnection::class);
 		$this->il10n = $this->getMockBuilder(IL10N::class)->getMock();
 
 		$this->dbHandler = new DbHandler(

--- a/apps/files/lib/BackgroundJob/CleanupFileLocks.php
+++ b/apps/files/lib/BackgroundJob/CleanupFileLocks.php
@@ -10,6 +10,8 @@ namespace OCA\Files\BackgroundJob;
 use OC\Lock\DBLockingProvider;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\Lock\ILockingProvider;
+use OCP\Server;
 
 /**
  * Clean up all file locks that are expired for the DB file locking provider
@@ -30,7 +32,7 @@ class CleanupFileLocks extends TimedJob {
 	 * @throws \Exception
 	 */
 	public function run($argument) {
-		$lockingProvider = \OC::$server->getLockingProvider();
+		$lockingProvider = Server::get(ILockingProvider::class);
 		if ($lockingProvider instanceof DBLockingProvider) {
 			$lockingProvider->cleanExpiredLocks();
 		}

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -24,6 +24,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -102,8 +103,8 @@ class Scan extends Base {
 		$scanner = new Scanner(
 			$user,
 			new ConnectionAdapter($connection),
-			\OC::$server->get(IEventDispatcher::class),
-			\OC::$server->get(LoggerInterface::class)
+			Server::get(IEventDispatcher::class),
+			Server::get(LoggerInterface::class)
 		);
 
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception
@@ -310,7 +311,7 @@ class Scan extends Base {
 
 	protected function reconnectToDatabase(OutputInterface $output): Connection {
 		/** @var Connection $connection */
-		$connection = \OC::$server->get(Connection::class);
+		$connection = Server::get(Connection::class);
 		try {
 			$connection->close();
 		} catch (\Exception $ex) {

--- a/apps/files/lib/Command/ScanAppData.php
+++ b/apps/files/lib/Command/ScanAppData.php
@@ -18,6 +18,7 @@ use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IConfig;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
@@ -70,8 +71,8 @@ class ScanAppData extends Base {
 		$scanner = new Scanner(
 			null,
 			new ConnectionAdapter($connection),
-			\OC::$server->query(IEventDispatcher::class),
-			\OC::$server->get(LoggerInterface::class)
+			Server::get(IEventDispatcher::class),
+			Server::get(LoggerInterface::class)
 		);
 
 		# check on each file/folder if there was a user interrupt (ctrl-c) and throw an exception
@@ -213,7 +214,7 @@ class ScanAppData extends Base {
 
 	protected function reconnectToDatabase(OutputInterface $output): Connection {
 		/** @var Connection $connection */
-		$connection = \OC::$server->get(Connection::class);
+		$connection = Server::get(Connection::class);
 		try {
 			$connection->close();
 		} catch (\Exception $ex) {

--- a/apps/files/lib/Helper.php
+++ b/apps/files/lib/Helper.php
@@ -9,8 +9,10 @@ namespace OCA\Files;
 
 use OC\Files\Filesystem;
 use OCP\Files\FileInfo;
+use OCP\Files\IMimeTypeDetector;
 use OCP\Files\NotFoundException;
 use OCP\ITagManager;
+use OCP\Server;
 use OCP\Util;
 
 /**
@@ -53,15 +55,15 @@ class Helper {
 	 */
 	public static function determineIcon($file) {
 		if ($file['type'] === 'dir') {
-			$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon('dir');
+			$icon = Server::get(IMimeTypeDetector::class)->mimeTypeIcon('dir');
 			// TODO: move this part to the client side, using mountType
 			if ($file->isShared()) {
-				$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon('dir-shared');
+				$icon = Server::get(IMimeTypeDetector::class)->mimeTypeIcon('dir-shared');
 			} elseif ($file->isMounted()) {
-				$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon('dir-external');
+				$icon = Server::get(IMimeTypeDetector::class)->mimeTypeIcon('dir-external');
 			}
 		} else {
-			$icon = \OC::$server->getMimeTypeDetector()->mimeTypeIcon($file->getMimetype());
+			$icon = Server::get(IMimeTypeDetector::class)->mimeTypeIcon($file->getMimetype());
 		}
 
 		return substr($icon, 0, -3) . 'svg';

--- a/apps/files/tests/Activity/Filter/GenericTest.php
+++ b/apps/files/tests/Activity/Filter/GenericTest.php
@@ -8,6 +8,7 @@ namespace OCA\Files\Tests\Activity\Filter;
 use OCA\Files\Activity\Filter\Favorites;
 use OCA\Files\Activity\Filter\FileChanges;
 use OCP\Activity\IFilter;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -29,7 +30,7 @@ class GenericTest extends TestCase {
 	 * @param string $filterClass
 	 */
 	public function testImplementsInterface($filterClass): void {
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
@@ -39,7 +40,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
@@ -49,7 +50,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
@@ -59,7 +60,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$priority = $filter->getPriority();
 		$this->assertIsInt($filter->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -72,7 +73,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIcon($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIcon());
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
@@ -83,7 +84,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testFilterTypes($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
@@ -93,7 +94,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testAllowedApps($filterClass): void {
 		/** @var IFilter $filter */
-		$filter = \OC::$server->query($filterClass);
+		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->allowedApps());
 	}
 }

--- a/apps/files/tests/Activity/Setting/GenericTest.php
+++ b/apps/files/tests/Activity/Setting/GenericTest.php
@@ -8,6 +8,7 @@ namespace OCA\Files\Tests\Activity\Setting;
 use OCA\Files\Activity\Settings\FavoriteAction;
 use OCA\Files\Activity\Settings\FileChanged;
 use OCP\Activity\ISetting;
+use OCP\Server;
 use Test\TestCase;
 
 class GenericTest extends TestCase {
@@ -24,7 +25,7 @@ class GenericTest extends TestCase {
 	 * @param string $settingClass
 	 */
 	public function testImplementsInterface($settingClass): void {
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
@@ -34,7 +35,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetIdentifier($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
@@ -44,7 +45,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetName($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
@@ -54,7 +55,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testGetPriority($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$priority = $setting->getPriority();
 		$this->assertIsInt($setting->getPriority());
 		$this->assertGreaterThanOrEqual(0, $priority);
@@ -67,7 +68,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeStream($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
@@ -77,7 +78,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledStream($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
@@ -87,7 +88,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testCanChangeMail($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
@@ -97,7 +98,7 @@ class GenericTest extends TestCase {
 	 */
 	public function testIsDefaultEnabledMail($settingClass): void {
 		/** @var ISetting $setting */
-		$setting = \OC::$server->query($settingClass);
+		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledMail());
 	}
 }

--- a/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
+++ b/apps/files/tests/BackgroundJob/DeleteOrphanedItemsJobTest.php
@@ -11,6 +11,7 @@ use OCA\Files\BackgroundJob\DeleteOrphanedItems;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -27,9 +28,9 @@ class DeleteOrphanedItemsJobTest extends \Test\TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->connection = \OC::$server->get(IDBConnection::class);
+		$this->connection = Server::get(IDBConnection::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->logger = \OC::$server->get(LoggerInterface::class);
+		$this->logger = Server::get(LoggerInterface::class);
 	}
 
 	protected function cleanMapping($table) {

--- a/apps/files/tests/BackgroundJob/ScanFilesTest.php
+++ b/apps/files/tests/BackgroundJob/ScanFilesTest.php
@@ -14,7 +14,9 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IUserMountCache;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 use Test\Traits\MountProviderTrait;
@@ -41,8 +43,8 @@ class ScanFilesTest extends TestCase {
 		$config = $this->createMock(IConfig::class);
 		$dispatcher = $this->createMock(IEventDispatcher::class);
 		$logger = $this->createMock(LoggerInterface::class);
-		$connection = \OC::$server->getDatabaseConnection();
-		$this->mountCache = \OC::$server->getUserMountCache();
+		$connection = Server::get(IDBConnection::class);
+		$this->mountCache = Server::get(IUserMountCache::class);
 
 		$this->scanFiles = $this->getMockBuilder('\OCA\Files\BackgroundJob\ScanFiles')
 			->setConstructorArgs([

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -12,6 +12,7 @@ use OCA\Files\Command\DeleteOrphanedFiles;
 use OCP\Files\IRootFolder;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Server;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -37,14 +38,14 @@ class DeleteOrphanedFilesTest extends TestCase {
 
 		$this->user1 = $this->getUniqueID('user1_');
 
-		$userManager = \OC::$server->getUserManager();
+		$userManager = Server::get(IUserManager::class);
 		$userManager->createUser($this->user1, 'pass');
 
 		$this->command = new DeleteOrphanedFiles($this->connection);
 	}
 
 	protected function tearDown(): void {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = Server::get(IUserManager::class);
 		$user1 = $userManager->get($this->user1);
 		if ($user1) {
 			$user1->delete();

--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -11,9 +11,12 @@ use OCA\Files\Service\TagService;
 use OCP\Activity\IManager;
 use OCP\Files\Folder;
 use OCP\Files\NotFoundException;
+use OCP\ITagManager;
 use OCP\ITags;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 
 /**
  * Class TagServiceTest
@@ -54,7 +57,7 @@ class TagServiceTest extends \Test\TestCase {
 		parent::setUp();
 		$this->user = static::getUniqueID('user');
 		$this->activityManager = $this->createMock(IManager::class);
-		\OC::$server->getUserManager()->createUser($this->user, 'test');
+		Server::get(IUserManager::class)->createUser($this->user, 'test');
 		\OC_User::setUserId($this->user);
 		\OC_Util::setupFS($this->user);
 		$user = $this->createMock(IUser::class);
@@ -69,7 +72,7 @@ class TagServiceTest extends \Test\TestCase {
 
 		$this->root = \OC::$server->getUserFolder();
 
-		$this->tagger = \OC::$server->getTagManager()->load('files');
+		$this->tagger = Server::get(ITagManager::class)->load('files');
 		$this->tagService = $this->getTagService(['addActivity']);
 	}
 
@@ -91,7 +94,7 @@ class TagServiceTest extends \Test\TestCase {
 
 	protected function tearDown(): void {
 		\OC_User::setUserId('');
-		$user = \OC::$server->getUserManager()->get($this->user);
+		$user = Server::get(IUserManager::class)->get($this->user);
 		if ($user !== null) {
 			$user->delete();
 		}

--- a/apps/files_external/ajax/applicable.php
+++ b/apps/files_external/ajax/applicable.php
@@ -1,4 +1,9 @@
 <?php
+
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Server;
+
 /**
  * SPDX-FileCopyrightText: 2018-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -23,12 +28,12 @@ if (isset($_GET['offset'])) {
 }
 
 $groups = [];
-foreach (\OC::$server->getGroupManager()->search($pattern, $limit, $offset) as $group) {
+foreach (Server::get(IGroupManager::class)->search($pattern, $limit, $offset) as $group) {
 	$groups[$group->getGID()] = $group->getDisplayName();
 }
 
 $users = [];
-foreach (\OC::$server->getUserManager()->searchDisplayName($pattern, $limit, $offset) as $user) {
+foreach (Server::get(IUserManager::class)->searchDisplayName($pattern, $limit, $offset) as $user) {
 	$users[$user->getUID()] = $user->getDisplayName();
 }
 

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -20,6 +20,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\ITempManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 
@@ -451,7 +452,7 @@ class AmazonS3 extends Common {
 				}
 			case 'w':
 			case 'wb':
-				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
+				$tmpFile = Server::get(ITempManager::class)->getTemporaryFile();
 
 				$handle = fopen($tmpFile, 'w');
 				return CallbackWrapper::wrap($handle, null, null, function () use ($path, $tmpFile): void {
@@ -472,7 +473,7 @@ class AmazonS3 extends Common {
 				} else {
 					$ext = '';
 				}
-				$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+				$tmpFile = Server::get(ITempManager::class)->getTemporaryFile($ext);
 				if ($this->file_exists($path)) {
 					$source = $this->readObject($path);
 					file_put_contents($tmpFile, $source);

--- a/apps/files_external/lib/Lib/Storage/FTP.php
+++ b/apps/files_external/lib/Lib/Storage/FTP.php
@@ -12,7 +12,10 @@ use OC\Files\Storage\Common;
 use OC\Files\Storage\PolyFill\CopyDirectory;
 use OCP\Constants;
 use OCP\Files\FileInfo;
+use OCP\Files\IMimeTypeDetector;
 use OCP\Files\StorageNotAvailableException;
+use OCP\ITempManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class FTP extends Common {
@@ -101,7 +104,7 @@ class FTP extends Common {
 			if ($this->is_dir($path)) {
 				$list = $this->getConnection()->mlsd($this->buildPath($path));
 				if (!$list) {
-					\OC::$server->get(LoggerInterface::class)->warning("Unable to get last modified date for ftp folder ($path), failed to list folder contents");
+					Server::get(LoggerInterface::class)->warning("Unable to get last modified date for ftp folder ($path), failed to list folder contents");
 					return time();
 				}
 				$currentDir = current(array_filter($list, function ($item) {
@@ -115,7 +118,7 @@ class FTP extends Common {
 					}
 					return $time->getTimestamp();
 				} else {
-					\OC::$server->get(LoggerInterface::class)->warning("Unable to get last modified date for ftp folder ($path), folder contents doesn't include current folder");
+					Server::get(LoggerInterface::class)->warning("Unable to get last modified date for ftp folder ($path), folder contents doesn't include current folder");
 					return time();
 				}
 			} else {
@@ -270,7 +273,7 @@ class FTP extends Common {
 					if (!$this->isCreatable(dirname($path))) {
 						return false;
 					}
-					$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
+					$tmpFile = Server::get(ITempManager::class)->getTemporaryFile();
 				}
 				$source = fopen($tmpFile, $mode);
 				return CallbackWrapper::wrap($source, null, null, function () use ($tmpFile, $path): void {
@@ -322,7 +325,7 @@ class FTP extends Common {
 
 	public function getDirectoryContent(string $directory): \Traversable {
 		$files = $this->getConnection()->mlsd($this->buildPath($directory));
-		$mimeTypeDetector = \OC::$server->getMimeTypeDetector();
+		$mimeTypeDetector = Server::get(IMimeTypeDetector::class);
 
 		foreach ($files as $file) {
 			$name = $file['name'];

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -327,7 +327,7 @@ class SFTP extends Common {
 					$context = stream_context_create(['sftp' => ['session' => $connection]]);
 					$fh = fopen('sftpwrite://' . trim($absPath, '/'), 'w', false, $context);
 					if ($fh) {
-						$fh = CallbackWrapper::wrap($fh, null, null, function () use ($path) {
+						$fh = CallbackWrapper::wrap($fh, null, null, function () use ($path): void {
 							$this->knownMTimes->set($path, time());
 						});
 					}

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -16,6 +16,7 @@ use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
 use OCP\Files\FileInfo;
 use OCP\Files\IMimeTypeDetector;
+use OCP\Server;
 use phpseclib\Net\SFTP\Stream;
 
 /**
@@ -94,7 +95,7 @@ class SFTP extends Common {
 
 		$this->knownMTimes = new CappedMemoryCache();
 
-		$this->mimeTypeDetector = \OC::$server->get(IMimeTypeDetector::class);
+		$this->mimeTypeDetector = Server::get(IMimeTypeDetector::class);
 	}
 
 	/**

--- a/apps/files_external/lib/Lib/Storage/SMB.php
+++ b/apps/files_external/lib/Lib/Storage/SMB.php
@@ -31,12 +31,14 @@ use OCA\Files_External\Lib\Notify\SMBNotifyHandler;
 use OCP\Cache\CappedMemoryCache;
 use OCP\Constants;
 use OCP\Files\EntityTooLargeException;
+use OCP\Files\IMimeTypeDetector;
 use OCP\Files\Notify\IChange;
 use OCP\Files\Notify\IRenameChange;
 use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\INotifyStorage;
 use OCP\Files\StorageAuthException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\ITempManager;
 use Psr\Log\LoggerInterface;
 
 class SMB extends Common implements INotifyStorage {
@@ -458,7 +460,7 @@ class SMB extends Common implements INotifyStorage {
 						if (!$this->isCreatable(dirname($path))) {
 							return false;
 						}
-						$tmpFile = \OC::$server->getTempManager()->getTemporaryFile($ext);
+						$tmpFile = \OCP\Server::get(ITempManager::class)->getTemporaryFile($ext);
 					}
 					$source = fopen($tmpFile, $mode);
 					$share = $this->share;
@@ -553,7 +555,7 @@ class SMB extends Common implements INotifyStorage {
 		if ($fileInfo->isDirectory()) {
 			$data['mimetype'] = 'httpd/unix-directory';
 		} else {
-			$data['mimetype'] = \OC::$server->getMimeTypeDetector()->detectPath($fileInfo->getPath());
+			$data['mimetype'] = \OCP\Server::get(IMimeTypeDetector::class)->detectPath($fileInfo->getPath());
 		}
 		$data['mtime'] = $fileInfo->getMTime();
 		if ($fileInfo->isDirectory()) {

--- a/apps/files_external/lib/MountConfig.php
+++ b/apps/files_external/lib/MountConfig.php
@@ -16,7 +16,10 @@ use OCA\Files_External\Service\UserGlobalStoragesService;
 use OCA\Files_External\Service\UserStoragesService;
 use OCP\AppFramework\QueryException;
 use OCP\Files\StorageNotAvailableException;
+use OCP\IConfig;
 use OCP\IL10N;
+use OCP\Security\ISecureRandom;
+use OCP\Server;
 use OCP\Util;
 use phpseclib\Crypt\AES;
 use Psr\Log\LoggerInterface;
@@ -51,7 +54,7 @@ class MountConfig {
 	 */
 	public static function substitutePlaceholdersInConfig($input, ?string $userId = null) {
 		/** @var BackendService $backendService */
-		$backendService = \OC::$server->get(BackendService::class);
+		$backendService = Server::get(BackendService::class);
 		/** @var IConfigHandler[] $handlers */
 		$handlers = $backendService->getConfigHandlers();
 		foreach ($handlers as $handler) {
@@ -99,7 +102,7 @@ class MountConfig {
 					throw $e;
 				}
 			} catch (\Exception $exception) {
-				\OC::$server->get(LoggerInterface::class)->error($exception->getMessage(), ['exception' => $exception, 'app' => 'files_external']);
+				Server::get(LoggerInterface::class)->error($exception->getMessage(), ['exception' => $exception, 'app' => 'files_external']);
 				throw $exception;
 			}
 		}
@@ -191,7 +194,7 @@ class MountConfig {
 	 */
 	private static function encryptPassword($password) {
 		$cipher = self::getCipher();
-		$iv = \OC::$server->getSecureRandom()->generate(16);
+		$iv = Server::get(ISecureRandom::class)->generate(16);
 		$cipher->setIV($iv);
 		return base64_encode($iv . $cipher->encrypt($password));
 	}
@@ -218,7 +221,7 @@ class MountConfig {
 	 */
 	private static function getCipher() {
 		$cipher = new AES(AES::MODE_CBC);
-		$cipher->setKey(\OC::$server->getConfig()->getSystemValue('passwordsalt', null));
+		$cipher->setKey(Server::get(IConfig::class)->getSystemValue('passwordsalt', null));
 		return $cipher;
 	}
 

--- a/apps/files_external/lib/Service/BackendService.php
+++ b/apps/files_external/lib/Service/BackendService.php
@@ -8,13 +8,14 @@ namespace OCA\Files_External\Service;
 
 use OCA\Files_External\Config\IConfigHandler;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
-
 use OCA\Files_External\Lib\Backend\Backend;
+
 use OCA\Files_External\Lib\Config\IAuthMechanismProvider;
 use OCA\Files_External\Lib\Config\IBackendProvider;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
+use OCP\Server;
 
 /**
  * Service class to manage backend definitions
@@ -88,7 +89,7 @@ class BackendService {
 	private function callForRegistrations() {
 		static $eventSent = false;
 		if (!$eventSent) {
-			\OC::$server->get(IEventDispatcher::class)->dispatch(
+			Server::get(IEventDispatcher::class)->dispatch(
 				'OCA\\Files_External::loadAdditionalBackends',
 				new GenericEvent()
 			);

--- a/apps/files_external/lib/Service/LegacyStoragesService.php
+++ b/apps/files_external/lib/Service/LegacyStoragesService.php
@@ -8,6 +8,7 @@ namespace OCA\Files_External\Service;
 
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\MountConfig;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -124,7 +125,7 @@ abstract class LegacyStoragesService {
 					$parts = explode('/', ltrim($rootMountPath, '/'), 3);
 					if (count($parts) < 3) {
 						// something went wrong, skip
-						\OC::$server->get(LoggerInterface::class)->error('Could not parse mount point "' . $rootMountPath . '"', ['app' => 'files_external']);
+						Server::get(LoggerInterface::class)->error('Could not parse mount point "' . $rootMountPath . '"', ['app' => 'files_external']);
 						continue;
 					}
 					$relativeMountPath = rtrim($parts[2], '/');
@@ -172,7 +173,7 @@ abstract class LegacyStoragesService {
 						}
 					} catch (\UnexpectedValueException $e) {
 						// don't die if a storage backend doesn't exist
-						\OC::$server->get(LoggerInterface::class)->error('Could not load storage.', [
+						Server::get(LoggerInterface::class)->error('Could not load storage.', [
 							'app' => 'files_external',
 							'exception' => $e,
 						]);

--- a/apps/files_external/lib/Service/StoragesService.php
+++ b/apps/files_external/lib/Service/StoragesService.php
@@ -19,6 +19,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\StorageNotAvailableException;
+use OCP\Server;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -76,13 +77,13 @@ abstract class StoragesService {
 			return $config;
 		} catch (\UnexpectedValueException $e) {
 			// don't die if a storage backend doesn't exist
-			\OC::$server->get(LoggerInterface::class)->error('Could not load storage.', [
+			Server::get(LoggerInterface::class)->error('Could not load storage.', [
 				'app' => 'files_external',
 				'exception' => $e,
 			]);
 			return null;
 		} catch (\InvalidArgumentException $e) {
-			\OC::$server->get(LoggerInterface::class)->error('Could not load storage.', [
+			Server::get(LoggerInterface::class)->error('Could not load storage.', [
 				'app' => 'files_external',
 				'exception' => $e,
 			]);

--- a/apps/files_external/templates/settings.php
+++ b/apps/files_external/templates/settings.php
@@ -107,7 +107,7 @@ function writeParameterInput($parameter, $options, $classes = []) {
 </div>
 
 <?php
-	$canCreateNewLocalStorage = \OC::$server->getConfig()->getSystemValue('files_external_allow_create_new_local', true);
+	$canCreateNewLocalStorage = \OCP\Server::get(\OCP\IConfig::class)->getSystemValue('files_external_allow_create_new_local', true);
 ?>
 <form data-can-create="<?php echo $canCreateMounts?'true':'false' ?>" data-can-create-local="<?php echo $canCreateNewLocalStorage?'true':'false' ?>" id="files_external" class="section" data-encryption-enabled="<?php echo $_['encryptionEnabled']?'true': 'false'; ?>">
 	<h2 class="inlineblock" data-anchor-name="external-storage"><?php p($l->t('External storage')); ?></h2>
@@ -168,7 +168,7 @@ uasort($sortedBackends, function ($a, $b) {
 								continue;
 							} // ignore deprecated backends?>
 							<option value="<?php p($backend->getIdentifier()); ?>"><?php p($backend->getText()); ?></option>
-						<?php endforeach; ?>
+<?php endforeach; ?>
 					</select>
 				</td>
 				<td class="authentication" data-mechanisms='<?php p(json_encode($_['authMechanisms'])); ?>'></td>

--- a/apps/files_external/tests/Service/DBConfigServiceTest.php
+++ b/apps/files_external/tests/Service/DBConfigServiceTest.php
@@ -8,6 +8,8 @@ namespace OCA\Files_External\Tests\Service;
 
 use OCA\Files_External\Service\DBConfigService;
 use OCP\IDBConnection;
+use OCP\Security\ICrypto;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -28,8 +30,8 @@ class DBConfigServiceTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->connection = \OC::$server->getDatabaseConnection();
-		$this->dbConfig = new DBConfigService($this->connection, \OC::$server->getCrypto());
+		$this->connection = Server::get(IDBConnection::class);
+		$this->dbConfig = new DBConfigService($this->connection, Server::get(ICrypto::class));
 	}
 
 	protected function tearDown(): void {

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -15,6 +15,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
+use OCP\Server;
 use Test\Traits\UserTrait;
 
 /**
@@ -47,7 +48,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 
 		$this->globalStoragesService = $this->service;
 
-		$this->user = new User(self::USER_ID, null, \OC::$server->get(IEventDispatcher::class));
+		$this->user = new User(self::USER_ID, null, Server::get(IEventDispatcher::class));
 		/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);
 		$userSession

--- a/apps/files_external/tests/Service/UserStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserStoragesServiceTest.php
@@ -9,12 +9,14 @@ namespace OCA\Files_External\Tests\Service;
 use OC\Files\Filesystem;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\MountConfig;
-
 use OCA\Files_External\NotFoundException;
 use OCA\Files_External\Service\GlobalStoragesService;
+
 use OCA\Files_External\Service\StoragesService;
 use OCA\Files_External\Service\UserStoragesService;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 use Test\Traits\UserTrait;
 
 /**
@@ -39,7 +41,7 @@ class UserStoragesServiceTest extends StoragesServiceTest {
 
 		$this->userId = $this->getUniqueID('user_');
 		$this->createUser($this->userId, $this->userId);
-		$this->user = \OC::$server->getUserManager()->get($this->userId);
+		$this->user = Server::get(IUserManager::class)->get($this->userId);
 
 		/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject $userSession */
 		$userSession = $this->createMock(IUserSession::class);

--- a/apps/files_external/tests/Storage/WebdavTest.php
+++ b/apps/files_external/tests/Storage/WebdavTest.php
@@ -8,6 +8,8 @@ namespace OCA\Files_External\Tests\Storage;
 
 use OC\Files\Storage\DAV;
 use OC\Files\Type\Detection;
+use OCP\Files\IMimeTypeDetector;
+use OCP\Server;
 
 /**
  * Class WebdavTest
@@ -45,7 +47,7 @@ class WebdavTest extends \Test\Files\Storage\Storage {
 		$this->instance->file_put_contents('foo.bar', 'asd');
 
 		/** @var Detection $mimeDetector */
-		$mimeDetector = \OC::$server->getMimeTypeDetector();
+		$mimeDetector = Server::get(IMimeTypeDetector::class);
 		$mimeDetector->registerType('bar', 'application/x-bar');
 
 		$this->assertEquals('application/x-bar', $this->instance->getMimeType('foo.bar'));

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -471,7 +471,7 @@ class ShareAPIController extends OCSController {
 				$share = $this->formatShare($share);
 
 				if ($include_tags) {
-					$share = Helper::populateTags([$share], \OCP\Server::get(ITagManager::class));
+					$share = Helper::populateTags([$share], Server::get(ITagManager::class));
 				} else {
 					$share = [$share];
 				}
@@ -754,7 +754,7 @@ class ShareAPIController extends OCSController {
 			$share->setSharedWith($shareWith);
 			$share->setPermissions($permissions);
 		} elseif ($shareType === IShare::TYPE_CIRCLE) {
-			if (!\OCP\Server::get(IAppManager::class)->isEnabledForUser('circles') || !class_exists('\OCA\Circles\ShareByCircleProvider')) {
+			if (!Server::get(IAppManager::class)->isEnabledForUser('circles') || !class_exists('\OCA\Circles\ShareByCircleProvider')) {
 				throw new OCSNotFoundException($this->l->t('You cannot share to a Team if the app is not enabled'));
 			}
 
@@ -842,7 +842,7 @@ class ShareAPIController extends OCSController {
 		}
 
 		if ($includeTags) {
-			$formatted = Helper::populateTags($formatted, \OCP\Server::get(ITagManager::class));
+			$formatted = Helper::populateTags($formatted, Server::get(ITagManager::class));
 		}
 
 		return $formatted;
@@ -1096,7 +1096,7 @@ class ShareAPIController extends OCSController {
 
 		if ($includeTags) {
 			$formatted =
-				Helper::populateTags($formatted, \OCP\Server::get(ITagManager::class));
+				Helper::populateTags($formatted, Server::get(ITagManager::class));
 		}
 
 		return $formatted;
@@ -1971,7 +1971,7 @@ class ShareAPIController extends OCSController {
 			return true;
 		}
 
-		if ($share->getShareType() === IShare::TYPE_CIRCLE && \OCP\Server::get(IAppManager::class)->isEnabledForUser('circles')
+		if ($share->getShareType() === IShare::TYPE_CIRCLE && Server::get(IAppManager::class)->isEnabledForUser('circles')
 			&& class_exists('\OCA\Circles\Api\v1\Circles')) {
 			$hasCircleId = (str_ends_with($share->getSharedWith(), ']'));
 			$shareWithStart = ($hasCircleId ? strrpos($share->getSharedWith(), '[') + 1 : 0);

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -328,7 +328,7 @@ class ShareAPIController extends OCSController {
 	private function getDisplayNameFromAddressBook(string $query, string $property): string {
 		// FIXME: If we inject the contacts manager it gets initialized before any address books are registered
 		try {
-			$result = \OC::$server->getContactsManager()->search($query, [$property], [
+			$result = Server::get(\OCP\Contacts\IManager::class)->search($query, [$property], [
 				'limit' => 1,
 				'enumeration' => false,
 				'strict_search' => true,

--- a/apps/files_sharing/lib/Controller/ShareesAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareesAPIController.php
@@ -12,6 +12,7 @@ use Generator;
 use OC\Collaboration\Collaborators\SearchResult;
 use OC\Share\Share;
 use OCA\Files_Sharing\ResponseDefinitions;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\DataResponse;
@@ -24,6 +25,7 @@ use OCP\Constants;
 use OCP\IConfig;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\Server;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use function array_slice;
@@ -155,7 +157,7 @@ class ShareesAPIController extends OCSController {
 		}
 
 		// FIXME: DI
-		if (\OC::$server->getAppManager()->isEnabledForUser('circles') && class_exists('\OCA\Circles\ShareByCircleProvider')) {
+		if (Server::get(IAppManager::class)->isEnabledForUser('circles') && class_exists('\OCA\Circles\ShareByCircleProvider')) {
 			$shareTypes[] = IShare::TYPE_CIRCLE;
 		}
 
@@ -328,7 +330,7 @@ class ShareesAPIController extends OCSController {
 		}
 
 		// FIXME: DI
-		if (\OC::$server->getAppManager()->isEnabledForUser('circles') && class_exists('\OCA\Circles\ShareByCircleProvider')) {
+		if (Server::get(IAppManager::class)->isEnabledForUser('circles') && class_exists('\OCA\Circles\ShareByCircleProvider')) {
 			$shareTypes[] = IShare::TYPE_CIRCLE;
 		}
 

--- a/apps/files_sharing/lib/External/MountProvider.php
+++ b/apps/files_sharing/lib/External/MountProvider.php
@@ -10,8 +10,10 @@ use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Federation\ICloudIdManager;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
+use OCP\Http\Client\IClientService;
 use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\Server;
 
 class MountProvider implements IMountProvider {
 	public const STORAGE = '\OCA\Files_Sharing\External\Storage';
@@ -42,7 +44,7 @@ class MountProvider implements IMountProvider {
 		$data['mountpoint'] = $mountPoint;
 		$data['cloudId'] = $this->cloudIdManager->getCloudId($data['owner'], $data['remote']);
 		$data['certificateManager'] = \OC::$server->getCertificateManager();
-		$data['HttpClientService'] = \OC::$server->getHTTPClientService();
+		$data['HttpClientService'] = Server::get(IClientService::class);
 		return new Mount(self::STORAGE, $mountPoint, $data, $manager, $storageFactory);
 	}
 

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -53,7 +53,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 	 * @param array{HttpClientService: IClientService, manager: ExternalShareManager, cloudId: ICloudId, mountpoint: string, token: string, password: ?string}|array $options
 	 */
 	public function __construct($options) {
-		$this->memcacheFactory = \OC::$server->getMemCacheFactory();
+		$this->memcacheFactory = Server::get(ICacheFactory::class);
 		$this->httpClient = $options['HttpClientService'];
 		$this->manager = $options['manager'];
 		$this->cloudId = $options['cloudId'];
@@ -304,7 +304,7 @@ class Storage extends DAV implements ISharedStorage, IDisableEncryptionStorage, 
 		$url = rtrim($remote, '/') . '/index.php/apps/files_sharing/shareinfo?t=' . $token;
 
 		// TODO: DI
-		$client = \OC::$server->getHTTPClientService()->newClient();
+		$client = Server::get(IClientService::class)->newClient();
 		try {
 			$response = $client->post($url, array_merge($this->getDefaultRequestOptions(), [
 				'body' => ['password' => $password, 'depth' => $depth],

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -9,6 +9,8 @@ namespace OCA\Files_Sharing;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files_Sharing\AppInfo\Application;
+use OCP\IConfig;
+use OCP\Server;
 use OCP\Util;
 
 class Helper {
@@ -52,7 +54,7 @@ class Helper {
 			$view = Filesystem::getView();
 		}
 
-		$config = \OC::$server->getConfig();
+		$config = Server::get(IConfig::class);
 		$systemDefault = $config->getSystemValue('share_folder', '/');
 		$allowCustomShareFolder = $config->getSystemValueBool('sharing.allow_custom_share_folder', true);
 
@@ -86,6 +88,6 @@ class Helper {
 	 * @param string $shareFolder
 	 */
 	public static function setShareFolder($shareFolder) {
-		\OC::$server->getConfig()->setSystemValue('share_folder', $shareFolder);
+		Server::get(IConfig::class)->setSystemValue('share_folder', $shareFolder);
 	}
 }

--- a/apps/files_sharing/lib/Hooks.php
+++ b/apps/files_sharing/lib/Hooks.php
@@ -8,10 +8,11 @@ namespace OCA\Files_Sharing;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
+use OCP\Server;
 
 class Hooks {
 	public static function deleteUser($params) {
-		$manager = \OC::$server->get(External\Manager::class);
+		$manager = Server::get(External\Manager::class);
 
 		$manager->removeUserShares($params['uid']);
 	}

--- a/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_sharing/lib/Listener/LoadAdditionalListener.php
@@ -12,6 +12,7 @@ use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\Server;
 use OCP\Share\IManager;
 use OCP\Util;
 
@@ -26,7 +27,7 @@ class LoadAdditionalListener implements IEventListener {
 		Util::addScript(Application::APP_ID, 'additionalScripts', 'files');
 		Util::addStyle(Application::APP_ID, 'icons');
 
-		$shareManager = \OC::$server->get(IManager::class);
+		$shareManager = Server::get(IManager::class);
 		if ($shareManager->shareApiEnabled() && class_exists('\OCA\Files\App')) {
 			Util::addInitScript(Application::APP_ID, 'init');
 		}

--- a/apps/files_sharing/lib/ShareBackend/File.php
+++ b/apps/files_sharing/lib/ShareBackend/File.php
@@ -12,6 +12,7 @@ use OC\Files\View;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Files_Sharing\Helper;
 use OCP\Files\NotFoundException;
+use OCP\IDBConnection;
 use OCP\Server;
 use OCP\Share\IShare;
 use OCP\Share_Backend_File_Dependent;
@@ -34,7 +35,7 @@ class File implements Share_Backend_File_Dependent {
 		if ($federatedShareProvider) {
 			$this->federatedShareProvider = $federatedShareProvider;
 		} else {
-			$this->federatedShareProvider = \OC::$server->query(FederatedShareProvider::class);
+			$this->federatedShareProvider = Server::get(FederatedShareProvider::class);
 		}
 	}
 
@@ -183,7 +184,7 @@ class File implements Share_Backend_File_Dependent {
 		if (isset($source['parent'])) {
 			$parent = $source['parent'];
 			while (isset($parent)) {
-				$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+				$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 				$qb->select('parent', 'uid_owner')
 					->from('share')
 					->where(

--- a/apps/files_sharing/lib/ShareBackend/Folder.php
+++ b/apps/files_sharing/lib/ShareBackend/Folder.php
@@ -6,6 +6,8 @@
  */
 namespace OCA\Files_Sharing\ShareBackend;
 
+use OCP\IDBConnection;
+use OCP\Server;
 use OCP\Share_Backend_Collection;
 
 class Folder extends File implements Share_Backend_Collection {
@@ -13,7 +15,7 @@ class Folder extends File implements Share_Backend_Collection {
 		$children = [];
 		$parents = [$itemSource];
 
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->select('id')
 			->from('mimetypes')
 			->where(
@@ -29,7 +31,7 @@ class Folder extends File implements Share_Backend_Collection {
 			$mimetype = -1;
 		}
 		while (!empty($parents)) {
-			$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 
 			$parents = array_map(function ($parent) use ($qb) {
 				return $qb->createNamedParameter($parent);

--- a/apps/files_sharing/lib/SharedMount.php
+++ b/apps/files_sharing/lib/SharedMount.php
@@ -17,6 +17,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\InvalidateMountCacheEvent;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\ICache;
+use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\Server;
 use OCP\Share\Events\VerifyMountPointEvent;
@@ -121,7 +122,7 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 
 		foreach ($this->groupedShares as $tmpShare) {
 			$tmpShare->setTarget($newPath);
-			\OC::$server->getShareManager()->moveShare($tmpShare, $this->user->getUID());
+			Server::get(\OCP\Share\IManager::class)->moveShare($tmpShare, $this->user->getUID());
 		}
 
 		$this->eventDispatcher->dispatchTyped(new InvalidateMountCacheEvent($this->user));
@@ -249,7 +250,7 @@ class SharedMount extends MountPoint implements MoveableMount, ISharedMountPoint
 		if (!is_null($this->getShare()->getNodeCacheEntry())) {
 			return $this->getShare()->getNodeCacheEntry()->getStorageId();
 		} else {
-			$builder = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+			$builder = Server::get(IDBConnection::class)->getQueryBuilder();
 
 			$query = $builder->select('storage')
 				->from('filecache')

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -36,6 +36,7 @@ use OCP\Files\Storage\ILockingStorage;
 use OCP\Files\Storage\ISharedStorage;
 use OCP\Files\Storage\IStorage;
 use OCP\Lock\ILockingProvider;
+use OCP\Server;
 use OCP\Share\IShare;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -90,7 +91,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 
 	public function __construct(array $parameters) {
 		$this->ownerView = $parameters['ownerView'];
-		$this->logger = \OC::$server->get(LoggerInterface::class);
+		$this->logger = Server::get(LoggerInterface::class);
 
 		$this->superShare = $parameters['superShare'];
 		$this->groupedShares = $parameters['groupedShares'];
@@ -150,7 +151,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 			}
 
 			/** @var IRootFolder $rootFolder */
-			$rootFolder = \OC::$server->get(IRootFolder::class);
+			$rootFolder = Server::get(IRootFolder::class);
 			$this->ownerUserFolder = $rootFolder->getUserFolder($this->superShare->getShareOwner());
 			$sourceId = $this->superShare->getNodeId();
 			$ownerNodes = $this->ownerUserFolder->getById($sourceId);
@@ -412,7 +413,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 		$this->cache = new Cache(
 			$storage,
 			$sourceRoot,
-			\OC::$server->get(CacheDependencies::class),
+			Server::get(CacheDependencies::class),
 			$this->getShare()
 		);
 		return $this->cache;
@@ -463,7 +464,7 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 	 */
 	public function unshareStorage(): bool {
 		foreach ($this->groupedShares as $share) {
-			\OC::$server->getShareManager()->deleteFromSelf($share, $this->user);
+			Server::get(\OCP\Share\IManager::class)->deleteFromSelf($share, $this->user);
 		}
 		return true;
 	}

--- a/apps/files_sharing/lib/Updater.php
+++ b/apps/files_sharing/lib/Updater.php
@@ -11,6 +11,7 @@ use OC\Files\Filesystem;
 use OC\Files\Mount\MountPoint;
 use OCP\Constants;
 use OCP\Files\Folder;
+use OCP\Files\Mount\IMountManager;
 use OCP\Server;
 use OCP\Share\IShare;
 
@@ -48,7 +49,7 @@ class Updater {
 
 		$src = $userFolder->get($path);
 
-		$shareManager = \OC::$server->getShareManager();
+		$shareManager = Server::get(\OCP\Share\IManager::class);
 
 		// We intentionally include invalid shares, as they have been automatically invalidated due to the node no longer
 		// being accessible for the user. Only in this case where we adjust the share after it was moved we want to ignore
@@ -88,7 +89,7 @@ class Updater {
 		}
 
 		// Check if the destination is inside a share
-		$mountManager = \OC::$server->getMountManager();
+		$mountManager = Server::get(IMountManager::class);
 		$dstMount = $mountManager->find($src->getPath());
 
 		//Ownership is moved over

--- a/apps/files_sharing/templates/Settings/personal.php
+++ b/apps/files_sharing/templates/Settings/personal.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-script(\OCA\Files_Sharing\AppInfo\Application::APP_ID, 'personal-settings');
+\OCP\Util::addScript(\OCA\Files_Sharing\AppInfo\Application::APP_ID, 'personal-settings', 'core');
 
 ?>
 <div id="files-sharing-personal-settings" class="section">

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -24,13 +24,13 @@
 <input type="hidden" name="filename" value="<?php p($_['filename']) ?>" id="filename">
 <input type="hidden" name="mimetype" value="<?php p($_['mimetype']) ?>" id="mimetype">
 <input type="hidden" name="previewSupported" value="<?php p($_['previewSupported'] ? 'true' : 'false'); ?>" id="previewSupported">
-<input type="hidden" name="mimetypeIcon" value="<?php p(\OC::$server->getMimeTypeDetector()->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
+<input type="hidden" name="mimetypeIcon" value="<?php p(\OCP\Server::get(\OCP\Files\IMimeTypeDetector::class)->mimeTypeIcon($_['mimetype'])); ?>" id="mimetypeIcon">
 <input type="hidden" name="hideDownload" value="<?php p($_['hideDownload'] ? 'true' : 'false'); ?>" id="hideDownload">
 <input type="hidden" id="disclaimerText" value="<?php p($_['disclaimer']) ?>">
 
 <?php
-$upload_max_filesize = OC::$server->get(\bantu\IniGetWrapper\IniGetWrapper::class)->getBytes('upload_max_filesize');
-$post_max_size = OC::$server->get(\bantu\IniGetWrapper\IniGetWrapper::class)->getBytes('post_max_size');
+$upload_max_filesize = \OCP\Server::get(\bantu\IniGetWrapper\IniGetWrapper::class)->getBytes('upload_max_filesize');
+$post_max_size = \OCP\Server::get(\bantu\IniGetWrapper\IniGetWrapper::class)->getBytes('post_max_size');
 $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 ?>
 <input type="hidden" name="maxFilesizeUpload" value="<?php p($maxUploadFilesize); ?>" id="maxFilesizeUpload">
@@ -137,7 +137,7 @@ $maxUploadFilesize = min($upload_max_filesize, $post_max_size);
 <?php if (!isset($_['hideFileList']) || (isset($_['hideFileList']) && $_['hideFileList'] !== true)): ?>
 	<div class="hiddenuploadfield">
 		<input type="file" id="file_upload_start" class="hiddenuploadfield" name="files[]"
-			   data-url="<?php p(\OC::$server->getURLGenerator()->linkTo('files', 'ajax/upload.php')); ?>" />
+			   data-url="<?php p(\OCP\Server::get(\OCP\IURLGenerator::class)->linkTo('files', 'ajax/upload.php')); ?>" />
 	</div>
 <?php endif; ?>
 </div>

--- a/apps/files_sharing/tests/CacheTest.php
+++ b/apps/files_sharing/tests/CacheTest.php
@@ -15,6 +15,8 @@ use OC\Files\View;
 use OCA\Files_Sharing\SharedStorage;
 use OCP\Constants;
 use OCP\Files\Cache\IWatcher;
+use OCP\IUserManager;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -47,10 +49,10 @@ class CacheTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->shareManager = \OC::$server->getShareManager();
+		$this->shareManager = Server::get(\OCP\Share\IManager::class);
 
 
-		$userManager = \OC::$server->getUserManager();
+		$userManager = Server::get(IUserManager::class);
 		$userManager->get(self::TEST_FILES_SHARING_API_USER1)->setDisplayName('User One');
 		$userManager->get(self::TEST_FILES_SHARING_API_USER2)->setDisplayName('User Two');
 

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -10,6 +10,7 @@ use OCA\Files_Sharing\Command\CleanupRemoteStorages;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
 use OCP\IDBConnection;
+use OCP\Server;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -51,13 +52,13 @@ class CleanupRemoteStoragesTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = Server::get(IDBConnection::class);
 
-		$storageQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$storageQuery = Server::get(IDBConnection::class)->getQueryBuilder();
 		$storageQuery->insert('storages')
 			->setValue('id', $storageQuery->createParameter('id'));
 
-		$shareExternalQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$shareExternalQuery = Server::get(IDBConnection::class)->getQueryBuilder();
 		$shareExternalQuery->insert('share_external')
 			->setValue('share_token', $shareExternalQuery->createParameter('share_token'))
 			->setValue('remote', $shareExternalQuery->createParameter('remote'))
@@ -67,7 +68,7 @@ class CleanupRemoteStoragesTest extends TestCase {
 			->setValue('mountpoint', $shareExternalQuery->createParameter('mountpoint'))
 			->setValue('mountpoint_hash', $shareExternalQuery->createParameter('mountpoint_hash'));
 
-		$filesQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$filesQuery = Server::get(IDBConnection::class)->getQueryBuilder();
 		$filesQuery->insert('filecache')
 			->setValue('storage', $filesQuery->createParameter('storage'))
 			->setValue('path', $filesQuery->createParameter('path'))
@@ -108,11 +109,11 @@ class CleanupRemoteStoragesTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$storageQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$storageQuery = Server::get(IDBConnection::class)->getQueryBuilder();
 		$storageQuery->delete('storages')
 			->where($storageQuery->expr()->eq('id', $storageQuery->createParameter('id')));
 
-		$shareExternalQuery = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$shareExternalQuery = Server::get(IDBConnection::class)->getQueryBuilder();
 		$shareExternalQuery->delete('share_external')
 			->where($shareExternalQuery->expr()->eq('share_token', $shareExternalQuery->createParameter('share_token')))
 			->andWhere($shareExternalQuery->expr()->eq('remote', $shareExternalQuery->createParameter('remote')));
@@ -134,7 +135,7 @@ class CleanupRemoteStoragesTest extends TestCase {
 	}
 
 	private function doesStorageExist($numericId) {
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->select('*')
 			->from('storages')
 			->where($qb->expr()->eq('numeric_id', $qb->createNamedParameter($numericId)));
@@ -146,7 +147,7 @@ class CleanupRemoteStoragesTest extends TestCase {
 			return true;
 		}
 
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->select('*')
 			->from('filecache')
 			->where($qb->expr()->eq('storage', $qb->createNamedParameter($numericId)));

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -34,6 +34,7 @@ use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Mail\IMailer;
+use OCP\Server;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IAttributes as IShareAttributes;
@@ -162,7 +163,7 @@ class ShareAPIControllerTest extends TestCase {
 	}
 
 	private function newShare() {
-		return \OCP\Server::get(IManager::class)->newShare();
+		return Server::get(IManager::class)->newShare();
 	}
 
 
@@ -911,7 +912,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->expectException(OCSNotFoundException::class);
 		$this->expectExceptionMessage('Wrong share ID, share does not exist');
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setSharedBy('initiator')
 			->setSharedWith('recipient')
 			->setShareOwner('owner');
@@ -942,7 +943,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getDirectoryListing')
 			->willReturn([$file1, $file2]);
 
-		$file1UserShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1UserShareOwner = Server::get(IManager::class)->newShare();
 		$file1UserShareOwner->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -956,7 +957,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1UserShareInitiator = \OCP\Server::get(IManager::class)->newShare();
+		$file1UserShareInitiator = Server::get(IManager::class)->newShare();
 		$file1UserShareInitiator->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('currentUser')
@@ -970,7 +971,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1UserShareRecipient = \OCP\Server::get(IManager::class)->newShare();
+		$file1UserShareRecipient = Server::get(IManager::class)->newShare();
 		$file1UserShareRecipient->setShareType(IShare::TYPE_USER)
 			->setSharedWith('currentUser')
 			->setSharedBy('initiator')
@@ -984,7 +985,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1UserShareOther = \OCP\Server::get(IManager::class)->newShare();
+		$file1UserShareOther = Server::get(IManager::class)->newShare();
 		$file1UserShareOther->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -998,7 +999,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1GroupShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1GroupShareOwner = Server::get(IManager::class)->newShare();
 		$file1GroupShareOwner->setShareType(IShare::TYPE_GROUP)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1012,7 +1013,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_GROUP,
 		];
 
-		$file1GroupShareRecipient = \OCP\Server::get(IManager::class)->newShare();
+		$file1GroupShareRecipient = Server::get(IManager::class)->newShare();
 		$file1GroupShareRecipient->setShareType(IShare::TYPE_GROUP)
 			->setSharedWith('currentUserGroup')
 			->setSharedBy('initiator')
@@ -1026,7 +1027,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_GROUP,
 		];
 
-		$file1GroupShareOther = \OCP\Server::get(IManager::class)->newShare();
+		$file1GroupShareOther = Server::get(IManager::class)->newShare();
 		$file1GroupShareOther->setShareType(IShare::TYPE_GROUP)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1035,7 +1036,7 @@ class ShareAPIControllerTest extends TestCase {
 			->setNode($file1)
 			->setId(108);
 
-		$file1LinkShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1LinkShareOwner = Server::get(IManager::class)->newShare();
 		$file1LinkShareOwner->setShareType(IShare::TYPE_LINK)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1049,7 +1050,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_LINK,
 		];
 
-		$file1EmailShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1EmailShareOwner = Server::get(IManager::class)->newShare();
 		$file1EmailShareOwner->setShareType(IShare::TYPE_EMAIL)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1063,7 +1064,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_EMAIL,
 		];
 
-		$file1CircleShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1CircleShareOwner = Server::get(IManager::class)->newShare();
 		$file1CircleShareOwner->setShareType(IShare::TYPE_CIRCLE)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1077,7 +1078,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_CIRCLE,
 		];
 
-		$file1RoomShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1RoomShareOwner = Server::get(IManager::class)->newShare();
 		$file1RoomShareOwner->setShareType(IShare::TYPE_ROOM)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1091,7 +1092,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_ROOM,
 		];
 
-		$file1RemoteShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1RemoteShareOwner = Server::get(IManager::class)->newShare();
 		$file1RemoteShareOwner->setShareType(IShare::TYPE_REMOTE)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1106,7 +1107,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_REMOTE,
 		];
 
-		$file1RemoteGroupShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file1RemoteGroupShareOwner = Server::get(IManager::class)->newShare();
 		$file1RemoteGroupShareOwner->setShareType(IShare::TYPE_REMOTE_GROUP)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -1121,7 +1122,7 @@ class ShareAPIControllerTest extends TestCase {
 			'share_type' => IShare::TYPE_REMOTE_GROUP,
 		];
 
-		$file2UserShareOwner = \OCP\Server::get(IManager::class)->newShare();
+		$file2UserShareOwner = Server::get(IManager::class)->newShare();
 		$file2UserShareOwner->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -2020,7 +2021,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(false);
 
@@ -2046,7 +2047,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 
 		$this->ocs->createShare('valid-path', Constants::PERMISSION_ALL, IShare::TYPE_LINK, null, 'true');
@@ -2073,7 +2074,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
@@ -2097,7 +2098,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
@@ -2136,7 +2137,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
@@ -2175,7 +2176,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
@@ -2222,7 +2223,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
@@ -2260,7 +2261,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
@@ -2306,7 +2307,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->rootFolder->method('getById')
 			->willReturn([]);
 
-		$this->shareManager->method('newShare')->willReturn(\OCP\Server::get(IManager::class)->newShare());
+		$this->shareManager->method('newShare')->willReturn(Server::get(IManager::class)->newShare());
 		$this->shareManager->method('shareApiAllowLinks')->willReturn(true);
 		$this->shareManager->method('shareApiLinkAllowPublicUpload')->willReturn(true);
 
@@ -2615,7 +2616,7 @@ class ShareAPIControllerTest extends TestCase {
 	 * TODO: Remove once proper solution is in place
 	 */
 	public function testCreateReshareOfFederatedMountNoDeletePermissions(): void {
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$this->shareManager->method('newShare')->willReturn($share);
 
 		/** @var ShareAPIController&MockObject $ocs */
@@ -2820,7 +2821,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -2877,7 +2878,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -2938,7 +2939,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -3026,7 +3027,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -3072,7 +3073,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$folder->method('getId')->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -3102,7 +3103,7 @@ class ShareAPIControllerTest extends TestCase {
 			->with($this->currentUser)
 			->willReturn($userFolder);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -3468,7 +3469,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -3529,7 +3530,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -3589,7 +3590,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_LINK)
@@ -3649,7 +3650,7 @@ class ShareAPIControllerTest extends TestCase {
 		$file->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setPermissions(Constants::PERMISSION_ALL)
 			->setSharedBy($this->currentUser)
 			->setShareType(IShare::TYPE_USER)
@@ -3695,7 +3696,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share
 			->setId(42)
 			->setSharedBy($this->currentUser)
@@ -3707,7 +3708,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		// note: updateShare will modify the received instance but getSharedWith will reread from the database,
 		// so their values will be different
-		$incomingShare = \OCP\Server::get(IManager::class)->newShare();
+		$incomingShare = Server::get(IManager::class)->newShare();
 		$incomingShare
 			->setId(42)
 			->setSharedBy($this->currentUser)
@@ -3770,7 +3771,7 @@ class ShareAPIControllerTest extends TestCase {
 		$folder->method('getId')
 			->willReturn(42);
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share
 			->setId(42)
 			->setSharedBy($this->currentUser)
@@ -3782,7 +3783,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		// note: updateShare will modify the received instance but getSharedWith will reread from the database,
 		// so their values will be different
-		$incomingShare = \OCP\Server::get(IManager::class)->newShare();
+		$incomingShare = Server::get(IManager::class)->newShare();
 		$incomingShare
 			->setId(42)
 			->setSharedBy($this->currentUser)
@@ -3945,7 +3946,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$result = [];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -4047,7 +4048,7 @@ class ShareAPIControllerTest extends TestCase {
 			], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -4101,7 +4102,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -4157,7 +4158,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		// with existing group
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_GROUP)
 			->setSharedWith('recipientGroup')
 			->setSharedBy('initiator')
@@ -4211,7 +4212,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// with unknown group / no group backend
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_GROUP)
 			->setSharedWith('recipientGroup2')
 			->setSharedBy('initiator')
@@ -4262,7 +4263,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_LINK)
 			->setSharedBy('initiator')
 			->setShareOwner('owner')
@@ -4321,7 +4322,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_LINK)
 			->setSharedBy('initiator')
 			->setShareOwner('owner')
@@ -4380,7 +4381,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_REMOTE)
 			->setSharedBy('initiator')
 			->setSharedWith('user@server.com')
@@ -4433,7 +4434,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_REMOTE_GROUP)
 			->setSharedBy('initiator')
 			->setSharedWith('user@server.com')
@@ -4487,7 +4488,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Circle with id, display name and avatar set by the Circles app
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_CIRCLE)
 			->setSharedBy('initiator')
 			->setSharedWith('Circle (Public circle, circleOwner) [4815162342]')
@@ -4543,7 +4544,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Circle with id set by the Circles app
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_CIRCLE)
 			->setSharedBy('initiator')
 			->setSharedWith('Circle (Public circle, circleOwner) [4815162342]')
@@ -4596,7 +4597,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Circle with id not set by the Circles app
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_CIRCLE)
 			->setSharedBy('initiator')
 			->setSharedWith('Circle (Public circle, circleOwner)')
@@ -4648,7 +4649,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_USER)
 			->setSharedBy('initiator')
 			->setSharedWith('recipient')
@@ -4663,7 +4664,7 @@ class ShareAPIControllerTest extends TestCase {
 			[], $share, [], true
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_EMAIL)
 			->setSharedBy('initiator')
 			->setSharedWith('user@server.com')
@@ -4718,7 +4719,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_EMAIL)
 			->setSharedBy('initiator')
 			->setSharedWith('user@server.com')
@@ -4775,7 +4776,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Preview is available
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_USER)
 			->setSharedWith('recipient')
 			->setSharedBy('initiator')
@@ -4941,7 +4942,7 @@ class ShareAPIControllerTest extends TestCase {
 
 		$result = [];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_ROOM)
 			->setSharedWith('recipientRoom')
 			->setSharedBy('initiator')
@@ -4993,7 +4994,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, false, []
 		];
 
-		$share = \OCP\Server::get(IManager::class)->newShare();
+		$share = Server::get(IManager::class)->newShare();
 		$share->setShareType(IShare::TYPE_ROOM)
 			->setSharedWith('recipientRoom')
 			->setSharedBy('initiator')

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -142,9 +142,9 @@ class ShareControllerTest extends \Test\TestCase {
 		$this->oldUser = \OC_User::getUser();
 
 		// Create a dummy user
-		$this->user = \OC::$server->getSecureRandom()->generate(12, ISecureRandom::CHAR_LOWER);
+		$this->user = Server::get(ISecureRandom::class)->generate(12, ISecureRandom::CHAR_LOWER);
 
-		\OC::$server->getUserManager()->createUser($this->user, $this->user);
+		Server::get(IUserManager::class)->createUser($this->user, $this->user);
 		\OC_Util::tearDownFS();
 		$this->loginAsUser($this->user);
 	}
@@ -153,13 +153,13 @@ class ShareControllerTest extends \Test\TestCase {
 		\OC_Util::tearDownFS();
 		\OC_User::setUserId('');
 		Filesystem::tearDown();
-		$user = \OC::$server->getUserManager()->get($this->user);
+		$user = Server::get(IUserManager::class)->get($this->user);
 		if ($user !== null) {
 			$user->delete();
 		}
 		\OC_User::setIncognitoMode(false);
 
-		\OC::$server->getSession()->set('public_link_authenticated', '');
+		Server::get(ISession::class)->set('public_link_authenticated', '');
 
 		// Set old user
 		\OC_User::setUserId($this->oldUser);
@@ -185,7 +185,7 @@ class ShareControllerTest extends \Test\TestCase {
 	public function testShowShareNotAuthenticated(): void {
 		$this->shareController->setToken('validtoken');
 
-		$share = \OC::$server->getShareManager()->newShare();
+		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setPassword('password');
 
 		$this->shareManager
@@ -637,7 +637,7 @@ class ShareControllerTest extends \Test\TestCase {
 		$file->method('isShareable')->willReturn(false);
 		$file->method('isReadable')->willReturn(true);
 
-		$share = \OC::$server->getShareManager()->newShare();
+		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setId(42);
 		$share->setPassword('password')
 			->setShareOwner('ownerUID')
@@ -702,7 +702,7 @@ class ShareControllerTest extends \Test\TestCase {
 		/* @var MockObject|Folder $folder */
 		$folder = $this->createMock(Folder::class);
 
-		$share = \OC::$server->getShareManager()->newShare();
+		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setId(42);
 		$share->setPermissions(Constants::PERMISSION_CREATE)
 			->setShareOwner('ownerUID')
@@ -743,7 +743,7 @@ class ShareControllerTest extends \Test\TestCase {
 		/* @var MockObject|Folder $folder */
 		$folder = $this->createMock(Folder::class);
 
-		$share = \OC::$server->getShareManager()->newShare();
+		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setId(42);
 		$share->setPermissions(Constants::PERMISSION_CREATE)
 			->setShareOwner('ownerUID')

--- a/apps/files_sharing/tests/EncryptedSizePropagationTest.php
+++ b/apps/files_sharing/tests/EncryptedSizePropagationTest.php
@@ -7,6 +7,8 @@
 namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\View;
+use OCP\ITempManager;
+use OCP\Server;
 use Test\Traits\EncryptionTrait;
 
 /**
@@ -17,7 +19,7 @@ class EncryptedSizePropagationTest extends SizePropagationTest {
 
 	protected function setupUser($name, $password = '') {
 		$this->createUser($name, $password);
-		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
 		$this->config->setAppValue('encryption', 'useMasterKey', '0');
 		$this->setupForUser($name, $password);

--- a/apps/files_sharing/tests/EtagPropagationTest.php
+++ b/apps/files_sharing/tests/EtagPropagationTest.php
@@ -9,6 +9,8 @@ namespace OCA\Files_Sharing\Tests;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\Constants;
+use OCP\Files\IRootFolder;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -33,8 +35,8 @@ class EtagPropagationTest extends PropagationTestCase {
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER3] = [];
 		$this->fileIds[self::TEST_FILES_SHARING_API_USER4] = [];
 
-		$rootFolder = \OC::$server->getRootFolder();
-		$shareManager = \OC::$server->getShareManager();
+		$rootFolder = Server::get(IRootFolder::class);
+		$shareManager = Server::get(\OCP\Share\IManager::class);
 
 		$this->rootView = new View('');
 		$this->loginAsUser(self::TEST_FILES_SHARING_API_USER1);
@@ -264,7 +266,7 @@ class EtagPropagationTest extends PropagationTestCase {
 		$this->assertInstanceOf('\OC\Files\FileInfo', $folderInfo);
 
 		$node = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1)->get('/sub1/sub2/folder');
-		$shareManager = \OC::$server->getShareManager();
+		$shareManager = Server::get(\OCP\Share\IManager::class);
 		$shares = $shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, IShare::TYPE_USER, $node, true);
 
 		foreach ($shares as $share) {
@@ -287,7 +289,7 @@ class EtagPropagationTest extends PropagationTestCase {
 		$this->assertInstanceOf('\OC\Files\FileInfo', $folderInfo);
 
 		$node = \OC::$server->getUserFolder(self::TEST_FILES_SHARING_API_USER1)->get('/sub1/sub2/folder/inside');
-		$shareManager = \OC::$server->getShareManager();
+		$shareManager = Server::get(\OCP\Share\IManager::class);
 		$shares = $shareManager->getSharesBy(self::TEST_FILES_SHARING_API_USER1, IShare::TYPE_USER, $node, true);
 
 		foreach ($shares as $share) {

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -6,10 +6,13 @@
  */
 namespace OCA\Files_Sharing\Tests;
 
+use OC\SystemConfig;
 use OCA\Files_Sharing\ExpireSharesJob;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
 use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\Server;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 
@@ -37,26 +40,26 @@ class ExpireSharesJobTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = Server::get(IDBConnection::class);
 		// clear occasional leftover shares from other tests
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
 
 		$this->user1 = $this->getUniqueID('user1_');
 		$this->user2 = $this->getUniqueID('user2_');
 
-		$userManager = \OC::$server->getUserManager();
+		$userManager = Server::get(IUserManager::class);
 		$userManager->createUser($this->user1, 'longrandompassword');
 		$userManager->createUser($this->user2, 'longrandompassword');
 
-		\OC::registerShareHooks(\OC::$server->getSystemConfig());
+		\OC::registerShareHooks(Server::get(SystemConfig::class));
 
-		$this->job = new ExpireSharesJob(\OC::$server->get(ITimeFactory::class), \OC::$server->get(IManager::class), $this->connection);
+		$this->job = new ExpireSharesJob(Server::get(ITimeFactory::class), Server::get(IManager::class), $this->connection);
 	}
 
 	protected function tearDown(): void {
 		$this->connection->executeUpdate('DELETE FROM `*PREFIX*share`');
 
-		$userManager = \OC::$server->getUserManager();
+		$userManager = Server::get(IUserManager::class);
 		$user1 = $userManager->get($this->user1);
 		if ($user1) {
 			$user1->delete();
@@ -115,7 +118,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		$user1Folder = \OC::$server->getUserFolder($this->user1);
 		$testFolder = $user1Folder->newFolder('test');
 
-		$shareManager = \OC::$server->getShareManager();
+		$shareManager = Server::get(\OCP\Share\IManager::class);
 		$share = $shareManager->newShare();
 
 		$share->setNode($testFolder)
@@ -172,7 +175,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		$user1Folder = \OC::$server->getUserFolder($this->user1);
 		$testFolder = $user1Folder->newFolder('test');
 
-		$shareManager = \OC::$server->getShareManager();
+		$shareManager = Server::get(\OCP\Share\IManager::class);
 		$share = $shareManager->newShare();
 
 		$share->setNode($testFolder)

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -22,6 +22,7 @@ use OCP\Files\NotFoundException;
 use OCP\Http\Client\IClientService;
 use OCP\Http\Client\IResponse;
 use OCP\ICacheFactory;
+use OCP\IDBConnection;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -29,6 +30,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\OCS\IDiscoveryService;
+use OCP\Server;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 use Test\Traits\UserTrait;
@@ -105,7 +107,7 @@ class ManagerTest extends TestCase {
 
 		$this->manager = $this->createManagerForUser($this->uid);
 
-		$this->testMountProvider = new MountProvider(\OC::$server->getDatabaseConnection(), function () {
+		$this->testMountProvider = new MountProvider(Server::get(IDBConnection::class), function () {
 			return $this->manager;
 		}, new CloudIdManager(
 			$this->contactsManager,
@@ -134,7 +136,7 @@ class ManagerTest extends TestCase {
 
 	protected function tearDown(): void {
 		// clear the share external table to avoid side effects
-		$query = \OC::$server->getDatabaseConnection()->prepare('DELETE FROM `*PREFIX*share_external`');
+		$query = Server::get(IDBConnection::class)->prepare('DELETE FROM `*PREFIX*share_external`');
 		$result = $query->execute();
 		$result->closeCursor();
 
@@ -152,12 +154,12 @@ class ManagerTest extends TestCase {
 		return $this->getMockBuilder(Manager::class)
 			->setConstructorArgs(
 				[
-					\OC::$server->getDatabaseConnection(),
+					Server::get(IDBConnection::class),
 					$this->mountManager,
 					new StorageFactory(),
 					$this->clientService,
-					\OC::$server->getNotificationManager(),
-					\OC::$server->query(IDiscoveryService::class),
+					Server::get(\OCP\Notification\IManager::class),
+					Server::get(IDiscoveryService::class),
 					$this->cloudFederationProviderManager,
 					$this->cloudFederationFactory,
 					$this->groupManager,

--- a/apps/files_sharing/tests/HelperTest.php
+++ b/apps/files_sharing/tests/HelperTest.php
@@ -8,6 +8,8 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\Helper;
+use OCP\IConfig;
+use OCP\Server;
 
 /**
  * Class HelperTest
@@ -29,6 +31,6 @@ class HelperTest extends TestCase {
 		$this->assertTrue(Filesystem::is_dir($sharedFolder));
 
 		// cleanup
-		\OC::$server->getConfig()->deleteSystemValue('share_folder');
+		Server::get(IConfig::class)->deleteSystemValue('share_folder');
 	}
 }

--- a/apps/files_sharing/tests/LockingTest.php
+++ b/apps/files_sharing/tests/LockingTest.php
@@ -9,8 +9,10 @@ namespace OCA\Files_Sharing\Tests;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\Constants;
+use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -33,7 +35,7 @@ class LockingTest extends TestCase {
 		parent::setUp();
 
 		$this->userBackend = new \Test\Util\User\Dummy();
-		\OC::$server->getUserManager()->registerBackend($this->userBackend);
+		Server::get(IUserManager::class)->registerBackend($this->userBackend);
 
 		$this->ownerUid = $this->getUniqueID('owner_');
 		$this->recipientUid = $this->getUniqueID('recipient_');
@@ -58,7 +60,7 @@ class LockingTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		\OC::$server->getUserManager()->removeBackend($this->userBackend);
+		Server::get(IUserManager::class)->removeBackend($this->userBackend);
 		parent::tearDown();
 	}
 

--- a/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
+++ b/apps/files_sharing/tests/Migration/SetPasswordColumnTest.php
@@ -11,6 +11,7 @@ use OCA\Files_Sharing\Tests\TestCase;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -34,7 +35,7 @@ class SetPasswordColumnTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = Server::get(IDBConnection::class);
 		$this->config = $this->createMock(IConfig::class);
 		$this->migration = new SetPasswordColumn($this->connection, $this->config);
 

--- a/apps/files_sharing/tests/PropagationTestCase.php
+++ b/apps/files_sharing/tests/PropagationTestCase.php
@@ -8,6 +8,8 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\View;
 use OCA\Files_Sharing\Helper;
+use OCP\IUserSession;
+use OCP\Server;
 
 abstract class PropagationTestCase extends TestCase {
 	/**
@@ -42,7 +44,7 @@ abstract class PropagationTestCase extends TestCase {
 	 * @param string $subPath
 	 */
 	protected function assertEtagsChanged($users, $subPath = '') {
-		$oldUser = \OC::$server->getUserSession()->getUser();
+		$oldUser = Server::get(IUserSession::class)->getUser();
 		foreach ($users as $user) {
 			$this->loginAsUser($user);
 			$id = $this->fileIds[$user][$subPath];
@@ -59,7 +61,7 @@ abstract class PropagationTestCase extends TestCase {
 	 * @param string $subPath
 	 */
 	protected function assertEtagsNotChanged($users, $subPath = '') {
-		$oldUser = \OC::$server->getUserSession()->getUser();
+		$oldUser = Server::get(IUserSession::class)->getUser();
 		foreach ($users as $user) {
 			$this->loginAsUser($user);
 			$id = $this->fileIds[$user][$subPath];

--- a/apps/files_sharing/tests/ShareTest.php
+++ b/apps/files_sharing/tests/ShareTest.php
@@ -10,6 +10,10 @@ use OC\Files\FileInfo;
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\Helper;
 use OCP\Constants;
+use OCP\IConfig;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -53,8 +57,8 @@ class ShareTest extends TestCase {
 	}
 
 	public function testUnshareFromSelf(): void {
-		$groupManager = \OC::$server->getGroupManager();
-		$userManager = \OC::$server->getUserManager();
+		$groupManager = Server::get(IGroupManager::class);
+		$userManager = Server::get(IUserManager::class);
 
 		$testGroup = $groupManager->createGroup('testGroup');
 		$user1 = $userManager->get(self::TEST_FILES_SHARING_API_USER2);
@@ -140,7 +144,7 @@ class ShareTest extends TestCase {
 		$this->assertTrue(Filesystem::file_exists('/Shared/subfolder/' . $this->folder));
 
 		//cleanup
-		\OC::$server->getConfig()->deleteSystemValue('share_folder');
+		Server::get(IConfig::class)->deleteSystemValue('share_folder');
 	}
 
 	public function testShareWithGroupUniqueName(): void {

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -13,6 +13,7 @@ use OCA\Files_Sharing\MountProvider;
 use OCA\Files_Sharing\SharedMount;
 use OCP\Constants;
 use OCP\ICacheFactory;
+use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
 use OCP\Server;
@@ -50,8 +51,8 @@ class SharedMountTest extends TestCase {
 		$this->view->file_put_contents($this->folder . $this->filename, 'file in subfolder');
 		$this->view->file_put_contents($this->folder2 . $this->filename, 'file in subfolder2');
 
-		$this->groupManager = \OC::$server->getGroupManager();
-		$this->userManager = \OC::$server->getUserManager();
+		$this->groupManager = Server::get(IGroupManager::class);
+		$this->userManager = Server::get(IUserManager::class);
 	}
 
 	protected function tearDown(): void {
@@ -266,7 +267,7 @@ class SharedMountTest extends TestCase {
 		$testGroup->addUser($user2);
 		$testGroup->addUser($user3);
 
-		$connection = \OC::$server->getDatabaseConnection();
+		$connection = Server::get(IDBConnection::class);
 
 		// Share item with group
 		$fileinfo = $this->view->getFileInfo($this->folder);

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -16,7 +16,10 @@ use OCA\Files_Sharing\SharedStorage;
 use OCA\Files_Trashbin\AppInfo\Application;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\Constants;
+use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\NotFoundException;
+use OCP\IUserManager;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -389,8 +392,8 @@ class SharedStorageTest extends TestCase {
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER2);
 		$this->assertTrue($rootView->file_exists('/' . self::TEST_FILES_SHARING_API_USER2 . '/files/' . $this->folder));
 
-		$mountConfigManager = \OC::$server->getMountProviderCollection();
-		$mounts = $mountConfigManager->getMountsForUser(\OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER3));
+		$mountConfigManager = Server::get(IMountProviderCollection::class);
+		$mounts = $mountConfigManager->getMountsForUser(Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER3));
 		array_walk($mounts, [Filesystem::getMountManager(), 'addMount']);
 
 		$this->assertTrue($rootView->file_exists('/' . self::TEST_FILES_SHARING_API_USER3 . '/files/' . $this->filename));

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -20,6 +20,7 @@ use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
 use OCP\Mail\IMessage;
+use OCP\Server;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,9 +45,9 @@ class SharesReminderJobTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->get(IDBConnection::class);
-		$this->shareManager = \OC::$server->get(IManager::class);
-		$this->userManager = \OC::$server->get(IUserManager::class);
+		$this->db = Server::get(IDBConnection::class);
+		$this->shareManager = Server::get(IManager::class);
+		$this->userManager = Server::get(IUserManager::class);
 		$this->mailer = $this->createMock(IMailer::class);
 
 		// Clear occasional leftover shares from other tests
@@ -60,26 +61,26 @@ class SharesReminderJobTest extends \Test\TestCase {
 		$user1->setSystemEMailAddress('user1@test.com');
 		$user2->setSystemEMailAddress('user2@test.com');
 
-		\OC::registerShareHooks(\OC::$server->get(SystemConfig::class));
+		\OC::registerShareHooks(Server::get(SystemConfig::class));
 
 		$this->job = new SharesReminderJob(
-			\OC::$server->get(ITimeFactory::class),
+			Server::get(ITimeFactory::class),
 			$this->db,
-			\OC::$server->get(IManager::class),
+			Server::get(IManager::class),
 			$this->userManager,
-			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->get(IURLGenerator::class),
-			\OC::$server->get(IFactory::class),
+			Server::get(LoggerInterface::class),
+			Server::get(IURLGenerator::class),
+			Server::get(IFactory::class),
 			$this->mailer,
-			\OC::$server->get(Defaults::class),
-			\OC::$server->get(IMimeTypeLoader::class),
+			Server::get(Defaults::class),
+			Server::get(IMimeTypeLoader::class),
 		);
 	}
 
 	protected function tearDown(): void {
 		$this->db->executeUpdate('DELETE FROM `*PREFIX*share`');
 
-		$userManager = \OC::$server->get(IUserManager::class);
+		$userManager = Server::get(IUserManager::class);
 		$user1 = $userManager->get($this->user1);
 		if ($user1) {
 			$user1->delete();
@@ -156,7 +157,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 	): void {
 		$this->loginAsUser($this->user1);
 
-		$user1Folder = \OC::$server->get(IRootFolder::class)->getUserFolder($this->user1);
+		$user1Folder = Server::get(IRootFolder::class)->getUserFolder($this->user1);
 		$testFolder = $user1Folder->newFolder('test');
 
 		if (!$isEmpty) {

--- a/apps/files_sharing/tests/SizePropagationTest.php
+++ b/apps/files_sharing/tests/SizePropagationTest.php
@@ -8,6 +8,8 @@ namespace OCA\Files_Sharing\Tests;
 
 use OC\Files\View;
 use OCP\Constants;
+use OCP\ITempManager;
+use OCP\Server;
 use OCP\Share\IShare;
 use Test\Traits\UserTrait;
 
@@ -23,7 +25,7 @@ class SizePropagationTest extends TestCase {
 
 	protected function setupUser($name, $password = '') {
 		$this->createUser($name, $password);
-		$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
 		$this->loginAsUser($name);
 		return new View('/' . $name . '/files');

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -10,12 +10,18 @@ use OC\Files\Cache\Storage;
 use OC\Files\Filesystem;
 use OC\Files\View;
 use OC\Group\Database;
+use OC\SystemConfig;
 use OC\User\DisplayNameCache;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Sharing\External\MountProvider as ExternalMountProvider;
 use OCA\Files_Sharing\MountProvider;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\Files\IRootFolder;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Server;
 use OCP\Share\IShare;
 use Test\Traits\MountProviderTrait;
 
@@ -59,18 +65,18 @@ abstract class TestCase extends \Test\TestCase {
 
 		$app = new Application();
 		$app->registerMountProviders(
-			\OC::$server->get(IMountProviderCollection::class),
-			\OC::$server->get(MountProvider::class),
-			\OC::$server->get(ExternalMountProvider::class),
+			Server::get(IMountProviderCollection::class),
+			Server::get(MountProvider::class),
+			Server::get(ExternalMountProvider::class),
 		);
 
 		// reset backend
 		\OC_User::clearBackends();
-		\OC::$server->getGroupManager()->clearBackends();
+		Server::get(IGroupManager::class)->clearBackends();
 
 		// clear share hooks
 		\OC_Hook::clear('OCP\\Share');
-		\OC::registerShareHooks(\OC::$server->getSystemConfig());
+		\OC::registerShareHooks(Server::get(SystemConfig::class));
 
 		// create users
 		$backend = new \Test\Util\User\Dummy();
@@ -94,12 +100,12 @@ abstract class TestCase extends \Test\TestCase {
 		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER3, 'group2');
 		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER4, 'group3');
 		$groupBackend->addToGroup(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_GROUP1);
-		\OC::$server->getGroupManager()->addBackend($groupBackend);
+		Server::get(IGroupManager::class)->addBackend($groupBackend);
 	}
 
 	protected function setUp(): void {
 		parent::setUp();
-		\OC::$server->get(DisplayNameCache::class)->clear();
+		Server::get(DisplayNameCache::class)->clear();
 
 		//login as user1
 		self::loginHelper(self::TEST_FILES_SHARING_API_USER1);
@@ -108,20 +114,20 @@ abstract class TestCase extends \Test\TestCase {
 		$this->view = new View('/' . self::TEST_FILES_SHARING_API_USER1 . '/files');
 		$this->view2 = new View('/' . self::TEST_FILES_SHARING_API_USER2 . '/files');
 
-		$this->shareManager = \OC::$server->getShareManager();
-		$this->rootFolder = \OC::$server->getRootFolder();
+		$this->shareManager = Server::get(\OCP\Share\IManager::class);
+		$this->rootFolder = Server::get(IRootFolder::class);
 	}
 
 	protected function tearDown(): void {
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->delete('share');
 		$qb->execute();
 
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->delete('mounts');
 		$qb->execute();
 
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->delete('filecache')->runAcrossAllShards();
 		$qb->execute();
 
@@ -130,21 +136,21 @@ abstract class TestCase extends \Test\TestCase {
 
 	public static function tearDownAfterClass(): void {
 		// cleanup users
-		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER1);
+		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER1);
 		if ($user !== null) {
 			$user->delete();
 		}
-		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER2);
+		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER2);
 		if ($user !== null) {
 			$user->delete();
 		}
-		$user = \OC::$server->getUserManager()->get(self::TEST_FILES_SHARING_API_USER3);
+		$user = Server::get(IUserManager::class)->get(self::TEST_FILES_SHARING_API_USER3);
 		if ($user !== null) {
 			$user->delete();
 		}
 
 		// delete group
-		$group = \OC::$server->getGroupManager()->get(self::TEST_FILES_SHARING_API_GROUP1);
+		$group = Server::get(IGroupManager::class)->get(self::TEST_FILES_SHARING_API_GROUP1);
 		if ($group) {
 			$group->delete();
 		}
@@ -156,8 +162,8 @@ abstract class TestCase extends \Test\TestCase {
 		// reset backend
 		\OC_User::clearBackends();
 		\OC_User::useBackend('database');
-		\OC::$server->getGroupManager()->clearBackends();
-		\OC::$server->getGroupManager()->addBackend(new Database());
+		Server::get(IGroupManager::class)->clearBackends();
+		Server::get(IGroupManager::class)->addBackend(new Database());
 
 		parent::tearDownAfterClass();
 	}
@@ -173,8 +179,8 @@ abstract class TestCase extends \Test\TestCase {
 		}
 
 		if ($create) {
-			$userManager = \OC::$server->getUserManager();
-			$groupManager = \OC::$server->getGroupManager();
+			$userManager = Server::get(IUserManager::class);
+			$groupManager = Server::get(IGroupManager::class);
 
 			$userObject = $userManager->createUser($user, $password);
 			$group = $groupManager->createGroup('group');
@@ -186,9 +192,9 @@ abstract class TestCase extends \Test\TestCase {
 
 		\OC_Util::tearDownFS();
 		Storage::getGlobalCache()->clearCache();
-		\OC::$server->getUserSession()->setUser(null);
+		Server::get(IUserSession::class)->setUser(null);
 		Filesystem::tearDown();
-		\OC::$server->getUserSession()->login($user, $password);
+		Server::get(IUserSession::class)->login($user, $password);
 		\OC::$server->getUserFolder($user);
 
 		\OC_Util::setupFS($user);
@@ -200,7 +206,7 @@ abstract class TestCase extends \Test\TestCase {
 	 * @return array with: item_source, share_type, share_with, item_type, permissions
 	 */
 	protected function getShareFromId($shareID) {
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb->select('item_source', '`share_type', 'share_with', 'item_type', 'permissions')
 			->from('share')
 			->where(

--- a/apps/files_sharing/tests/UpdaterTest.php
+++ b/apps/files_sharing/tests/UpdaterTest.php
@@ -11,8 +11,11 @@ use OC\Files\Filesystem;
 use OC\Files\View;
 use OCA\Files_Sharing\Helper;
 use OCA\Files_Trashbin\AppInfo\Application;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\Constants;
+use OCP\IConfig;
+use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -56,7 +59,7 @@ class UpdaterTest extends TestCase {
 	 * that the mount point doesn't end up at the trash bin
 	 */
 	public function testDeleteParentFolder(): void {
-		$status = \OC::$server->getAppManager()->isEnabledForUser('files_trashbin');
+		$status = Server::get(IAppManager::class)->isEnabledForUser('files_trashbin');
 		(new \OC_App())->enable('files_trashbin');
 
 		// register trashbin hooks
@@ -113,7 +116,7 @@ class UpdaterTest extends TestCase {
 		$rootView->deleteAll('files_trashin');
 
 		if ($status === false) {
-			\OC::$server->getAppManager()->disableApp('files_trashbin');
+			Server::get(IAppManager::class)->disableApp('files_trashbin');
 		}
 
 		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
@@ -134,7 +137,7 @@ class UpdaterTest extends TestCase {
 	 * @param string $shareFolder share folder to use
 	 */
 	public function testShareFile($shareFolder): void {
-		$config = \OC::$server->getConfig();
+		$config = Server::get(IConfig::class);
 		$oldShareFolder = $config->getSystemValue('share_folder');
 		$config->setSystemValue('share_folder', $shareFolder);
 

--- a/apps/files_trashbin/lib/Command/Expire.php
+++ b/apps/files_trashbin/lib/Command/Expire.php
@@ -9,6 +9,8 @@ namespace OCA\Files_Trashbin\Command;
 use OC\Command\FileAccess;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Command\ICommand;
+use OCP\IUserManager;
+use OCP\Server;
 
 class Expire implements ICommand {
 	use FileAccess;
@@ -22,7 +24,7 @@ class Expire implements ICommand {
 	}
 
 	public function handle() {
-		$userManager = \OC::$server->getUserManager();
+		$userManager = Server::get(IUserManager::class);
 		if (!$userManager->userExists($this->user)) {
 			// User has been deleted already
 			return;

--- a/apps/files_trashbin/lib/Helper.php
+++ b/apps/files_trashbin/lib/Helper.php
@@ -10,6 +10,8 @@ use OC\Files\FileInfo;
 use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\IMimeTypeDetector;
+use OCP\Server;
 
 class Helper {
 	/**
@@ -63,7 +65,7 @@ class Helper {
 			$i = [
 				'name' => $name,
 				'mtime' => $timestamp,
-				'mimetype' => $type === 'dir' ? 'httpd/unix-directory' : \OC::$server->getMimeTypeDetector()->detectPath($name),
+				'mimetype' => $type === 'dir' ? 'httpd/unix-directory' : Server::get(IMimeTypeDetector::class)->detectPath($name),
 				'type' => $type,
 				'directory' => ($dir === '/') ? '' : $dir,
 				'size' => $entry->getSize(),

--- a/apps/files_trashbin/lib/Sabre/RootCollection.php
+++ b/apps/files_trashbin/lib/Sabre/RootCollection.php
@@ -10,6 +10,8 @@ namespace OCA\Files_Trashbin\Sabre;
 
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCP\IConfig;
+use OCP\IUserSession;
+use OCP\Server;
 use Sabre\DAV\INode;
 use Sabre\DAVACL\AbstractPrincipalCollection;
 use Sabre\DAVACL\PrincipalBackend;
@@ -36,7 +38,7 @@ class RootCollection extends AbstractPrincipalCollection {
 	 */
 	public function getChildForPrincipal(array $principalInfo): TrashHome {
 		[, $name] = \Sabre\Uri\split($principalInfo['uri']);
-		$user = \OC::$server->getUserSession()->getUser();
+		$user = Server::get(IUserSession::class)->getUser();
 		if (is_null($user) || $name !== $user->getUID()) {
 			throw new \Sabre\DAV\Exception\Forbidden();
 		}

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -148,12 +148,12 @@ class Storage extends Wrapper {
 	 * Setup the storage wrapper callback
 	 */
 	public static function setupStorage(): void {
-		$trashManager = \OC::$server->get(ITrashManager::class);
-		$userManager = \OC::$server->get(IUserManager::class);
-		$logger = \OC::$server->get(LoggerInterface::class);
-		$eventDispatcher = \OC::$server->get(IEventDispatcher::class);
-		$rootFolder = \OC::$server->get(IRootFolder::class);
-		$request = \OC::$server->get(IRequest::class);
+		$trashManager = Server::get(ITrashManager::class);
+		$userManager = Server::get(IUserManager::class);
+		$logger = Server::get(LoggerInterface::class);
+		$eventDispatcher = Server::get(IEventDispatcher::class);
+		$rootFolder = Server::get(IRootFolder::class);
+		$request = Server::get(IRequest::class);
 		Filesystem::addStorageWrapper(
 			'oc_trashbin',
 			function (string $mountPoint, IStorage $storage) use ($trashManager, $userManager, $logger, $eventDispatcher, $rootFolder, $request) {

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -10,6 +10,7 @@ use OC\User\Manager;
 use OCA\Files_Trashbin\Command\CleanUp;
 use OCP\Files\IRootFolder;
 use OCP\IDBConnection;
+use OCP\Server;
 use OCP\UserInterface;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputInterface;
@@ -51,7 +52,7 @@ class CleanUpTest extends TestCase {
 		$this->userManager = $this->getMockBuilder('OC\User\Manager')
 			->disableOriginalConstructor()->getMock();
 
-		$this->dbConnection = \OC::$server->getDatabaseConnection();
+		$this->dbConnection = Server::get(IDBConnection::class);
 
 		$this->cleanup = new CleanUp($this->rootFolder, $this->userManager, $this->dbConnection);
 	}

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -25,6 +25,7 @@ use OCP\Files\Node;
 use OCP\Files\Storage\IStorage;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
+use OCP\Server;
 use OCP\Share\IShare;
 use Psr\Log\LoggerInterface;
 use Test\Traits\MountProviderTrait;
@@ -80,7 +81,7 @@ class StorageTest extends \Test\TestCase {
 		$trashbinApp->boot($this->createMock(IBootContext::class));
 
 		$this->user = $this->getUniqueId('user');
-		\OC::$server->getUserManager()->createUser($this->user, $this->user);
+		Server::get(IUserManager::class)->createUser($this->user, $this->user);
 
 		// this will setup the FS
 		$this->loginAsUser($this->user);
@@ -100,7 +101,7 @@ class StorageTest extends \Test\TestCase {
 	protected function tearDown(): void {
 		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 		$this->logout();
-		$user = \OC::$server->getUserManager()->get($this->user);
+		$user = Server::get(IUserManager::class)->get($this->user);
 		if ($user !== null) {
 			$user->delete();
 		}
@@ -316,17 +317,17 @@ class StorageTest extends \Test\TestCase {
 		$this->assertEquals(1, count($results));
 
 		$recipientUser = $this->getUniqueId('recipient_');
-		\OC::$server->getUserManager()->createUser($recipientUser, $recipientUser);
+		Server::get(IUserManager::class)->createUser($recipientUser, $recipientUser);
 
 		$node = \OC::$server->getUserFolder($this->user)->get('share');
-		$share = \OC::$server->getShareManager()->newShare();
+		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setNode($node)
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy($this->user)
 			->setSharedWith($recipientUser)
 			->setPermissions(Constants::PERMISSION_ALL);
-		$share = \OC::$server->getShareManager()->createShare($share);
-		\OC::$server->getShareManager()->acceptShare($share, $recipientUser);
+		$share = Server::get(\OCP\Share\IManager::class)->createShare($share);
+		Server::get(\OCP\Share\IManager::class)->acceptShare($share, $recipientUser);
 
 		$this->loginAsUser($recipientUser);
 
@@ -368,17 +369,17 @@ class StorageTest extends \Test\TestCase {
 		$this->assertEquals(1, count($results));
 
 		$recipientUser = $this->getUniqueId('recipient_');
-		\OC::$server->getUserManager()->createUser($recipientUser, $recipientUser);
+		Server::get(IUserManager::class)->createUser($recipientUser, $recipientUser);
 
 		$node = \OC::$server->getUserFolder($this->user)->get('share');
-		$share = \OC::$server->getShareManager()->newShare();
+		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setNode($node)
 			->setShareType(IShare::TYPE_USER)
 			->setSharedBy($this->user)
 			->setSharedWith($recipientUser)
 			->setPermissions(Constants::PERMISSION_ALL);
-		$share = \OC::$server->getShareManager()->createShare($share);
-		\OC::$server->getShareManager()->acceptShare($share, $recipientUser);
+		$share = Server::get(\OCP\Share\IManager::class)->createShare($share);
+		Server::get(\OCP\Share\IManager::class)->acceptShare($share, $recipientUser);
 
 		$this->loginAsUser($recipientUser);
 
@@ -649,7 +650,7 @@ class StorageTest extends \Test\TestCase {
 		$timeFactory->method('getTime')
 			->willReturn(1000);
 
-		$lockingProvider = \OC::$server->getLockingProvider();
+		$lockingProvider = Server::get(ILockingProvider::class);
 
 		$this->overwriteService(ITimeFactory::class, $timeFactory);
 

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -42,6 +42,7 @@ use OCP\IServerContainer;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Server;
 use OCP\Share\IManager as IShareManager;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -68,7 +69,7 @@ class Application extends App implements IBootstrap {
 			return new Principal(
 				$server->get(IUserManager::class),
 				$server->get(IGroupManager::class),
-				\OC::$server->get(IAccountManager::class),
+				Server::get(IAccountManager::class),
 				$server->get(IShareManager::class),
 				$server->get(IUserSession::class),
 				$server->get(IAppManager::class),

--- a/apps/files_versions/lib/Command/Expire.php
+++ b/apps/files_versions/lib/Command/Expire.php
@@ -11,6 +11,7 @@ use OCA\Files_Versions\Storage;
 use OCP\Command\ICommand;
 use OCP\Files\StorageNotAvailableException;
 use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 class Expire implements ICommand {
@@ -24,7 +25,7 @@ class Expire implements ICommand {
 
 	public function handle(): void {
 		/** @var IUserManager $userManager */
-		$userManager = \OC::$server->get(IUserManager::class);
+		$userManager = Server::get(IUserManager::class);
 		if (!$userManager->userExists($this->user)) {
 			// User has been deleted already
 			return;
@@ -36,7 +37,7 @@ class Expire implements ICommand {
 			// In case of external storage and session credentials, the expiration
 			// fails because the command does not have those credentials
 
-			$logger = \OC::$server->get(LoggerInterface::class);
+			$logger = Server::get(LoggerInterface::class);
 			$logger->warning($e->getMessage(), [
 				'exception' => $e,
 				'uid' => $this->user,

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -18,6 +18,7 @@ use OCP\Files\Node;
 use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 use OCP\Lock\ManuallyLockedException;
+use OCP\Server;
 
 class VersionManager implements IVersionManager, IDeletableVersionBackend, INeedSyncVersionBackend, IMetadataVersionBackend {
 	/** @var (IVersionBackend[])[] */
@@ -176,9 +177,9 @@ class VersionManager implements IVersionManager, IDeletableVersionBackend, INeed
 			// when checking the lock against the current scope.
 			// So we do not need to get the actual node here
 			// and use the root node instead.
-			$root = \OC::$server->get(IRootFolder::class);
+			$root = Server::get(IRootFolder::class);
 			$lockContext = new LockContext($root, ILock::TYPE_APP, $owner);
-			$lockManager = \OC::$server->get(ILockManager::class);
+			$lockManager = Server::get(ILockManager::class);
 			$result = null;
 			$lockManager->runInScope($lockContext, function () use ($callback, &$result): void {
 				$result = $callback();

--- a/apps/files_versions/tests/StorageTest.php
+++ b/apps/files_versions/tests/StorageTest.php
@@ -12,6 +12,7 @@ use OCA\Files_Versions\Expiration;
 use OCA\Files_Versions\Storage;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\Server;
 use Test\TestCase;
 use Test\Traits\UserTrait;
 
@@ -40,7 +41,7 @@ class StorageTest extends TestCase {
 		$this->createUser('version_test', '');
 		$this->loginAsUser('version_test');
 		/** @var IRootFolder $root */
-		$root = \OC::$server->get(IRootFolder::class);
+		$root = Server::get(IRootFolder::class);
 		$this->userFolder = $root->getUserFolder('version_test');
 	}
 

--- a/apps/oauth2/templates/admin.php
+++ b/apps/oauth2/templates/admin.php
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-script('oauth2', 'oauth2');
+\OCP\Util::addScript('oauth2', 'oauth2', 'core');
 
 ?>
 

--- a/apps/oauth2/tests/Controller/SettingsControllerTest.php
+++ b/apps/oauth2/tests/Controller/SettingsControllerTest.php
@@ -18,6 +18,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -119,7 +120,7 @@ class SettingsControllerTest extends TestCase {
 
 	public function testDeleteClient(): void {
 
-		$userManager = \OC::$server->getUserManager();
+		$userManager = Server::get(IUserManager::class);
 		// count other users in the db before adding our own
 		$count = 0;
 		$function = function (IUser $user) use (&$count): void {

--- a/apps/oauth2/tests/Db/AccessTokenMapperTest.php
+++ b/apps/oauth2/tests/Db/AccessTokenMapperTest.php
@@ -9,6 +9,8 @@ use OCA\OAuth2\Db\AccessToken;
 use OCA\OAuth2\Db\AccessTokenMapper;
 use OCA\OAuth2\Exceptions\AccessTokenNotFoundException;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -20,7 +22,7 @@ class AccessTokenMapperTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->accessTokenMapper = new AccessTokenMapper(\OC::$server->getDatabaseConnection(), \OC::$server->get(ITimeFactory::class));
+		$this->accessTokenMapper = new AccessTokenMapper(Server::get(IDBConnection::class), Server::get(ITimeFactory::class));
 	}
 
 	public function testGetByCode(): void {

--- a/apps/oauth2/tests/Db/ClientMapperTest.php
+++ b/apps/oauth2/tests/Db/ClientMapperTest.php
@@ -8,6 +8,8 @@ namespace OCA\OAuth2\Tests\Db;
 use OCA\OAuth2\Db\Client;
 use OCA\OAuth2\Db\ClientMapper;
 use OCA\OAuth2\Exceptions\ClientNotFoundException;
+use OCP\IDBConnection;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -19,11 +21,11 @@ class ClientMapperTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->clientMapper = new ClientMapper(\OC::$server->getDatabaseConnection());
+		$this->clientMapper = new ClientMapper(Server::get(IDBConnection::class));
 	}
 
 	protected function tearDown(): void {
-		$query = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('oauth2_clients')->execute();
 
 		parent::tearDown();

--- a/apps/profile/lib/Controller/ProfilePageController.php
+++ b/apps/profile/lib/Controller/ProfilePageController.php
@@ -28,6 +28,7 @@ use OCP\Profile\BeforeTemplateRenderedEvent;
 use OCP\Profile\IProfileManager;
 use OCP\Share\IManager as IShareManager;
 use OCP\UserStatus\IManager as IUserStatusManager;
+use OCP\Util;
 
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ProfilePageController extends Controller {
@@ -103,7 +104,7 @@ class ProfilePageController extends Controller {
 
 		$this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($targetUserId));
 
-		\OCP\Util::addScript('profile', 'main');
+		Util::addScript('profile', 'main');
 
 		return new TemplateResponse(
 			'profile',

--- a/apps/profile/templates/404-profile.php
+++ b/apps/profile/templates/404-profile.php
@@ -10,7 +10,7 @@
 if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
 	require_once '../../lib/base.php';
 
-	$urlGenerator = \OC::$server->getURLGenerator();
+	$urlGenerator = \OCP\Server::get(\OCP\IURLGenerator::class);
 	header('Location: ' . $urlGenerator->getAbsoluteURL('/'));
 	exit;
 }
@@ -23,7 +23,7 @@ if (!isset($_)) { //standalone  page is not supported anymore - redirect to /
 		<div class="icon-big icon-error"></div>
 		<h2><?php p($l->t('Profile not found')); ?></h2>
 		<p class="infogroup"><?php p($l->t('The profile does not exist.')); ?></p>
-		<p><a class="button primary" href="<?php p(\OC::$server->getURLGenerator()->linkTo('', 'index.php')) ?>">
+		<p><a class="button primary" href="<?php p(\OCP\Server::get(\OCP\IURLGenerator::class)->linkTo('', 'index.php')) ?>">
 				<?php p($l->t('Back to %s', [$theme->getName()])); ?>
 			</a></p>
 	</div>

--- a/apps/provisioning_api/lib/Capabilities.php
+++ b/apps/provisioning_api/lib/Capabilities.php
@@ -8,6 +8,7 @@ namespace OCA\Provisioning_API;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
+use OCP\Server;
 
 class Capabilities implements ICapability {
 
@@ -36,7 +37,7 @@ class Capabilities implements ICapability {
 		$federatedFileSharingEnabled = $this->appManager->isEnabledForUser('federatedfilesharing');
 		if ($federatedFileSharingEnabled) {
 			/** @var FederatedShareProvider $shareProvider */
-			$shareProvider = \OC::$server->query(FederatedShareProvider::class);
+			$shareProvider = Server::get(FederatedShareProvider::class);
 			$publishedScopeEnabled = $shareProvider->isLookupServerUploadEnabled();
 		}
 

--- a/apps/provisioning_api/lib/Controller/AUserDataOCSController.php
+++ b/apps/provisioning_api/lib/Controller/AUserDataOCSController.php
@@ -28,6 +28,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
+use OCP\Server;
 use OCP\User\Backend\ISetDisplayNameBackend;
 use OCP\User\Backend\ISetPasswordBackend;
 use OCP\Util;
@@ -307,7 +308,7 @@ abstract class AUserDataOCSController extends OCSController {
 				'used' => 0
 			];
 		} catch (\Exception $e) {
-			\OC::$server->get(\Psr\Log\LoggerInterface::class)->error(
+			Server::get(\Psr\Log\LoggerInterface::class)->error(
 				'Could not load storage info for {user}',
 				[
 					'app' => 'provisioning_api',

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -11,8 +11,10 @@ use OCA\Provisioning_API\Controller\AppsController;
 use OCA\Provisioning_API\Tests\TestCase;
 use OCP\App\IAppManager;
 use OCP\AppFramework\OCS\OCSException;
+use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
+use OCP\Server;
 
 /**
  * Class AppsTest
@@ -32,9 +34,9 @@ class AppsControllerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->appManager = \OC::$server->getAppManager();
-		$this->groupManager = \OC::$server->getGroupManager();
-		$this->userSession = \OC::$server->getUserSession();
+		$this->appManager = Server::get(IAppManager::class);
+		$this->groupManager = Server::get(IGroupManager::class);
+		$this->userSession = Server::get(IUserSession::class);
 
 		$request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()

--- a/apps/provisioning_api/tests/TestCase.php
+++ b/apps/provisioning_api/tests/TestCase.php
@@ -10,6 +10,7 @@ namespace OCA\Provisioning_API\Tests;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
 
 abstract class TestCase extends \Test\TestCase {
 
@@ -25,8 +26,8 @@ abstract class TestCase extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->userManager = \OC::$server->getUserManager();
-		$this->groupManager = \OC::$server->getGroupManager();
+		$this->userManager = Server::get(IUserManager::class);
+		$this->groupManager = Server::get(IGroupManager::class);
 		$this->groupManager->createGroup('admin');
 	}
 

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -87,9 +87,7 @@ use OCP\Defaults;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
-use OCP\IGroupManager;
 use OCP\IServerContainer;
-use OCP\IUserSession;
 use OCP\Settings\Events\DeclarativeSettingsGetValueEvent;
 use OCP\Settings\Events\DeclarativeSettingsSetValueEvent;
 use OCP\Settings\IManager;
@@ -133,15 +131,6 @@ class Application extends App implements IBootstrap {
 		/**
 		 * Core class wrappers
 		 */
-		/** FIXME: Remove once OC_SubAdmin is non-static and mockable */
-		$context->registerService('isSubAdmin', function () {
-			$userObject = \OCP\Server::get(IUserSession::class)->getUser();
-			$isSubAdmin = false;
-			if ($userObject !== null) {
-				$isSubAdmin = \OCP\Server::get(IGroupManager::class)->getSubAdmin()->isSubAdmin($userObject);
-			}
-			return $isSubAdmin;
-		});
 		$context->registerService(IProvider::class, function (IAppContainer $appContainer) {
 			/** @var IServerContainer $serverContainer */
 			$serverContainer = $appContainer->query(IServerContainer::class);

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -87,7 +87,9 @@ use OCP\Defaults;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserAddedEvent;
 use OCP\Group\Events\UserRemovedEvent;
+use OCP\IGroupManager;
 use OCP\IServerContainer;
+use OCP\IUserSession;
 use OCP\Settings\Events\DeclarativeSettingsGetValueEvent;
 use OCP\Settings\Events\DeclarativeSettingsSetValueEvent;
 use OCP\Settings\IManager;
@@ -133,10 +135,10 @@ class Application extends App implements IBootstrap {
 		 */
 		/** FIXME: Remove once OC_SubAdmin is non-static and mockable */
 		$context->registerService('isSubAdmin', function () {
-			$userObject = \OC::$server->getUserSession()->getUser();
+			$userObject = \OCP\Server::get(IUserSession::class)->getUser();
 			$isSubAdmin = false;
 			if ($userObject !== null) {
-				$isSubAdmin = \OC::$server->getGroupManager()->getSubAdmin()->isSubAdmin($userObject);
+				$isSubAdmin = \OCP\Server::get(IGroupManager::class)->getSubAdmin()->isSubAdmin($userObject);
 			}
 			return $isSubAdmin;
 		});

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -15,6 +15,7 @@ use OC\App\AppStore\Version\VersionParser;
 use OC\App\DependencyAnalyzer;
 use OC\App\Platform;
 use OC\Installer;
+use OCA\AppAPI\Service\ExAppsPageService;
 use OCP\App\AppPathNotFoundException;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
@@ -94,7 +95,7 @@ class AppSettingsController extends Controller {
 
 		if ($this->appManager->isEnabledForAnyone('app_api')) {
 			try {
-				Server::get(\OCA\AppAPI\Service\ExAppsPageService::class)->provideAppApiState($this->initialState);
+				Server::get(ExAppsPageService::class)->provideAppApiState($this->initialState);
 			} catch (\Psr\Container\NotFoundExceptionInterface|\Psr\Container\ContainerExceptionInterface $e) {
 			}
 		}

--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -39,6 +39,7 @@ use OCP\Files\SimpleFS\ISimpleFolder;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
 use OCP\IGroup;
+use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
@@ -520,7 +521,7 @@ class AppSettingsController extends Controller {
 
 				// Check if app is already downloaded
 				/** @var Installer $installer */
-				$installer = \OC::$server->get(Installer::class);
+				$installer = Server::get(Installer::class);
 				$isDownloaded = $installer->isDownloaded($appId);
 
 				if (!$isDownloaded) {
@@ -546,7 +547,7 @@ class AppSettingsController extends Controller {
 	}
 
 	private function getGroupList(array $groups) {
-		$groupManager = \OC::$server->getGroupManager();
+		$groupManager = Server::get(IGroupManager::class);
 		$groupsList = [];
 		foreach ($groups as $group) {
 			$groupItem = $groupManager->get($group);

--- a/apps/settings/lib/Controller/UsersController.php
+++ b/apps/settings/lib/Controller/UsersController.php
@@ -43,11 +43,13 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IL10N;
+use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Mail\IMailer;
+use OCP\Server;
 use OCP\Util;
 use function in_array;
 
@@ -101,7 +103,7 @@ class UsersController extends Controller {
 		$isAdmin = $this->groupManager->isAdmin($uid);
 		$isDelegatedAdmin = $this->groupManager->isDelegatedAdmin($uid);
 
-		\OC::$server->getNavigationManager()->setActiveEntry('core_users');
+		Server::get(INavigationManager::class)->setActiveEntry('core_users');
 
 		/* SORT OPTION: SORT_USERCOUNT or SORT_GROUPNAME */
 		$sortGroupsBy = MetaData::SORT_USERCOUNT;

--- a/apps/settings/lib/Middleware/SubadminMiddleware.php
+++ b/apps/settings/lib/Middleware/SubadminMiddleware.php
@@ -1,9 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2019-2024 Nextcloud GmbH and Nextcloud contributors/**
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Settings\Middleware;
 
 use OC\AppFramework\Http;
@@ -12,27 +16,29 @@ use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Middleware;
+use OCP\Group\ISubAdmin;
 use OCP\IL10N;
+use OCP\IUserSession;
 
 /**
  * Verifies whether an user has at least subadmin rights.
  * To bypass use the `@NoSubAdminRequired` annotation
  */
 class SubadminMiddleware extends Middleware {
-	/** @var ControllerMethodReflector */
-	protected $reflector;
-
-	/**
-	 * @param ControllerMethodReflector $reflector
-	 * @param bool $isSubAdmin
-	 * @param IL10N $l10n
-	 */
 	public function __construct(
-		ControllerMethodReflector $reflector,
-		protected $isSubAdmin,
+		protected ControllerMethodReflector $reflector,
+		protected IUserSession $userSession,
+		protected ISubAdmin $subAdminManager,
 		private IL10N $l10n,
 	) {
-		$this->reflector = $reflector;
+	}
+
+	private function isSubAdmin(): bool {
+		$userObject = $this->userSession->getUser();
+		if ($userObject === null) {
+			return false;
+		}
+		return $this->subAdminManager->isSubAdmin($userObject);
 	}
 
 	/**
@@ -43,7 +49,7 @@ class SubadminMiddleware extends Middleware {
 	 */
 	public function beforeController($controller, $methodName) {
 		if (!$this->reflector->hasAnnotation('NoSubAdminRequired') && !$this->reflector->hasAnnotation('AuthorizedAdminSetting')) {
-			if (!$this->isSubAdmin) {
+			if (!$this->isSubAdmin()) {
 				throw new NotAdminException($this->l10n->t('Logged in account must be a subadmin'));
 			}
 		}

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -27,6 +27,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\L10N\IFactory;
 use OCP\Notification\IManager;
+use OCP\Server;
 use OCP\Settings\ISettings;
 
 class PersonalInfo implements ISettings {
@@ -55,7 +56,7 @@ class PersonalInfo implements ISettings {
 		$lookupServerUploadEnabled = false;
 		if ($federatedFileSharingEnabled) {
 			/** @var FederatedShareProvider $shareProvider */
-			$shareProvider = \OC::$server->query(FederatedShareProvider::class);
+			$shareProvider = Server::get(FederatedShareProvider::class);
 			$lookupServerUploadEnabled = $shareProvider->isLookupServerUploadEnabled();
 		}
 

--- a/apps/settings/templates/settings/admin/delegation.php
+++ b/apps/settings/templates/settings/admin/delegation.php
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-script('settings', 'vue-settings-admin-delegation');
+\OCP\Util::addScript('settings', 'vue-settings-admin-delegation', 'core');
 ?>
 
 <div id="admin-right-sub-granting">

--- a/apps/settings/templates/settings/admin/overview.php
+++ b/apps/settings/templates/settings/admin/overview.php
@@ -45,7 +45,7 @@
 		<ul class="info hidden"></ul>
 	</div>
 	<p id="postsetupchecks-hint" class="hidden">
-		<?php print_unescaped($l->t('Please double check the <a target="_blank" rel="noreferrer noopener" href="%1$s">installation guides ↗</a>, and check for any errors or warnings in the <a href="%2$s">log</a>.', [link_to_docs('admin-install'), \OC::$server->getURLGenerator()->linkToRoute('settings.AdminSettings.index', ['section' => 'logging'])])); ?>
+		<?php print_unescaped($l->t('Please double check the <a target="_blank" rel="noreferrer noopener" href="%1$s">installation guides ↗</a>, and check for any errors or warnings in the <a href="%2$s">log</a>.', [link_to_docs('admin-install'), \OCP\Server::get(\OCP\IURLGenerator::class)->linkToRoute('settings.AdminSettings.index', ['section' => 'logging'])])); ?>
 	</p>
 
 	<p class="extra-top-margin">

--- a/apps/settings/templates/settings/frame.php
+++ b/apps/settings/templates/settings/frame.php
@@ -5,9 +5,9 @@
  */
 
 style('settings', 'settings');
-script('settings', 'settings');
+\OCP\Util::addScript('settings', 'settings', 'core');
 \OCP\Util::addScript('settings', 'legacy-admin');
-script('core', 'setupchecks');
+\OCP\Util::addScript('core', 'setupchecks', 'core');
 
 ?>
 
@@ -19,7 +19,7 @@ script('core', 'setupchecks');
 		<ul>
 			<?php foreach ($_['forms']['personal'] as $form) {
 				if (isset($form['anchor'])) {
-					$anchor = \OC::$server->getURLGenerator()->linkToRoute('settings.PersonalSettings.index', ['section' => $form['anchor']]);
+					$anchor = \OCP\Server::get(\OCP\IURLGenerator::class)->linkToRoute('settings.PersonalSettings.index', ['section' => $form['anchor']]);
 					$class = 'nav-icon-' . $form['anchor'];
 					$sectionName = $form['section-name']; ?>
 					<li <?php print_unescaped($form['active'] ? ' class="active"' : ''); ?> data-section-id="<?php print_unescaped($form['anchor']); ?>" data-section-type="personal">
@@ -46,7 +46,7 @@ script('core', 'setupchecks');
 		<ul>
 			<?php foreach ($_['forms']['admin'] as $form) {
 				if (isset($form['anchor'])) {
-					$anchor = \OC::$server->getURLGenerator()->linkToRoute('settings.AdminSettings.index', ['section' => $form['anchor']]);
+					$anchor = \OCP\Server::get(\OCP\IURLGenerator::class)->linkToRoute('settings.AdminSettings.index', ['section' => $form['anchor']]);
 					$class = 'nav-icon-' . $form['anchor'];
 					$sectionName = $form['section-name']; ?>
 					<li <?php print_unescaped($form['active'] ? ' class="active"' : ''); ?> data-section-id="<?php print_unescaped($form['anchor']); ?>" data-section-type="admin">

--- a/apps/settings/templates/settings/personal/security/authtokens.php
+++ b/apps/settings/templates/settings/personal/security/authtokens.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-script('settings', 'vue-settings-personal-security');
+\OCP\Util::addScript('settings', 'vue-settings-personal-security', 'core');
 
 ?>
 

--- a/apps/settings/templates/settings/personal/security/webauthn.php
+++ b/apps/settings/templates/settings/personal/security/webauthn.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-script('settings', 'vue-settings-personal-webauthn');
+\OCP\Util::addScript('settings', 'vue-settings-personal-webauthn', 'core');
 
 ?>
 

--- a/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
+++ b/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
@@ -1,9 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2019-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2014 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Settings\Tests\Middleware;
 
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
@@ -11,7 +15,11 @@ use OC\AppFramework\Utility\ControllerMethodReflector;
 use OCA\Settings\Middleware\SubadminMiddleware;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\Group\ISubAdmin;
 use OCP\IL10N;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Verifies whether an user has at least subadmin rights.
@@ -20,31 +28,40 @@ use OCP\IL10N;
  * @package Tests\Settings\Middleware
  */
 class SubadminMiddlewareTest extends \Test\TestCase {
-	/** @var SubadminMiddleware */
-	private $subadminMiddlewareAsSubAdmin;
-	/** @var SubadminMiddleware */
-	private $subadminMiddleware;
-	/** @var ControllerMethodReflector */
-	private $reflector;
-	/** @var Controller */
-	private $controller;
-	/** @var IL10N */
-	private $l10n;
+	private SubadminMiddleware $subadminMiddleware;
+
+	private IUserSession&MockObject $userSession;
+	private ISubAdmin&MockObject $subAdminManager;
+	private ControllerMethodReflector&MockObject $reflector;
+	private Controller&MockObject $controller;
+	private IL10N&MockObject $l10n;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->reflector = $this->getMockBuilder(ControllerMethodReflector::class)
 			->disableOriginalConstructor()->getMock();
-		$this->controller = $this->getMockBuilder(Controller::class)
-			->disableOriginalConstructor()->getMock();
+		$this->userSession = $this->createMock(IUserSession::class);
+		$this->subAdminManager = $this->createMock(ISubAdmin::class);
 		$this->l10n = $this->createMock(IL10N::class);
 
-		$this->subadminMiddlewareAsSubAdmin = new SubadminMiddleware($this->reflector, true, $this->l10n);
-		$this->subadminMiddleware = new SubadminMiddleware($this->reflector, false, $this->l10n);
+		$this->subadminMiddleware = new SubadminMiddleware(
+			$this->reflector,
+			$this->userSession,
+			$this->subAdminManager,
+			$this->l10n,
+		);
+
+		$this->controller = $this->getMockBuilder(Controller::class)
+			->disableOriginalConstructor()->getMock();
+
+		$this->userSession
+			->expects(self::any())
+			->method('getUser')
+			->willReturn($this->createMock(IUser::class));
 	}
 
 
-	public function testBeforeControllerAsUserWithExemption(): void {
+	public function testBeforeControllerAsUserWithoutAnnotation(): void {
 		$this->expectException(NotAdminException::class);
 
 		$this->reflector
@@ -54,20 +71,31 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 				['NoSubAdminRequired'],
 				['AuthorizedAdminSetting'],
 			)->willReturn(false);
+
+		$this->subAdminManager
+			->expects(self::once())
+			->method('isSubAdmin')
+			->willReturn(false);
+
 		$this->subadminMiddleware->beforeController($this->controller, 'foo');
 	}
 
 
-	public function testBeforeControllerAsUserWithoutExemption(): void {
+	public function testBeforeControllerWithAnnotation(): void {
 		$this->reflector
 			->expects($this->once())
 			->method('hasAnnotation')
 			->with('NoSubAdminRequired')
 			->willReturn(true);
+
+		$this->subAdminManager
+			->expects(self::never())
+			->method('isSubAdmin');
+
 		$this->subadminMiddleware->beforeController($this->controller, 'foo');
 	}
 
-	public function testBeforeControllerAsSubAdminWithoutExemption(): void {
+	public function testBeforeControllerAsSubAdminWithoutAnnotation(): void {
 		$this->reflector
 			->expects($this->exactly(2))
 			->method('hasAnnotation')
@@ -75,16 +103,13 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 				['NoSubAdminRequired'],
 				['AuthorizedAdminSetting'],
 			)->willReturn(false);
-		$this->subadminMiddlewareAsSubAdmin->beforeController($this->controller, 'foo');
-	}
 
-	public function testBeforeControllerAsSubAdminWithExemption(): void {
-		$this->reflector
-			->expects($this->once())
-			->method('hasAnnotation')
-			->with('NoSubAdminRequired')
+		$this->subAdminManager
+			->expects(self::once())
+			->method('isSubAdmin')
 			->willReturn(true);
-		$this->subadminMiddlewareAsSubAdmin->beforeController($this->controller, 'foo');
+
+		$this->subadminMiddleware->beforeController($this->controller, 'foo');
 	}
 
 	public function testAfterNotAdminException(): void {

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -46,7 +46,7 @@ class ServerTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->connection = \OC::$server->getDatabaseConnection();
+		$this->connection = \OCP\Server::get(IDBConnection::class);
 		$this->initialStateService = $this->createMock(IInitialState::class);
 		$this->profileManager = $this->createMock(ProfileManager::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);

--- a/apps/settings/tests/Settings/Admin/SharingTest.php
+++ b/apps/settings/tests/Settings/Admin/SharingTest.php
@@ -101,7 +101,7 @@ class SharingTest extends TestCase {
 		$this->initialState
 			->expects($this->exactly(3))
 			->method('provideInitialState')
-			->willReturnCallback(function (string $key) use (&$initialStateCalls) {
+			->willReturnCallback(function (string $key) use (&$initialStateCalls): void {
 				$initialStateCalls[$key] = func_get_args();
 			});
 		
@@ -198,7 +198,7 @@ class SharingTest extends TestCase {
 		$this->initialState
 			->expects($this->exactly(3))
 			->method('provideInitialState')
-			->willReturnCallback(function (string $key) use (&$initialStateCalls) {
+			->willReturnCallback(function (string $key) use (&$initialStateCalls): void {
 				$initialStateCalls[$key] = func_get_args();
 			});
 

--- a/apps/settings/tests/UserMigration/AccountMigratorTest.php
+++ b/apps/settings/tests/UserMigration/AccountMigratorTest.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\App;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IUserManager;
+use OCP\Server;
 use OCP\UserMigration\IExportDestination;
 use OCP\UserMigration\IImportSource;
 use PHPUnit\Framework\Constraint\JsonMatches;
@@ -67,7 +68,7 @@ class AccountMigratorTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		\OCP\Server::get(IConfig::class)->setSystemValue('has_internet_connection', true);
+		Server::get(IConfig::class)->setSystemValue('has_internet_connection', true);
 		parent::tearDown();
 	}
 

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -1145,8 +1145,8 @@ class ShareByMailProviderTest extends TestCase {
 	}
 
 	public function testGetSharesInFolder(): void {
-		$userManager = \OC::$server->getUserManager();
-		$rootFolder = \OC::$server->getRootFolder();
+		$userManager = Server::get(IUserManager::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		$this->shareManager->expects($this->any())
 			->method('newShare')
@@ -1192,8 +1192,8 @@ class ShareByMailProviderTest extends TestCase {
 	}
 
 	public function testGetAccessList(): void {
-		$userManager = \OC::$server->getUserManager();
-		$rootFolder = \OC::$server->getRootFolder();
+		$userManager = Server::get(IUserManager::class);
+		$rootFolder = Server::get(IRootFolder::class);
 
 		$this->shareManager->expects($this->any())
 			->method('newShare')

--- a/apps/testing/lib/AlternativeHomeUserBackend.php
+++ b/apps/testing/lib/AlternativeHomeUserBackend.php
@@ -6,6 +6,8 @@
 namespace OCA\Testing;
 
 use OC\User\Database;
+use OCP\IConfig;
+use OCP\Server;
 
 /**
  * Alternative home user backend.
@@ -34,7 +36,7 @@ class AlternativeHomeUserBackend extends Database {
 			if ($uid !== 'admin') {
 				$uid = md5($uid);
 			}
-			return \OC::$server->getConfig()->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid;
+			return Server::get(IConfig::class)->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/' . $uid;
 		}
 
 		return false;

--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -13,6 +13,7 @@ use OCP\Files\NotFoundException;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IConfig;
 use OCP\IUserSession;
+use OCP\Server;
 use OCP\ServerVersion;
 
 class Util {
@@ -302,7 +303,7 @@ class Util {
 	}
 
 	public function getCacheBuster(): string {
-		$userSession = \OC::$server->get(IUserSession::class);
+		$userSession = Server::get(IUserSession::class);
 		$userId = '';
 		$user = $userSession->getUser();
 		if (!is_null($user)) {

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -25,7 +25,9 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
+use OCP\ITempManager;
 use OCP\IURLGenerator;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -355,8 +357,8 @@ class ThemingControllerTest extends TestCase {
 
 	/** @dataProvider dataUpdateImages */
 	public function testUpdateLogoNormalLogoUpload($mimeType, $folderExists = true): void {
-		$tmpLogo = \OC::$server->getTempManager()->getTemporaryFolder() . '/logo.svg';
-		$destination = \OC::$server->getTempManager()->getTemporaryFolder();
+		$tmpLogo = Server::get(ITempManager::class)->getTemporaryFolder() . '/logo.svg';
+		$destination = Server::get(ITempManager::class)->getTemporaryFolder();
 
 		touch($tmpLogo);
 		copy(__DIR__ . '/../../../../tests/data/testimage.png', $tmpLogo);
@@ -407,7 +409,7 @@ class ThemingControllerTest extends TestCase {
 
 	/** @dataProvider dataUpdateImages */
 	public function testUpdateLogoLoginScreenUpload($folderExists): void {
-		$tmpLogo = \OC::$server->getTempManager()->getTemporaryFolder() . 'logo.png';
+		$tmpLogo = Server::get(ITempManager::class)->getTemporaryFolder() . 'logo.png';
 
 		touch($tmpLogo);
 		copy(__DIR__ . '/../../../../tests/data/desktopapp.png', $tmpLogo);
@@ -455,7 +457,7 @@ class ThemingControllerTest extends TestCase {
 	}
 
 	public function testUpdateLogoLoginScreenUploadWithInvalidImage(): void {
-		$tmpLogo = \OC::$server->getTempManager()->getTemporaryFolder() . '/logo.svg';
+		$tmpLogo = Server::get(ITempManager::class)->getTemporaryFolder() . '/logo.svg';
 
 		touch($tmpLogo);
 		file_put_contents($tmpLogo, file_get_contents(__DIR__ . '/../../../../tests/data/data.zip'));

--- a/apps/theming/tests/Migration/Version2006Date20240905111627Test.php
+++ b/apps/theming/tests/Migration/Version2006Date20240905111627Test.php
@@ -16,6 +16,7 @@ use OCP\IAppConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
 use OCP\Migration\IOutput;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -88,11 +89,11 @@ class Version2006Date20240905111627Test extends TestCase {
 			->willReturn(false);
 
 		// Create a user
-		$manager = \OCP\Server::get(IUserManager::class);
+		$manager = Server::get(IUserManager::class);
 		$user = $manager->createUser('theming_legacy', 'theming_legacy');
 		self::assertNotFalse($user);
 		// Set the users theming value to legacy key
-		$config = \OCP\Server::get(IUserConfig::class);
+		$config = Server::get(IUserConfig::class);
 		$config->setValueString('theming_legacy', 'theming', 'background_color', 'ffab00');
 
 		// expect some output
@@ -109,7 +110,7 @@ class Version2006Date20240905111627Test extends TestCase {
 		$migration = new Version2006Date20240905111627(
 			$this->jobList,
 			$this->appConfig,
-			\OCP\Server::get(IDBConnection::class),
+			Server::get(IDBConnection::class),
 		);
 		// Run the migration
 		$migration->changeSchema($output, fn () => null, []);
@@ -138,13 +139,13 @@ class Version2006Date20240905111627Test extends TestCase {
 			->willReturn(false);
 
 		// Create a user
-		$manager = \OCP\Server::get(IUserManager::class);
+		$manager = Server::get(IUserManager::class);
 		$legacyUser = $manager->createUser('theming_legacy', 'theming_legacy');
 		self::assertNotFalse($legacyUser);
 		$user = $manager->createUser('theming_no_legacy', 'theming_no_legacy');
 		self::assertNotFalse($user);
 		// Set the users theming value to legacy key
-		$config = \OCP\Server::get(IUserConfig::class);
+		$config = Server::get(IUserConfig::class);
 		$config->setValueString($user->getUID(), 'theming', 'primary_color', '999999');
 		$config->setValueString($user->getUID(), 'theming', 'background_color', '111111');
 		$config->setValueString($legacyUser->getUID(), 'theming', 'background_color', 'ffab00');
@@ -163,7 +164,7 @@ class Version2006Date20240905111627Test extends TestCase {
 		$migration = new Version2006Date20240905111627(
 			$this->jobList,
 			$this->appConfig,
-			\OCP\Server::get(IDBConnection::class),
+			Server::get(IDBConnection::class),
 		);
 		// Run the migration
 		$migration->changeSchema($output, fn () => null, []);

--- a/apps/twofactor_backupcodes/templates/personal.php
+++ b/apps/twofactor_backupcodes/templates/personal.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-script('twofactor_backupcodes', 'settings');
+\OCP\Util::addScript('twofactor_backupcodes', 'settings', 'core');
 
 ?>
 

--- a/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
+++ b/apps/twofactor_backupcodes/tests/Db/BackupCodeMapperTest.php
@@ -12,6 +12,7 @@ use OCA\TwoFactorBackupCodes\Db\BackupCode;
 use OCA\TwoFactorBackupCodes\Db\BackupCodeMapper;
 use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -38,8 +39,8 @@ class BackupCodeMapperTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
-		$this->mapper = \OC::$server->query(BackupCodeMapper::class);
+		$this->db = Server::get(IDBConnection::class);
+		$this->mapper = Server::get(BackupCodeMapper::class);
 
 		$this->resetDB();
 	}

--- a/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
+++ b/apps/twofactor_backupcodes/tests/Service/BackupCodeStorageTest.php
@@ -12,6 +12,7 @@ use OCA\TwoFactorBackupCodes\Service\BackupCodeStorage;
 use OCP\IUser;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
+use OCP\Server;
 use Test\TestCase;
 
 /**
@@ -31,11 +32,11 @@ class BackupCodeStorageTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->storage = \OC::$server->query(BackupCodeStorage::class);
+		$this->storage = Server::get(BackupCodeStorage::class);
 
 		$this->notificationManager = $this->createMock(IManager::class);
 		$this->notificationManager->method('createNotification')
-			->willReturn(\OC::$server->query(IManager::class)->createNotification());
+			->willReturn(Server::get(IManager::class)->createNotification());
 		$this->overwriteService(IManager::class, $this->notificationManager);
 	}
 

--- a/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Listener/ClearNotificationsTest.php
@@ -14,6 +14,7 @@ use OCP\EventDispatcher\Event;
 use OCP\IUser;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
+use OCP\Server;
 use Test\TestCase;
 
 class ClearNotificationsTest extends TestCase {
@@ -29,7 +30,7 @@ class ClearNotificationsTest extends TestCase {
 
 		$this->notificationManager = $this->createMock(IManager::class);
 		$this->notificationManager->method('createNotification')
-			->willReturn(\OC::$server->query(IManager::class)->createNotification());
+			->willReturn(Server::get(IManager::class)->createNotification());
 
 		$this->listener = new ClearNotifications($this->notificationManager);
 	}

--- a/apps/user_ldap/ajax/clearMappings.php
+++ b/apps/user_ldap/ajax/clearMappings.php
@@ -8,6 +8,8 @@
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Server;
 use OCP\User\Events\BeforeUserIdUnassignedEvent;
 use OCP\User\Events\UserIdUnassignedEvent;
@@ -28,15 +30,15 @@ try {
 		$result = $mapping->clearCb(
 			function (string $uid) use ($dispatcher): void {
 				$dispatcher->dispatchTyped(new BeforeUserIdUnassignedEvent($uid));
-				\OC::$server->getUserManager()->emit('\OC\User', 'preUnassignedUserId', [$uid]);
+				Server::get(IUserManager::class)->emit('\OC\User', 'preUnassignedUserId', [$uid]);
 			},
 			function (string $uid) use ($dispatcher): void {
 				$dispatcher->dispatchTyped(new UserIdUnassignedEvent($uid));
-				\OC::$server->getUserManager()->emit('\OC\User', 'postUnassignedUserId', [$uid]);
+				Server::get(IUserManager::class)->emit('\OC\User', 'postUnassignedUserId', [$uid]);
 			}
 		);
 	} elseif ($subject === 'group') {
-		$mapping = new GroupMapping(\OC::$server->getDatabaseConnection());
+		$mapping = new GroupMapping(Server::get(IDBConnection::class));
 		$result = $mapping->clear();
 	}
 

--- a/apps/user_ldap/ajax/clearMappings.php
+++ b/apps/user_ldap/ajax/clearMappings.php
@@ -30,10 +30,12 @@ try {
 		$result = $mapping->clearCb(
 			function (string $uid) use ($dispatcher): void {
 				$dispatcher->dispatchTyped(new BeforeUserIdUnassignedEvent($uid));
+				/** @psalm-suppress UndefinedInterfaceMethod For now we have to emit, will be removed when all hooks are removed */
 				Server::get(IUserManager::class)->emit('\OC\User', 'preUnassignedUserId', [$uid]);
 			},
 			function (string $uid) use ($dispatcher): void {
 				$dispatcher->dispatchTyped(new UserIdUnassignedEvent($uid));
+				/** @psalm-suppress UndefinedInterfaceMethod For now we have to emit, will be removed when all hooks are removed */
 				Server::get(IUserManager::class)->emit('\OC\User', 'postUnassignedUserId', [$uid]);
 			}
 		);

--- a/apps/user_ldap/ajax/deleteConfiguration.php
+++ b/apps/user_ldap/ajax/deleteConfiguration.php
@@ -1,6 +1,9 @@
 <?php
 
 use OCA\User_LDAP\Helper;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Server;
 use OCP\Util;
 
 /**
@@ -14,7 +17,7 @@ use OCP\Util;
 \OC_JSON::callCheck();
 
 $prefix = (string)$_POST['ldap_serverconfig_chooser'];
-$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 if ($helper->deleteServerConfiguration($prefix)) {
 	\OC_JSON::success();
 } else {

--- a/apps/user_ldap/ajax/getNewServerConfigPrefix.php
+++ b/apps/user_ldap/ajax/getNewServerConfigPrefix.php
@@ -2,6 +2,9 @@
 
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\Helper;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Server;
 
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
@@ -13,7 +16,7 @@ use OCA\User_LDAP\Helper;
 \OC_JSON::checkAppEnabled('user_ldap');
 \OC_JSON::callCheck();
 
-$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 $serverConnections = $helper->getServerConfigurationPrefixes();
 sort($serverConnections);
 $lk = array_pop($serverConnections);

--- a/apps/user_ldap/ajax/testConfiguration.php
+++ b/apps/user_ldap/ajax/testConfiguration.php
@@ -1,6 +1,8 @@
 <?php
 
 use OCA\User_LDAP\LDAP;
+use OCP\ISession;
+use OCP\Server;
 use OCP\Util;
 
 /**
@@ -35,7 +37,7 @@ try {
 		 * contact the LDAP backup server the first time when it should, but there shouldn't be any
 		 * problem with that other than the extra connection.
 		 */
-		\OC::$server->getSession()->close();
+		Server::get(ISession::class)->close();
 		if ($connection->bind()) {
 			/*
 			 * This shiny if block is an ugly hack to find out whether anonymous

--- a/apps/user_ldap/ajax/wizard.php
+++ b/apps/user_ldap/ajax/wizard.php
@@ -4,6 +4,7 @@ use OCA\User_LDAP\AccessFactory;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\Wizard;
+use OCP\Server;
 use OCP\Util;
 
 /**
@@ -36,7 +37,7 @@ $con->setConfiguration($configuration->getConfiguration());
 $con->ldapConfigurationActive = (string)true;
 $con->setIgnoreValidation(true);
 
-$factory = \OC::$server->get(AccessFactory::class);
+$factory = Server::get(AccessFactory::class);
 $access = $factory->get($con);
 
 $wizard = new Wizard($configuration, $ldapWrapper, $access);

--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -19,7 +19,9 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\HintException;
 use OCP\IAppConfig;
 use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IUserManager;
+use OCP\Server;
 use OCP\User\Events\UserIdAssignedEvent;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
@@ -594,7 +596,7 @@ class Access extends LDAPUtility {
 		$this->connection->setConfiguration(['ldapCacheTTL' => 0]);
 		if ($intName !== ''
 			&& (($isUser && !$this->ncUserManager->userExists($intName))
-				|| (!$isUser && !\OC::$server->getGroupManager()->groupExists($intName))
+				|| (!$isUser && !Server::get(IGroupManager::class)->groupExists($intName))
 			)
 		) {
 			$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
@@ -828,7 +830,7 @@ class Access extends LDAPUtility {
 			// Check to be really sure it is unique
 			// while loop is just a precaution. If a name is not generated within
 			// 20 attempts, something else is very wrong. Avoids infinite loop.
-			if (!\OC::$server->getGroupManager()->groupExists($altName)) {
+			if (!Server::get(IGroupManager::class)->groupExists($altName)) {
 				return $altName;
 			}
 			$altName = $name . '_' . ($lastNo + $attempts);
@@ -1586,7 +1588,7 @@ class Access extends LDAPUtility {
 	 * a *
 	 */
 	private function prepareSearchTerm(string $term): string {
-		$config = \OC::$server->getConfig();
+		$config = Server::get(IConfig::class);
 
 		$allowEnum = $config->getAppValue('core', 'shareapi_allow_share_dialog_user_enumeration', 'yes');
 

--- a/apps/user_ldap/lib/Command/Search.php
+++ b/apps/user_ldap/lib/Command/Search.php
@@ -12,6 +12,8 @@ use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\User_Proxy;
 use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Server;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -81,7 +83,7 @@ class Search extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$helper = new Helper($this->ocConfig, \OC::$server->getDatabaseConnection());
+		$helper = new Helper($this->ocConfig, Server::get(IDBConnection::class));
 		$configPrefixes = $helper->getServerConfigurationPrefixes(true);
 		$ldapWrapper = new LDAP();
 

--- a/apps/user_ldap/lib/Command/SetConfig.php
+++ b/apps/user_ldap/lib/Command/SetConfig.php
@@ -11,6 +11,9 @@ use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\ConnectionFactory;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Server;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,7 +43,7 @@ class SetConfig extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 		$availableConfigs = $helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if (!in_array($configID, $availableConfigs)) {

--- a/apps/user_ldap/lib/Configuration.php
+++ b/apps/user_ldap/lib/Configuration.php
@@ -7,6 +7,7 @@
  */
 namespace OCA\User_LDAP;
 
+use OCP\IConfig;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 
@@ -439,7 +440,7 @@ class Configuration {
 
 	protected function getSystemValue(string $varName): string {
 		//FIXME: if another system value is added, softcode the default value
-		return \OC::$server->getConfig()->getSystemValue($varName, false);
+		return Server::get(IConfig::class)->getSystemValue($varName, false);
 	}
 
 	protected function getValue(string $varName): string {
@@ -447,7 +448,7 @@ class Configuration {
 		if (is_null($defaults)) {
 			$defaults = $this->getDefaults();
 		}
-		return \OC::$server->getConfig()->getAppValue('user_ldap',
+		return Server::get(IConfig::class)->getAppValue('user_ldap',
 			$this->configPrefix . $varName,
 			$defaults[$varName]);
 	}
@@ -476,7 +477,7 @@ class Configuration {
 	}
 
 	protected function saveValue(string $varName, string $value): bool {
-		\OC::$server->getConfig()->setAppValue(
+		Server::get(IConfig::class)->setAppValue(
 			'user_ldap',
 			$this->configPrefix . $varName,
 			$value

--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -9,6 +9,10 @@ namespace OCA\User_LDAP;
 
 use OC\ServerNotAvailableException;
 use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -145,14 +149,14 @@ class Connection extends LDAPUtility {
 	) {
 		parent::__construct($ldap);
 		$this->configuration = new Configuration($this->configPrefix, !is_null($this->configID));
-		$memcache = \OC::$server->getMemCacheFactory();
+		$memcache = Server::get(ICacheFactory::class);
 		if ($memcache->isAvailable()) {
 			$this->cache = $memcache->createDistributed();
 		}
-		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 		$this->doNotValidate = !in_array($this->configPrefix,
 			$helper->getServerConfigurationPrefixes());
-		$this->logger = \OC::$server->get(LoggerInterface::class);
+		$this->logger = Server::get(LoggerInterface::class);
 	}
 
 	public function __destruct() {

--- a/apps/user_ldap/lib/Helper.php
+++ b/apps/user_ldap/lib/Helper.php
@@ -11,6 +11,7 @@ use OCP\Cache\CappedMemoryCache;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\Server;
 
 class Helper {
 	/** @var CappedMemoryCache<string> */
@@ -269,7 +270,7 @@ class Helper {
 			throw new \Exception('key uid is expected to be set in $param');
 		}
 
-		$userBackend = \OC::$server->get(User_Proxy::class);
+		$userBackend = Server::get(User_Proxy::class);
 		$uid = $userBackend->loginName2UserName($param['uid']);
 		if ($uid !== false) {
 			$param['uid'] = $uid;

--- a/apps/user_ldap/lib/Jobs/CleanUp.php
+++ b/apps/user_ldap/lib/Jobs/CleanUp.php
@@ -49,7 +49,7 @@ class CleanUp extends TimedJob {
 		protected DeletedUsersIndex $dui,
 	) {
 		parent::__construct($timeFactory);
-		$minutes = \OC::$server->getConfig()->getSystemValue(
+		$minutes = Server::get(IConfig::class)->getSystemValue(
 			'ldapUserCleanupInterval', (string)$this->defaultIntervalMin);
 		$this->setInterval((int)$minutes * 60);
 	}
@@ -67,13 +67,13 @@ class CleanUp extends TimedJob {
 		if (isset($arguments['helper'])) {
 			$this->ldapHelper = $arguments['helper'];
 		} else {
-			$this->ldapHelper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+			$this->ldapHelper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 		}
 
 		if (isset($arguments['ocConfig'])) {
 			$this->ocConfig = $arguments['ocConfig'];
 		} else {
-			$this->ocConfig = \OC::$server->getConfig();
+			$this->ocConfig = Server::get(IConfig::class);
 		}
 
 		if (isset($arguments['userBackend'])) {
@@ -83,7 +83,7 @@ class CleanUp extends TimedJob {
 		if (isset($arguments['db'])) {
 			$this->db = $arguments['db'];
 		} else {
-			$this->db = \OC::$server->getDatabaseConnection();
+			$this->db = Server::get(IDBConnection::class);
 		}
 
 		if (isset($arguments['mapping'])) {

--- a/apps/user_ldap/lib/LDAP.php
+++ b/apps/user_ldap/lib/LDAP.php
@@ -25,7 +25,7 @@ class LDAP implements ILDAPWrapper {
 		protected string $logFile = '',
 	) {
 		/** @var IProfiler $profiler */
-		$profiler = \OC::$server->get(IProfiler::class);
+		$profiler = Server::get(IProfiler::class);
 		if ($profiler->isEnabled()) {
 			$this->dataCollector = new LdapDataCollector();
 			$profiler->add($this->dataCollector);

--- a/apps/user_ldap/lib/Proxy.php
+++ b/apps/user_ldap/lib/Proxy.php
@@ -10,6 +10,7 @@ namespace OCA\User_LDAP;
 use OCA\User_LDAP\Mapping\GroupMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
 use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\Server;
 
 /**
@@ -33,7 +34,7 @@ abstract class Proxy {
 		private ILDAPWrapper $ldap,
 		private AccessFactory $accessFactory,
 	) {
-		$memcache = \OC::$server->getMemCacheFactory();
+		$memcache = Server::get(ICacheFactory::class);
 		if ($memcache->isAvailable()) {
 			$this->cache = $memcache->createDistributed();
 		}

--- a/apps/user_ldap/lib/Settings/Admin.php
+++ b/apps/user_ldap/lib/Settings/Admin.php
@@ -8,7 +8,10 @@ namespace OCA\User_LDAP\Settings;
 use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\Helper;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IL10N;
+use OCP\Server;
 use OCP\Settings\IDelegatedSettings;
 use OCP\Template;
 
@@ -25,7 +28,7 @@ class Admin implements IDelegatedSettings {
 	 * @return TemplateResponse
 	 */
 	public function getForm() {
-		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 		$prefixes = $helper->getServerConfigurationPrefixes();
 		if (count($prefixes) === 0) {
 			$newPrefix = $helper->getNextServerConfigurationPrefix();

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -18,6 +18,7 @@ use OCP\Accounts\PropertyDoesNotExistException;
 use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\Image;
+use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
@@ -769,10 +770,10 @@ class User {
 				if (!empty($pwdGraceAuthNLimit)
 					&& count($pwdGraceUseTime) < (int)$pwdGraceAuthNLimit[0]) { //at least one more grace login available?
 					$this->config->setUserValue($uid, 'user_ldap', 'needsPasswordReset', 'true');
-					header('Location: ' . \OC::$server->getURLGenerator()->linkToRouteAbsolute(
+					header('Location: ' . Server::get(IURLGenerator::class)->linkToRouteAbsolute(
 						'user_ldap.renewPassword.showRenewPasswordForm', ['user' => $uid]));
 				} else { //no more grace login available
-					header('Location: ' . \OC::$server->getURLGenerator()->linkToRouteAbsolute(
+					header('Location: ' . Server::get(IURLGenerator::class)->linkToRouteAbsolute(
 						'user_ldap.renewPassword.showLoginFormInvalidPassword', ['user' => $uid]));
 				}
 				exit();
@@ -780,7 +781,7 @@ class User {
 			//handle pwdReset attribute
 			if (!empty($pwdReset) && $pwdReset[0] === 'TRUE') { //user must change their password
 				$this->config->setUserValue($uid, 'user_ldap', 'needsPasswordReset', 'true');
-				header('Location: ' . \OC::$server->getURLGenerator()->linkToRouteAbsolute(
+				header('Location: ' . Server::get(IURLGenerator::class)->linkToRouteAbsolute(
 					'user_ldap.renewPassword.showRenewPasswordForm', ['user' => $uid]));
 				exit();
 			}

--- a/apps/user_ldap/lib/Wizard.php
+++ b/apps/user_ldap/lib/Wizard.php
@@ -11,6 +11,7 @@ namespace OCA\User_LDAP;
 use OC\ServerNotAvailableException;
 use OCP\IL10N;
 use OCP\L10N\IFactory as IL10NFactory;
+use OCP\Server;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -40,10 +41,10 @@ class Wizard extends LDAPUtility {
 	) {
 		parent::__construct($ldap);
 		if (is_null(static::$l)) {
-			static::$l = \OC::$server->get(IL10NFactory::class)->get('user_ldap');
+			static::$l = Server::get(IL10NFactory::class)->get('user_ldap');
 		}
 		$this->result = new WizardResult();
-		$this->logger = \OC::$server->get(LoggerInterface::class);
+		$this->logger = Server::get(LoggerInterface::class);
 	}
 
 	public function __destruct() {
@@ -709,7 +710,7 @@ class Wizard extends LDAPUtility {
 		//this did not help :(
 		//Let's see whether we can parse the Host URL and convert the domain to
 		//a base DN
-		$helper = \OC::$server->get(Helper::class);
+		$helper = Server::get(Helper::class);
 		$domain = $helper->getDomainFromURL($this->configuration->ldapHost);
 		if (!$domain) {
 			return false;

--- a/apps/user_ldap/templates/renewpassword.php
+++ b/apps/user_ldap/templates/renewpassword.php
@@ -6,11 +6,11 @@
  */
 /** @var \OCP\IL10N $l */
 
-script('user_ldap', 'renewPassword');
+\OCP\Util::addScript('user_ldap', 'renewPassword', 'core');
 style('user_ldap', 'renewPassword');
 ?>
 
-<form method="post" name="renewpassword" id="renewpassword" action="<?php p(\OC::$server->getURLGenerator()->linkToRoute('user_ldap.renewPassword.tryRenewPassword')); ?>">
+<form method="post" name="renewpassword" id="renewpassword" action="<?php p(\OCP\Server::get(\OCP\IURLGenerator::class)->linkToRoute('user_ldap.renewPassword.tryRenewPassword')); ?>">
 	<fieldset>
 		<div class="warning title">
 			<?php p($l->t('Please renew your password.')); ?><br>

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -23,9 +23,11 @@ use OCP\HintException;
 use OCP\IAppConfig;
 use OCP\IAvatarManager;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\Image;
 use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Server;
 use OCP\Share\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -117,7 +119,7 @@ class AccessTest extends TestCase {
 				$this->createMock(INotificationManager::class),
 				$this->shareManager])
 			->getMock();
-		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 
 		return [$lw, $connector, $um, $helper];
 	}

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -21,6 +21,8 @@ use OCP\GroupInterface;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Security\ISecureRandom;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -155,7 +157,7 @@ class Group_LDAPTest extends TestCase {
 		$this->access->expects($this->any())
 			->method('dn2username')
 			->willReturnCallback(function () {
-				return 'foobar' . \OC::$server->getSecureRandom()->generate(7);
+				return 'foobar' . Server::get(ISecureRandom::class)->generate(7);
 			});
 		$this->access->expects($this->any())
 			->method('isDNPartOfBase')

--- a/apps/user_ldap/tests/HelperTest.php
+++ b/apps/user_ldap/tests/HelperTest.php
@@ -7,6 +7,8 @@ namespace OCA\User_LDAP\Tests;
 
 use OCA\User_LDAP\Helper;
 use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Server;
 
 /**
  * @group DB
@@ -23,7 +25,7 @@ class HelperTest extends \Test\TestCase {
 		parent::setUp();
 
 		$this->config = $this->createMock(IConfig::class);
-		$this->helper = new Helper($this->config, \OC::$server->getDatabaseConnection());
+		$this->helper = new Helper($this->config, Server::get(IDBConnection::class));
 	}
 
 	public function testGetServerConfigurationPrefixes(): void {

--- a/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
+++ b/apps/user_ldap/tests/Integration/AbstractIntegrationTest.php
@@ -15,7 +15,10 @@ use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\User\Manager;
 use OCA\User_LDAP\UserPluginManager;
 use OCP\IAvatarManager;
+use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\Image;
+use OCP\IUserManager;
 use OCP\Server;
 use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
@@ -108,13 +111,13 @@ abstract class AbstractIntegrationTest {
 	 */
 	protected function initUserManager() {
 		$this->userManager = new Manager(
-			\OC::$server->getConfig(),
-			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->get(IAvatarManager::class),
+			Server::get(IConfig::class),
+			Server::get(LoggerInterface::class),
+			Server::get(IAvatarManager::class),
 			new Image(),
-			\OC::$server->getUserManager(),
-			\OC::$server->getNotificationManager(),
-			\OC::$server->get(IManager::class)
+			Server::get(IUserManager::class),
+			Server::get(\OCP\Notification\IManager::class),
+			Server::get(IManager::class)
 		);
 	}
 
@@ -122,14 +125,14 @@ abstract class AbstractIntegrationTest {
 	 * initializes the test Helper
 	 */
 	protected function initHelper() {
-		$this->helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$this->helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 	}
 
 	/**
 	 * initializes the Access test instance
 	 */
 	protected function initAccess() {
-		$this->access = new Access($this->connection, $this->ldap, $this->userManager, $this->helper, \OC::$server->getConfig(), Server::get(LoggerInterface::class));
+		$this->access = new Access($this->connection, $this->ldap, $this->userManager, $this->helper, Server::get(IConfig::class), Server::get(LoggerInterface::class));
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestAttributeDetection.php
@@ -14,6 +14,10 @@ use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\UserPluginManager;
 use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\IGroupManager;
+use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../Bootstrap.php';
@@ -28,28 +32,28 @@ class IntegrationTestAttributeDetection extends AbstractIntegrationTest {
 		$this->connection->setConfiguration(['ldapGroupFilter' => 'objectClass=groupOfNames']);
 		$this->connection->setConfiguration(['ldapGroupMemberAssocAttr' => 'member']);
 
-		$userMapper = new UserMapping(\OC::$server->getDatabaseConnection());
+		$userMapper = new UserMapping(Server::get(IDBConnection::class));
 		$userMapper->clear();
 		$this->access->setUserMapper($userMapper);
 
-		$groupMapper = new GroupMapping(\OC::$server->getDatabaseConnection());
+		$groupMapper = new GroupMapping(Server::get(IDBConnection::class));
 		$groupMapper->clear();
 		$this->access->setGroupMapper($groupMapper);
 
-		$userBackend = new User_LDAP($this->access, \OC::$server->getNotificationManager(), \OC::$server->get(UserPluginManager::class), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DeletedUsersIndex::class));
-		$userManager = \OC::$server->getUserManager();
+		$userBackend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
+		$userManager = Server::get(IUserManager::class);
 		$userManager->clearBackends();
 		$userManager->registerBackend($userBackend);
 
-		$groupBackend = new Group_LDAP($this->access, \OC::$server->query(GroupPluginManager::class), \OC::$server->get(IConfig::class));
-		$groupManger = \OC::$server->getGroupManager();
+		$groupBackend = new Group_LDAP($this->access, Server::get(GroupPluginManager::class), Server::get(IConfig::class));
+		$groupManger = Server::get(IGroupManager::class);
 		$groupManger->clearBackends();
 		$groupManger->addBackend($groupBackend);
 	}
 
 	protected function caseNativeUUIDAttributeUsers() {
 		// trigger importing of users which also triggers UUID attribute detection
-		\OC::$server->getUserManager()->search('', 5, 0);
+		Server::get(IUserManager::class)->search('', 5, 0);
 		return $this->connection->ldapUuidUserAttribute === 'entryuuid';
 	}
 
@@ -58,7 +62,7 @@ class IntegrationTestAttributeDetection extends AbstractIntegrationTest {
 		// are similar, but we take no chances.
 
 		// trigger importing of users which also triggers UUID attribute detection
-		\OC::$server->getGroupManager()->search('', 5, 0);
+		Server::get(IGroupManager::class)->search('', 5, 0);
 		return $this->connection->ldapUuidGroupAttribute === 'entryuuid';
 	}
 }

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestFetchUsersByLoginName.php
@@ -12,6 +12,8 @@ use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\UserPluginManager;
+use OCP\IDBConnection;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../Bootstrap.php';
@@ -31,10 +33,10 @@ class IntegrationTestFetchUsersByLoginName extends AbstractIntegrationTest {
 		require(__DIR__ . '/../setup-scripts/createExplicitUsers.php');
 		parent::init();
 
-		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
+		$this->mapping = new UserMapping(Server::get(IDBConnection::class));
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$this->backend = new User_LDAP($this->access, \OC::$server->getNotificationManager(), \OC::$server->get(UserPluginManager::class), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DeletedUsersIndex::class));
+		$this->backend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
+++ b/apps/user_ldap/tests/Integration/Lib/IntegrationTestPaging.php
@@ -12,6 +12,7 @@ use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\UserPluginManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../Bootstrap.php';
@@ -34,7 +35,7 @@ class IntegrationTestPaging extends AbstractIntegrationTest {
 		require(__DIR__ . '/../setup-scripts/createExplicitUsers.php');
 		parent::init();
 
-		$this->backend = new User_LDAP($this->access, \OC::$server->getNotificationManager(), \OC::$server->get(UserPluginManager::class), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DeletedUsersIndex::class));
+		$this->backend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
 	}
 
 	public function initConnection() {

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
@@ -15,7 +15,11 @@ use OCA\User_LDAP\User\User;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\UserPluginManager;
 use OCP\IAvatarManager;
+use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\Image;
+use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../../Bootstrap.php';
@@ -31,10 +35,10 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 	public function init() {
 		require(__DIR__ . '/../../setup-scripts/createExplicitUsers.php');
 		parent::init();
-		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
+		$this->mapping = new UserMapping(Server::get(IDBConnection::class));
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$userBackend = new User_LDAP($this->access, \OC::$server->getNotificationManager(), \OC::$server->get(UserPluginManager::class), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DeletedUsersIndex::class));
+		$userBackend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
 		\OC_User::useBackend($userBackend);
 	}
 
@@ -57,9 +61,9 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($username);
 		\OC::$server->getUserFolder($username);
-		\OC::$server->getConfig()->deleteUserValue($username, 'user_ldap', User::USER_PREFKEY_LASTREFRESH);
-		if (\OC::$server->get(IAvatarManager::class)->getAvatar($username)->exists()) {
-			\OC::$server->get(IAvatarManager::class)->getAvatar($username)->remove();
+		Server::get(IConfig::class)->deleteUserValue($username, 'user_ldap', User::USER_PREFKEY_LASTREFRESH);
+		if (Server::get(IAvatarManager::class)->getAvatar($username)->exists()) {
+			Server::get(IAvatarManager::class)->getAvatar($username)->remove();
 		}
 
 		// finally attempt to get the avatar set
@@ -79,7 +83,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 
 		$this->execFetchTest($dn, $username, $image);
 
-		return \OC::$server->get(IAvatarManager::class)->getAvatar($username)->exists();
+		return Server::get(IAvatarManager::class)->getAvatar($username)->exists();
 	}
 
 	/**
@@ -96,7 +100,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 
 		$this->execFetchTest($dn, $username, $image);
 
-		return !\OC::$server->get(IAvatarManager::class)->getAvatar($username)->exists();
+		return !Server::get(IAvatarManager::class)->getAvatar($username)->exists();
 	}
 
 	/**
@@ -113,13 +117,13 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 
 	protected function initUserManager() {
 		$this->userManager = new Manager(
-			\OC::$server->getConfig(),
-			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->get(IAvatarManager::class),
+			Server::get(IConfig::class),
+			Server::get(LoggerInterface::class),
+			Server::get(IAvatarManager::class),
 			new Image(),
-			\OC::$server->getDatabaseConnection(),
-			\OC::$server->getUserManager(),
-			\OC::$server->getNotificationManager()
+			Server::get(IDBConnection::class),
+			Server::get(IUserManager::class),
+			Server::get(\OCP\Notification\IManager::class)
 		);
 	}
 

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserCleanUp.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserCleanUp.php
@@ -13,6 +13,9 @@ use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\UserPluginManager;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../../Bootstrap.php';
@@ -28,11 +31,11 @@ class IntegrationTestUserCleanUp extends AbstractIntegrationTest {
 	public function init() {
 		require(__DIR__ . '/../../setup-scripts/createExplicitUsers.php');
 		parent::init();
-		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
+		$this->mapping = new UserMapping(Server::get(IDBConnection::class));
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
 
-		$userBackend = new User_LDAP($this->access, \OC::$server->getNotificationManager(), \OC::$server->get(UserPluginManager::class), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DeletedUsersIndex::class));
+		$userBackend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
 		\OC_User::useBackend($userBackend);
 	}
 
@@ -70,13 +73,13 @@ class IntegrationTestUserCleanUp extends AbstractIntegrationTest {
 		// user instance must not be requested from global user manager, before
 		// it is deleted from the LDAP server. The instance will be returned
 		// from cache and may false-positively confirm the correctness.
-		$user = \OC::$server->getUserManager()->get($username);
+		$user = Server::get(IUserManager::class)->get($username);
 		if ($user === null) {
 			return false;
 		}
 		$user->delete();
 
-		return \OC::$server->getUserManager()->get($username) === null;
+		return Server::get(IUserManager::class)->get($username) === null;
 	}
 }
 

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
@@ -12,6 +12,9 @@ use OCA\User_LDAP\Tests\Integration\AbstractIntegrationTest;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\UserPluginManager;
+use OCP\IDBConnection;
+use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 require_once __DIR__ . '/../../Bootstrap.php';
@@ -27,10 +30,10 @@ class IntegrationTestUserDisplayName extends AbstractIntegrationTest {
 	public function init() {
 		require(__DIR__ . '/../../setup-scripts/createExplicitUsers.php');
 		parent::init();
-		$this->mapping = new UserMapping(\OC::$server->getDatabaseConnection());
+		$this->mapping = new UserMapping(Server::get(IDBConnection::class));
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
-		$userBackend = new User_LDAP($this->access, \OC::$server->getNotificationManager(), \OC::$server->get(UserPluginManager::class), \OC::$server->get(LoggerInterface::class), \OC::$server->get(DeletedUsersIndex::class));
+		$userBackend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
 		\OC_User::useBackend($userBackend);
 	}
 
@@ -54,7 +57,7 @@ class IntegrationTestUserDisplayName extends AbstractIntegrationTest {
 		$username = 'alice1337';
 		$dn = 'uid=alice,ou=Users,' . $this->base;
 		$this->prepareUser($dn, $username);
-		$displayName = \OC::$server->getUserManager()->get($username)->getDisplayName();
+		$displayName = Server::get(IUserManager::class)->get($username)->getDisplayName();
 
 		return str_contains($displayName, '(Alice@example.com)');
 	}
@@ -71,7 +74,7 @@ class IntegrationTestUserDisplayName extends AbstractIntegrationTest {
 		$username = 'boris23421';
 		$dn = 'uid=boris,ou=Users,' . $this->base;
 		$this->prepareUser($dn, $username);
-		$displayName = \OC::$server->getUserManager()->get($username)->getDisplayName();
+		$displayName = Server::get(IUserManager::class)->get($username)->getDisplayName();
 
 		return !str_contains($displayName, '(Boris@example.com)');
 	}

--- a/apps/user_ldap/tests/LDAPProviderTest.php
+++ b/apps/user_ldap/tests/LDAPProviderTest.php
@@ -18,7 +18,9 @@ use OCA\User_LDAP\User_LDAP;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\IDBConnection;
 use OCP\IServerContainer;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -204,7 +206,7 @@ class LDAPProviderTest extends \Test\TestCase {
 
 		$server = $this->getServerMock($userBackend, $this->getDefaultGroupBackendMock());
 
-		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 
 		$ldapProvider = $this->getLDAPProvider($server);
 		$this->assertEquals(
@@ -220,7 +222,7 @@ class LDAPProviderTest extends \Test\TestCase {
 
 		$server = $this->getServerMock($userBackend, $this->getDefaultGroupBackendMock());
 
-		$helper = new Helper(\OC::$server->getConfig(), \OC::$server->getDatabaseConnection());
+		$helper = new Helper(Server::get(IConfig::class), Server::get(IDBConnection::class));
 
 		$ldapProvider = $this->getLDAPProvider($server);
 		$this->assertEquals(

--- a/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
+++ b/apps/user_ldap/tests/Mapping/AbstractMappingTest.php
@@ -9,6 +9,7 @@ namespace OCA\User_LDAP\Tests\Mapping;
 
 use OCA\User_LDAP\Mapping\AbstractMapping;
 use OCP\IDBConnection;
+use OCP\Server;
 
 abstract class AbstractMappingTest extends \Test\TestCase {
 	abstract public function getMapper(IDBConnection $dbMock);
@@ -70,7 +71,7 @@ abstract class AbstractMappingTest extends \Test\TestCase {
 	 *               users or groups
 	 */
 	private function initTest() {
-		$dbc = \OC::$server->getDatabaseConnection();
+		$dbc = Server::get(IDBConnection::class);
 		$mapper = $this->getMapper($dbc);
 		$data = $this->getTestData();
 		// make sure DB is pristine, then fill it with test entries

--- a/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
+++ b/apps/user_ldap/tests/User/DeletedUsersIndexTest.php
@@ -9,6 +9,7 @@ use OCA\User_LDAP\Mapping\UserMapping;
 use OCA\User_LDAP\User\DeletedUsersIndex;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\Server;
 use OCP\Share\IManager;
 
 /**
@@ -37,8 +38,8 @@ class DeletedUsersIndexTest extends \Test\TestCase {
 		parent::setUp();
 
 		// no mocks for those as tests go against DB
-		$this->config = \OC::$server->getConfig();
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->config = Server::get(IConfig::class);
+		$this->db = Server::get(IDBConnection::class);
 
 		// ensure a clean database
 		$this->config->deleteAppFromAllUsers('user_ldap');

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -20,8 +20,12 @@ use OCA\User_LDAP\User_LDAP;
 use OCA\User_LDAP\User_LDAP as UserLDAP;
 use OCA\User_LDAP\UserPluginManager;
 use OCP\HintException;
+use OCP\IConfig;
+use OCP\IGroupManager;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Notification\IManager as INotificationManager;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -57,7 +61,7 @@ class User_LDAPTest extends TestCase {
 		parent::setUp();
 
 		\OC_User::clearBackends();
-		\OC::$server->getGroupManager()->clearBackends();
+		Server::get(IGroupManager::class)->clearBackends();
 
 		$this->connection = $this->createMock(Connection::class);
 		$this->userManager = $this->createMock(Manager::class);
@@ -236,7 +240,7 @@ class User_LDAPTest extends TestCase {
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		\OC_User::useBackend($backend);
 
-		$user = \OC::$server->getUserManager()->checkPassword('roland', 'dt19');
+		$user = Server::get(IUserManager::class)->checkPassword('roland', 'dt19');
 		$result = false;
 		if ($user !== false) {
 			$result = $user->getUID();
@@ -249,7 +253,7 @@ class User_LDAPTest extends TestCase {
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		\OC_User::useBackend($backend);
 
-		$user = \OC::$server->getUserManager()->checkPassword('roland', 'wrong');
+		$user = Server::get(IUserManager::class)->checkPassword('roland', 'wrong');
 		$result = false;
 		if ($user !== false) {
 			$result = $user->getUID();
@@ -262,7 +266,7 @@ class User_LDAPTest extends TestCase {
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		\OC_User::useBackend($backend);
 
-		$user = \OC::$server->getUserManager()->checkPassword('mallory', 'evil');
+		$user = Server::get(IUserManager::class)->checkPassword('mallory', 'evil');
 		$result = false;
 		if ($user !== false) {
 			$result = $user->getUID();
@@ -436,7 +440,7 @@ class User_LDAPTest extends TestCase {
 	}
 
 	private function getUsers($search = '', $limit = null, $offset = null) {
-		$users = \OC::$server->getUserManager()->search($search, $limit, $offset);
+		$users = Server::get(IUserManager::class)->search($search, $limit, $offset);
 		$uids = array_map(function (IUser $user) {
 			return $user->getUID();
 		}, $users);
@@ -583,7 +587,7 @@ class User_LDAPTest extends TestCase {
 			->willReturn($this->createMock(UserMapping::class));
 
 		//test for existing user
-		$result = \OC::$server->getUserManager()->userExists('gunslinger');
+		$result = Server::get(IUserManager::class)->userExists('gunslinger');
 		$this->assertTrue($result);
 	}
 
@@ -653,7 +657,7 @@ class User_LDAPTest extends TestCase {
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
 
-		$dataDir = \OC::$server->getConfig()->getSystemValue(
+		$dataDir = Server::get(IConfig::class)->getSystemValue(
 			'datadirectory', \OC::$SERVERROOT . '/data');
 
 		$this->connection->expects($this->any())
@@ -1000,11 +1004,11 @@ class User_LDAPTest extends TestCase {
 			});
 
 		//with displayName
-		$result = \OC::$server->getUserManager()->get('gunslinger')?->getDisplayName();
+		$result = Server::get(IUserManager::class)->get('gunslinger')?->getDisplayName();
 		$this->assertEquals('Roland Deschain', $result);
 
 		//empty displayname retrieved
-		$result = \OC::$server->getUserManager()->get('newyorker') === null ? 'newyorker' : \OC::$server->getUserManager()->get('newyorker')->getDisplayName();
+		$result = Server::get(IUserManager::class)->get('newyorker') === null ? 'newyorker' : Server::get(IUserManager::class)->get('newyorker')->getDisplayName();
 		$this->assertEquals('newyorker', $result);
 	}
 

--- a/apps/workflowengine/lib/BackgroundJobs/Rotate.php
+++ b/apps/workflowengine/lib/BackgroundJobs/Rotate.php
@@ -8,7 +8,9 @@ namespace OCA\WorkflowEngine\BackgroundJobs;
 use OCA\WorkflowEngine\AppInfo\Application;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
 use OCP\Log\RotationTrait;
+use OCP\Server;
 
 class Rotate extends TimedJob {
 	use RotationTrait;
@@ -19,7 +21,7 @@ class Rotate extends TimedJob {
 	}
 
 	protected function run($argument) {
-		$config = \OC::$server->getConfig();
+		$config = Server::get(IConfig::class);
 		$default = $config->getSystemValue('datadirectory', \OC::$SERVERROOT . '/data') . '/flow.log';
 		$this->filePath = trim((string)$config->getAppValue(Application::APP_ID, 'logfile', $default));
 

--- a/apps/workflowengine/tests/ManagerTest.php
+++ b/apps/workflowengine/tests/ManagerTest.php
@@ -24,6 +24,7 @@ use OCP\IServerContainer;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\WorkflowEngine\Events\RegisterEntitiesEvent;
 use OCP\WorkflowEngine\ICheck;
@@ -64,7 +65,7 @@ class ManagerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->db = \OC::$server->getDatabaseConnection();
+		$this->db = Server::get(IDBConnection::class);
 		$this->container = $this->createMock(IServerContainer::class);
 		/** @var IL10N|MockObject $l */
 		$this->l = $this->createMock(IL10N::class);
@@ -80,7 +81,7 @@ class ManagerTest extends TestCase {
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 
 		$this->manager = new Manager(
-			\OC::$server->getDatabaseConnection(),
+			Server::get(IDBConnection::class),
 			$this->container,
 			$this->l,
 			$this->logger,

--- a/build/psalm-baseline-security.xml
+++ b/build/psalm-baseline-security.xml
@@ -22,11 +22,6 @@
       <code><![CDATA['Location: ' . \OC::$WEBROOT . '/']]></code>
     </TaintedHeader>
   </file>
-  <file src="lib/private/AppFramework/Utility/SimpleContainer.php">
-    <TaintedCallable>
-      <code><![CDATA[$name]]></code>
-    </TaintedCallable>
-  </file>
   <file src="lib/private/Config.php">
     <TaintedHtml>
       <code><![CDATA[$this->cache]]></code>
@@ -60,11 +55,6 @@
       <code><![CDATA[$appNameSpace . '\\Controller\\' . basename($file->getPathname(), '.php')]]></code>
     </TaintedCallable>
   </file>
-  <file src="lib/private/ServerContainer.php">
-    <TaintedCallable>
-      <code><![CDATA[$applicationClassName]]></code>
-    </TaintedCallable>
-  </file>
   <file src="lib/private/Session/CryptoWrapper.php">
     <TaintedCookie>
       <code><![CDATA[$this->passphrase]]></code>
@@ -92,14 +82,6 @@
     <TaintedHeader>
       <code><![CDATA['Location: ' . \OC::$WEBROOT]]></code>
     </TaintedHeader>
-    <TaintedHtml>
-      <code><![CDATA[self::encode($data)]]></code>
-      <code><![CDATA[self::encode($data)]]></code>
-    </TaintedHtml>
-    <TaintedTextWithQuotes>
-      <code><![CDATA[self::encode($data)]]></code>
-      <code><![CDATA[self::encode($data)]]></code>
-    </TaintedTextWithQuotes>
   </file>
   <file src="lib/private/legacy/OC_Template.php">
     <TaintedHtml>

--- a/build/rector.php
+++ b/build/rector.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+use Nextcloud\Rector\Set\NextcloudSets;
 use PhpParser\Node;
 use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
 use Rector\Config\RectorConfig;
@@ -72,6 +73,9 @@ $config = RectorConfig::configure()
 	->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
 		'inline_public' => true,
 		'rename_property' => true,
+	])
+	->withSets([
+		NextcloudSets::NEXTCLOUD_25,
 	]);
 
 $config->registerService(NextcloudNamespaceSkipVoter::class, tag:ClassNameImportSkipVoterInterface::class);

--- a/vendor-bin/rector/composer.json
+++ b/vendor-bin/rector/composer.json
@@ -1,6 +1,6 @@
 {
     "require-dev": {
         "rector/rector": "^1.2",
-        "nextcloud/rector": "^0.2.0"
+        "nextcloud/rector": "^0.3.1"
     }
 }

--- a/vendor-bin/rector/composer.lock
+++ b/vendor-bin/rector/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "10939f70efcd3b6d290ecf8f7e9d9da0",
+    "content-hash": "f197bd1bcd2c1d4cfc5c4b1756a5b20e",
     "packages": [],
     "packages-dev": [
         {
             "name": "nextcloud/rector",
-            "version": "v0.2.0",
+            "version": "v0.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-libraries/rector.git",
-                "reference": "c5cceb7faf2d4df61fe1fd8f82e19c7b106dbe00"
+                "reference": "25e71025c3acdf346f2d26034d3edd8e17e4596e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-libraries/rector/zipball/c5cceb7faf2d4df61fe1fd8f82e19c7b106dbe00",
-                "reference": "c5cceb7faf2d4df61fe1fd8f82e19c7b106dbe00",
+                "url": "https://api.github.com/repos/nextcloud-libraries/rector/zipball/25e71025c3acdf346f2d26034d3edd8e17e4596e",
+                "reference": "25e71025c3acdf346f2d26034d3edd8e17e4596e",
                 "shasum": ""
             },
             "require": {
@@ -34,12 +34,12 @@
                 "captainhook": {
                     "force-install": true
                 },
+                "ramsey/devtools": {
+                    "memory-limit": "-1",
+                    "command-prefix": "dev"
+                },
                 "ramsey/conventional-commits": {
                     "configFile": "conventional-commits.json"
-                },
-                "ramsey/devtools": {
-                    "command-prefix": "dev",
-                    "memory-limit": "-1"
                 }
             },
             "autoload": {
@@ -65,22 +65,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nextcloud-libraries/rector/issues",
-                "source": "https://github.com/nextcloud-libraries/rector/tree/v0.2.0"
+                "source": "https://github.com/nextcloud-libraries/rector/tree/v0.3.1"
             },
-            "time": "2024-09-19T09:54:28+00:00"
+            "time": "2025-02-06T09:32:20+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.4",
+            "version": "1.12.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd"
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e0bb5cb78545aae631220735aa706eac633a6be9",
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9",
                 "shasum": ""
             },
             "require": {
@@ -125,25 +125,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-19T07:58:01+00:00"
+            "time": "2025-01-21T14:50:05+00:00"
         },
         {
             "name": "rector/rector",
-            "version": "1.2.5",
+            "version": "1.2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rectorphp/rector.git",
-                "reference": "e98aa793ca3fcd17e893cfaf9103ac049775d339"
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e98aa793ca3fcd17e893cfaf9103ac049775d339",
-                "reference": "e98aa793ca3fcd17e893cfaf9103ac049775d339",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/40f9cf38c05296bd32f444121336a521a293fa61",
+                "reference": "40f9cf38c05296bd32f444121336a521a293fa61",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2|^8.0",
-                "phpstan/phpstan": "^1.12.2"
+                "phpstan/phpstan": "^1.12.5"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -176,7 +176,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/1.2.5"
+                "source": "https://github.com/rectorphp/rector/tree/1.2.10"
             },
             "funding": [
                 {
@@ -184,15 +184,15 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-08T17:43:24+00:00"
+            "time": "2024-11-08T13:59:10+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

1. Apply current rector configuration to apps folder
2. Bump rector/rector and nextcloud/rector to latest version
3. Add `NextcloudSets::NEXTCLOUD_25` to configuration
4. Run rector on apps folder again

You can note that `\OC::$server->get` calls are correctly replaced but not `\OC::$server->query` ones, that’s an oversight of the Set and will need to be fixed upstream.
Apart from that the changes look sound to me.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
