### PR TITLE
fix(DnsPinMiddleware): Don't log  misleading port value / log request port instead

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -110,15 +110,15 @@ class DnsPinMiddleware {
 				}
 
 				$hostName = (string)$request->getUri()->getHost();
-				$port = $request->getUri()->getPort();
+				$requestPort = $request->getUri()->getPort();
 
 				$ports = [
 					'80',
 					'443',
 				];
 
-				if ($port !== null) {
-					$ports[] = (string)$port;
+				if ($requestPort !== null) {
+					$ports[] = (string)$requestPort;
 				}
 
 				$targetIps = $this->dnsResolve(idn_to_utf8($hostName), 0);
@@ -135,7 +135,8 @@ class DnsPinMiddleware {
 					foreach ($targetIps as $ip) {
 						if ($this->ipAddressClassifier->isLocalAddress($ip)) {
 							// TODO: continue with all non-local IPs?
-							throw new LocalServerException('Host "' . $ip . '" (' . $hostName . ') violates local access rules');
+							// log requestPort because that's more relevant to the admin
+							throw new LocalServerException('Host "' . $ip . '" (' . $hostName . ':' . $requestPort . ') violates local access rules');
 						}
 						$curlResolves["$hostName:$port"][] = $ip;
 					}

--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -135,7 +135,7 @@ class DnsPinMiddleware {
 					foreach ($targetIps as $ip) {
 						if ($this->ipAddressClassifier->isLocalAddress($ip)) {
 							// TODO: continue with all non-local IPs?
-							throw new LocalServerException('Host "' . $ip . '" (' . $hostName . ':' . $port . ') violates local access rules');
+							throw new LocalServerException('Host "' . $ip . '" (' . $hostName . ') violates local access rules');
 						}
 						$curlResolves["$hostName:$port"][] = $ip;
 					}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://help.nextcloud.com/t/oauth2-openid-discovery-endpoint-nextcloud-omits-to-connect-via-https-and-uses-port-80/216182/4 <!-- related github issue -->

## Summary

#43650 added logging of the host that triggers the `LocalServerException`. It also added the `port` to that log output. 

However the logged port is misleading and logging it does not make sense in this context because... it's not the actual port specified in the request. 

The `port` here is merely the one that happens to be the current one in the `foreach` iterator when the IP in question triggers `isLocalAddress($ip)` to be true. (We check a list of ports that is essentially {requestPort + 80 + 443}. Ultimately that'll be `80` every time which, again, has nothing to do with the current request.

So either don't log any port or, since we do have the request port, go ahead and log it for the admin since it's more relevant.

P.S. Hmm. Actually upon reflection I think we can probably just move the entire `foreach ($ports as $port) {` below the `isLocalAddress()` check too. The ports list is only used for properly populating the `CURLOPT_RESOLVE`. The ports themselves are not used for the check itself so no reason to run the check within the port combo iterator. 

https://github.com/nextcloud/server/blob/a1be491c27df49d30acc460f1778d08b8cbb0773/lib/private/Http/Client/DnsPinMiddleware.php#L132-L133

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
