### PR TITLE
fix(FilesDrop): MKCOL should be allowed along with PUT

### DIFF
--- a/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
+++ b/apps/dav/lib/Files/Sharing/FilesDropPlugin.php
@@ -53,8 +53,8 @@ class FilesDropPlugin extends ServerPlugin {
 		}
 
 		// Only allow file drop
-		if ($request->getMethod() !== 'PUT') {
-			throw new MethodNotAllowed('Only PUT is allowed on files drop');
+		if ($request->getMethod() !== 'PUT' && $request->getMethod() !== 'MKCOL') {
+			throw new MethodNotAllowed('Only PUT or MKCOL are allowed on files drop');
 		}
 
 		// Always upload at the root level

--- a/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
+++ b/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
@@ -9,7 +9,6 @@ use OC\Files\View;
 use OCA\DAV\Files\Sharing\FilesDropPlugin;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
-use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\Server;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
@@ -128,19 +127,6 @@ class FilesDropPluginTest extends TestCase {
 		$this->request->expects($this->once())
 			->method('setUrl')
 			->with($this->equalTo('https://example.com/file (2).txt'));
-
-		$this->plugin->beforeMethod($this->request, $this->response);
-	}
-
-	public function testNoMKCOL(): void {
-		$this->plugin->enable();
-		$this->plugin->setView($this->view);
-		$this->plugin->setShare($this->share);
-
-		$this->request->method('getMethod')
-			->willReturn('MKCOL');
-
-		$this->expectException(MethodNotAllowed::class);
 
 		$this->plugin->beforeMethod($this->request, $this->response);
 	}

--- a/build/integration/filesdrop_features/filesdrop.feature
+++ b/build/integration/filesdrop_features/filesdrop.feature
@@ -47,19 +47,6 @@ Feature: FilesDrop
     And Downloading file "/drop/a.txt"
     Then Downloaded content should be "abc"
 
-  Scenario: Files drop forbis MKCOL
-    Given user "user0" exists
-    And As an "user0"
-    And user "user0" created a folder "/drop"
-    And as "user0" creating a share with
-      | path | drop |
-      | shareType | 3 |
-      | publicUpload | true |
-    And Updating last share with
-      | permissions | 4 |
-    When Creating folder "folder" in drop
-    Then the HTTP status code should be "405"
-
   Scenario: Files request drop
     Given user "user0" exists
     And As an "user0"


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/50584

## Summary

This has been removed by https://github.com/nextcloud/server/pull/46589 but IMO this method should be allowed too.

I'm not sure if this is on purpose _(not allowing folders upload/creation)_, but if it is, then this should be cleared stated in both documentation and in the WebUI interface of files drop. Something like: `Only single files can be uploaded` somewhere **before** the user tries to upload something.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
