### PR TITLE
fix(core): Always try to generate some kind of preview

### DIFF
--- a/apps/files/lib/Dashboard/FavoriteWidget.php
+++ b/apps/files/lib/Dashboard/FavoriteWidget.php
@@ -95,7 +95,6 @@ class FavoriteWidget implements IIconWidget, IAPIWidgetV2, IButtonWidget, IOptio
 						'y' => 256,
 						'fileId' => $node->getId(),
 						'c' => $node->getEtag(),
-						'mimeFallback' => true,
 					]);
 				} else {
 					$icon = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'filetypes/folder.svg'));

--- a/apps/files/src/components/FileEntry/FileEntryPreview.vue
+++ b/apps/files/src/components/FileEntry/FileEntryPreview.vue
@@ -163,7 +163,6 @@ export default defineComponent({
 				// Request tiny previews
 				url.searchParams.set('x', this.gridMode ? '128' : '32')
 				url.searchParams.set('y', this.gridMode ? '128' : '32')
-				url.searchParams.set('mimeFallback', 'true')
 
 				// Etag to force refresh preview on change
 				const etag = this.source?.attributes?.etag || ''

--- a/apps/files_versions/src/utils/versions.ts
+++ b/apps/files_versions/src/utils/versions.ts
@@ -78,7 +78,7 @@ function formatVersion(version: any, fileInfo: any): Version {
 	let previewUrl = ''
 
 	if (mtime === fileInfo.mtime) { // Version is the current one
-		previewUrl = generateUrl('/core/preview?fileId={fileId}&c={fileEtag}&x=250&y=250&forceIcon=0&a=0', {
+		previewUrl = generateUrl('/core/preview?fileId={fileId}&c={fileEtag}&x=250&y=250&a=0', {
 			fileId: fileInfo.id,
 			fileEtag: fileInfo.etag,
 		})

--- a/core/Controller/PreviewController.php
+++ b/core/Controller/PreviewController.php
@@ -42,6 +42,8 @@ class PreviewController extends Controller {
 	/**
 	 * Get a preview by file path
 	 *
+	 * Deprecated: Use getPreviewByFileId instead
+	 * @deprecated Use getPreviewByFileId instead
 	 * @param string $file Path of the file
 	 * @param int $x Width of the preview. A width of -1 will use the original image width.
 	 * @param int $y Height of the preview. A height of -1 will use the original image height.

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -8254,19 +8254,6 @@
                         }
                     },
                     {
-                        "name": "forceIcon",
-                        "in": "query",
-                        "description": "Force returning an icon",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
                         "name": "mode",
                         "in": "query",
                         "description": "How to crop the image",
@@ -8276,19 +8263,6 @@
                             "enum": [
                                 "fill",
                                 "cover"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "mimeFallback",
-                        "in": "query",
-                        "description": "Whether to fallback to the mime icon if no preview is available",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
                             ]
                         }
                     }
@@ -8330,7 +8304,7 @@
                         }
                     },
                     "303": {
-                        "description": "Redirect to the mime icon url if mimeFallback is true",
+                        "description": "Redirect to the mime icon url",
                         "headers": {
                             "Location": {
                                 "schema": {
@@ -8402,19 +8376,6 @@
                         }
                     },
                     {
-                        "name": "forceIcon",
-                        "in": "query",
-                        "description": "Force returning an icon",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
                         "name": "mode",
                         "in": "query",
                         "description": "How to crop the image",
@@ -8424,19 +8385,6 @@
                             "enum": [
                                 "fill",
                                 "cover"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "mimeFallback",
-                        "in": "query",
-                        "description": "Whether to fallback to the mime icon if no preview is available",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
                             ]
                         }
                     }
@@ -8478,7 +8426,7 @@
                         }
                     },
                     "303": {
-                        "description": "Redirect to the mime icon url if mimeFallback is true",
+                        "description": "Redirect to the mime icon url",
                         "headers": {
                             "Location": {
                                 "schema": {

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -8197,6 +8197,8 @@
             "get": {
                 "operationId": "preview-get-preview",
                 "summary": "Get a preview by file path",
+                "description": "Deprecated: Use getPreviewByFileId instead",
+                "deprecated": true,
                 "tags": [
                     "preview"
                 ],

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -8254,19 +8254,6 @@
                         }
                     },
                     {
-                        "name": "forceIcon",
-                        "in": "query",
-                        "description": "Force returning an icon",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
                         "name": "mode",
                         "in": "query",
                         "description": "How to crop the image",
@@ -8276,19 +8263,6 @@
                             "enum": [
                                 "fill",
                                 "cover"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "mimeFallback",
-                        "in": "query",
-                        "description": "Whether to fallback to the mime icon if no preview is available",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
                             ]
                         }
                     }
@@ -8330,7 +8304,7 @@
                         }
                     },
                     "303": {
-                        "description": "Redirect to the mime icon url if mimeFallback is true",
+                        "description": "Redirect to the mime icon url",
                         "headers": {
                             "Location": {
                                 "schema": {
@@ -8402,19 +8376,6 @@
                         }
                     },
                     {
-                        "name": "forceIcon",
-                        "in": "query",
-                        "description": "Force returning an icon",
-                        "schema": {
-                            "type": "integer",
-                            "default": 1,
-                            "enum": [
-                                0,
-                                1
-                            ]
-                        }
-                    },
-                    {
                         "name": "mode",
                         "in": "query",
                         "description": "How to crop the image",
@@ -8424,19 +8385,6 @@
                             "enum": [
                                 "fill",
                                 "cover"
-                            ]
-                        }
-                    },
-                    {
-                        "name": "mimeFallback",
-                        "in": "query",
-                        "description": "Whether to fallback to the mime icon if no preview is available",
-                        "schema": {
-                            "type": "integer",
-                            "default": 0,
-                            "enum": [
-                                0,
-                                1
                             ]
                         }
                     }
@@ -8478,7 +8426,7 @@
                         }
                     },
                     "303": {
-                        "description": "Redirect to the mime icon url if mimeFallback is true",
+                        "description": "Redirect to the mime icon url",
                         "headers": {
                             "Location": {
                                 "schema": {

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -8197,6 +8197,8 @@
             "get": {
                 "operationId": "preview-get-preview",
                 "summary": "Get a preview by file path",
+                "description": "Deprecated: Use getPreviewByFileId instead",
+                "deprecated": true,
                 "tags": [
                     "preview"
                 ],

--- a/core/src/OC/dialogs.js
+++ b/core/src/OC/dialogs.js
@@ -345,7 +345,7 @@ const Dialogs = {
 		}
 
 		const dialog = builder.build()
-	
+
 		if (allowHtml) {
 			dialog.setHTML(content)
 		}
@@ -560,7 +560,6 @@ const Dialogs = {
 				x: 96,
 				y: 96,
 				c: original.etag,
-				forceIcon: 0
 			}
 			var previewpath = Files.generatePreviewUrl(urlSpec)
 			// Escaping single quotes


### PR DESCRIPTION
## Summary

Instead of providing the option to generate fallback previews this PR changes it to always generate some kind of preview if possible.
I don't see a reason why we shouldn't ever fallback to the mimetype or symbolic icon in case we are not able to generate a proper preview or it's a folder.
This also improves the UX, in case developers forget to manually request the mimeFallback, as now the users still see some preview.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)