### PR TITLE
feat(login-flow-v2): Restrict allowed apps by user agent check

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2516,6 +2516,20 @@ $CONFIG = [
 ],
 
 /**
+ * This option allows you to specify a list of allowed user agents for the Login Flow V2.
+ * If a user agent is not in this list, it will not be allowed to use the Login Flow V2.
+ * The user agents are defined using regular expressions.
+ *
+ * WARNING: only use this if you know what you are doing
+ *
+ * Example: Allow only the Nextcloud Android app to use the Login Flow V2
+ * 'core.login_flow_v2.allowed_user_agents' => ['/Nextcloud-android/i'],
+ *
+ * Defaults to an empty array.
+ */
+'core.login_flow_v2.allowed_user_agents' => [],
+
+/**
  * By default, there is on public pages a link shown that allows users to
  * learn about the "simple sign up" - see https://nextcloud.com/signup/
  *

--- a/core/Controller/ClientFlowLoginV2Controller.php
+++ b/core/Controller/ClientFlowLoginV2Controller.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\Core\Controller;
 
 use OC\Core\Db\LoginFlowV2;
+use OC\Core\Exception\LoginFlowV2ClientForbiddenException;
 use OC\Core\Exception\LoginFlowV2NotFoundException;
 use OC\Core\ResponseDefinitions;
 use OC\Core\Service\LoginFlowV2Service;
@@ -109,6 +110,8 @@ class ClientFlowLoginV2Controller extends Controller {
 			$flow = $this->getFlowByLoginToken();
 		} catch (LoginFlowV2NotFoundException $e) {
 			return $this->loginTokenForbiddenResponse();
+		} catch (LoginFlowV2ClientForbiddenException $e) {
+			return $this->loginTokenForbiddenClientResponse();
 		}
 
 		$stateToken = $this->random->generate(
@@ -152,6 +155,8 @@ class ClientFlowLoginV2Controller extends Controller {
 			$flow = $this->getFlowByLoginToken();
 		} catch (LoginFlowV2NotFoundException $e) {
 			return $this->loginTokenForbiddenResponse();
+		} catch (LoginFlowV2ClientForbiddenException $e) {
+			return $this->loginTokenForbiddenClientResponse();
 		}
 
 		/** @var IUser $user */
@@ -188,6 +193,8 @@ class ClientFlowLoginV2Controller extends Controller {
 			$this->getFlowByLoginToken();
 		} catch (LoginFlowV2NotFoundException $e) {
 			return $this->loginTokenForbiddenResponse();
+		} catch (LoginFlowV2ClientForbiddenException $e) {
+			return $this->loginTokenForbiddenClientResponse();
 		}
 
 		$loginToken = $this->session->get(self::TOKEN_NAME);
@@ -233,6 +240,8 @@ class ClientFlowLoginV2Controller extends Controller {
 			$this->getFlowByLoginToken();
 		} catch (LoginFlowV2NotFoundException $e) {
 			return $this->loginTokenForbiddenResponse();
+		} catch (LoginFlowV2ClientForbiddenException $e) {
+			return $this->loginTokenForbiddenClientResponse();
 		}
 
 		$loginToken = $this->session->get(self::TOKEN_NAME);
@@ -333,6 +342,7 @@ class ClientFlowLoginV2Controller extends Controller {
 	/**
 	 * @return LoginFlowV2
 	 * @throws LoginFlowV2NotFoundException
+	 * @throws LoginFlowV2ClientForbiddenException
 	 */
 	private function getFlowByLoginToken(): LoginFlowV2 {
 		$currentToken = $this->session->get(self::TOKEN_NAME);
@@ -349,6 +359,19 @@ class ClientFlowLoginV2Controller extends Controller {
 			'403',
 			[
 				'message' => $this->l10n->t('Your login token is invalid or has expired'),
+			],
+			'guest'
+		);
+		$response->setStatus(Http::STATUS_FORBIDDEN);
+		return $response;
+	}
+
+	private function loginTokenForbiddenClientResponse(): StandaloneTemplateResponse {
+		$response = new StandaloneTemplateResponse(
+			$this->appName,
+			'403',
+			[
+				'message' => $this->l10n->t('Please use original client'),
 			],
 			'guest'
 		);

--- a/core/Exception/LoginFlowV2ClientForbiddenException.php
+++ b/core/Exception/LoginFlowV2ClientForbiddenException.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Core\Exception;
+
+class LoginFlowV2ClientForbiddenException extends \Exception {
+}

--- a/lib/composer/autoload.php
+++ b/lib/composer/autoload.php
@@ -14,7 +14,10 @@ if (PHP_VERSION_ID < 50600) {
             echo $err;
         }
     }
-    throw new RuntimeException($err);
+    trigger_error(
+        $err,
+        E_USER_ERROR
+    );
 }
 
 require_once __DIR__ . '/composer/autoload_real.php';

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1371,6 +1371,7 @@ return array(
     'OC\\Core\\Db\\ProfileConfigMapper' => $baseDir . '/core/Db/ProfileConfigMapper.php',
     'OC\\Core\\Events\\BeforePasswordResetEvent' => $baseDir . '/core/Events/BeforePasswordResetEvent.php',
     'OC\\Core\\Events\\PasswordResetEvent' => $baseDir . '/core/Events/PasswordResetEvent.php',
+    'OC\\Core\\Exception\\LoginFlowV2ClientForbiddenException' => $baseDir . '/core/Exception/LoginFlowV2ClientForbiddenException.php',
     'OC\\Core\\Exception\\LoginFlowV2NotFoundException' => $baseDir . '/core/Exception/LoginFlowV2NotFoundException.php',
     'OC\\Core\\Exception\\ResetPasswordException' => $baseDir . '/core/Exception/ResetPasswordException.php',
     'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => $baseDir . '/core/Listener/BeforeMessageLoggedEventListener.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1412,6 +1412,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Db\\ProfileConfigMapper' => __DIR__ . '/../../..' . '/core/Db/ProfileConfigMapper.php',
         'OC\\Core\\Events\\BeforePasswordResetEvent' => __DIR__ . '/../../..' . '/core/Events/BeforePasswordResetEvent.php',
         'OC\\Core\\Events\\PasswordResetEvent' => __DIR__ . '/../../..' . '/core/Events/PasswordResetEvent.php',
+        'OC\\Core\\Exception\\LoginFlowV2ClientForbiddenException' => __DIR__ . '/../../..' . '/core/Exception/LoginFlowV2ClientForbiddenException.php',
         'OC\\Core\\Exception\\LoginFlowV2NotFoundException' => __DIR__ . '/../../..' . '/core/Exception/LoginFlowV2NotFoundException.php',
         'OC\\Core\\Exception\\ResetPasswordException' => __DIR__ . '/../../..' . '/core/Exception/ResetPasswordException.php',
         'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => __DIR__ . '/../../..' . '/core/Listener/BeforeMessageLoggedEventListener.php',

--- a/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginV2ControllerTest.php
@@ -11,6 +11,7 @@ namespace Test\Core\Controller;
 use OC\Core\Controller\ClientFlowLoginV2Controller;
 use OC\Core\Data\LoginFlowV2Credentials;
 use OC\Core\Db\LoginFlowV2;
+use OC\Core\Exception\LoginFlowV2ClientForbiddenException;
 use OC\Core\Exception\LoginFlowV2NotFoundException;
 use OC\Core\Service\LoginFlowV2Service;
 use OCP\AppFramework\Http;
@@ -56,6 +57,12 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->defaults = $this->createMock(Defaults::class);
 		$this->l = $this->createMock(IL10N::class);
+		$this->l
+			->expects($this->any())
+			->method('t')
+			->willReturnCallback(function ($text, $parameters = []) {
+				return vsprintf($text, $parameters);
+			});
 		$this->controller = new ClientFlowLoginV2Controller(
 			'core',
 			$this->request,
@@ -150,6 +157,22 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 		$this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
 	}
 
+	public function testShowAuthPickerForbiddenUserClient() {
+		$this->session->method('get')
+			->with('client.flow.v2.login.token')
+			->willReturn('loginToken');
+
+		$this->loginFlowV2Service->method('getByLoginToken')
+			->with('loginToken')
+			->willThrowException(new LoginFlowV2ClientForbiddenException());
+
+		$result = $this->controller->showAuthPickerPage();
+
+		$this->assertInstanceOf(Http\StandaloneTemplateResponse::class, $result);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+		$this->assertSame('Please use original client', $result->getParams()['message']);
+	}
+
 	public function testShowAuthPickerValidLoginToken(): void {
 		$this->session->method('get')
 			->with('client.flow.v2.login.token')
@@ -204,6 +227,29 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 		$result = $this->controller->grantPage('stateToken');
 		$this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+	}
+
+	public function testGrantPageForbiddenUserClient() {
+		$this->session->method('get')
+			->willReturnCallback(function ($name) {
+				if ($name === 'client.flow.v2.state.token') {
+					return 'stateToken';
+				}
+				if ($name === 'client.flow.v2.login.token') {
+					return 'loginToken';
+				}
+				return null;
+			});
+
+		$this->loginFlowV2Service->method('getByLoginToken')
+			->with('loginToken')
+			->willThrowException(new LoginFlowV2ClientForbiddenException());
+
+		$result = $this->controller->grantPage('stateToken');
+
+		$this->assertInstanceOf(Http\StandaloneTemplateResponse::class, $result);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+		$this->assertSame('Please use original client', $result->getParams()['message']);
 	}
 
 	public function testGrantPageValid(): void {
@@ -264,6 +310,29 @@ class ClientFlowLoginV2ControllerTest extends TestCase {
 
 		$result = $this->controller->generateAppPassword('stateToken');
 		$this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+	}
+
+	public function testGenerateAppPasswordForbiddenUserClient() {
+		$this->session->method('get')
+			->willReturnCallback(function ($name) {
+				if ($name === 'client.flow.v2.state.token') {
+					return 'stateToken';
+				}
+				if ($name === 'client.flow.v2.login.token') {
+					return 'loginToken';
+				}
+				return null;
+			});
+
+		$this->loginFlowV2Service->method('getByLoginToken')
+			->with('loginToken')
+			->willThrowException(new LoginFlowV2ClientForbiddenException());
+
+		$result = $this->controller->generateAppPassword('stateToken');
+
+		$this->assertInstanceOf(Http\StandaloneTemplateResponse::class, $result);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $result->getStatus());
+		$this->assertSame('Please use original client', $result->getParams()['message']);
 	}
 
 	public function testGenerateAppPassworValid(): void {


### PR DESCRIPTION
add config value to `config.php`:
```php
	"core.login_flow_v2.allowed_user_agents" => [
			'/Custom Foo/i'
	],
```
or via occ
```shell
./occ config:system:set core.login_flow_v2.allowed_user_agents 0  --value '/Custom Foo/i'
```


# Test Allowed client
```shell
curl -s -A "Custom Foo Curl Client/1.0" -X POST http://localhost:8080/index.php/login/v2 | jq
```
click on generated `login` url.

# Test Forbidden client
```shell
curl -s -A "Rogue Curl Client/1.0" -X POST http://localhost:8080/index.php/login/v2 | jq
```
click on generated `login` url.
observe 
![Selection_20250204-003](https://github.com/user-attachments/assets/93a0a111-abc7-423e-8db2-4dbc4fc6a205)

## Unitests
* Run tests with coverage
* Add test suite `phpunit-autotest-core.xml` file
<details>
<summary>phpunit-autotest-core.xml</summary>

```xml
<?xml version="1.0" encoding="utf-8" ?>
<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
		 bootstrap="bootstrap.php"
		 verbose="true"
		 backupGlobals="false"
		 timeoutForSmallTests="900"
		 timeoutForMediumTests="900"
		 timeoutForLargeTests="900"
		 convertDeprecationsToExceptions="true"
		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
	<testsuite name='test LoginFlowV2'>
		<directory suffix=".php">./Core/Controller/ClientFlowLoginV2ControllerTest.php</directory>
		<directory suffix=".php">./Core/Service/LoginFlowV2ServiceUnitTest.php</directory>
	</testsuite>
	<coverage>
		<include>
			<directory suffix=".php">../core/*</directory>
		</include>
		<exclude>
			<directory suffix=".js">../**/</directory>

			<directory suffix=".php">../3rdparty/**/*</directory>
			<directory suffix=".php">../apps/**/*</directory>
			<directory suffix=".php">../apps-custom/**/*</directory>
			<directory suffix=".php">../apps-external/**/*</directory>
			<directory suffix=".php">../custom-npms/**/*</directory>
			<directory suffix=".php">../build</directory>
			<directory suffix=".php">../IONOS/**/*</directory>
			<directory suffix=".php">../lib/composer</directory>
			<directory suffix=".php">../vendor/**/*</directory>
			<directory suffix=".php">../tests</directory>
		</exclude>
	</coverage>
	<listeners>
		<listener class="StartSessionListener" file="startsessionlistener.php" />
	</listeners>
</phpunit>
```

</details>

* run tests
```shell
export XDEBUG_MODE=coverage && phpunit --configuration tests/phpunit-autotest-core.xml --coverage-html coverage
```
* observe coverage in ./coverage folder




## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
