### PR TITLE
fix(theming): high contrast themes scrollbar

### DIFF
--- a/apps/theming/lib/Themes/DarkHighContrastTheme.php
+++ b/apps/theming/lib/Themes/DarkHighContrastTheme.php
@@ -89,7 +89,7 @@ class DarkHighContrastTheme extends DarkTheme implements ITheme {
 				'--color-info-hover' => $this->util->lighten($colorInfo, 10),
 				'--color-info-text' => $this->util->lighten($colorInfo, 20),
 
-				'--color-scrollbar' => 'auto',
+				'--color-scrollbar' => 'auto transparent',
 
 				// used for the icon loading animation
 				'--color-loading-light' => '#000000',

--- a/apps/theming/lib/Themes/HighContrastTheme.php
+++ b/apps/theming/lib/Themes/HighContrastTheme.php
@@ -94,7 +94,7 @@ class HighContrastTheme extends DefaultTheme implements ITheme {
 
 				'--color-favorite' => '#936B06',
 
-				'--color-scrollbar' => 'auto',
+				'--color-scrollbar' => 'auto transparent',
 
 				// used for the icon loading animation
 				'--color-loading-light' => '#dddddd',


### PR DESCRIPTION
Fix https://github.com/nextcloud/server/issues/49426

| Webkit | Firefox |
|:---------:|:------:|
|![image](https://github.com/user-attachments/assets/b527ee6a-b44a-4bd4-9083-fcf4b5980d8a)|![image](https://github.com/user-attachments/assets/9e3b6a76-7bf1-471d-85b7-1e72e2b06bab)|