### PR TITLE
enh: improve occ file:transfer-ownership logging

### DIFF
--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -141,6 +141,8 @@ class OwnershipTransferService {
 			$sourcePath
 		);
 
+		$sourceSize = $view->getFileInfo($sourcePath)->getSize();
+
 		// transfer the files
 		$this->transferFiles(
 			$sourceUid,
@@ -149,6 +151,7 @@ class OwnershipTransferService {
 			$view,
 			$output
 		);
+		$sizeDifference = $sourceSize - $view->getFileInfo($finalTarget)->getSize();
 
 		// transfer the incoming shares
 		if ($transferIncomingShares === true) {
@@ -184,6 +187,9 @@ class OwnershipTransferService {
 			$shares,
 			$output
 		);
+		if ($sizeDifference !== 0) {
+			$output->writeln("Transferred folder have a size difference of: $sizeDifference Bytes which means the transfer may be incomplete. Please check the logs if there was any issue during the transfer operation.");
+		}
 	}
 
 	private function sanitizeFolderName(string $name): string {


### PR DESCRIPTION
When using occ file:transfer-ownership, we had issues reported that not all files where transferred when using s3 buckets as file storage.

This PR improves the logging of the occ command to inform users when not all files are transferred.