### PR TITLE
fix(apps): Remove jobs when an app gets disabled

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -672,6 +672,7 @@ class AppManager implements IAppManager {
 		$appData = $this->getAppInfo($appId);
 		if (!is_null($appData)) {
 			\OC_App::executeRepairSteps($appId, $appData['repair-steps']['uninstall']);
+			\OC_App::removeBackgroundJobs($appData['background-jobs']);
 		}
 
 		$this->dispatcher->dispatchTyped(new AppDisableEvent($appId));

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -755,6 +755,13 @@ class OC_App {
 		$r->run();
 	}
 
+	public static function removeBackgroundJobs(array $jobs) {
+		$queue = \OC::$server->getJobList();
+		foreach ($jobs as $job) {
+			$queue->remove($job);
+		}
+	}
+
 	public static function setupBackgroundJobs(array $jobs) {
 		$queue = \OC::$server->getJobList();
 		foreach ($jobs as $job) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: nextcloud/app_api#481 <!-- related github issue -->

## Summary

Automatically remove background jobs when an app gets disabled rather than waiting for the job to fail at the next run (where we currently disable it reactively).

Current behavior is reactive only and triggers an unnecessary warning that gets logged at the next attempt to run the job:

https://github.com/nextcloud/server/blob/f9c03f760653c4293cbf29560e1cacbd3cf8a997/lib/private/BackgroundJob/JobList.php#L289-L299

(keeping that to catch apps that get disabled externally - or that fail to load in other ways; this PR just makes it so that apps that are disabled cleanly also have their background jobs removed).

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
