### PR TITLE
[stable31] build(deps): Bump phpseclib/phpseclib from 2.0.47 to 2.0.48

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -843,7 +843,6 @@
       <code><![CDATA[encrypt]]></code>
       <code><![CDATA[setIV]]></code>
       <code><![CDATA[setIV]]></code>
-      <code><![CDATA[setKey]]></code>
     </InternalMethod>
     <TooManyArguments>
       <code><![CDATA[test]]></code>


### PR DESCRIPTION
* [x] https://github.com/nextcloud/3rdparty/pull/2040

| Production Changes  | From   | To     | Compare                                                               |
|---------------------|--------|--------|-----------------------------------------------------------------------|
| phpseclib/phpseclib | 2.0.47 | 2.0.48 | [...](https://github.com/phpseclib/phpseclib/compare/2.0.47...2.0.48) |
