### PR TITLE
fix(files_reminders): Only allow updating reminders if the file is accessible

### DIFF
--- a/apps/files_reminders/lib/Controller/ApiController.php
+++ b/apps/files_reminders/lib/Controller/ApiController.php
@@ -57,7 +57,7 @@ class ApiController extends OCSController {
 				'dueDate' => $reminder->getDueDate()->format(DateTimeInterface::ATOM), // ISO 8601
 			];
 			return new DataResponse($reminderData, Http::STATUS_OK);
-		} catch (DoesNotExistException $e) {
+		} catch (NodeNotFoundException | DoesNotExistException $e) {
 			$reminderData = [
 				'dueDate' => null,
 			];
@@ -125,7 +125,7 @@ class ApiController extends OCSController {
 		try {
 			$this->reminderService->remove($user, $fileId);
 			return new DataResponse([], Http::STATUS_OK);
-		} catch (DoesNotExistException $e) {
+		} catch (NodeNotFoundException | DoesNotExistException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 	}

--- a/apps/files_reminders/lib/Controller/ApiController.php
+++ b/apps/files_reminders/lib/Controller/ApiController.php
@@ -57,7 +57,7 @@ class ApiController extends OCSController {
 				'dueDate' => $reminder->getDueDate()->format(DateTimeInterface::ATOM), // ISO 8601
 			];
 			return new DataResponse($reminderData, Http::STATUS_OK);
-		} catch (NodeNotFoundException | DoesNotExistException $e) {
+		} catch (NodeNotFoundException|DoesNotExistException $e) {
 			$reminderData = [
 				'dueDate' => null,
 			];
@@ -125,7 +125,7 @@ class ApiController extends OCSController {
 		try {
 			$this->reminderService->remove($user, $fileId);
 			return new DataResponse([], Http::STATUS_OK);
-		} catch (NodeNotFoundException | DoesNotExistException $e) {
+		} catch (NodeNotFoundException|DoesNotExistException $e) {
 			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 	}

--- a/apps/files_reminders/lib/Service/ReminderService.php
+++ b/apps/files_reminders/lib/Service/ReminderService.php
@@ -74,6 +74,11 @@ class ReminderService {
 	 */
 	public function createOrUpdate(IUser $user, int $fileId, DateTime $dueDate): bool {
 		$now = new DateTime('now', new DateTimeZone('UTC'));
+		$userFolder = $this->root->getUserFolder($user->getUID());
+		$node = $userFolder->getFirstNodeById($fileId);
+		if (!$node) {
+			throw new NodeNotFoundException();
+		}
 		try {
 			$reminder = $this->reminderMapper->findDueForUser($user, $fileId);
 			$reminder->setDueDate($dueDate);
@@ -81,10 +86,6 @@ class ReminderService {
 			$this->reminderMapper->update($reminder);
 			return false;
 		} catch (DoesNotExistException $e) {
-			$node = $this->root->getUserFolder($user->getUID())->getFirstNodeById($fileId);
-			if (!$node) {
-				throw new NodeNotFoundException();
-			}
 			// Create new reminder if no reminder is found
 			$reminder = new Reminder();
 			$reminder->setUserId($user->getUID());


### PR DESCRIPTION
## Summary

No changes should be made for inaccessible files

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)