### PR TITLE
[30] don't use cached root info from shared cache if the watcher has detected an update

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -198,4 +198,8 @@ class Cache extends CacheJail {
 			return null;
 		}
 	}
+
+	public function markRootChanged(): void {
+		$this->rootUnchanged = false;
+	}
 }

--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -460,7 +460,12 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements LegacyISha
 			// for shares from the home storage we can rely on the home storage to keep itself up to date
 			// for other storages we need use the proper watcher
 			if (!(str_starts_with($storageId, 'home::') || str_starts_with($storageId, 'object::user'))) {
+				$cache = $this->getCache();
 				$this->watcher = parent::getWatcher($path, $storage);
+				if ($cache instanceof Cache && $this->watcher instanceof Watcher) {
+					$this->watcher->onUpdate([$cache, 'markRootChanged']);
+				}
+
 				return $this->watcher;
 			}
 		}

--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -33,6 +33,9 @@ class Watcher implements IWatcher {
 	 */
 	protected $scanner;
 
+	/** @var callable[] */
+	protected $onUpdate = [];
+
 	/**
 	 * @param \OC\Files\Storage\Storage $storage
 	 */
@@ -100,6 +103,9 @@ class Watcher implements IWatcher {
 		if ($this->cache instanceof Cache) {
 			$this->cache->correctFolderSize($path);
 		}
+		foreach ($this->onUpdate as $callback) {
+			$callback($path);
+		}
 	}
 
 	/**
@@ -129,5 +135,12 @@ class Watcher implements IWatcher {
 				$this->cache->remove($entry['path']);
 			}
 		}
+	}
+
+	/**
+	 * register a callback to be called whenever the watcher triggers and update
+	 */
+	public function onUpdate(callable $callback): void {
+		$this->onUpdate[] = $callback;
 	}
 }

--- a/lib/private/Files/Cache/Wrapper/JailWatcher.php
+++ b/lib/private/Files/Cache/Wrapper/JailWatcher.php
@@ -55,4 +55,7 @@ class JailWatcher extends Watcher {
 		$this->watcher->cleanFolder($this->getSourcePath($path));
 	}
 
+	public function onUpdate(callable $callback): void {
+		$this->watcher->onUpdate($callback);
+	}
 }


### PR DESCRIPTION
Backport of #50324 without the interface changes