### PR TITLE
fix(setupcheck): Update setup check for PHP version to be more accurate

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpOutdated.php
+++ b/apps/settings/lib/SetupChecks/PhpOutdated.php
@@ -14,6 +14,11 @@ use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
 class PhpOutdated implements ISetupCheck {
+	public const DEPRECATED_PHP_VERSION = '8.1';
+	public const DEPRECATED_SINCE = '30';
+	public const FUTURE_REQUIRED_PHP_VERSION = '8.2';
+	public const FUTURE_REQUIRED_STARTING = '32';
+
 	public function __construct(
 		private IL10N $l10n,
 	) {
@@ -29,7 +34,13 @@ class PhpOutdated implements ISetupCheck {
 
 	public function run(): SetupResult {
 		if (PHP_VERSION_ID < 80200) {
-			return SetupResult::warning($this->l10n->t('You are currently running PHP %s. PHP 8.1 is now deprecated in Nextcloud 30. Nextcloud 31 may require at least PHP 8.2. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [PHP_VERSION]), 'https://secure.php.net/supported-versions.php');
+			return SetupResult::warning($this->l10n->t('You are currently running PHP %1$s. PHP %2$s is deprecated since Nextcloud %3$s. Nextcloud %4$s may require at least PHP %5$s. Please upgrade to one of the officially supported PHP versions provided by the PHP Group as soon as possible.', [
+				PHP_VERSION,
+				self::DEPRECATED_PHP_VERSION,
+				self::DEPRECATED_SINCE,
+				self::FUTURE_REQUIRED_STARTING,
+				self::FUTURE_REQUIRED_PHP_VERSION,
+			]), 'https://secure.php.net/supported-versions.php');
 		}
 		return SetupResult::success($this->l10n->t('You are currently running PHP %s.', [PHP_VERSION]));
 	}


### PR DESCRIPTION
Despite this being a language change, I'd still backport it, to avoid confusion before and during updates.
Should also backport to 30 and 31

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
