### PR TITLE
Update doc comment for prefixTableName

### DIFF
--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -1339,6 +1339,8 @@ class QueryBuilder implements IQueryBuilder {
 	/**
 	 * Returns the table name with database prefix as needed by the implementation
 	 *
+	 * Was protected until version 30.
+  	 *
 	 * @param string $table
 	 * @return string
 	 */


### PR DESCRIPTION
I just pushed a small patch to better handle the prefix, but it turns out the API wasn't accessible. So I'm adding a comment so other users are aware of that.