### PR TITLE
perf(cron): Delay (re)checking timed jobs

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -20,6 +20,7 @@ use OCP\IDBConnection;
 use Psr\Log\LoggerInterface;
 use function get_class;
 use function json_encode;
+use function min;
 use function strlen;
 
 class JobList implements IJobList {
@@ -207,6 +208,26 @@ class JobList implements IJobList {
 				$update->executeStatement();
 
 				return $this->getNext($onlyTimeSensitive, $jobClasses);
+			}
+
+			if ($job instanceof \OCP\BackgroundJob\TimedJob) {
+				$now = $this->timeFactory->getTime();
+				$nextPossibleRun = $job->getLastRun() + $job->getInterval();
+				if ($now < $nextPossibleRun) {
+					// This job is not ready for execution yet. Set timestamps to the future to avoid
+					// re-checking with every cron run.
+					// To avoid bugs that lead to jobs never executing again, the future timestamp is
+					// capped at two days.
+					$nextCheck = min($nextPossibleRun, $now + 48 * 3600);
+					$updateTimedJob = $this->connection->getQueryBuilder();
+					$updateTimedJob->update('jobs')
+						->set('last_checked', $updateTimedJob->createNamedParameter($nextCheck, IQueryBuilder::PARAM_INT))
+						->where($updateTimedJob->expr()->eq('id', $updateTimedJob->createParameter('jobid')));
+					$updateTimedJob->setParameter('jobid', $row['id']);
+					$updateTimedJob->executeStatement();
+
+					return $this->getNext($onlyTimeSensitive, $jobClasses);
+				}
 			}
 
 			$update = $this->connection->getQueryBuilder();

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -33,6 +33,15 @@ abstract class TimedJob extends Job {
 	}
 
 	/**
+	 * Get the interval [seconds] for the job
+	 *
+	 * @since 32.0.0
+	 */
+	public function getInterval(): int {
+		return $this->interval;
+	}
+
+	/**
 	 * Whether the background job is time sensitive and needs to run soon after
 	 * the scheduled interval, of if it is okay to be delayed until a later time.
 	 *

--- a/tests/lib/BackgroundJob/TestTimedJobNew.php
+++ b/tests/lib/BackgroundJob/TestTimedJobNew.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace Test\BackgroundJob;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+
+class TestTimedJobNew extends TimedJob {
+	public bool $ran = false;
+
+	public function __construct(ITimeFactory $timeFactory) {
+		parent::__construct($timeFactory);
+		$this->setInterval(10);
+	}
+
+	public function run($argument) {
+		$this->ran = true;
+	}
+}

--- a/tests/lib/BackgroundJob/TimedJobTest.php
+++ b/tests/lib/BackgroundJob/TimedJobTest.php
@@ -8,20 +8,6 @@
 namespace Test\BackgroundJob;
 
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\TimedJob;
-
-class TestTimedJobNew extends TimedJob {
-	public bool $ran = false;
-
-	public function __construct(ITimeFactory $timeFactory) {
-		parent::__construct($timeFactory);
-		$this->setInterval(10);
-	}
-
-	public function run($argument) {
-		$this->ran = true;
-	}
-}
 
 class TimedJobTest extends \Test\TestCase {
 	private DummyJobList $jobList;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Right now timed jobs are always loaded from the db and instantiated. Jobs with intervals higher than the cron interval are continuously loaded and checked, `\OCP\BackgroundJob\TimedJob::start` prevents the actual execution.
As an optimization we can preemptively check if a job is ready. Otherwise we park it for a later check.

## How to test

1. Set breakpoints in timed jobs constructors
2. Observe how the jobs are instantiated once for the initial check and only every instantiated again when they are ready or two days have passed.

## TODO

- [x] Make the changes
- [x] Manually test the changes
  - Jobs that are ready are executed like before
  - Jobs are parked as expected
  - Once the parked timestamp elapsed, jobs run again like before

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
