### PR TITLE
fix: Only keep allowed characters in appid, and flag the method as escaping

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -956,6 +956,6 @@ class AppManager implements IAppManager {
 	 */
 	public function cleanAppId(string $app): string {
 		/* Only lowercase alphanumeric is allowed */
-		return preg_replace('/[^a-z0-9_]+/', '', $app);
+		return preg_replace('/(^[0-9_]|[^a-z0-9_]+|_$)/', '', $app);
 	}
 }

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -939,8 +939,23 @@ class AppManager implements IAppManager {
 		return false;
 	}
 
+	/**
+	 * Clean the appId from forbidden characters
+	 *
+	 * @psalm-taint-escape callable
+	 * @psalm-taint-escape cookie
+	 * @psalm-taint-escape file
+	 * @psalm-taint-escape has_quotes
+	 * @psalm-taint-escape header
+	 * @psalm-taint-escape html
+	 * @psalm-taint-escape include
+	 * @psalm-taint-escape ldap
+	 * @psalm-taint-escape shell
+	 * @psalm-taint-escape sql
+	 * @psalm-taint-escape unserialize
+	 */
 	public function cleanAppId(string $app): string {
-		// FIXME should list allowed characters instead
-		return str_replace(['<', '>', '"', "'", '\0', '/', '\\', '..'], '', $app);
+		/* Only lowercase alphanumeric is allowed */
+		return preg_replace('/[^a-z0-9_]+/', '', $app);
 	}
 }

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -309,10 +309,17 @@ interface IAppManager {
 	/**
 	 * Clean the appId from forbidden characters
 	 *
+	 * @psalm-taint-escape callable
+	 * @psalm-taint-escape cookie
 	 * @psalm-taint-escape file
-	 * @psalm-taint-escape include
-	 * @psalm-taint-escape html
 	 * @psalm-taint-escape has_quotes
+	 * @psalm-taint-escape header
+	 * @psalm-taint-escape html
+	 * @psalm-taint-escape include
+	 * @psalm-taint-escape ldap
+	 * @psalm-taint-escape shell
+	 * @psalm-taint-escape sql
+	 * @psalm-taint-escape unserialize
 	 *
 	 * @since 31.0.0
 	 */


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

There are a few more psalm-taint types than what was listed, and I had to add the phpdoc on the implementation as well to get psalm to take it into account.

I also fixed the FIXME in there by only keeping explicitely allowed characters in appid.
Should be fine as the xsd schema is already enforcing this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
