### PR TITLE
fix(session): Update `last_seen` when user session is validated

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -214,6 +214,11 @@ class Session implements IUserSession, Emitter {
 			// Session was invalidated
 			$this->logout();
 		}
+
+		// Update last seen timestamp
+		if ($this->isLoggedIn()) {
+			$this->getUser()->updateLastLoginTimestamp();
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

While doing some maintenance on my instance, I've saw a lot of users with `last_seen` timestamp a few months ago, like 7 months ago or even more than a year. So, I've disabled them.

A couple of minutes later, some of them were complaining their user account was disabled 😿 

Example:

```
# occ user:info USER
  - user_id: USER
  - display_name: USER
  - email: USER@email.com
  - cloud_id: USER@my.instance.com
  - enabled: true
  - groups:
    - Users
  - quota: 10 GB
  - storage:
    - free: 10737418240
    - used: 0
    - total: 10737418240
    - relative: 0
    - quota: 10737418240
  - last_seen: 2024-08-12T17:19:46+00:00
  - user_directory: /var/www/data/USER
  - backend: Database
```

As you can see, `last_seen` states user was last seen (wrongly) 6 **months** ago.
Yet, on the webserver log, we can see that this same user performed some operations only **minutes** ago:

```
cat /var/log/nginx/*.log | grep -F 'USER'

"[15/Feb/2025:11:08:49 +0100]" my.instance.com PROPFIND /remote.php/dav/calendars/USER/personal_shared_by_another/ 207 0.077 0.062 "DAVx5/4.3.12.1-ose (2023/12/27; dav4jvm; okhttp/4.12.0) Android/12"
"[15/Feb/2025:11:39:14 +0100]" my.instance.com PROPFIND /remote.php/dav/calendars/USER/personal/ 207 0.324 0.309 "DAVx5/4.3.12.1-ose (2023/12/27; dav4jvm; okhttp/4.12.0) Android/12"
```

Problem is that those users NEVER use the WebUI, they only use some apps to sync their data, like Calendar or Contacts sync, etc. So, they never complete a [full logout + full login](https://github.com/nextcloud/server/blob/a1bc474607825c4f1d1a30a7eb441ad6c8960f1a/lib/private/User/Session.php#L322).

My proposal here is to update the `last_seen` timestamp also when we validate their session, since that, in my opinion, as an instance administrator, I want to be able to rely on the `last_seen` field to **really know when the user was last seen** (and by last seen, I mean user has done some kind of legit activity on the instance, while being a valid user). As per actual logic, it would be updated, at most, [once every 60s](https://github.com/nextcloud/server/blob/9edabfa21fa7e587c0ad95d2d230d215b060ade0/lib/private/User/User.php#L233).

IMO, this is actually a bug (not a feature) because updating `last_seen` field only on full logout + login is not reliable.

Please review.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
