### PR TITLE
fix: block downloading of files with 'hide download' option

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -359,6 +359,10 @@ class ShareController extends AuthPublicShareController {
 			return new DataResponse('Share has no read permission');
 		}
 
+		if ($share->getHideDownload()) {
+			return new DataResponse('Share has no download permission');
+		}
+
 		if (!$this->validateShare($share)) {
 			throw new NotFoundException();
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

If you make a public share with the “hide download” option, the download button is hidden, but the direct link allows you to get the file.

This fix fixes it.

I understand that there are different ways to download a file. The point here is to reduce the number of such places. 

## TODO

- Create link for image
![image](https://github.com/user-attachments/assets/9d94cc99-50f9-49d5-ac1c-cd90a6c50c49)

- Example http://nextcloud.local/index.php/s/p98WonbBMd8PFcX
- Can be downloaded at the link http://nextcloud.local/index.php/s/p98WonbBMd8PFcX**/download**
- After fix
![image](https://github.com/user-attachments/assets/d851ab1a-044e-4d60-bed7-7d1f65508c65)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
