### PR TITLE
fix: Fix psalm taint false-positives by small refactorings

### DIFF
--- a/apps/files_external/lib/Config/ConfigAdapter.php
+++ b/apps/files_external/lib/Config/ConfigAdapter.php
@@ -40,6 +40,19 @@ class ConfigAdapter implements IMountProvider {
 	}
 
 	/**
+	 * @param class-string $class
+	 * @return class-string<IObjectStore>
+	 * @throws \InvalidArgumentException
+	 * @psalm-taint-escape callable
+	 */
+	private function validateObjectStoreClassString(string $class): string {
+		if (!\is_subclass_of($class, IObjectStore::class)) {
+			throw new \InvalidArgumentException('Invalid object store');
+		}
+		return $class;
+	}
+
+	/**
 	 * Process storage ready for mounting
 	 *
 	 * @throws QueryException
@@ -51,10 +64,7 @@ class ConfigAdapter implements IMountProvider {
 
 		$objectStore = $storage->getBackendOption('objectstore');
 		if ($objectStore) {
-			$objectClass = $objectStore['class'];
-			if (!is_subclass_of($objectClass, IObjectStore::class)) {
-				throw new \InvalidArgumentException('Invalid object store');
-			}
+			$objectClass = $this->validateObjectStoreClassString($objectStore['class']);
 			$storage->setBackendOption('objectstore', new $objectClass($objectStore));
 		}
 

--- a/apps/theming/lib/Util.php
+++ b/apps/theming/lib/Util.php
@@ -197,7 +197,7 @@ class Util {
 	 * @return string|ISimpleFile path to app icon / file of logo
 	 */
 	public function getAppIcon($app) {
-		$app = str_replace(['\0', '/', '\\', '..'], '', $app);
+		$app = $this->appManager->cleanAppId($app);
 		try {
 			$appPath = $this->appManager->getAppPath($app);
 			$icon = $appPath . '/img/' . $app . '.svg';
@@ -228,7 +228,10 @@ class Util {
 	 * @return string|false absolute path to image
 	 */
 	public function getAppImage($app, $image) {
-		$app = str_replace(['\0', '/', '\\', '..'], '', $app);
+		$app = $this->appManager->cleanAppId($app);
+		/**
+		 * @psalm-taint-escape file
+		 */
 		$image = str_replace(['\0', '\\', '..'], '', $image);
 		if ($app === 'core') {
 			$icon = \OC::$SERVERROOT . '/core/img/' . $image;

--- a/build/psalm-baseline-security.xml
+++ b/build/psalm-baseline-security.xml
@@ -1,41 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
-  <file src="apps/files_external/lib/Config/ConfigAdapter.php">
-    <TaintedCallable>
-      <code><![CDATA[$objectClass]]></code>
-    </TaintedCallable>
-  </file>
-  <file src="apps/theming/lib/IconBuilder.php">
-    <TaintedFile>
-      <code><![CDATA[$appIcon]]></code>
-      <code><![CDATA[$imageFile]]></code>
-    </TaintedFile>
-  </file>
-  <file src="lib/private/Config.php">
-    <TaintedHtml>
-      <code><![CDATA[$this->cache]]></code>
-    </TaintedHtml>
-  </file>
-  <file src="lib/private/Route/Router.php">
-    <TaintedCallable>
-      <code><![CDATA[$appNameSpace . '\\Controller\\' . basename($file->getPathname(), '.php')]]></code>
-    </TaintedCallable>
-  </file>
-  <file src="lib/private/Session/CryptoWrapper.php">
-    <TaintedCookie>
-      <code><![CDATA[$this->passphrase]]></code>
-    </TaintedCookie>
-  </file>
-  <file src="lib/private/Setup.php">
-    <TaintedFile>
-      <code><![CDATA[$dataDir]]></code>
-    </TaintedFile>
-  </file>
-  <file src="lib/private/Setup/Sqlite.php">
-    <TaintedFile>
-      <code><![CDATA[$sqliteFile]]></code>
-    </TaintedFile>
-  </file>
   <file src="lib/public/DB/QueryBuilder/IQueryBuilder.php">
     <TaintedSql>
       <code><![CDATA[$column]]></code>

--- a/core/Controller/SetupController.php
+++ b/core/Controller/SetupController.php
@@ -97,6 +97,9 @@ class SetupController {
 		exit();
 	}
 
+	/**
+	 * @psalm-taint-escape file we trust file path given in POST for setup
+	 */
 	public function loadAutoConfig(array $post): array {
 		if (file_exists($this->autoConfigFile)) {
 			$this->logger->info('Autoconfig file found, setting up Nextcloud…');

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -266,7 +266,7 @@ class Config {
 	 * @throws HintException If the config file cannot be written to
 	 * @throws \Exception If no file lock can be acquired
 	 */
-	private function writeData() {
+	private function writeData(): void {
 		$this->checkReadOnly();
 
 		if (!is_file(\OC::$configDir . '/CAN_INSTALL') && !isset($this->cache['version'])) {
@@ -276,7 +276,7 @@ class Config {
 		// Create a php file ...
 		$content = "<?php\n";
 		$content .= '$CONFIG = ';
-		$content .= var_export($this->cache, true);
+		$content .= var_export(self::trustSystemConfig($this->cache), true);
 		$content .= ";\n";
 
 		touch($this->configFilePath);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1109,7 +1109,6 @@ class Server extends ServerContainer implements IServerContainer {
 			);
 
 			return new CryptoWrapper(
-				$c->get(\OCP\IConfig::class),
 				$c->get(ICrypto::class),
 				$c->get(ISecureRandom::class),
 				$request

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -1,13 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Session;
 
-use OCP\IConfig;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\Security\ICrypto;
@@ -30,37 +32,19 @@ use OCP\Security\ISecureRandom;
  * @package OC\Session
  */
 class CryptoWrapper {
+	/** @var string */
 	public const COOKIE_NAME = 'oc_sessionPassphrase';
 
-	/** @var IConfig */
-	protected $config;
-	/** @var ISession */
-	protected $session;
-	/** @var ICrypto */
-	protected $crypto;
-	/** @var ISecureRandom */
-	protected $random;
-	/** @var string */
-	protected $passphrase;
+	protected string $passphrase;
 
-	/**
-	 * @param IConfig $config
-	 * @param ICrypto $crypto
-	 * @param ISecureRandom $random
-	 * @param IRequest $request
-	 */
-	public function __construct(IConfig $config,
-		ICrypto $crypto,
+	public function __construct(
+		protected ICrypto $crypto,
 		ISecureRandom $random,
-		IRequest $request) {
-		$this->crypto = $crypto;
-		$this->config = $config;
-		$this->random = $random;
-
-		if (!is_null($request->getCookie(self::COOKIE_NAME))) {
-			$this->passphrase = $request->getCookie(self::COOKIE_NAME);
-		} else {
-			$this->passphrase = $this->random->generate(128);
+		IRequest $request,
+	) {
+		$passphrase = $request->getCookie(self::COOKIE_NAME);
+		if ($passphrase === null) {
+			$passphrase = $random->generate(128);
 			$secureCookie = $request->getServerProtocol() === 'https';
 			// FIXME: Required for CI
 			if (!defined('PHPUNIT_RUN')) {
@@ -71,7 +55,7 @@ class CryptoWrapper {
 
 				setcookie(
 					self::COOKIE_NAME,
-					$this->passphrase,
+					$passphrase,
 					[
 						'expires' => 0,
 						'path' => $webRoot,
@@ -83,13 +67,10 @@ class CryptoWrapper {
 				);
 			}
 		}
+		$this->passphrase = $passphrase;
 	}
 
-	/**
-	 * @param ISession $session
-	 * @return ISession
-	 */
-	public function wrapSession(ISession $session) {
+	public function wrapSession(ISession $session): ISession {
 		if (!($session instanceof CryptoSessionData)) {
 			return new CryptoSessionData($session, $this->crypto, $this->passphrase);
 		}


### PR DESCRIPTION
## Summary

Follow-up of #50800
Mostly make it clear that we trust admin input or that we correctly
 escape strings.

There is one last taint error, but I do not know how to avoid it. Psalm confuses array keys and values at some point and thinks there is a tainted value in array key while it’s in value.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
