### PR TITLE
Fix/calendar reminders

### DIFF
--- a/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
+++ b/apps/dav/lib/CalDAV/Reminder/NotificationProvider/EmailProvider.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\DAV\CalDAV\Reminder\NotificationProvider;
 
 use DateTime;
+use OCP\Defaults;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -82,12 +83,15 @@ class EmailProvider extends AbstractProvider {
 		$sortedByLanguage = $this->sortEMailAddressesByLanguage($emailAddresses, $fallbackLanguage);
 		$organizer = $this->getOrganizerEMailAndNameFromEvent($vevent);
 
+		$fromEMail = Util::getDefaultEmailAddress('reminders-noreply');
+		$defaults = new Defaults();
+		$fromName = $defaults->getName();
+
 		foreach ($sortedByLanguage as $lang => $emailAddresses) {
 			if (!$this->hasL10NForLang($lang)) {
 				$lang = $fallbackLanguage;
 			}
 			$l10n = $this->getL10NForLang($lang);
-			$fromEMail = Util::getDefaultEmailAddress('reminders-noreply');
 
 			$template = $this->mailer->createEMailTemplate('dav.calendarReminder');
 			$template->addHeader();
@@ -102,7 +106,7 @@ class EmailProvider extends AbstractProvider {
 				}
 
 				$message = $this->mailer->createMessage();
-				$message->setFrom([$fromEMail]);
+				$message->setFrom([$fromEMail => $fromName]);
 				if ($organizer) {
 					$message->setReplyTo($organizer);
 				}
@@ -128,7 +132,7 @@ class EmailProvider extends AbstractProvider {
 	 * @param VEvent $vevent
 	 */
 	private function addSubjectAndHeading(IEMailTemplate $template, IL10N $l10n, VEvent $vevent):void {
-		$template->setSubject('Notification: ' . $this->getTitleFromVEvent($vevent, $l10n));
+		$template->setSubject($l10n->t('Notification: %s', [$this->getTitleFromVEvent($vevent, $l10n)]));
 		$template->addHeading($this->getTitleFromVEvent($vevent, $l10n));
 	}
 

--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -122,7 +122,7 @@ class ReminderService {
 				continue;
 			}
 
-			if ($this->config->getAppValue('dav', 'sendEventRemindersToSharedUsers', 'yes') === 'no') {
+			if ($this->config->getAppValue('dav', 'sendEventRemindersToSharedUsers', 'yes') !== 'no') {
 				$users = $this->getAllUsersWithWriteAccessToCalendar($reminder['calendar_id']);
 			} else {
 				$users = [];

--- a/apps/dav/lib/CalDAV/Reminder/ReminderService.php
+++ b/apps/dav/lib/CalDAV/Reminder/ReminderService.php
@@ -534,13 +534,13 @@ class ReminderService {
 
 			$principal = explode('/', $share['{http://owncloud.org/ns}principal']);
 			if ($principal[1] === 'users') {
-				$user = $this->userManager->get($principal[2]);
+				$user = $this->userManager->get(urldecode($principal[2]));
 				if ($user) {
 					$users[] = $user;
-					$userIds[] = $principal[2];
+					$userIds[] = urldecode($principal[2]);
 				}
 			} elseif ($principal[1] === 'groups') {
-				$groups[] = $principal[2];
+				$groups[] = urldecode($principal[2]);
 			}
 		}
 
@@ -724,7 +724,7 @@ class ReminderService {
 			return null;
 		}
 
-		$userId = substr($principalUri, 17);
+		$userId = urldecode(substr($principalUri, 17));
 		return $this->userManager->get($userId);
 	}
 


### PR DESCRIPTION
* Resolves: #41203

## Summary

Following problems are fixed:

* The Groupware setting "Send reminder notifications to calendar sharees as well" (`sendEventRemindersToSharedUsers`) behaved exactly the other way round.
  If it was activated, sharees din't receive a notification.
* Members of groups with names that contain special characters (also spaces) didn't receive notifications.
* Calendar principal user received reminder notification twice if he/she was also a sharee (emails not affected as EmailProvider filters duplicates)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] ~Screenshots before/after for front-end changes~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or **is not required**
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
