### PR TITLE
fix(BackgroundJob): Add time leeway in start condition in TimedJob

### DIFF
--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -18,6 +18,7 @@ use Psr\Log\LoggerInterface;
  * @since 15.0.0
  */
 abstract class TimedJob extends Job {
+	protected static int $lastRunCheckMargin = 20;
 	protected int $interval = 0;
 	protected int $timeSensitivity = IJob::TIME_SENSITIVE;
 
@@ -81,7 +82,7 @@ abstract class TimedJob extends Job {
 	 * @since 25.0.0
 	 */
 	final public function start(IJobList $jobList): void {
-		if (($this->time->getTime() - $this->lastRun) > $this->interval) {
+		if (($this->time->getTime() - $this->lastRun) > $this->interval - self::$lastRunCheckMargin) {
 			if ($this->interval >= 12 * 60 * 60 && $this->isTimeSensitive()) {
 				Server::get(LoggerInterface::class)->debug('TimedJob ' . get_class($this) . ' has a configured interval of ' . $this->interval . ' seconds, but is also marked as time sensitive. Please consider marking it as time insensitive to allow more sensitive jobs to run when needed.');
 			}


### PR DESCRIPTION
* Resolves: #34499

## Summary

Since cron jobs may not always run at the very same second (observed in web hosting environment), e.g. at 10:45:16 and at 10:50:14, some jobs (depending on the interval) that should actually run wouldn't be started when exactly comparing the interval with the time of the last run. Therefore, a time leeway of a few seconds should be allowed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] ~Screenshots before/after for front-end changes~
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or **is not required**
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
