### PR TITLE
fix(files_sharing): block downloading if needed

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -359,6 +359,11 @@ class ShareController extends AuthPublicShareController {
 			return new DataResponse('Share has no read permission');
 		}
 
+		$attributes = $share->getAttributes();
+		if ($attributes?->getAttribute('permissions', 'download') === false) {
+			return new DataResponse('Share has no download permission');
+		}
+
 		if (!$this->validateShare($share)) {
 			throw new NotFoundException();
 		}


### PR DESCRIPTION
* Closes https://github.com/nextcloud/server/pull/50842

## Summary

Check the share has download permissions when downloading using the legacy endpoint.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
