### PR TITLE
fix: Initialize lastConnectionCheck after first connection

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -218,14 +218,14 @@ class Connection extends PrimaryReadReplicaConnection {
 				return parent::connect();
 			}
 
-			$this->lastConnectionCheck[$this->getConnectionName()] = time();
-
 			// Only trigger the event logger for the initial connect call
 			$eventLogger = Server::get(IEventLogger::class);
 			$eventLogger->start('connect:db', 'db connection opened');
 			/** @psalm-suppress InternalMethod */
 			$status = parent::connect();
 			$eventLogger->end('connect:db');
+
+			$this->lastConnectionCheck[$this->getConnectionName()] = time();
 
 			return $status;
 		} catch (Exception $e) {


### PR DESCRIPTION
## Summary

We are checking whether the DB connection is alive once every 30 seconds. But when we are lacking the last check time, we are skipping the check and reconnect logic. This is causing the reconnect logic to never fire in those cases.

## Investigation

It seems to me that "those cases", are actually always the case, as upon initialization, we are not using the proper connection name to store the time.

In the `connect()` logic, when `$this->_conn` is null, `$this->getConnectionName()` is returning `replica`, so `$this->lastConnectionCheck` will be equal to `['replica' => time()];`

https://github.com/nextcloud/server/blob/60711ea4cfde6f53d0b18bcd7e166a34a43056a5/lib/private/DB/Connection.php#L215-L221

https://github.com/nextcloud/server/blob/60711ea4cfde6f53d0b18bcd7e166a34a43056a5/lib/private/DB/Connection.php#L891-L893

https://github.com/nextcloud/3rdparty/blob/2b6d7bf65ff242ea050e736925f752a38d8da220/doctrine/dbal/src/Connections/PrimaryReadReplicaConnection.php#L136-L139

Then, if the connection name ends up as being 'primary', the reconnect logic is skipped:

https://github.com/nextcloud/server/blob/60711ea4cfde6f53d0b18bcd7e166a34a43056a5/lib/private/DB/Connection.php#L874-L880

## Other solution

Find a more reliable way to get the connection name.

Follow-up of https://github.com/nextcloud/server/pull/41819

## Key word

MySQL server has gone away