### PR TITLE
fix(files_sharing): Hide download should not prevent download

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1288,16 +1288,11 @@ class ShareAPIController extends OCSController {
 			|| $share->getShareType() === IShare::TYPE_EMAIL) {
 
 			// Update hide download state
-			$attributes = $share->getAttributes() ?? $share->newAttributes();
 			if ($hideDownload === 'true') {
 				$share->setHideDownload(true);
-				$attributes->setAttribute('permissions', 'download', false);
 			} elseif ($hideDownload === 'false') {
 				$share->setHideDownload(false);
-				$attributes->setAttribute('permissions', 'download', true);
 			}
-			$share->setAttributes($attributes);
-
 
 			// If either manual permissions are specified or publicUpload
 			// then we need to also update the permissions of the share

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -169,7 +169,7 @@
 						@update:checked="queueUpdate('hideDownload')">
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch v-else
+					<NcCheckboxRadioSwitch v-if="isPublicShare"
 						:disabled="!canSetDownload"
 						:checked.sync="canDownload"
 						data-cy-files-sharing-share-permissions-checkbox="download">
@@ -930,6 +930,7 @@ export default {
 					this.setCustomPermissions = true
 				}
 			}
+
 			// Read permission required for share creation
 			if (!this.canRemoveReadPermission) {
 				this.hasRead = true


### PR DESCRIPTION
Hide download is meant to hide the download button from the UI not enforce the `download:false` attribute.

This commit also modifies the advanced options to only show "Allow download and sync" on public shares.

Resolves : https://github.com/nextcloud/server/issues/48954

