### PR TITLE
fix(files_versions): Do not expire versions newer than min age

### DIFF
--- a/apps/files_versions/lib/Expiration.php
+++ b/apps/files_versions/lib/Expiration.php
@@ -99,6 +99,20 @@ class Expiration {
 	}
 
 	/**
+	 * Get minimal retention obligation as a timestamp
+	 *
+	 * @return int|false
+	 */
+	public function getMinAgeAsTimestamp() {
+		$minAge = false;
+		if ($this->isEnabled() && $this->minAge !== self::NO_OBLIGATION) {
+			$time = $this->timeFactory->getTime();
+			$minAge = $time - ($this->minAge * 86400);
+		}
+		return $minAge;
+	}
+
+	/**
 	 * Get maximal retention obligation as a timestamp
 	 *
 	 * @return int|false

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -696,7 +696,15 @@ class Storage {
 		$expiration = self::getExpiration();
 
 		if ($expiration->shouldAutoExpire()) {
-			[$toDelete, $size] = self::getAutoExpireList($time, $versions);
+			// Exclude versions that are newer than the minimum age from the auto expiration logic.
+			$minAge = $expiration->getMinAgeAsTimestamp();
+			if ($minAge !== false) {
+				$versionsToAutoExpire = array_filter($versions, fn ($version) => $version['version'] < $minAge);
+			} else {
+				$versionsToAutoExpire = $versions;
+			}
+
+			[$toDelete, $size] = self::getAutoExpireList($time, $versionsToAutoExpire);
 		} else {
 			$size = 0;
 			$toDelete = [];  // versions we want to delete


### PR DESCRIPTION
The auto expire logic does not take into account the min retention age set by the admin. So versions were eagerly deleted.

Fix https://github.com/nextcloud/server/issues/19791