### PR TITLE
chore: Adjust `OCP\Server::get` annotation to work with phpstan

### DIFF
--- a/lib/public/Server.php
+++ b/lib/public/Server.php
@@ -15,6 +15,7 @@ use Psr\Container\NotFoundExceptionInterface;
  * use whenever possible dependency injections instead.
  *
  * ```php
+ * use OCP\ITagManager;
  * use OCP\Server;
  *
  * $tagManager = Server::get(ITagManager::class);
@@ -24,12 +25,9 @@ use Psr\Container\NotFoundExceptionInterface;
  */
 final class Server {
 	/**
-	 * @template T
-	 * @param class-string<T>|string $serviceName
-	 * @return T|mixed
-	 * @psalm-template S as class-string<T>|string
-	 * @psalm-param S $serviceName
-	 * @psalm-return (S is class-string<T> ? T : mixed)
+	 * @psalm-template T
+	 * @psalm-param class-string<T>|string $serviceName
+	 * @psalm-return ($serviceName is class-string<T> ? T : mixed)
 	 * @throws ContainerExceptionInterface
 	 * @throws NotFoundExceptionInterface
 	 * @since 25.0.0


### PR DESCRIPTION
Notices `\OCP\Server::get` does not correctly work with my IDE, seems the previous annoations were too complex and `T` was not referenced directly in a parameter, only in the constraint of `S`, so it was not getting resolved.

This annotation is simpler and also works with phpstan