### PR TITLE
enh(SystemTag): Make MapperEvent webhook compatible

### DIFF
--- a/lib/public/SystemTag/MapperEvent.php
+++ b/lib/public/SystemTag/MapperEvent.php
@@ -9,13 +9,14 @@ declare(strict_types=1);
 namespace OCP\SystemTag;
 
 use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IWebhookCompatibleEvent;
 
 /**
  * Class MapperEvent
  *
  * @since 9.0.0
  */
-class MapperEvent extends Event {
+class MapperEvent extends Event implements IWebhookCompatibleEvent {
 	/**
 	 * @since 9.0.0
 	 * @deprecated 22.0.0
@@ -83,5 +84,18 @@ class MapperEvent extends Event {
 	 */
 	public function getTags(): array {
 		return $this->tags;
+	}
+
+	/**
+	 * @return array
+	 * @since 32.0.0
+	 */
+	public function getWebhookSerializable(): array {
+		return [
+			'eventType' => $this->getEvent(),
+			'objectType' => $this->getObjectType(),
+			'objectId' => $this->getObjectId(),
+			'tagIds' => $this->getTags(),
+		];
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Make MapperEvent webhook compatible so it can be used with the new Windmill Workflows


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
