### PR TITLE
feat(setupcheck): check logging level for validity

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -103,6 +103,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\JavaScriptModules' => $baseDir . '/../lib/SetupChecks/JavaScriptModules.php',
     'OCA\\Settings\\SetupChecks\\JavaScriptSourceMaps' => $baseDir . '/../lib/SetupChecks/JavaScriptSourceMaps.php',
     'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => $baseDir . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
+    'OCA\\Settings\\SetupChecks\\LoggingLevel' => $baseDir . '/../lib/SetupChecks/LoggingLevel.php',
     'OCA\\Settings\\SetupChecks\\MaintenanceWindowStart' => $baseDir . '/../lib/SetupChecks/MaintenanceWindowStart.php',
     'OCA\\Settings\\SetupChecks\\MemcacheConfigured' => $baseDir . '/../lib/SetupChecks/MemcacheConfigured.php',
     'OCA\\Settings\\SetupChecks\\MimeTypeMigrationAvailable' => $baseDir . '/../lib/SetupChecks/MimeTypeMigrationAvailable.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -118,6 +118,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\JavaScriptModules' => __DIR__ . '/..' . '/../lib/SetupChecks/JavaScriptModules.php',
         'OCA\\Settings\\SetupChecks\\JavaScriptSourceMaps' => __DIR__ . '/..' . '/../lib/SetupChecks/JavaScriptSourceMaps.php',
         'OCA\\Settings\\SetupChecks\\LegacySSEKeyFormat' => __DIR__ . '/..' . '/../lib/SetupChecks/LegacySSEKeyFormat.php',
+        'OCA\\Settings\\SetupChecks\\LoggingLevel' => __DIR__ . '/..' . '/../lib/SetupChecks/LoggingLevel.php',
         'OCA\\Settings\\SetupChecks\\MaintenanceWindowStart' => __DIR__ . '/..' . '/../lib/SetupChecks/MaintenanceWindowStart.php',
         'OCA\\Settings\\SetupChecks\\MemcacheConfigured' => __DIR__ . '/..' . '/../lib/SetupChecks/MemcacheConfigured.php',
         'OCA\\Settings\\SetupChecks\\MimeTypeMigrationAvailable' => __DIR__ . '/..' . '/../lib/SetupChecks/MimeTypeMigrationAvailable.php',

--- a/apps/settings/lib/SetupChecks/LoggingLevel.php
+++ b/apps/settings/lib/SetupChecks/LoggingLevel.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Settings\SetupChecks;
+
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class LoggingLevel implements ISetupCheck {
+	public function __construct(
+		private IL10N $l10n,
+		private IConfig $config,
+		private IURLGenerator $urlGenerator,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Logging level');
+	}
+
+	public function getCategory(): string {
+		return 'system';
+	}
+
+	public function run(): SetupResult {
+		$configLogLevel = $this->config->getSystemValue('loglevel', ILogger::WARN);
+		if (!is_int($configLogLevel)
+			|| $configLogLevel < ILogger::DEBUG
+			|| $configLogLevel > ILogger::FATAL
+		) {
+			return SetupResult::error(
+				$this->l10n->t('The %1$s configuration option must be a valid integer value.', ['`loglevel`']),
+				$this->urlGenerator->linkToDocs('admin-logging'),
+			);
+		}
+
+		if ($configLogLevel === ILogger::DEBUG) {
+			return SetupResult::warning(
+				$this->l10n->t('The logging level is set to debug level. Use debug level only when you have a problem to diagnose, and then reset your log level to a less-verbose level as it outputs a lot of information, and can affect your server performance.'),
+				$this->urlGenerator->linkToDocs('admin-logging'),
+			);
+		}
+
+		return SetupResult::success($this->l10n->t('Logging level configured correctly.'));
+	}
+}

--- a/apps/settings/tests/SetupChecks/LoggingLevelTest.php
+++ b/apps/settings/tests/SetupChecks/LoggingLevelTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Settings\Tests;
+
+use OCA\Settings\SetupChecks\LoggingLevel;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\SetupResult;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LogLevel;
+use Test\TestCase;
+
+class LoggingLevelTest extends TestCase {
+	private IL10N&MockObject $l10n;
+	private IConfig&MockObject $config;
+	private IURLGenerator&MockObject $urlGenerator;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->l10n->expects($this->any())
+			->method('t')
+			->willReturnCallback(function ($message, array $replace) {
+				return vsprintf($message, $replace);
+			});
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+	}
+
+	public static function dataRun(): array {
+		return [
+			[ILogger::INFO, SetupResult::SUCCESS],
+			[ILogger::WARN, SetupResult::SUCCESS],
+			[ILogger::ERROR, SetupResult::SUCCESS],
+			[ILogger::FATAL, SetupResult::SUCCESS],
+
+			// Debug is valid but will result in an warning
+			[ILogger::DEBUG, SetupResult::WARNING],
+
+			// negative - invalid range
+			[-1, SetupResult::ERROR],
+			// string value instead of number
+			['1', SetupResult::ERROR],
+			// random string value
+			['error', SetupResult::ERROR],
+			// PSR logger value
+			[LogLevel::ALERT, SetupResult::ERROR],
+			// out of range
+			[ILogger::FATAL + 1, SetupResult::ERROR],
+		];
+	}
+
+	/** @dataProvider dataRun */
+	public function testRun(mixed $value, string $expected): void {
+		$this->urlGenerator->method('linkToDocs')->willReturn('admin-logging');
+
+		$this->config->expects(self::once())
+			->method('getSystemValue')
+			->with('loglevel', ILogger::WARN)
+			->willReturn($value);
+
+		$check = new LoggingLevel($this->l10n, $this->config, $this->urlGenerator);
+
+		$result = $check->run();
+		$this->assertEquals($expected, $result->getSeverity());
+	}
+}


### PR DESCRIPTION
## Summary

* Resolves: https://github.com/nextcloud/server/issues/50885
* Requires: https://github.com/nextcloud/documentation/pull/12745

Check for log level validity to detect issues before they happen.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
