### PR TITLE
Fix: NotFoundException for anonymous users

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -359,7 +359,11 @@ class FileEventsListener implements IEventListener {
 			}
 		}
 
-		$owner = $node->getOwner()?->getUid();
+		try {
+			$owner = $node->getOwner()?->getUid();
+		} catch (\OCP\Files\NotFoundException) {
+			$owner = null;
+		}
 
 		// If no owner, extract it from the path.
 		// e.g. /user/files/foobar.txt


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/forms/issues/2435

- Follow-up of https://github.com/nextcloud/server/pull/41749

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
