### PR TITLE
fix(user_ldap): sync users even when no display name is set

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -926,10 +926,6 @@ class Access extends LDAPUtility {
 	public function batchApplyUserAttributes(array $ldapRecords): void {
 		$displayNameAttribute = strtolower((string)$this->connection->ldapUserDisplayName);
 		foreach ($ldapRecords as $userRecord) {
-			if (!isset($userRecord[$displayNameAttribute])) {
-				// displayName is obligatory
-				continue;
-			}
 			$ocName = $this->dn2ocname($userRecord['dn'][0], null, true);
 			if ($ocName === false) {
 				continue;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/39751

## Summary
Removes the check for display name when doing `batchApplyUserAttributes`, as that is no longer a bug anymore (it was first introduced in https://github.com/owncloud/core/pull/20804 ). This works well in combination with https://github.com/nextcloud/server/pull/46114 , which also fixes the enforcement of display name + it fixes logic that was applied for both users and groups, even though it only applied to groups.

I think this PR ,as well as the previous linked one, we will be able to close this issue https://github.com/nextcloud/server/issues/39751 , which is largely misconfiguration, however, there is no need for enforcing display name anymore.

Opening this in the hope of getting someone smarter to say if this is a good/bad idea. Spent most of a day debugging this, and the codebase is still very large to navigate for me.

I'm thinking @come-nc will have some insight this area :)  Hopefully tagging is not frowned upon.

## TODO

- [ ] Should be created as a backbort, as #46040 also has.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
