### PR TITLE
fix(admin_audit): Fix incorrect truncation of files path in admin audit log

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -37,7 +37,7 @@ class Files extends Action {
 			$node = $event->getNode();
 			$params = [
 				'id' => $node instanceof NonExistingFile ? null : $node->getId(),
-				'path' => mb_substr($node->getInternalPath(), 5),
+				'path' => $node->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(
@@ -76,8 +76,8 @@ class Files extends Action {
 			$originalSource = $this->renamedNodes[$target->getId()];
 			$params = [
 				'newid' => $target->getId(),
-				'oldpath' => mb_substr($originalSource->getInternalPath(), 5),
-				'newpath' => mb_substr($target->getInternalPath(), 5),
+				'oldpath' => $originalSource->getPath(),
+				'newpath' => $target->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(
@@ -101,7 +101,7 @@ class Files extends Action {
 		try {
 			$params = [
 				'id' => $event->getNode()->getId(),
-				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
+				'path' => $event->getNode()->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(
@@ -127,8 +127,8 @@ class Files extends Action {
 			$params = [
 				'oldid' => $event->getSource()->getId(),
 				'newid' => $event->getTarget()->getId(),
-				'oldpath' => mb_substr($event->getSource()->getInternalPath(), 5),
-				'newpath' => mb_substr($event->getTarget()->getInternalPath(), 5),
+				'oldpath' => $event->getSource()->getPath(),
+				'newpath' => $event->getTarget()->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(
@@ -151,7 +151,7 @@ class Files extends Action {
 		try {
 			$params = [
 				'id' => $node->getId(),
-				'path' => mb_substr($node->getInternalPath(), 5),
+				'path' => $node->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(
@@ -177,7 +177,7 @@ class Files extends Action {
 		try {
 			$params = [
 				'id' => $event->getNode()->getId(),
-				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
+				'path' => $event->getNode()->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			Server::get(LoggerInterface::class)->error(

--- a/apps/admin_audit/lib/Listener/FileEventListener.php
+++ b/apps/admin_audit/lib/Listener/FileEventListener.php
@@ -40,7 +40,7 @@ class FileEventListener extends Action implements IEventListener {
 				'height' => $event->getHeight(),
 				'crop' => $event->isCrop(),
 				'mode' => $event->getMode(),
-				'path' => mb_substr($file->getInternalPath(), 5)
+				'path' => $file->getPath(),
 			];
 			$this->log(
 				'Preview accessed: (id: "%s", width: "%s", height: "%s" crop: "%s", mode: "%s", path: "%s")',


### PR DESCRIPTION
## Summary

Follow-up of https://github.com/nextcloud/server/pull/44871
When the file is not in a home folder directly, the path in the audit log was incorrectly truncated.
Now the absolute path relative to data folder is shown, avoiding trouble and/or ambiguous path.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
