### PR TITLE
fix: Replace OC_App calls by IAppManager

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -5,7 +5,6 @@
  */
 namespace OCA\DAV\CalDAV\Activity\Provider;
 
-use OC_App;
 use OCP\Activity\Exceptions\UnknownActivityException;
 use OCP\Activity\IEvent;
 use OCP\Activity\IEventMerger;
@@ -67,7 +66,7 @@ class Event extends Base {
 		if (isset($eventData['link']) && is_array($eventData['link']) && $this->appManager->isEnabledForUser('calendar')) {
 			try {
 				// The calendar app needs to be manually loaded for the routes to be loaded
-				OC_App::loadApp('calendar');
+				$this->appManager->loadApp('calendar');
 				$linkData = $eventData['link'];
 				$calendarUri = $this->urlencodeLowerHex($linkData['calendar_uri']);
 				if ($affectedUser === $linkData['owner']) {

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -94,6 +94,9 @@ class ViewControllerTest extends TestCase {
 		$this->appManager->expects($this->any())
 			->method('getAppPath')
 			->willReturnCallback(fn (string $appid): string => \OC::$SERVERROOT . '/apps/' . $appid);
+		$this->appManager->expects($this->any())
+			->method('isAppLoaded')
+			->willReturn(true);
 
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->logger = $this->createMock(LoggerInterface::class);

--- a/apps/files_sharing/tests/UpdaterTest.php
+++ b/apps/files_sharing/tests/UpdaterTest.php
@@ -59,8 +59,9 @@ class UpdaterTest extends TestCase {
 	 * that the mount point doesn't end up at the trash bin
 	 */
 	public function testDeleteParentFolder(): void {
-		$status = Server::get(IAppManager::class)->isEnabledForUser('files_trashbin');
-		(new \OC_App())->enable('files_trashbin');
+		$appManager = Server::get(IAppManager::class);
+		$status = $appManager->isEnabledForUser('files_trashbin');
+		$appManager->enableApp('files_trashbin');
 
 		// register trashbin hooks
 		$trashbinApp = new Application();
@@ -116,7 +117,7 @@ class UpdaterTest extends TestCase {
 		$rootView->deleteAll('files_trashin');
 
 		if ($status === false) {
-			Server::get(IAppManager::class)->disableApp('files_trashbin');
+			$appManager->disableApp('files_trashbin');
 		}
 
 		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');

--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -70,7 +70,7 @@ class Repair extends Command {
 			if (!is_array($info)) {
 				continue;
 			}
-			\OC_App::loadApp($app);
+			$this->appManager->loadApp($app);
 			$steps = $info['repair-steps']['post-migration'];
 			foreach ($steps as $step) {
 				try {

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -142,7 +142,7 @@ class Router implements IRouter {
 
 		foreach ($routingFiles as $app => $file) {
 			if (!isset($this->loadedApps[$app])) {
-				if (!\OC_App::isAppLoaded($app)) {
+				if (!$this->appManager->isAppLoaded($app)) {
 					// app MUST be loaded before app routes
 					// try again next time loadRoutes() is called
 					$this->loaded = false;
@@ -257,8 +257,8 @@ class Router implements IRouter {
 			$this->loadRoutes('settings');
 		} elseif (str_starts_with($url, '/core/')) {
 			\OC::$REQUESTEDAPP = $url;
-			if (!$this->config->getSystemValueBool('maintenance') && !Util::needUpgrade()) {
-				\OC_App::loadApps();
+			if ($this->config->getSystemValueBool('installed', false) && !Util::needUpgrade()) {
+				$this->appManager->loadApps();
 			}
 			$this->loadRoutes('core');
 		} else {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -838,7 +838,7 @@ class Server extends ServerContainer implements IServerContainer {
 			if ($busClass) {
 				[$app, $class] = explode('::', $busClass, 2);
 				if ($c->get(IAppManager::class)->isEnabledForUser($app)) {
-					\OC_App::loadApp($app);
+					$c->get(IAppManager::class)->loadApp($app);
 					return $c->get($class);
 				} else {
 					throw new ServiceUnavailableException("The app providing the command bus ($app) is not enabled");

--- a/public.php
+++ b/public.php
@@ -1,18 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OCP\App\IAppManager;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\Server;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
-/**
- * @param $service
- * @return string
- */
 function resolveService(string $service): string {
 	$services = [
 		'webdav' => 'dav/appinfo/v1/publicwebdav.php',
@@ -22,7 +26,7 @@ function resolveService(string $service): string {
 		return $services[$service];
 	}
 
-	return \OC::$server->getConfig()->getAppValue('core', 'remote_' . $service);
+	return Server::get(IConfig::class)->getAppValue('core', 'remote_' . $service);
 }
 
 try {
@@ -34,13 +38,13 @@ try {
 	header("Content-Security-Policy: default-src 'none';");
 
 	// Check if Nextcloud is in maintenance mode
-	if (\OCP\Util::needUpgrade()) {
+	if (Util::needUpgrade()) {
 		// since the behavior of apps or remotes are unpredictable during
 		// an upgrade, return a 503 directly
 		throw new \Exception('Service unavailable', 503);
 	}
 
-	$request = \OC::$server->getRequest();
+	$request = Server::get(IRequest::class);
 	$pathInfo = $request->getPathInfo();
 	if ($pathInfo === false || $pathInfo === '') {
 		throw new \Exception('Path not found', 404);
@@ -64,18 +68,19 @@ try {
 	$app = $parts[0];
 
 	// Load all required applications
+	$appManager = Server::get(IAppManager::class);
 	\OC::$REQUESTEDAPP = $app;
-	OC_App::loadApps(['authentication']);
-	OC_App::loadApps(['extended_authentication']);
-	OC_App::loadApps(['filesystem', 'logging']);
+	$appManager->loadApps(['authentication']);
+	$appManager->loadApps(['extended_authentication']);
+	$appManager->loadApps(['filesystem', 'logging']);
 
 	// Check if the app is enabled
-	if (!\OC::$server->getAppManager()->isEnabledForUser($app)) {
+	if (!$appManager->isEnabledForUser($app)) {
 		throw new \Exception('App not installed: ' . $app);
 	}
 
 	// Load the app
-	OC_App::loadApp($app);
+	$appManager->loadApp($app);
 	OC_User::setIncognitoMode(true);
 
 	$baseuri = OC::$WEBROOT . '/public.php/' . $service . '/';
@@ -86,10 +91,10 @@ try {
 		$status = 503;
 	}
 	//show the user a detailed error page
-	\OCP\Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'public', 'exception' => $ex]);
+	Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'public', 'exception' => $ex]);
 	OC_Template::printExceptionErrorPage($ex, $status);
 } catch (Error $ex) {
 	//show the user a detailed error page
-	\OCP\Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'public', 'exception' => $ex]);
+	Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'public', 'exception' => $ex]);
 	OC_Template::printExceptionErrorPage($ex, 500);
 }

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -63,6 +63,9 @@ class RouterTest extends TestCase {
 		$this->appManager->expects(self::atLeastOnce())
 			->method('getAppPath')
 			->willReturnCallback(fn (string $appid): string => \OC::$SERVERROOT . '/apps/' . $appid);
+		$this->appManager->expects(self::atLeastOnce())
+			->method('isAppLoaded')
+			->willReturn(true);
 
 		$this->assertEquals('/index.php/apps/files/', $this->router->generate('files.view.index'));
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Migrate some more calls from OC_App to IAppManager.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
