### PR TITLE
fix: Remove check for PHP modules in checkServer which are already tested by setupchecks

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -477,40 +477,17 @@ class OC_Util {
 		// If the dependency is not found the missing module name is shown to the EndUser
 		// When adding new checks always verify that they pass on CI as well
 		$dependencies = [
-			'classes' => [
-				'ZipArchive' => 'zip',
-				'DOMDocument' => 'dom',
-				'XMLWriter' => 'XMLWriter',
-				'XMLReader' => 'XMLReader',
-			],
 			'functions' => [
-				'xml_parser_create' => 'libxml',
-				'mb_strcut' => 'mbstring',
-				'ctype_digit' => 'ctype',
-				'json_encode' => 'JSON',
-				'gd_info' => 'GD',
-				'gzencode' => 'zlib',
 				'simplexml_load_string' => 'SimpleXML',
 				'hash' => 'HASH Message Digest Framework',
-				'curl_init' => 'cURL',
-				'openssl_verify' => 'OpenSSL',
 			],
 			'defined' => [
 				'PDO::ATTR_DRIVER_NAME' => 'PDO'
 			],
-			'ini' => [
-				'default_charset' => 'UTF-8',
-			],
 		];
 		$missingDependencies = [];
-		$invalidIniSettings = [];
 
 		$iniWrapper = \OC::$server->get(IniGetWrapper::class);
-		foreach ($dependencies['classes'] as $class => $module) {
-			if (!class_exists($class)) {
-				$missingDependencies[] = $module;
-			}
-		}
 		foreach ($dependencies['functions'] as $function => $module) {
 			if (!function_exists($function)) {
 				$missingDependencies[] = $module;
@@ -521,23 +498,11 @@ class OC_Util {
 				$missingDependencies[] = $module;
 			}
 		}
-		foreach ($dependencies['ini'] as $setting => $expected) {
-			if (strtolower($iniWrapper->getString($setting)) !== strtolower($expected)) {
-				$invalidIniSettings[] = [$setting, $expected];
-			}
-		}
 
 		foreach ($missingDependencies as $missingDependency) {
 			$errors[] = [
 				'error' => $l->t('PHP module %s not installed.', [$missingDependency]),
 				'hint' => $l->t('Please ask your server administrator to install the module.'),
-			];
-			$webServerRestart = true;
-		}
-		foreach ($invalidIniSettings as $setting) {
-			$errors[] = [
-				'error' => $l->t('PHP setting "%s" is not set to "%s".', [$setting[0], var_export($setting[1], true)]),
-				'hint' => $l->t('Adjusting this setting in php.ini will make Nextcloud run again')
 			];
 			$webServerRestart = true;
 		}

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -495,15 +495,8 @@ class OC_Util {
 				'curl_init' => 'cURL',
 				'openssl_verify' => 'OpenSSL',
 			],
-			'defined' => [
-				'PDO::ATTR_DRIVER_NAME' => 'PDO'
-			],
-			'ini' => [
-				'default_charset' => 'UTF-8',
-			],
 		];
 		$missingDependencies = [];
-		$invalidIniSettings = [];
 
 		$iniWrapper = \OC::$server->get(IniGetWrapper::class);
 		foreach ($dependencies['classes'] as $class => $module) {
@@ -516,28 +509,11 @@ class OC_Util {
 				$missingDependencies[] = $module;
 			}
 		}
-		foreach ($dependencies['defined'] as $defined => $module) {
-			if (!defined($defined)) {
-				$missingDependencies[] = $module;
-			}
-		}
-		foreach ($dependencies['ini'] as $setting => $expected) {
-			if (strtolower($iniWrapper->getString($setting)) !== strtolower($expected)) {
-				$invalidIniSettings[] = [$setting, $expected];
-			}
-		}
 
 		foreach ($missingDependencies as $missingDependency) {
 			$errors[] = [
 				'error' => $l->t('PHP module %s not installed.', [$missingDependency]),
 				'hint' => $l->t('Please ask your server administrator to install the module.'),
-			];
-			$webServerRestart = true;
-		}
-		foreach ($invalidIniSettings as $setting) {
-			$errors[] = [
-				'error' => $l->t('PHP setting "%s" is not set to "%s".', [$setting[0], var_export($setting[1], true)]),
-				'hint' => $l->t('Adjusting this setting in php.ini will make Nextcloud run again')
 			];
 			$webServerRestart = true;
 		}

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -477,17 +477,40 @@ class OC_Util {
 		// If the dependency is not found the missing module name is shown to the EndUser
 		// When adding new checks always verify that they pass on CI as well
 		$dependencies = [
+			'classes' => [
+				'ZipArchive' => 'zip',
+				'DOMDocument' => 'dom',
+				'XMLWriter' => 'XMLWriter',
+				'XMLReader' => 'XMLReader',
+			],
 			'functions' => [
+				'xml_parser_create' => 'libxml',
+				'mb_strcut' => 'mbstring',
+				'ctype_digit' => 'ctype',
+				'json_encode' => 'JSON',
+				'gd_info' => 'GD',
+				'gzencode' => 'zlib',
 				'simplexml_load_string' => 'SimpleXML',
 				'hash' => 'HASH Message Digest Framework',
+				'curl_init' => 'cURL',
+				'openssl_verify' => 'OpenSSL',
 			],
 			'defined' => [
 				'PDO::ATTR_DRIVER_NAME' => 'PDO'
 			],
+			'ini' => [
+				'default_charset' => 'UTF-8',
+			],
 		];
 		$missingDependencies = [];
+		$invalidIniSettings = [];
 
 		$iniWrapper = \OC::$server->get(IniGetWrapper::class);
+		foreach ($dependencies['classes'] as $class => $module) {
+			if (!class_exists($class)) {
+				$missingDependencies[] = $module;
+			}
+		}
 		foreach ($dependencies['functions'] as $function => $module) {
 			if (!function_exists($function)) {
 				$missingDependencies[] = $module;
@@ -498,11 +521,23 @@ class OC_Util {
 				$missingDependencies[] = $module;
 			}
 		}
+		foreach ($dependencies['ini'] as $setting => $expected) {
+			if (strtolower($iniWrapper->getString($setting)) !== strtolower($expected)) {
+				$invalidIniSettings[] = [$setting, $expected];
+			}
+		}
 
 		foreach ($missingDependencies as $missingDependency) {
 			$errors[] = [
 				'error' => $l->t('PHP module %s not installed.', [$missingDependency]),
 				'hint' => $l->t('Please ask your server administrator to install the module.'),
+			];
+			$webServerRestart = true;
+		}
+		foreach ($invalidIniSettings as $setting) {
+			$errors[] = [
+				'error' => $l->t('PHP setting "%s" is not set to "%s".', [$setting[0], var_export($setting[1], true)]),
+				'hint' => $l->t('Adjusting this setting in php.ini will make Nextcloud run again')
 			];
 			$webServerRestart = true;
 		}


### PR DESCRIPTION
## Summary

There is a method OC_Util::checkServer which is run once for each PHP session (I think?).
It checks a lot of stuff about the server setup, some of which is aready checked by setupchecks if the admin needs to know.

## TODO

- [ ] module checks
- [ ] pdo checks
- [ ] data directory checks
- [ ] setlocale check
- [ ] annotation check
- [ ] apps intall path check
- [ ] ini mbstring setting chck
- [ ] empty secret/instanceid/passwordsalt check

For each check we should remove it if it’s already done by setupchecks, or add the missing setupcheck, or decide if it still has to be tested this way.
For some stuff a setupcheck makes no sense because we cannot reach setupchecks if it fails.

There is also a check command which could be deprecated in favor of setupchecks, maybe?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
