### PR TITLE
SetupChecks: larger HSTS max-age value

### DIFF
--- a/apps/settings/lib/SetupChecks/SecurityHeaders.php
+++ b/apps/settings/lib/SetupChecks/SecurityHeaders.php
@@ -99,7 +99,7 @@ class SecurityHeaders implements ISetupCheck {
 				}
 
 				$transportSecurityValidity = $response->getHeader('Strict-Transport-Security');
-				$minimumSeconds = 15552000;
+				$minimumSeconds = 31536000;
 				if (preg_match('/^max-age=(\d+)(;.*)?$/', $transportSecurityValidity, $m)) {
 					$transportSecurityValidity = (int)$m[1];
 					if ($transportSecurityValidity < $minimumSeconds) {


### PR DESCRIPTION
Nowadays, the common recommendation is to set HTTP Strict Transport Security max-age value to at least 1 year. It's also min. acceptable value for preload lists.   
Please see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#preload   

Complements https://github.com/nextcloud/documentation/pull/12596