### PR TITLE
fix: Transfer ownership with S3 as primary

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -592,7 +592,14 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 
 	public function moveFromStorage(IStorage $sourceStorage, string $sourceInternalPath, string $targetInternalPath, ?ICacheEntry $sourceCacheEntry = null): bool {
 		$sourceCache = $sourceStorage->getCache();
-		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class) && $sourceStorage->getObjectStore()->getStorageId() === $this->getObjectStore()->getStorageId()) {
+		if (
+			$sourceStorage->instanceOfStorage(ObjectStoreStorage::class) &&
+			$sourceStorage->getObjectStore()->getStorageId() === $this->getObjectStore()->getStorageId()
+		) {
+			if ($this->getCache()->get($targetInternalPath)) {
+				$this->unlink($targetInternalPath);
+				$this->getCache()->remove($targetInternalPath);
+			}
 			$this->getCache()->moveFromCache($sourceCache, $sourceInternalPath, $targetInternalPath);
 			// Do not import any data when source and target bucket are identical.
 			return true;
@@ -614,6 +621,10 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		if ($sourceStorage->instanceOfStorage(ObjectStoreStorage::class)) {
 			/** @var ObjectStoreStorage $sourceStorage */
 			$sourceStorage->setPreserveCacheOnDelete(false);
+		}
+		if ($this->getCache()->get($targetInternalPath)) {
+			$this->unlink($targetInternalPath);
+			$this->getCache()->remove($targetInternalPath);
 		}
 		$this->getCache()->moveFromCache($sourceCache, $sourceInternalPath, $targetInternalPath);
 

--- a/tests/lib/Files/Storage/StoragesTest.php
+++ b/tests/lib/Files/Storage/StoragesTest.php
@@ -42,6 +42,24 @@ abstract class StoragesTest extends TestCase {
 		$this->assertEquals('foo', $this->storage1->file_get_contents($target));
 	}
 
+	public function testMoveFileFromStorageWithExistingTarget() {
+		$source = 'source.txt';
+		$target = 'target.txt';
+		$this->storage1->file_put_contents($target, 'bar');
+		$this->storage2->file_put_contents($source, 'foo');
+
+		$targetURN = $this->storage1->getURN($this->storage1->getCache()->get($target)->getID());
+		$sourceURN = $this->storage2->getURN($this->storage2->getCache()->get($source)->getID());
+
+		$this->storage1->moveFromStorage($this->storage2, $source, $target);
+
+		$this->assertTrue($this->storage1->file_exists($target), $target . ' was not created in DB');
+		$this->assertFalse($this->storage2->file_exists($source), $source . ' still exists in DB');
+		$this->assertTrue($this->storage1->getObjectStore()->objectExists($sourceURN), $sourceURN . ' was not created in bucket');
+		$this->assertFalse($this->storage1->getObjectStore()->objectExists($targetURN), $targetURN . ' still exists in bucket');
+		$this->assertEquals('foo', $this->storage1->file_get_contents($target));
+	}
+
 	public function testMoveDirectoryFromStorage() {
 		$this->storage2->mkdir('source');
 		$this->storage2->file_put_contents('source/test1.txt', 'foo');


### PR DESCRIPTION
## Issue

When using S3 as primary storage, transferring ownership with the `--move` option fail with the following error:

`SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '8-45b963397aa40d4a0063e0d85e4fe7a1' for key 'fs_storage_path_hash'`

The `--move` option moves the entire home folder from one account to another.
The error means that the move failed because the destination folder already exist in `oc_filecache`.

Might have been introduced by: https://github.com/nextcloud/server/pull/26149

## Investigation

1. With S3 as primary storage, folders only exists as entries in `oc_filecache`.
2. With S3 as primary storage, `moveFromStorage(...)` only moves the cache entry, as nothing needs to be moved on disk. This cache move does not delete potentially pre-existing destination folder.
3. With Local storage, `moveFromStorage(...)` calls `rename(...)` which delete pre-existing folder.

#### S3's `moveFromStorage`

https://github.com/nextcloud/server/blob/373107b6e4ebfd3487c69a122ff3230057a4ae51/lib/private/Files/ObjectStore/ObjectStoreStorage.php#L593-L599

#### Local's `rename`, called by `moveFromStorage`

https://github.com/nextcloud/server/blob/373107b6e4ebfd3487c69a122ff3230057a4ae51/lib/private/Files/Storage/Local.php#L346-L352

## Solution

Delete pre-existing folder in `moveFromStorage(...)`

**Does it make sense to have that here? It feels off.**

## Todo

- [x] Target master
- [x] Add tests to `tests/lib/Files/Storage/StoragesTest.php`