### PR TITLE
fix: Report duplicated extra files in integrity check

### DIFF
--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -335,8 +335,8 @@ class Checker {
 
 		// Compare the list of files which are not identical
 		$currentInstanceHashes = $this->generateHashes($this->getFolderIterator($basePath), $basePath);
-		$differencesA = array_diff($expectedHashes, $currentInstanceHashes);
-		$differencesB = array_diff($currentInstanceHashes, $expectedHashes);
+		$differencesA = array_diff_assoc($expectedHashes, $currentInstanceHashes);
+		$differencesB = array_diff_assoc($currentInstanceHashes, $expectedHashes);
 		$differences = array_unique(array_merge($differencesA, $differencesB));
 		$differenceArray = [];
 		foreach ($differences as $filename => $hash) {


### PR DESCRIPTION
The `array_diff` is not comparing the array keys. This means that an extra key with an expected hash will not be reported. Using `array_diff_assoc` will report such files.

For example, copying `status.php` to `status 2.php`, will only be reported with the new version.

