### PR TITLE
Fix SQL query so that it is ansi safe fixing #51067

### DIFF
--- a/apps/settings/lib/SetupChecks/MysqlRowFormat.php
+++ b/apps/settings/lib/SetupChecks/MysqlRowFormat.php
@@ -56,11 +56,11 @@ class MysqlRowFormat implements ISetupCheck {
 	 * @return string[]
 	 */
 	private function getRowNotDynamicTables(): array {
-		$sql = 'SELECT table_name
+		$sql = "SELECT table_name
 			FROM information_schema.tables
 			WHERE table_schema = ?
-			  AND table_name LIKE "*PREFIX*%"
-			  AND row_format != "Dynamic";';
+			  AND table_name LIKE '*PREFIX*%'
+			  AND row_format != 'Dynamic';";
 
 		return $this->connection->executeQuery(
 			$sql,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #51067 

## Summary
Fixes so that sql query in the file is ansi safe.  


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
