### PR TITLE
fix(files_reminders): Do not attempt to send reminders after a user has left a share

### DIFF
--- a/apps/files_reminders/lib/Notification/Notifier.php
+++ b/apps/files_reminders/lib/Notification/Notifier.php
@@ -14,6 +14,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\IURLGenerator;
 use OCP\L10N\IFactory;
+use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IAction;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
@@ -51,8 +52,8 @@ class Notifier implements INotifier {
 				$fileId = $params['fileId'];
 
 				$node = $this->root->getUserFolder($notification->getUser())->getFirstNodeById($fileId);
-				if (!$node) {
-					throw new UnknownNotificationException();
+				if ($node === null) {
+					throw new AlreadyProcessedException();
 				}
 
 				$path = rtrim($node->getPath(), '/');


### PR DESCRIPTION
## Summary

In cases where a user is shared a file and leaves the share or the file becomes unshared, the notification remains and will attempt to be resent continually

This makes sure that the notification is properly deleted

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)