### PR TITLE
feat(PWA): add `display_override` to set the display-mode to `minimal-ui` on supported browsers

### DIFF
--- a/apps/theming/lib/Controller/ThemingController.php
+++ b/apps/theming/lib/Controller/ThemingController.php
@@ -422,7 +422,7 @@ class ThemingController extends Controller {
 	 *
 	 * @param string $app ID of the app
 	 * @psalm-suppress LessSpecificReturnStatement The content of the Manifest doesn't need to be described in the return type
-	 * @return JSONResponse<Http::STATUS_OK, array{name: string, short_name: string, start_url: string, theme_color: string, background_color: string, description: string, icons: list<array{src: non-empty-string, type: string, sizes: string}>, display: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{}, array{}>
+	 * @return JSONResponse<Http::STATUS_OK, array{name: string, short_name: string, start_url: string, theme_color: string, background_color: string, description: string, icons: list<array{src: non-empty-string, type: string, sizes: string}>, display_override: list<string>, display: string}, array{}>|JSONResponse<Http::STATUS_NOT_FOUND, array{}, array{}>
 	 *
 	 * 200: Manifest returned
 	 * 404: App not found
@@ -481,6 +481,7 @@ class ThemingController extends Controller {
 						'sizes' => '16x16'
 					]
 				],
+			'display_override' => [$this->config->getSystemValueBool('theming.standalone_window.enabled', true) ? 'minimal-ui' : ''],
 			'display' => $this->config->getSystemValueBool('theming.standalone_window.enabled', true) ? 'standalone' : 'browser'
 		];
 		$response = new JSONResponse($responseJS);

--- a/apps/theming/openapi.json
+++ b/apps/theming/openapi.json
@@ -343,6 +343,7 @@
                                         "background_color",
                                         "description",
                                         "icons",
+                                        "display_override",
                                         "display"
                                     ],
                                     "properties": {
@@ -385,6 +386,12 @@
                                                         "type": "string"
                                                     }
                                                 }
+                                            }
+                                        },
+                                        "display_override": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
                                             }
                                         },
                                         "display": {

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -745,7 +745,7 @@ class ThemingControllerTest extends TestCase {
 				['theming.Icon.getFavicon', ['app' => 'core'], 'favicon'],
 			]);
 		$this->config
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('getSystemValueBool')
 			->with('theming.standalone_window.enabled', true)
 			->willReturn($standalone);
@@ -765,6 +765,7 @@ class ThemingControllerTest extends TestCase {
 						'sizes' => '16x16'
 					]
 				],
+			'display_override' => [$standalone ? 'minimal-ui' : ''],
 			'display' => $standalone ? 'standalone' : 'browser',
 			'short_name' => 'Nextcloud',
 			'theme_color' => null,

--- a/core/img/manifest.json
+++ b/core/img/manifest.json
@@ -10,5 +10,6 @@
 		"type": "image/svg+xml",
 		"sizes": "16x16"
 	}],
+	"display_override": ["minimal-ui"],
     "display": "standalone"
 }


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/49868