### PR TITLE
fix(LDAP): use ldap_set_option over putenv to disable cert check

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -627,19 +627,6 @@ class Connection extends LDAPUtility {
 
 				return false;
 			}
-			if ($this->configuration->turnOffCertCheck) {
-				if (putenv('LDAPTLS_REQCERT=never')) {
-					$this->logger->debug(
-						'Turned off SSL certificate validation successfully.',
-						['app' => 'user_ldap']
-					);
-				} else {
-					$this->logger->warning(
-						'Could not turn off SSL certificate validation.',
-						['app' => 'user_ldap']
-					);
-				}
-			}
 
 			$hasBackupHost = (trim($this->configuration->ldapBackupHost ?? '') !== '');
 			$hasBackgroundHost = (trim($this->configuration->ldapBackgroundHost ?? '') !== '');
@@ -718,6 +705,20 @@ class Connection extends LDAPUtility {
 		}
 
 		if ($this->configuration->ldapTLS) {
+			if ($this->configuration->turnOffCertCheck) {
+				if ($this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_X_TLS_REQUIRE_CERT, LDAP_OPT_X_TLS_NEVER)) {
+					$this->logger->debug(
+						'Turned off SSL certificate validation successfully.',
+						['app' => 'user_ldap']
+					);
+				} else {
+					$this->logger->warning(
+						'Could not turn off SSL certificate validation.',
+						['app' => 'user_ldap']
+					);
+				}
+			}
+
 			if (!$this->ldap->startTls($this->ldapConnectionRes)) {
 				throw new ServerNotAvailableException('Start TLS failed, when connecting to LDAP host ' . $host . '.');
 			}


### PR DESCRIPTION
## Summary

the putenv option was not working reliable anymore anyway

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
