### PR TITLE
[stable30] feat(admin_audit): write admin audit log for login failed

### DIFF
--- a/apps/admin_audit/lib/Actions/Auth.php
+++ b/apps/admin_audit/lib/Actions/Auth.php
@@ -42,4 +42,15 @@ class Auth extends Action {
 			[]
 		);
 	}
+
+	public function loginFailed(array $params): void {
+		$this->log(
+			'Login failed: "%s"',
+			$params,
+			[
+				'uid',
+			],
+			true
+		);
+	}
 }

--- a/apps/admin_audit/lib/AppInfo/Application.php
+++ b/apps/admin_audit/lib/AppInfo/Application.php
@@ -145,6 +145,7 @@ class Application extends App implements IBootstrap {
 		Util::connectHook('OC_User', 'pre_login', $authActions, 'loginAttempt');
 		Util::connectHook('OC_User', 'post_login', $authActions, 'loginSuccessful');
 		Util::connectHook('OC_User', 'logout', $authActions, 'logout');
+		Util::connectHook('OC_User', 'login_failed', $authActions, 'loginFailed');
 	}
 
 	private function appHooks(IAuditLogger $logger,

--- a/lib/private/Authentication/Listeners/LoginFailedListener.php
+++ b/lib/private/Authentication/Listeners/LoginFailedListener.php
@@ -40,6 +40,7 @@ class LoginFailedListener implements IEventListener {
 		$this->dispatcher->dispatchTyped(new AnyLoginFailedEvent($event->getLoginName(), $event->getPassword()));
 
 		$uid = $event->getLoginName();
+		\OC_Hook::emit('OC_User', 'login_failed', ['run' => true, 'uid' => $uid]);
 		Util::emitHook(
 			'\OCA\Files_Sharing\API\Server2Server',
 			'preLoginNameUsedAsUserName',


### PR DESCRIPTION
* Resolves: #50223 for stable30

## Summary
Write admin audit log for login failed event.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
