### PR TITLE
feat(AppFramework): extend range check to optional parameters

### DIFF
--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -50,7 +50,7 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 			// extract type parameter information
 			preg_match_all('/@param\h+(?P<type>\w+)\h+\$(?P<var>\w+)/', $docs, $matches);
 			$this->types = array_combine($matches['var'], $matches['type']);
-			preg_match_all('/@psalm-param\h+(?P<type>\w+)<(?P<rangeMin>(-?\d+|min)),\h*(?P<rangeMax>(-?\d+|max))>\h+\$(?P<var>\w+)/', $docs, $matches);
+			preg_match_all('/@psalm-param\h+(\?)?(?P<type>\w+)<(?P<rangeMin>(-?\d+|min)),\h*(?P<rangeMax>(-?\d+|max))>(\|null)?\h+\$(?P<var>\w+)/', $docs, $matches);
 			foreach ($matches['var'] as $index => $varName) {
 				if ($matches['type'][$index] !== 'int') {
 					// only int ranges are possible at the moment

--- a/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
+++ b/tests/lib/AppFramework/Utility/ControllerMethodReflectorTest.php
@@ -43,9 +43,11 @@ class MiddleController extends BaseController {
 	/**
 	 * @psalm-param int<-4, 42> $rangedOne
 	 * @psalm-param int<min, max> $rangedTwo
+	 * @psalm-param int<1, 6>|null $rangedThree
+	 * @psalm-param ?int<-70, -30> $rangedFour
 	 * @return void
 	 */
-	public function test4(int $rangedOne, int $rangedTwo) {
+	public function test4(int $rangedOne, int $rangedTwo, ?int $rangedThree, ?int $rangedFour) {
 	}
 }
 
@@ -239,5 +241,13 @@ class ControllerMethodReflectorTest extends \Test\TestCase {
 		$rangeInfo2 = $reader->getRange('rangedTwo');
 		$this->assertSame(PHP_INT_MIN, $rangeInfo2['min']);
 		$this->assertSame(PHP_INT_MAX, $rangeInfo2['max']);
+
+		$rangeInfo3 = $reader->getRange('rangedThree');
+		$this->assertSame(1, $rangeInfo3['min']);
+		$this->assertSame(6, $rangeInfo3['max']);
+
+		$rangeInfo3 = $reader->getRange('rangedFour');
+		$this->assertSame(-70, $rangeInfo3['min']);
+		$this->assertSame(-30, $rangeInfo3['max']);
 	}
 }


### PR DESCRIPTION
## Summary

Now it also applies when a parameter is documented with a preceding `?` or  pending `|null`, but no further unionation is considered.

So previously the range check worked against parameters that were not nullable:

```php
/**
  * @psalm-param int<1,500> $thisWasChecked
  * @psalm-param int<1,500>|null $thisWentUnderTheRadar
  * @psalm-param ?int<1,500> $thisWentUnderTheRadarAsWell
  * /
```

Now all cases are handled.

To keep in mind: when a parameter is passed in the query string without a value, it is considered an empty string, not a null value. To not risk breakage, we should refrain from backporting.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
