### PR TITLE
feat(occ): add json output option to admin-delegation:show

### DIFF
--- a/apps/settings/lib/Command/AdminDelegation/Show.php
+++ b/apps/settings/lib/Command/AdminDelegation/Show.php
@@ -14,6 +14,7 @@ use OCP\Settings\IDelegatedSettings;
 use OCP\Settings\IManager;
 use OCP\Settings\ISettings;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -29,39 +30,56 @@ class Show extends Base {
 		$this
 			->setName('admin-delegation:show')
 			->setDescription('show delegated settings')
+			->addOption(
+				'output',
+				null,
+				InputOption::VALUE_OPTIONAL,
+				'Output format (plain, json or json_pretty, default is plain)',
+				$this->defaultOutputFormat
+			)
 		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$io = new SymfonyStyle($input, $output);
-		$io->title('Current delegations');
-
 		$sections = $this->settingManager->getAdminSections();
-		$settings = [];
-		$headers = ['Name', 'SettingId', 'Delegated to groups'];
-		foreach ($sections as $sectionPriority) {
-			foreach ($sectionPriority as $section) {
-				$sectionSettings = $this->settingManager->getAdminSettings($section->getId());
-				$sectionSettings = array_reduce($sectionSettings, [$this, 'getDelegatedSettings'], []);
-				if (empty($sectionSettings)) {
-					continue;
-				}
 
-				$io->section('Section: ' . $section->getID());
-				$io->table($headers, array_map(function (IDelegatedSettings $setting) use ($section) {
-					$className = get_class($setting);
-					$groups = array_map(
-						static fn (AuthorizedGroup $group) => $group->getGroupId(),
-						$this->authorizedGroupService->findExistingGroupsForClass($className)
-					);
-					natsort($groups);
-					return [
-						$setting->getName() ?: 'Global',
-						$className,
-						implode(', ', $groups),
-					];
-				}, $sectionSettings));
-			}
+		$settings = [];
+		switch ($input->getOption('output')) {
+			case self::OUTPUT_FORMAT_JSON:
+				$output->writeln(json_encode($this->buildJsonOutput($sections)));
+				break;
+			case self::OUTPUT_FORMAT_JSON_PRETTY:
+				$output->writeln(json_encode($this->buildJsonOutput($sections), JSON_PRETTY_PRINT));
+				break;
+			default:
+				$io = new SymfonyStyle($input, $output);
+				$io->title('Current delegations');
+
+				$headers = ['Name', 'SettingId', 'Delegated to groups'];
+				foreach ($sections as $sectionPriority) {
+					foreach ($sectionPriority as $section) {
+						$sectionSettings = $this->settingManager->getAdminSettings($section->getId());
+						$sectionSettings = array_reduce($sectionSettings, [$this, 'getDelegatedSettings'], []);
+						if (empty($sectionSettings)) {
+							continue;
+						}
+
+						$io->section('Section: ' . $section->getID());
+						$io->table($headers, array_map(function (IDelegatedSettings $setting) use ($section) {
+							$className = get_class($setting);
+							$groups = array_map(
+								static fn (AuthorizedGroup $group) => $group->getGroupId(),
+								$this->authorizedGroupService->findExistingGroupsForClass($className)
+							);
+							natsort($groups);
+							return [
+								$setting->getName() ?: 'Global',
+								$className,
+								implode(', ', $groups),
+							];
+						}, $sectionSettings));
+					}
+				}
 		}
 
 		return 0;
@@ -73,5 +91,41 @@ class Show extends Base {
 	 */
 	private function getDelegatedSettings(array $settings, array $innerSection): array {
 		return $settings + array_filter($innerSection, fn (ISettings $setting) => $setting instanceof IDelegatedSettings);
+	}
+
+	protected function buildJsonOutput(array $sections): array {
+		$currentDelegations = [
+			'current_delegations' => []
+		];
+
+		foreach ($sections as $sectionPriority) {
+			foreach ($sectionPriority as $section) {
+				$sectionSettings = $this->settingManager->getAdminSettings($section->getId());
+				$sectionSettings = array_reduce($sectionSettings, [$this, 'getDelegatedSettings'], []);
+				if (empty($sectionSettings)) {
+					continue;
+				}
+
+				$currentDelegations['current_delegations'][] = [
+					'section' => $section->getID(),
+					'delegations' =>
+						array_map(function (IDelegatedSettings $setting) use ($section, $headers) {
+							$className = get_class($setting);
+							$groups = array_map(
+								static fn (AuthorizedGroup $group) => $group->getGroupId(),
+								$this->authorizedGroupService->findExistingGroupsForClass($className)
+							);
+							natsort($groups);
+							return [
+								"name" => $setting->getName() ?: 'Global',
+								"settingId" => $className,
+								"delegatedToGroups" => implode(', ', $groups)
+							];
+						}, $sectionSettings)
+				];
+			}
+		}
+
+		return $currentDelegations;
 	}
 }

--- a/apps/settings/lib/Command/AdminDelegation/Show.php
+++ b/apps/settings/lib/Command/AdminDelegation/Show.php
@@ -93,9 +93,9 @@ class Show extends Base {
 		return $settings + array_filter($innerSection, fn (ISettings $setting) => $setting instanceof IDelegatedSettings);
 	}
 
-	protected function buildJsonOutput(array $sections): array {
+	private function buildJsonOutput(array $sections): array {
 		$currentDelegations = [
-			'current_delegations' => []
+			'currentDelegations' => []
 		];
 
 		foreach ($sections as $sectionPriority) {
@@ -106,7 +106,7 @@ class Show extends Base {
 					continue;
 				}
 
-				$currentDelegations['current_delegations'][] = [
+				$currentDelegations['currentDelegations'][] = [
 					'section' => $section->getID(),
 					'delegations' =>
 						array_map(function (IDelegatedSettings $setting) use ($section, $headers) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #46610  <!-- related github issue -->

## Summary

Add option to output json with admin-delegation:show using --output=json or --output=json_pretty

Example Output (plain json):
```
{"currentDelegations":[{"section":"overview","delegations":[{"name":"Security & setup checks","settingId":"OCA\\Settings\\Settings\\Admin\\Overview","delegatedToGroups":""}]},{"section":"server","delegations":[{"name":"Background jobs","settingId":"OCA\\Settings\\Settings\\Admin\\Server","delegatedToGroups":""}]},{"section":"sharing","delegations":[{"name":"Global","settingId":"OCA\\Settings\\Settings\\Admin\\Sharing","delegatedToGroups":""}]},{"section":"theming","delegations":[{"name":"Global","settingId":"OCA\\Theming\\Settings\\Admin","delegatedToGroups":""}]},{"section":"ai","delegations":[{"name":"Artificial Intelligence","settingId":"OCA\\Settings\\Settings\\Admin\\ArtificialIntelligence","delegatedToGroups":""}]},{"section":"admindelegation","delegations":[{"name":"Users","settingId":"OCA\\Settings\\Settings\\Admin\\Users","delegatedToGroups":""},{"name":"Webhooks","settingId":"OCA\\WebhookListeners\\Settings\\Admin","delegatedToGroups":""}]}]}
```

Example Output (pretty json):
```
{
    "currentDelegations": [
        {
            "section": "overview",
            "delegations": [
                {
                    "name": "Security & setup checks",
                    "settingId": "OCA\\Settings\\Settings\\Admin\\Overview",
                    "delegatedToGroups": ""
                }
            ]
        },
        {
            "section": "server",
            "delegations": [
                {
                    "name": "Background jobs",
                    "settingId": "OCA\\Settings\\Settings\\Admin\\Server",
                    "delegatedToGroups": ""
                }
            ]
        },
        {
            "section": "sharing",
            "delegations": [
                {
                    "name": "Global",
                    "settingId": "OCA\\Settings\\Settings\\Admin\\Sharing",
                    "delegatedToGroups": ""
                }
            ]
        },
        {
            "section": "theming",
            "delegations": [
                {
                    "name": "Global",
                    "settingId": "OCA\\Theming\\Settings\\Admin",
                    "delegatedToGroups": ""
                }
            ]
        },
        {
            "section": "ai",
            "delegations": [
                {
                    "name": "Artificial Intelligence",
                    "settingId": "OCA\\Settings\\Settings\\Admin\\ArtificialIntelligence",
                    "delegatedToGroups": ""
                }
            ]
        },
        {
            "section": "admindelegation",
            "delegations": [
                {
                    "name": "Users",
                    "settingId": "OCA\\Settings\\Settings\\Admin\\Users",
                    "delegatedToGroups": ""
                },
                {
                    "name": "Webhooks",
                    "settingId": "OCA\\WebhookListeners\\Settings\\Admin",
                    "delegatedToGroups": ""
                }
            ]
        }
    ]
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
