### PR TITLE
fix: Do not build encrypted password if there is none

### DIFF
--- a/lib/private/Authentication/LoginCredentials/Store.php
+++ b/lib/private/Authentication/LoginCredentials/Store.php
@@ -50,7 +50,9 @@ class Store implements IStore {
 	 * @param array $params
 	 */
 	public function authenticate(array $params) {
-		$params['password'] = $this->crypto->encrypt((string)$params['password']);
+		if ($params['password'] !== null) {
+			$params['password'] = $this->crypto->encrypt((string)$params['password']);
+		}
 		$this->session->set('login_credentials', json_encode($params));
 	}
 
@@ -97,10 +99,12 @@ class Store implements IStore {
 		if ($trySession && $this->session->exists('login_credentials')) {
 			/** @var array $creds */
 			$creds = json_decode($this->session->get('login_credentials'), true);
-			try {
-				$creds['password'] = $this->crypto->decrypt($creds['password']);
-			} catch (Exception $e) {
-				//decryption failed, continue with old password as it is
+			if ($creds['password'] !== null) {
+				try {
+					$creds['password'] = $this->crypto->decrypt($creds['password']);
+				} catch (Exception $e) {
+					//decryption failed, continue with old password as it is
+				}
 			}
 			return new Credentials(
 				$creds['uid'],


### PR DESCRIPTION
This fixes a regression from https://github.com/nextcloud/server/pull/48915 where user backends without passwords would store an encrypted empty password for new app passwords.

While they first work, after 5 minutes the password is checked and cannot be validated as there is none so the token expired.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
