### PR TITLE
ci: fix request-reviews workflow

### DIFF
--- a/.github/workflows/request-reviews.yml
+++ b/.github/workflows/request-reviews.yml
@@ -64,7 +64,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             '/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers' \
-            -f "team_reviewers[]=nextcloud/server-backend"
+            -f "team_reviewers[]=server-backend"
       - name: Assign frontend engineers
         if: needs.changes.outputs.frontend == 'true'
         env:
@@ -75,4 +75,4 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             '/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/requested_reviewers' \
-            -f "team_reviewers[]=nextcloud/server-frontend"
+            -f "team_reviewers[]=server-frontend"


### PR DESCRIPTION
* For https://github.com/nextcloud/server/pull/50991

The team names are not scoped so we must remove the `nextcloud/` part. Otherwise it fails with "is not a collaborator".
