### PR TITLE
fix(dav): Create SAB at installation

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -49,6 +49,9 @@
 		<live-migration>
 			<step>OCA\DAV\Migration\ChunkCleanup</step>
 		</live-migration>
+		<install>
+			<step>OCA\DAV\Migration\CreateSystemAddressBookStep</step>
+		</install>
 	</repair-steps>
 
 	<commands>

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -306,6 +306,7 @@ return array(
     'OCA\\DAV\\Migration\\BuildSocialSearchIndexBackgroundJob' => $baseDir . '/../lib/Migration/BuildSocialSearchIndexBackgroundJob.php',
     'OCA\\DAV\\Migration\\CalDAVRemoveEmptyValue' => $baseDir . '/../lib/Migration/CalDAVRemoveEmptyValue.php',
     'OCA\\DAV\\Migration\\ChunkCleanup' => $baseDir . '/../lib/Migration/ChunkCleanup.php',
+    'OCA\\DAV\\Migration\\CreateSystemAddressBookStep' => $baseDir . '/../lib/Migration/CreateSystemAddressBookStep.php',
     'OCA\\DAV\\Migration\\DeleteSchedulingObjects' => $baseDir . '/../lib/Migration/DeleteSchedulingObjects.php',
     'OCA\\DAV\\Migration\\FixBirthdayCalendarComponent' => $baseDir . '/../lib/Migration/FixBirthdayCalendarComponent.php',
     'OCA\\DAV\\Migration\\RefreshWebcalJobRegistrar' => $baseDir . '/../lib/Migration/RefreshWebcalJobRegistrar.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -321,6 +321,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Migration\\BuildSocialSearchIndexBackgroundJob' => __DIR__ . '/..' . '/../lib/Migration/BuildSocialSearchIndexBackgroundJob.php',
         'OCA\\DAV\\Migration\\CalDAVRemoveEmptyValue' => __DIR__ . '/..' . '/../lib/Migration/CalDAVRemoveEmptyValue.php',
         'OCA\\DAV\\Migration\\ChunkCleanup' => __DIR__ . '/..' . '/../lib/Migration/ChunkCleanup.php',
+        'OCA\\DAV\\Migration\\CreateSystemAddressBookStep' => __DIR__ . '/..' . '/../lib/Migration/CreateSystemAddressBookStep.php',
         'OCA\\DAV\\Migration\\DeleteSchedulingObjects' => __DIR__ . '/..' . '/../lib/Migration/DeleteSchedulingObjects.php',
         'OCA\\DAV\\Migration\\FixBirthdayCalendarComponent' => __DIR__ . '/..' . '/../lib/Migration/FixBirthdayCalendarComponent.php',
         'OCA\\DAV\\Migration\\RefreshWebcalJobRegistrar' => __DIR__ . '/..' . '/../lib/Migration/RefreshWebcalJobRegistrar.php',

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -119,6 +119,12 @@ class SyncService {
 		}
 	}
 
+	public function ensureLocalSystemAddressBookExists(): ?array {
+		return $this->ensureSystemAddressBookExists('principals/system/system', 'system', [
+			'{' . Plugin::NS_CARDDAV . '}addressbook-description' => 'System addressbook which holds all users of this instance'
+		]);
+	}
+
 	private function prepareUri(string $host, string $path): string {
 		/*
 		 * The trailing slash is important for merging the uris together.
@@ -275,10 +281,7 @@ class SyncService {
 	 */
 	public function getLocalSystemAddressBook() {
 		if (is_null($this->localSystemAddressBook)) {
-			$systemPrincipal = 'principals/system/system';
-			$this->localSystemAddressBook = $this->ensureSystemAddressBookExists($systemPrincipal, 'system', [
-				'{' . Plugin::NS_CARDDAV . '}addressbook-description' => 'System addressbook which holds all users of this instance'
-			]);
+			$this->localSystemAddressBook = $this->ensureLocalSystemAddressBookExists();
 		}
 
 		return $this->localSystemAddressBook;

--- a/apps/dav/lib/Migration/CreateSystemAddressBookStep.php
+++ b/apps/dav/lib/Migration/CreateSystemAddressBookStep.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Migration;
+
+use OCA\DAV\CardDAV\SyncService;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class CreateSystemAddressBookStep implements IRepairStep {
+
+	public function __construct(
+		private SyncService $syncService,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Create system address book';
+	}
+
+	public function run(IOutput $output): void {
+		$this->syncService->ensureLocalSystemAddressBookExists();
+	}
+}

--- a/apps/dav/tests/unit/Migration/CreateSystemAddressBookStepTest.php
+++ b/apps/dav/tests/unit/Migration/CreateSystemAddressBookStepTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\Unit\Migration;
+
+use OCA\DAV\CardDAV\SyncService;
+use OCA\DAV\Migration\CreateSystemAddressBookStep;
+use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CreateSystemAddressBookStepTest extends TestCase {
+
+	private SyncService|MockObject $syncService;
+	private CreateSystemAddressBookStep $step;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->syncService = $this->createMock(SyncService::class);
+
+		$this->step = new CreateSystemAddressBookStep(
+			$this->syncService,
+		);
+	}
+
+	public function testGetName(): void {
+		$name = $this->step->getName();
+
+		self::assertEquals('Create system address book', $name);
+	}
+
+	public function testRun(): void {
+		$output = $this->createMock(IOutput::class);
+
+		$this->step->run($output);
+
+		$this->addToAssertionCount(1);
+	}
+
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: n/a

## Summary

The SAB is created *on demand*. Weirdly enough this only happens for the *second* user of an instance, and in high concurrent setups there can be a race for the creation of the AB.
This moves the creation to an *install repair step* that is run *once* at installation time.

This change was tested with https://github.com/nextcloud/mail/pull/10707. Recently Mail integration tests failed when the SAB didn't exist and tests created it while being in a transaction.

## TODO

- [x] do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
