### PR TITLE
build(integration): Disable password_policy app

### DIFF
--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -24,6 +24,8 @@ if [ "$INSTALLED" == "true" ]; then
     $OCC config:system:set allow_local_remote_servers --value true --type bool
     # Allow self signed certificates
     $OCC config:system:set sharing.federation.allowSelfSignedCertificates --value true --type bool
+	# Allow creating users with dummy passwords
+	$OCC app:disable password_policy
 else
     if [ "$SCENARIO_TO_RUN" != "setup_features/setup.feature" ]; then
         echo "Nextcloud instance needs to be installed" >&2


### PR DESCRIPTION
## Summary

I had the password_policy app enabled and couldn't run most tests because the created users were trying to use passwords that are not allowed by the app.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
