### PR TITLE
feat: Add event to highlight active menu

### DIFF
--- a/core/src/components/AppMenu.vue
+++ b/core/src/components/AppMenu.vue
@@ -88,10 +88,12 @@ export default defineComponent({
 
 	mounted() {
 		subscribe('nextcloud:app-menu.refresh', this.setApps)
+		subscribe('nextcloud:app-menu.active', this.setActive)
 	},
 
 	beforeDestroy() {
 		unsubscribe('nextcloud:app-menu.refresh', this.setApps)
+		unsubscribe('nextcloud:app-menu.active', this.setActive)
 	},
 
 	methods: {
@@ -99,6 +101,19 @@ export default defineComponent({
 			const app = this.appList.find(({ app }) => app === id)
 			if (app) {
 				this.$set(app, 'unread', counter)
+			} else {
+				logger.warn(`Could not find app "${id}" for setting navigation count`)
+			}
+		},
+
+		setActive(id: string) {
+			this.appList.forEach((app) => {
+				this.$set(app, 'active', false)
+			})
+
+			const app = this.appList.find(({ id: menuItemId }) => menuItemId === id)
+			if (app) {
+				this.$set(app, 'active', true)
 			} else {
 				logger.warn(`Could not find app "${id}" for setting navigation count`)
 			}


### PR DESCRIPTION
See https://github.com/nextcloud/tables/pull/1477#issuecomment-2503165265

## Summary
Right now some modules uses css manipulations to mark some items as active. Would be nice to have proper API for that.

## TODO

- [ ] Decide what we want: event or `OC` method

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
