### PR TITLE
feat: Add bases and gidNumber attribute to ldap:test-user-settings output

### DIFF
--- a/apps/user_ldap/lib/Command/TestUserSettings.php
+++ b/apps/user_ldap/lib/Command/TestUserSettings.php
@@ -101,6 +101,8 @@ class TestUserSettings extends Command {
 			$output->writeln('');
 
 			$attributeNames = [
+				'ldapBase',
+				'ldapBaseUsers',
 				'ldapExpertUsernameAttr',
 				'ldapUuidUserAttribute',
 				'ldapExpertUUIDUserAttr',
@@ -120,11 +122,17 @@ class TestUserSettings extends Command {
 				'ldapAttributeBiography',
 				'ldapAttributeBirthDate',
 				'ldapAttributePronouns',
+				'ldapGidNumber',
+				'hasGidNumber',
 			];
 			$output->writeln('Attributes set in configuration:');
 			foreach ($attributeNames as $attributeName) {
-				if ($connection->$attributeName !== '') {
-					$output->writeln("- $attributeName: <info>" . $connection->$attributeName . '</info>');
+				if (($connection->$attributeName !== '') && ($connection->$attributeName !== [])) {
+					if (\is_string($connection->$attributeName)) {
+						$output->writeln("- $attributeName: <info>" . $connection->$attributeName . '</info>');
+					} else {
+						$output->writeln("- $attributeName: <info>" . \json_encode($connection->$attributeName) . '</info>');
+					}
 				}
 			}
 
@@ -133,6 +141,9 @@ class TestUserSettings extends Command {
 			$attrs[] = strtolower($connection->ldapExpertUsernameAttr);
 			if ($connection->ldapUuidUserAttribute !== 'auto') {
 				$attrs[] = strtolower($connection->ldapUuidUserAttribute);
+			}
+			if ($connection->hasGidNumber) {
+				$attrs[] = strtolower($connection->ldapGidNumber);
 			}
 			$attrs[] = 'memberof';
 			$attrs = array_values(array_unique($attrs));
@@ -170,6 +181,7 @@ class TestUserSettings extends Command {
 			$output->writeln('Group information:');
 
 			$attributeNames = [
+				'ldapBaseGroups',
 				'ldapDynamicGroupMemberURL',
 				'ldapGroupFilter',
 				'ldapGroupMemberAssocAttr',


### PR DESCRIPTION
## Summary

Based on user feedback in https://github.com/nextcloud/server/issues/42195#issuecomment-2695333231 , add missing attributes to `ldap:test-user-settings` output to make it more useful.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
