### PR TITLE
fix(l10n): Remove leading space from translation string

### DIFF
--- a/apps/encryption/templates/settings-personal.php
+++ b/apps/encryption/templates/settings-personal.php
@@ -25,7 +25,7 @@
 			<br />
 			<?php p($l->t('Set your old private key password to your current log-in password:')); ?>
 			<?php if ($_['recoveryEnabledForUser']):
-				p($l->t(" If you don't remember your old password you can ask your administrator to recover your files."));
+				p(' ' . $l->t('If you do not remember your old password you can ask your administrator to recover your files.'));
 			endif; ?>
 			<br />
 			<input


### PR DESCRIPTION

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
