### PR TITLE
fix: optimize FileUtils::getFilesByUser

### DIFF
--- a/core/Command/Info/FileUtils.php
+++ b/core/Command/Info/FileUtils.php
@@ -46,13 +46,12 @@ class FileUtils {
 
 		$mounts = $this->userMountCache->getMountsForFileId($id);
 		$result = [];
-		foreach ($mounts as $mount) {
-			if (isset($result[$mount->getUser()->getUID()])) {
-				continue;
-			}
-
-			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
-			$result[$mount->getUser()->getUID()] = $userFolder->getById($id);
+		foreach ($mounts as $cachedMount) {
+			$mount = $this->rootFolder->getMount($cachedMount->getMountPoint());
+			$cache = $mount->getStorage()->getCache();
+			$cacheEntry = $cache->get($id);
+			$node = $this->rootFolder->getNodeFromCacheEntryAndMount($cacheEntry, $mount);
+			$result[$cachedMount->getUser()->getUID()][] = $node;
 		}
 
 		return $result;

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -522,9 +522,9 @@ class Root extends Folder implements IRootFolder {
 		$isDir = $info->getType() === FileInfo::TYPE_FOLDER;
 		$view = new View('');
 		if ($isDir) {
-			return new Folder($this, $view, $path, $info, $parent);
+			return new Folder($this, $view, $fullPath, $info, $parent);
 		} else {
-			return new File($this, $view, $path, $info, $parent);
+			return new File($this, $view, $fullPath, $info, $parent);
 		}
 	}
 }


### PR DESCRIPTION
We already know what mount the file is in, so no need to go through the full `$userFolder->getById` logic