### PR TITLE
feat(security): simplify decrypt error handling

### DIFF
--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -91,18 +91,10 @@ class Crypto implements ICrypto {
 	 */
 	public function decrypt(string $authenticatedCiphertext, string $password = ''): string {
 		$secret = $this->config->getSystemValue('secret');
-		try {
-			if ($password === '') {
-				return $this->decryptWithoutSecret($authenticatedCiphertext, $secret);
-			}
-			return $this->decryptWithoutSecret($authenticatedCiphertext, $password);
-		} catch (Exception $e) {
-			if ($password === '') {
-				// Retry with empty secret as a fallback for instances where the secret might not have been set by accident
-				return $this->decryptWithoutSecret($authenticatedCiphertext, '');
-			}
-			throw $e;
+		if ($password === '') {
+			return $this->decryptWithoutSecret($authenticatedCiphertext, $secret);
 		}
+		return $this->decryptWithoutSecret($authenticatedCiphertext, $password);
 	}
 
 	private function decryptWithoutSecret(string $authenticatedCiphertext, string $password = ''): string {


### PR DESCRIPTION
## Summary

Before this patch, when decrypting a value without using a password, it would call `decryptWithoutSecret` with the system `secret` as `password`. When this fails, it would retry with an empty string as `password`.

This has the practical disadvantage that it can lead to confusing error messages. For example, when using the TOTP app, when the system `secret` is misconfigured, the first invocation will throw a sensible `HMAC does not match.` error, but then it is retried and the retry throws a `Hash_hkdf(): Argument #2 ($key) cannot be empty` error causing confusion (e.g.
https://help.nextcloud.com/t/hash-hkdf-argument-2-key-cannot-be-empty/192556).

Of course this fallback to using an empty string is likely part of some sort of graceful migration from the days when the secret could be empty (e.g. https://github.com/nextcloud/server/issues/34012, https://github.com/nextcloud/server/pull/31499, /cc @juliusknorr ).

However, taking a wider perspective, such 'fallback logic' in security-critical areas makes things more complex, which is a risk. It's not quite the same scenario, but Heartbleed does come to mind.

For this reason, rather than a 'surgical' improvement for the particular case encountered above (increasing complexity further), I think it'd be worth it to start considering removing this fallback entirely (perhaps in the next major version?) - hence this conversation-starter PR.

I'll keep this in draft for now because it needs a unit test, but otherwise I'd love to start the review/conversation.

## TODO

- [ ] add a unit test
- [ ] (perhaps in a follow-up PR) remove the fallback in more places

## Checklist

- [ ] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
