### PR TITLE
fix(encryption): Listen for user login and logout to set encryption key

### DIFF
--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -31,6 +31,8 @@ use OCP\User\Events\BeforePasswordUpdatedEvent;
 use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserDeletedEvent;
+use OCP\User\Events\UserLoggedInEvent;
+use OCP\User\Events\UserLoggedOutEvent;
 use Psr\Log\LoggerInterface;
 
 class Application extends App implements IBootstrap {
@@ -87,6 +89,8 @@ class Application extends App implements IBootstrap {
 		$eventDispatcher->addServiceListener(PasswordUpdatedEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(BeforePasswordResetEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(PasswordResetEvent::class, UserEventsListener::class);
+		$eventDispatcher->addServiceListener(UserLoggedInEvent::class, UserEventsListener::class);
+		$eventDispatcher->addServiceListener(UserLoggedOutEvent::class, UserEventsListener::class);
 	}
 
 	public function registerEncryptionModule(IManager $encryptionManager) {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/51066

## Summary
Missing in https://github.com/nextcloud/server/pull/48332 so caused a regression.
The event listener has the correct methods but I forgot to register the events :see_no_evil: 



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
