### PR TITLE
fix(cardav): only show users from enabled addressBooks in contacts menu

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -279,12 +279,11 @@ class Application extends App implements IBootstrap {
 		$cm->setupContactsProvider($contactsManager, $userID, $urlGenerator);
 	}
 
-	private function setupSystemContactsProvider(IContactsManager $contactsManager,
-		IAppContainer $container): void {
+	private function setupSystemContactsProvider(IContactsManager $contactsManager, IAppContainer $container): void {
 		/** @var ContactsManager $cm */
 		$cm = $container->query(ContactsManager::class);
 		$urlGenerator = $container->getServer()->getURLGenerator();
-		$cm->setupSystemContactsProvider($contactsManager, $urlGenerator);
+		$cm->setupSystemContactsProvider($contactsManager, null, $urlGenerator);
 	}
 
 	public function registerCalendarManager(ICalendarManager $calendarManager,

--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -7,15 +7,16 @@
  */
 namespace OCA\DAV\CardDAV;
 
+use OCA\DAV\Db\PropertyMapper;
 use OCP\Constants;
-use OCP\IAddressBook;
+use OCP\IAddressBookEnabled;
 use OCP\IURLGenerator;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Property;
 use Sabre\VObject\Reader;
 use Sabre\VObject\UUIDUtil;
 
-class AddressBookImpl implements IAddressBook {
+class AddressBookImpl implements IAddressBookEnabled {
 
 	/**
 	 * AddressBookImpl constructor.
@@ -30,6 +31,8 @@ class AddressBookImpl implements IAddressBook {
 		private array $addressBookInfo,
 		private CardDavBackend $backend,
 		private IURLGenerator $urlGenerator,
+		private PropertyMapper $propertyMapper,
+		private ?string $userId,
 	) {
 	}
 
@@ -307,5 +310,26 @@ class AddressBookImpl implements IAddressBook {
 			$this->addressBookInfo['uri'] === 'system' ||
 			$this->addressBookInfo['{DAV:}displayname'] === $this->urlGenerator->getBaseUrl()
 		);
+	}
+
+	public function isEnabled(): bool {
+		if (!$this->userId) {
+			return true;
+		}
+
+		if ($this->isSystemAddressBook()) {
+			$user = $this->userId ;
+			$uri = 'z-server-generated--system';
+		} else {
+			$user = str_replace('principals/users/', '', $this->addressBookInfo['principaluri']);
+			$uri = $this->addressBookInfo['uri'];
+		}
+		
+		$path = 'addressbooks/users/' . $user . '/' . $uri;
+		$properties = $this->propertyMapper->findPropertyByPathAndName($user, $path, '{http://owncloud.org/ns}enabled');
+		if (count($properties) > 0) {
+			return (bool)$properties[0]->getPropertyvalue();
+		}
+		return true;
 	}
 }

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Tests\unit\CardDAV;
 use OCA\DAV\CardDAV\AddressBook;
 use OCA\DAV\CardDAV\AddressBookImpl;
 use OCA\DAV\CardDAV\CardDavBackend;
+use OCA\DAV\Db\PropertyMapper;
 use OCP\IURLGenerator;
 use Sabre\VObject\Component\VCard;
 use Sabre\VObject\Property\Text;
@@ -32,6 +33,9 @@ class AddressBookImplTest extends TestCase {
 	/** @var CardDavBackend | \PHPUnit\Framework\MockObject\MockObject */
 	private $backend;
 
+	/** @var PropertyMapper | \PHPUnit\Framework\MockObject\MockObject */
+	private $propertyMapper;
+
 	/** @var VCard | \PHPUnit\Framework\MockObject\MockObject */
 	private $vCard;
 
@@ -50,12 +54,15 @@ class AddressBookImplTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->vCard = $this->createMock(VCard::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->propertyMapper = $this->createMock(PropertyMapper::class);
 
 		$this->addressBookImpl = new AddressBookImpl(
 			$this->addressBook,
 			$this->addressBookInfo,
 			$this->backend,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->propertyMapper,
+			null
 		);
 	}
 
@@ -78,6 +85,8 @@ class AddressBookImplTest extends TestCase {
 					$this->addressBookInfo,
 					$this->backend,
 					$this->urlGenerator,
+					$this->propertyMapper,
+					null
 				]
 			)
 			->setMethods(['vCard2Array', 'readCard'])
@@ -124,6 +133,8 @@ class AddressBookImplTest extends TestCase {
 					$this->addressBookInfo,
 					$this->backend,
 					$this->urlGenerator,
+					$this->propertyMapper,
+					null
 				]
 			)
 			->setMethods(['vCard2Array', 'createUid', 'createEmptyVCard'])
@@ -174,6 +185,8 @@ class AddressBookImplTest extends TestCase {
 					$this->addressBookInfo,
 					$this->backend,
 					$this->urlGenerator,
+					$this->propertyMapper,
+					null
 				]
 			)
 			->setMethods(['vCard2Array', 'createUid', 'createEmptyVCard', 'readCard'])
@@ -211,6 +224,8 @@ class AddressBookImplTest extends TestCase {
 					$this->addressBookInfo,
 					$this->backend,
 					$this->urlGenerator,
+					$this->propertyMapper,
+					null
 				]
 			)
 			->setMethods(['vCard2Array', 'createUid', 'createEmptyVCard', 'readCard'])
@@ -292,6 +307,8 @@ class AddressBookImplTest extends TestCase {
 					$this->addressBookInfo,
 					$this->backend,
 					$this->urlGenerator,
+					$this->propertyMapper,
+					null
 				]
 			)
 			->setMethods(['getUid'])
@@ -488,7 +505,9 @@ class AddressBookImplTest extends TestCase {
 			$this->addressBook,
 			$addressBookInfo,
 			$this->backend,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->propertyMapper,
+			null
 		);
 
 		$this->assertTrue($addressBookImpl->isSystemAddressBook());
@@ -507,7 +526,9 @@ class AddressBookImplTest extends TestCase {
 			$this->addressBook,
 			$addressBookInfo,
 			$this->backend,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->propertyMapper,
+			'user2'
 		);
 
 		$this->assertFalse($addressBookImpl->isSystemAddressBook());
@@ -527,7 +548,9 @@ class AddressBookImplTest extends TestCase {
 			$this->addressBook,
 			$addressBookInfo,
 			$this->backend,
-			$this->urlGenerator
+			$this->urlGenerator,
+			$this->propertyMapper,
+			'user2'
 		);
 
 		$this->assertFalse($addressBookImpl->isSystemAddressBook());

--- a/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
+++ b/apps/dav/tests/unit/CardDAV/ContactsManagerTest.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Tests\unit\CardDAV;
 
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\ContactsManager;
+use OCA\DAV\Db\PropertyMapper;
 use OCP\Contacts\IManager;
 use OCP\IL10N;
 use OCP\IURLGenerator;
@@ -25,9 +26,10 @@ class ContactsManagerTest extends TestCase {
 		$backEnd->method('getAddressBooksForUser')->willReturn([
 			['{DAV:}displayname' => 'Test address book', 'uri' => 'default'],
 		]);
+		$propertyMapper = $this->createMock(PropertyMapper::class);
 
 		$l = $this->createMock(IL10N::class);
-		$app = new ContactsManager($backEnd, $l);
+		$app = new ContactsManager($backEnd, $l, $propertyMapper);
 		$app->setupContactsProvider($cm, 'user01', $urlGenerator);
 	}
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -558,6 +558,7 @@ return array(
     'OCP\\Http\\WellKnown\\IResponse' => $baseDir . '/lib/public/Http/WellKnown/IResponse.php',
     'OCP\\Http\\WellKnown\\JrdResponse' => $baseDir . '/lib/public/Http/WellKnown/JrdResponse.php',
     'OCP\\IAddressBook' => $baseDir . '/lib/public/IAddressBook.php',
+    'OCP\\IAddressBookEnabled' => $baseDir . '/lib/public/IAddressBookEnabled.php',
     'OCP\\IAppConfig' => $baseDir . '/lib/public/IAppConfig.php',
     'OCP\\IAvatar' => $baseDir . '/lib/public/IAvatar.php',
     'OCP\\IAvatarManager' => $baseDir . '/lib/public/IAvatarManager.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -607,6 +607,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Http\\WellKnown\\IResponse' => __DIR__ . '/../../..' . '/lib/public/Http/WellKnown/IResponse.php',
         'OCP\\Http\\WellKnown\\JrdResponse' => __DIR__ . '/../../..' . '/lib/public/Http/WellKnown/JrdResponse.php',
         'OCP\\IAddressBook' => __DIR__ . '/../../..' . '/lib/public/IAddressBook.php',
+        'OCP\\IAddressBookEnabled' => __DIR__ . '/../../..' . '/lib/public/IAddressBookEnabled.php',
         'OCP\\IAppConfig' => __DIR__ . '/../../..' . '/lib/public/IAppConfig.php',
         'OCP\\IAvatar' => __DIR__ . '/../../..' . '/lib/public/IAvatar.php',
         'OCP\\IAvatarManager' => __DIR__ . '/../../..' . '/lib/public/IAvatarManager.php',

--- a/lib/private/ContactsManager.php
+++ b/lib/private/ContactsManager.php
@@ -10,6 +10,7 @@ namespace OC;
 use OCP\Constants;
 use OCP\Contacts\IManager;
 use OCP\IAddressBook;
+use OCP\IAddressBookEnabled;
 
 class ContactsManager implements IManager {
 	/**
@@ -34,6 +35,9 @@ class ContactsManager implements IManager {
 		$this->loadAddressBooks();
 		$result = [];
 		foreach ($this->addressBooks as $addressBook) {
+			if ($addressBook instanceof IAddressBookEnabled && !$addressBook->isEnabled()) {
+				continue;
+			}
 			$searchOptions = $options;
 			$strictSearch = array_key_exists('strict_search', $options) && $options['strict_search'] === true;
 

--- a/lib/public/IAddressBookEnabled.php
+++ b/lib/public/IAddressBookEnabled.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors"
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal Nextcloud classes
+
+namespace OCP;
+
+/**
+ * IAddressBook Interface extension for checking if the address book is enabled
+ *
+ * @since 32.0.0
+ */
+interface IAddressBookEnabled extends IAddressBook {
+	/**
+	 * Check if the address book is enabled
+	 * @return bool
+	 * @since 32.0.0
+	 */
+	public function isEnabled(): bool;
+}

--- a/tests/lib/ContactsManagerTest.php
+++ b/tests/lib/ContactsManagerTest.php
@@ -67,9 +67,13 @@ class ContactsManagerTest extends \Test\TestCase {
 	 */
 	public function testSearch($search1, $search2, $expectedResult): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook1 = $this->getMockBuilder('\OCP\IAddressBook')
+		$addressbook1 = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
+
+		$addressbook1->expects($this->once())
+			->method('isEnabled')
+			->willReturn(true);
 
 		$addressbook1->expects($this->once())
 			->method('search')
@@ -79,9 +83,13 @@ class ContactsManagerTest extends \Test\TestCase {
 			->method('getKey')
 			->willReturn('simple:1');
 
-		$addressbook2 = $this->getMockBuilder('\OCP\IAddressBook')
+		$addressbook2 = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
+
+		$addressbook2->expects($this->once())
+			->method('isEnabled')
+			->willReturn(true);
 
 		$addressbook2->expects($this->once())
 			->method('search')
@@ -98,10 +106,48 @@ class ContactsManagerTest extends \Test\TestCase {
 		$this->assertEquals($expectedResult, $result);
 	}
 
+	/**
+	 * @dataProvider searchProvider
+	 */
+	public function testSearchDisabledAb($search1): void {
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook1 = $this->getMockBuilder('\OCP\IAddressBookEnabled')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$addressbook1->expects($this->once())
+			->method('isEnabled')
+			->willReturn(true);
+
+		$addressbook1->expects($this->once())
+			->method('search')
+			->willReturn($search1);
+
+		$addressbook1->expects($this->any())
+			->method('getKey')
+			->willReturn('simple:1');
+
+		$addressbook2 = $this->getMockBuilder('\OCP\IAddressBookEnabled')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$addressbook2->expects($this->once())
+			->method('isEnabled')
+			->willReturn(false);
+
+		$addressbook2->expects($this->never())
+			->method('search');
+
+		$this->cm->registerAddressBook($addressbook1);
+		$this->cm->registerAddressBook($addressbook2);
+		$result = $this->cm->search('');
+		$this->assertEquals($search1, $result);
+	}
+
 
 	public function testDeleteHavePermission(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -123,8 +169,8 @@ class ContactsManagerTest extends \Test\TestCase {
 	}
 
 	public function testDeleteNoPermission(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -145,8 +191,8 @@ class ContactsManagerTest extends \Test\TestCase {
 	}
 
 	public function testDeleteNoAddressbook(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -163,8 +209,8 @@ class ContactsManagerTest extends \Test\TestCase {
 	}
 
 	public function testCreateOrUpdateHavePermission(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -186,8 +232,8 @@ class ContactsManagerTest extends \Test\TestCase {
 	}
 
 	public function testCreateOrUpdateNoPermission(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -208,8 +254,8 @@ class ContactsManagerTest extends \Test\TestCase {
 	}
 
 	public function testCreateOrUpdateNOAdressbook(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -231,8 +277,8 @@ class ContactsManagerTest extends \Test\TestCase {
 	}
 
 	public function testIsEnabledIfSo(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -247,8 +293,8 @@ class ContactsManagerTest extends \Test\TestCase {
 
 	public function testAddressBookEnumeration(): void {
 		// create mock for the addressbook
-		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
-		$addressbook = $this->getMockBuilder('\OCP\IAddressBook')
+		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
+		$addressbook = $this->getMockBuilder('\OCP\IAddressBookEnabled')
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary
Only show contacts from Enabled address Books in contact menu

## TODO

- [x] Fix tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
