### PR TITLE
fix(lookup-server): Only flag new users for lookup update / delete

### DIFF
--- a/core/BackgroundJobs/LookupServerSendCheckBackgroundJob.php
+++ b/core/BackgroundJobs/LookupServerSendCheckBackgroundJob.php
@@ -28,7 +28,11 @@ class LookupServerSendCheckBackgroundJob extends QueuedJob {
 	 */
 	public function run($argument): void {
 		$this->userManager->callForSeenUsers(function (IUser $user) {
-			$this->config->setUserValue($user->getUID(), 'lookup_server_connector', 'dataSend', '1');
+			// If the user data was not updated yet (check if LUS is enabled and if then update on LUS or delete on LUS)
+			// then we need to flag the user data to be checked
+			if ($this->config->getUserValue($user->getUID(), 'lookup_server_connector', 'dataSend', '') === '') {
+				$this->config->setUserValue($user->getUID(), 'lookup_server_connector', 'dataSend', '1');
+			}
 		});
 	}
 }


### PR DESCRIPTION
## Summary

If the flag was already set then we do not need to overwrite it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
