### PR TITLE
fix: skip caching lastSeenQuotaUsage for remote shares

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -286,6 +286,7 @@ class DirectoryTest extends \Test\TestCase {
 			->willReturnMap([
 				['\OCA\Files_Sharing\SharedStorage', false],
 				['\OC\Files\Storage\Wrapper\Quota', false],
+				[\OCA\Files_Sharing\External\Storage::class, false],
 			]);
 
 		$storage->expects($this->once())
@@ -341,6 +342,7 @@ class DirectoryTest extends \Test\TestCase {
 			->willReturnMap([
 				['\OCA\Files_Sharing\SharedStorage', false],
 				['\OC\Files\Storage\Wrapper\Quota', true],
+				[\OCA\Files_Sharing\External\Storage::class, false],
 			]);
 
 		$storage->expects($this->once())

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -541,9 +541,16 @@ class OC_Helper {
 			$relative = 0;
 		}
 
+		/*
+		 * \OCA\Files_Sharing\External\Storage returns the cloud ID as the owner for the storage.
+		 * It is unnecessary to query the user manager for the display name, as it won't have this information.
+		 */
+		$isRemoteShare = $storage->instanceOfStorage(\OCA\Files_Sharing\External\Storage::class);
+
 		$ownerId = $storage->getOwner($path);
 		$ownerDisplayName = '';
-		if ($ownerId !== false) {
+
+		if ($isRemoteShare === false && $ownerId !== false) {
 			$ownerDisplayName = \OC::$server->getUserManager()->getDisplayName($ownerId) ?? '';
 		}
 
@@ -565,7 +572,7 @@ class OC_Helper {
 			'mountPoint' => trim($mountPoint, '/'),
 		];
 
-		if ($ownerId && $path === '/') {
+		if ($isRemoteShare === false && $ownerId !== false && $path === '/') {
 			// If path is root, store this as last known quota usage for this user
 			\OCP\Server::get(\OCP\IConfig::class)->setUserValue($ownerId, 'files', 'lastSeenQuotaUsage', (string)$relative);
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

\OCA\Files_Sharing\External\Storage returns the cloud ID as the owner for the storage.
It is unnecessary to query the user manager for the display name, as it won't have this information.


## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
