### PR TITLE
add command to list shares

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -812,6 +812,7 @@ class FederatedShareProvider implements IShareProvider {
 			->setPermissions((int)$data['permissions'])
 			->setTarget($data['file_target'])
 			->setMailSend((bool)$data['mail_send'])
+			->setStatus((int)$data['accepted'])
 			->setToken($data['token']);
 
 		$shareTime = new \DateTime();

--- a/apps/files_sharing/appinfo/info.xml
+++ b/apps/files_sharing/appinfo/info.xml
@@ -50,6 +50,7 @@ Turning the feature off removes shared files and folders on the server for all s
 		<command>OCA\Files_Sharing\Command\ExiprationNotification</command>
 		<command>OCA\Files_Sharing\Command\DeleteOrphanShares</command>
 		<command>OCA\Files_Sharing\Command\FixShareOwners</command>
+		<command>OCA\Files_Sharing\Command\ListShares</command>
 	</commands>
 
 	<settings>

--- a/apps/files_sharing/composer/composer/autoload_classmap.php
+++ b/apps/files_sharing/composer/composer/autoload_classmap.php
@@ -28,6 +28,7 @@ return array(
     'OCA\\Files_Sharing\\Command\\DeleteOrphanShares' => $baseDir . '/../lib/Command/DeleteOrphanShares.php',
     'OCA\\Files_Sharing\\Command\\ExiprationNotification' => $baseDir . '/../lib/Command/ExiprationNotification.php',
     'OCA\\Files_Sharing\\Command\\FixShareOwners' => $baseDir . '/../lib/Command/FixShareOwners.php',
+    'OCA\\Files_Sharing\\Command\\ListShares' => $baseDir . '/../lib/Command/ListShares.php',
     'OCA\\Files_Sharing\\Controller\\AcceptController' => $baseDir . '/../lib/Controller/AcceptController.php',
     'OCA\\Files_Sharing\\Controller\\DeletedShareAPIController' => $baseDir . '/../lib/Controller/DeletedShareAPIController.php',
     'OCA\\Files_Sharing\\Controller\\ExternalSharesController' => $baseDir . '/../lib/Controller/ExternalSharesController.php',

--- a/apps/files_sharing/composer/composer/autoload_static.php
+++ b/apps/files_sharing/composer/composer/autoload_static.php
@@ -43,6 +43,7 @@ class ComposerStaticInitFiles_Sharing
         'OCA\\Files_Sharing\\Command\\DeleteOrphanShares' => __DIR__ . '/..' . '/../lib/Command/DeleteOrphanShares.php',
         'OCA\\Files_Sharing\\Command\\ExiprationNotification' => __DIR__ . '/..' . '/../lib/Command/ExiprationNotification.php',
         'OCA\\Files_Sharing\\Command\\FixShareOwners' => __DIR__ . '/..' . '/../lib/Command/FixShareOwners.php',
+        'OCA\\Files_Sharing\\Command\\ListShares' => __DIR__ . '/..' . '/../lib/Command/ListShares.php',
         'OCA\\Files_Sharing\\Controller\\AcceptController' => __DIR__ . '/..' . '/../lib/Controller/AcceptController.php',
         'OCA\\Files_Sharing\\Controller\\DeletedShareAPIController' => __DIR__ . '/..' . '/../lib/Controller/DeletedShareAPIController.php',
         'OCA\\Files_Sharing\\Controller\\ExternalSharesController' => __DIR__ . '/..' . '/../lib/Controller/ExternalSharesController.php',

--- a/apps/files_sharing/lib/Command/ListShares.php
+++ b/apps/files_sharing/lib/Command/ListShares.php
@@ -10,10 +10,9 @@ namespace OCA\Files_Sharing\Command;
 
 use OC\Core\Command\Base;
 use OCP\Files\Folder;
-use OCP\Files\Node;
 use OCP\Files\IRootFolder;
+use OCP\Files\Node;
 use OCP\Files\NotFoundException;
-use OCP\IDBConnection;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
 use Symfony\Component\Console\Input\InputInterface;
@@ -21,11 +20,27 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ListShares extends Base {
-	/** @var array{string, Node} */
-	private $fileCache = [];
+	/** @var array<string, Node> */
+	private array $fileCache = [];
+
+	private const SHARE_TYPE_NAMES = [
+		IShare::TYPE_USER => 'user',
+		IShare::TYPE_GROUP => 'group',
+		IShare::TYPE_LINK => 'link',
+		IShare::TYPE_EMAIL => 'email',
+		IShare::TYPE_REMOTE => 'remote',
+		IShare::TYPE_REMOTE_GROUP => 'group',
+		IShare::TYPE_ROOM => 'room',
+		IShare::TYPE_DECK => 'deck',
+	];
+
+	private const SHARE_STATUS_NAMES = [
+		IShare::STATUS_PENDING => 'pending',
+		IShare::STATUS_ACCEPTED => 'accepted',
+		IShare::STATUS_REJECTED => 'rejected',
+	];
 
 	public function __construct(
-		private readonly IDBConnection $connection,
 		private readonly IManager $shareManager,
 		private readonly IRootFolder $rootFolder,
 	) {
@@ -35,40 +50,52 @@ class ListShares extends Base {
 	protected function configure() {
 		parent::configure();
 		$this
-			->setName('sharing:list')
+			->setName('share:list')
 			->setDescription('List available shares')
 			->addOption('owner', null, InputOption::VALUE_REQUIRED, 'only show shares owned by a specific user')
 			->addOption('recipient', null, InputOption::VALUE_REQUIRED, 'only show shares with a specific recipient')
 			->addOption('by', null, InputOption::VALUE_REQUIRED, 'only show shares with by as specific user')
 			->addOption('file', null, InputOption::VALUE_REQUIRED, 'only show shares of a specific file')
 			->addOption('parent', null, InputOption::VALUE_REQUIRED, 'only show shares of files inside a specific folder')
-			->addOption('recursive', null, InputOption::VALUE_NONE, 'also show shares nested deep inside the specified parent folder');
+			->addOption('recursive', null, InputOption::VALUE_NONE, 'also show shares nested deep inside the specified parent folder')
+			->addOption('type', null, InputOption::VALUE_REQUIRED, 'only show shares of a specific type')
+			->addOption('status', null, InputOption::VALUE_REQUIRED, 'only show shares with a specific status');
 	}
 
 	public function execute(InputInterface $input, OutputInterface $output): int {
-		$shares = iterator_to_array($this->shareManager->getAllShares());
-		$shares = array_filter($shares, function (IShare $share) use ($input) {
+		if ($input->getOption('recursive') && !$input->getOption('parent')) {
+			$output->writeln("<error>recursive option can't be used without parent option</error>");
+			return 1;
+		}
+
+		// todo: do some pre-filtering instead of first querying all shares
+		/** @var \Iterator<IShare> $allShares */
+		$allShares = $this->shareManager->getAllShares();
+		$shares = new \CallbackFilterIterator($allShares, function (IShare $share) use ($input) {
 			return $this->shouldShowShare($input, $share);
 		});
+		$shares = iterator_to_array($shares);
 		$data = array_map(function (IShare $share) {
 			return [
 				'id' => $share->getId(),
 				'file' => $share->getNodeId(),
+				'target-path' => $share->getTarget(),
+				'source-path' => $share->getNode()->getPath(),
 				'owner' => $share->getShareOwner(),
 				'recipient' => $share->getSharedWith(),
 				'by' => $share->getSharedBy(),
+				'type' => self::SHARE_TYPE_NAMES[$share->getShareType()] ?? 'unknown',
+				'status' => self::SHARE_STATUS_NAMES[$share->getStatus()] ?? 'unknown',
 			];
 		}, $shares);
-		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
-			$this->writeTableInOutputFormat($input, $output, $data);
-		} else {
-			$this->writeArrayInOutputFormat($input, $output, $data);
-		}
+
+		$this->writeTableInOutputFormat($input, $output, $data);
+		return 0;
 	}
 
 	private function getFileId(string $file): int {
 		if (is_numeric($file)) {
-			return $file;
+			return (int)$file;
 		}
 		return $this->getFile($file)->getId();
 	}
@@ -79,7 +106,7 @@ class ListShares extends Base {
 		}
 
 		if (is_numeric($file)) {
-			$node = $this->rootFolder->getFirstNodeById($file);
+			$node = $this->rootFolder->getFirstNodeById((int)$file);
 			if (!$node) {
 				throw new NotFoundException("File with id $file not found");
 			}
@@ -88,6 +115,24 @@ class ListShares extends Base {
 		}
 		$this->fileCache[$file] = $node;
 		return $node;
+	}
+
+	private function getShareType(string $type): int {
+		foreach (self::SHARE_TYPE_NAMES as $shareType => $shareTypeName) {
+			if ($shareTypeName === $type) {
+				return $shareType;
+			}
+		}
+		throw new \Exception("Unknown share type $type");
+	}
+
+	private function getShareStatus(string $status): int {
+		foreach (self::SHARE_STATUS_NAMES as $shareStatus => $shareStatusName) {
+			if ($shareStatusName === $status) {
+				return $shareStatus;
+			}
+		}
+		throw new \Exception("Unknown share status $status");
 	}
 
 	private function shouldShowShare(InputInterface $input, IShare $share): bool {
@@ -110,7 +155,11 @@ class ListShares extends Base {
 			}
 			$recursive = $input->getOption('recursive');
 			if (!$recursive) {
-				if ($share->getNodeCacheEntry()->getParent() !== $parent->getId()) {
+				$shareCacheEntry = $share->getNodeCacheEntry();
+				if (!$shareCacheEntry) {
+					$shareCacheEntry = $share->getNode();
+				}
+				if ($shareCacheEntry->getParentId() !== $parent->getId()) {
 					return false;
 				}
 			} else {
@@ -119,6 +168,12 @@ class ListShares extends Base {
 					return false;
 				}
 			}
+		}
+		if ($input->getOption('type') && $share->getShareType() !== $this->getShareType($input->getOption('type'))) {
+			return false;
+		}
+		if ($input->getOption('status') && $share->getStatus() !== $this->getShareStatus($input->getOption('status'))) {
+			return false;
 		}
 		return true;
 	}

--- a/apps/files_sharing/lib/Command/ListShares.php
+++ b/apps/files_sharing/lib/Command/ListShares.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Robin Appelman <robin@icewind.nl>
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_Sharing\Command;
+
+use OC\Core\Command\Base;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\IDBConnection;
+use OCP\Share\IManager;
+use OCP\Share\IShare;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListShares extends Base {
+	/** @var array{string, Node} */
+	private $fileCache = [];
+
+	public function __construct(
+		private readonly IDBConnection $connection,
+		private readonly IManager $shareManager,
+		private readonly IRootFolder $rootFolder,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		parent::configure();
+		$this
+			->setName('sharing:list')
+			->setDescription('List available shares')
+			->addOption('owner', null, InputOption::VALUE_REQUIRED, 'only show shares owned by a specific user')
+			->addOption('recipient', null, InputOption::VALUE_REQUIRED, 'only show shares with a specific recipient')
+			->addOption('by', null, InputOption::VALUE_REQUIRED, 'only show shares with by as specific user')
+			->addOption('file', null, InputOption::VALUE_REQUIRED, 'only show shares of a specific file')
+			->addOption('parent', null, InputOption::VALUE_REQUIRED, 'only show shares of files inside a specific folder')
+			->addOption('recursive', null, InputOption::VALUE_NONE, 'also show shares nested deep inside the specified parent folder');
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$shares = iterator_to_array($this->shareManager->getAllShares());
+		$shares = array_filter($shares, function (IShare $share) use ($input) {
+			return $this->shouldShowShare($input, $share);
+		});
+		$data = array_map(function (IShare $share) {
+			return [
+				'id' => $share->getId(),
+				'file' => $share->getNodeId(),
+				'owner' => $share->getShareOwner(),
+				'recipient' => $share->getSharedWith(),
+				'by' => $share->getSharedBy(),
+			];
+		}, $shares);
+		if ($input->getOption('output') === self::OUTPUT_FORMAT_PLAIN) {
+			$this->writeTableInOutputFormat($input, $output, $data);
+		} else {
+			$this->writeArrayInOutputFormat($input, $output, $data);
+		}
+	}
+
+	private function getFileId(string $file): int {
+		if (is_numeric($file)) {
+			return $file;
+		}
+		return $this->getFile($file)->getId();
+	}
+
+	private function getFile(string $file): Node {
+		if (isset($this->fileCache[$file])) {
+			return $this->fileCache[$file];
+		}
+
+		if (is_numeric($file)) {
+			$node = $this->rootFolder->getFirstNodeById($file);
+			if (!$node) {
+				throw new NotFoundException("File with id $file not found");
+			}
+		} else {
+			$node = $this->rootFolder->get($file);
+		}
+		$this->fileCache[$file] = $node;
+		return $node;
+	}
+
+	private function shouldShowShare(InputInterface $input, IShare $share): bool {
+		if ($input->getOption('owner') && $share->getShareOwner() !== $input->getOption('owner')) {
+			return false;
+		}
+		if ($input->getOption('recipient') && $share->getSharedWith() !== $input->getOption('recipient')) {
+			return false;
+		}
+		if ($input->getOption('by') && $share->getSharedBy() !== $input->getOption('by')) {
+			return false;
+		}
+		if ($input->getOption('file') && $share->getNodeId() !== $this->getFileId($input->getOption('file'))) {
+			return false;
+		}
+		if ($input->getOption('parent')) {
+			$parent = $this->getFile($input->getOption('parent'));
+			if (!$parent instanceof Folder) {
+				throw new \Exception("Parent {$parent->getPath()} is not a folder");
+			}
+			$recursive = $input->getOption('recursive');
+			if (!$recursive) {
+				if ($share->getNodeCacheEntry()->getParent() !== $parent->getId()) {
+					return false;
+				}
+			} else {
+				$shareNode = $share->getNode();
+				if ($parent->getRelativePath($shareNode->getPath()) === null) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+}

--- a/apps/files_sharing/lib/Command/ListShares.php
+++ b/apps/files_sharing/lib/Command/ListShares.php
@@ -34,12 +34,6 @@ class ListShares extends Base {
 		IShare::TYPE_DECK => 'deck',
 	];
 
-	private const SHARE_STATUS_NAMES = [
-		IShare::STATUS_PENDING => 'pending',
-		IShare::STATUS_ACCEPTED => 'accepted',
-		IShare::STATUS_REJECTED => 'rejected',
-	];
-
 	public function __construct(
 		private readonly IManager $shareManager,
 		private readonly IRootFolder $rootFolder,
@@ -85,7 +79,6 @@ class ListShares extends Base {
 				'recipient' => $share->getSharedWith(),
 				'by' => $share->getSharedBy(),
 				'type' => self::SHARE_TYPE_NAMES[$share->getShareType()] ?? 'unknown',
-				'status' => self::SHARE_STATUS_NAMES[$share->getStatus()] ?? 'unknown',
 			];
 		}, $shares);
 
@@ -126,15 +119,6 @@ class ListShares extends Base {
 		throw new \Exception("Unknown share type $type");
 	}
 
-	private function getShareStatus(string $status): int {
-		foreach (self::SHARE_STATUS_NAMES as $shareStatus => $shareStatusName) {
-			if ($shareStatusName === $status) {
-				return $shareStatus;
-			}
-		}
-		throw new \Exception("Unknown share status $status");
-	}
-
 	private function shouldShowShare(InputInterface $input, IShare $share): bool {
 		if ($input->getOption('owner') && $share->getShareOwner() !== $input->getOption('owner')) {
 			return false;
@@ -170,9 +154,6 @@ class ListShares extends Base {
 			}
 		}
 		if ($input->getOption('type') && $share->getShareType() !== $this->getShareType($input->getOption('type'))) {
-			return false;
-		}
-		if ($input->getOption('status') && $share->getStatus() !== $this->getShareStatus($input->getOption('status'))) {
 			return false;
 		}
 		return true;

--- a/lib/private/Files/Cache/CacheEntry.php
+++ b/lib/private/Files/Cache/CacheEntry.php
@@ -110,6 +110,10 @@ class CacheEntry implements ICacheEntry {
 		return $this->data['upload_time'] ?? null;
 	}
 
+	public function getParentId(): int {
+		return $this->data['parent'];
+	}
+
 	public function getData() {
 		return $this->data;
 	}

--- a/lib/public/Files/Cache/ICacheEntry.php
+++ b/lib/public/Files/Cache/ICacheEntry.php
@@ -161,4 +161,12 @@ interface ICacheEntry extends ArrayAccess {
 	 * @since 25.0.0
 	 */
 	public function getUnencryptedSize(): int;
+
+	/**
+	 * Get the file id of the parent folder
+	 *
+	 * @return int
+	 * @since 32.0.0
+	 */
+	public function getParentId(): int;
 }


### PR DESCRIPTION
Adds command `occ share:list` to show all shares on the system with a number of filtering options.

Obvious room for improvements in the performance of querying the shares and increasing the information shown and the number of filters available. But it should still be useful in it's current state.