### PR TITLE
perf(db): Extend index on cards_properties to cover name and value

### DIFF
--- a/apps/dav/lib/Migration/Version1004Date20170924124212.php
+++ b/apps/dav/lib/Migration/Version1004Date20170924124212.php
@@ -28,7 +28,10 @@ class Version1004Date20170924124212 extends SimpleMigrationStep {
 		$table->addIndex(['addressbookid', 'uri'], 'cards_abiduri');
 
 		$table = $schema->getTable('cards_properties');
-		$table->addIndex(['addressbookid'], 'cards_prop_abid');
+		// Removed later on
+		// $table->addIndex(['addressbookid'], 'cards_prop_abid');
+		// Added later on
+		$table->addIndex(['addressbookid', 'name', 'value'], 'cards_prop_abid_name_value', );
 
 		return $schema;
 	}

--- a/core/Application.php
+++ b/core/Application.php
@@ -147,12 +147,12 @@ class Application extends App {
 				true
 			);
 
-			$event->addMissingIndex(
+			$event->replaceIndex(
 				'cards_properties',
-				'cards_prop_abid',
-				['addressbookid'],
-				[],
-				true
+				['cards_prop_abid'],
+				'cards_prop_abid_name_value',
+				['addressbookid', 'name', 'value'],
+				false,
 			);
 
 			$event->addMissingIndex(


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Search in in addressbooks dispatches a query like

```sql
SELECT DISTINCT `cp`.`cardid`
FROM `oc_cards_properties` `cp`
WHERE (`cp`.`addressbookid` IN (18))
  AND (`cp`.`name` IN ('FN'))
  AND (`cp`.`value` COLLATE utf8mb4_general_ci LIKE '%john%')
LIMIT 20
```

MariaDB picks `card_name_index`, which only covers `name`, and still has to scan 712 index entries and then do a table access.

```json
{
  "query_optimization": {
    "r_total_time_ms": 0.144922892
  },
  "query_block": {
    "select_id": 1,
    "cost": 0.6448338,
    "r_loops": 1,
    "r_total_time_ms": 1.652976417,
    "temporary_table": {
      "nested_loop": [
        {
          "table": {
            "table_name": "cp",
            "access_type": "range",
            "possible_keys": ["card_name_index"],
            "key": "card_name_index",
            "key_length": "259",
            "used_key_parts": ["name"],
            "loops": 1,
            "r_loops": 1,
            "rows": 712,
            "r_index_rows": 712,
            "r_rows": 712,
            "cost": 0.6448338,
            "r_table_time_ms": 1.404896605,
            "r_other_time_ms": 0.240330463,
            "r_engine_stats": {
              "pages_accessed": 1426
            },
            "filtered": 100,
            "r_total_filtered": 0.140449438,
            "index_condition": "cp.`name` = 'FN'",
            "r_icp_filtered": 100,
            "attached_condition": "cp.addressbookid = 18 and cp.`value` collate utf8mb4_general_ci like '%user0%'",
            "r_filtered": 0.140449438
          }
        }
      ]
    }
  }
}
```

Look at the **r_rows**

With the new query everything but the `cardid` is covered. It takes 1 index access and one table access to find the result.

```json
{
  "query_optimization": {
    "r_total_time_ms": 0.258566593
  },
  "query_block": {
    "select_id": 1,
    "cost": 0.6448338,
    "r_loops": 1,
    "r_total_time_ms": 0.712225566,
    "temporary_table": {
      "nested_loop": [
        {
          "table": {
            "table_name": "cp",
            "access_type": "range",
            "possible_keys": ["card_name_index", "cards_prop_abid_name_value"],
            "key": "cards_prop_abid_name_value",
            "key_length": "267",
            "used_key_parts": ["addressbookid", "name"],
            "loops": 1,
            "r_loops": 1,
            "rows": 638,
            "r_index_rows": 638,
            "r_rows": 1,
            "cost": 0.6448338,
            "r_table_time_ms": 0.672583116,
            "r_other_time_ms": 0.029195924,
            "r_engine_stats": {
              "pages_accessed": 6
            },
            "filtered": 100,
            "r_total_filtered": 0.156739812,
            "index_condition": "cp.addressbookid = 18 and cp.`name` = 'FN' and cp.`value` collate utf8mb4_general_ci like '%user0%'",
            "r_icp_filtered": 0.156739812,
            "r_filtered": 100
          }
        }
      ]
    }
  }
}
```

I have also experimented with `cardid` but then MariaDB no longer uses the index. This is likely because a custom collation is used on `value`, so query optimizer sees the index as not worthy.

## TODO

- [x] Make the changes 
- [x] Test the changes

## How to test

1. Check out the branch
2. Run example queries with EXPLAIN

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
