### PR TITLE
fix(db): Create replacement index where original index is missing

### DIFF
--- a/core/Command/Db/AddMissingIndices.php
+++ b/core/Command/Db/AddMissingIndices.php
@@ -86,14 +86,7 @@ class AddMissingIndices extends Command {
 				if ($schema->hasTable($toReplaceIndex['tableName'])) {
 					$table = $schema->getTable($toReplaceIndex['tableName']);
 
-					$allOldIndicesExists = true;
-					foreach ($toReplaceIndex['oldIndexNames'] as $oldIndexName) {
-						if (!$table->hasIndex($oldIndexName)) {
-							$allOldIndicesExists = false;
-						}
-					}
-
-					if (!$allOldIndicesExists) {
+					if ($table->hasIndex($toReplaceIndex['newIndexName'])) {
 						continue;
 					}
 
@@ -110,8 +103,10 @@ class AddMissingIndices extends Command {
 					}
 
 					foreach ($toReplaceIndex['oldIndexNames'] as $oldIndexName) {
-						$output->writeln('<info>Removing ' . $oldIndexName . ' index from the ' . $table->getName() . ' table</info>');
-						$table->dropIndex($oldIndexName);
+						if ($table->hasIndex($oldIndexName)) {
+							$output->writeln('<info>Removing ' . $oldIndexName . ' index from the ' . $table->getName() . ' table</info>');
+							$table->dropIndex($oldIndexName);
+						}
 					}
 
 					if (!$dryRun) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/mail/issues/9810

## Summary

While working on https://github.com/nextcloud/server/pull/51438 I noticed that replacement indexes are not created if the old indexes don't exist. This can happen in the following deployment

1. Table is created but without index
2. Optional index is added but admin never applies it
3. The previously optional index is replaced by another one

Before: old and new index were missing
After: new index is added

The setup check has already reported the affected indices as missing, but they were never added.

## TODO

- [x] Make the changes
- [x] Test the changes

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
