### PR TITLE
fix(CalDav): alter invitation attachment filename and type

### DIFF
--- a/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
+++ b/apps/dav/lib/CalDAV/Schedule/IMipPlugin.php
@@ -275,8 +275,8 @@ class IMipPlugin extends SabreIMipPlugin {
 				$message->setBodyHtml($template->renderHtml());
 				$message->setAttachments((new Attachment(
 					$itip_msg,
-					'event.ics',
-					'text/calendar; method=' . $iTipMessage->method,
+					null,
+					'text/calendar; name=event.ics; method=' . $iTipMessage->method,
 					true
 				)));
 				// send message


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/mail/issues/10416
* Requires: https://github.com/nextcloud/mail/pull/10851

## Summary
Alters the attachment header options.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
