### PR TITLE
fix(RichObjectStrings): Make exception messages for invalid parameters more useful for debugging

### DIFF
--- a/lib/private/Activity/Event.php
+++ b/lib/private/Activity/Event.php
@@ -34,7 +34,7 @@ class Event implements IEvent {
 	protected $subjectParsed = '';
 	/** @var string */
 	protected $subjectRich = '';
-	/** @var array */
+	/** @var array<string, array<string, string>> */
 	protected $subjectRichParameters = [];
 	/** @var string */
 	protected $message = '';
@@ -44,7 +44,7 @@ class Event implements IEvent {
 	protected $messageParsed = '';
 	/** @var string */
 	protected $messageRich = '';
-	/** @var array */
+	/** @var array<string, array<string, string>> */
 	protected $messageRichParameters = [];
 	/** @var string */
 	protected $objectType = '';

--- a/lib/private/RichObjectStrings/Validator.php
+++ b/lib/private/RichObjectStrings/Validator.php
@@ -56,7 +56,7 @@ class Validator implements IValidator {
 				throw new InvalidObjectExeption('Parameter is malformed');
 			}
 
-			$this->validateParameter($parameter);
+			$this->validateParameter($placeholder, $parameter);
 		}
 	}
 
@@ -64,7 +64,7 @@ class Validator implements IValidator {
 	 * @param array $parameter
 	 * @throws InvalidObjectExeption
 	 */
-	protected function validateParameter(array $parameter): void {
+	protected function validateParameter(string $placeholder, array $parameter): void {
 		if (!isset($parameter['type'])) {
 			throw new InvalidObjectExeption('Object type is undefined');
 		}
@@ -74,15 +74,15 @@ class Validator implements IValidator {
 
 		$missingKeys = array_diff($requiredParameters, array_keys($parameter));
 		if (!empty($missingKeys)) {
-			throw new InvalidObjectExeption('Object is invalid, missing keys:' . json_encode($missingKeys));
+			throw new InvalidObjectExeption('Object for placeholder ' . $placeholder . ' is invalid, missing keys:' . json_encode($missingKeys));
 		}
 
 		foreach ($parameter as $key => $value) {
 			if (!is_string($key)) {
-				throw new InvalidObjectExeption('Object is invalid, key ' . $key . ' is not a string');
+				throw new InvalidObjectExeption('Object for placeholder ' . $placeholder . ' is invalid, key ' . $key . ' is not a string');
 			}
 			if (!is_string($value)) {
-				throw new InvalidObjectExeption('Object is invalid, value ' . $value . ' is not a string');
+				throw new InvalidObjectExeption('Object for placeholder ' . $placeholder . ' is invalid, value ' . $value . ' for key ' . $key . ' is not a string');
 			}
 		}
 	}

--- a/tests/lib/RichObjectStrings/ValidatorTest.php
+++ b/tests/lib/RichObjectStrings/ValidatorTest.php
@@ -39,7 +39,7 @@ class ValidatorTest extends TestCase {
 
 		$this->expectException(InvalidObjectExeption::class);
 
-		$this->expectExceptionMessage('Object is invalid, value 123 is not a string');
+		$this->expectExceptionMessage('Object for placeholder string1 is invalid, value 123 for key key is not a string');
 		$v->validate('test {string1} test.', [
 			'string1' => [
 				'type' => 'user',
@@ -49,7 +49,7 @@ class ValidatorTest extends TestCase {
 			],
 		]);
 
-		$this->expectExceptionMessage('Object is invalid, key 456 is not a string');
+		$this->expectExceptionMessage('Object for placeholder string1 is invalid, key 456 is not a string');
 		$v->validate('test {string1} test.', [
 			'string1' => [
 				'type' => 'user',


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Makes it easier to figure what exactly is wrong, given that only the value was currently logged and this was not enough to properly debug it even with an available stacktrace.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
