### PR TITLE
Fix download multiple files path

### DIFF
--- a/apps/files/src/actions/downloadAction.ts
+++ b/apps/files/src/actions/downloadAction.ts
@@ -55,10 +55,10 @@ const downloadNodes = function(nodes: Node[]) {
 			url.searchParams.append('accept', 'zip')
 		}
 	} else {
-		url = new URL(nodes[0].source)
+		url = new URL(nodes[0].encodedSource)
 		let base = url.pathname
 		for (const node of nodes.slice(1)) {
-			base = longestCommonPath(base, (new URL(node.source).pathname))
+			base = longestCommonPath(base, (new URL(node.encodedSource).pathname))
 		}
 		url.pathname = base
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Hello, with the release 31.0.0 of nextcloud, we got a 404 error while downloading multiple files in a zip archive from a directory containing the ':' character in its name. It seems to be related to the function "downloadNodes". The url.pathname is computed using node.source and later it is used to compute the path of files that uses node.encodedSource.
When the ':' character is present in the string, this causes a wrong substring computation of the file name.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
