### PR TITLE
fix: resolve typo in authMethod enum cases

### DIFF
--- a/apps/webhook_listeners/lib/Controller/WebhooksController.php
+++ b/apps/webhook_listeners/lib/Controller/WebhooksController.php
@@ -110,7 +110,7 @@ class WebhooksController extends OCSController {
 	 * @param ?array<string,mixed> $eventFilter Mongo filter to apply to the serialized data to decide if firing
 	 * @param ?string $userIdFilter User id to filter on. The webhook will only be called by requests from this user. Empty or null means no filtering.
 	 * @param ?array<string,string> $headers Array of headers to send
-	 * @param "none"|"headers"|null $authMethod Authentication method to use
+	 * @param "none"|"header"|null $authMethod Authentication method to use
 	 * @param ?array<string,mixed> $authData Array of data for authentication
 	 *
 	 * @return DataResponse<Http::STATUS_OK, WebhookListenersWebhookInfo, array{}>
@@ -178,7 +178,7 @@ class WebhooksController extends OCSController {
 	 * @param ?array<string,mixed> $eventFilter Mongo filter to apply to the serialized data to decide if firing
 	 * @param ?string $userIdFilter User id to filter on. The webhook will only be called by requests from this user. Empty or null means no filtering.
 	 * @param ?array<string,string> $headers Array of headers to send
-	 * @param "none"|"headers"|null $authMethod Authentication method to use
+	 * @param "none"|"header"|null $authMethod Authentication method to use
 	 * @param ?array<string,mixed> $authData Array of data for authentication
 	 *
 	 * @return DataResponse<Http::STATUS_OK, WebhookListenersWebhookInfo, array{}>

--- a/apps/webhook_listeners/openapi.json
+++ b/apps/webhook_listeners/openapi.json
@@ -236,7 +236,7 @@
                                         "nullable": true,
                                         "enum": [
                                             "none",
-                                            "headers"
+                                            "header"
                                         ],
                                         "description": "Authentication method to use"
                                     },
@@ -519,7 +519,7 @@
                                         "nullable": true,
                                         "enum": [
                                             "none",
-                                            "headers"
+                                            "header"
                                         ],
                                         "description": "Authentication method to use"
                                     },


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

We just worked with Nextcloud webhooks. We noticed that the OpenAPI specification defines the `authMethod` which uses headers for authentication as `headers`. This seems to be a typo in both the OpenAPI spec as well as the docblocks inside the code itself. The `AuthMethod` enum itself defines the cases `Header` and `None`, which map to `header` (singular) and `none` respectively.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
