### PR TITLE
fix(dav): do not require CSRF for safe and indempotent HTTP methods

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -118,8 +118,9 @@ class Auth extends AbstractBasic {
 	 * Checks whether a CSRF check is required on the request
 	 */
 	private function requiresCSRFCheck(): bool {
-		// GET requires no check at all
-		if ($this->request->getMethod() === 'GET') {
+		
+		$methodsWithoutCsrf = ['GET', 'HEAD', 'OPTIONS'];
+		if (in_array($this->request->getMethod(), $methodsWithoutCsrf)) {
 			return false;
 		}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/18856

## Summary
Safe methods (and idempotent) do not need CSRF protection - especially as HEAD is basically a GET without a body.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
