### PR TITLE
refactor(account-management): Separate group views from internal views

### DIFF
--- a/apps/settings/src/components/GroupListItem.vue
+++ b/apps/settings/src/components/GroupListItem.vue
@@ -29,9 +29,9 @@
 		</NcModal>
 
 		<NcAppNavigationItem :key="id"
-			:exact="true"
+			exact
 			:name="name"
-			:to="{ name: 'group', params: { selectedGroup: encodeURIComponent(id) } }"
+			:to="{ name: 'group', params: { view: 'group', selectedGroup: encodeURIComponent(id) } }"
 			:loading="loadingRenameGroup"
 			:menu-open="openGroupMenu"
 			@update:menuOpen="handleGroupMenuOpen">
@@ -45,7 +45,7 @@
 				</NcCounterBubble>
 			</template>
 			<template #actions>
-				<NcActionInput v-if="id !== 'admin' && id !== 'disabled' && (settings.isAdmin || settings.isDelegatedAdmin)"
+				<NcActionInput v-if="settings.isAdmin || settings.isDelegatedAdmin"
 					ref="displayNameInput"
 					:trailing-button-label="t('settings', 'Submit')"
 					type="text"
@@ -56,7 +56,7 @@
 						<Pencil :size="20" />
 					</template>
 				</NcActionInput>
-				<NcActionButton v-if="id !== 'admin' && id !== 'disabled' && (settings.isAdmin || settings.isDelegatedAdmin)"
+				<NcActionButton v-if="settings.isAdmin || settings.isDelegatedAdmin"
 					@click="showRemoveGroupModal = true">
 					<template #icon>
 						<Delete :size="20" />

--- a/apps/settings/src/router/index.ts
+++ b/apps/settings/src/router/index.ts
@@ -19,4 +19,23 @@ const router = new Router({
 	routes,
 })
 
+const ALL_VIEWS = [
+	'all',
+	'disabled',
+	'group',
+	'recent',
+]
+
+router.beforeEach((to, from, next) => {
+	// make sure old URLs without the `/group/` part keep working
+	if (to.name === 'users-view' && !ALL_VIEWS.includes(to.params.view)) {
+		return next({ name: 'group', params: { selectedGroup: to.params.view } })
+	}
+	// if there is no group selected redirect to all accounts
+	if (to.name === 'users-view' && to.params.view === 'group' && !to.params.selectedGroup) {
+		return next({ name: 'users-view', params: { view: 'all' } })
+	}
+	next()
+})
+
 export default router

--- a/apps/settings/src/router/routes.ts
+++ b/apps/settings/src/router/routes.ts
@@ -24,10 +24,22 @@ const routes: RouteConfig[] = [
 			navigation: UserManagementNavigation,
 		},
 		props: true,
+
+		redirect: {
+			name: 'users-view',
+			params: {
+				view: 'all',
+			},
+		},
+
 		children: [
 			{
-				path: ':selectedGroup',
+				path: ':view(group)/:selectedGroup',
 				name: 'group',
+			},
+			{
+				path: ':view',
+				name: 'users-view',
 			},
 		],
 	},

--- a/apps/settings/src/store/users.js
+++ b/apps/settings/src/store/users.js
@@ -338,12 +338,18 @@ const actions = {
 	 * @param {string} options.group Get users from group
 	 * @return {Promise}
 	 */
-	getUsers(context, { offset, limit, search, group }) {
+	getUsers(context, options) {
+		let { offset, limit, search, group } = {
+			offset: context.getters.getUsersOffset,
+			limit: context.getters.getUsersLimit,
+			search: '',
+			...options,
+		}
+
 		if (searchRequestCancelSource) {
 			searchRequestCancelSource.cancel('Operation canceled by another search request.')
 		}
 		searchRequestCancelSource = CancelToken.source()
-		search = typeof search === 'string' ? search : ''
 
 		/**
 		 * Adding filters in the search bar such as in:files, in:users, etc.
@@ -398,7 +404,12 @@ const actions = {
 	 * @param {string} options.search Search query
 	 * @return {Promise<number>}
 	 */
-	async getRecentUsers(context, { offset, limit, search }) {
+	async getRecentUsers(context, options) {
+		const { offset, limit, search } = {
+			limit: context.getters.getUsersLimit,
+			offset: context.getters.getUsersOffset,
+			...options,
+		}
 		const url = generateOcsUrl('cloud/users/recent?offset={offset}&limit={limit}&search={search}', { offset, limit, search })
 		try {
 			const response = await api.get(url)
@@ -419,10 +430,16 @@ const actions = {
 	 * @param {object} options destructuring object
 	 * @param {number} options.offset List offset to request
 	 * @param {number} options.limit List number to return from offset
-	 * @param options.search
+	 * @param {string} options.search
 	 * @return {Promise<number>}
 	 */
-	async getDisabledUsers(context, { offset, limit, search }) {
+	async getDisabledUsers(context, options) {
+		const { offset, limit, search } = {
+			limit: context.getters.getDisabledUsersLimit,
+			offset: context.getters.getDisabledUsersOffset,
+			...options,
+		}
+
 		const url = generateOcsUrl('cloud/users/disabled?offset={offset}&limit={limit}&search={search}', { offset, limit, search })
 		try {
 			const response = await api.get(url)

--- a/apps/settings/src/views/UserManagement.vue
+++ b/apps/settings/src/views/UserManagement.vue
@@ -5,8 +5,9 @@
 
 <template>
 	<NcAppContent :page-heading="pageHeading">
-		<UserList :selected-group="selectedGroupDecoded"
-			:external-actions="externalActions" />
+		<UserList :external-actions="externalActions"
+			:selected-group="selectedGroupDecoded"
+			:view="currentView" />
 	</NcAppContent>
 </template>
 
@@ -34,15 +35,23 @@ export default defineComponent({
 	},
 
 	computed: {
+		currentView() {
+			return this.$route.params.view ?? 'all'
+		},
+
 		pageHeading() {
-			if (this.selectedGroupDecoded === null) {
+			if (this.currentView === 'all') {
 				return t('settings', 'All accounts')
+			} else if (this.currentView === 'recent') {
+				return t('settings', 'Recently active accounts')
+			} else if (this.currentView === 'disabled') {
+				return t('settings', 'Disabled acounts')
+			} else {
+				if (this.selectedGroupDecoded === 'admin') {
+					return t('settings', 'Admins')
+				}
+				return t('settings', 'Account group: {group}', { group: this.selectedGroupDecoded })
 			}
-			const matchHeading = {
-				admin: t('settings', 'Admins'),
-				disabled: t('settings', 'Disabled accounts'),
-			}
-			return matchHeading[this.selectedGroupDecoded] ?? t('settings', 'Account group: {group}', { group: this.selectedGroupDecoded })
 		},
 
 		selectedGroup() {

--- a/apps/settings/src/views/UserManagementNavigation.vue
+++ b/apps/settings/src/views/UserManagementNavigation.vue
@@ -16,15 +16,15 @@
 
 		<NcAppNavigationList class="account-management__system-list"
 			data-cy-users-settings-navigation-groups="system">
-			<NcAppNavigationItem id="everyone"
+			<NcAppNavigationItem id="view-all"
 				:exact="true"
 				:name="t('settings', 'All accounts')"
-				:to="{ name: 'users' }">
+				:to="{ name: 'users-view', params: { view: 'all' } }">
 				<template #icon>
 					<NcIconSvgWrapper :path="mdiAccount" />
 				</template>
 				<template #counter>
-					<NcCounterBubble v-if="userCount" :type="!selectedGroupDecoded ? 'highlighted' : undefined">
+					<NcCounterBubble v-if="userCount" :type="currentView === 'all' ? 'highlighted' : undefined">
 						{{ userCount }}
 					</NcCounterBubble>
 				</template>
@@ -32,9 +32,9 @@
 
 			<NcAppNavigationItem v-if="settings.isAdmin"
 				id="admin"
-				:exact="true"
+				exact
 				:name="t('settings', 'Admins')"
-				:to="{ name: 'group', params: { selectedGroup: 'admin' } }">
+				:to="{ name: 'group', params: { view: 'group', selectedGroup: 'admin' } }">
 				<template #icon>
 					<NcIconSvgWrapper :path="mdiShieldAccount" />
 				</template>
@@ -47,16 +47,16 @@
 			</NcAppNavigationItem>
 
 			<NcAppNavigationItem v-if="isAdminOrDelegatedAdmin"
-				id="recent"
+				id="view-recent"
 				:exact="true"
 				:name="t('settings', 'Recently active')"
-				:to="{ name: 'group', params: { selectedGroup: '__nc_internal_recent' } }">
+				:to="{ name: 'users-view', params: { view: 'recent' } }">
 				<template #icon>
 					<NcIconSvgWrapper :path="mdiHistory" />
 				</template>
 				<template #counter>
 					<NcCounterBubble v-if="recentGroup?.usercount"
-						:type="selectedGroupDecoded === '__nc_internal_recent' ? 'highlighted' : undefined">
+						:type="currentView === 'recent' ? 'highlighted' : undefined">
 						{{ recentGroup.usercount }}
 					</NcCounterBubble>
 				</template>
@@ -64,15 +64,15 @@
 
 			<!-- Hide the disabled if none, if we don't have the data (-1) show it -->
 			<NcAppNavigationItem v-if="disabledGroup && (disabledGroup.usercount > 0 || disabledGroup.usercount === -1)"
-				id="disabled"
+				id="view-disabled"
 				:exact="true"
 				:name="t('settings', 'Disabled accounts')"
-				:to="{ name: 'group', params: { selectedGroup: 'disabled' } }">
+				:to="{ name: 'users-view', params: { view: 'disabled' } }">
 				<template #icon>
 					<NcIconSvgWrapper :path="mdiAccountOff" />
 				</template>
 				<template v-if="disabledGroup.usercount > 0" #counter>
-					<NcCounterBubble :type="selectedGroupDecoded === 'disabled' ? 'highlighted' : undefined">
+					<NcCounterBubble :type="currentView === 'disabled' ? 'highlighted' : undefined">
 						{{ disabledGroup.usercount }}
 					</NcCounterBubble>
 				</template>
@@ -160,6 +160,8 @@ const store = useStore()
 
 /** State of the 'new-account' dialog */
 const isDialogOpen = ref(false)
+
+const currentView = computed(() => route.params.view ?? 'all')
 
 /** Current active group in the view - this is URL encoded */
 const selectedGroup = computed(() => route.params?.selectedGroup)


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/46776

## Summary

Some refactoring of the route handling for the account management. We separate internal views like *disabled* or *recent* accounts from group views like *admin* or *custom-group-id*.

The new URL looks like:
`/settings/users/VIEW(/GROUP)` for example a real group like `admin` has this new URL: `/settings/users/group/admin`.
While internal views like *recent* users look like: `/settings/users/recent`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
