### PR TITLE
feat(dav): validate and normalize email properties in CardDAV vCards

### DIFF
--- a/apps/dav/lib/CardDAV/Validation/CardDavValidatePlugin.php
+++ b/apps/dav/lib/CardDAV/Validation/CardDavValidatePlugin.php
@@ -63,11 +63,11 @@ class CardDavValidatePlugin extends ServerPlugin {
 
 		// Loop through all emails, validate. If needed trim email
 		foreach ($vCard->EMAIL as $email) {
-			$trimedEmail = trim((string)$email);
+			$trimedEmail = trim((string) $email);
 			if ($trimedEmail !== '' && !$mailer->validateMailAddress($trimedEmail)) {
 				throw new BadRequest('Invalid email in vCard');
 			}
-			if ($trimedEmail !== $email) {
+			if ($trimedEmail !== (string) $email) {
 				$vCard->remove($email);
 				$vCard->add('EMAIL', $trimedEmail, ['type' => $email['TYPE']]);
 			}

--- a/apps/dav/lib/CardDAV/Validation/CardDavValidatePlugin.php
+++ b/apps/dav/lib/CardDAV/Validation/CardDavValidatePlugin.php
@@ -63,11 +63,11 @@ class CardDavValidatePlugin extends ServerPlugin {
 
 		// Loop through all emails, validate. If needed trim email
 		foreach ($vCard->EMAIL as $email) {
-			$trimedEmail = trim((string) $email);
+			$trimedEmail = trim((string)$email);
 			if ($trimedEmail !== '' && !$mailer->validateMailAddress($trimedEmail)) {
 				throw new BadRequest('Invalid email in vCard');
 			}
-			if ($trimedEmail !== (string) $email) {
+			if ($trimedEmail !== (string)$email) {
 				$vCard->remove($email);
 				$vCard->add('EMAIL', $trimedEmail, ['type' => $email['TYPE']]);
 			}

--- a/apps/dav/tests/unit/CardDAV/Validation/CardDavValidatePluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/Validation/CardDavValidatePluginTest.php
@@ -72,7 +72,7 @@ class CardDavValidatePluginTest extends TestCase {
 	}
 
 	public function testPutNoEmail(): void {
-		$vcard = $this->getVCardWithEmail();
+		$vcard = $this->getVCardWithEmail('');
 
 		$this->request
 			->method('getBodyAsString')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves:

## Summary

Related to nextcloud/contacts#4379:

Complements nextcloud/contacts#4380 and nextcloud/contacts#4424 by validating and normalizing email properties at the CardDAV boundary, so clients that bypass the Contacts editor cannot persist malformed vCard email values.

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
