### PR TITLE
chore: drop outdated deprecation comment from Mailer

### DIFF
--- a/lib/private/Mail/Mailer.php
+++ b/lib/private/Mail/Mailer.php
@@ -232,9 +232,6 @@ class Mailer implements IMailer {
 	}
 
 	/**
-	 * @deprecated 26.0.0 Implicit validation is done in \OC\Mail\Message::setRecipients
-	 *                    via \Symfony\Component\Mime\Address::__construct
-	 *
 	 * @param string $email Email address to be validated
 	 * @return bool True if the mail address is valid, false otherwise
 	 */


### PR DESCRIPTION
* Leftover from https://github.com/nextcloud/server/commit/e123d270fcf099d780d8b35f9b7000c28b02fd5d

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
