### PR TITLE
Remove files and enrypted folders from "Move or copy" dialog window

### DIFF
--- a/apps/files/src/actions/moveOrCopyAction.ts
+++ b/apps/files/src/actions/moveOrCopyAction.ts
@@ -244,7 +244,8 @@ async function openFilePickerForAction(
 		.setFilter((n: Node) => {
 			// We only want to show folders in the file picker
 			// We don't want to show encrypted folders in the file picker
-			return !(n.attributes?.['type'] !== "directory" || n.attributes?.['is-encrypted'] === 1)
+			return n.type === FileType.File
+				&& n.attributes?.['is-encrypted'] !== 1
 		})
 		.setMimeTypeFilter([])
 		.setMultiSelect(false)

--- a/apps/files/src/actions/moveOrCopyAction.ts
+++ b/apps/files/src/actions/moveOrCopyAction.ts
@@ -241,6 +241,11 @@ async function openFilePickerForAction(
 			// We don't want to show the current nodes in the file picker
 			return !fileIDs.includes(n.fileid)
 		})
+		.setFilter((n: Node) => {
+			// We only want to show folders in the file picker
+			// We don't want to show encrypted folders in the file picker
+			return !(n.attributes?.['type'] !== "directory" || n.attributes?.['is-encrypted'] === 1)
+		})
 		.setMimeTypeFilter([])
 		.setMultiSelect(false)
 		.startAt(dir)


### PR DESCRIPTION
In the context of the "Move or copy file" dialog it doesn't make sense to show all other files in the list or encrypted folders. 
In order to improve clarity and usability, these should be filtered out.