### PR TITLE
fix(database): Cast users count to integer

### DIFF
--- a/lib/private/User/Database.php
+++ b/lib/private/User/Database.php
@@ -487,9 +487,12 @@ class Database extends ABackend implements
 		$query = $dbConn->getQueryBuilder();
 		$query->select($query->func()->count('uid'))
 			->from($this->table);
-		$result = $query->executeQuery();
+		$result = $query->executeQuery()->fetchOne();
+		if ($result === false) {
+			return false;
+		}
 
-		return $result->fetchOne();
+		return (int)$result;
 	}
 
 	/**

--- a/tests/lib/User/DatabaseTest.php
+++ b/tests/lib/User/DatabaseTest.php
@@ -25,6 +25,9 @@ class DatabaseTest extends Backend {
 	/** @var IEventDispatcher|MockObject */
 	private $eventDispatcher;
 
+	/** @var \OC\User\Database */
+	protected $backend;
+
 	public function getUser() {
 		$user = parent::getUser();
 		$this->users[] = $user;
@@ -138,5 +141,15 @@ class DatabaseTest extends Backend {
 
 		$result = $this->backend->getDisplayNames('@nextcloud.COM');
 		$this->assertCount(2, $result);
+	}
+
+	public function testUserCount(): void {
+		$base = $this->backend->countUsers() ?: 0;
+		$users = $this->backend->getUsers();
+		self::assertEquals($base, count($users));
+
+		$user = $this->getUser();
+		$this->backend->createUser($user, $user);
+		self::assertEquals($base + 1, $this->backend->countUsers());
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #51486 

`int` is required since https://github.com/nextcloud/server/pull/50171

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
