### PR TITLE
fix(dav): allow uploading of files with long filenames

### DIFF
--- a/build/integration/dav_features/dav-v2.feature
+++ b/build/integration/dav_features/dav-v2.feature
@@ -108,6 +108,24 @@ Feature: dav-v2
 		When User "user0" uploads file "data/textfile.txt" to "/testquota/asdf.txt"
 		Then the HTTP status code should be "201"
 
+	Scenario: Uploading a file with very long filename
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" has a quota of "10 MB"
+		And As an "user0"
+		When User "user0" uploads file "data/textfile.txt" to "/long-filename-with-250-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.txt"
+		Then the HTTP status code should be "201"
+
+	Scenario: Uploading a file with a too long filename
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And user "user0" has a quota of "10 MB"
+		And As an "user0"
+		When User "user0" uploads file "data/textfile.txt" to "/long-filename-with-251-characters-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.txt"
+		Then the HTTP status code should be "400"
+
 	Scenario: Create a search query on image
 		Given using new dav path
 		And As an "admin"
@@ -132,3 +150,14 @@ Feature: dav-v2
 		Then Favorite search should work
 		And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"
 
+	Scenario: Create a search query on favorite
+		Given using new dav path
+		And As an "admin"
+		And user "user0" exists
+		And As an "user0"
+		When User "user0" uploads file "data/green-square-256.png" to "/fav_image.png"
+		Then Favorite search should work
+		And the response should be empty
+		When user "user0" favorites element "/fav_image.png"
+		Then Favorite search should work
+		And the single response should contain a property "{http://owncloud.org/ns}favorite" with value "1"


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/24224
* Resolves https://github.com/nextcloud/server/issues/4046

## Summary
 A filename must be less or equal 255 characters, but when adding the
`.part` and `.ocfiletransfer` extensions we might overflow this limit.
So we should also use filename hashes for uploading when the file has a
long filename, similar like when we are uploading to the user storage directly.

## TODO

- [ ] discuss if it makes sense to align `oc_filecache.name`. Meaning to increase it from 250 to 255. cc @icewind1991 

## Tests

### Before
![Bildschirmfoto_20250315_135643](https://github.com/user-attachments/assets/a9b547f9-6c93-4868-a06d-0ac0fcb32d27)

### After
![Bildschirmfoto_20250315_135602](https://github.com/user-attachments/assets/6aa5a7f0-c3b0-4f91-85fa-ff3132637efe)


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
