### PR TITLE
fix(User\Manager): Only count currently enabled users when counting seen users

### DIFF
--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -190,12 +190,11 @@ interface IUserManager {
 	public function countDisabledUsers();
 
 	/**
-	 * returns how many users have logged in once
+	 * returns how many enabled users have logged in once
 	 *
-	 * @return int
 	 * @since 11.0.0
 	 */
-	public function countSeenUsers();
+	public function countSeenUsers(): int;
 
 	/**
 	 * @param \Closure $callback


### PR DESCRIPTION
## Summary

The `countSeenUsers()` method is used to count "active users" which currently also includes disabled users which is very counterintuitive.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
