### PR TITLE
fix(IMimeTypeDetector): use correct return type

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -23,7 +23,7 @@ class Detection implements IMimeTypeDetector {
 	private const CUSTOM_MIMETYPEMAPPING = 'mimetypemapping.json';
 	private const CUSTOM_MIMETYPEALIASES = 'mimetypealiases.json';
 
-	/** @var array<string, list{string, string|null}> */
+	/** @var array<list{string, string|null}> */
 	protected array $mimetypes = [];
 	protected array $secureMimeTypes = [];
 
@@ -140,7 +140,7 @@ class Detection implements IMimeTypeDetector {
 	}
 
 	/**
-	 * @return array<string, list{string, string|null}>
+	 * @return array<list{string, string|null}>
 	 */
 	public function getAllMappings(): array {
 		$this->loadMappings();

--- a/lib/public/Files/IMimeTypeDetector.php
+++ b/lib/public/Files/IMimeTypeDetector.php
@@ -75,7 +75,15 @@ interface IMimeTypeDetector {
 	public function getAllAliases(): array;
 
 	/**
-	 * @return array<string, list{string, string|null}>
+	 * Get all extension to MIME type mappings.
+	 *
+	 * The return format is an array of the file extension, as the key,
+	 * mapped to a list where the first entry is the MIME type
+	 * and the second entry is the secure MIME type (or null if none).
+	 * Due to PHP idiosyncrasies if a numeric string is set as the extension,
+	 * then also the array key (file extension) is a number instead of a string.
+	 *
+	 * @return array<list{string, string|null}>
 	 * @since 32.0.0
 	 */
 	public function getAllMappings(): array;


### PR DESCRIPTION
## Summary
In PHP array keys that are integers are always kept as integer, meaning the type of the key of `$a = ["1" => "one"]` will be integer not string.
While are hacks to circumvent this (case std object with string keys to an assoc. array) those hacks are performance wise awefull and also not needed as in PHP you can always access that element with `$a[1]` or `$a["1"]`.

So TL;DR;: do not lie about return types.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
