### PR TITLE
refactor(IMimeTypeDetector): use consistent capitalization

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2037,11 +2037,6 @@
       <code><![CDATA[!$isDefaultTemplates]]></code>
     </RedundantCondition>
   </file>
-  <file src="lib/private/Files/Type/Detection.php">
-    <ParamNameMismatch>
-      <code><![CDATA[$mimetype]]></code>
-    </ParamNameMismatch>
-  </file>
   <file src="lib/private/Files/View.php">
     <InvalidScalarArgument>
       <code><![CDATA[$mtime]]></code>

--- a/lib/public/Files/IMimeTypeDetector.php
+++ b/lib/public/Files/IMimeTypeDetector.php
@@ -14,11 +14,11 @@ namespace OCP\Files;
  * Interface IMimeTypeDetector
  * @since 8.2.0
  *
- * Interface to handle mimetypes (detection and icon retrieval)
+ * Interface to handle MIME type (detection and icon retrieval)
  **/
 interface IMimeTypeDetector {
 	/**
-	 * detect mimetype only based on filename, content of file is not used
+	 * Detect MIME type only based on filename, content of file is not used
 	 * @param string $path
 	 * @return string
 	 * @since 8.2.0
@@ -26,7 +26,7 @@ interface IMimeTypeDetector {
 	public function detectPath($path);
 
 	/**
-	 * detect mimetype only based on the content of file
+	 * Detect MIME type only based on the content of file
 	 * @param string $path
 	 * @return string
 	 * @since 18.0.0
@@ -34,7 +34,7 @@ interface IMimeTypeDetector {
 	public function detectContent(string $path): string;
 
 	/**
-	 * detect mimetype based on both filename and content
+	 * Detect MIME type based on both filename and content
 	 *
 	 * @param string $path
 	 * @return string
@@ -43,7 +43,7 @@ interface IMimeTypeDetector {
 	public function detect($path);
 
 	/**
-	 * Get a secure mimetype that won't expose potential XSS.
+	 * Get a secure MIME type that won't expose potential XSS.
 	 *
 	 * @param string $mimeType
 	 * @return string
@@ -52,7 +52,7 @@ interface IMimeTypeDetector {
 	public function getSecureMimeType($mimeType);
 
 	/**
-	 * detect mimetype based on the content of a string
+	 * Detect MIME type based on the content of a string
 	 *
 	 * @param string $data
 	 * @return string


### PR DESCRIPTION
* Follow up on https://github.com/nextcloud/server/pull/51564

## Summary
- use consistently `mimeType` as it is called MIME type
- fix issues where implementation and interface had different parameter names (this is an issue since PHP has named parameters).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
