### PR TITLE
feat(files): Add capability for clients to check WCF state

### DIFF
--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -16,6 +16,7 @@ return array(
     'OCA\\Files\\Activity\\Settings\\FileActivitySettings' => $baseDir . '/../lib/Activity/Settings/FileActivitySettings.php',
     'OCA\\Files\\Activity\\Settings\\FileChanged' => $baseDir . '/../lib/Activity/Settings/FileChanged.php',
     'OCA\\Files\\Activity\\Settings\\FileFavoriteChanged' => $baseDir . '/../lib/Activity/Settings/FileFavoriteChanged.php',
+    'OCA\\Files\\AdvancedCapabilities' => $baseDir . '/../lib/AdvancedCapabilities.php',
     'OCA\\Files\\App' => $baseDir . '/../lib/App.php',
     'OCA\\Files\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
     'OCA\\Files\\BackgroundJob\\CleanupDirectEditingTokens' => $baseDir . '/../lib/BackgroundJob/CleanupDirectEditingTokens.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -31,6 +31,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Activity\\Settings\\FileActivitySettings' => __DIR__ . '/..' . '/../lib/Activity/Settings/FileActivitySettings.php',
         'OCA\\Files\\Activity\\Settings\\FileChanged' => __DIR__ . '/..' . '/../lib/Activity/Settings/FileChanged.php',
         'OCA\\Files\\Activity\\Settings\\FileFavoriteChanged' => __DIR__ . '/..' . '/../lib/Activity/Settings/FileFavoriteChanged.php',
+        'OCA\\Files\\AdvancedCapabilities' => __DIR__ . '/..' . '/../lib/AdvancedCapabilities.php',
         'OCA\\Files\\App' => __DIR__ . '/..' . '/../lib/App.php',
         'OCA\\Files\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
         'OCA\\Files\\BackgroundJob\\CleanupDirectEditingTokens' => __DIR__ . '/..' . '/../lib/BackgroundJob/CleanupDirectEditingTokens.php',

--- a/apps/files/lib/AdvancedCapabilities.php
+++ b/apps/files/lib/AdvancedCapabilities.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files;
+
+use OCA\Files\Service\SettingsService;
+use OCP\Capabilities\ICapability;
+use OCP\Capabilities\IInitialStateExcludedCapability;
+
+/**
+ * Capabilities not needed for every request.
+ * This capabilities might be hard to compute or no used by the webui.
+ */
+class AdvancedCapabilities implements ICapability, IInitialStateExcludedCapability {
+
+	public function __construct(
+		protected SettingsService $service,
+	) {
+	}
+
+	/**
+	 * Return this classes capabilities
+	 *
+	 * @return array{files: array{'windows_compatible_filenames': bool}}
+	 */
+	public function getCapabilities(): array {
+		return [
+			'files' => [
+				'windows_compatible_filenames' => $this->service->hasFilesWindowsSupport(),
+			],
+		];
+	}
+}

--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Files\AppInfo;
 
 use Closure;
+use OCA\Files\AdvancedCapabilities;
 use OCA\Files\Capabilities;
 use OCA\Files\Collaboration\Resources\Listener;
 use OCA\Files\Collaboration\Resources\ResourceProvider;
@@ -107,6 +108,7 @@ class Application extends App implements IBootstrap {
 		 * Register capabilities
 		 */
 		$context->registerCapability(Capabilities::class);
+		$context->registerCapability(AdvancedCapabilities::class);
 		$context->registerCapability(DirectEditingCapabilities::class);
 
 		$context->registerDeclarativeSettings(DeclarativeAdminSettings::class);

--- a/apps/files/openapi.json
+++ b/apps/files/openapi.json
@@ -29,6 +29,7 @@
                     "files": {
                         "type": "object",
                         "required": [
+                            "windows_compatible_filenames",
                             "$comment",
                             "bigfilechunking",
                             "blacklisted_files",
@@ -41,6 +42,9 @@
                             "directEditing"
                         ],
                         "properties": {
+                            "windows_compatible_filenames": {
+                                "type": "boolean"
+                            },
                             "$comment": {
                                 "type": "string",
                                 "nullable": true

--- a/apps/files/tests/AdvancedCapabilitiesTest.php
+++ b/apps/files/tests/AdvancedCapabilitiesTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files;
+
+use OCA\Files\Service\SettingsService;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class AdvancedCapabilitiesTest extends TestCase {
+
+	protected SettingsService&MockObject $service;
+	protected AdvancedCapabilities $capabilities;
+
+	protected function setUp(): void {
+		$this->service = $this->createMock(SettingsService::class);
+		$this->capabilities = new AdvancedCapabilities($this->service);
+	}
+
+	/**
+	 * @dataProvider dataGetCapabilities
+	 */
+	public function testGetCapabilities(bool $wcf): void {
+		$this->service
+			->expects(self::once())
+			->method('hasFilesWindowsSupport')
+			->willReturn($wcf);
+
+		self::assertEqualsCanonicalizing(['files' => [ 'windows_compatible_filenames' => $wcf ]], $this->capabilities->getCapabilities());
+	}
+
+	public static function dataGetCapabilities(): array {
+		return [
+			'WCF enabled' => [
+				true,
+			],
+			'WCF disabled' => [
+				false,
+			],
+		];
+	}
+}


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/51525

## Summary
This adds a non-initial-state capability for the
windows-compatibile-filenames feature.
It is not required by the webui and it might have performance impacts (always compares system config against windows presets), so it is not included in every page load, but instead for querying from the clients.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
