### PR TITLE
fix(dav): throw invalid argument when property type does not match

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -422,10 +422,16 @@ class FileSearchBackend implements ISearchBackend {
 					$field = $this->mapPropertyNameToColumn($property);
 				}
 
+				try {
+					$castedValue = $this->castValue($property, $value ?? '');
+				} catch (\Error $e) {
+					throw new \InvalidArgumentException('Invalid property value for ' . $property->name, previous: $e);
+				}
+
 				return new SearchComparison(
 					$trimmedType,
 					$field,
-					$this->castValue($property, $value ?? ''),
+					$castedValue,
 					$extra ?? ''
 				);
 


### PR DESCRIPTION
## Summary
* Resolves https://github.com/nextcloud/server/issues/49972

Currently a TypeError is thrown when casting fails, this lead to a HTTP 500 error. Instead throw a proper InvalidArgumentError so the user receives a HTTP 400.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
