### PR TITLE
fix(occ): Suppress errors when checking config.php fileowner

### DIFF
--- a/occ
+++ b/occ
@@ -17,7 +17,7 @@ function dropPrivileges(): void {
 	}
 
 	$configPath = __DIR__ . '/config/config.php';
-	$uid = fileowner($configPath);
+	$uid = @fileowner($configPath);
 	if ($uid === false) {
 		return;
 	}


### PR DESCRIPTION
## Summary

In a docker container of mine I've seen that I'm unable to install since https://github.com/nextcloud/server/pull/33545:

```
+ ./occ maintenance:install --admin-pass admin --admin-email admin@example.com

Warning: fileowner(): stat failed for /usr/src/nextcloud/config/config.php in /usr/src/nextcloud/occ on line 20
An unhandled exception has been thrown:
Exception: Config file has leading content, please remove everything before "<?php" in apcu.config.php in /usr/src/nextcloud/lib/private/Config.php:222
Stack trace:
#0 /usr/src/nextcloud/lib/private/Config.php(40): OC\Config->readData()
#1 /usr/src/nextcloud/lib/base.php(94): OC\Config->__construct('/usr/src/nextcl...')
#2 /usr/src/nextcloud/lib/base.php(615): OC::initPaths()
#3 /usr/src/nextcloud/lib/base.php(1156): OC::init()
#4 /usr/src/nextcloud/console.php(28): require_once('/usr/src/nextcl...')
#5 /usr/src/nextcloud/occ(33): require_once('/usr/src/nextcl...')
#6 {main}
```

I have never seen it fail locally, but I have seen a few times that if something goes wrong in occ, odd errors are thrown down the line.
I tried this patch in the docker container and it makes it successfully install again.
I'm quite surprised, that I didn't find any reports about this issue in the server or docker repos.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
