### PR TITLE
feat: Limit `ExpireTrash` job to 30 minutes

### DIFF
--- a/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
@@ -11,31 +11,31 @@ use OCA\Files_Trashbin\BackgroundJob\ExpireTrash;
 use OCA\Files_Trashbin\Expiration;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ExpireTrashTest extends TestCase {
-	/** @var IConfig|MockObject */
-	private $config;
+	/** @var IAppConfig&MockObject */
+	private $appConfig;
 
-	/** @var IUserManager|MockObject */
+	/** @var IUserManager&MockObject */
 	private $userManager;
 
-	/** @var Expiration|MockObject */
+	/** @var Expiration&MockObject */
 	private $expiration;
 
-	/** @var IJobList|MockObject */
+	/** @var IJobList&MockObject */
 	private $jobList;
 
-	/** @var ITimeFactory|MockObject */
+	/** @var ITimeFactory&MockObject */
 	private $time;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->config = $this->createMock(IConfig::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->expiration = $this->createMock(Expiration::class);
 		$this->jobList = $this->createMock(IJobList::class);
@@ -51,22 +51,25 @@ class ExpireTrashTest extends TestCase {
 	}
 
 	public function testConstructAndRun(): void {
-		$this->config->method('getAppValue')
+		$this->appConfig->method('getValueString')
 			->with('files_trashbin', 'background_job_expire_trash', 'yes')
 			->willReturn('yes');
+		$this->appConfig->method('getValueInt')
+			->with('files_trashbin', 'background_job_expire_trash_offset', 0)
+			->willReturn(0);
 
-		$job = new ExpireTrash($this->config, $this->userManager, $this->expiration, $this->time);
+		$job = new ExpireTrash($this->appConfig, $this->userManager, $this->expiration, $this->time);
 		$job->start($this->jobList);
 	}
 
 	public function testBackgroundJobDeactivated(): void {
-		$this->config->method('getAppValue')
+		$this->appConfig->method('getValueString')
 			->with('files_trashbin', 'background_job_expire_trash', 'yes')
 			->willReturn('no');
 		$this->expiration->expects($this->never())
 			->method('getMaxAgeAsTimestamp');
 
-		$job = new ExpireTrash($this->config, $this->userManager, $this->expiration, $this->time);
+		$job = new ExpireTrash($this->appConfig, $this->userManager, $this->expiration, $this->time);
 		$job->start($this->jobList);
 	}
 }

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -628,30 +628,14 @@ class Manager extends PublicEmitter implements IUserManager {
 		return $result;
 	}
 
-	/**
-	 * @param \Closure $callback
-	 * @psalm-param \Closure(\OCP\IUser):?bool $callback
-	 * @since 11.0.0
-	 */
 	public function callForSeenUsers(\Closure $callback) {
-		$limit = 1000;
-		$offset = 0;
-		do {
-			$userIds = $this->getSeenUserIds($limit, $offset);
-			$offset += $limit;
-			foreach ($userIds as $userId) {
-				foreach ($this->backends as $backend) {
-					if ($backend->userExists($userId)) {
-						$user = $this->getUserObject($userId, $backend, false);
-						$return = $callback($user);
-						if ($return === false) {
-							return;
-						}
-						break;
-					}
-				}
+		$users = $this->getSeenUsers();
+		foreach ($users as $user) {
+			$return = $callback($user);
+			if ($return === false) {
+				return;
 			}
-		} while (count($userIds) >= $limit);
+		}
 	}
 
 	/**

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -827,4 +827,30 @@ class Manager extends PublicEmitter implements IUserManager {
 	public function getDisplayNameCache(): DisplayNameCache {
 		return $this->displayNameCache;
 	}
+
+	/**
+	 * Gets the list of users sorted by lastLogin, from most recent to least recent
+	 *
+	 * @param int $offset from which offset to fetch
+	 * @return \Iterator<IUser> list of user IDs
+	 * @since 30.0.0
+	 */
+	public function getSeenUsers(int $offset = 0): \Iterator {
+		$limit = 1000;
+
+		do {
+			$userIds = $this->getSeenUserIds($limit, $offset);
+			$offset += $limit;
+
+			foreach ($userIds as $userId) {
+				foreach ($this->backends as $backend) {
+					if ($backend->userExists($userId)) {
+						$user = $this->getUserObject($userId, $backend, false);
+						yield $user;
+						break;
+					}
+				}
+			}
+		} while (count($userIds) === $limit);
+	}
 }

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -231,4 +231,15 @@ interface IUserManager {
 	 * @since 30.0.0
 	 */
 	public function getLastLoggedInUsers(?int $limit = null, int $offset = 0, string $search = ''): array;
+
+	/**
+	 * Gets the list of users.
+	 * An iterator is returned allowing the caller to stop the iteration at any time.
+	 * The offset argument allows the caller to continue the iteration at a specific offset.
+	 *
+	 * @param int $offset from which offset to fetch
+	 * @return \Iterator<IUser> list of IUser object
+	 * @since 32.0.0
+	 */
+	public function getSeenUsers(int $offset = 0): \Iterator;
 }


### PR DESCRIPTION
1. feat: Implements `getSeenUsers` to iterate over users
2. chore: Refactor `callForSeenUsers` to use `getSeenUsers`
3. feat: Limit `ExpireTrash` job to 30 minutes