### PR TITLE
Add command to list orphan objects

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -50,6 +50,7 @@
 		<command>OCA\Files\Command\Object\Get</command>
 		<command>OCA\Files\Command\Object\Put</command>
 		<command>OCA\Files\Command\Object\Info</command>
+		<command>OCA\Files\Command\Object\ListObject</command>
 	</commands>
 
 	<settings>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -51,6 +51,7 @@
 		<command>OCA\Files\Command\Object\Put</command>
 		<command>OCA\Files\Command\Object\Info</command>
 		<command>OCA\Files\Command\Object\ListObject</command>
+		<command>OCA\Files\Command\Object\Orphans</command>
 	</commands>
 
 	<settings>

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -49,6 +49,7 @@
 		<command>OCA\Files\Command\Object\Delete</command>
 		<command>OCA\Files\Command\Object\Get</command>
 		<command>OCA\Files\Command\Object\Put</command>
+		<command>OCA\Files\Command\Object\Info</command>
 	</commands>
 
 	<settings>

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -35,6 +35,7 @@ return array(
     'OCA\\Files\\Command\\Move' => $baseDir . '/../lib/Command/Move.php',
     'OCA\\Files\\Command\\Object\\Delete' => $baseDir . '/../lib/Command/Object/Delete.php',
     'OCA\\Files\\Command\\Object\\Get' => $baseDir . '/../lib/Command/Object/Get.php',
+    'OCA\\Files\\Command\\Object\\Info' => $baseDir . '/../lib/Command/Object/Info.php',
     'OCA\\Files\\Command\\Object\\ObjectUtil' => $baseDir . '/../lib/Command/Object/ObjectUtil.php',
     'OCA\\Files\\Command\\Object\\Put' => $baseDir . '/../lib/Command/Object/Put.php',
     'OCA\\Files\\Command\\Put' => $baseDir . '/../lib/Command/Put.php',

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -38,6 +38,7 @@ return array(
     'OCA\\Files\\Command\\Object\\Info' => $baseDir . '/../lib/Command/Object/Info.php',
     'OCA\\Files\\Command\\Object\\ListObject' => $baseDir . '/../lib/Command/Object/ListObject.php',
     'OCA\\Files\\Command\\Object\\ObjectUtil' => $baseDir . '/../lib/Command/Object/ObjectUtil.php',
+    'OCA\\Files\\Command\\Object\\Orphans' => $baseDir . '/../lib/Command/Object/Orphans.php',
     'OCA\\Files\\Command\\Object\\Put' => $baseDir . '/../lib/Command/Object/Put.php',
     'OCA\\Files\\Command\\Put' => $baseDir . '/../lib/Command/Put.php',
     'OCA\\Files\\Command\\RepairTree' => $baseDir . '/../lib/Command/RepairTree.php',

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -36,6 +36,7 @@ return array(
     'OCA\\Files\\Command\\Object\\Delete' => $baseDir . '/../lib/Command/Object/Delete.php',
     'OCA\\Files\\Command\\Object\\Get' => $baseDir . '/../lib/Command/Object/Get.php',
     'OCA\\Files\\Command\\Object\\Info' => $baseDir . '/../lib/Command/Object/Info.php',
+    'OCA\\Files\\Command\\Object\\ListObject' => $baseDir . '/../lib/Command/Object/ListObject.php',
     'OCA\\Files\\Command\\Object\\ObjectUtil' => $baseDir . '/../lib/Command/Object/ObjectUtil.php',
     'OCA\\Files\\Command\\Object\\Put' => $baseDir . '/../lib/Command/Object/Put.php',
     'OCA\\Files\\Command\\Put' => $baseDir . '/../lib/Command/Put.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -51,6 +51,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Command\\Object\\Delete' => __DIR__ . '/..' . '/../lib/Command/Object/Delete.php',
         'OCA\\Files\\Command\\Object\\Get' => __DIR__ . '/..' . '/../lib/Command/Object/Get.php',
         'OCA\\Files\\Command\\Object\\Info' => __DIR__ . '/..' . '/../lib/Command/Object/Info.php',
+        'OCA\\Files\\Command\\Object\\ListObject' => __DIR__ . '/..' . '/../lib/Command/Object/ListObject.php',
         'OCA\\Files\\Command\\Object\\ObjectUtil' => __DIR__ . '/..' . '/../lib/Command/Object/ObjectUtil.php',
         'OCA\\Files\\Command\\Object\\Put' => __DIR__ . '/..' . '/../lib/Command/Object/Put.php',
         'OCA\\Files\\Command\\Put' => __DIR__ . '/..' . '/../lib/Command/Put.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -53,6 +53,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Command\\Object\\Info' => __DIR__ . '/..' . '/../lib/Command/Object/Info.php',
         'OCA\\Files\\Command\\Object\\ListObject' => __DIR__ . '/..' . '/../lib/Command/Object/ListObject.php',
         'OCA\\Files\\Command\\Object\\ObjectUtil' => __DIR__ . '/..' . '/../lib/Command/Object/ObjectUtil.php',
+        'OCA\\Files\\Command\\Object\\Orphans' => __DIR__ . '/..' . '/../lib/Command/Object/Orphans.php',
         'OCA\\Files\\Command\\Object\\Put' => __DIR__ . '/..' . '/../lib/Command/Object/Put.php',
         'OCA\\Files\\Command\\Put' => __DIR__ . '/..' . '/../lib/Command/Put.php',
         'OCA\\Files\\Command\\RepairTree' => __DIR__ . '/..' . '/../lib/Command/RepairTree.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -50,6 +50,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\Command\\Move' => __DIR__ . '/..' . '/../lib/Command/Move.php',
         'OCA\\Files\\Command\\Object\\Delete' => __DIR__ . '/..' . '/../lib/Command/Object/Delete.php',
         'OCA\\Files\\Command\\Object\\Get' => __DIR__ . '/..' . '/../lib/Command/Object/Get.php',
+        'OCA\\Files\\Command\\Object\\Info' => __DIR__ . '/..' . '/../lib/Command/Object/Info.php',
         'OCA\\Files\\Command\\Object\\ObjectUtil' => __DIR__ . '/..' . '/../lib/Command/Object/ObjectUtil.php',
         'OCA\\Files\\Command\\Object\\Put' => __DIR__ . '/..' . '/../lib/Command/Object/Put.php',
         'OCA\\Files\\Command\\Put' => __DIR__ . '/..' . '/../lib/Command/Put.php',

--- a/apps/files/lib/Command/Object/Info.php
+++ b/apps/files/lib/Command/Object/Info.php
@@ -11,6 +11,7 @@ namespace OCA\Files\Command\Object;
 use OC\Core\Command\Base;
 use OCP\Files\IMimeTypeDetector;
 use OCP\Files\ObjectStore\IObjectStoreMetaData;
+use OCP\Util;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -59,7 +60,7 @@ class Info extends Base {
 		}
 
 		if ($input->getOption('output') === 'plain' && isset($meta['size'])) {
-			$meta['size'] = \OC_Helper::humanFileSize($meta['size']);
+			$meta['size'] = Util::humanFileSize($meta['size']);
 		}
 		if (isset($meta['mtime'])) {
 			$meta['mtime'] = $meta['mtime']->format(\DateTimeImmutable::ATOM);

--- a/apps/files/lib/Command/Object/Info.php
+++ b/apps/files/lib/Command/Object/Info.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files\Command\Object;
+
+use OC\Core\Command\Base;
+use OCP\Files\IMimeTypeDetector;
+use OCP\Files\ObjectStore\IObjectStoreMetaData;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Info extends Base {
+	public function __construct(
+		private ObjectUtil $objectUtils,
+		private IMimeTypeDetector $mimeTypeDetector,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setName('files:object:info')
+			->setDescription('Get the metadata of an object')
+			->addArgument('object', InputArgument::REQUIRED, 'Object to get')
+			->addOption('bucket', 'b', InputOption::VALUE_REQUIRED, "Bucket to get the object from, only required in cases where it can't be determined from the config");
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$object = $input->getArgument('object');
+		$objectStore = $this->objectUtils->getObjectStore($input->getOption('bucket'), $output);
+		if (!$objectStore) {
+			return self::FAILURE;
+		}
+
+		if (!$objectStore instanceof IObjectStoreMetaData) {
+			$output->writeln('<error>Configured object store does currently not support retrieve metadata</error>');
+			return self::FAILURE;
+		}
+
+		if (!$objectStore->objectExists($object)) {
+			$output->writeln("<error>Object $object does not exist</error>");
+			return self::FAILURE;
+		}
+
+		try {
+			$meta = $objectStore->getObjectMetaData($object);
+		} catch (\Exception $e) {
+			$msg = $e->getMessage();
+			$output->writeln("<error>Failed to read $object from object store: $msg</error>");
+			return self::FAILURE;
+		}
+
+		if ($input->getOption('output') === 'plain' && isset($meta['size'])) {
+			$meta['size'] = \OC_Helper::humanFileSize($meta['size']);
+		}
+		if (isset($meta['mtime'])) {
+			$meta['mtime'] = $meta['mtime']->format(\DateTimeImmutable::ATOM);
+		}
+		if (!isset($meta['mimetype'])) {
+			$handle = $objectStore->readObject($object);
+			$head = fread($handle, 8192);
+			fclose($handle);
+			$meta['mimetype'] = $this->mimeTypeDetector->detectString($head);
+		}
+
+		$this->writeArrayInOutputFormat($input, $output, $meta);
+
+		return self::SUCCESS;
+	}
+
+}

--- a/apps/files/lib/Command/Object/ListObject.php
+++ b/apps/files/lib/Command/Object/ListObject.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files\Command\Object;
+
+use OC\Core\Command\Base;
+use OCP\Files\ObjectStore\IObjectStoreMetaData;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListObject extends Base {
+	private const CHUNK_SIZE = 100;
+
+	public function __construct(
+		private readonly ObjectUtil $objectUtils,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setName('files:object:list')
+			->setDescription('List all objects in the object store')
+			->addOption('bucket', 'b', InputOption::VALUE_REQUIRED, "Bucket to list the objects from, only required in cases where it can't be determined from the config");
+	}
+
+	public function execute(InputInterface $input, OutputInterface $output): int {
+		$objectStore = $this->objectUtils->getObjectStore($input->getOption('bucket'), $output);
+		if (!$objectStore) {
+			return self::FAILURE;
+		}
+
+		if (!$objectStore instanceof IObjectStoreMetaData) {
+			$output->writeln('<error>Configured object store does currently not support listing objects</error>');
+			return self::FAILURE;
+		}
+		$outputType = $input->getOption('output');
+		$humanOutput = $outputType === self::OUTPUT_FORMAT_PLAIN;
+
+		if (!$humanOutput) {
+			$output->writeln('[');
+		}
+		$objects = $objectStore->listObjects();
+		$first = true;
+
+		foreach ($this->chunkIterator($objects, self::CHUNK_SIZE) as $chunk) {
+			if ($outputType === self::OUTPUT_FORMAT_PLAIN) {
+				$this->outputChunk($input, $output, $chunk);
+			} else {
+				foreach ($chunk as $object) {
+					if (!$first) {
+						$output->writeln(',');
+					}
+					$row = $this->formatObject($object, $humanOutput);
+					if ($outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
+						$output->write(json_encode($row, JSON_PRETTY_PRINT));
+					} else {
+						$output->write(json_encode($row));
+					}
+					$first = false;
+				}
+			}
+		}
+
+		if (!$humanOutput) {
+			$output->writeln("\n]");
+		}
+
+		return self::SUCCESS;
+	}
+
+	private function formatObject(array $object, bool $humanOutput): array {
+		$row = array_merge([
+			'urn' => $object['urn'],
+		], ($object['metadata'] ?? []));
+
+		if ($humanOutput && isset($row['size'])) {
+			$row['size'] = \OC_Helper::humanFileSize($row['size']);
+		}
+		if (isset($row['mtime'])) {
+			$row['mtime'] = $row['mtime']->format(\DateTimeImmutable::ATOM);
+		}
+		return $row;
+	}
+
+	private function outputChunk(InputInterface $input, OutputInterface $output, iterable $chunk): void {
+		$result = [];
+		$humanOutput = $input->getOption('output') === "plain";
+
+		foreach ($chunk as $object) {
+			$result[] = $this->formatObject($object, $humanOutput);
+		}
+		$this->writeTableInOutputFormat($input, $output, $result);
+	}
+
+	function chunkIterator(\Iterator $iterator, int $count): \Iterator {
+		$chunk = [];
+
+		for($i = 0; $iterator->valid(); $i++){
+			$chunk[] = $iterator->current();
+			$iterator->next();
+			if(count($chunk) == $count){
+				yield $chunk;
+				$chunk = [];
+			}
+		}
+
+		if(count($chunk)){
+			yield $chunk;
+		}
+	}
+}

--- a/apps/files/lib/Command/Object/ListObject.php
+++ b/apps/files/lib/Command/Object/ListObject.php
@@ -42,7 +42,8 @@ class ListObject extends Base {
 			return self::FAILURE;
 		}
 		$objects = $objectStore->listObjects();
-		$this->objectUtils->writeIteratorToOutput($input, $output, $objects, self::CHUNK_SIZE);
+		$objects = $this->objectUtils->formatObjects($objects, $input->getOption('output') === self::OUTPUT_FORMAT_PLAIN);
+		$this->writeStreamingTableInOutputFormat($input, $output, $objects, self::CHUNK_SIZE);
 
 		return self::SUCCESS;
 	}

--- a/apps/files/lib/Command/Object/ObjectUtil.php
+++ b/apps/files/lib/Command/Object/ObjectUtil.php
@@ -8,13 +8,15 @@ declare(strict_types=1);
 
 namespace OCA\Files\Command\Object;
 
+use OC\Core\Command\Base;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ObjectUtil {
+class ObjectUtil extends Base {
 	public function __construct(
 		private IConfig $config,
 		private IDBConnection $connection,
@@ -90,5 +92,79 @@ class ObjectUtil {
 		}
 
 		return $fileId;
+	}
+
+	public function writeIteratorToOutput(InputInterface $input, OutputInterface $output, \Iterator $objects, int $chunkSize): void {
+		$outputType = $input->getOption('output');
+		$humanOutput = $outputType === Base::OUTPUT_FORMAT_PLAIN;
+		$first = true;
+
+		if (!$humanOutput) {
+			$output->writeln('[');
+		}
+
+		foreach ($this->chunkIterator($objects, $chunkSize) as $chunk) {
+			if ($outputType === Base::OUTPUT_FORMAT_PLAIN) {
+				$this->outputChunk($input, $output, $chunk);
+			} else {
+				foreach ($chunk as $object) {
+					if (!$first) {
+						$output->writeln(',');
+					}
+					$row = $this->formatObject($object, $humanOutput);
+					if ($outputType === Base::OUTPUT_FORMAT_JSON_PRETTY) {
+						$output->write(json_encode($row, JSON_PRETTY_PRINT));
+					} else {
+						$output->write(json_encode($row));
+					}
+					$first = false;
+				}
+			}
+		}
+
+		if (!$humanOutput) {
+			$output->writeln("\n]");
+		}
+	}
+
+	private function formatObject(array $object, bool $humanOutput): array {
+		$row = array_merge([
+			'urn' => $object['urn'],
+		], ($object['metadata'] ?? []));
+
+		if ($humanOutput && isset($row['size'])) {
+			$row['size'] = \OC_Helper::humanFileSize($row['size']);
+		}
+		if (isset($row['mtime'])) {
+			$row['mtime'] = $row['mtime']->format(\DateTimeImmutable::ATOM);
+		}
+		return $row;
+	}
+
+	private function outputChunk(InputInterface $input, OutputInterface $output, iterable $chunk): void {
+		$result = [];
+		$humanOutput = $input->getOption('output') === 'plain';
+
+		foreach ($chunk as $object) {
+			$result[] = $this->formatObject($object, $humanOutput);
+		}
+		$this->writeTableInOutputFormat($input, $output, $result);
+	}
+
+	public function chunkIterator(\Iterator $iterator, int $count): \Iterator {
+		$chunk = [];
+
+		for ($i = 0; $iterator->valid(); $i++) {
+			$chunk[] = $iterator->current();
+			$iterator->next();
+			if (count($chunk) == $count) {
+				yield $chunk;
+				$chunk = [];
+			}
+		}
+
+		if (count($chunk)) {
+			yield $chunk;
+		}
 	}
 }

--- a/apps/files/lib/Command/Object/Orphans.php
+++ b/apps/files/lib/Command/Object/Orphans.php
@@ -9,25 +9,35 @@ declare(strict_types=1);
 namespace OCA\Files\Command\Object;
 
 use OC\Core\Command\Base;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\ObjectStore\IObjectStoreMetaData;
+use OCP\IDBConnection;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ListObject extends Base {
+class Orphans extends Base {
 	private const CHUNK_SIZE = 100;
+
+	private IQueryBuilder $query;
 
 	public function __construct(
 		private readonly ObjectUtil $objectUtils,
+		IDBConnection $connection,
 	) {
 		parent::__construct();
+
+		$this->query = $connection->getQueryBuilder();
+		$this->query->select('fileid')
+			->from('filecache')
+			->where($this->query->expr()->eq('fileid', $this->query->createParameter('file_id')));
 	}
 
 	protected function configure(): void {
 		parent::configure();
 		$this
-			->setName('files:object:list')
-			->setDescription('List all objects in the object store')
+			->setName('files:object:orphans')
+			->setDescription('List all objects in the object store that don\'t have a matching entry in the database')
 			->addOption('bucket', 'b', InputOption::VALUE_REQUIRED, "Bucket to list the objects from, only required in cases where it can't be determined from the config");
 	}
 
@@ -41,9 +51,23 @@ class ListObject extends Base {
 			$output->writeln('<error>Configured object store does currently not support listing objects</error>');
 			return self::FAILURE;
 		}
-		$objects = $objectStore->listObjects();
-		$this->objectUtils->writeIteratorToOutput($input, $output, $objects, self::CHUNK_SIZE);
+		$prefixLength = strlen('urn:oid:');
+
+		$objects = $objectStore->listObjects('urn:oid:');
+		$objects->rewind();
+		$orphans = new \CallbackFilterIterator($objects, function (array $object) use ($prefixLength) {
+			$fileId = (int)substr($object['urn'], $prefixLength);
+			return !$this->fileIdInDb($fileId);
+		});
+		$orphans = new \ArrayIterator(iterator_to_array($orphans));
+		$this->objectUtils->writeIteratorToOutput($input, $output, $orphans, self::CHUNK_SIZE);
 
 		return self::SUCCESS;
+	}
+
+	private function fileIdInDb(int $fileId): bool {
+		$this->query->setParameter('file_id', $fileId, IQueryBuilder::PARAM_INT);
+		$result = $this->query->executeQuery();
+		return $result->fetchOne() !== false;
 	}
 }

--- a/apps/files/lib/Command/Object/Orphans.php
+++ b/apps/files/lib/Command/Object/Orphans.php
@@ -63,9 +63,9 @@ class Orphans extends Base {
 			$fileId = (int)substr($object['urn'], $prefixLength);
 			return !$this->fileIdInDb($fileId);
 		});
-		$orphans->rewind();
 
-		$this->objectUtils->writeIteratorToOutput($input, $output, $orphans, self::CHUNK_SIZE);
+		$orphans = $this->objectUtils->formatObjects($orphans, $input->getOption('output') === self::OUTPUT_FORMAT_PLAIN);
+		$this->writeStreamingTableInOutputFormat($input, $output, $orphans, self::CHUNK_SIZE);
 
 		return self::SUCCESS;
 	}

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -88,6 +88,58 @@ class Base extends Command implements CompletionAwareInterface {
 		}
 	}
 
+	protected function writeStreamingTableInOutputFormat(InputInterface $input, OutputInterface $output, \Iterator $items, int $tableGroupSize): void {
+		switch ($input->getOption('output')) {
+			case self::OUTPUT_FORMAT_JSON:
+			case self::OUTPUT_FORMAT_JSON_PRETTY:
+				$this->writeStreamingJsonArray($input, $output, $items);
+				break;
+			default:
+				foreach ($this->chunkIterator($items, $tableGroupSize) as $chunk) {
+					$this->writeTableInOutputFormat($input, $output, $chunk);
+				}
+				break;
+		}
+	}
+
+	protected function writeStreamingJsonArray(InputInterface $input, OutputInterface $output, \Iterator $items): void {
+		$first = true;
+		$outputType = $input->getOption('output');
+
+		$output->writeln('[');
+		foreach ($items as $item) {
+			if (!$first) {
+				$output->writeln(',');
+			}
+			if ($outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
+				$output->write(json_encode($item, JSON_PRETTY_PRINT));
+			} else {
+				$output->write(json_encode($item));
+			}
+			$first = false;
+		}
+		$output->writeln("\n]");
+	}
+
+	public function chunkIterator(\Iterator $iterator, int $count): \Iterator {
+		$chunk = [];
+
+		for ($i = 0; $iterator->valid(); $i++) {
+			$chunk[] = $iterator->current();
+			$iterator->next();
+			if (count($chunk) == $count) {
+				// Got a full chunk, yield and start a new one
+				yield $chunk;
+				$chunk = [];
+			}
+		}
+
+		if (count($chunk)) {
+			// Yield the last chunk even if incomplete
+			yield $chunk;
+		}
+	}
+
 
 	/**
 	 * @param mixed $item

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -456,6 +456,7 @@ return array(
     'OCP\\Files\\Notify\\INotifyHandler' => $baseDir . '/lib/public/Files/Notify/INotifyHandler.php',
     'OCP\\Files\\Notify\\IRenameChange' => $baseDir . '/lib/public/Files/Notify/IRenameChange.php',
     'OCP\\Files\\ObjectStore\\IObjectStore' => $baseDir . '/lib/public/Files/ObjectStore/IObjectStore.php',
+    'OCP\\Files\\ObjectStore\\IObjectStoreMetaData' => $baseDir . '/lib/public/Files/ObjectStore/IObjectStoreMetaData.php',
     'OCP\\Files\\ObjectStore\\IObjectStoreMultiPartUpload' => $baseDir . '/lib/public/Files/ObjectStore/IObjectStoreMultiPartUpload.php',
     'OCP\\Files\\ReservedWordException' => $baseDir . '/lib/public/Files/ReservedWordException.php',
     'OCP\\Files\\Search\\ISearchBinaryOperator' => $baseDir . '/lib/public/Files/Search/ISearchBinaryOperator.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -505,6 +505,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\Notify\\INotifyHandler' => __DIR__ . '/../../..' . '/lib/public/Files/Notify/INotifyHandler.php',
         'OCP\\Files\\Notify\\IRenameChange' => __DIR__ . '/../../..' . '/lib/public/Files/Notify/IRenameChange.php',
         'OCP\\Files\\ObjectStore\\IObjectStore' => __DIR__ . '/../../..' . '/lib/public/Files/ObjectStore/IObjectStore.php',
+        'OCP\\Files\\ObjectStore\\IObjectStoreMetaData' => __DIR__ . '/../../..' . '/lib/public/Files/ObjectStore/IObjectStoreMetaData.php',
         'OCP\\Files\\ObjectStore\\IObjectStoreMultiPartUpload' => __DIR__ . '/../../..' . '/lib/public/Files/ObjectStore/IObjectStoreMultiPartUpload.php',
         'OCP\\Files\\ReservedWordException' => __DIR__ . '/../../..' . '/lib/public/Files/ReservedWordException.php',
         'OCP\\Files\\Search\\ISearchBinaryOperator' => __DIR__ . '/../../..' . '/lib/public/Files/Search/ISearchBinaryOperator.php',

--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -118,8 +118,8 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload, IObjectStoreMetaD
 				foreach ($result['Contents'] as $object) {
 					yield [
 						'urn' => basename($object['Key']),
-						'meta' => [
-							'mtime' => strtotime($object['LastModified']),
+						'metadata' => [
+							'mtime' => $object['LastModified'],
 							'etag' => trim($object['ETag'], '"'),
 							'size' => (int)($object['Size'] ?? $object['ContentLength']),
 						],

--- a/lib/private/Files/ObjectStore/S3.php
+++ b/lib/private/Files/ObjectStore/S3.php
@@ -3,14 +3,16 @@
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OC\Files\ObjectStore;
 
 use Aws\Result;
 use Exception;
 use OCP\Files\ObjectStore\IObjectStore;
+use OCP\Files\ObjectStore\IObjectStoreMetaData;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
 
-class S3 implements IObjectStore, IObjectStoreMultiPartUpload {
+class S3 implements IObjectStore, IObjectStoreMultiPartUpload, IObjectStoreMetaData {
 	use S3ConnectionTrait;
 	use S3ObjectTrait;
 
@@ -61,7 +63,7 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload {
 				'Key' => $urn,
 				'UploadId' => $uploadId,
 				'MaxParts' => 1000,
-				'PartNumberMarker' => $partNumberMarker
+				'PartNumberMarker' => $partNumberMarker,
 			] + $this->getSSECParameters());
 			$parts = array_merge($parts, $result->get('Parts') ?? []);
 			$isTruncated = $result->get('IsTruncated');
@@ -89,7 +91,41 @@ class S3 implements IObjectStore, IObjectStoreMultiPartUpload {
 		$this->getConnection()->abortMultipartUpload([
 			'Bucket' => $this->bucket,
 			'Key' => $urn,
-			'UploadId' => $uploadId
+			'UploadId' => $uploadId,
 		]);
+	}
+
+	public function getObjectMetaData(string $urn): array {
+		$object = $this->getConnection()->headObject([
+			'Bucket' => $this->bucket,
+			'Key' => $urn
+		] + $this->getSSECParameters())->toArray();
+		return [
+			'mtime' => $object['LastModified'],
+			'etag' => trim($object['ETag'], '"'),
+			'size' => (int)($object['Size'] ?? $object['ContentLength']),
+		];
+	}
+
+	public function listObjects(string $prefix = ''): \Iterator {
+		$results = $this->getConnection()->getPaginator('ListObjectsV2', [
+			'Bucket' => $this->bucket,
+			'Prefix' => $prefix,
+		] + $this->getSSECParameters());
+
+		foreach ($results as $result) {
+			if (is_array($result['Contents'])) {
+				foreach ($result['Contents'] as $object) {
+					yield [
+						'urn' => basename($object['Key']),
+						'meta' => [
+							'mtime' => strtotime($object['LastModified']),
+							'etag' => trim($object['ETag'], '"'),
+							'size' => (int)($object['Size'] ?? $object['ContentLength']),
+						],
+					];
+				}
+			}
+		}
 	}
 }

--- a/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
+++ b/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OCP\Files\ObjectStore;
+
+/**
+ * Interface IObjectStoreMetaData
+ *
+ * @psalm-type ObjectMetaData = array{mtime?: \DateTime, etag?: string, size?: int, mimetype?: string, filename?: string}
+ *
+ * @since 32.0.0
+ */
+interface IObjectStoreMetaData {
+	/**
+	 * Get metadata for an object.
+	 *
+	 * @param string $urn
+	 * @return ObjectMetaData
+	 *
+	 * @since 32.0.0
+	 */
+	public function getObjectMetaData(string $urn): array;
+
+	/**
+	 * List all objects in the object store.
+	 *
+	 * If the object store implementation can do it efficiently, the metadata for each object is also included.
+	 *
+	 * @param string $prefix
+	 * @return \Iterator<array{urn: string, meta: ?ObjectMetaData}>
+	 */
+	public function listObjects(string $prefix = ''): \Iterator;
+}

--- a/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
+++ b/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
@@ -30,7 +30,9 @@ interface IObjectStoreMetaData {
 	 * If the object store implementation can do it efficiently, the metadata for each object is also included.
 	 *
 	 * @param string $prefix
-	 * @return \Iterator<array{urn: string, meta: ?ObjectMetaData}>
+	 * @return \Iterator<array{urn: string, metadata: ?ObjectMetaData}>
+	 *
+	 * @since 32.0.0
 	 */
 	public function listObjects(string $prefix = ''): \Iterator;
 }


### PR DESCRIPTION
Adds the following commands:

- `occ files:object:info <object id>` get metadata from an object
- `occ files:object:list` list all objects
- `occ files:object:orphans` list all objects not referenced in the database

Only implemented for S3 at the moment