### PR TITLE
fix(Quota): throw NotEnoughSpaceException if file quota exceeded

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -11,6 +11,7 @@ use OC\Files\Filesystem;
 use OC\SystemConfig;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\FileInfo;
+use OCP\Files\NotEnoughSpaceException;
 use OCP\Files\Storage\IStorage;
 
 class Quota extends Wrapper {
@@ -180,7 +181,7 @@ class Quota extends Wrapper {
 		}
 		$free = $this->free_space($path);
 		if ($this->shouldApplyQuota($path) && $free == 0) {
-			return false;
+			throw new NotEnoughSpaceException('Unable to create directory (' . $path . '): not enough free space');
 		}
 
 		return parent::mkdir($path);

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -10,6 +10,7 @@ namespace Test\Files\Storage\Wrapper;
 //ensure the constants are loaded
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\Local;
+use OCP\Files\NotEnoughSpaceException;
 
 \OC::$loader->load('\OC\Files\Filesystem');
 
@@ -211,7 +212,8 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 	public function testNoMkdirQuotaZero(): void {
 		$instance = $this->getLimitedStorage(0.0);
 		$this->assertFalse($instance->mkdir('files'));
-		$this->assertFalse($instance->mkdir('files/foobar'));
+		$this->expectException(NotEnoughSpaceException::class);
+		$instance->mkdir('files/foobar');
 	}
 
 	public function testMkdirQuotaZeroTrashbin(): void {


### PR DESCRIPTION
## Summary

Throw `NotEnoughSpaceException` with a more descriptive error message rather than `return false` for mkdir operation, fixing HTTP MKCOL requests to `remote.php/dav/files/<user>/<folder>` that return a generic "internal server error" message.

## TODO

- [ ] Apply `throw new NotEnoughSpaceException` to remaining file operations after testing.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
