### PR TITLE
fix(files_versions): only handle path updates when there is path

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -332,11 +332,19 @@ class FileEventsListener implements IEventListener {
 			return;
 		}
 
-		// if we rename a movable mount point, then the versions don't have
-		// to be renamed
+		// if we rename a movable mount point, then the versions don't have to be renamed
 		$oldPath = $this->getPathForNode($source);
 		$newPath = $this->getPathForNode($target);
-		$absOldPath = Filesystem::normalizePath('/' . \OC_User::getUser() . '/files' . $oldPath);
+		if ($oldPath === null || $newPath === null) {
+			return;
+		}
+
+		$user = $this->userSession->getUser()?->getUID();
+		if ($user === null) {
+			return;
+		}
+
+		$absOldPath = Filesystem::normalizePath('/' . $user . '/files' . $oldPath);
 		$manager = Filesystem::getMountManager();
 		$mount = $manager->find($absOldPath);
 		$internalPath = $mount->getInternalPath($absOldPath);
@@ -344,7 +352,7 @@ class FileEventsListener implements IEventListener {
 			return;
 		}
 
-		$view = new View(\OC_User::getUser() . '/files');
+		$view = new View($user . '/files');
 		if ($view->file_exists($newPath)) {
 			Storage::store($newPath);
 		} else {


### PR DESCRIPTION
## Summary
`getPathForNode` can fail with null for various reasons (e.g. no owner), in this cases we need to just skip the event handling.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
