### PR TITLE
fix(ocm): `publicKey` can be disabled so capabilities do not match

### DIFF
--- a/apps/cloud_federation_api/lib/Capabilities.php
+++ b/apps/cloud_federation_api/lib/Capabilities.php
@@ -38,7 +38,7 @@ class Capabilities implements ICapability {
 	 *     	   apiVersion: '1.0-proposal1',
 	 *         enabled: bool,
 	 *         endPoint: string,
-	 *         publicKey: array{
+	 *         publicKey?: array{
 	 *             keyId: string,
 	 *             publicKeyPem: string,
 	 *         },

--- a/apps/cloud_federation_api/openapi.json
+++ b/apps/cloud_federation_api/openapi.json
@@ -46,7 +46,6 @@
                             "apiVersion",
                             "enabled",
                             "endPoint",
-                            "publicKey",
                             "resourceTypes",
                             "version"
                         ],

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -213,7 +213,7 @@ class OCMProvider implements IOCMProvider {
 	 *      enabled: bool,
 	 *      apiVersion: '1.0-proposal1',
 	 *      endPoint: string,
-	 *      publicKey: array{
+	 *      publicKey?: array{
 	 *          keyId: string,
 	 *          publicKeyPem: string
 	 *      },
@@ -236,7 +236,7 @@ class OCMProvider implements IOCMProvider {
 			'apiVersion' => '1.0-proposal1', // deprecated, but keep it to stay compatible with old version
 			'version' => $this->getApiVersion(), // informative but real version
 			'endPoint' => $this->getEndPoint(),
-			'publicKey' => $this->getSignatory()->jsonSerialize(),
+			'publicKey' => $this->getSignatory()?->jsonSerialize(),
 			'resourceTypes' => $resourceTypes
 		];
 	}

--- a/lib/public/OCM/IOCMProvider.php
+++ b/lib/public/OCM/IOCMProvider.php
@@ -151,7 +151,7 @@ interface IOCMProvider extends JsonSerializable {
 	 *     enabled: bool,
 	 *     apiVersion: '1.0-proposal1',
 	 *     endPoint: string,
-	 *     publicKey: array{
+	 *     publicKey?: array{
 	 *         keyId: string,
 	 *         publicKeyPem: string
 	 *	   },


### PR DESCRIPTION
## Summary
When the public key feature is disabled null is returned for `publicKey`. So in this case we need to adjust the capabilities and return type of `jsonSerialize()`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
