### PR TITLE
fix(systemtags): Dispatch events when bulk assigning system tags

### DIFF
--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -284,6 +284,9 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 	 * {@inheritdoc}
 	 */
 	public function setObjectIdsForTag(string $tagId, string $objectType, array $objectIds): void {
+		$currentObjectIds = $this->getObjectIdsForTags($tagId, $objectType);
+		$removedObjectIds = array_diff($currentObjectIds, $objectIds);
+		$addedObjectIds = array_diff($objectIds, $currentObjectIds);
 		$this->connection->beginTransaction();
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::RELATION_TABLE)
@@ -291,6 +294,15 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 			->andWhere($query->expr()->eq('objecttype', $query->createNamedParameter($objectType)))
 			->executeStatement();
 		$this->connection->commit();
+
+		foreach ($removedObjectIds as $objectId) {
+			$this->dispatcher->dispatch(MapperEvent::EVENT_UNASSIGN, new MapperEvent(
+				MapperEvent::EVENT_UNASSIGN,
+				$objectType,
+				(string)$objectId,
+				[(int)$tagId]
+			));
+		}
 
 		if (empty($objectIds)) {
 			return;
@@ -312,6 +324,14 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 
 		$this->updateEtagForTags([$tagId]);
 		$this->connection->commit();
+		foreach ($addedObjectIds as $objectId) {
+			$this->dispatcher->dispatch(MapperEvent::EVENT_ASSIGN, new MapperEvent(
+				MapperEvent::EVENT_ASSIGN,
+				$objectType,
+				(string)$objectId,
+				[(int)$tagId]
+			));
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
The setObjectIdsForTag method is missing event dispatching. This prevents apps from reacting
to tag changes when using the bulk tag assignment feature which was added with Nextcloud 31.
This creates a different beheaviour to when tags are assigend via the sidebar, where the assignTags and unassignTags methods are used which do dispatch the events.

This fix:
- Calculates which objects are removed and which are added
- Dispatches MapperEvent::EVENT_UNASSIGN for removed objects
- Dispatches MapperEvent::EVENT_ASSIGN for added objects


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
