### PR TITLE
cookie_domain config option for setting cookie on a wider domain

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -87,6 +87,14 @@ $CONFIG = [
 	'[2001:db8::1]'
 ],
 
+/**
+ * The validity domain for cookies, for example '' (cookies will be sent only
+ * the domain that defined it, e.g. 'demo.example.org'), 'demo.example.org'
+ * (cookies will be valid for the domain and all subdomains), ...
+ *
+ * Defaults to '' (safe option)
+ */
+'cookie_domain' => '',
 
 /**
  * Where user files are stored. The SQLite database is also stored here, when

--- a/lib/base.php
+++ b/lib/base.php
@@ -393,6 +393,12 @@ class OC {
 		$cookie_path = OC::$WEBROOT ? : '/';
 		ini_set('session.cookie_path', $cookie_path);
 
+		// set the cookie domain to the Nextcloud domain
+		$cookie_domain = self::$config->getValue('cookie_domain', '');
+		if ($cookie_domain) {
+			ini_set('session.cookie_domain', $cookie_domain);
+		}
+
 		// Let the session name be changed in the initSession Hook
 		$sessionName = OC_Util::getInstanceId();
 

--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -59,7 +59,7 @@ class CryptoWrapper {
 					[
 						'expires' => 0,
 						'path' => $webRoot,
-						'domain' => '',
+						'domain' => \OCP\Server::get(\OCP\IConfig::class)->getSystemValueString('cookie_domain'),
 						'secure' => $secureCookie,
 						'httponly' => true,
 						'samesite' => 'Lax',

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -967,6 +967,7 @@ class Session implements IUserSession, Emitter {
 		if ($webRoot === '') {
 			$webRoot = '/';
 		}
+		$domain = $this->config->getSystemValueString('cookie_domain');
 
 		$maxAge = $this->config->getSystemValueInt('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
 		\OC\Http\CookieHelper::setCookie(
@@ -974,7 +975,7 @@ class Session implements IUserSession, Emitter {
 			$username,
 			$maxAge,
 			$webRoot,
-			'',
+			$domain,
 			$secureCookie,
 			true,
 			\OC\Http\CookieHelper::SAMESITE_LAX
@@ -984,7 +985,7 @@ class Session implements IUserSession, Emitter {
 			$token,
 			$maxAge,
 			$webRoot,
-			'',
+			$domain,
 			$secureCookie,
 			true,
 			\OC\Http\CookieHelper::SAMESITE_LAX
@@ -995,7 +996,7 @@ class Session implements IUserSession, Emitter {
 				$this->session->getId(),
 				$maxAge,
 				$webRoot,
-				'',
+				$domain,
 				$secureCookie,
 				true,
 				\OC\Http\CookieHelper::SAMESITE_LAX
@@ -1011,18 +1012,19 @@ class Session implements IUserSession, Emitter {
 	public function unsetMagicInCookie() {
 		//TODO: DI for cookies and IRequest
 		$secureCookie = OC::$server->getRequest()->getServerProtocol() === 'https';
+		$domain = $this->config->getSystemValueString('cookie_domain');
 
 		unset($_COOKIE['nc_username']); //TODO: DI
 		unset($_COOKIE['nc_token']);
 		unset($_COOKIE['nc_session_id']);
-		setcookie('nc_username', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT, '', $secureCookie, true);
-		setcookie('nc_token', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT, '', $secureCookie, true);
-		setcookie('nc_session_id', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT, '', $secureCookie, true);
+		setcookie('nc_username', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT, $domain, $secureCookie, true);
+		setcookie('nc_token', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT, $domain, $secureCookie, true);
+		setcookie('nc_session_id', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT, $domain, $secureCookie, true);
 		// old cookies might be stored under /webroot/ instead of /webroot
 		// and Firefox doesn't like it!
-		setcookie('nc_username', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT . '/', '', $secureCookie, true);
-		setcookie('nc_token', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT . '/', '', $secureCookie, true);
-		setcookie('nc_session_id', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT . '/', '', $secureCookie, true);
+		setcookie('nc_username', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT . '/', $domain, $secureCookie, true);
+		setcookie('nc_token', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT . '/', $domain, $secureCookie, true);
+		setcookie('nc_session_id', '', $this->timeFactory->getTime() - 3600, OC::$WEBROOT . '/', $domain, $secureCookie, true);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds a `cookie_domain` option to define to which domain(s) the cookies sent by Nextcloud are valid. By default, it is set to `''` which is the safe option (i.e. the browser is instructed to send the cookie only for request to the exact same domain that issued it).

But when your instance is accessible over 2 domains, for example 'mycloud.mydomain.example' and 'sub.mycloud.mydomain.example', setting `cookie_domain` to 'mycloud.mydomain.example' will make the cookie valid for `mycloud.mydomain.example` and any subdomain (but *not* for `mydomain.example`).

Documentation : [MDN / Cookies / Define where cookies are sent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Cookies#define_where_cookies_are_sent).

## TODO

I've updated config.sample.php, but it's not clear where should this functionality should be documented.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included : not clear if applicable
- Screenshots before/after for front-end changes (n.a.)
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [Backports not requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
