### PR TITLE
fix: Go back to soft typing for template function p

### DIFF
--- a/lib/private/Template/functions.php
+++ b/lib/private/Template/functions.php
@@ -13,7 +13,10 @@ use OCP\IURLGenerator;
 use OCP\Server;
 use OCP\Util;
 
-function p(string $string): void {
+/**
+ * @param string $string
+ */
+function p($string): void {
 	print(Util::sanitizeHTML($string));
 }
 


### PR DESCRIPTION
* Resolves: #51618 

## Summary

Strong typing breaks legacy code in this case.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
