### PR TITLE
Add OC_App::getAppVersions replacement in IAppManager

### DIFF
--- a/apps/updatenotification/tests/Notification/NotifierTest.php
+++ b/apps/updatenotification/tests/Notification/NotifierTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\UpdateNotification\Tests\Notification;
 
 use OCA\UpdateNotification\Notification\Notifier;
+use OCP\App\IAppManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IURLGenerator;
@@ -17,22 +18,20 @@ use OCP\L10N\IFactory;
 use OCP\Notification\AlreadyProcessedException;
 use OCP\Notification\IManager;
 use OCP\Notification\INotification;
+use OCP\ServerVersion;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class NotifierTest extends TestCase {
 
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	protected $urlGenerator;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $config;
-	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $notificationManager;
-	/** @var IFactory|\PHPUnit\Framework\MockObject\MockObject */
-	protected $l10nFactory;
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	protected $userSession;
-	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $groupManager;
+	protected IURLGenerator&MockObject $urlGenerator;
+	protected IConfig&MockObject $config;
+	protected IManager&MockObject $notificationManager;
+	protected IFactory&MockObject $l10nFactory;
+	protected IUserSession&MockObject $userSession;
+	protected IGroupManager&MockObject $groupManager;
+	protected IAppManager&MockObject $appManager;
+	protected ServerVersion&MockObject $serverVersion;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,6 +42,8 @@ class NotifierTest extends TestCase {
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->serverVersion = $this->createMock(ServerVersion::class);
 	}
 
 	/**
@@ -57,7 +58,9 @@ class NotifierTest extends TestCase {
 				$this->notificationManager,
 				$this->l10nFactory,
 				$this->userSession,
-				$this->groupManager
+				$this->groupManager,
+				$this->appManager,
+				$this->serverVersion,
 			);
 		}
 		{
@@ -69,6 +72,8 @@ class NotifierTest extends TestCase {
 					$this->l10nFactory,
 					$this->userSession,
 					$this->groupManager,
+					$this->appManager,
+					$this->serverVersion,
 				])
 				->onlyMethods($methods)
 				->getMock();

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ListApps extends Base {
 	public function __construct(
-		protected IAppManager $manager,
+		protected IAppManager $appManager,
 	) {
 		parent::__construct();
 	}
@@ -56,16 +56,16 @@ class ListApps extends Base {
 		$showEnabledApps = $input->getOption('enabled') || !$input->getOption('disabled');
 		$showDisabledApps = $input->getOption('disabled') || !$input->getOption('enabled');
 
-		$apps = \OC_App::getAllApps();
+		$apps = $this->appManager->getAllAppsInAppsFolders();
 		$enabledApps = $disabledApps = [];
-		$versions = \OC_App::getAppVersions();
+		$versions = $this->appManager->getAppInstalledVersions();
 
 		//sort enabled apps above disabled apps
 		foreach ($apps as $app) {
-			if ($shippedFilter !== null && $this->manager->isShipped($app) !== $shippedFilter) {
+			if ($shippedFilter !== null && $this->appManager->isShipped($app) !== $shippedFilter) {
 				continue;
 			}
-			if ($this->manager->isEnabledForAnyone($app)) {
+			if ($this->appManager->isEnabledForAnyone($app)) {
 				$enabledApps[] = $app;
 			} else {
 				$disabledApps[] = $app;
@@ -88,7 +88,7 @@ class ListApps extends Base {
 
 			sort($disabledApps);
 			foreach ($disabledApps as $app) {
-				$apps['disabled'][$app] = $this->manager->getAppVersion($app) . (isset($versions[$app]) ? ' (installed ' . $versions[$app] . ')' : '');
+				$apps['disabled'][$app] = $this->appManager->getAppVersion($app) . (isset($versions[$app]) ? ' (installed ' . $versions[$app] . ')' : '');
 			}
 		}
 

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -19,7 +19,6 @@ use OCP\Collaboration\AutoComplete\IManager as IAutoCompleteManager;
 use OCP\Collaboration\Collaborators\ISearch as ICollaboratorSearch;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -818,13 +817,7 @@ class AppManager implements IAppManager {
 	 * @return array<string, string>
 	 */
 	public function getAppInstalledVersions(): array {
-		static $versions;
-
-		if (!$versions) {
-			/** @var array<string, string> */
-			$versions = $this->getAppConfig()->searchValues('installed_version', false, IAppConfig::VALUE_STRING);
-		}
-		return $versions;
+		return $this->getAppConfig()->getAppInstalledVersions();
 	}
 
 	/**

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -19,6 +19,7 @@ use OCP\Collaboration\AutoComplete\IManager as IAutoCompleteManager;
 use OCP\Collaboration\Collaborators\ISearch as ICollaboratorSearch;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -809,6 +810,21 @@ class AppManager implements IAppManager {
 			}
 		}
 		return $this->appVersions[$appId];
+	}
+
+	/**
+	 * Returns the installed versions of all apps
+	 *
+	 * @return array<string, string>
+	 */
+	public function getAppInstalledVersions(): array {
+		static $versions;
+
+		if (!$versions) {
+			/** @var array<string, string> */
+			$versions = $this->getAppConfig()->searchValues('installed_version', false, IAppConfig::VALUE_STRING);
+		}
+		return $versions;
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -62,6 +62,9 @@ class AppConfig implements IAppConfig {
 	/** @var array<array-key, array{entries: array<array-key, ConfigLexiconEntry>, strictness: ConfigLexiconStrictness}> ['app_id' => ['strictness' => ConfigLexiconStrictness, 'entries' => ['config_key' => ConfigLexiconEntry[]]] */
 	private array $configLexiconDetails = [];
 
+	/** @var ?array<string, string> */
+	private ?array $appVersionsCache = null;
+
 	public function __construct(
 		protected IDBConnection $connection,
 		protected LoggerInterface $logger,
@@ -1646,5 +1649,18 @@ class AppConfig implements IAppConfig {
 		}
 
 		return $this->configLexiconDetails[$appId];
+	}
+
+	/**
+	 * Returns the installed versions of all apps
+	 *
+	 * @return array<string, string>
+	 */
+	public function getAppInstalledVersions(): array {
+		if ($this->appVersionsCache === null) {
+			/** @var array<string, string> */
+			$this->appVersionsCache = $this->searchValues('installed_version', false, IAppConfig::VALUE_STRING);
+		}
+		return $this->appVersionsCache;
 	}
 }

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -337,4 +337,13 @@ class AppConfig implements IAppConfig {
 	public function deleteUserValue(string $userId, string $key): void {
 		$this->config->deleteUserValue($userId, $this->appName, $key);
 	}
+
+	/**
+	 * Returns the installed versions of all apps
+	 *
+	 * @return array<string, string>
+	 */
+	public function getAppInstalledVersions(): array {
+		return $this->appConfig->getAppInstalledVersions();
+	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -610,7 +610,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$prefixClosure = function () use ($logQuery, $serverVersion): ?string {
 					if (!$logQuery) {
 						try {
-							$v = \OCP\Server::get(IAppManager::class)->getAppVersions();
+							$v = \OC_App::getAppVersions();
 						} catch (\Doctrine\DBAL\Exception $e) {
 							// Database service probably unavailable
 							// Probably related to https://github.com/nextcloud/server/issues/37424

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -610,7 +610,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$prefixClosure = function () use ($logQuery, $serverVersion): ?string {
 					if (!$logQuery) {
 						try {
-							$v = \OC_App::getAppVersions();
+							$v = \OCP\Server::get(IAppConfig::class)->getAppInstalledVersions();
 						} catch (\Doctrine\DBAL\Exception $e) {
 							// Database service probably unavailable
 							// Probably related to https://github.com/nextcloud/server/issues/37424

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -604,14 +604,13 @@ class Server extends ServerContainer implements IServerContainer {
 			$config = $c->get(SystemConfig::class);
 			/** @var ServerVersion $serverVersion */
 			$serverVersion = $c->get(ServerVersion::class);
-			$appManager = $c->get(IAppManager::class);
 
 			if ($config->getValue('installed', false) && !(defined('PHPUNIT_RUN') && PHPUNIT_RUN)) {
 				$logQuery = $config->getValue('log_query');
-				$prefixClosure = function () use ($logQuery, $serverVersion, $appManager): ?string {
+				$prefixClosure = function () use ($logQuery, $serverVersion): ?string {
 					if (!$logQuery) {
 						try {
-							$v = $appManager->getAppInstalledVersions();
+							$v = \OCP\Server::get(IAppManager::class)->getAppVersions();
 						} catch (\Doctrine\DBAL\Exception $e) {
 							// Database service probably unavailable
 							// Probably related to https://github.com/nextcloud/server/issues/37424

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -48,6 +48,7 @@ class TemplateLayout {
 		private InitialStateService $initialState,
 		private INavigationManager $navigationManager,
 		private ITemplateManager $templateManager,
+		private ServerVersion $serverVersion,
 	) {
 	}
 
@@ -204,8 +205,8 @@ class TemplateLayout {
 
 		if ($this->config->getSystemValueBool('installed', false)) {
 			if (empty(self::$versionHash)) {
-				$v = \OC_App::getAppVersions();
-				$v['core'] = implode('.', \OCP\Util::getVersion());
+				$v = $this->appManager->getAppInstalledVersions();
+				$v['core'] = implode('.', $this->serverVersion->getVersion());
 				self::$versionHash = substr(md5(implode(',', $v)), 0, 8);
 			}
 		} else {
@@ -220,7 +221,7 @@ class TemplateLayout {
 			// this is on purpose outside of the if statement below so that the initial state is prefilled (done in the getConfig() call)
 			// see https://github.com/nextcloud/server/pull/22636 for details
 			$jsConfigHelper = new JSConfigHelper(
-				\OCP\Server::get(ServerVersion::class),
+				$this->serverVersion,
 				\OCP\Util::getL10N('lib'),
 				\OCP\Server::get(Defaults::class),
 				$this->appManager,

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -456,10 +456,9 @@ class OC_App {
 	/**
 	 * List all supported apps
 	 *
-	 * @return array
+	 * @deprecated 32.0.0 Use \OCP\Support\Subscription\IRegistry::delegateGetSupportedApps instead
 	 */
 	public function getSupportedApps(): array {
-		/** @var \OCP\Support\Subscription\IRegistry $subscriptionRegistry */
 		$subscriptionRegistry = \OCP\Server::get(\OCP\Support\Subscription\IRegistry::class);
 		$supportedApps = $subscriptionRegistry->delegateGetSupportedApps();
 		return $supportedApps;
@@ -643,6 +642,7 @@ class OC_App {
 
 	/**
 	 * get the installed version of all apps
+	 * @deprecated 32.0.0 Use IAppManager::getAppInstalledVersions instead
 	 */
 	public static function getAppVersions() {
 		static $versions;

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -642,17 +642,10 @@ class OC_App {
 
 	/**
 	 * get the installed version of all apps
-	 * @deprecated 32.0.0 Use IAppManager::getAppInstalledVersions instead
+	 * @deprecated 32.0.0 Use IAppManager::getAppInstalledVersions or IAppConfig::getAppInstalledVersions instead
 	 */
-	public static function getAppVersions() {
-		static $versions;
-
-		if (!$versions) {
-			/** @var IAppConfig $appConfig */
-			$appConfig = \OCP\Server::get(IAppConfig::class);
-			$versions = $appConfig->searchValues('installed_version');
-		}
-		return $versions;
+	public static function getAppVersions(): array {
+		return \OCP\Server::get(IAppConfig::class)->getAppInstalledVersions();
 	}
 
 	/**

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -52,6 +52,14 @@ interface IAppManager {
 	public function getAppVersion(string $appId, bool $useCache = true): string;
 
 	/**
+	 * Returns the installed version of all apps
+	 *
+	 * @return array<string, string>
+	 * @since 32.0.0
+	 */
+	public function getAppInstalledVersions(): array;
+
+	/**
 	 * Returns the app icon or null if none is found
 	 *
 	 * @param string $appId

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -507,4 +507,12 @@ interface IAppConfig {
 	 * @deprecated 29.0.0 Use {@see getAllValues()} or {@see searchValues()}
 	 */
 	public function getFilteredValues($app);
+
+	/**
+	 * Returns the installed version of all apps
+	 *
+	 * @return array<string, string>
+	 * @since 32.0.0
+	 */
+	public function getAppInstalledVersions(): array;
 }

--- a/tests/lib/TemplateLayoutTest.php
+++ b/tests/lib/TemplateLayoutTest.php
@@ -15,6 +15,7 @@ use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
 use OCP\INavigationManager;
+use OCP\ServerVersion;
 use OCP\Template\ITemplateManager;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -24,6 +25,7 @@ class TemplateLayoutTest extends \Test\TestCase {
 	private InitialStateService&MockObject $initialState;
 	private INavigationManager&MockObject $navigationManager;
 	private ITemplateManager&MockObject $templateManager;
+	private ServerVersion&MockObject $serverVersion;
 
 	private TemplateLayout $templateLayout;
 
@@ -35,6 +37,7 @@ class TemplateLayoutTest extends \Test\TestCase {
 		$this->initialState = $this->createMock(InitialStateService::class);
 		$this->navigationManager = $this->createMock(INavigationManager::class);
 		$this->templateManager = $this->createMock(ITemplateManager::class);
+		$this->serverVersion = $this->createMock(ServerVersion::class);
 	}
 
 	/** @dataProvider dataVersionHash */
@@ -69,6 +72,7 @@ class TemplateLayoutTest extends \Test\TestCase {
 				$this->initialState,
 				$this->navigationManager,
 				$this->templateManager,
+				$this->serverVersion,
 			])
 			->getMock();
 


### PR DESCRIPTION
## Summary

Add a replacement for OC_App::getAppVersions in IAppManager.
Use it in all places where the deprecated version was used.
Another nail in OC_App coffin.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
