### PR TITLE
[stable30] fix(admin_audit): Fix incorrect truncation of files path in admin audit log

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -37,7 +37,7 @@ class Files extends Action {
 			$node = $event->getNode();
 			$params = [
 				'id' => $node instanceof NonExistingFile ? null : $node->getId(),
-				'path' => mb_substr($node->getInternalPath(), 5),
+				'path' => $node->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(
@@ -76,8 +76,8 @@ class Files extends Action {
 			$originalSource = $this->renamedNodes[$target->getId()];
 			$params = [
 				'newid' => $target->getId(),
-				'oldpath' => mb_substr($originalSource->getInternalPath(), 5),
-				'newpath' => mb_substr($target->getInternalPath(), 5),
+				'oldpath' => $originalSource->getPath(),
+				'newpath' => $target->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(
@@ -101,7 +101,7 @@ class Files extends Action {
 		try {
 			$params = [
 				'id' => $event->getNode()->getId(),
-				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
+				'path' => $event->getNode()->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(
@@ -127,8 +127,8 @@ class Files extends Action {
 			$params = [
 				'oldid' => $event->getSource()->getId(),
 				'newid' => $event->getTarget()->getId(),
-				'oldpath' => mb_substr($event->getSource()->getInternalPath(), 5),
-				'newpath' => mb_substr($event->getTarget()->getInternalPath(), 5),
+				'oldpath' => $event->getSource()->getPath(),
+				'newpath' => $event->getTarget()->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(
@@ -151,7 +151,7 @@ class Files extends Action {
 		try {
 			$params = [
 				'id' => $node->getId(),
-				'path' => mb_substr($node->getInternalPath(), 5),
+				'path' => $node->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(
@@ -177,7 +177,7 @@ class Files extends Action {
 		try {
 			$params = [
 				'id' => $event->getNode()->getId(),
-				'path' => mb_substr($event->getNode()->getInternalPath(), 5),
+				'path' => $event->getNode()->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(
@@ -206,7 +206,7 @@ class Files extends Action {
 				'height' => $event->getHeight(),
 				'crop' => $event->isCrop(),
 				'mode' => $event->getMode(),
-				'path' => mb_substr($file->getInternalPath(), 5)
+				'path' => $file->getPath(),
 			];
 		} catch (InvalidPathException|NotFoundException $e) {
 			\OCP\Server::get(LoggerInterface::class)->error(


### PR DESCRIPTION
- Manual backport of https://github.com/nextcloud/server/pull/50992
- `apps/admin_audit/lib/Listener/FileEventListener.php` is missing - not migrated in 30