### PR TITLE
Fix files_sorting cypress tests

### DIFF
--- a/cypress/e2e/files/files-sorting.cy.ts
+++ b/cypress/e2e/files/files-sorting.cy.ts
@@ -166,7 +166,6 @@ describe('Files: Sorting the file list', { testIsolation: true }, () => {
 		cy.visit('/apps/files')
 
 		cy.log('By name - ascending')
-		cy.get('th').contains('button', 'Name').click()
 		cy.contains('th', 'Name').should('have.attr', 'aria-sort', 'ascending')
 
 		cy.get('[data-cy-files-list-row]').each(($row, index) => {


### PR DESCRIPTION
## Summary

The test is clicking on Name to sort by Name but it’s already the case so it reverts the sorting and fails. I think.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
