### PR TITLE
feat(theming): define `nextcloud-theme-dark` variable

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -1,6 +1,7 @@
 /** SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors */
 /** SPDX-License-Identifier: AGPL-3.0-or-later */
 :root {
+  --nextcloud-theme-dark: 0;
   --color-main-background: #ffffff;
   --color-main-background-rgb: 255,255,255;
   --color-main-background-translucent: rgba(var(--color-main-background-rgb), .97);

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -61,6 +61,8 @@ class DarkTheme extends DefaultTheme implements ITheme {
 			$defaultVariables,
 			$this->generatePrimaryVariables($colorMainBackground, $colorMainText),
 			[
+				'--nextcloud-theme-dark' => 1,
+
 				'--color-main-text' => $colorMainText,
 				'--color-main-background' => $colorMainBackground,
 				'--color-main-background-rgb' => $colorMainBackgroundRGB,

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -101,6 +101,8 @@ class DefaultTheme implements ITheme {
 		};
 
 		$variables = [
+			'--nextcloud-theme-dark' => 0,
+
 			'--color-main-background' => $colorMainBackground,
 			'--color-main-background-rgb' => $colorMainBackgroundRGB,
 			'--color-main-background-translucent' => 'rgba(var(--color-main-background-rgb), .97)',


### PR DESCRIPTION
Following discussion from https://github.com/nextcloud-libraries/nextcloud-vue/pull/5698#issuecomment-2751699395 :)

This should allow to have a clean way to check if the dark theme is enabled or not.
This should also allow us to do some simple css-only dark theme computation
```css
.element {
	opacity: calc(var(--nextcloud-theme-dark) * 1); /* 0 (hidden) or 1 (visible) */
}
```
 (why would we want to do that is another topic lol, but hey, it's _possible!_)
