### PR TITLE
feat(mimetypes): Added musicxml mimetypes

### DIFF
--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -342,6 +342,7 @@ class RepairMimeTypes implements IRepairStep {
 	 * @since 32.0.0
 	 */
 	private function introduceMusicxmlType(): IResult|int|null {
+		$updatedMimetypes = [
 			'mxl' => 'application/vnd.recordare.musicxml',
 			'musicxml' => 'application/vnd.recordare.musicxml+xml',
 		];

--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -338,6 +338,20 @@ class RepairMimeTypes implements IRepairStep {
 	}
 
 	/**
+	 * @throws Exception
+	 * @since 32.0.0
+	 */
+	private function introduceMusicxmlType(): IResult|int|null {
+			'mxl' => 'application/vnd.recordare.musicxml',
+			'musicxml' => 'application/vnd.recordare.musicxml+xml',
+		];
+
+		return $this->updateMimetypes($updatedMimetypes);
+	}
+
+	
+
+	/**
 	 * Check if there are any migrations available
 	 *
 	 * @throws Exception
@@ -445,6 +459,10 @@ class RepairMimeTypes implements IRepairStep {
 
 		if (version_compare($mimeTypeVersion, '31.0.0.0', '<') && $this->introduceZstType()) {
 			$out->info('Fixed zst mime type');
+		}
+
+		if (version_compare($mimeTypeVersion, '32.0.0.0', '<') && $this->introduceMusicxmlType()) {
+			$out->info('Fixed musicxml mime type');
 		}
 
 		if (!$this->dryRun) {

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -129,6 +129,8 @@
 	"msi": ["application/x-msi"],
 	"mt2s": ["video/MP2T"],
 	"mts": ["video/MP2T"],
+	"musicxml": ["application/vnd.recordare.musicxml+xml"],
+	"mxl": ["application/vnd.recordare.musicxml"],
 	"nef": ["image/x-dcraw"],
 	"nfo": ["text/x-nfo"],
 	"numbers": ["application/x-iwork-numbers-sffnumbers"],


### PR DESCRIPTION
## Summary
Adds the musicxml MIME types

Needed by Viewer adaptions: https://github.com/nextcloud/viewer/pull/2752 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
