### PR TITLE
Fix: task type translations

### DIFF
--- a/lib/public/TaskProcessing/TaskTypes/AudioToText.php
+++ b/lib/public/TaskProcessing/TaskTypes/AudioToText.php
@@ -34,7 +34,7 @@ class AudioToText implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php
+++ b/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php
@@ -31,7 +31,7 @@ class ContextAgentInteraction implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 	/**

--- a/lib/public/TaskProcessing/TaskTypes/ContextWrite.php
+++ b/lib/public/TaskProcessing/TaskTypes/ContextWrite.php
@@ -34,7 +34,7 @@ class ContextWrite implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php
+++ b/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php
@@ -34,7 +34,7 @@ class GenerateEmoji implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToImage.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToImage.php
@@ -34,7 +34,7 @@ class TextToImage implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToText.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToText.php
@@ -34,7 +34,7 @@ class TextToText implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextChangeTone.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextChangeTone.php
@@ -31,7 +31,7 @@ class TextToTextChangeTone implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 	/**

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextChat.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextChat.php
@@ -34,7 +34,7 @@ class TextToTextChat implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextChatWithTools.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextChatWithTools.php
@@ -31,7 +31,7 @@ class TextToTextChatWithTools implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 	/**

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextFormalization.php
@@ -34,7 +34,7 @@ class TextToTextFormalization implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextHeadline.php
@@ -34,7 +34,7 @@ class TextToTextHeadline implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextProofread.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextProofread.php
@@ -33,7 +33,7 @@ class TextToTextProofread implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextReformulation.php
@@ -34,7 +34,7 @@ class TextToTextReformulation implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextSimplification.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextSimplification.php
@@ -34,7 +34,7 @@ class TextToTextSimplification implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextSummary.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextSummary.php
@@ -33,7 +33,7 @@ class TextToTextSummary implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextTopics.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextTopics.php
@@ -34,7 +34,7 @@ class TextToTextTopics implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 

--- a/lib/public/TaskProcessing/TaskTypes/TextToTextTranslate.php
+++ b/lib/public/TaskProcessing/TaskTypes/TextToTextTranslate.php
@@ -34,7 +34,7 @@ class TextToTextTranslate implements ITaskType {
 	public function __construct(
 		IFactory $l10nFactory,
 	) {
-		$this->l = $l10nFactory->get('core');
+		$this->l = $l10nFactory->get('lib');
 	}
 
 


### PR DESCRIPTION
* Resolves nextcloud/assistant#208

## Summary

changes location of translation files to the correct one so the strings can be found

before 
![image](https://github.com/user-attachments/assets/a499707c-2600-450b-9909-7310fec9c3cf)

after 
![image](https://github.com/user-attachments/assets/158fbda9-8ed4-41d2-b6ca-5668b51b95dd)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] ~~Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included~~ n/a
- [x] Screenshots before/after for front-end changes
- [x] ~~Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated~~ not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
