### PR TITLE
fix(files_reminders): Lower disabled notifications app error to info

### DIFF
--- a/apps/files_reminders/lib/AppInfo/Application.php
+++ b/apps/files_reminders/lib/AppInfo/Application.php
@@ -42,5 +42,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
 
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalScriptsListener::class);
+
+		$context->registerSetupCheck(NeedNotificationsApp::class);
 	}
 }

--- a/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
@@ -31,7 +31,6 @@ class LoadAdditionalScriptsListener implements IEventListener {
 		}
 
 		if (!$this->appManager->isEnabledForUser('notifications')) {
-			$this->logger->info('Skipped registering the `files_reminders` app because the `notifications` app is disabled.', ['app' => 'files_reminders']);
 			return;
 		}
 

--- a/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
+++ b/apps/files_reminders/lib/Listener/LoadAdditionalScriptsListener.php
@@ -31,7 +31,7 @@ class LoadAdditionalScriptsListener implements IEventListener {
 		}
 
 		if (!$this->appManager->isEnabledForUser('notifications')) {
-			$this->logger->error('Failed to register the `files_reminders` app. This could happen due to the `notifications` app being disabled.', ['app' => 'files_reminders']);
+			$this->logger->info('Skipped registering the `files_reminders` app because the `notifications` app is disabled.', ['app' => 'files_reminders']);
 			return;
 		}
 

--- a/apps/files_reminders/lib/SetupChecks/NeedNotificationsApp.php
+++ b/apps/files_reminders/lib/SetupChecks/NeedNotificationsApp.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\SetupChecks;
+
+use OCP\App\IAppManager;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+
+class NeedNotificationsApp implements ISetupCheck {
+	public function __construct(
+		private IAppManager $appManager,
+	) {
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Files reminder');
+	}
+
+	public function getCategory(): string {
+		return 'system';
+	}
+
+	public function run(): SetupResult {
+		if ($this->appManager->isInstalled('notifications')) {
+			return SetupResult::success($this->l10n->t('This files_reminder can work properly.'));
+		} else {
+			return SetupResult::warning($this->l10n->t('The files_reminder app needs the notification app to work properly. You should either enable notifications or disable files_reminder.'));
+		}
+	}
+}


### PR DESCRIPTION
This is spamming the cypress server logs.

Original: https://github.com/nextcloud/server/pull/49232

Or should we write a setup check instead?