### PR TITLE
perf(cache): force Firefox to send cache headers

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -49,7 +49,7 @@
   # Add cache control for static resources
   <FilesMatch "\.(css|js|mjs|svg|gif|png|jpg|webp|ico|wasm|tflite)$">
     <If "%{QUERY_STRING} =~ /(^|&)v=/">
-      Header set Cache-Control "max-age=15778463, immutable"
+      Header set Cache-Control "max-age=15778463, must-revalidate, immutable"
     </If>
     <Else>
       Header set Cache-Control "max-age=15778463"

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -89,7 +89,7 @@ class Response {
 	public function cacheFor(int $cacheSeconds, bool $public = false, bool $immutable = false) {
 		if ($cacheSeconds > 0) {
 			$cacheStore = $public ? 'public' : 'private';
-			$this->addHeader('Cache-Control', sprintf('%s, max-age=%s, %s', $cacheStore, $cacheSeconds, ($immutable ? 'immutable' : 'must-revalidate')));
+			$this->addHeader('Cache-Control', sprintf('%s, max-age=%s, %s', $cacheStore, $cacheSeconds, ($immutable ? 'must-revalidate, immutable' : 'must-revalidate')));
 
 			// Set expires header
 			$expires = new \DateTime();


### PR DESCRIPTION
## Summary
`immutable` header is only supported by Firefox and Safari. When the resource is stale, Firefox don't send `If-None-Match` and `If-Not-Modified-Since` headers.
This commit force Firefox to send these headers when resources are stale.

## Checklist
- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
