### PR TITLE
store original path in object metadata

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -482,6 +482,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$mimetype = $mimetypeDetector->detectPath($path);
 		$metadata = [
 			'mimetype' => $mimetype,
+			'original-storage' => $this->getId(),
+			'original-path' => $path,
 		];
 
 		$stat['mimetype'] = $mimetype;

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -22,6 +22,7 @@ use OCP\Files\FileInfo;
 use OCP\Files\GenericFileException;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
+use OCP\Files\ObjectStore\IObjectStoreMetaData;
 use OCP\Files\ObjectStore\IObjectStoreMultiPartUpload;
 use OCP\Files\Storage\IChunkedFileWrite;
 use OCP\Files\Storage\IStorage;
@@ -479,6 +480,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 
 		$mimetypeDetector = \OC::$server->getMimeTypeDetector();
 		$mimetype = $mimetypeDetector->detectPath($path);
+		$metadata = [
+			'mimetype' => $mimetype,
+		];
 
 		$stat['mimetype'] = $mimetype;
 		$stat['etag'] = $this->getETag($path);
@@ -507,13 +511,21 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 					]);
 					$size = $writtenSize;
 				});
-				$this->objectStore->writeObject($urn, $countStream, $mimetype);
+				if ($this->objectStore instanceof IObjectStoreMetaData) {
+					$this->objectStore->writeObjectWithMetaData($urn, $countStream, $metadata);
+				} else {
+					$this->objectStore->writeObject($urn, $countStream, $metadata['mimetype']);
+				}
 				if (is_resource($countStream)) {
 					fclose($countStream);
 				}
 				$stat['size'] = $size;
 			} else {
-				$this->objectStore->writeObject($urn, $stream, $mimetype);
+				if ($this->objectStore instanceof IObjectStoreMetaData) {
+					$this->objectStore->writeObjectWithMetaData($urn, $stream, $metadata);
+				} else {
+					$this->objectStore->writeObject($urn, $stream, $metadata['mimetype']);
+				}
 				if (is_resource($stream)) {
 					fclose($stream);
 				}

--- a/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
+++ b/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
@@ -35,4 +35,13 @@ interface IObjectStoreMetaData {
 	 * @since 32.0.0
 	 */
 	public function listObjects(string $prefix = ''): \Iterator;
+
+	/**
+	 * @param string $urn the unified resource name used to identify the object
+	 * @param resource $stream stream with the data to write
+	 * @param ObjectMetaData $metaData the metadata to set for the object
+	 * @throws \Exception when something goes wrong, message will be logged
+	 * @since 32.0.0
+	 */
+	public function writeObjectWithMetaData(string $urn, $stream, array $metaData): void;
 }

--- a/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
+++ b/lib/public/Files/ObjectStore/IObjectStoreMetaData.php
@@ -9,7 +9,7 @@ namespace OCP\Files\ObjectStore;
 /**
  * Interface IObjectStoreMetaData
  *
- * @psalm-type ObjectMetaData = array{mtime?: \DateTime, etag?: string, size?: int, mimetype?: string, filename?: string}
+ * @psalm-type ObjectMetaData = array{mtime?: \DateTime, etag?: string, size?: int, mimetype?: string, filename?: string, original-path?: string, original-storage?: string}
  *
  * @since 32.0.0
  */


### PR DESCRIPTION
- [x] depends on https://github.com/nextcloud/server/pull/51603

Save the original (at time of upload) storage id and path in object metadata.

This primarily intended to aid with recovering orphaned objects and should not be relied on for any logic. No attempt is made to update the metadata during moves etc.