### PR TITLE
notification manager deterministic app call order

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2223,6 +2223,11 @@
       <code><![CDATA[mixed]]></code>
     </LessSpecificImplementedReturnType>
   </file>
+  <file src="lib/private/Notification/Manager.php">
+    <UndefinedClass>
+      <code><![CDATA[\OCA\Notifications\App]]></code>
+    </UndefinedClass>
+  </file>
   <file src="lib/private/Preview/BackgroundCleanupJob.php">
     <InvalidReturnStatement>
       <code><![CDATA[[]]]></code>

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -74,7 +74,15 @@ class Manager implements IManager {
 	 * @since 17.0.0
 	 */
 	public function registerApp(string $appClass): void {
-		$this->appClasses[] = $appClass;
+		// other apps may want to rely on the 'main' notification app so make it deterministic that
+		// the 'main' notification app adds it's notifications first and removes it's notifications last
+		if ($appClass === \OCA\Notifications\App::class) {
+			// add 'main' notifications app to start of internal list of apps
+			array_unshift($this->appClasses, $appClass);
+		} else {
+			// add app to end of internal list of apps
+			$this->appClasses[] = $appClass;
+		}
 	}
 
 	/**
@@ -237,7 +245,7 @@ class Manager implements IManager {
 		$alreadyDeferring = $this->deferPushing;
 		$this->deferPushing = true;
 
-		$apps = $this->getApps();
+		$apps = array_reverse($this->getApps());
 
 		foreach ($apps as $app) {
 			if ($app instanceof IDeferrableApp) {
@@ -252,7 +260,7 @@ class Manager implements IManager {
 	 * @since 20.0.0
 	 */
 	public function flush(): void {
-		$apps = $this->getApps();
+		$apps = array_reverse($this->getApps());
 
 		foreach ($apps as $app) {
 			if (!$app instanceof IDeferrableApp) {
@@ -384,7 +392,7 @@ class Manager implements IManager {
 	 * @param INotification $notification
 	 */
 	public function markProcessed(INotification $notification): void {
-		$apps = $this->getApps();
+		$apps = array_reverse($this->getApps());
 
 		foreach ($apps as $app) {
 			$app->markProcessed($notification);
@@ -396,7 +404,7 @@ class Manager implements IManager {
 	 * @return int
 	 */
 	public function getCount(INotification $notification): int {
-		$apps = $this->getApps();
+		$apps = array_reverse($this->getApps());
 
 		$count = 0;
 		foreach ($apps as $app) {


### PR DESCRIPTION
## Summary

Changes to allow a deterministic calling order of notification apps by the notification manager.

#### More detail

The notification manager will always call `notify()` on the 'main' notifications app before other notification apps.
The notification manager will always call `markProcessed()` , `count()` and `flush()` on other notifications apps before calling it on the 'main' notification app.

#### Reason for change

I have built, and others might build, notification apps that depend on the 'main' notification app and, therefore, require a definitive calling order by the notification manager.


No internal or external api changes.
No new tests required. no current tests changed.
No front-end changes.
No documentation updates required.
No backporting required.
