### PR TITLE
feat: Add new methods to list distinct mounts and retrieve all files in a mount

### DIFF
--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -139,7 +139,6 @@ class FileAccess implements IFileAccess {
 			$subQuery = $this->getQuery()->select('p.encrypted')
 				->from('filecache', 'p')
 				->andWhere($qb->expr()->eq('p.fileid', 'f.parent'))
-				->setMaxResults(1)
 				->getSQL();
 
 			$qb->andWhere(

--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -193,6 +193,7 @@ class FileAccess implements IFileAccess {
 		if ($excludeMountPoints !== false) {
 			$qb->andWhere($qb->expr()->notLike('mount_point', $qb->createPositionalParameter($excludeMountPoints)));
 		}
+		$qb->orderBy('root_id', 'ASC');
 		$result = $qb->executeQuery();
 
 
@@ -217,7 +218,7 @@ class FileAccess implements IFileAccess {
 						->andWhere($qb->expr()->eq('filecache.path', $qb->createNamedParameter('files')))
 						->executeQuery()->fetch();
 					if ($root !== false) {
-						$overrideRoot = intval($root['fileid']);
+						$overrideRoot = (int)$root['fileid'];
 					}
 				} catch (Exception $e) {
 					$this->logger->error('Could not fetch home storage files root for storage ' . $storageId, ['exception' => $e]);

--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -196,9 +196,9 @@ class FileAccess implements IFileAccess {
 			$rootId = (int)$row['root_id'];
 			$overrideRoot = $rootId;
 			if ($rewriteHomeDirectories && in_array($row['mount_provider_class'], [
-					\OC\Files\Mount\LocalHomeMountProvider::class,
-					\OC\Files\Mount\ObjectHomeMountProvider::class,
-				], true)) {
+				\OC\Files\Mount\LocalHomeMountProvider::class,
+				\OC\Files\Mount\ObjectHomeMountProvider::class,
+			], true)) {
 				// Only crawl files, not cache or trashbin
 				$qb = $this->getQuery();
 				try {

--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -158,7 +158,7 @@ class FileAccess implements IFileAccess {
 		$files->closeCursor();
 	}
 
-	public function getDistinctMounts(array $mountProviders = [], bool $excludeTrashbinMounts = true, bool $rewriteHomeDirectories = true): \Generator {
+	public function getDistinctMounts(array $mountProviders = [], bool $rewriteHomeDirectories = true): \Generator {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->selectDistinct(['root_id', 'storage_id', 'mount_provider_class'])
 			->from('mounts');
@@ -188,11 +188,7 @@ class FileAccess implements IFileAccess {
 						->from('filecache')
 						->where($qb->expr()->eq('storage', $qb->createNamedParameter($storageId, IQueryBuilder::PARAM_INT)))
 						->andWhere($qb->expr()->eq('parent', $qb->createNamedParameter($rootId, IQueryBuilder::PARAM_INT)))
-						->andWhere($qb->expr()->eq('name', $qb->createNamedParameter('files')));
-					if ($excludeTrashbinMounts === true) {
-						$qb->andWhere($qb->expr()->notLike('path', $qb->createNamedParameter('files_trashbin/%')))
-							->andWhere($qb->expr()->notLike('path', $qb->createNamedParameter('__groupfolders/trash/%')));
-					}
+						->andWhere($qb->expr()->eq('path', $qb->createNamedParameter('files')));
 					/** @var array|false $root */
 					$root = $qb->executeQuery()->fetch();
 					if ($root !== false) {

--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -194,8 +194,8 @@ class FileAccess implements IFileAccess {
 			$rootId = (int)$row['root_id'];
 			$overrideRoot = $rootId;
 			if (in_array($row['mount_provider_class'], [
-				OC\Files\Mount\LocalHomeMountProvider::class,
-				OC\Files\Mount\ObjectHomeMountProvider::class,
+				\OC\Files\Mount\LocalHomeMountProvider::class,
+				\OC\Files\Mount\ObjectHomeMountProvider::class,
 			])) {
 				// Only crawl files, not cache or trashbin
 				$qb = $this->getQuery();

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -104,11 +104,11 @@ interface IFileAccess {
 	 * Optionally rewrites home directory root paths to avoid cache and trashbin.
 	 *
 	 * @param list<string> $mountProviders An array of mount provider class names to filter. If empty, all providers will be included.
-	 * @param bool $rewriteHomeDirectories Whether to rewrite the root path IDs for home directories to only include user files.
+	 * @param bool $onlyUserFilesMounts Whether to rewrite the root IDs for home directories to only include user files and to only consider mounts with mount points in the user files.
 	 * @return \Generator<array{storage_id: int, root_id: int, overridden_root: int}> A generator yielding mount configurations as an array containing 'storage_id', 'root_id', and 'override_root'.
 	 * @throws \OCP\DB\Exception
 	 *
 	 * @since 32.0.0
 	 */
-	public function getDistinctMounts(array $mountProviders = [], bool $rewriteHomeDirectories = true): \Generator;
+	public function getDistinctMounts(array $mountProviders = [], bool $onlyUserFilesMounts = true): \Generator;
 }

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
  */
 namespace OCP\Files\Cache;
 
-use OCP\DB\Exception;
-
 /**
  * Low level access to the file cache.
  *

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -94,7 +94,7 @@ interface IFileAccess {
 	 * @param bool $serverSideEncrypted Whether to include ServerSideEncrypted files
 	 * @param int $maxResults The maximum number of results to retrieve. If set to 0, all matching files will be retrieved.
 	 * @return \Generator A generator yielding matching files as cache entries.
-	 * @throws Exception
+	 * @throws \OCP\DB\Exception
 	 *
 	 * @since 32.0.0
 	 */
@@ -106,10 +106,10 @@ interface IFileAccess {
 	 * Optionally rewrites home directory root paths to avoid cache and trashbin.
 	 *
 	 * @param list<string> $mountProviders An array of mount provider class names to filter. If empty, all providers will be included.
-	 * @param string|false $excludeMountPoints A string pattern to exclude mount points. Set to false to not exclude any mount points.
+	 * @param string|false $excludeMountPoints A string containing an SQL LIKE pattern to exclude mount points. Set to false to not exclude any mount points.
 	 * @param bool $rewriteHomeDirectories Whether to rewrite the root path IDs for home directories to only include user files.
 	 * @return \Generator A generator yielding mount configurations as an array containing 'storage_id', 'root_id', and 'override_root'.
-	 * @throws Exception
+	 * @throws \OCP\DB\Exception
 	 *
 	 * @since 32.0.0
 	 */

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -89,7 +89,7 @@ interface IFileAccess {
 	 * @param int $storageId The ID of the storage to search within.
 	 * @param int $rootId The file ID of the ancestor to base the search on.
 	 * @param int $lastFileId The last processed file ID. Only files with a higher ID will be included. Defaults to 0.
-	 * @param array $mimeTypes An array of mime types to filter the results. If empty, no mime type filtering will be applied.
+	 * @param list<int> $mimeTypes An array of mime types to filter the results. If empty, no mime type filtering will be applied.
 	 * @param bool $endToEndEncrypted Whether to include EndToEndEncrypted files
 	 * @param bool $serverSideEncrypted Whether to include ServerSideEncrypted files
 	 * @param int $maxResults The maximum number of results to retrieve. If set to 0, all matching files will be retrieved.

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  */
 namespace OCP\Files\Cache;
 
+use OCP\DB\Exception;
+
 /**
  * Low level access to the file cache.
  *
@@ -79,4 +81,22 @@ interface IFileAccess {
 	 * @since 29.0.0
 	 */
 	public function getByFileIdsInStorage(array $fileIds, int $storageId): array;
+
+	/**
+	 * Retrieves files stored in a specific storage that have a specified ancestor in the file hierarchy.
+	 * Allows filtering by mime types, encryption status, and limits the number of results.
+	 *
+	 * @param int $storageId The ID of the storage to search within.
+	 * @param int $rootId The file ID of the ancestor to base the search on.
+	 * @param int $lastFileId The last processed file ID. Only files with a higher ID will be included. Defaults to 0.
+	 * @param array $mimeTypes An array of mime types to filter the results. If empty, no mime type filtering will be applied.
+	 * @param bool $endToEndEncrypted Whether to include EndToEndEncrypted files
+	 * @param bool $serverSideEncrypted Whether to include ServerSideEncrypted files
+	 * @param int $maxResults The maximum number of results to retrieve. If set to 0, all matching files will be retrieved.
+	 * @return \Generator A generator yielding matching files as cache entries.
+	 * @throws Exception
+	 *
+	 * @since 32.0.0
+	 */
+	public function getByAncestorInStorage(int $storageId, int $rootId, int $lastFileId = 0, array $mimeTypes = [], bool $endToEndEncrypted = true, bool $serverSideEncrypted = true, int $maxResults = 100): \Generator;
 }

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -85,18 +85,16 @@ interface IFileAccess {
 	 * Allows filtering by mime types, encryption status, and limits the number of results.
 	 *
 	 * @param int $storageId The ID of the storage to search within.
-	 * @param int $rootId The file ID of the ancestor to base the search on.
-	 * @param int $lastFileId The last processed file ID. Only files with a higher ID will be included. Defaults to 0.
-	 * @param list<int> $mimeTypes An array of mime types to filter the results. If empty, no mime type filtering will be applied.
+	 * @param int $folderId The file ID of the ancestor to base the search on.
+	 * @param int $fileIdCursor The last processed file ID. Only files with a higher ID will be included. Defaults to 0.
+	 * @param int $maxResults The maximum number of results to retrieve. If set to 0, all matching files will be retrieved.
+	 * @param list<int> $mimeTypeIds An array of mime types to filter the results. If empty, no mime type filtering will be applied.
 	 * @param bool $endToEndEncrypted Whether to include EndToEndEncrypted files
 	 * @param bool $serverSideEncrypted Whether to include ServerSideEncrypted files
-	 * @param int $maxResults The maximum number of results to retrieve. If set to 0, all matching files will be retrieved.
 	 * @return \Generator A generator yielding matching files as cache entries.
 	 * @throws \OCP\DB\Exception
-	 *
-	 * @since 32.0.0
 	 */
-	public function getByAncestorInStorage(int $storageId, int $rootId, int $lastFileId = 0, array $mimeTypes = [], bool $endToEndEncrypted = true, bool $serverSideEncrypted = true, int $maxResults = 100): \Generator;
+	public function getByAncestorInStorage(int $storageId, int $folderId, int $fileIdCursor = 0, int $maxResults = 100, array $mimeTypeIds = [], bool $endToEndEncrypted = true, bool $serverSideEncrypted = true): \Generator;
 
 	/**
 	 * Retrieves a list of all distinct mounts.
@@ -104,12 +102,12 @@ interface IFileAccess {
 	 * Optionally rewrites home directory root paths to avoid cache and trashbin.
 	 *
 	 * @param list<string> $mountProviders An array of mount provider class names to filter. If empty, all providers will be included.
-	 * @param string|false $excludeMountPoints A string containing an SQL LIKE pattern to exclude mount points. Set to false to not exclude any mount points.
+	 * @param bool $excludeTrashbinMounts Whether to include mounts that mount a directory in a user's trashbin.
 	 * @param bool $rewriteHomeDirectories Whether to rewrite the root path IDs for home directories to only include user files.
 	 * @return \Generator A generator yielding mount configurations as an array containing 'storage_id', 'root_id', and 'override_root'.
 	 * @throws \OCP\DB\Exception
 	 *
 	 * @since 32.0.0
 	 */
-	public function getDistinctMounts(array $mountProviders = [], string|false $excludeMountPoints = false, bool $rewriteHomeDirectories = true): \Generator;
+	public function getDistinctMounts(array $mountProviders = [], bool $excludeTrashbinMounts = true, bool $rewriteHomeDirectories = true): \Generator;
 }

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -100,16 +100,15 @@ interface IFileAccess {
 
 	/**
 	 * Retrieves a list of all distinct mounts.
-	 * Allows filtering by specific mount providers and excluding certain mount points.
+	 * Allows filtering by specific mount providers.
 	 * Optionally rewrites home directory root paths to avoid cache and trashbin.
 	 *
 	 * @param list<string> $mountProviders An array of mount provider class names to filter. If empty, all providers will be included.
-	 * @param bool $excludeTrashbinMounts Whether to include mounts that mount a directory in a user's trashbin.
 	 * @param bool $rewriteHomeDirectories Whether to rewrite the root path IDs for home directories to only include user files.
 	 * @return \Generator<array{storage_id: int, root_id: int, overridden_root: int}> A generator yielding mount configurations as an array containing 'storage_id', 'root_id', and 'override_root'.
 	 * @throws \OCP\DB\Exception
 	 *
 	 * @since 32.0.0
 	 */
-	public function getDistinctMounts(array $mountProviders = [], bool $excludeTrashbinMounts = true, bool $rewriteHomeDirectories = true): \Generator;
+	public function getDistinctMounts(array $mountProviders = [], bool $rewriteHomeDirectories = true): \Generator;
 }

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -91,8 +91,10 @@ interface IFileAccess {
 	 * @param list<int> $mimeTypeIds An array of mime types to filter the results. If empty, no mime type filtering will be applied.
 	 * @param bool $endToEndEncrypted Whether to include EndToEndEncrypted files
 	 * @param bool $serverSideEncrypted Whether to include ServerSideEncrypted files
-	 * @return \Generator A generator yielding matching files as cache entries.
+	 * @return \Generator<ICacheEntry> A generator yielding matching files as cache entries.
 	 * @throws \OCP\DB\Exception
+	 *
+	 * @since 32.0.0
 	 */
 	public function getByAncestorInStorage(int $storageId, int $folderId, int $fileIdCursor = 0, int $maxResults = 100, array $mimeTypeIds = [], bool $endToEndEncrypted = true, bool $serverSideEncrypted = true): \Generator;
 
@@ -104,7 +106,7 @@ interface IFileAccess {
 	 * @param list<string> $mountProviders An array of mount provider class names to filter. If empty, all providers will be included.
 	 * @param bool $excludeTrashbinMounts Whether to include mounts that mount a directory in a user's trashbin.
 	 * @param bool $rewriteHomeDirectories Whether to rewrite the root path IDs for home directories to only include user files.
-	 * @return \Generator A generator yielding mount configurations as an array containing 'storage_id', 'root_id', and 'override_root'.
+	 * @return \Generator<array{storage_id: int, root_id: int, overridden_root: int}> A generator yielding mount configurations as an array containing 'storage_id', 'root_id', and 'override_root'.
 	 * @throws \OCP\DB\Exception
 	 *
 	 * @since 32.0.0

--- a/lib/public/Files/Cache/IFileAccess.php
+++ b/lib/public/Files/Cache/IFileAccess.php
@@ -99,4 +99,19 @@ interface IFileAccess {
 	 * @since 32.0.0
 	 */
 	public function getByAncestorInStorage(int $storageId, int $rootId, int $lastFileId = 0, array $mimeTypes = [], bool $endToEndEncrypted = true, bool $serverSideEncrypted = true, int $maxResults = 100): \Generator;
+
+	/**
+	 * Retrieves a list of all distinct mounts.
+	 * Allows filtering by specific mount providers and excluding certain mount points.
+	 * Optionally rewrites home directory root paths to avoid cache and trashbin.
+	 *
+	 * @param list<string> $mountProviders An array of mount provider class names to filter. If empty, all providers will be included.
+	 * @param string|false $excludeMountPoints A string pattern to exclude mount points. Set to false to not exclude any mount points.
+	 * @param bool $rewriteHomeDirectories Whether to rewrite the root path IDs for home directories to only include user files.
+	 * @return \Generator A generator yielding mount configurations as an array containing 'storage_id', 'root_id', and 'override_root'.
+	 * @throws Exception
+	 *
+	 * @since 32.0.0
+	 */
+	public function getDistinctMounts(array $mountProviders = [], string|false $excludeMountPoints = false, bool $rewriteHomeDirectories = true): \Generator;
 }

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -179,6 +179,7 @@ class FileAccessTest extends TestCase {
 				'fileid' => $queryBuilder->createNamedParameter(99, IQueryBuilder::PARAM_INT),
 				'storage' => $queryBuilder->createNamedParameter(4, IQueryBuilder::PARAM_INT),
 				'path' => $queryBuilder->createNamedParameter('files'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files')),
 			])
 			->executeStatement();
 

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
- * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -18,25 +17,22 @@ use Test\TestCase;
  * @group DB
  */
 class FileAccessTest extends TestCase {
-	/** @var IDBConnection */
-	private $dbConnection;
-
-	/** @var FileAccess */
-	private $fileAccess;
+	private IDBConnection $dbConnection;
+	private FileAccess $fileAccess;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		// Setup the actual database connection (assume the database is configured properly in PHPUnit setup)
-		$this->dbConnection = \OC::$server->get(IDBConnection::class);
+		$this->dbConnection = \OCP\Server::get(IDBConnection::class);
 
 		// Ensure FileAccess is instantiated with the real connection
 		$this->fileAccess = new FileAccess(
 			$this->dbConnection,
-			\OC::$server->get(\OC\SystemConfig::class),
-			\OC::$server->get(LoggerInterface::class),
-			\OC::$server->get(\OC\FilesMetadata\FilesMetadataManager::class),
-			\OC::$server->get(\OCP\Files\IMimeTypeLoader::class)
+			\OCP\Server::get(\OC\SystemConfig::class),
+			\OCP\Server::get(LoggerInterface::class),
+			\OCP\Server::get(\OC\FilesMetadata\FilesMetadataManager::class),
+			\OCP\Server::get(\OCP\Files\IMimeTypeLoader::class)
 		);
 
 		// Clear and prepare `filecache` table for tests

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -40,7 +40,7 @@ class FileAccessTest extends TestCase {
 		);
 
 		// Clear and prepare `filecache` table for tests
-		$queryBuilder = $this->dbConnection->getQueryBuilder();
+		$queryBuilder = $this->dbConnection->getQueryBuilder()->runAcrossAllShards();
 		$queryBuilder->delete('filecache')->executeStatement();
 
 		// Clean up potential leftovers from other tests
@@ -173,7 +173,9 @@ class FileAccessTest extends TestCase {
 			->executeStatement();
 
 		// Simulate adding a "files" directory to the filecache table
+		$queryBuilder = $this->dbConnection->getQueryBuilder()->runAcrossAllShards();
 		$queryBuilder->delete('filecache')->executeStatement();
+		$queryBuilder = $this->dbConnection->getQueryBuilder();
 		$queryBuilder->insert('filecache')
 			->values([
 				'fileid' => $queryBuilder->createNamedParameter(99, IQueryBuilder::PARAM_INT),

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -141,7 +141,8 @@ class FileAccessTest extends TestCase {
 				'storage' => $queryBuilder->createNamedParameter(4, IQueryBuilder::PARAM_INT),
 				'parent' => $queryBuilder->createNamedParameter(40),
 				'name' => $queryBuilder->createNamedParameter('files'),
-				'path_hash' => $queryBuilder->createNamedParameter(md5('/home/user/files')),
+				'path' => $queryBuilder->createNamedParameter('files'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files')),
 			])
 			->executeStatement();
 

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -64,16 +64,6 @@ class FileAccessTest extends TestCase {
 
 		$queryBuilder->insert('mounts')
 			->values([
-				'storage_id' => $queryBuilder->createNamedParameter(2, IQueryBuilder::PARAM_INT),
-				'root_id' => $queryBuilder->createNamedParameter(20, IQueryBuilder::PARAM_INT),
-				'mount_provider_class' => $queryBuilder->createNamedParameter('TestProviderClass2'),
-				'mount_point' => $queryBuilder->createNamedParameter('/foobar/files_trashbin/test'),
-				'user_id' => $queryBuilder->createNamedParameter('test'),
-			])
-			->executeStatement();
-
-		$queryBuilder->insert('mounts')
-			->values([
 				'storage_id' => $queryBuilder->createNamedParameter(3, IQueryBuilder::PARAM_INT),
 				'root_id' => $queryBuilder->createNamedParameter(30, IQueryBuilder::PARAM_INT),
 				'mount_provider_class' => $queryBuilder->createNamedParameter('TestProviderClass1'),
@@ -123,33 +113,6 @@ class FileAccessTest extends TestCase {
 			'root_id' => 30,
 			'overridden_root' => 30,
 		], $result[1]);
-	}
-
-	/**
-	 * Test that getDistinctMounts excludes certain mount points
-	 */
-	public function testGetDistinctMountsWithExclusionFilter(): void {
-		$result = iterator_to_array($this->fileAccess->getDistinctMounts([], false));
-
-		$this->assertCount(3, $result);
-
-		$this->assertEquals([
-			'storage_id' => 1,
-			'root_id' => 10,
-			'overridden_root' => 10,
-		], $result[0]);
-
-		$this->assertEquals([
-			'storage_id' => 2,
-			'root_id' => 20,
-			'overridden_root' => 20,
-		], $result[1]);
-
-		$this->assertEquals([
-			'storage_id' => 3,
-			'root_id' => 30,
-			'overridden_root' => 30,
-		], $result[2]);
 	}
 
 	/**

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -1,0 +1,438 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Files\Cache;
+
+use OC\Files\Cache\CacheEntry;
+use OC\Files\Cache\FileAccess;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class FileAccessTest extends TestCase {
+	/** @var IDBConnection */
+	private $dbConnection;
+
+	/** @var FileAccess */
+	private $fileAccess;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Setup the actual database connection (assume the database is configured properly in PHPUnit setup)
+		$this->dbConnection = \OC::$server->get(IDBConnection::class);
+
+		// Ensure FileAccess is instantiated with the real connection
+		$this->fileAccess = new FileAccess(
+			$this->dbConnection,
+			\OC::$server->get(\OC\SystemConfig::class),
+			\OC::$server->get(LoggerInterface::class),
+			\OC::$server->get(\OC\FilesMetadata\FilesMetadataManager::class),
+			\OC::$server->get(\OCP\Files\IMimeTypeLoader::class)
+		);
+
+		// Clear and prepare `filecache` table for tests
+		$queryBuilder = $this->dbConnection->getQueryBuilder();
+		$queryBuilder->delete('filecache')->executeStatement();
+
+		// Clean up potential leftovers from other tests
+		$queryBuilder = $this->dbConnection->getQueryBuilder();
+		$queryBuilder->delete('mounts')->executeStatement();
+
+
+		$this->setUpTestDatabaseForGetDistinctMounts();
+		$this->setUpTestDatabaseForGetByAncestorInStorage();
+	}
+
+	private function setUpTestDatabaseForGetDistinctMounts(): void {
+		$queryBuilder = $this->dbConnection->getQueryBuilder();
+
+		// Insert test data
+		$queryBuilder->insert('mounts')
+			->values([
+				'storage_id' => $queryBuilder->createNamedParameter(1, IQueryBuilder::PARAM_INT),
+				'root_id' => $queryBuilder->createNamedParameter(10, IQueryBuilder::PARAM_INT),
+				'mount_provider_class' => $queryBuilder->createNamedParameter('TestProviderClass1'),
+				'mount_point' => $queryBuilder->createNamedParameter('/files'),
+				'user_id' => $queryBuilder->createNamedParameter('test'),
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('mounts')
+			->values([
+				'storage_id' => $queryBuilder->createNamedParameter(2, IQueryBuilder::PARAM_INT),
+				'root_id' => $queryBuilder->createNamedParameter(20, IQueryBuilder::PARAM_INT),
+				'mount_provider_class' => $queryBuilder->createNamedParameter('TestProviderClass2'),
+				'mount_point' => $queryBuilder->createNamedParameter('/cache'),
+				'user_id' => $queryBuilder->createNamedParameter('test'),
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('mounts')
+			->values([
+				'storage_id' => $queryBuilder->createNamedParameter(3, IQueryBuilder::PARAM_INT),
+				'root_id' => $queryBuilder->createNamedParameter(30, IQueryBuilder::PARAM_INT),
+				'mount_provider_class' => $queryBuilder->createNamedParameter('TestProviderClass1'),
+				'mount_point' => $queryBuilder->createNamedParameter('/trashbin'),
+				'user_id' => $queryBuilder->createNamedParameter('test'),
+			])
+			->executeStatement();
+	}
+
+	/**
+	 * Test that getDistinctMounts returns all mounts without filters
+	 */
+	public function testGetDistinctMountsWithoutFilters(): void {
+		$result = iterator_to_array($this->fileAccess->getDistinctMounts());
+
+		$this->assertCount(3, $result);
+
+		$this->assertEquals([
+			'storage_id' => 1,
+			'root_id' => 10,
+			'override_root' => 10,
+		], $result[0]);
+
+		$this->assertEquals([
+			'storage_id' => 2,
+			'root_id' => 20,
+			'override_root' => 20,
+		], $result[1]);
+
+		$this->assertEquals([
+			'storage_id' => 3,
+			'root_id' => 30,
+			'override_root' => 30,
+		], $result[2]);
+	}
+
+	/**
+	 * Test that getDistinctMounts applies filtering by mount providers
+	 */
+	public function testGetDistinctMountsWithMountProviderFilter(): void {
+		$result = iterator_to_array($this->fileAccess->getDistinctMounts(['TestProviderClass1']));
+
+		$this->assertCount(2, $result);
+
+		$this->assertEquals([
+			'storage_id' => 1,
+			'root_id' => 10,
+			'override_root' => 10,
+		], $result[0]);
+
+		$this->assertEquals([
+			'storage_id' => 3,
+			'root_id' => 30,
+			'override_root' => 30,
+		], $result[1]);
+	}
+
+	/**
+	 * Test that getDistinctMounts excludes certain mount points
+	 */
+	public function testGetDistinctMountsWithExclusionFilter(): void {
+		$result = iterator_to_array($this->fileAccess->getDistinctMounts([], '/cache'));
+
+		$this->assertCount(2, $result);
+
+		$this->assertEquals([
+			'storage_id' => 1,
+			'root_id' => 10,
+			'override_root' => 10,
+		], $result[0]);
+
+		$this->assertEquals([
+			'storage_id' => 3,
+			'root_id' => 30,
+			'override_root' => 30,
+		], $result[1]);
+	}
+
+	/**
+	 * Test that getDistinctMounts rewrites home directory paths
+	 */
+	public function testGetDistinctMountsWithRewriteHomeDirectories(): void {
+		// Add additional test data for a home directory mount
+		$queryBuilder = $this->dbConnection->getQueryBuilder();
+		$queryBuilder->insert('mounts')
+			->values([
+				'storage_id' => $queryBuilder->createNamedParameter(4, IQueryBuilder::PARAM_INT),
+				'root_id' => $queryBuilder->createNamedParameter(40, IQueryBuilder::PARAM_INT),
+				'mount_provider_class' => $queryBuilder->createNamedParameter(\OC\Files\Mount\LocalHomeMountProvider::class),
+				'mount_point' => $queryBuilder->createNamedParameter('/home/user'),
+				'user_id' => $queryBuilder->createNamedParameter('test'),
+			])
+			->executeStatement();
+
+		// Simulate adding a "files" directory to the filecache table
+		$queryBuilder->delete('filecache')->executeStatement();
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => $queryBuilder->createNamedParameter(99, IQueryBuilder::PARAM_INT),
+				'storage' => $queryBuilder->createNamedParameter(4, IQueryBuilder::PARAM_INT),
+				'path' => $queryBuilder->createNamedParameter('files'),
+			])
+			->executeStatement();
+
+		$result = iterator_to_array($this->fileAccess->getDistinctMounts());
+
+		$this->assertEquals([
+			'storage_id' => 4,
+			'root_id' => 40,
+			'override_root' => 99,
+		], end($result));
+	}
+
+	private function setUpTestDatabaseForGetByAncestorInStorage(): void {
+		// prepare `filecache` table for tests
+		$queryBuilder = $this->dbConnection->getQueryBuilder();
+
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => 1,
+				'parent' => 0,
+				'path' => $queryBuilder->createNamedParameter('files'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files')),
+				'storage' => $queryBuilder->createNamedParameter(1),
+				'name' => $queryBuilder->createNamedParameter('files'),
+				'mimetype' => 1,
+				'encrypted' => 0,
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => 2,
+				'parent' => 1,
+				'path' => $queryBuilder->createNamedParameter('files/documents'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files/documents')),
+				'storage' => $queryBuilder->createNamedParameter(1),
+				'name' => $queryBuilder->createNamedParameter('documents'),
+				'mimetype' => 2,
+				'encrypted' => 1,
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => 3,
+				'parent' => 1,
+				'path' => $queryBuilder->createNamedParameter('files/photos'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files/photos')),
+				'storage' => $queryBuilder->createNamedParameter(1),
+				'name' => $queryBuilder->createNamedParameter('photos'),
+				'mimetype' => 3,
+				'encrypted' => 1,
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => 4,
+				'parent' => 3,
+				'path' => $queryBuilder->createNamedParameter('files/photos/endtoendencrypted'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files/photos/endtoendencrypted')),
+				'storage' => $queryBuilder->createNamedParameter(1),
+				'name' => $queryBuilder->createNamedParameter('endtoendencrypted'),
+				'mimetype' => 4,
+				'encrypted' => 0,
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => 5,
+				'parent' => 0,
+				'path' => $queryBuilder->createNamedParameter('files/serversideencrypted'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files/serversideencrypted')),
+				'storage' => $queryBuilder->createNamedParameter(1),
+				'name' => $queryBuilder->createNamedParameter('serversideencrypted'),
+				'mimetype' => 4,
+				'encrypted' => 1,
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => 6,
+				'parent' => 0,
+				'path' => $queryBuilder->createNamedParameter('files/storage2'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files/storage2')),
+				'storage' => $queryBuilder->createNamedParameter(2),
+				'name' => $queryBuilder->createNamedParameter('storage2'),
+				'mimetype' => 5,
+				'encrypted' => 0,
+			])
+			->executeStatement();
+
+		$queryBuilder->insert('filecache')
+			->values([
+				'fileid' => 7,
+				'parent' => 6,
+				'path' => $queryBuilder->createNamedParameter('files/storage2/file'),
+				'path_hash' => $queryBuilder->createNamedParameter(md5('files/storage2/file')),
+				'storage' => $queryBuilder->createNamedParameter(2),
+				'name' => $queryBuilder->createNamedParameter('file'),
+				'mimetype' => 6,
+				'encrypted' => 0,
+			])
+			->executeStatement();
+	}
+
+	/**
+	 * Test fetching files by ancestor in storage.
+	 */
+	public function testGetByAncestorInStorage(): void {
+		$generator = $this->fileAccess->getByAncestorInStorage(
+			1, // storageId
+			1, // rootId
+			0, // lastFileId
+			[], // mimeTypes
+			true, // include end-to-end encrypted files
+			true, // include server-side encrypted files
+			10 // maxResults
+		);
+
+		$result = iterator_to_array($generator);
+
+		$this->assertCount(4, $result);
+
+		$paths = array_map(fn(CacheEntry $entry) => $entry->getPath(), $result);
+		$this->assertEquals([
+			'files/documents',
+			'files/photos',
+			'files/photos/endtoendencrypted',
+			'files/serversideencrypted',
+		], $paths);
+	}
+
+	/**
+	 * Test filtering by mime types.
+	 */
+	public function testGetByAncestorInStorageWithMimeTypes(): void {
+		$generator = $this->fileAccess->getByAncestorInStorage(
+			1,
+			1,
+			0,
+			[2], // Only include documents (mimetype=2)
+			true,
+			true,
+			10
+		);
+
+		$result = iterator_to_array($generator);
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('files/documents', $result[0]->getPath());
+	}
+
+	/**
+	 * Test excluding end-to-end encrypted files.
+	 */
+	public function testGetByAncestorInStorageWithoutEndToEndEncrypted(): void {
+		$generator = $this->fileAccess->getByAncestorInStorage(
+			1,
+			1,
+			0,
+			[],
+			false, // exclude end-to-end encrypted files
+			true,
+			10
+		);
+
+		$result = iterator_to_array($generator);
+
+		var_dump($result);
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('files/serversideencrypted', $result[0]->getPath());
+	}
+
+	/**
+	 * Test excluding server-side encrypted files.
+	 */
+	public function testGetByAncestorInStorageWithoutServerSideEncrypted(): void {
+		$generator = $this->fileAccess->getByAncestorInStorage(
+			1,
+			1,
+			0,
+			[],
+			true,
+			false, // exclude server-side encrypted files
+			10
+		);
+
+		$result = iterator_to_array($generator);
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('files/photos/endtoendencrypted', $result[0]->getPath());
+	}
+
+	/**
+	 * Test max result limits.
+	 */
+	public function testGetByAncestorInStorageWithMaxResults(): void {
+		$generator = $this->fileAccess->getByAncestorInStorage(
+			1,
+			1,
+			0,
+			[],
+			true,
+			true,
+			1 // Limit to 1 result
+		);
+
+		$result = iterator_to_array($generator);
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('files/documents', $result[0]->getPath());
+	}
+
+	/**
+	 * Test rootId filter
+	 */
+	public function testGetByAncestorInStorageWithRootIdFilter(): void {
+		$generator = $this->fileAccess->getByAncestorInStorage(
+			1,
+			3, // Filter by rootId
+			0,
+			[],
+			true,
+			true,
+			10
+		);
+
+		$result = iterator_to_array($generator);
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('files/photos/endtoendencrypted', $result[0]->getPath());
+	}
+
+	/**
+	 * Test rootId filter
+	 */
+	public function testGetByAncestorInStorageWithStorageFilter(): void {
+		$generator = $this->fileAccess->getByAncestorInStorage(
+			2, // Filter by storage
+			6, // and by rootId
+			0,
+			[],
+			true,
+			true,
+			10
+		);
+
+		$result = iterator_to_array($generator);
+
+		$this->assertCount(1, $result);
+		$this->assertEquals('files/storage2/file', $result[0]->getPath());
+	}
+}

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -250,7 +250,7 @@ class FileAccessTest extends TestCase {
 		$queryBuilder->insert('filecache')
 			->values([
 				'fileid' => 5,
-				'parent' => 0,
+				'parent' => 1,
 				'path' => $queryBuilder->createNamedParameter('files/serversideencrypted'),
 				'path_hash' => $queryBuilder->createNamedParameter(md5('files/serversideencrypted')),
 				'storage' => $queryBuilder->createNamedParameter(1),
@@ -350,10 +350,9 @@ class FileAccessTest extends TestCase {
 
 		$result = iterator_to_array($generator);
 
-		var_dump($result);
-
-		$this->assertCount(1, $result);
-		$this->assertEquals('files/serversideencrypted', $result[0]->getPath());
+		$this->assertCount(3, $result);
+		$paths = array_map(fn(CacheEntry $entry) => $entry->getPath(), $result);
+		$this->assertEquals(['files/documents', 'files/photos', 'files/serversideencrypted'], $paths);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
These methods are needed for context chat and recognize to efficiently enumerate all files in the nextcloud instance.

In context chat and recognize we need to index all files of all users that fit certain criteria. To do this efficiently, we enumerate all essential mounts like home folders, external storage and groupfolders, excluding stuff like shares and trashbin. For this I implemented the getDistinctMounts method. It allows to filter by mount provider, so we can exclude shares etc. It also allows to adjust (override) home directory mounts to the actual files folder in a home directory, so we don't catch stuff that the user cannot see. 

Once we have the distinct mounts, we enumerate all files non-recursively for each mount with getFilesByAncestorInStorage, it can filter by mimetypes and encryption state, and also takes a limit as well as a fileId cursor.

This is currently implemented in the context chat app, but as it makes use of the CacheQuery builder and core tables, the integrations team thinks it would be beneficial to have it in server.

## Todo

- [x] Tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
