### PR TITLE
feat(cron): Emit event before/after background job execution

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -180,6 +180,8 @@ return array(
     'OCP\\Authentication\\TwoFactorAuth\\TwoFactorProviderForUserUnregistered' => $baseDir . '/lib/public/Authentication/TwoFactorAuth/TwoFactorProviderForUserUnregistered.php',
     'OCP\\Authentication\\TwoFactorAuth\\TwoFactorProviderUserDeleted' => $baseDir . '/lib/public/Authentication/TwoFactorAuth/TwoFactorProviderUserDeleted.php',
     'OCP\\AutoloadNotAllowedException' => $baseDir . '/lib/public/AutoloadNotAllowedException.php',
+    'OCP\\BackgroundJob\\Events\\BeforeJobExecutedEvent' => $baseDir . '/lib/public/BackgroundJob/Events/BeforeJobExecutedEvent.php',
+    'OCP\\BackgroundJob\\Events\\JobExecutedEvent' => $baseDir . '/lib/public/BackgroundJob/Events/JobExecutedEvent.php',
     'OCP\\BackgroundJob\\IJob' => $baseDir . '/lib/public/BackgroundJob/IJob.php',
     'OCP\\BackgroundJob\\IJobList' => $baseDir . '/lib/public/BackgroundJob/IJobList.php',
     'OCP\\BackgroundJob\\IParallelAwareJob' => $baseDir . '/lib/public/BackgroundJob/IParallelAwareJob.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -229,6 +229,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Authentication\\TwoFactorAuth\\TwoFactorProviderForUserUnregistered' => __DIR__ . '/../../..' . '/lib/public/Authentication/TwoFactorAuth/TwoFactorProviderForUserUnregistered.php',
         'OCP\\Authentication\\TwoFactorAuth\\TwoFactorProviderUserDeleted' => __DIR__ . '/../../..' . '/lib/public/Authentication/TwoFactorAuth/TwoFactorProviderUserDeleted.php',
         'OCP\\AutoloadNotAllowedException' => __DIR__ . '/../../..' . '/lib/public/AutoloadNotAllowedException.php',
+        'OCP\\BackgroundJob\\Events\\BeforeJobExecutedEvent' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/Events/BeforeJobExecutedEvent.php',
+        'OCP\\BackgroundJob\\Events\\JobExecutedEvent' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/Events/JobExecutedEvent.php',
         'OCP\\BackgroundJob\\IJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJob.php',
         'OCP\\BackgroundJob\\IJobList' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IJobList.php',
         'OCP\\BackgroundJob\\IParallelAwareJob' => __DIR__ . '/../../..' . '/lib/public/BackgroundJob/IParallelAwareJob.php',

--- a/lib/public/BackgroundJob/Events/BeforeJobExecutedEvent.php
+++ b/lib/public/BackgroundJob/Events/BeforeJobExecutedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCP\BackgroundJob\Events;
+
+use OCP\BackgroundJob\IJob;
+use OCP\EventDispatcher\Event;
+
+/**
+ * Emitted before a background job is executed
+ *
+ * @since 32.0.0
+ */
+class BeforeJobExecutedEvent extends Event {
+
+	/**
+	 * @since 32.0.0
+	 */
+	public function __construct(
+		private IJob $job,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @since 32.0.0
+	 */
+	public function getJob(): IJob {
+		return $this->job;
+	}
+
+}

--- a/lib/public/BackgroundJob/Events/JobExecutedEvent.php
+++ b/lib/public/BackgroundJob/Events/JobExecutedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCP\BackgroundJob\Events;
+
+use OCP\BackgroundJob\IJob;
+use OCP\EventDispatcher\Event;
+
+/**
+ * Emitted before a background job is executed
+ *
+ * @since 32.0.0
+ */
+class JobExecutedEvent extends Event {
+
+	/**
+	 * @since 32.0.0
+	 */
+	public function __construct(
+		private IJob $job,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * @since 32.0.0
+	 */
+	public function getJob(): IJob {
+		return $this->job;
+	}
+
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Required for https://github.com/ChristophWurst/nextcloud_sentry/pull/707

## Summary

Emit events before and after running background jobs.

## TODO

- [x] Implement
- [x] Test

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
