### PR TITLE
chore(legacy): Remove deprecated OC_Util::addScript and functions depending on it

### DIFF
--- a/lib/private/Template/functions.php
+++ b/lib/private/Template/functions.php
@@ -123,22 +123,6 @@ function script($app, $file = null): void {
 }
 
 /**
- * Shortcut for adding vendor scripts to a page
- * @param string $app the appname
- * @param string|string[] $file the filename,
- *                              if an array is given it will add all scripts
- */
-function vendor_script($app, $file = null): void {
-	if (is_array($file)) {
-		foreach ($file as $f) {
-			OC_Util::addVendorScript($app, $f);
-		}
-	} else {
-		OC_Util::addVendorScript($app, $file);
-	}
-}
-
-/**
  * Shortcut for adding styles to a page
  * @param string $app the appname
  * @param string|string[] $file the filename,
@@ -176,7 +160,7 @@ function vendor_style($app, $file = null): void {
  *                    if an array is given it will add all styles
  */
 function translation($app): void {
-	OC_Util::addTranslations($app);
+	Util::addTranslations($app);
 }
 
 /**

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -214,8 +214,7 @@ class TemplateLayout {
 		}
 
 		// Add the js files
-		// TODO: remove deprecated OC_Util injection
-		$jsFiles = self::findJavascriptFiles(array_merge(\OC_Util::$scripts, Util::getScripts()));
+		$jsFiles = self::findJavascriptFiles(Util::getScripts());
 		$page->assign('jsfiles', []);
 		if ($this->config->getSystemValueBool('installed', false) && $renderAs != TemplateResponse::RENDER_AS_ERROR) {
 			// this is on purpose outside of the if statement below so that the initial state is prefilled (done in the getConfig() call)

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -20,7 +20,6 @@ use OCP\Share\IManager;
 use Psr\Log\LoggerInterface;
 
 class OC_Util {
-	public static $scripts = [];
 	public static $styles = [];
 	public static $headers = [];
 
@@ -236,60 +235,6 @@ class OC_Util {
 	}
 
 	/**
-	 * add a javascript file
-	 *
-	 * @deprecated 24.0.0 - Use \OCP\Util::addScript
-	 *
-	 * @param string $application application id
-	 * @param string|null $file filename
-	 * @param bool $prepend prepend the Script to the beginning of the list
-	 * @return void
-	 */
-	public static function addScript($application, $file = null, $prepend = false) {
-		$path = OC_Util::generatePath($application, 'js', $file);
-
-		// core js files need separate handling
-		if ($application !== 'core' && $file !== null) {
-			self::addTranslations($application);
-		}
-		self::addExternalResource($application, $prepend, $path, 'script');
-	}
-
-	/**
-	 * add a javascript file from the vendor sub folder
-	 *
-	 * @param string $application application id
-	 * @param string|null $file filename
-	 * @param bool $prepend prepend the Script to the beginning of the list
-	 * @return void
-	 */
-	public static function addVendorScript($application, $file = null, $prepend = false) {
-		$path = OC_Util::generatePath($application, 'vendor', $file);
-		self::addExternalResource($application, $prepend, $path, 'script');
-	}
-
-	/**
-	 * add a translation JS file
-	 *
-	 * @deprecated 24.0.0
-	 *
-	 * @param string $application application id
-	 * @param string|null $languageCode language code, defaults to the current language
-	 * @param bool|null $prepend prepend the Script to the beginning of the list
-	 */
-	public static function addTranslations($application, $languageCode = null, $prepend = false) {
-		if (is_null($languageCode)) {
-			$languageCode = \OC::$server->get(IFactory::class)->findLanguage($application);
-		}
-		if (!empty($application)) {
-			$path = "$application/l10n/$languageCode";
-		} else {
-			$path = "l10n/$languageCode";
-		}
-		self::addExternalResource($application, $prepend, $path, 'script');
-	}
-
-	/**
 	 * add a css file
 	 *
 	 * @param string $application application id
@@ -331,14 +276,6 @@ class OC_Util {
 					array_unshift(self::$styles, $path);
 				} else {
 					self::$styles[] = $path;
-				}
-			}
-		} elseif ($type === 'script') {
-			if (!in_array($path, self::$scripts)) {
-				if ($prepend === true) {
-					array_unshift(self::$scripts, $path);
-				} else {
-					self::$scripts [] = $path;
 				}
 			}
 		}

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -8,6 +8,7 @@
 namespace Test;
 
 use OC_Util;
+use OCP\Util;
 
 /**
  * Class UtilTest
@@ -17,7 +18,7 @@ use OC_Util;
  */
 class UtilTest extends \Test\TestCase {
 	public function testGetVersion(): void {
-		$version = \OCP\Util::getVersion();
+		$version = Util::getVersion();
 		$this->assertTrue(is_array($version));
 		foreach ($version as $num) {
 			$this->assertTrue(is_int($num));
@@ -86,7 +87,7 @@ class UtilTest extends \Test\TestCase {
 	 * So we check that with strict email verification we fallback to the default
 	 */
 	public function testGetDefaultEmailAddressStrict(): void {
-		$email = \OCP\Util::getDefaultEmailAddress('no-reply');
+		$email = Util::getDefaultEmailAddress('no-reply');
 		$this->assertEquals('no-reply@localhost.localdomain', $email);
 	}
 
@@ -96,7 +97,7 @@ class UtilTest extends \Test\TestCase {
 	public function testGetDefaultEmailAddress(): void {
 		$config = \OC::$server->getConfig();
 		$config->setAppValue('core', 'enforce_strict_email_check', 'no');
-		$email = \OCP\Util::getDefaultEmailAddress('no-reply');
+		$email = Util::getDefaultEmailAddress('no-reply');
 		$this->assertEquals('no-reply@localhost', $email);
 		$config->deleteAppValue('core', 'enforce_strict_email_check');
 	}
@@ -104,7 +105,7 @@ class UtilTest extends \Test\TestCase {
 	public function testGetDefaultEmailAddressFromConfig(): void {
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('mail_domain', 'example.com');
-		$email = \OCP\Util::getDefaultEmailAddress('no-reply');
+		$email = Util::getDefaultEmailAddress('no-reply');
 		$this->assertEquals('no-reply@example.com', $email);
 		$config->deleteSystemValue('mail_domain');
 	}
@@ -113,7 +114,7 @@ class UtilTest extends \Test\TestCase {
 		$config = \OC::$server->getConfig();
 		$config->setSystemValue('mail_domain', 'example.com');
 		$config->setSystemValue('mail_from_address', 'owncloud');
-		$email = \OCP\Util::getDefaultEmailAddress('no-reply');
+		$email = Util::getDefaultEmailAddress('no-reply');
 		$this->assertEquals('owncloud@example.com', $email);
 		$config->deleteSystemValue('mail_domain');
 		$config->deleteSystemValue('mail_from_address');
@@ -135,19 +136,19 @@ class UtilTest extends \Test\TestCase {
 		$oldConfigVersion = $config->getSystemValue('version', '0.0.0');
 		$oldSessionVersion = \OC::$server->getSession()->get('OC_Version');
 
-		$this->assertFalse(\OCP\Util::needUpgrade());
+		$this->assertFalse(Util::needUpgrade());
 
 		$config->setSystemValue('version', '7.0.0.0');
 		\OC::$server->getSession()->set('OC_Version', [7, 0, 0, 1]);
-		self::invokePrivate(new \OCP\Util, 'needUpgradeCache', [null]);
+		self::invokePrivate(new Util, 'needUpgradeCache', [null]);
 
-		$this->assertTrue(\OCP\Util::needUpgrade());
+		$this->assertTrue(Util::needUpgrade());
 
 		$config->setSystemValue('version', $oldConfigVersion);
 		\OC::$server->getSession()->set('OC_Version', $oldSessionVersion);
-		self::invokePrivate(new \OCP\Util, 'needUpgradeCache', [null]);
+		self::invokePrivate(new Util, 'needUpgradeCache', [null]);
 
-		$this->assertFalse(\OCP\Util::needUpgrade());
+		$this->assertFalse(Util::needUpgrade());
 	}
 
 	public function testCheckDataDirectoryValidity(): void {
@@ -170,39 +171,37 @@ class UtilTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		\OC_Util::$scripts = [];
 		\OC_Util::$styles = [];
-		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
-		self::invokePrivate(\OCP\Util::class, 'scriptDeps', [[]]);
+		self::invokePrivate(Util::class, 'scripts', [[]]);
+		self::invokePrivate(Util::class, 'scriptDeps', [[]]);
 	}
 	protected function tearDown(): void {
 		parent::tearDown();
 
-		\OC_Util::$scripts = [];
 		\OC_Util::$styles = [];
-		self::invokePrivate(\OCP\Util::class, 'scripts', [[]]);
-		self::invokePrivate(\OCP\Util::class, 'scriptDeps', [[]]);
+		self::invokePrivate(Util::class, 'scripts', [[]]);
+		self::invokePrivate(Util::class, 'scriptDeps', [[]]);
 	}
 
 	public function testAddScript(): void {
-		\OCP\Util::addScript('first', 'myFirstJSFile');
-		\OCP\Util::addScript('core', 'myFancyJSFile1');
-		\OCP\Util::addScript('files', 'myFancyJSFile2', 'core');
-		\OCP\Util::addScript('myApp5', 'myApp5JSFile', 'myApp2');
-		\OCP\Util::addScript('myApp', 'myFancyJSFile3');
-		\OCP\Util::addScript('core', 'myFancyJSFile4');
+		Util::addScript('first', 'myFirstJSFile');
+		Util::addScript('core', 'myFancyJSFile1');
+		Util::addScript('files', 'myFancyJSFile2', 'core');
+		Util::addScript('myApp5', 'myApp5JSFile', 'myApp2');
+		Util::addScript('myApp', 'myFancyJSFile3');
+		Util::addScript('core', 'myFancyJSFile4');
 		// after itself
-		\OCP\Util::addScript('core', 'myFancyJSFile5', 'core');
+		Util::addScript('core', 'myFancyJSFile5', 'core');
 		// add duplicate
-		\OCP\Util::addScript('core', 'myFancyJSFile1');
+		Util::addScript('core', 'myFancyJSFile1');
 		// dependency chain
-		\OCP\Util::addScript('myApp4', 'myApp4JSFile', 'myApp3');
-		\OCP\Util::addScript('myApp3', 'myApp3JSFile', 'myApp2');
-		\OCP\Util::addScript('myApp2', 'myApp2JSFile', 'myApp');
-		\OCP\Util::addScript('core', 'common');
-		\OCP\Util::addScript('core', 'main');
+		Util::addScript('myApp4', 'myApp4JSFile', 'myApp3');
+		Util::addScript('myApp3', 'myApp3JSFile', 'myApp2');
+		Util::addScript('myApp2', 'myApp2JSFile', 'myApp');
+		Util::addScript('core', 'common');
+		Util::addScript('core', 'main');
 
-		$scripts = \OCP\Util::getScripts();
+		$scripts = Util::getScripts();
 
 		// Core should appear first
 		$this->assertEquals(
@@ -278,37 +277,20 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testAddScriptCircularDependency(): void {
-		\OCP\Util::addScript('circular', 'file1', 'dependency');
-		\OCP\Util::addScript('dependency', 'file2', 'circular');
+		Util::addScript('circular', 'file1', 'dependency');
+		Util::addScript('dependency', 'file2', 'circular');
 
-		$scripts = \OCP\Util::getScripts();
+		$scripts = Util::getScripts();
 		$this->assertContains('circular/js/file1', $scripts);
 		$this->assertContains('dependency/js/file2', $scripts);
 	}
 
-	public function testAddVendorScript(): void {
-		\OC_Util::addVendorScript('core', 'myFancyJSFile1');
-		\OC_Util::addVendorScript('myApp', 'myFancyJSFile2');
-		\OC_Util::addVendorScript('core', 'myFancyJSFile0', true);
-		\OC_Util::addVendorScript('core', 'myFancyJSFile10', true);
-		// add duplicate
-		\OC_Util::addVendorScript('core', 'myFancyJSFile1');
-
-		$this->assertEquals([
-			'core/vendor/myFancyJSFile10',
-			'core/vendor/myFancyJSFile0',
-			'core/vendor/myFancyJSFile1',
-			'myApp/vendor/myFancyJSFile2',
-		], \OC_Util::$scripts);
-		$this->assertEquals([], \OC_Util::$styles);
-	}
-
 	public function testAddTranslations(): void {
-		\OC_Util::addTranslations('appId', 'de');
+		Util::addTranslations('appId', 'de');
 
 		$this->assertEquals([
 			'appId/l10n/de'
-		], \OC_Util::$scripts);
+		], Util::getScripts());
 		$this->assertEquals([], \OC_Util::$styles);
 	}
 
@@ -320,7 +302,7 @@ class UtilTest extends \Test\TestCase {
 		// add duplicate
 		\OC_Util::addStyle('core', 'myFancyCSSFile1');
 
-		$this->assertEquals([], \OC_Util::$scripts);
+		$this->assertEquals([], Util::getScripts());
 		$this->assertEquals([
 			'core/css/myFancyCSSFile10',
 			'core/css/myFancyCSSFile0',
@@ -337,7 +319,7 @@ class UtilTest extends \Test\TestCase {
 		// add duplicate
 		\OC_Util::addVendorStyle('core', 'myFancyCSSFile1');
 
-		$this->assertEquals([], \OC_Util::$scripts);
+		$this->assertEquals([], Util::getScripts());
 		$this->assertEquals([
 			'core/vendor/myFancyCSSFile10',
 			'core/vendor/myFancyCSSFile0',
@@ -347,9 +329,9 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testShortenMultibyteString(): void {
-		$this->assertEquals('Short nuff', \OCP\Util::shortenMultibyteString('Short nuff', 255));
-		$this->assertEquals('ABC', \OCP\Util::shortenMultibyteString('ABCDEF', 3));
+		$this->assertEquals('Short nuff', Util::shortenMultibyteString('Short nuff', 255));
+		$this->assertEquals('ABC', Util::shortenMultibyteString('ABCDEF', 3));
 		// each of the characters is 12 bytes
-		$this->assertEquals('🙈', \OCP\Util::shortenMultibyteString('🙈🙊🙉', 16, 2));
+		$this->assertEquals('🙈', Util::shortenMultibyteString('🙈🙊🙉', 16, 2));
 	}
 }


### PR DESCRIPTION
## Summary

Deprecated since 24, currently unused.
Sadly not all related functions were officially marked as deprecated, but all of them were unused.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
