### PR TITLE
Mark all methods of OC_Util as deprecated

### DIFF
--- a/apps/settings/templates/help.php
+++ b/apps/settings/templates/help.php
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-\OC_Util::addStyle('settings', 'help');
+\OCP\Util::addStyle('settings', 'help');
 ?>
 <?php if ($_['knowledgebaseEmbedded'] === true) : ?>
 	<div id="app-navigation" role="navigation" tabindex="0">

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2607,11 +2607,6 @@
       <code><![CDATA[\Test\Util\User\Dummy]]></code>
     </UndefinedClass>
   </file>
-  <file src="lib/private/legacy/OC_Util.php">
-    <InvalidReturnType>
-      <code><![CDATA[void]]></code>
-    </InvalidReturnType>
-  </file>
   <file src="lib/public/AppFramework/ApiController.php">
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>

--- a/core/Listener/BeforeTemplateRenderedListener.php
+++ b/core/Listener/BeforeTemplateRenderedListener.php
@@ -37,7 +37,7 @@ class BeforeTemplateRenderedListener implements IEventListener {
 			Util::addScript('core', 'public');
 		}
 
-		\OC_Util::addStyle('server', null, true);
+		Util::addStyle('server', null, true);
 
 		if ($event instanceof BeforeLoginTemplateRenderedEvent) {
 			// todo: make login work without these

--- a/core/js/tests/specs/coreSpec.js
+++ b/core/js/tests/specs/coreSpec.js
@@ -359,7 +359,7 @@ describe('Core base tests', function() {
 		// to make sure they run.
 		var cit = window.isPhantom?xit:it;
 
-		// must provide the same results as \OC_Util::naturalSortCompare
+		// must provide the same results as \OCP\Util::naturalSortCompare
 		it('sorts alphabetically', function() {
 			var a = [
 				'def',

--- a/cypress/e2e/settings/users.cy.ts
+++ b/cypress/e2e/settings/users.cy.ts
@@ -115,11 +115,12 @@ describe('Settings: Create and delete accounts', function() {
 
 			// The "Delete account" action in the actions menu is shown and clicked
 			cy.get('.action-item__popper .action').contains('Delete account').should('exist').click({ force: true })
-			// And confirmation dialog accepted
-			cy.get('.nc-generic-dialog button').contains(`Delete ${testUser.userId}`).click({ force: true })
 
 			// Make sure no confirmation modal is shown
 			handlePasswordConfirmation(admin.password)
+
+			// And confirmation dialog accepted
+			cy.get('.nc-generic-dialog button').contains(`Delete ${testUser.userId}`).click({ force: true })
 
 			// deleted clicked the user is not shown anymore
 			getUserListRow(testUser.userId).should('not.exist')

--- a/lib/base.php
+++ b/lib/base.php
@@ -704,7 +704,7 @@ class OC {
 			if (count($errors) > 0) {
 				if (!self::$CLI) {
 					http_response_code(503);
-					OC_Util::addStyle('guest');
+					Util::addStyle('guest');
 					try {
 						Server::get(ITemplateManager::class)->printGuestPage('', 'error', ['errors' => $errors]);
 						exit;

--- a/lib/private/Image.php
+++ b/lib/private/Image.php
@@ -56,7 +56,7 @@ class Image implements IImage {
 		$this->appConfig = $appConfig ?? Server::get(IAppConfig::class);
 		$this->config = $config ?? Server::get(IConfig::class);
 
-		if (\OC_Util::fileInfoLoaded()) {
+		if (class_exists(finfo::class)) {
 			$this->fileInfo = new finfo(FILEINFO_MIME_TYPE);
 		}
 	}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1967,7 +1967,7 @@ class Manager implements IManager {
 	/**
 	 * Check if sharing is disabled for the current user
 	 */
-	public function sharingDisabledForUser(string $userId): bool {
+	public function sharingDisabledForUser(?string $userId): bool {
 		return $this->shareDisableChecker->sharingDisabledForUser($userId);
 	}
 

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1965,14 +1965,9 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * Copied from \OC_Util::isSharingDisabledForUser
-	 *
-	 * TODO: Deprecate function from OC_Util
-	 *
-	 * @param string $userId
-	 * @return bool
+	 * Check if sharing is disabled for the current user
 	 */
-	public function sharingDisabledForUser($userId) {
+	public function sharingDisabledForUser(string $userId): bool {
 		return $this->shareDisableChecker->sharingDisabledForUser($userId);
 	}
 

--- a/lib/private/Share20/ShareDisableChecker.php
+++ b/lib/private/Share20/ShareDisableChecker.php
@@ -25,12 +25,7 @@ class ShareDisableChecker {
 		$this->sharingDisabledForUsersCache = new CappedMemoryCache();
 	}
 
-
-	/**
-	 * @param ?string $userId
-	 * @return bool
-	 */
-	public function sharingDisabledForUser(?string $userId) {
+	public function sharingDisabledForUser(?string $userId): bool {
 		if ($userId === null) {
 			return false;
 		}

--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -30,6 +30,7 @@ use OCP\ILogger;
 use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUser;
+use OCP\Server;
 use OCP\ServerVersion;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\Share\IManager as IShareManager;
@@ -161,6 +162,8 @@ class JSConfigHelper {
 			'enable_non-accessible_features' => $this->config->getSystemValueBool('enable_non-accessible_features', true),
 		];
 
+		$shareManager = Server::get(IShareManager::class);
+
 		$array = [
 			'_oc_debug' => $this->config->getSystemValue('debug', false) ? 'true' : 'false',
 			'_oc_isadmin' => $uid !== null && $this->groupManager->isAdmin($uid) ? 'true' : 'false',
@@ -235,11 +238,11 @@ class JSConfigHelper {
 					'defaultExpireDateEnforced' => $enforceDefaultExpireDate,
 					'enforcePasswordForPublicLink' => Util::isPublicLinkPasswordRequired(),
 					'enableLinkPasswordByDefault' => $enableLinkPasswordByDefault,
-					'sharingDisabledForUser' => Util::isSharingDisabledForUser(),
+					'sharingDisabledForUser' => $shareManager->sharingDisabledForUser($uid),
 					'resharingAllowed' => Share::isResharingAllowed(),
 					'remoteShareAllowed' => $outgoingServer2serverShareEnabled,
 					'federatedCloudShareDoc' => $this->urlGenerator->linkToDocs('user-sharing-federated'),
-					'allowGroupSharing' => \OC::$server->get(IShareManager::class)->allowGroupSharing(),
+					'allowGroupSharing' => $shareManager->allowGroupSharing(),
 					'defaultInternalExpireDateEnabled' => $defaultInternalExpireDateEnabled,
 					'defaultInternalExpireDate' => $defaultInternalExpireDate,
 					'defaultInternalExpireDateEnforced' => $defaultInternalExpireDateEnforced,

--- a/lib/private/Template/functions.php
+++ b/lib/private/Template/functions.php
@@ -131,10 +131,10 @@ function script($app, $file = null): void {
 function style($app, $file = null): void {
 	if (is_array($file)) {
 		foreach ($file as $f) {
-			OC_Util::addStyle($app, $f);
+			Util::addStyle($app, $f);
 		}
 	} else {
-		OC_Util::addStyle($app, $file);
+		Util::addStyle($app, $file);
 	}
 }
 
@@ -143,6 +143,7 @@ function style($app, $file = null): void {
  * @param string $app the appname
  * @param string|string[] $file the filename,
  *                              if an array is given it will add all styles
+ * @deprecated 32.0.0
  */
 function vendor_style($app, $file = null): void {
 	if (is_array($file)) {

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -58,7 +58,7 @@ class OC_Util {
 	 *
 	 * @param bool $checkGroupMembership Check group membership exclusion
 	 * @return bool
-	 * @deprecated 32.0.0 use shareApiLinkEnforcePassword directly
+	 * @deprecated 32.0.0 use OCP\Share\IManager's shareApiLinkEnforcePassword directly
 	 */
 	public static function isPublicLinkPasswordRequired(bool $checkGroupMembership = true) {
 		/** @var IManager $shareManager */
@@ -72,7 +72,7 @@ class OC_Util {
 	 * @param IGroupManager $groupManager
 	 * @param IUser|null $user
 	 * @return bool
-	 * @deprecated 32.0.0 use sharingDisabledForUser directly
+	 * @deprecated 32.0.0 use OCP\Share\IManager's sharingDisabledForUser directly
 	 */
 	public static function isSharingDisabledForUser(IConfig $config, IGroupManager $groupManager, $user) {
 		/** @var IManager $shareManager */
@@ -85,7 +85,7 @@ class OC_Util {
 	 * check if share API enforces a default expire date
 	 *
 	 * @return bool
-	 * @deprecated 32.0.0 use shareApiLinkDefaultExpireDateEnforced directly
+	 * @deprecated 32.0.0 use OCP\Share\IManager's shareApiLinkDefaultExpireDateEnforced directly
 	 */
 	public static function isDefaultExpireDateEnforced() {
 		/** @var IManager $shareManager */
@@ -615,7 +615,7 @@ class OC_Util {
 	 * the apps visible for the current user
 	 *
 	 * @return string URL
-	 * @deprecated 32.0.0 use linkToDefaultPageUrl directly
+	 * @deprecated 32.0.0 use IURLGenerator's linkToDefaultPageUrl directly
 	 */
 	public static function getDefaultPageUrl() {
 		/** @var IURLGenerator $urlGenerator */

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -25,10 +25,6 @@ class OC_Util {
 	public static $styles = [];
 	public static $headers = [];
 
-	protected static function getAppManager() {
-		return \OC::$server->getAppManager();
-	}
-
 	/**
 	 * Setup the file system
 	 *

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -57,8 +57,8 @@ class OC_Util {
 	 * Check if a password is required for each public link
 	 *
 	 * @param bool $checkGroupMembership Check group membership exclusion
-	 * @return boolean
-	 * @suppress PhanDeprecatedFunction
+	 * @return bool
+	 * @deprecated 32.0.0 use shareApiLinkEnforcePassword directly
 	 */
 	public static function isPublicLinkPasswordRequired(bool $checkGroupMembership = true) {
 		/** @var IManager $shareManager */
@@ -72,6 +72,7 @@ class OC_Util {
 	 * @param IGroupManager $groupManager
 	 * @param IUser|null $user
 	 * @return bool
+	 * @deprecated 32.0.0 use sharingDisabledForUser directly
 	 */
 	public static function isSharingDisabledForUser(IConfig $config, IGroupManager $groupManager, $user) {
 		/** @var IManager $shareManager */
@@ -84,7 +85,7 @@ class OC_Util {
 	 * check if share API enforces a default expire date
 	 *
 	 * @return bool
-	 * @suppress PhanDeprecatedFunction
+	 * @deprecated 32.0.0 use shareApiLinkDefaultExpireDateEnforced directly
 	 */
 	public static function isDefaultExpireDateEnforced() {
 		/** @var IManager $shareManager */
@@ -200,12 +201,10 @@ class OC_Util {
 	}
 
 	/**
-	 * @return void
-	 * @suppress PhanUndeclaredMethod
+	 * @deprecated 32.0.0 Call tearDown directly on SetupManager
 	 */
-	public static function tearDownFS() {
-		/** @var SetupManager $setupManager */
-		$setupManager = \OC::$server->get(SetupManager::class);
+	public static function tearDownFS(): void {
+		$setupManager = \OCP\Server::get(SetupManager::class);
 		$setupManager->tearDown();
 	}
 
@@ -214,10 +213,9 @@ class OC_Util {
 	 *
 	 * @param string $application application to get the files from
 	 * @param string $directory directory within this application (css, js, vendor, etc)
-	 * @param string $file the file inside of the above folder
-	 * @return string the path
+	 * @param ?string $file the file inside of the above folder
 	 */
-	private static function generatePath($application, $directory, $file) {
+	private static function generatePath($application, $directory, $file): string {
 		if (is_null($file)) {
 			$file = $application;
 			$application = '';
@@ -235,9 +233,9 @@ class OC_Util {
 	 * @param string $application application id
 	 * @param string|null $file filename
 	 * @param bool $prepend prepend the Style to the beginning of the list
-	 * @return void
+	 * @deprecated 32.0.0 Use \OCP\Util::addStyle
 	 */
-	public static function addStyle($application, $file = null, $prepend = false) {
+	public static function addStyle($application, $file = null, $prepend = false): void {
 		$path = OC_Util::generatePath($application, 'css', $file);
 		self::addExternalResource($application, $prepend, $path, 'style');
 	}
@@ -248,9 +246,9 @@ class OC_Util {
 	 * @param string $application application id
 	 * @param string|null $file filename
 	 * @param bool $prepend prepend the Style to the beginning of the list
-	 * @return void
+	 * @deprecated 32.0.0
 	 */
-	public static function addVendorStyle($application, $file = null, $prepend = false) {
+	public static function addVendorStyle($application, $file = null, $prepend = false): void {
 		$path = OC_Util::generatePath($application, 'vendor', $file);
 		self::addExternalResource($application, $prepend, $path, 'style');
 	}
@@ -262,9 +260,8 @@ class OC_Util {
 	 * @param bool $prepend prepend the file to the beginning of the list
 	 * @param string $path
 	 * @param string $type (script or style)
-	 * @return void
 	 */
-	private static function addExternalResource($application, $prepend, $path, $type = 'script') {
+	private static function addExternalResource($application, $prepend, $path, $type = 'script'): void {
 		if ($type === 'style') {
 			if (!in_array($path, self::$styles)) {
 				if ($prepend === true) {
@@ -284,8 +281,9 @@ class OC_Util {
 	 * @param array $attributes array of attributes for the element
 	 * @param string $text the text content for the element
 	 * @param bool $prepend prepend the header to the beginning of the list
+	 * @deprecated 32.0.0 Use \OCP\Util::addHeader instead
 	 */
-	public static function addHeader($tag, $attributes, $text = null, $prepend = false) {
+	public static function addHeader($tag, $attributes, $text = null, $prepend = false): void {
 		$header = [
 			'tag' => $tag,
 			'attributes' => $attributes,
@@ -301,7 +299,6 @@ class OC_Util {
 	/**
 	 * check if the current server configuration is suitable for ownCloud
 	 *
-	 * @param \OC\SystemConfig $config
 	 * @return array arrays with error messages and hints
 	 */
 	public static function checkServer(\OC\SystemConfig $config) {
@@ -524,6 +521,7 @@ class OC_Util {
 	 *
 	 * @param string $dataDirectory
 	 * @return array arrays with error messages and hints
+	 * @internal
 	 */
 	public static function checkDataDirectoryPermissions($dataDirectory) {
 		if (!\OC::$server->getConfig()->getSystemValueBool('check_data_directory_permissions', true)) {
@@ -552,6 +550,7 @@ class OC_Util {
 	 *
 	 * @param string $dataDirectory data directory path
 	 * @return array errors found
+	 * @internal
 	 */
 	public static function checkDataDirectoryValidity($dataDirectory) {
 		$l = \OC::$server->getL10N('lib');
@@ -576,9 +575,9 @@ class OC_Util {
 	 * Check if the user is logged in, redirects to home if not. With
 	 * redirect URL parameter to the request URI.
 	 *
-	 * @return void
+	 * @deprecated 32.0.0
 	 */
-	public static function checkLoggedIn() {
+	public static function checkLoggedIn(): void {
 		// Check if we are a user
 		if (!\OC::$server->getUserSession()->isLoggedIn()) {
 			header('Location: ' . \OC::$server->getURLGenerator()->linkToRoute(
@@ -600,10 +599,10 @@ class OC_Util {
 	/**
 	 * Check if the user is a admin, redirects to home if not
 	 *
-	 * @return void
+	 * @deprecated 32.0.0
 	 */
-	public static function checkAdminUser() {
-		OC_Util::checkLoggedIn();
+	public static function checkAdminUser(): void {
+		self::checkLoggedIn();
 		if (!OC_User::isAdminUser(OC_User::getUser())) {
 			header('Location: ' . \OCP\Util::linkToAbsolute('', 'index.php'));
 			exit();
@@ -616,7 +615,7 @@ class OC_Util {
 	 * the apps visible for the current user
 	 *
 	 * @return string URL
-	 * @suppress PhanDeprecatedFunction
+	 * @deprecated 32.0.0 use linkToDefaultPageUrl directly
 	 */
 	public static function getDefaultPageUrl() {
 		/** @var IURLGenerator $urlGenerator */
@@ -627,9 +626,9 @@ class OC_Util {
 	/**
 	 * Redirect to the user default page
 	 *
-	 * @return void
+	 * @deprecated 32.0.0
 	 */
-	public static function redirectToDefaultPage() {
+	public static function redirectToDefaultPage(): void {
 		$location = self::getDefaultPageUrl();
 		header('Location: ' . $location);
 		exit();
@@ -640,7 +639,7 @@ class OC_Util {
 	 *
 	 * @return string
 	 */
-	public static function getInstanceId() {
+	public static function getInstanceId(): string {
 		$id = \OC::$server->getSystemConfig()->getValue('instanceid', null);
 		if (is_null($id)) {
 			// We need to guarantee at least one letter in instanceid so it can be used as the session_name
@@ -658,6 +657,7 @@ class OC_Util {
 	 *
 	 * @param string|string[] $value
 	 * @return ($value is array ? string[] : string)
+	 * @deprecated 32.0.0 use \OCP\Util::sanitizeHTML instead
 	 */
 	public static function sanitizeHTML($value) {
 		if (is_array($value)) {
@@ -680,6 +680,7 @@ class OC_Util {
 	 *
 	 * @param string $component part of URI to encode
 	 * @return string
+	 * @deprecated 32.0.0 use \OCP\Util::encodePath instead
 	 */
 	public static function encodePath($component) {
 		$encoded = rawurlencode($component);
@@ -706,9 +707,9 @@ class OC_Util {
 	 * Check if the setlocale call does not work. This can happen if the right
 	 * local packages are not available on the server.
 	 *
-	 * @return bool
+	 * @internal
 	 */
-	public static function isSetLocaleWorking() {
+	public static function isSetLocaleWorking(): bool {
 		if (self::isNonUTF8Locale()) {
 			// Borrowed from \Patchwork\Utf8\Bootup::initLocale
 			setlocale(LC_ALL, 'C.UTF-8', 'C');
@@ -726,9 +727,9 @@ class OC_Util {
 	/**
 	 * Check if it's possible to get the inline annotations
 	 *
-	 * @return bool
+	 * @internal
 	 */
-	public static function isAnnotationsWorking() {
+	public static function isAnnotationsWorking(): bool {
 		if (PHP_VERSION_ID >= 80300) {
 			/** @psalm-suppress UndefinedMethod */
 			$reflection = \ReflectionMethod::createFromMethodName(__METHOD__);
@@ -743,9 +744,9 @@ class OC_Util {
 	/**
 	 * Check if the PHP module fileinfo is loaded.
 	 *
-	 * @return bool
+	 * @internal
 	 */
-	public static function fileInfoLoaded() {
+	public static function fileInfoLoaded(): bool {
 		return function_exists('finfo_open');
 	}
 
@@ -815,6 +816,7 @@ class OC_Util {
 	 * @param \OC\SystemConfig $config
 	 * @return bool whether the core or any app needs an upgrade
 	 * @throws \OCP\HintException When the upgrade from the given version is not allowed
+	 * @deprecated 32.0.0 Use \OCP\Util::needUpgrade instead
 	 */
 	public static function needUpgrade(\OC\SystemConfig $config) {
 		if ($config->getValue('installed', false)) {

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -485,10 +485,9 @@ interface IManager {
 	/**
 	 * Check if sharing is disabled for the given user
 	 *
-	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function sharingDisabledForUser(string $userId);
+	public function sharingDisabledForUser(?string $userId): bool;
 
 	/**
 	 * Check if outgoing server2server shares are allowed

--- a/lib/public/Share/IManager.php
+++ b/lib/public/Share/IManager.php
@@ -485,11 +485,10 @@ interface IManager {
 	/**
 	 * Check if sharing is disabled for the given user
 	 *
-	 * @param string $userId
 	 * @return bool
 	 * @since 9.0.0
 	 */
-	public function sharingDisabledForUser($userId);
+	public function sharingDisabledForUser(string $userId);
 
 	/**
 	 * Check if outgoing server2server shares are allowed

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -78,19 +78,16 @@ class Util {
 	 *
 	 * @return boolean
 	 * @since 7.0.0
-	 * @deprecated 9.1.0 Use \OC::$server->get(\OCP\Share\IManager::class)->sharingDisabledForUser
+	 * @deprecated 9.1.0 Use Server::get(\OCP\Share\IManager::class)->sharingDisabledForUser
 	 */
 	public static function isSharingDisabledForUser() {
 		if (self::$shareManager === null) {
-			self::$shareManager = \OC::$server->get(IManager::class);
+			self::$shareManager = Server::get(IManager::class);
 		}
 
-		$user = \OC::$server->getUserSession()->getUser();
-		if ($user !== null) {
-			$user = $user->getUID();
-		}
+		$user = Server::get(\OCP\IUserSession::class)->getUser();
 
-		return self::$shareManager->sharingDisabledForUser($user);
+		return self::$shareManager->sharingDisabledForUser($user?->getUID());
 	}
 
 	/**

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -102,13 +102,15 @@ class Util {
 	}
 
 	/**
-	 * add a css file
-	 * @param string $application
-	 * @param string $file
+	 * Add a css file
+	 *
+	 * @param string $application application id
+	 * @param ?string $file filename
+	 * @param bool $prepend prepend the style to the beginning of the list
 	 * @since 4.0.0
 	 */
-	public static function addStyle($application, $file = null): void {
-		\OC_Util::addStyle($application, $file);
+	public static function addStyle(string $application, ?string $file = null, bool $prepend = false): void {
+		\OC_Util::addStyle($application, $file, $prepend);
 	}
 
 	/**

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -42,25 +42,25 @@ class UtilTest extends \Test\TestCase {
 				'And It Even May &lt;strong&gt;Nest&lt;/strong&gt;'
 			],
 		];
-		$result = OC_Util::sanitizeHTML($badArray);
+		$result = Util::sanitizeHTML($badArray);
 		$this->assertEquals($goodArray, $result);
 
 		$badString = '<img onload="alert(1)" />';
-		$result = OC_Util::sanitizeHTML($badString);
+		$result = Util::sanitizeHTML($badString);
 		$this->assertEquals('&lt;img onload=&quot;alert(1)&quot; /&gt;', $result);
 
 		$badString = "<script>alert('Hacked!');</script>";
-		$result = OC_Util::sanitizeHTML($badString);
+		$result = Util::sanitizeHTML($badString);
 		$this->assertEquals('&lt;script&gt;alert(&#039;Hacked!&#039;);&lt;/script&gt;', $result);
 
 		$goodString = 'This is a good string without HTML.';
-		$result = OC_Util::sanitizeHTML($goodString);
+		$result = Util::sanitizeHTML($goodString);
 		$this->assertEquals('This is a good string without HTML.', $result);
 	}
 
 	public function testEncodePath(): void {
 		$component = '/§#@test%&^ä/-child';
-		$result = OC_Util::encodePath($component);
+		$result = Util::encodePath($component);
 		$this->assertEquals('/%C2%A7%23%40test%25%26%5E%C3%A4/-child', $result);
 	}
 
@@ -295,12 +295,12 @@ class UtilTest extends \Test\TestCase {
 	}
 
 	public function testAddStyle(): void {
-		\OC_Util::addStyle('core', 'myFancyCSSFile1');
-		\OC_Util::addStyle('myApp', 'myFancyCSSFile2');
-		\OC_Util::addStyle('core', 'myFancyCSSFile0', true);
-		\OC_Util::addStyle('core', 'myFancyCSSFile10', true);
+		Util::addStyle('core', 'myFancyCSSFile1');
+		Util::addStyle('myApp', 'myFancyCSSFile2');
+		Util::addStyle('core', 'myFancyCSSFile0', true);
+		Util::addStyle('core', 'myFancyCSSFile10', true);
 		// add duplicate
-		\OC_Util::addStyle('core', 'myFancyCSSFile1');
+		Util::addStyle('core', 'myFancyCSSFile1');
 
 		$this->assertEquals([], Util::getScripts());
 		$this->assertEquals([


### PR DESCRIPTION
## Summary

- [x] https://github.com/nextcloud/server/pull/51836

Make sure all (most) methods in OC_Util are correctly flagged as deprecated and document the alternative when there is one.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
