### PR TITLE
fix(encryption): init keys also when logged in using cookie auth

### DIFF
--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -32,6 +32,7 @@ use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\User\Events\UserLoggedInEvent;
+use OCP\User\Events\UserLoggedInWithCookieEvent;
 use OCP\User\Events\UserLoggedOutEvent;
 use Psr\Log\LoggerInterface;
 
@@ -90,6 +91,7 @@ class Application extends App implements IBootstrap {
 		$eventDispatcher->addServiceListener(BeforePasswordResetEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(PasswordResetEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(UserLoggedInEvent::class, UserEventsListener::class);
+		$eventDispatcher->addServiceListener(UserLoggedInWithCookieEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(UserLoggedOutEvent::class, UserEventsListener::class);
 	}
 

--- a/apps/encryption/lib/Listeners/UserEventsListener.php
+++ b/apps/encryption/lib/Listeners/UserEventsListener.php
@@ -26,10 +26,11 @@ use OCP\User\Events\PasswordUpdatedEvent;
 use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\User\Events\UserLoggedInEvent;
+use OCP\User\Events\UserLoggedInWithCookieEvent;
 use OCP\User\Events\UserLoggedOutEvent;
 
 /**
- * @template-implements IEventListener<UserCreatedEvent|UserDeletedEvent|UserLoggedInEvent|UserLoggedOutEvent|BeforePasswordUpdatedEvent|PasswordUpdatedEvent|BeforePasswordResetEvent|PasswordResetEvent>
+ * @template-implements IEventListener<UserCreatedEvent|UserDeletedEvent|UserLoggedInEvent|UserLoggedInWithCookieEvent|UserLoggedOutEvent|BeforePasswordUpdatedEvent|PasswordUpdatedEvent|BeforePasswordResetEvent|PasswordResetEvent>
  */
 class UserEventsListener implements IEventListener {
 
@@ -50,7 +51,7 @@ class UserEventsListener implements IEventListener {
 			$this->onUserCreated($event->getUid(), $event->getPassword());
 		} elseif ($event instanceof UserDeletedEvent) {
 			$this->onUserDeleted($event->getUid());
-		} elseif ($event instanceof UserLoggedInEvent) {
+		} elseif ($event instanceof UserLoggedInEvent || $event instanceof UserLoggedInWithCookieEvent) {
 			$this->onUserLogin($event->getUser(), $event->getPassword());
 		} elseif ($event instanceof UserLoggedOutEvent) {
 			$this->onUserLogout();


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/51627

## Summary
Before the refactoring `OC_User::post_login` hook was used, this is replaced by `UserLoggedInEvent` **but also** `UserLoggedInWithCookieEvent`.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
