### PR TITLE
perf(db): Optimize jobs table indexes

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -194,7 +194,7 @@ class Application extends App {
 				'jobs',
 				['jobs_time_sensitive'],
 				'jobs_sensitive_lastcheck_reserved',
-				['time_sensitive', 'last_checked', 'reserved_at'],
+				['last_checked', 'time_sensitive', 'reserved_at'],
 				false,
 			);
 

--- a/core/Application.php
+++ b/core/Application.php
@@ -190,6 +190,13 @@ class Application extends App {
 				'job_lastcheck_reserved',
 				['last_checked', 'reserved_at']
 			);
+			$event->replaceIndex(
+				'jobs',
+				['jobs_time_sensitive'],
+				'jobs_sensitive_lastcheck_reserved',
+				['time_sensitive', 'last_checked', 'reserved_at'],
+				false,
+			);
 
 			$event->addMissingIndex(
 				'direct_edit',

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -501,7 +501,9 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 				'default' => 0,
 			]);
 			$table->setPrimaryKey(['id']);
-			$table->addIndex(['class'], 'job_class_index');
+			// Redundant after Version24000Date20211230140012
+			// Removed in Version32000Date20250402070341
+			// $table->addIndex(['class'], 'job_class_index');
 			$table->addIndex(['last_checked', 'reserved_at'], 'job_lastcheck_reserved');
 		}
 

--- a/core/Migrations/Version24000Date20220131153041.php
+++ b/core/Migrations/Version24000Date20220131153041.php
@@ -33,7 +33,7 @@ class Version24000Date20220131153041 extends SimpleMigrationStep {
 			// jobs_time_sensitive replaced by jobs_sensitive_lastcheck_reserved
 			// $table->addIndex(['time_sensitive'], 'jobs_time_sensitive');
 			// Added later on (32 and backported)
-			$table->addIndex(['time_sensitive', 'last_checked', 'reserved_at'], 'jobs_sensitive_lastcheck_reserved');
+			$table->addIndex(['last_checked', 'time_sensitive', 'reserved_at'], 'jobs_sensitive_lastcheck_reserved');
 			return $schema;
 		}
 		return null;

--- a/core/Migrations/Version24000Date20220131153041.php
+++ b/core/Migrations/Version24000Date20220131153041.php
@@ -30,7 +30,10 @@ class Version24000Date20220131153041 extends SimpleMigrationStep {
 			$table->addColumn('time_sensitive', Types::SMALLINT, [
 				'default' => 1,
 			]);
-			$table->addIndex(['time_sensitive'], 'jobs_time_sensitive');
+			// jobs_time_sensitive replaced by jobs_sensitive_lastcheck_reserved
+			// $table->addIndex(['time_sensitive'], 'jobs_time_sensitive');
+			// Added later on (32 and backported)
+			$table->addIndex(['time_sensitive', 'last_checked', 'reserved_at'], 'jobs_sensitive_lastcheck_reserved');
 			return $schema;
 		}
 		return null;

--- a/core/Migrations/Version32000Date20250402070341.php
+++ b/core/Migrations/Version32000Date20250402070341.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\DropIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+#[DropIndex('jobs',	IndexType::INDEX, 'Drops redundant index', notes: ['job_argument_hash is used instead'])]
+class Version32000Date20250402070341 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('jobs')) {
+			return null;
+		}
+		$jobsTable = $schema->getTable('jobs');
+		if (!$jobsTable->hasIndex('job_class_index')) {
+			return null;
+		}
+
+		$jobsTable->dropIndex('job_class_index');
+
+		return $schema;
+	}
+
+}

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [32, 0, 0, 0];
+$OC_Version = [32, 0, 0, 1];
 
 // The human-readable string
 $OC_VersionString = '32.0.0 dev';


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/49842

## Summary

* Drop redundant index on `class`
* Extend index on `time_sensitive` to be more useful

For existing installations we will only drop the redundant index. The replacement will be done by the admin via occ. This avoids long downtime and times without the new index.
For new installations the index will exist out of the box.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
