### PR TITLE
fix: improve handling of newFolder race condition handling

### DIFF
--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -126,8 +126,21 @@ class Folder extends Node implements \OCP\Files\Folder {
 			$fullPath = $this->getFullPath($path);
 			$nonExisting = new NonExistingFolder($this->root, $this->view, $fullPath);
 			$this->sendHooks(['preWrite', 'preCreate'], [$nonExisting]);
-			if (!$this->view->mkdir($fullPath) && !$this->view->is_dir($fullPath)) {
-				throw new NotPermittedException('Could not create folder "' . $fullPath . '"');
+			if (!$this->view->mkdir($fullPath)) {
+				// maybe another concurrent process created the folder already
+				if (!$this->view->is_dir($fullPath)) {
+					throw new NotPermittedException('Could not create folder "' . $fullPath . '"');
+				} else {
+					// we need to ensure we don't return before the concurrent request has finished updating the cache
+					$tries = 5;
+					while (!$this->view->getFileInfo($fullPath)) {
+						if ($tries < 1) {
+							throw new NotPermittedException('Could not create folder "' . $fullPath . '", folder exists but unable to get cache entry');
+						}
+						usleep(5 * 1000);
+						$tries--;
+					}
+				}
 			}
 			$parent = dirname($fullPath) === $this->getPath() ? $this : null;
 			$node = new Folder($this->root, $this->view, $fullPath, null, $parent);


### PR DESCRIPTION
When a race condition happens, we need to ensure the folder also exists in cache before we return.

To test:

- create a new user (or delete the `uploads` folder for an existing user from both disk and cache)
- Upload multiple 100mb+ (to trigger chunking) files at the same time

Without this patch, some of the uploads will fail sometimes (failure rate will depend on random factors), with this patch all uploads always succeed