### PR TITLE
fix: ensure enabled themes are set on the template

### DIFF
--- a/apps/theming/lib/Service/ThemesService.php
+++ b/apps/theming/lib/Service/ThemesService.php
@@ -148,8 +148,7 @@ class ThemesService {
 	}
 
 	/**
-	 * Get the list of all enabled themes IDs
-	 * for the logged-in user
+	 * Get the list of all enabled themes IDs for the current user.
 	 *
 	 * @return string[]
 	 */

--- a/cypress/e2e/core/404-error.cy.ts
+++ b/cypress/e2e/core/404-error.cy.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+describe('404 error page', { testIsolation: true }, () => {
+	it('renders 404 page', () => {
+		cy.visit('/doesnotexist', { failOnStatusCode: false })
+
+		cy.findByRole('heading', { name: /Page not found/ })
+			.should('be.visible')
+		cy.findByRole('link', { name: /Back to Nextcloud/ })
+			.should('be.visible')
+			.click()
+
+		cy.url()
+			.should('match', /(\/index.php)\/login$/)
+	})
+})

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -81,13 +81,6 @@ class TemplateLayout extends \OC_Template {
 			} else {
 				Util::addScript('core', 'unified-search', 'core');
 			}
-			// Set body data-theme
-			$this->assign('enabledThemes', []);
-			if ($this->appManager->isEnabledForUser('theming') && class_exists('\OCA\Theming\Service\ThemesService')) {
-				/** @var \OCA\Theming\Service\ThemesService */
-				$themesService = \OC::$server->get(\OCA\Theming\Service\ThemesService::class);
-				$this->assign('enabledThemes', $themesService->getEnabledThemes());
-			}
 
 			// Set logo link target
 			$logoUrl = $this->config->getSystemValueString('logo_url', '');
@@ -151,22 +144,12 @@ class TemplateLayout extends \OC_Template {
 			if ($user) {
 				$userDisplayName = $user->getDisplayName();
 			}
-			$theme = $this->config->getSystemValueString('enforce_theme', '');
-			$this->assign('enabledThemes', $theme === '' ? [] : [$theme]);
 			$this->assign('user_displayname', $userDisplayName);
 			$this->assign('user_uid', \OC_User::getUser());
 		} elseif ($renderAs === TemplateResponse::RENDER_AS_PUBLIC) {
 			parent::__construct('core', 'layout.public');
 			$this->assign('appid', $appId);
 			$this->assign('bodyid', 'body-public');
-
-			// Set body data-theme
-			$this->assign('enabledThemes', []);
-			if ($this->appManager->isEnabledForUser('theming') && class_exists('\OCA\Theming\Service\ThemesService')) {
-				/** @var \OCA\Theming\Service\ThemesService $themesService */
-				$themesService = \OC::$server->get(\OCA\Theming\Service\ThemesService::class);
-				$this->assign('enabledThemes', $themesService->getEnabledThemes());
-			}
 
 			// Set logo link target
 			$logoUrl = $this->config->getSystemValueString('logo_url', '');
@@ -195,10 +178,15 @@ class TemplateLayout extends \OC_Template {
 		} else {
 			parent::__construct('core', 'layout.base');
 		}
+
+		// Set body data-theme
+		$themesService = \OCP\Server::get(\OCA\Theming\Service\ThemesService::class);
+		$this->assign('enabledThemes', $themesService->getEnabledThemes());
+
 		// Send the language, locale, and direction to our layouts
 		$lang = \OC::$server->get(IFactory::class)->findLanguage();
 		$locale = \OC::$server->get(IFactory::class)->findLocale($lang);
-		$direction = \OC::$server->getL10NFactory()->getLanguageDirection($lang);
+		$direction = \OC::$server->get(IFactory::class)->getLanguageDirection($lang);
 
 		$lang = str_replace('_', '-', $lang);
 		$this->assign('language', $lang);

--- a/tests/lib/TemplateLayoutTest.php
+++ b/tests/lib/TemplateLayoutTest.php
@@ -11,6 +11,7 @@ namespace Test;
 
 use OC\InitialStateService;
 use OC\TemplateLayout;
+use OCA\Theming\Service\ThemesService;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IConfig;
@@ -45,7 +46,12 @@ class TemplateLayoutTest extends \Test\TestCase {
 			->willReturn('42');
 
 		$initialState = $this->createMock(InitialStateService::class);
+		$themesService = $this->createMock(ThemesService::class);
+		$themesService->expects(self::once())
+			->method('getEnabledThemes')
+			->willReturn([]);
 
+		$this->overwriteService(ThemesService::class, $themesService);
 		$this->overwriteService(IConfig::class, $config);
 		$this->overwriteService(IAppManager::class, $appManager);
 		$this->overwriteService(InitialStateService::class, $initialState);


### PR DESCRIPTION
## Summary

Ensure enabled themes are always set on the template.
`isEnabledForUser` is not needed since Nextcloud 22 as this app is force-enabled for all users.
Also `class_exists` is not needed as this is shipped since 22. Moreover the check prevented the fallback to enforced theme when no user is logged in.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
