### PR TITLE
Add selectors to sharingtab checkboxes

### DIFF
--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -22,7 +22,7 @@
 		<div class="sharingTabDetailsView__wrapper">
 			<div ref="quickPermissions" class="sharingTabDetailsView__quick-permissions">
 				<div>
-					<NcCheckboxRadioSwitch :button-variant="true"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-READ_ONLY" :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="read-only"
 						:checked.sync="sharingPermission"
 						:value="bundledPermissions.READ_ONLY.toString()"
@@ -35,7 +35,7 @@
 							<ViewIcon :size="20" />
 						</template>
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :button-variant="true"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-ALL" :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="upload-edit"
 						:checked.sync="sharingPermission"
 						:value="bundledPermissions.ALL.toString()"
@@ -54,6 +54,7 @@
 						</template>
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch v-if="allowsFileDrop"
+						class="sharingTabDetailsView__permission-bundle-FILE_DROP"
 						data-cy-files-sharing-share-permissions-bundle="file-drop"
 						:button-variant="true"
 						:checked.sync="sharingPermission"
@@ -68,7 +69,7 @@
 							<UploadIcon :size="20" />
 						</template>
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :button-variant="true"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-CUSTOM" :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="custom"
 						:checked.sync="sharingPermission"
 						:value="'custom'"
@@ -109,7 +110,7 @@
 						:label="t('files_sharing', 'Share label')"
 						:value.sync="share.label" />
 					<template v-if="isPublicShare">
-						<NcCheckboxRadioSwitch :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__password-protection" :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
 							{{ t('files_sharing', 'Set password') }}
 						</NcCheckboxRadioSwitch>
 						<NcPasswordField v-if="isPasswordProtected"
@@ -129,12 +130,12 @@
 							{{ t('files_sharing', 'Password expired') }}
 						</span>
 					</template>
-					<NcCheckboxRadioSwitch v-if="canTogglePasswordProtectedByTalkAvailable"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__video-verification" v-if="canTogglePasswordProtectedByTalkAvailable"
 						:checked.sync="isPasswordProtectedByTalk"
 						@update:checked="onPasswordProtectedByTalkChange">
 						{{ t('files_sharing', 'Video verification') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :checked.sync="hasExpirationDate" :disabled="isExpiryDateEnforced">
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__expiration-date" :checked.sync="hasExpirationDate" :disabled="isExpiryDateEnforced">
 						{{ isExpiryDateEnforced
 							? t('files_sharing', 'Expiration date (enforced)')
 							: t('files_sharing', 'Set expiration date') }}
@@ -149,19 +150,19 @@
 						:placeholder="t('files_sharing', 'Expiration date')"
 						type="date"
 						@input="onExpirationChange" />
-					<NcCheckboxRadioSwitch v-if="isPublicShare"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__hide-download" v-if="isPublicShare"
 						:disabled="canChangeHideDownload"
 						:checked.sync="share.hideDownload"
 						@update:checked="queueUpdate('hideDownload')">
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch v-if="!isPublicShare"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__allow-download" v-if="!isPublicShare"
 						:disabled="!canSetDownload"
 						:checked.sync="canDownload"
 						data-cy-files-sharing-share-permissions-checkbox="download">
 						{{ t('files_sharing', 'Allow download and sync') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :checked.sync="writeNoteToRecipientIsChecked">
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__note-to-recipient" :checked.sync="writeNoteToRecipientIsChecked">
 						{{ t('files_sharing', 'Note to recipient') }}
 					</NcCheckboxRadioSwitch>
 					<template v-if="writeNoteToRecipientIsChecked">
@@ -176,33 +177,33 @@
 						:action="action"
 						:file-info="fileInfo"
 						:share="share" />
-					<NcCheckboxRadioSwitch :checked.sync="setCustomPermissions">
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__custom-permissions" :checked.sync="setCustomPermissions">
 						{{ t('files_sharing', 'Custom permissions') }}
 					</NcCheckboxRadioSwitch>
 					<section v-if="setCustomPermissions" class="custom-permissions-group">
-						<NcCheckboxRadioSwitch :disabled="!canRemoveReadPermission"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-read" :disabled="!canRemoveReadPermission"
 							:checked.sync="hasRead"
 							data-cy-files-sharing-share-permissions-checkbox="read">
 							{{ t('files_sharing', 'Read') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch v-if="isFolder"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-create" v-if="isFolder"
 							:disabled="!canSetCreate"
 							:checked.sync="canCreate"
 							data-cy-files-sharing-share-permissions-checkbox="create">
 							{{ t('files_sharing', 'Create') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch :disabled="!canSetEdit"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-edit" :disabled="!canSetEdit"
 							:checked.sync="canEdit"
 							data-cy-files-sharing-share-permissions-checkbox="update">
 							{{ t('files_sharing', 'Edit') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch v-if="resharingIsPossible"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-share" v-if="resharingIsPossible"
 							:disabled="!canSetReshare"
 							:checked.sync="canReshare"
 							data-cy-files-sharing-share-permissions-checkbox="share">
 							{{ t('files_sharing', 'Share') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch :disabled="!canSetDelete"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-delete" :disabled="!canSetDelete"
 							:checked.sync="canDelete"
 							data-cy-files-sharing-share-permissions-checkbox="delete">
 							{{ t('files_sharing', 'Delete') }}
@@ -913,24 +914,10 @@ export default {
 
 				this.creating = true
 				const share = await this.addShare(incomingShare)
-				// ugly hack to make code work - we need the id to be set but at the same time we need to keep values we want to update
-				this.share._share.id = share.id
-				await this.queueUpdate(...permissionsAndAttributes)
-				// Also a ugly hack to update the updated permissions
-				for (const prop of permissionsAndAttributes) {
-					if (prop in share && prop in this.share) {
-						try {
-							share[prop] = this.share[prop]
-						} catch {
-							share._share[prop] = this.share[prop]
-						}
-					}
-				}
-				this.share = share
 				this.creating = false
+				this.share = share
 				this.$emit('add:share', this.share)
 			} else {
-				// Let's update after creation as some attrs are only available after creation
 				this.$emit('update:share', this.share)
 				emit('update:share', this.share)
 				this.queueUpdate(...permissionsAndAttributes)


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary
Within our application of nextcloud we faced an issue with the remote share settings. 
We looked for a way to hide some of the options in the extended share and weren't able to securely discern them.
I have added some selector classes to the checkboxes. It is a purely service and discernability for extensions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
