### PR TITLE
feat(sharing): add selector classes to extended share settings

### DIFF
--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -1006,8 +1006,21 @@ export default {
 
 				this.creating = true
 				const share = await this.addShare(incomingShare)
-				this.creating = false
+				// ugly hack to make code work - we need the id to be set but at the same time we need to keep values we want to update
+				this.share._share.id = share.id
+				await this.queueUpdate(...permissionsAndAttributes)
+				// Also a ugly hack to update the updated permissions
+				for (const prop of permissionsAndAttributes) {
+					if (prop in share && prop in this.share) {
+						try {
+							share[prop] = this.share[prop]
+						} catch {
+							share._share[prop] = this.share[prop]
+						}
+					}
+				}
 				this.share = share
+				this.creating = false
 				this.$emit('add:share', this.share)
 			} else {
 				this.$emit('update:share', this.share)

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -1023,6 +1023,7 @@ export default {
 				this.creating = false
 				this.$emit('add:share', this.share)
 			} else {
+				// Let's update after creation as some attrs are only available after creation
 				this.$emit('update:share', this.share)
 				emit('update:share', this.share)
 				this.queueUpdate(...permissionsAndAttributes)

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -22,7 +22,7 @@
 		<div class="sharingTabDetailsView__wrapper">
 			<div ref="quickPermissions" class="sharingTabDetailsView__quick-permissions">
 				<div>
-					<NcCheckboxRadioSwitch :button-variant="true"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-READ_ONLY" :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="read-only"
 						:checked.sync="sharingPermission"
 						:value="bundledPermissions.READ_ONLY.toString()"
@@ -35,7 +35,7 @@
 							<ViewIcon :size="20" />
 						</template>
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :button-variant="true"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-ALL" :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="upload-edit"
 						:checked.sync="sharingPermission"
 						:value="bundledPermissions.ALL.toString()"
@@ -54,6 +54,7 @@
 						</template>
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch v-if="allowsFileDrop"
+						class="sharingTabDetailsView__permission-bundle-FILE_DROP"
 						data-cy-files-sharing-share-permissions-bundle="file-drop"
 						:button-variant="true"
 						:checked.sync="sharingPermission"
@@ -68,7 +69,7 @@
 							<UploadIcon :size="20" />
 						</template>
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :button-variant="true"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-CUSTOM" :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="custom"
 						:checked.sync="sharingPermission"
 						:value="'custom'"
@@ -123,7 +124,7 @@
 						</template>
 					</NcInputField>
 					<template v-if="isPublicShare">
-						<NcCheckboxRadioSwitch :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__password-protection" :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
 							{{ t('files_sharing', 'Set password') }}
 						</NcCheckboxRadioSwitch>
 						<NcPasswordField v-if="isPasswordProtected"
@@ -143,12 +144,12 @@
 							{{ t('files_sharing', 'Password expired') }}
 						</span>
 					</template>
-					<NcCheckboxRadioSwitch v-if="canTogglePasswordProtectedByTalkAvailable"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__video-verification" v-if="canTogglePasswordProtectedByTalkAvailable"
 						:checked.sync="isPasswordProtectedByTalk"
 						@update:checked="onPasswordProtectedByTalkChange">
 						{{ t('files_sharing', 'Video verification') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :checked.sync="hasExpirationDate" :disabled="isExpiryDateEnforced">
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__expiration-date" :checked.sync="hasExpirationDate" :disabled="isExpiryDateEnforced">
 						{{ isExpiryDateEnforced
 							? t('files_sharing', 'Expiration date (enforced)')
 							: t('files_sharing', 'Set expiration date') }}
@@ -163,19 +164,19 @@
 						:placeholder="t('files_sharing', 'Expiration date')"
 						type="date"
 						@input="onExpirationChange" />
-					<NcCheckboxRadioSwitch v-if="isPublicShare"
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__hide-download" v-if="isPublicShare"
 						:disabled="canChangeHideDownload"
 						:checked.sync="share.hideDownload"
 						@update:checked="queueUpdate('hideDownload')">
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch v-else
+					<NcCheckboxRadioSwitch v-else class="sharingTabDetailsView__allow-download"
 						:disabled="!canSetDownload"
 						:checked.sync="canDownload"
 						data-cy-files-sharing-share-permissions-checkbox="download">
 						{{ t('files_sharing', 'Allow download and sync') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch :checked.sync="writeNoteToRecipientIsChecked">
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__note-to-recipient" :checked.sync="writeNoteToRecipientIsChecked">
 						{{ t('files_sharing', 'Note to recipient') }}
 					</NcCheckboxRadioSwitch>
 					<template v-if="writeNoteToRecipientIsChecked">
@@ -194,33 +195,33 @@
 						:action="action"
 						:file-info="fileInfo"
 						:share="share" />
-					<NcCheckboxRadioSwitch :checked.sync="setCustomPermissions">
+					<NcCheckboxRadioSwitch class="sharingTabDetailsView__custom-permissions" :checked.sync="setCustomPermissions">
 						{{ t('files_sharing', 'Custom permissions') }}
 					</NcCheckboxRadioSwitch>
 					<section v-if="setCustomPermissions" class="custom-permissions-group">
-						<NcCheckboxRadioSwitch :disabled="!canRemoveReadPermission"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-read" :disabled="!canRemoveReadPermission"
 							:checked.sync="hasRead"
 							data-cy-files-sharing-share-permissions-checkbox="read">
 							{{ t('files_sharing', 'Read') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch v-if="isFolder"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-create" v-if="isFolder"
 							:disabled="!canSetCreate"
 							:checked.sync="canCreate"
 							data-cy-files-sharing-share-permissions-checkbox="create">
 							{{ t('files_sharing', 'Create') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch :disabled="!canSetEdit"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-edit" :disabled="!canSetEdit"
 							:checked.sync="canEdit"
 							data-cy-files-sharing-share-permissions-checkbox="update">
 							{{ t('files_sharing', 'Edit') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch v-if="resharingIsPossible"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-share" v-if="resharingIsPossible"
 							:disabled="!canSetReshare"
 							:checked.sync="canReshare"
 							data-cy-files-sharing-share-permissions-checkbox="share">
 							{{ t('files_sharing', 'Share') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch :disabled="!canSetDelete"
+						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-delete" :disabled="!canSetDelete"
 							:checked.sync="canDelete"
 							data-cy-files-sharing-share-permissions-checkbox="delete">
 							{{ t('files_sharing', 'Delete') }}
@@ -1005,24 +1006,10 @@ export default {
 
 				this.creating = true
 				const share = await this.addShare(incomingShare)
-				// ugly hack to make code work - we need the id to be set but at the same time we need to keep values we want to update
-				this.share._share.id = share.id
-				await this.queueUpdate(...permissionsAndAttributes)
-				// Also a ugly hack to update the updated permissions
-				for (const prop of permissionsAndAttributes) {
-					if (prop in share && prop in this.share) {
-						try {
-							share[prop] = this.share[prop]
-						} catch {
-							share._share[prop] = this.share[prop]
-						}
-					}
-				}
-				this.share = share
 				this.creating = false
+				this.share = share
 				this.$emit('add:share', this.share)
 			} else {
-				// Let's update after creation as some attrs are only available after creation
 				this.$emit('update:share', this.share)
 				emit('update:share', this.share)
 				this.queueUpdate(...permissionsAndAttributes)

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -22,7 +22,7 @@
 		<div class="sharingTabDetailsView__wrapper">
 			<div ref="quickPermissions" class="sharingTabDetailsView__quick-permissions">
 				<div>
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-READ_ONLY" :button-variant="true"
+					<NcCheckboxRadioSwitch :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="read-only"
 						:checked.sync="sharingPermission"
 						:value="bundledPermissions.READ_ONLY.toString()"
@@ -35,7 +35,7 @@
 							<ViewIcon :size="20" />
 						</template>
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-ALL" :button-variant="true"
+					<NcCheckboxRadioSwitch :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="upload-edit"
 						:checked.sync="sharingPermission"
 						:value="bundledPermissions.ALL.toString()"
@@ -54,7 +54,6 @@
 						</template>
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch v-if="allowsFileDrop"
-						class="sharingTabDetailsView__permission-bundle-FILE_DROP"
 						data-cy-files-sharing-share-permissions-bundle="file-drop"
 						:button-variant="true"
 						:checked.sync="sharingPermission"
@@ -69,7 +68,7 @@
 							<UploadIcon :size="20" />
 						</template>
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-bundle-CUSTOM" :button-variant="true"
+					<NcCheckboxRadioSwitch :button-variant="true"
 						data-cy-files-sharing-share-permissions-bundle="custom"
 						:checked.sync="sharingPermission"
 						:value="'custom'"
@@ -124,7 +123,7 @@
 						</template>
 					</NcInputField>
 					<template v-if="isPublicShare">
-						<NcCheckboxRadioSwitch class="sharingTabDetailsView__password-protection" :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
+						<NcCheckboxRadioSwitch data-cy-files-sharing-share-advanced-section="password-protection" :checked.sync="isPasswordProtected" :disabled="isPasswordEnforced">
 							{{ t('files_sharing', 'Set password') }}
 						</NcCheckboxRadioSwitch>
 						<NcPasswordField v-if="isPasswordProtected"
@@ -144,12 +143,12 @@
 							{{ t('files_sharing', 'Password expired') }}
 						</span>
 					</template>
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__video-verification" v-if="canTogglePasswordProtectedByTalkAvailable"
+					<NcCheckboxRadioSwitch data-cy-files-sharing-share-advanced-section="video-verification" v-if="canTogglePasswordProtectedByTalkAvailable"
 						:checked.sync="isPasswordProtectedByTalk"
 						@update:checked="onPasswordProtectedByTalkChange">
 						{{ t('files_sharing', 'Video verification') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__expiration-date" :checked.sync="hasExpirationDate" :disabled="isExpiryDateEnforced">
+					<NcCheckboxRadioSwitch data-cy-files-sharing-share-advanced-section="expiration-date" :checked.sync="hasExpirationDate" :disabled="isExpiryDateEnforced">
 						{{ isExpiryDateEnforced
 							? t('files_sharing', 'Expiration date (enforced)')
 							: t('files_sharing', 'Set expiration date') }}
@@ -164,19 +163,19 @@
 						:placeholder="t('files_sharing', 'Expiration date')"
 						type="date"
 						@input="onExpirationChange" />
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__hide-download" v-if="isPublicShare"
+					<NcCheckboxRadioSwitch data-cy-files-sharing-share-advanced-section="hide-download" v-if="isPublicShare"
 						:disabled="canChangeHideDownload"
 						:checked.sync="share.hideDownload"
 						@update:checked="queueUpdate('hideDownload')">
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch v-else class="sharingTabDetailsView__allow-download"
+					<NcCheckboxRadioSwitch v-else data-cy-files-sharing-share-advanced-section="allow-download"
 						:disabled="!canSetDownload"
 						:checked.sync="canDownload"
 						data-cy-files-sharing-share-permissions-checkbox="download">
 						{{ t('files_sharing', 'Allow download and sync') }}
 					</NcCheckboxRadioSwitch>
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__note-to-recipient" :checked.sync="writeNoteToRecipientIsChecked">
+					<NcCheckboxRadioSwitch data-cy-files-sharing-share-advanced-section="note-to-recipient" :checked.sync="writeNoteToRecipientIsChecked">
 						{{ t('files_sharing', 'Note to recipient') }}
 					</NcCheckboxRadioSwitch>
 					<template v-if="writeNoteToRecipientIsChecked">
@@ -195,33 +194,33 @@
 						:action="action"
 						:file-info="fileInfo"
 						:share="share" />
-					<NcCheckboxRadioSwitch class="sharingTabDetailsView__custom-permissions" :checked.sync="setCustomPermissions">
+					<NcCheckboxRadioSwitch data-cy-files-sharing-share-advanced-section="custom-permissions" :checked.sync="setCustomPermissions">
 						{{ t('files_sharing', 'Custom permissions') }}
 					</NcCheckboxRadioSwitch>
 					<section v-if="setCustomPermissions" class="custom-permissions-group">
-						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-read" :disabled="!canRemoveReadPermission"
+						<NcCheckboxRadioSwitch :disabled="!canRemoveReadPermission"
 							:checked.sync="hasRead"
 							data-cy-files-sharing-share-permissions-checkbox="read">
 							{{ t('files_sharing', 'Read') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-create" v-if="isFolder"
+						<NcCheckboxRadioSwitch v-if="isFolder"
 							:disabled="!canSetCreate"
 							:checked.sync="canCreate"
 							data-cy-files-sharing-share-permissions-checkbox="create">
 							{{ t('files_sharing', 'Create') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-edit" :disabled="!canSetEdit"
+						<NcCheckboxRadioSwitch :disabled="!canSetEdit"
 							:checked.sync="canEdit"
 							data-cy-files-sharing-share-permissions-checkbox="update">
 							{{ t('files_sharing', 'Edit') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-share" v-if="resharingIsPossible"
+						<NcCheckboxRadioSwitch v-if="resharingIsPossible"
 							:disabled="!canSetReshare"
 							:checked.sync="canReshare"
 							data-cy-files-sharing-share-permissions-checkbox="share">
 							{{ t('files_sharing', 'Share') }}
 						</NcCheckboxRadioSwitch>
-						<NcCheckboxRadioSwitch class="sharingTabDetailsView__permission-delete" :disabled="!canSetDelete"
+						<NcCheckboxRadioSwitch :disabled="!canSetDelete"
 							:checked.sync="canDelete"
 							data-cy-files-sharing-share-permissions-checkbox="delete">
 							{{ t('files_sharing', 'Delete') }}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary
Within our application of nextcloud we faced an issue with the remote share settings. 
We looked for a way to hide some of the options in the extended share and weren't able to securely discern them.
I have added some selector classes to the checkboxes. It is a purely service and discernability for extensions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [X] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [X] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
