### PR TITLE
fix(files_reminders): add missing import

### DIFF
--- a/apps/files_reminders/composer/composer/autoload_classmap.php
+++ b/apps/files_reminders/composer/composer/autoload_classmap.php
@@ -26,4 +26,5 @@ return array(
     'OCA\\FilesReminders\\Model\\RichReminder' => $baseDir . '/../lib/Model/RichReminder.php',
     'OCA\\FilesReminders\\Notification\\Notifier' => $baseDir . '/../lib/Notification/Notifier.php',
     'OCA\\FilesReminders\\Service\\ReminderService' => $baseDir . '/../lib/Service/ReminderService.php',
+    'OCA\\FilesReminders\\SetupChecks\\NeedNotificationsApp' => $baseDir . '/../lib/SetupChecks/NeedNotificationsApp.php',
 );

--- a/apps/files_reminders/composer/composer/autoload_static.php
+++ b/apps/files_reminders/composer/composer/autoload_static.php
@@ -41,6 +41,7 @@ class ComposerStaticInitFilesReminders
         'OCA\\FilesReminders\\Model\\RichReminder' => __DIR__ . '/..' . '/../lib/Model/RichReminder.php',
         'OCA\\FilesReminders\\Notification\\Notifier' => __DIR__ . '/..' . '/../lib/Notification/Notifier.php',
         'OCA\\FilesReminders\\Service\\ReminderService' => __DIR__ . '/..' . '/../lib/Service/ReminderService.php',
+        'OCA\\FilesReminders\\SetupChecks\\NeedNotificationsApp' => __DIR__ . '/..' . '/../lib/SetupChecks/NeedNotificationsApp.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/apps/files_reminders/lib/AppInfo/Application.php
+++ b/apps/files_reminders/lib/AppInfo/Application.php
@@ -16,6 +16,7 @@ use OCA\FilesReminders\Listener\NodeDeletedListener;
 use OCA\FilesReminders\Listener\SabrePluginAddListener;
 use OCA\FilesReminders\Listener\UserDeletedListener;
 use OCA\FilesReminders\Notification\Notifier;
+use OCA\FilesReminders\SetupChecks\NeedNotificationsApp;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;

--- a/apps/files_reminders/lib/Notification/Notifier.php
+++ b/apps/files_reminders/lib/Notification/Notifier.php
@@ -76,7 +76,7 @@ class Notifier implements INotifier {
 						[
 							'name' => [
 								'type' => 'highlight',
-								'id' => $node->getId(),
+								'id' => (string)$node->getId(),
 								'name' => $node->getName(),
 							],
 						],

--- a/apps/files_reminders/lib/SetupChecks/NeedNotificationsApp.php
+++ b/apps/files_reminders/lib/SetupChecks/NeedNotificationsApp.php
@@ -10,12 +10,14 @@ declare(strict_types=1);
 namespace OCA\FilesReminders\SetupChecks;
 
 use OCP\App\IAppManager;
+use OCP\IL10N;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
 class NeedNotificationsApp implements ISetupCheck {
 	public function __construct(
 		private IAppManager $appManager,
+		private IL10N $l10n,
 	) {
 	}
 
@@ -28,7 +30,7 @@ class NeedNotificationsApp implements ISetupCheck {
 	}
 
 	public function run(): SetupResult {
-		if ($this->appManager->isInstalled('notifications')) {
+		if ($this->appManager->isEnabledForAnyone('notifications')) {
 			return SetupResult::success($this->l10n->t('This files_reminder can work properly.'));
 		} else {
 			return SetupResult::warning($this->l10n->t('The files_reminder app needs the notification app to work properly. You should either enable notifications or disable files_reminder.'));

--- a/apps/files_reminders/lib/SetupChecks/NeedNotificationsApp.php
+++ b/apps/files_reminders/lib/SetupChecks/NeedNotificationsApp.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\SetupChecks;
+namespace OCA\FilesReminders\SetupChecks;
 
 use OCP\App\IAppManager;
 use OCP\SetupCheck\ISetupCheck;

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -843,6 +843,12 @@
       <code><![CDATA[test]]></code>
     </TooManyArguments>
   </file>
+  <file src="apps/files_reminders/lib/Model/RichReminder.php">
+    <ConstructorSignatureMismatch>
+      <code><![CDATA[public function __construct(]]></code>
+      <code><![CDATA[public function __construct(]]></code>
+    </ConstructorSignatureMismatch>
+  </file>
   <file src="apps/files_sharing/lib/Controller/ShareAPIController.php">
     <RedundantCast>
       <code><![CDATA[(int)$code]]></code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -30,6 +30,7 @@
 		<directory name="apps/federation"/>
 		<directory name="apps/files"/>
 		<directory name="apps/files_external"/>
+		<directory name="apps/files_reminders"/>
 		<directory name="apps/files_sharing"/>
 		<directory name="apps/files_trashbin"/>
 		<directory name="apps/files_versions"/>


### PR DESCRIPTION
- Resolves https://github.com/nextcloud/server/issues/51943
- Regression of https://github.com/nextcloud/server/pull/51760

## Summary

1. Add missing import of setup check in application class
2. Add missing `l10n` constructor parameter.
3. Lint the app using psalm so this does not happen again.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
