### PR TITLE
fix(federation): allows equal signs in federation id

### DIFF
--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -106,7 +106,10 @@ class CloudIdManager implements ICloudIdManager {
 			$user = substr($id, 0, $lastValidAtPos);
 			$remote = substr($id, $lastValidAtPos + 1);
 
-			$this->userManager->validateUserId($user);
+			// We accept slightly more chars when working with federationId than with a local userId.
+			// We remove those eventual chars from the UserId before using
+			// the IUserManager API to confirm its format.
+			$this->userManager->validateUserId(str_replace('=', '-', $user));
 
 			if (!empty($user) && !empty($remote)) {
 				$remote = $this->ensureDefaultProtocol($remote);

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -91,6 +91,10 @@ class CloudIdManagerTest extends TestCase {
 			['test@example.com/cloud/', 'test', 'example.com/cloud', 'test@example.com/cloud'],
 			['test@example.com/cloud/index.php', 'test', 'example.com/cloud', 'test@example.com/cloud'],
 			['test@example.com@example.com', 'test@example.com', 'example.com', 'test@example.com@example.com'],
+
+			// Equal signs are not valid on Nextcloud side, but can be used by other federated OCM compatible servers
+			['test==@example.com', 'test==', 'example.com', 'test==@example.com'],
+			['==@example.com', '==', 'example.com', '==@example.com'],
 		];
 	}
 


### PR DESCRIPTION
Having a equalsign `=` in your userid is a blocker for federation.

The equal sign is usually filtered during creation of a new user, unless using SSO. 

Assuming having an equal sign in your userId/federationId does not bring security issue, 
this fix allows remote users with equal sign to be part of the federation.