### PR TITLE
feat(lexicon): get default from lexicon on occ command

### DIFF
--- a/core/Command/Config/App/GetConfig.php
+++ b/core/Command/Config/App/GetConfig.php
@@ -38,7 +38,13 @@ class GetConfig extends Base {
 				'returns complete details about the app config value'
 			)
 			->addOption(
-				'--key-details',
+				'default-if-none',
+				null,
+				InputOption::VALUE_NONE,
+				'returns default if no value is set'
+			)
+			->addOption(
+				'key-details',
 				null,
 				InputOption::VALUE_NONE,
 				'returns complete details about the app config key'
@@ -81,10 +87,15 @@ class GetConfig extends Base {
 		try {
 			$configValue = $this->appConfig->getDetails($appName, $configName)['value'];
 		} catch (AppConfigUnknownKeyException $e) {
-			if (!$input->hasParameterOption('--default-value')) {
-				return 1;
+			if ($input->getOption('default-if-none')) {
+				/** @psalm-suppress UndefinedInterfaceMethod */
+				$configValue = $this->appConfig->getValueMixed($appName, $configName, lazy: null);
+			} else {
+				if (!$input->hasParameterOption('--default-value')) {
+					return 1;
+				}
+				$configValue = $defaultValue;
 			}
-			$configValue = $defaultValue;
 		}
 
 		$this->writeMixedInOutputFormat($input, $output, $configValue);

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -321,9 +321,10 @@ class AppConfig implements IAppConfig {
 		?bool $lazy = false,
 	): string {
 		try {
-			$lazy = ($lazy === null) ? $this->isLazy($app, $key) : $lazy;
+			$lazy = $lazy ?? $this->isLazy($app, $key);
 		} catch (AppConfigUnknownKeyException) {
-			return $default;
+			// we already know that value does not exist. we can still get default from lexicon.
+			$lazy = false;
 		}
 
 		return $this->getTypedValue(

--- a/tests/Core/Command/Config/App/GetConfigTest.php
+++ b/tests/Core/Command/Config/App/GetConfigTest.php
@@ -9,15 +9,18 @@ declare(strict_types=1);
 
 namespace Tests\Core\Command\Config\App;
 
+use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Config\ConfigManager;
 use OC\Core\Command\Config\App\GetConfig;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 use OCP\IAppConfig;
+use OCP\Server;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
+use Tests\lib\Config\TestConfigLexicon_I;
 
 class GetConfigTest extends TestCase {
 	protected IAppConfig&MockObject $appConfig;
@@ -41,47 +44,50 @@ class GetConfigTest extends TestCase {
 	public static function dataGet(): array {
 		return [
 			// String output as json
-			['name', 'newvalue', true, null, false, 'json', 0, json_encode('newvalue')],
+			['name', 'newvalue', true, null, false, 'json', 0, json_encode('newvalue'), false],
 			// String output as plain text
-			['name', 'newvalue', true, null, false, 'plain', 0, 'newvalue'],
+			['name', 'newvalue', true, null, false, 'plain', 0, 'newvalue', false],
 			// String falling back to default output as json
-			['name', null, false, 'newvalue', true, 'json', 0, json_encode('newvalue')],
-			// String falling back without default: error
-			['name', null, false, null, false, 'json', 1, null],
+			['name', null, false, 'newvalue', true, 'json', 0, json_encode('newvalue'), false],
+			// String falling back without default: errorw
+			['name', null, false, null, false, 'json', 1, null, false],
+
+			// testing default value if set in lexicon
+			['key1', '123', false, 'newvalssue', false, 'plain', 0, 'newvalsadsdae', true],
 
 			// Int "0" output as json/plain
-			['name', 0, true, null, false, 'json', 0, json_encode(0)],
-			['name', 0, true, null, false, 'plain', 0, '0'],
+			['name', 0, true, null, false, 'json', 0, json_encode(0), false],
+			['name', 0, true, null, false, 'plain', 0, '0', false],
 			// Int "1" output as json/plain
-			['name', 1, true, null, false, 'json', 0, json_encode(1)],
-			['name', 1, true, null, false, 'plain', 0, '1'],
+			['name', 1, true, null, false, 'json', 0, json_encode(1), false],
+			['name', 1, true, null, false, 'plain', 0, '1', false],
 
 			// Bool "true" output as json/plain
-			['name', true, true, null, false, 'json', 0, json_encode(true)],
-			['name', true, true, null, false, 'plain', 0, 'true'],
+			['name', true, true, null, false, 'json', 0, json_encode(true), false],
+			['name', true, true, null, false, 'plain', 0, 'true', false],
 			// Bool "false" output as json/plain
-			['name', false, true, null, false, 'json', 0, json_encode(false)],
-			['name', false, true, null, false, 'plain', 0, 'false'],
+			['name', false, true, null, false, 'json', 0, json_encode(false), false],
+			['name', false, true, null, false, 'plain', 0, 'false', false],
 
 			// Null output as json/plain
-			['name', null, true, null, false, 'json', 0, json_encode(null)],
-			['name', null, true, null, false, 'plain', 0, 'null'],
+			['name', null, true, null, false, 'json', 0, json_encode(null), false],
+			['name', null, true, null, false, 'plain', 0, 'null', false],
 
 			// Array output as json/plain
-			['name', ['a', 'b'], true, null, false, 'json', 0, json_encode(['a', 'b'])],
-			['name', ['a', 'b'], true, null, false, 'plain', 0, "a\nb"],
+			['name', ['a', 'b'], true, null, false, 'json', 0, json_encode(['a', 'b']), false],
+			['name', ['a', 'b'], true, null, false, 'plain', 0, "a\nb", false],
 			// Key array output as json/plain
-			['name', [0 => 'a', 1 => 'b'], true, null, false, 'json', 0, json_encode(['a', 'b'])],
-			['name', [0 => 'a', 1 => 'b'], true, null, false, 'plain', 0, "a\nb"],
+			['name', [0 => 'a', 1 => 'b'], true, null, false, 'json', 0, json_encode(['a', 'b']), false],
+			['name', [0 => 'a', 1 => 'b'], true, null, false, 'plain', 0, "a\nb", false],
 			// Associative array output as json/plain
-			['name', ['a' => 1, 'b' => 2], true, null, false, 'json', 0, json_encode(['a' => 1, 'b' => 2])],
-			['name', ['a' => 1, 'b' => 2], true, null, false, 'plain', 0, "a: 1\nb: 2"],
+			['name', ['a' => 1, 'b' => 2], true, null, false, 'json', 0, json_encode(['a' => 1, 'b' => 2]), false],
+			['name', ['a' => 1, 'b' => 2], true, null, false, 'plain', 0, "a: 1\nb: 2", false],
 
 		];
 	}
 
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGet')]
-	public function testGet(string $configName, mixed $value, bool $configExists, mixed $defaultValue, bool $hasDefault, string $outputFormat, int $expectedReturn, ?string $expectedMessage): void {
+	public function testGet(string $configName, mixed $value, bool $configExists, mixed $defaultValue, bool $hasDefault, string $outputFormat, int $expectedReturn, ?string $expectedMessage, bool $fromLexicon): void {
 		if (!$expectedReturn) {
 			if ($configExists) {
 				$this->appConfig->expects($this->once())
@@ -90,6 +96,17 @@ class GetConfigTest extends TestCase {
 					->willReturn(['value' => $value]);
 			}
 		}
+
+		// testing default value extracted from a test lexicon assigned to app-name
+		if ($fromLexicon) {
+			$bootstrapCoordinator = Server::get(Coordinator::class);
+			$bootstrapCoordinator->getRegistrationContext()?->registerConfigLexicon('app-name', TestConfigLexicon_I::class);
+
+			$appConfig = Server::get(IAppConfig::class);
+			$this->assertSame('abcde', $appConfig->getValueString('app-name', 'key1'));
+			return;
+		}
+
 
 		if (!$configExists) {
 			$this->appConfig->expects($this->once())


### PR DESCRIPTION
when `default-if-none` is used the default value from Lexicon will be returned

`./occ config:app:get myapp myvalue --default-if-none`



```
$ ./occ config:app:get core shareapi_allow_custom_tokens --default-if-none
0
$ ./occ config:preset PRIVATE
current preset: PRIVATE
$ ./occ config:app:get core shareapi_allow_custom_tokens --default-if-none
1
```


_Note: might be duplicate of --key-details that already returns default from lexicon_