### PR TITLE
fix: Handle missing share providers when promoting reshares

### DIFF
--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1065,7 +1065,12 @@ class Manager implements IManager {
 
 		foreach ($userIds as $userId) {
 			foreach ($shareTypes as $shareType) {
-				$provider = $this->factory->getProviderForType($shareType);
+				try {
+					$provider = $this->factory->getProviderForType($shareType);
+				} catch (ProviderException $e) {
+					continue;
+				}
+
 				if ($node instanceof Folder) {
 					/* We need to get all shares by this user to get subshares */
 					$shares = $provider->getSharesBy($userId, $shareType, null, false, -1, 0);


### PR DESCRIPTION
* Resolves: #50907 (which is a regression introduced in #47425)

## Summary

The provider for mail shares is not available when [the `sharebymail` app is disabled](https://github.com/nextcloud/server/blob/7ae62cfe47675e7b5fca4c2a7f07dbf45d7172b8/lib/private/Share20/ProviderFactory.php#L165-L167)), and in that case a `ProviderException` is thrown when trying to get it.

Note that this fix only catches the exception and that is it. If the `sharebymail` app is disabled and the deleted share had a mail reshare that reshare will not be promoted, and therefore it will still be a reshare if the `sharebymail` app is enabled again (the reshare will not be deleted either because deleting a share only deletes [the children returned by its provider](https://github.com/nextcloud/server/blob/0df4817be1eb04c78fd83380fb97f4c2cea65380/lib/private/Share20/Manager.php#L1014), and the default provider used for user and group shares [does not return mail shares](https://github.com/nextcloud/server/blob/b464469bc1a93ff4c0034d5a180361826c178cfc/lib/private/Share20/DefaultShareProvider.php#L377-L379)).

No tests were added to reduce the possible conflicts in the backports and ease including them in the RCs :see_no_evil: 

## How to test

- Disable the `sharebymail` app
- Open the Files app
- Create a share with another user
- Delete the share

### Result with this pull request

The share is deleted

### Result without this pull request

`Error deleting the share` is shown. However, if the page is reloaded it can be seen that the share was actually deleted (as the error happened when promoting the reshares, and at that point the share was already deleted).
