### PR TITLE
fix(preview): Fix constructor parameter name and default value

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -32,8 +32,8 @@ class Movie extends ProviderV2 {
 	/** @var string */
 	private $binary;
 
-	public function __construct(array $config) {
-		parent::__construct($config);
+	public function __construct(array $options = []) {
+		parent::__construct($options);
 		$this->config = Server::get(IConfig::class);
 	}
 

--- a/tests/lib/Preview/MovieTest.php
+++ b/tests/lib/Preview/MovieTest.php
@@ -7,6 +7,9 @@
 
 namespace Test\Preview;
 
+use OCP\IBinaryFinder;
+use OCP\Server;
+
 /**
  * Class MovieTest
  *
@@ -16,20 +19,20 @@ namespace Test\Preview;
  */
 class MovieTest extends Provider {
 	protected function setUp(): void {
-		$avconvBinary = \OC_Helper::findBinaryPath('avconv');
-		$ffmpegBinary = ($avconvBinary) ? null : \OC_Helper::findBinaryPath('ffmpeg');
+		$binaryFinder = Server::get(IBinaryFinder::class);
+		$movieBinary = $binaryFinder->findBinaryPath('avconv');
+		if (!is_string($movieBinary)) {
+			$movieBinary = $binaryFinder->findBinaryPath('ffmpeg');
+		}
 
-		if ($avconvBinary || $ffmpegBinary) {
+		if (is_string($movieBinary)) {
 			parent::setUp();
-
-			\OC\Preview\Movie::$avconvBinary = $avconvBinary;
-			\OC\Preview\Movie::$ffmpegBinary = $ffmpegBinary;
 
 			$fileName = 'testimage.mp4';
 			$this->imgPath = $this->prepareTestFile($fileName, \OC::$SERVERROOT . '/tests/data/' . $fileName);
 			$this->width = 560;
 			$this->height = 320;
-			$this->provider = new \OC\Preview\Movie;
+			$this->provider = new \OC\Preview\Movie(['movieBinary' => $movieBinary]);
 		} else {
 			$this->markTestSkipped('No Movie provider present');
 		}


### PR DESCRIPTION
This should fix tests for movie preview provider

* Follow-up of #51712

## Summary

- Fixes `OC\Preview\Movie` constructor to fix tests.
- Cleanup its code for deprecated stuff and psalm warnings.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
