### PR TITLE
refactor(RichObjectStrings): Only log error if key or value is not string in validator

### DIFF
--- a/lib/private/RichObjectStrings/Validator.php
+++ b/lib/private/RichObjectStrings/Validator.php
@@ -10,6 +10,8 @@ namespace OC\RichObjectStrings;
 use OCP\RichObjectStrings\Definitions;
 use OCP\RichObjectStrings\InvalidObjectExeption;
 use OCP\RichObjectStrings\IValidator;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class Validator
@@ -79,10 +81,10 @@ class Validator implements IValidator {
 
 		foreach ($parameter as $key => $value) {
 			if (!is_string($key)) {
-				throw new InvalidObjectExeption('Object for placeholder ' . $placeholder . ' is invalid, key ' . $key . ' is not a string');
+				Server::get(LoggerInterface::class)->error('Object for placeholder ' . $placeholder . ' is invalid, key ' . $key . ' is not a string');
 			}
 			if (!is_string($value)) {
-				throw new InvalidObjectExeption('Object for placeholder ' . $placeholder . ' is invalid, value ' . $value . ' for key ' . $key . ' is not a string');
+				Server::get(LoggerInterface::class)->error('Object for placeholder ' . $placeholder . ' is invalid, value ' . $value . ' for key ' . $key . ' is not a string');
 			}
 		}
 	}

--- a/tests/lib/RichObjectStrings/ValidatorTest.php
+++ b/tests/lib/RichObjectStrings/ValidatorTest.php
@@ -10,7 +10,6 @@ namespace Test\RichObjectStrings;
 
 use OC\RichObjectStrings\Validator;
 use OCP\RichObjectStrings\Definitions;
-use OCP\RichObjectStrings\InvalidObjectExeption;
 use Test\TestCase;
 
 class ValidatorTest extends TestCase {
@@ -37,9 +36,6 @@ class ValidatorTest extends TestCase {
 		]);
 		$this->addToAssertionCount(2);
 
-		$this->expectException(InvalidObjectExeption::class);
-
-		$this->expectExceptionMessage('Object for placeholder string1 is invalid, value 123 for key key is not a string');
 		$v->validate('test {string1} test.', [
 			'string1' => [
 				'type' => 'user',
@@ -49,7 +45,6 @@ class ValidatorTest extends TestCase {
 			],
 		]);
 
-		$this->expectExceptionMessage('Object for placeholder string1 is invalid, key 456 is not a string');
 		$v->validate('test {string1} test.', [
 			'string1' => [
 				'type' => 'user',


### PR DESCRIPTION
Fixes https://github.com/nextcloud/server/issues/51427
Fixes https://github.com/nextcloud/activity/issues/1875

## Summary

https://github.com/nextcloud/server/pull/47662 was a bit too hard and has caused quite a few issues because there are so many places that are wrong.
While it makes developers more aware, it also breaks a lot of users which is not good. Therefore I'm downgrading it to an error message for now, so developers hopefully still notice it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
