### PR TITLE
fix: more optimized caching for share target verification

### DIFF
--- a/apps/files_sharing/tests/MountProviderTest.php
+++ b/apps/files_sharing/tests/MountProviderTest.php
@@ -11,6 +11,7 @@ use OC\Share20\Share;
 use OCA\Files_Sharing\MountProvider;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\ICacheFactory;
 use OCP\IConfig;
@@ -55,8 +56,9 @@ class MountProviderTest extends \Test\TestCase {
 		$cacheFactory = $this->createMock(ICacheFactory::class);
 		$cacheFactory->method('createLocal')
 			->willReturn(new NullCache());
+		$mountManager = $this->createMock(IMountManager::class);
 
-		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger, $eventDispatcher, $cacheFactory);
+		$this->provider = new MountProvider($this->config, $this->shareManager, $this->logger, $eventDispatcher, $cacheFactory, $mountManager);
 	}
 
 	private function makeMockShareAttributes($attrs) {


### PR DESCRIPTION
Instead of caching the "validated" status per-share, instead track the latest share (by share id) that is validated.

This uses the fact that once a unique target is generated for the share, new files can't suddenly appear at the share target.
An exception to this is admin-created mount points (groupfolders, external storages, etc). So conflicts with other mount points is always done (but this is very cheap).