### PR TITLE
fix: don't construct storage when checking if a sub-mount is applicable

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1466,8 +1466,7 @@ class View {
 	public function addSubMounts(FileInfo $info, $extOnly = false): void {
 		$mounts = Filesystem::getMountManager()->findIn($info->getPath());
 		$info->setSubMounts(array_filter($mounts, function (IMountPoint $mount) use ($extOnly) {
-			$subStorage = $mount->getStorage();
-			return !($extOnly && $subStorage instanceof \OCA\Files_Sharing\SharedStorage);
+			return !($extOnly && $mount instanceof SharedMount);
 		}));
 	}
 


### PR DESCRIPTION
constructing the storage isn't particularly expensive, but it can add up if you have thousands