### PR TITLE
Revert "refactor(RichObjectStrings): Only log error if key or value i…

### DIFF
--- a/lib/private/RichObjectStrings/Validator.php
+++ b/lib/private/RichObjectStrings/Validator.php
@@ -10,8 +10,6 @@ namespace OC\RichObjectStrings;
 use OCP\RichObjectStrings\Definitions;
 use OCP\RichObjectStrings\InvalidObjectExeption;
 use OCP\RichObjectStrings\IValidator;
-use OCP\Server;
-use Psr\Log\LoggerInterface;
 
 /**
  * Class Validator
@@ -81,10 +79,10 @@ class Validator implements IValidator {
 
 		foreach ($parameter as $key => $value) {
 			if (!is_string($key)) {
-				Server::get(LoggerInterface::class)->error('Object for placeholder ' . $placeholder . ' is invalid, key ' . $key . ' is not a string');
+				throw new InvalidObjectExeption('Object for placeholder ' . $placeholder . ' is invalid, key ' . $key . ' is not a string');
 			}
 			if (!is_string($value)) {
-				Server::get(LoggerInterface::class)->error('Object for placeholder ' . $placeholder . ' is invalid, value ' . $value . ' for key ' . $key . ' is not a string');
+				throw new InvalidObjectExeption('Object for placeholder ' . $placeholder . ' is invalid, value ' . $value . ' for key ' . $key . ' is not a string');
 			}
 		}
 	}

--- a/tests/lib/RichObjectStrings/ValidatorTest.php
+++ b/tests/lib/RichObjectStrings/ValidatorTest.php
@@ -10,6 +10,7 @@ namespace Test\RichObjectStrings;
 
 use OC\RichObjectStrings\Validator;
 use OCP\RichObjectStrings\Definitions;
+use OCP\RichObjectStrings\InvalidObjectExeption;
 use Test\TestCase;
 
 class ValidatorTest extends TestCase {
@@ -36,6 +37,9 @@ class ValidatorTest extends TestCase {
 		]);
 		$this->addToAssertionCount(2);
 
+		$this->expectException(InvalidObjectExeption::class);
+
+		$this->expectExceptionMessage('Object for placeholder string1 is invalid, value 123 for key key is not a string');
 		$v->validate('test {string1} test.', [
 			'string1' => [
 				'type' => 'user',
@@ -45,6 +49,7 @@ class ValidatorTest extends TestCase {
 			],
 		]);
 
+		$this->expectExceptionMessage('Object for placeholder string1 is invalid, key 456 is not a string');
 		$v->validate('test {string1} test.', [
 			'string1' => [
 				'type' => 'user',


### PR DESCRIPTION
…s not string in validator"

- This reverts commit fd156d3408a030c6bb98d9cdaf3790375d766eb5.
- This reverts #52035 
- For reasoning see https://github.com/nextcloud/server/pull/52059 and https://github.com/nextcloud/server/pull/52035#issuecomment-2788320935
- @provokateurin Assuming the idea was to reduce the log messages, this PR failed it's purpose
- Also the spaming was quite low and therefore I'm not sure what the goal was
- If the idea was to alert developers more, we need to wrap the additional logging with a check for debug. But removing the throwing was even a change to the API and method calls that were expected to throw did not anymore.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
