### PR TITLE
fix(federation): Don't load the addressbook when resolving a cloud ID

### DIFF
--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -28,6 +28,7 @@ class CloudIdManager implements ICloudIdManager {
 	/** @var IUserManager */
 	private $userManager;
 	private ICache $memCache;
+	private ICache $displayNameCache;
 	/** @var array[] */
 	private array $cache = [];
 
@@ -42,6 +43,7 @@ class CloudIdManager implements ICloudIdManager {
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
 		$this->memCache = $cacheFactory->createDistributed('cloud_id_');
+		$this->displayNameCache = $cacheFactory->createDistributed('cloudid_name_');
 		$eventDispatcher->addListener(UserChangedEvent::class, [$this, 'handleUserEvent']);
 		$eventDispatcher->addListener(CardUpdatedEvent::class, [$this, 'handleCardEvent']);
 	}
@@ -108,13 +110,18 @@ class CloudIdManager implements ICloudIdManager {
 
 			if (!empty($user) && !empty($remote)) {
 				$remote = $this->ensureDefaultProtocol($remote);
-				return new CloudId($id, $user, $remote, $this->getDisplayNameFromContact($id));
+				return new CloudId($id, $user, $remote, null);
 			}
 		}
 		throw new \InvalidArgumentException('Invalid cloud id');
 	}
 
-	protected function getDisplayNameFromContact(string $cloudId): ?string {
+	public function getDisplayNameFromContact(string $cloudId): ?string {
+		$cachedName = $this->displayNameCache->get($cloudId);
+		if ($cachedName !== null) {
+			return $cachedName;
+		}
+
 		$addressBookEntries = $this->contactsManager->search($cloudId, ['CLOUD'], [
 			'limit' => 1,
 			'enumeration' => false,
@@ -128,14 +135,17 @@ class CloudIdManager implements ICloudIdManager {
 						// Warning, if user decides to make their full name local only,
 						// no FN is found on federated servers
 						if (isset($entry['FN'])) {
+							$this->displayNameCache->set($cloudId, $entry['FN'], 15 * 60);
 							return $entry['FN'];
 						} else {
+							$this->displayNameCache->set($cloudId, $cloudID, 15 * 60);
 							return $cloudID;
 						}
 					}
 				}
 			}
 		}
+		$this->displayNameCache->set($cloudId, $cloudId, 15 * 60);
 		return null;
 	}
 
@@ -168,7 +178,7 @@ class CloudIdManager implements ICloudIdManager {
 			$localUser = $this->userManager->get($user);
 			$displayName = $localUser ? $localUser->getDisplayName() : '';
 		} else {
-			$displayName = $this->getDisplayNameFromContact($user . '@' . $host);
+			$displayName = null;
 		}
 
 		// For the visible cloudID we only strip away https

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -10,11 +13,15 @@ use OC\Federation\CloudIdManager;
 use OC\Memcache\ArrayCache;
 use OCP\Contacts\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Federation\ICloudIdManager;
 use OCP\ICacheFactory;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use Test\TestCase;
 
+/**
+ * @group DB
+ */
 class CloudIdManagerTest extends TestCase {
 	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
 	protected $contactsManager;
@@ -36,7 +43,7 @@ class CloudIdManagerTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
-		$this->cacheFactory->method('createLocal')
+		$this->cacheFactory->method('createDistributed')
 			->willReturn(new ArrayCache(''));
 
 		$this->cloudIdManager = new CloudIdManager(
@@ -46,6 +53,7 @@ class CloudIdManagerTest extends TestCase {
 			$this->cacheFactory,
 			$this->createMock(IEventDispatcher::class)
 		);
+		$this->overwriteService(ICloudIdManager::class, $this->cloudIdManager);
 	}
 
 	public function cloudIdProvider(): array {
@@ -70,7 +78,7 @@ class CloudIdManagerTest extends TestCase {
 			->willReturn([
 				[
 					'CLOUD' => [$cleanId],
-					'FN' => 'Ample Ex',
+					'FN' => $displayName,
 				]
 			]);
 
@@ -92,9 +100,6 @@ class CloudIdManagerTest extends TestCase {
 
 	/**
 	 * @dataProvider invalidCloudIdProvider
-	 *
-	 * @param string $cloudId
-	 *
 	 */
 	public function testInvalidCloudId(string $cloudId): void {
 		$this->expectException(\InvalidArgumentException::class);

--- a/tests/lib/Federation/CloudIdTest.php
+++ b/tests/lib/Federation/CloudIdTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -7,25 +10,42 @@
 namespace Test\Federation;
 
 use OC\Federation\CloudId;
+use OC\Federation\CloudIdManager;
+use OCP\Federation\ICloudIdManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
+/**
+ * @group DB
+ */
 class CloudIdTest extends TestCase {
-	public function dataGetDisplayCloudId() {
+	protected CloudIdManager&MockObject $cloudIdManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->cloudIdManager = $this->createMock(CloudIdManager::class);
+		$this->overwriteService(ICloudIdManager::class, $this->cloudIdManager);
+	}
+
+	public function dataGetDisplayCloudId(): array {
 		return [
-			['test@example.com', 'test@example.com'],
-			['test@http://example.com', 'test@example.com'],
-			['test@https://example.com', 'test@example.com'],
+			['test@example.com', 'test', 'example.com', 'test@example.com'],
+			['test@http://example.com', 'test', 'http://example.com', 'test@example.com'],
+			['test@https://example.com', 'test', 'https://example.com', 'test@example.com'],
+			['test@https://example.com', 'test', 'https://example.com', 'Beloved Amy@example.com', 'Beloved Amy'],
 		];
 	}
 
 	/**
 	 * @dataProvider dataGetDisplayCloudId
-	 *
-	 * @param string $id
-	 * @param string $display
 	 */
-	public function testGetDisplayCloudId($id, $display): void {
-		$cloudId = new CloudId($id, '', '');
+	public function testGetDisplayCloudId(string $id, string $user, string $remote, string $display, ?string $addressbookName = null): void {
+		$this->cloudIdManager->expects($this->once())
+			->method('getDisplayNameFromContact')
+			->willReturn($addressbookName);
+
+		$cloudId = new CloudId($id, $user, $remote);
 		$this->assertEquals($display, $cloudId->getDisplayId());
 	}
 }


### PR DESCRIPTION
Instead we delay the lookup of the display name until it is actually used

## Summary

This saves the addressbook setup in all usages of Talk where we just resolve the cloud id to properly get the object with split user ID and server URL. The display name is never used in talk as we cache it into the comments and attendees table.
So this saves 5+ queries in all cases that involve federated users.

Display name still properly loads in:
- File list (incoming):
  ![Bildschirmfoto vom 2025-04-09 10-21-13](https://github.com/user-attachments/assets/20912d4d-bd63-4915-99d7-9f43cbd66036)
- Right sidebar owner chip (incoming):
  ![Bildschirmfoto vom 2025-04-09 10-21-04](https://github.com/user-attachments/assets/b6f6744c-0231-4a0a-b157-669a999997fb)
- Notification (incoming):
  ![Bildschirmfoto vom 2025-04-09 10-20-37](https://github.com/user-attachments/assets/3aa9c897-d486-42ca-b1e3-0539c23c1048)
- Share list (outgoing):
  ![Bildschirmfoto vom 2025-04-09 10-20-45](https://github.com/user-attachments/assets/7dca5e68-68db-4c7c-9b26-649ba9f0c067)




## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
