### PR TITLE
test: Improve comments manager test output in case of failure

### DIFF
--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -507,14 +507,14 @@ class ManagerTest extends TestCase {
 		}
 
 		$saveSuccessful = $manager->save($comment);
-		$this->assertTrue($saveSuccessful);
-		$this->assertTrue($comment->getId() !== '');
-		$this->assertTrue($comment->getId() !== '0');
-		$this->assertTrue(!is_null($comment->getCreationDateTime()));
+		$this->assertTrue($saveSuccessful, 'Comment saving was not successful');
+		$this->assertNotEquals('', $comment->getId(), 'Comment ID should not be empty');
+		$this->assertNotEquals('0', $comment->getId(), 'Comment ID should not be string \'0\'');
+		$this->assertNotNull($comment->getCreationDateTime(), 'Comment creation date should not be null');
 
 		$loadedComment = $manager->get($comment->getId());
-		$this->assertSame($comment->getMessage(), $loadedComment->getMessage());
-		$this->assertEquals($comment->getCreationDateTime()->getTimestamp(), $loadedComment->getCreationDateTime()->getTimestamp());
+		$this->assertSame($comment->getMessage(), $loadedComment->getMessage(), 'Comment message should match');
+		$this->assertEquals($comment->getCreationDateTime()->getTimestamp(), $loadedComment->getCreationDateTime()->getTimestamp(), 'Comment creation date should match');
 		return $comment;
 	}
 


### PR DESCRIPTION
Trying to get more useful output in cases like:
https://github.com/nextcloud/server/actions/runs/14355117298/job/40242678881?pr=52068#step:8:112

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
