### PR TITLE
fix(previews): avoid large file downloads for remote movie storage

### DIFF
--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -54,10 +54,15 @@ class Movie extends ProviderV2 {
 
 		$result = null;
 		if ($this->useTempFile($file)) {
-			// try downloading 5 MB first as it's likely that the first frames are present there
-			// in some cases this doesn't work for example when the moov atom is at the
-			// end of the file, so if it fails we fall back to getting the full file
-			$sizeAttempts = [5242880, null];
+			// Try downloading 5 MB first, as it's likely that the first frames are present there.
+			// In some cases this doesn't work, for example when the moov atom is at the
+			// end of the file, so if it fails we fall back to getting the full file.
+			// Unless the file is not local (e.g. S3) as we do not want to download the whole (e.g. 37Gb) file
+			if ($file->getStorage()->isLocal()) {
+				$sizeAttempts = [5242880, null];
+			} else {
+				$sizeAttempts = [5242880];
+			}
 		} else {
 			// size is irrelevant, only attempt once
 			$sizeAttempts = [null];


### PR DESCRIPTION
## Summary
* On NC configured with remote storage like S3
   * User uploads video file of 3.7Gb
   * While file uploads it also stored to S3
   * After the upload is complete, when the user navigates to the folder containing the newly uploaded file, the thumbnail generation logic starts
* The current logic downloads the entire 3.7 GB file from S3 to create the thumbnail (as observed in the network traffic screen).

![Selection_20250408-002](https://github.com/user-attachments/assets/4924e6b3-9a9b-4fb4-b744-1b62799964e8)

Error produced by ffmpeg
```
Movie preview generation failed Output: ffmpeg version 6.1.1 Copyright (c) 2000-2023 the FFmpeg developers
  built with gcc 13.2.1 (Alpine 13.2.1_git20240309) 20240309
  configuration: --prefix=/usr --disable-librtmp --disable-lzma --disable-static --disable-stripping --enable-avfilter --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libdav1d --enable-libdrm --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libharfbuzz --enable-libmp3lame --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-librav1e --enable-librist --enable-libsoxr --enable-libsrt --enable-libssh --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-lto=auto --enable-lv2 --enable-openssl --enable-pic --enable-postproc --enable-pthreads --enable-shared --enable-vaapi --enable-vdpau --enable-version3 --enable-vulkan --optflags=-O3 --enable-libjxl --enable-libsvtav1 --enable-libvpl
  libavutil      58. 29.100 / 58. 29.100
  libavcodec     60. 31.102 / 60. 31.102
  libavformat    60. 16.100 / 60. 16.100
  libavdevice    60.  3.100 / 60.  3.100
  libavfilter     9. 12.100 /  9. 12.100
  libswscale      7.  5.100 /  7.  5.100
  libswresample   4. 12.100 /  4. 12.100
  libpostproc    57.  3.100 / 57.  3.100
  [mov,mp4,m4a,3gp,3g2,mj2 @ 0x7f53f2e9c600] moov atom not found
[in#0 @ 0x7f53f2f928c0] Error opening input: Invalid data found when processing input
Error opening input file /tmp/oc_tmp_POfcbD.
Error opening input files: Invalid data found when processing input
```

## Proposed Solution

Prevent downloading entire movie files from remote storage (e.g., S3) when the 'moov atom' is located at the end of the file.


## Test

Can be tested (locally with Minio) with video files larger than 5Mb with "moov atom" at the end of the file

Download sample video with missing "moov atom" at the beginning of the file
`wget https://www.sample-videos.com/video321/mp4/720/big_buck_bunny_720p_10mb.mp4`
 

* Upload file before proposed change. Observe - thumbnail exist. I happens because after the error in log "Movie preview generation failed Output" the whole file is downloaded from S3.
* Upload file with proposed change.
   * Observe - no thumbnail is generated


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.
html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
