### PR TITLE
fix: reuse default navigation entry when updating navigation entries

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -110,9 +110,10 @@ class NavigationManager implements INavigationManager {
 	}
 
 	private function updateDefaultEntries() {
+		$defaultEntryId = $this->getDefaultEntryIdForUser($this->userSession->getUser(), false);
 		foreach ($this->entries as $id => $entry) {
 			if ($entry['type'] === 'link') {
-				$this->entries[$id]['default'] = $id === $this->getDefaultEntryIdForUser($this->userSession->getUser(), false);
+				$this->entries[$id]['default'] = $id === $defaultEntryId;
 			}
 		}
 	}


### PR DESCRIPTION
Tiny perf improvement for a trivial change