### PR TITLE
fix(federation): Fix returning "no display name" after cache result

### DIFF
--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -119,6 +119,9 @@ class CloudIdManager implements ICloudIdManager {
 	public function getDisplayNameFromContact(string $cloudId): ?string {
 		$cachedName = $this->displayNameCache->get($cloudId);
 		if ($cachedName !== null) {
+			if ($cachedName === $cloudId) {
+				return null;
+			}
 			return $cachedName;
 		}
 
@@ -138,8 +141,8 @@ class CloudIdManager implements ICloudIdManager {
 							$this->displayNameCache->set($cloudId, $entry['FN'], 15 * 60);
 							return $entry['FN'];
 						} else {
-							$this->displayNameCache->set($cloudId, $cloudID, 15 * 60);
-							return $cloudID;
+							$this->displayNameCache->set($cloudId, $cloudId, 15 * 60);
+							return null;
 						}
 					}
 				}

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -56,6 +56,34 @@ class CloudIdManagerTest extends TestCase {
 		$this->overwriteService(ICloudIdManager::class, $this->cloudIdManager);
 	}
 
+	public function dataGetDisplayNameFromContact(): array {
+		return [
+			['test1@example.tld', 'test', 'test'],
+			['test2@example.tld', null, null],
+			['test3@example.tld', 'test3@example', 'test3@example'],
+			['test4@example.tld', 'test4@example.tld', null],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetDisplayNameFromContact
+	 */
+	public function testGetDisplayNameFromContact(string $cloudId, ?string $displayName, ?string $expected): void {
+		$returnedContact = [
+			'CLOUD' => [$cloudId],
+			'FN' => $expected,
+		];
+		if ($displayName === null) {
+			unset($returnedContact['FN']);
+		}
+		$this->contactsManager->method('search')
+			->with($cloudId, ['CLOUD'])
+			->willReturn([$returnedContact]);
+
+		$this->assertEquals($expected, $this->cloudIdManager->getDisplayNameFromContact($cloudId));
+		$this->assertEquals($expected, $this->cloudIdManager->getDisplayNameFromContact($cloudId));
+	}
+
 	public function cloudIdProvider(): array {
 		return [
 			['test@example.com', 'test', 'example.com', 'test@example.com'],


### PR DESCRIPTION
Fix https://github.com/nextcloud/spreed/actions/runs/14371336448/job/40294827713

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
