### PR TITLE
Cleanup user backends related methods

### DIFF
--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -29,12 +29,12 @@ abstract class TestCase extends \Test\TestCase {
 		parent::setUpBeforeClass();
 
 		// reset backend
-		\OC_User::clearBackends();
+		Server::get(IUserManager::class)->clearBackends();
 		Server::get(IGroupManager::class)->clearBackends();
 
 		// create users
 		$backend = new \Test\Util\User\Dummy();
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 		$backend->createUser(self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER1);
 		$backend->createUser(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER2);
 	}
@@ -62,8 +62,8 @@ abstract class TestCase extends \Test\TestCase {
 		Filesystem::tearDown();
 
 		// reset backend
-		\OC_User::clearBackends();
-		\OC_User::useBackend('database');
+		Server::get(IUserManager::class)->clearBackends();
+		Server::get(IUserManager::class)->registerBackend(new \OC\User\Database());
 		Server::get(IGroupManager::class)->clearBackends();
 		Server::get(IGroupManager::class)->addBackend(new Database());
 

--- a/apps/files_sharing/tests/TestCase.php
+++ b/apps/files_sharing/tests/TestCase.php
@@ -71,7 +71,7 @@ abstract class TestCase extends \Test\TestCase {
 		);
 
 		// reset backend
-		\OC_User::clearBackends();
+		Server::get(IUserManager::class)->clearBackends();
 		Server::get(IGroupManager::class)->clearBackends();
 
 		// clear share hooks
@@ -80,7 +80,7 @@ abstract class TestCase extends \Test\TestCase {
 
 		// create users
 		$backend = new \Test\Util\User\Dummy();
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 		$backend->createUser(self::TEST_FILES_SHARING_API_USER1, self::TEST_FILES_SHARING_API_USER1);
 		$backend->createUser(self::TEST_FILES_SHARING_API_USER2, self::TEST_FILES_SHARING_API_USER2);
 		$backend->createUser(self::TEST_FILES_SHARING_API_USER3, self::TEST_FILES_SHARING_API_USER3);
@@ -160,8 +160,8 @@ abstract class TestCase extends \Test\TestCase {
 		Filesystem::tearDown();
 
 		// reset backend
-		\OC_User::clearBackends();
-		\OC_User::useBackend('database');
+		Server::get(IUserManager::class)->clearBackends();
+		Server::get(IUserManager::class)->registerBackend(new \OC\User\Database());
 		Server::get(IGroupManager::class)->clearBackends();
 		Server::get(IGroupManager::class)->addBackend(new Database());
 

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -58,8 +58,8 @@ class TrashbinTest extends \Test\TestCase {
 		self::$trashBinStatus = $appManager->isEnabledForUser('files_trashbin');
 
 		// reset backend
-		\OC_User::clearBackends();
-		\OC_User::useBackend('database');
+		Server::get(IUserManager::class)->clearBackends();
+		Server::get(IUserManager::class)->registerBackend(new \OC\User\Database());
 
 		// clear share hooks
 		\OC_Hook::clear('OCP\\Share');

--- a/apps/user_ldap/lib/AppInfo/Application.php
+++ b/apps/user_ldap/lib/AppInfo/Application.php
@@ -105,6 +105,7 @@ class Application extends App implements IBootstrap {
 			INotificationManager $notificationManager,
 			IAppContainer $appContainer,
 			IEventDispatcher $dispatcher,
+			IUserManager $userManager,
 			IGroupManager $groupManager,
 			User_Proxy $userBackend,
 			Group_Proxy $groupBackend,
@@ -115,7 +116,7 @@ class Application extends App implements IBootstrap {
 				$userPluginManager = $appContainer->get(UserPluginManager::class);
 				$groupPluginManager = $appContainer->get(GroupPluginManager::class);
 
-				\OC_User::useBackend($userBackend);
+				$userManager->registerBackend($userBackend);
 				$groupManager->addBackend($groupBackend);
 
 				$userBackendRegisteredEvent = new UserBackendRegistered($userBackend, $userPluginManager);

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserAvatar.php
@@ -39,7 +39,7 @@ class IntegrationTestUserAvatar extends AbstractIntegrationTest {
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
 		$userBackend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
-		\OC_User::useBackend($userBackend);
+		Server::get(IUserManager::class)->registerBackend($userBackend);
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserCleanUp.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserCleanUp.php
@@ -36,7 +36,7 @@ class IntegrationTestUserCleanUp extends AbstractIntegrationTest {
 		$this->access->setUserMapper($this->mapping);
 
 		$userBackend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
-		\OC_User::useBackend($userBackend);
+		Server::get(IUserManager::class)->registerBackend($userBackend);
 	}
 
 	/**

--- a/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
+++ b/apps/user_ldap/tests/Integration/Lib/User/IntegrationTestUserDisplayName.php
@@ -34,7 +34,7 @@ class IntegrationTestUserDisplayName extends AbstractIntegrationTest {
 		$this->mapping->clear();
 		$this->access->setUserMapper($this->mapping);
 		$userBackend = new User_LDAP($this->access, Server::get(\OCP\Notification\IManager::class), Server::get(UserPluginManager::class), Server::get(LoggerInterface::class), Server::get(DeletedUsersIndex::class));
-		\OC_User::useBackend($userBackend);
+		Server::get(IUserManager::class)->registerBackend($userBackend);
 	}
 
 	/**

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -60,7 +60,7 @@ class User_LDAPTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		\OC_User::clearBackends();
+		Server::get(IUserManager::class)->clearBackends();
 		Server::get(IGroupManager::class)->clearBackends();
 
 		$this->connection = $this->createMock(Connection::class);
@@ -187,7 +187,7 @@ class User_LDAPTest extends TestCase {
 
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'dt19');
 		$this->assertEquals('gunslinger', $result);
@@ -196,7 +196,7 @@ class User_LDAPTest extends TestCase {
 	public function testCheckPasswordWrongPassword(): void {
 		$this->prepareAccessForCheckPassword();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'wrong');
 		$this->assertFalse($result);
@@ -205,7 +205,7 @@ class User_LDAPTest extends TestCase {
 	public function testCheckPasswordWrongUser(): void {
 		$this->prepareAccessForCheckPassword();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $backend->checkPassword('mallory', 'evil');
 		$this->assertFalse($result);
@@ -220,7 +220,7 @@ class User_LDAPTest extends TestCase {
 			->willReturn(null);
 
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $backend->checkPassword('roland', 'dt19');
 		$this->assertFalse($result);
@@ -238,7 +238,7 @@ class User_LDAPTest extends TestCase {
 			->willReturn($user);
 
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user = Server::get(IUserManager::class)->checkPassword('roland', 'dt19');
 		$result = false;
@@ -251,7 +251,7 @@ class User_LDAPTest extends TestCase {
 	public function testCheckPasswordPublicAPIWrongPassword(): void {
 		$this->prepareAccessForCheckPassword();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user = Server::get(IUserManager::class)->checkPassword('roland', 'wrong');
 		$result = false;
@@ -264,7 +264,7 @@ class User_LDAPTest extends TestCase {
 	public function testCheckPasswordPublicAPIWrongUser(): void {
 		$this->prepareAccessForCheckPassword();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user = Server::get(IUserManager::class)->checkPassword('mallory', 'evil');
 		$result = false;
@@ -450,7 +450,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetUsersViaAPINoParam(): void {
 		$this->prepareAccessForGetUsers();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers();
 		$this->assertEquals(3, count($result));
@@ -459,7 +459,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetUsersViaAPILimitOffset(): void {
 		$this->prepareAccessForGetUsers();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('', 1, 2);
 		$this->assertEquals(1, count($result));
@@ -468,7 +468,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetUsersViaAPILimitOffset2(): void {
 		$this->prepareAccessForGetUsers();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('', 2, 1);
 		$this->assertEquals(2, count($result));
@@ -477,7 +477,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetUsersViaAPISearchWithResult(): void {
 		$this->prepareAccessForGetUsers();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('yo');
 		$this->assertEquals(2, count($result));
@@ -486,7 +486,7 @@ class User_LDAPTest extends TestCase {
 	public function testGetUsersViaAPISearchEmptyResult(): void {
 		$this->prepareAccessForGetUsers();
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$result = $this->getUsers('nix');
 		$this->assertEquals(0, count($result));
@@ -561,7 +561,7 @@ class User_LDAPTest extends TestCase {
 	public function testUserExistsPublicAPI(): void {
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
 		$this->prepareMockForUserExists();
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user = $this->createMock(User::class);
 		$user->expects($this->any())
@@ -950,7 +950,7 @@ class User_LDAPTest extends TestCase {
 				return true;
 			});
 
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$user1 = $this->createMock(User::class);
 		$user1->expects($this->once())
@@ -1250,7 +1250,7 @@ class User_LDAPTest extends TestCase {
 			->method('get')
 			->willReturn($this->createMock(User::class));
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$this->assertTrue(\OC_User::setPassword('roland', 'dt'));
 	}
@@ -1267,7 +1267,7 @@ class User_LDAPTest extends TestCase {
 			->method('get')
 			->willReturn($this->createMock(User::class));
 
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$this->assertTrue(\OC_User::setPassword('roland', 'dt12234$'));
 	}
@@ -1279,7 +1279,7 @@ class User_LDAPTest extends TestCase {
 
 		$this->prepareAccessForSetPassword(false);
 		$backend = new UserLDAP($this->access, $this->notificationManager, $this->pluginManager, $this->logger, $this->deletedUsersIndex);
-		\OC_User::useBackend($backend);
+		Server::get(IUserManager::class)->registerBackend($backend);
 
 		$this->assertFalse(\OC_User::setPassword('roland', 'dt12234$'));
 	}

--- a/lib/base.php
+++ b/lib/base.php
@@ -741,7 +741,7 @@ class OC {
 			self::$server->getSession()->set('user_id', '');
 		}
 
-		OC_User::useBackend(new \OC\User\Database());
+		Server::get(\OCP\IUserManager::class)->registerBackend(new \OC\User\Database());
 		Server::get(\OCP\IGroupManager::class)->addBackend(new \OC\Group\Database());
 
 		// Subscribe to the hook

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -54,7 +54,7 @@ use Psr\Log\LoggerInterface;
  */
 class Manager extends PublicEmitter implements IUserManager {
 	/**
-	 * @var \OCP\UserInterface[] $backends
+	 * @var UserInterface[] $backends
 	 */
 	private array $backends = [];
 
@@ -82,37 +82,24 @@ class Manager extends PublicEmitter implements IUserManager {
 
 	/**
 	 * Get the active backends
-	 * @return \OCP\UserInterface[]
+	 * @return UserInterface[]
 	 */
-	public function getBackends() {
+	public function getBackends(): array {
 		return $this->backends;
 	}
 
-	/**
-	 * register a user backend
-	 *
-	 * @param \OCP\UserInterface $backend
-	 */
-	public function registerBackend($backend) {
+	public function registerBackend(UserInterface $backend): void {
 		$this->backends[] = $backend;
 	}
 
-	/**
-	 * remove a user backend
-	 *
-	 * @param \OCP\UserInterface $backend
-	 */
-	public function removeBackend($backend) {
+	public function removeBackend(UserInterface $backend): void {
 		$this->cachedUsers = [];
 		if (($i = array_search($backend, $this->backends)) !== false) {
 			unset($this->backends[$i]);
 		}
 	}
 
-	/**
-	 * remove all user backends
-	 */
-	public function clearBackends() {
+	public function clearBackends(): void {
 		$this->cachedUsers = [];
 		$this->backends = [];
 	}

--- a/lib/public/IUserManager.php
+++ b/lib/public/IUserManager.php
@@ -32,14 +32,14 @@ interface IUserManager {
 	/**
 	 * register a user backend
 	 *
-	 * @param \OCP\UserInterface $backend
 	 * @since 8.0.0
+	 * @return void
 	 */
-	public function registerBackend($backend);
+	public function registerBackend(UserInterface $backend);
 
 	/**
 	 * Get the active backends
-	 * @return \OCP\UserInterface[]
+	 * @return UserInterface[]
 	 * @since 8.0.0
 	 */
 	public function getBackends();
@@ -47,16 +47,17 @@ interface IUserManager {
 	/**
 	 * remove a user backend
 	 *
-	 * @param \OCP\UserInterface $backend
 	 * @since 8.0.0
+	 * @return void
 	 */
-	public function removeBackend($backend);
+	public function removeBackend(UserInterface $backend);
 
 	/**
 	 * remove all user backends
 	 * @since 8.0.0
+	 * @return void
 	 */
-	public function clearBackends() ;
+	public function clearBackends();
 
 	/**
 	 * get a user by user id

--- a/tests/lib/Files/EtagTest.php
+++ b/tests/lib/Files/EtagTest.php
@@ -10,6 +10,8 @@ namespace Test\Files;
 use OC\Files\Filesystem;
 use OCA\Files_Sharing\AppInfo\Application;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -45,7 +47,7 @@ class EtagTest extends \Test\TestCase {
 		$config->setSystemValue('datadirectory', $this->tmpDir);
 
 		$this->userBackend = new \Test\Util\User\Dummy();
-		\OC_User::useBackend($this->userBackend);
+		Server::get(IUserManager::class)->registerBackend($this->userBackend);
 	}
 
 	protected function tearDown(): void {

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -13,6 +13,8 @@ use OC\User\NoUserException;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Server;
 
 class DummyMountProvider implements IMountProvider {
 	private $mounts = [];
@@ -295,7 +297,7 @@ class FilesystemTest extends \Test\TestCase {
 		} else {
 			$user = self::TEST_FILESYSTEM_USER1;
 			$backend = new \Test\Util\User\Dummy();
-			\OC_User::useBackend($backend);
+			Server::get(IUserManager::class)->registerBackend($backend);
 			$backend->createUser($user, $user);
 			$userObj = \OC::$server->getUserManager()->get($user);
 			\OC::$server->getUserSession()->setUser($userObj);

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -26,6 +26,7 @@ use OCP\Files\GenericFileException;
 use OCP\Files\Mount\IMountManager;
 use OCP\Files\Storage\IStorage;
 use OCP\IDBConnection;
+use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
 use OCP\Server;
@@ -100,8 +101,8 @@ class ViewTest extends \Test\TestCase {
 		parent::setUp();
 		\OC_Hook::clear();
 
-		\OC_User::clearBackends();
-		\OC_User::useBackend(new \Test\Util\User\Dummy());
+		Server::get(IUserManager::class)->clearBackends();
+		Server::get(IUserManager::class)->registerBackend(new \Test\Util\User\Dummy());
 
 		//login
 		$userManager = \OC::$server->getUserManager();

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -10,7 +10,9 @@ namespace Test;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -33,10 +35,10 @@ class TagsTest extends \Test\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		\OC_User::clearBackends();
-		\OC_User::useBackend('dummy');
+		Server::get(IUserManager::class)->clearBackends();
+		Server::get(IUserManager::class)->registerBackend(new \Test\Util\User\Dummy());
 		$userId = $this->getUniqueID('user_');
-		\OC::$server->getUserManager()->createUser($userId, 'pass');
+		Server::get(IUserManager::class)->createUser($userId, 'pass');
 		\OC_User::setUserId($userId);
 		$this->user = $this->createMock(IUser::class);
 		$this->user->method('getUID')


### PR DESCRIPTION
## Summary

Spotted in https://github.com/nextcloud/user_saml/pull/611/files#r929120902
We were still using OC_User calls in applications registering a user backend, despite having the appropriate methods in the IUserManager already.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
