### PR TITLE
fix: don't return other mounts from share mount provider

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -60,7 +60,8 @@ class MountProvider implements IMountProvider {
 
 		$superShares = $this->buildSuperShares($shares, $user);
 
-		$mounts = $this->mountManager->getAll();
+		$otherMounts = $this->mountManager->getAll();
+		$mounts = [];
 		$view = new View('/' . $user->getUID() . '/files');
 		$ownerViews = [];
 		$sharingDisabledForUser = $this->shareManager->sharingDisabledForUser($user->getUID());
@@ -90,7 +91,7 @@ class MountProvider implements IMountProvider {
 				$shareId = (int)$parentShare->getId();
 				$mount = new SharedMount(
 					'\OCA\Files_Sharing\SharedStorage',
-					$mounts,
+					array_merge($mounts, $otherMounts),
 					[
 						'user' => $user->getUID(),
 						// parent share
@@ -105,7 +106,7 @@ class MountProvider implements IMountProvider {
 					$foldersExistCache,
 					$this->eventDispatcher,
 					$user,
-					($shareId <= $maxValidatedShare)
+					($shareId <= $maxValidatedShare),
 				);
 
 				$newMaxValidatedShare = max($shareId, $newMaxValidatedShare);


### PR DESCRIPTION
Should fix oc_mounts churn caused by https://github.com/nextcloud/server/pull/52045