### PR TITLE
fix: disable direct download for shares

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -555,4 +555,9 @@ class SharedStorage extends Jail implements LegacyISharedStorage, ISharedStorage
 		$this->init();
 		return parent::getUnjailedPath($path);
 	}
+
+	public function getDirectDownload(string $path): array|false {
+		// disable direct download for shares
+		return [];
+	}
 }


### PR DESCRIPTION
I'm not aware of any storage backend that implements this but this still requires setting up the share source to forward the call currently.

Additionally I'm unsure if shares should even use the same direct download link as their source.