### PR TITLE
fix: Remove support for app.php loading

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1324,11 +1324,6 @@
       <code><![CDATA[$this->fastCache[$app][$key] ?? $default]]></code>
     </NullableReturnStatement>
   </file>
-  <file src="lib/private/AppFramework/Bootstrap/Coordinator.php">
-    <InvalidPropertyAssignmentValue>
-      <code><![CDATA[$this->bootedApps]]></code>
-    </InvalidPropertyAssignmentValue>
-  </file>
   <file src="lib/private/AppFramework/Bootstrap/FunctionInjector.php">
     <UndefinedMethod>
       <code><![CDATA[getName]]></code>

--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -30,8 +30,8 @@ class Coordinator {
 	/** @var RegistrationContext|null */
 	private $registrationContext;
 
-	/** @var string[] */
-	private $bootedApps = [];
+	/** @var array<string,true> */
+	private array $bootedApps = [];
 
 	public function __construct(
 		private IServerContainer $serverContainer,

--- a/lib/public/AppFramework/Bootstrap/IBootstrap.php
+++ b/lib/public/AppFramework/Bootstrap/IBootstrap.php
@@ -25,8 +25,6 @@ interface IBootstrap {
 	 * At this stage you can assume that all services are registered and the DI
 	 * container(s) are ready to be queried.
 	 *
-	 * This is also the state where an optional `appinfo/app.php` was loaded.
-	 *
 	 * @param IBootContext $context
 	 *
 	 * @since 20.0.0


### PR DESCRIPTION
* Resolves: #32132 

## Summary

It has been deprecated for a long time, and the last known active application to use it (user_saml) is now migrated to the modern API.
Presence of the file is still checked in order to log an error. This behavior may be removed as well in a few versions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
