### PR TITLE
chore: Output error content when test smb-kerberos-sso is failing

### DIFF
--- a/apps/files_external/tests/sso-setup/test-sso-smb.sh
+++ b/apps/files_external/tests/sso-setup/test-sso-smb.sh
@@ -16,6 +16,7 @@ if [[ "$LOGIN_CONTENT" =~ "Location: http://localhost/success" ]]; then
   echo "✔️"
 else
   echo "❌"
+  echo "$CONTENT"
   exit 1
 fi
 echo -n "Getting test file: "
@@ -26,5 +27,6 @@ if [[ $CONTENT == "testfile" ]]; then
   echo "✔️"
 else
   echo "❌"
+  echo "$CONTENT"
   exit 1
 fi


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Output more info to help debugging.
Helped debugging https://github.com/nextcloud/user_saml/pull/943

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
