### PR TITLE
fix(sharing): ignore inexisting memberships during reshare check

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -1992,7 +1992,7 @@ class ShareAPIController extends OCSController {
 					return true;
 				}
 				return false;
-			} catch (ContainerExceptionInterface $e) {
+			} catch (\Exception) {
 				return false;
 			}
 		}


### PR DESCRIPTION
This to avoid an exception when a file is shared to multiple teams and current user is not a member of one of them.

Reproduce the original issue:

- 3 users: `user1`, `user2`, `user3`.
- 2 teams: `team1` with `user2`+`user3` and `team2` with `user2`
- 1 folder created by `user1` and shared to `user2`
- `user2` reshare the shared folder to `team1` and `team2`
- shares to `team1` has no reshare permission,
- `user3` when browsing the right panel sharing tab will generate an exception.

The reason for that is that when verifying resharing rights, all shares are checked until resharing permissions are found.
When checking those shares, if current user is not a member of recipient team, an exception is generated but not properly catched.
