### PR TITLE
fix(usermanager): Don't throw when checking if a too long user id is an existing user

### DIFF
--- a/lib/private/User/DisplayNameCache.php
+++ b/lib/private/User/DisplayNameCache.php
@@ -24,6 +24,8 @@ use OCP\User\Events\UserDeletedEvent;
  * @template-implements IEventListener<UserChangedEvent|UserDeletedEvent>
  */
 class DisplayNameCache implements IEventListener {
+	/** @see \OC\Config\UserConfig::USER_MAX_LENGTH */
+	public const MAX_USERID_LENGTH = 64;
 	private array $cache = [];
 	private ICache $memCache;
 	private IUserManager $userManager;
@@ -37,6 +39,11 @@ class DisplayNameCache implements IEventListener {
 		if (isset($this->cache[$userId])) {
 			return $this->cache[$userId];
 		}
+
+		if (strlen($userId) > self::MAX_USERID_LENGTH) {
+			return null;
+		}
+
 		$displayName = $this->memCache->get($userId);
 		if ($displayName) {
 			$this->cache[$userId] = $displayName;

--- a/lib/private/User/DisplayNameCache.php
+++ b/lib/private/User/DisplayNameCache.php
@@ -11,6 +11,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\ICache;
 use OCP\ICacheFactory;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\User\Events\UserChangedEvent;
 use OCP\User\Events\UserDeletedEvent;
@@ -24,8 +25,6 @@ use OCP\User\Events\UserDeletedEvent;
  * @template-implements IEventListener<UserChangedEvent|UserDeletedEvent>
  */
 class DisplayNameCache implements IEventListener {
-	/** @see \OC\Config\UserConfig::USER_MAX_LENGTH */
-	public const MAX_USERID_LENGTH = 64;
 	private array $cache = [];
 	private ICache $memCache;
 	private IUserManager $userManager;
@@ -40,7 +39,7 @@ class DisplayNameCache implements IEventListener {
 			return $this->cache[$userId];
 		}
 
-		if (strlen($userId) > self::MAX_USERID_LENGTH) {
+		if (strlen($userId) > IUser::MAX_USERID_LENGTH) {
 			return null;
 		}
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -53,9 +53,6 @@ use Psr\Log\LoggerInterface;
  * @package OC\User
  */
 class Manager extends PublicEmitter implements IUserManager {
-	/** @see \OC\Config\UserConfig::USER_MAX_LENGTH */
-	public const MAX_USERID_LENGTH = 64;
-
 	/**
 	 * @var UserInterface[] $backends
 	 */
@@ -121,7 +118,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			return $this->cachedUsers[$uid];
 		}
 
-		if (strlen($uid) > self::MAX_USERID_LENGTH) {
+		if (strlen($uid) > IUser::MAX_USERID_LENGTH) {
 			return null;
 		}
 
@@ -184,7 +181,7 @@ class Manager extends PublicEmitter implements IUserManager {
 	 * @return bool
 	 */
 	public function userExists($uid) {
-		if (strlen($uid) > self::MAX_USERID_LENGTH) {
+		if (strlen($uid) > IUser::MAX_USERID_LENGTH) {
 			return false;
 		}
 
@@ -726,7 +723,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		}
 
 		// User ID is too long
-		if (strlen($uid) > self::MAX_USERID_LENGTH) {
+		if (strlen($uid) > IUser::MAX_USERID_LENGTH) {
 			throw new \InvalidArgumentException($l->t('Login is too long'));
 		}
 

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -16,6 +16,11 @@ use InvalidArgumentException;
  */
 interface IUser {
 	/**
+	 * @since 32.0.0
+	 */
+	public const MAX_USERID_LENGTH = 64;
+
+	/**
 	 * get the user id
 	 *
 	 * @return string

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -79,6 +79,20 @@ class ManagerTest extends TestCase {
 		$this->assertTrue($manager->userExists('foo'));
 	}
 
+	public function testUserExistsTooLong(): void {
+		/** @var \Test\Util\User\Dummy|MockObject $backend */
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->expects($this->never())
+			->method('userExists')
+			->with($this->equalTo('foo'))
+			->willReturn(true);
+
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager->registerBackend($backend);
+
+		$this->assertFalse($manager->userExists('foo' . str_repeat('a', 62)));
+	}
+
 	public function testUserExistsSingleBackendNotExists(): void {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit\Framework\MockObject\MockObject $backend
@@ -230,6 +244,20 @@ class ManagerTest extends TestCase {
 		$this->assertEquals(null, $manager->get('foo'));
 	}
 
+	public function testGetTooLong(): void {
+		/** @var \Test\Util\User\Dummy|MockObject $backend */
+		$backend = $this->createMock(\Test\Util\User\Dummy::class);
+		$backend->expects($this->never())
+			->method('userExists')
+			->with($this->equalTo('foo'))
+			->willReturn(false);
+
+		$manager = new \OC\User\Manager($this->config, $this->cacheFactory, $this->eventDispatcher, $this->logger);
+		$manager->registerBackend($backend);
+
+		$this->assertEquals(null, $manager->get('foo' . str_repeat('a', 62)));
+	}
+
 	public function testGetOneBackendDoNotTranslateLoginNames(): void {
 		/**
 		 * @var \Test\Util\User\Dummy | \PHPUnit\Framework\MockObject\MockObject $backend
@@ -333,6 +361,7 @@ class ManagerTest extends TestCase {
 			['..', 'foo', 'Username must not consist of dots only'],
 			['.test', '', 'A valid password must be provided'],
 			['test', '', 'A valid password must be provided'],
+			['test' . str_repeat('a', 61), '', 'Login is too long'],
 		];
 	}
 


### PR DESCRIPTION
## Steps

- Write a comment or chat message with `@` followed by 65+ a-z0-9 characters and enable LDAP
- When LDAP checks if the user exists, it checks preferences
- But preferences throws `InvalidArgumentException` in `UserConfig::assertParams` although it's not documented
- Regression from https://github.com/nextcloud/server/pull/47658 @ArtificialOwl 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
