### PR TITLE
add log entries to know about quota and expiration information

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -860,7 +860,7 @@ class Storage {
 			// calculate available space for version history
 			// subtract size of files and current versions size from quota
 			if ($quota >= 0) {
-				$logger->error('DEBUG 72738::quota greater than 0 '.$quota);
+				$logger->error('DEBUG 72738::quota greater than 0 ' . $quota);
 				if ($softQuota) {
 					$root = \OC::$server->get(IRootFolder::class);
 					$userFolder = $root->getUserFolder($uid);

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -860,24 +860,30 @@ class Storage {
 			// calculate available space for version history
 			// subtract size of files and current versions size from quota
 			if ($quota >= 0) {
+				$logger->error('DEBUG 72738::quota greater than 0 '.$quota);
 				if ($softQuota) {
 					$root = \OC::$server->get(IRootFolder::class);
 					$userFolder = $root->getUserFolder($uid);
 					if (is_null($userFolder)) {
 						$availableSpace = 0;
+						$logger->error('DEBUG 72738::available space is ', [$availableSpace]);
 					} else {
 						$free = $quota - $userFolder->getSize(false); // remaining free space for user
+						$logger->error('DEBUG 72738::free space is ', [$free]);
 						if ($free > 0) {
 							$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $versionsSize; // how much space can be used for versions
 						} else {
 							$availableSpace = $free - $versionsSize;
 						}
+						$logger->error('DEBUG 72738::available space is not null ', [$availableSpace]);
 					}
 				} else {
 					$availableSpace = $quota;
+					$logger->error('DEBUG 72738::available space is quota ', [$availableSpace]);
 				}
 			} else {
 				$availableSpace = PHP_INT_MAX;
+				$logger->error('DEBUG 72738::available space is PHP INT MAX ', [$availableSpace]);
 			}
 
 			$allVersions = Storage::getVersions($uid, $filename);
@@ -895,8 +901,11 @@ class Storage {
 
 				foreach ($result['by_file'] as $versions) {
 					[$toDeleteNew, $size] = self::getExpireList($time, $versions, $availableSpace <= 0);
+					$logger->error('DEBUG 72738::to delete ', [$toDeleteNew]);
+					$logger->error('DEBUG 72738::size ',[$size]);
 					$toDelete = array_merge($toDelete, $toDeleteNew);
 					$sizeOfDeletedVersions += $size;
+					$logger->error('DEBUG 72738::version size ', [$sizeOfDeletedVersions]);
 				}
 				$availableSpace = $availableSpace + $sizeOfDeletedVersions;
 				$versionsSize = $versionsSize - $sizeOfDeletedVersions;

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -902,7 +902,7 @@ class Storage {
 				foreach ($result['by_file'] as $versions) {
 					[$toDeleteNew, $size] = self::getExpireList($time, $versions, $availableSpace <= 0);
 					$logger->error('DEBUG 72738::to delete ', [$toDeleteNew]);
-					$logger->error('DEBUG 72738::size ',[$size]);
+					$logger->error('DEBUG 72738::size ', [$size]);
 					$toDelete = array_merge($toDelete, $toDeleteNew);
 					$sizeOfDeletedVersions += $size;
 					$logger->error('DEBUG 72738::version size ', [$sizeOfDeletedVersions]);


### PR DESCRIPTION
add log entries to know about quota and expiration information
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
