### PR TITLE
fix(S3): Use original folder size during copy

### DIFF
--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -710,6 +710,10 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 				$cache->remove($to);
 			}
 			$this->mkdir($to);
+			$cacheEntry = $cache->get(($to));
+			$cache->update($cacheEntry->getId(), [
+				'size' => $sourceEntry->getSize(),
+			]);
 
 			foreach ($sourceCache->getFolderContentsById($sourceEntry->getId()) as $child) {
 				$this->copyInner($sourceCache, $child, $to . '/' . $child->getName());

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -67,7 +67,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$this->logger = \OCP\Server::get(LoggerInterface::class);
 	}
 
-	public function mkdir(string $path, bool $force = false): bool {
+	public function mkdir(string $path, bool $force = false, array $metadata = []): bool {
 		$path = $this->normalizePath($path);
 		if (!$force && $this->file_exists($path)) {
 			$this->logger->warning("Tried to create an object store folder that already exists: $path");
@@ -77,7 +77,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$mTime = time();
 		$data = [
 			'mimetype' => 'httpd/unix-directory',
-			'size' => 0,
+			'size' => $metadata['size'] ?? 0,
 			'mtime' => $mTime,
 			'storage_mtime' => $mTime,
 			'permissions' => \OCP\Constants::PERMISSION_ALL,
@@ -709,11 +709,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 			if ($cache->inCache($to)) {
 				$cache->remove($to);
 			}
-			$this->mkdir($to);
-			$cacheEntry = $cache->get(($to));
-			$cache->update($cacheEntry->getId(), [
-				'size' => $sourceEntry->getSize(),
-			]);
+			$this->mkdir($to, false, ['size' => $sourceEntry->getSize()]);
 
 			foreach ($sourceCache->getFolderContentsById($sourceEntry->getId()) as $child) {
 				$this->copyInner($sourceCache, $child, $to . '/' . $child->getName());

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -262,4 +262,17 @@ class ObjectStoreStorageTest extends Storage {
 		$this->assertTrue($cache->inCache('new.txt'));
 		$this->assertEquals(\OCP\Constants::PERMISSION_ALL, $instance->getPermissions('new.txt'));
 	}
+
+	public function testCopyFolderSize(): void {
+		$cache = $this->instance->getCache();
+
+		$this->instance->mkdir('source');
+		$this->instance->file_put_contents('source/test.txt', 'foo');
+		$this->instance->getUpdater()->update('source/test.txt');
+		$this->assertEquals(3, $cache->get('source')->getSize());
+
+		$this->assertTrue($this->instance->copy('source', 'target'));
+
+		$this->assertEquals(3, $cache->get('target')->getSize());
+	}
 }


### PR DESCRIPTION
This prevents having copied folders with a wrongly set size of 0KB.

- Fix https://github.com/nextcloud/server/issues/51916

~~Not sure about the `handleCopiesAsOwned` part, but I kept it from `copyFile` to preserve the same behaviour. It was introduced in https://github.com/nextcloud/server/pull/41565. Maybe @susnux you can judge whether it makes sense or not.~~ Validated.