### PR TITLE
fix(Log): revert swich to ?? operator

### DIFF
--- a/lib/private/Log/LogDetails.php
+++ b/lib/private/Log/LogDetails.php
@@ -37,7 +37,7 @@ abstract class LogDetails {
 		$url = ($request->getRequestUri() !== '') ? $request->getRequestUri() : '--';
 		$method = is_string($request->getMethod()) ? $request->getMethod() : '--';
 		if ($this->config->getValue('installed', false)) {
-			$user = \OC_User::getUser() ?? '--';
+			$user = \OC_User::getUser() ?: '--';
 		} else {
 			$user = '--';
 		}


### PR DESCRIPTION
false is expected, not null. The changed caused "user" in the log files to be false instead of "--", which is breaking behaviour.

This was introduced with c57e684e7b22a02c7017450d1fdaaec9afc83d62