### PR TITLE
feat(provisioning-api): Add endpoint to invalidate user tokens

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -38,6 +38,7 @@ return [
 		['root' => '/cloud', 'name' => 'Users#editUser', 'url' => '/users/{userId}', 'verb' => 'PUT'],
 		['root' => '/cloud', 'name' => 'Users#editUserMultiValue', 'url' => '/users/{userId}/{collectionName}', 'verb' => 'PUT', 'requirements' => ['collectionName' => '^(?!enable$|disable$)[a-zA-Z0-9_]*$']],
 		['root' => '/cloud', 'name' => 'Users#wipeUserDevices', 'url' => '/users/{userId}/wipe', 'verb' => 'POST'],
+		['root' => '/cloud', 'name' => 'Users#invalidateUserTokens', 'url' => '/users/{userId}/sessions', 'verb' => 'DELETE'],
 		['root' => '/cloud', 'name' => 'Users#deleteUser', 'url' => '/users/{userId}', 'verb' => 'DELETE'],
 		['root' => '/cloud', 'name' => 'Users#enableUser', 'url' => '/users/{userId}/enable', 'verb' => 'PUT'],
 		['root' => '/cloud', 'name' => 'Users#disableUser', 'url' => '/users/{userId}/disable', 'verb' => 'PUT'],

--- a/apps/provisioning_api/openapi-full.json
+++ b/apps/provisioning_api/openapi-full.json
@@ -3736,6 +3736,75 @@
                 }
             }
         },
+        "/ocs/v2.php/cloud/users/{userId}/sessions": {
+            "delete": {
+                "operationId": "users-invalidate-user-tokens",
+                "summary": "Invalidate all tokens of a user",
+                "description": "This API endpoint is not used by the Nextcloud web interface or mobile apps. It is specifically intended for external systems that manage user passwords independently and need a way to invalidate existing Nextcloud session tokens after a password change.",
+                "tags": [
+                    "users"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID of the user",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Invalidated all user tokens successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/cloud/users/{userId}/enable": {
             "put": {
                 "operationId": "users-enable-user",

--- a/apps/provisioning_api/openapi.json
+++ b/apps/provisioning_api/openapi.json
@@ -2168,6 +2168,75 @@
                 }
             }
         },
+        "/ocs/v2.php/cloud/users/{userId}/sessions": {
+            "delete": {
+                "operationId": "users-invalidate-user-tokens",
+                "summary": "Invalidate all tokens of a user",
+                "description": "This API endpoint is not used by the Nextcloud web interface or mobile apps. It is specifically intended for external systems that manage user passwords independently and need a way to invalidate existing Nextcloud session tokens after a password change.",
+                "tags": [
+                    "users"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID of the user",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Invalidated all user tokens successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/cloud/users/{userId}/enable": {
             "put": {
                 "operationId": "users-enable-user",

--- a/lib/private/Authentication/Events/AUserTokensInvalidationEvent.php
+++ b/lib/private/Authentication/Events/AUserTokensInvalidationEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Authentication\Events;
+
+use OCP\EventDispatcher\Event;
+
+abstract class AUserTokensInvalidationEvent extends Event {
+	public function __construct(
+		protected string $uid,
+	) {
+		parent::__construct();
+	}
+
+	public function getUserId(): string {
+		return $this->uid;
+	}
+}

--- a/lib/private/Authentication/Events/TokensInvalidationFinished.php
+++ b/lib/private/Authentication/Events/TokensInvalidationFinished.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Authentication\Events;
+
+class TokensInvalidationFinished extends AUserTokensInvalidationEvent {
+}

--- a/lib/private/Authentication/Events/TokensInvalidationStarted.php
+++ b/lib/private/Authentication/Events/TokensInvalidationStarted.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Authentication\Events;
+
+class TokensInvalidationStarted extends AUserTokensInvalidationEvent {
+}

--- a/lib/private/Authentication/Token/Invalidator.php
+++ b/lib/private/Authentication/Token/Invalidator.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Authentication\Token;
+
+use OC\Authentication\Events\TokensInvalidationFinished;
+use OC\Authentication\Events\TokensInvalidationStarted;
+use OCP\EventDispatcher\IEventDispatcher;
+use Psr\Log\LoggerInterface;
+
+class Invalidator {
+	public function __construct(
+		protected IProvider $tokenProvider,
+		protected IEventDispatcher $eventDispatcher,
+		protected LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @param string $uid user id
+	 *
+	 * @return bool true if all tokens have been invalidated
+	 */
+	public function invalidateAllUserTokens(string $uid): bool {
+		$this->logger->info("Invalidating all tokens for user: $uid");
+		$this->eventDispatcher->dispatchTyped(new TokensInvalidationStarted($uid));
+
+		$tokens = $this->tokenProvider->getTokenByUser($uid);
+		foreach ($tokens as $token) {
+			$this->tokenProvider->invalidateTokenById($uid, $token->getId());
+		}
+
+		$this->eventDispatcher->dispatchTyped(new TokensInvalidationFinished($uid));
+		return true;
+	}
+}

--- a/openapi.json
+++ b/openapi.json
@@ -25861,6 +25861,75 @@
                 }
             }
         },
+        "/ocs/v2.php/cloud/users/{userId}/sessions": {
+            "delete": {
+                "operationId": "provisioning_api-users-invalidate-user-tokens",
+                "summary": "Invalidate all tokens of a user",
+                "description": "This API endpoint is not used by the Nextcloud web interface or mobile apps. It is specifically intended for external systems that manage user passwords independently and need a way to invalidate existing Nextcloud session tokens after a password change.",
+                "tags": [
+                    "provisioning_api/users"
+                ],
+                "security": [
+                    {
+                        "bearer_auth": []
+                    },
+                    {
+                        "basic_auth": []
+                    }
+                ],
+                "parameters": [
+                    {
+                        "name": "userId",
+                        "in": "path",
+                        "description": "ID of the user",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "OCS-APIRequest",
+                        "in": "header",
+                        "description": "Required to be true for the API request to pass",
+                        "required": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Invalidated all user tokens successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": [
+                                        "ocs"
+                                    ],
+                                    "properties": {
+                                        "ocs": {
+                                            "type": "object",
+                                            "required": [
+                                                "meta",
+                                                "data"
+                                            ],
+                                            "properties": {
+                                                "meta": {
+                                                    "$ref": "#/components/schemas/OCSMeta"
+                                                },
+                                                "data": {}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/ocs/v2.php/cloud/users/{userId}/enable": {
             "put": {
                 "operationId": "provisioning_api-users-enable-user",

--- a/tests/lib/Authentication/Token/InvalidatorTest.php
+++ b/tests/lib/Authentication/Token/InvalidatorTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace lib\Authentication\Token;
+
+use OC\Authentication\Events\TokensInvalidationFinished;
+use OC\Authentication\Events\TokensInvalidationStarted;
+use OC\Authentication\Token\Invalidator;
+use OC\Authentication\Token\IProvider as ITokenProvider;
+use OC\Authentication\Token\IToken;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventDispatcher;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class InvalidatorTest extends TestCase {
+	/** @var ITokenProvider|MockObject */
+	private $tokenProvider;
+
+	/** @var IEventDispatcher|MockObject */
+	private $eventDispatcher;
+
+	/** @var LoggerInterface|MockObject */
+	private $logger;
+
+	/** @var Invalidator */
+	private $invalidator;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->tokenProvider = $this->createMock(ITokenProvider::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+
+		$this->invalidator = new Invalidator(
+			$this->tokenProvider,
+			$this->eventDispatcher,
+			$this->logger
+		);
+	}
+
+	public function testInvalidateAllUserTokens(): void {
+		$uid = 'user123';
+		$tokens = [
+			$this->createMock(IToken::class),
+			$this->createMock(IToken::class),
+		];
+
+		$tokens[0]->method('getId')->willReturn(1111);
+		$tokens[1]->method('getId')->willReturn(2222);
+
+		$this->tokenProvider
+			->expects($this->once())
+			->method('getTokenByUser')
+			->with($uid)
+			->willReturn($tokens);
+
+		$dispatchTypedInvokedCount = $this->exactly(2);
+		$this->eventDispatcher
+			->expects($dispatchTypedInvokedCount)
+			->method('dispatchTyped')
+			->willReturnCallback(function (Event $event) use ($uid, $dispatchTypedInvokedCount) {
+				if ($dispatchTypedInvokedCount->getInvocationCount() === 1) {
+					$this->assertInstanceOf(TokensInvalidationStarted::class, $event);
+					$this->assertSame($uid, $event->getUserId());
+				} elseif ($dispatchTypedInvokedCount->getInvocationCount() === 2) {
+					$this->assertInstanceOf(TokensInvalidationFinished::class, $event);
+					$this->assertSame($uid, $event->getUserId());
+				}
+			});
+
+		$invokedCount = $this->exactly(2);
+		$this->tokenProvider
+			->expects($invokedCount)
+			->method('invalidateTokenById')
+			->willReturnCallback(function ($uid, $tokenId) use ($invokedCount) {
+				if ($invokedCount->getInvocationCount() === 1) {
+					$this->assertSame(['user123', 1111], [$uid, $tokenId]);
+				} elseif ($invokedCount->getInvocationCount() === 2) {
+					$this->assertSame(['user123', 2222], [$uid, $tokenId]);
+				}
+			});
+
+		$this->logger
+			->expects($this->once())
+			->method('info')
+			->with("Invalidating all tokens for user: $uid");
+
+		$result = $this->invalidator->invalidateAllUserTokens($uid);
+
+		$this->assertTrue($result);
+	}
+}


### PR DESCRIPTION
## Summary

Introduce a core API endpoint *for external user management systems* to invalidate user tokens.  
This action removes all tokens of the target user, effectively logging them out from all sessions (browser, apps) without wiping data on their devices.

```shell
# usage example
curl -s -X DELETE "$NEXTCLOUD_URL/ocs/v2.php/cloud/users/${testUserId}/sessions?format=json" \
	-u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
	-H "OCS-APIRequest: true" \
	-H "User-Agent: $USER_AGENT"
```

## Test
* create user
* add 3 clients to the user
* log with user via new incognito browser session to NC
* check current token count
* make invalidate API call (as admin user)
* Observe
   * User is logged out in incognito browser window
   * User has no app tokens in the list
   * Observe user is logged out from all devices.
   * Observe data on devices was *not* wiped."


You can use following script
```shell
./test_token_invalidation_api.sh
```
<details>
<summary>test_token_invalidation_api.sh</summary>

```shell
#!/usr/bin/env bash

# This script tests the creation, authentication, and invalidation of user tokens
# in a Nextcloud instance via its OCS API. It performs the following steps:
# 1. Verifies admin credentials and API access.
# 2. Checks if a test user exists, creates the user if not present.
# 3. Generates three authentication tokens for the test user.
# 4. Prompts the user to manually verify tokens in the browser.
# 5. Invalidates all authentication tokens for the test user via the API.
# 6. Prompts the user to verify that the test user is logged out from all devices.


ADMIN_USERNAME="admin"
ADMIN_PASSWORD="admin"
USER_AGENT="HiDrive Next Test Client"

NEXTCLOUD_URL="http://localhost:8080"

# username to be tested on
testUserId="foo"
testUserPass="foo"

echo "[i] Testing user 'admin' credentials on API..."
response=$(curl -s -X GET "$NEXTCLOUD_URL/ocs/v2.php/cloud/user?format=json" \
	-u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
	-H "OCS-APIRequest: true" \
	-H "User-Agent: $USER_AGENT")

if echo "$response" | grep -q '"status":"ok"'; then
	echo "[i] User '$ADMIN_USERNAME' is logged on successfully."
else
	echo "[w] User '$ADMIN_USERNAME' does not exist or API request failed."
	echo "[w] Response: "
	echo "$response" | jq
	exit 1
fi

echo "[i] Testing user '${testUserId}' existence..."
isUserExists=false
response=$(curl -s -X GET "$NEXTCLOUD_URL/ocs/v1.php/cloud/users/${testUserId}?format=json" \
	-u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
	-H "OCS-APIRequest: true" \
	-H "User-Agent: $USER_AGENT")

if echo "$response" | grep -q '"status":"ok"'; then
	echo "[i] User '${testUserId}' exists."
	isUserExists=true
else
	echo "[i] User '${testUserId}' does not exist."
fi

if [ "$isUserExists" = false ]; then
	echo "[i] Creating user '${testUserId}'..."
	response=$(curl -s -X POST "$NEXTCLOUD_URL/ocs/v1.php/cloud/users?format=json" \
		-u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
		-H "OCS-APIRequest: true" \
		-H "User-Agent: $USER_AGENT" \
		-d "userid=${testUserId}&password=${testUserPass}")

	if echo "$response" | grep -q '"status":"ok"'; then
		echo "[i] User '${testUserId}' created successfully."
	else
		echo "[e] Failed to create user '${testUserId}'."
		echo "[e] Response: "
		echo "$response" | jq
	fi
fi

echo "[i] Creating user '${testUserId}' 3 auth-tokens..."
for i in {1..3}; do
	response=$(curl -s "$NEXTCLOUD_URL/ocs/v2.php/core/getapppassword?format=json" \
		-u "${testUserId}:${testUserPass}" \
		-H "OCS-APIRequest: true" \
		-H "User-Agent: $USER_AGENT")

	if echo "$response" | grep -q '"status":"ok"'; then
		echo "[i] Token ${i} created successfully."
	else
		echo "[e] Failed to create token ${i}."
		echo "[e] Response: "
		echo "$response" | jq
	fi
done

echo "[!] Open browser at ${NEXTCLOUD_URL} and login as '${testUserId}' with password '${testUserPass}'..."
echo "[!] Check tokens $NEXTCLOUD_URL/index.php/settings/user/security"
read -r -p "[?] Press any key to continue... " -n1 -s
echo

echo "[i] Invalidating user '${testUserId}' auth-tokens via API call..."
response=$(curl -s -X DELETE "$NEXTCLOUD_URL/ocs/v2.php/cloud/users/${testUserId}/sessions?format=json" \
	-u "$ADMIN_USERNAME:$ADMIN_PASSWORD" \
	-H "OCS-APIRequest: true" \
	-H "User-Agent: $USER_AGENT")

if echo "$response" | grep -q '"status":"ok"'; then
	echo "[i] User '${testUserId}' token invalidation is successful."
	echo "[i] Response: "
	echo "$response" | jq
else
	echo "[e] Failed to invalidate user '${testUserId}' tokens."
	echo "[e] Response: "
	echo "$response" | jq
fi

echo "[!] Reload browser and check if you are logged out."
echo "[!] User has no app tokens in the list"
echo "[!] Observe user is logged out from all devices."
echo "[!] Observe data on devices was *not* wiped."
```
</details>


### Unitests
```shell
phpunit --configuration tests/phpunit-autotest-user-invalidate.xml
```
<details>
<summary>tests/phpunit-autotest-user-invalidate.xml</summary>
```xml
<?xml version="1.0" encoding="utf-8" ?>
<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
		 bootstrap="bootstrap.php"
		 verbose="true"
		 backupGlobals="false"
		 timeoutForSmallTests="900"
		 timeoutForMediumTests="900"
		 timeoutForLargeTests="900"
		 convertDeprecationsToExceptions="true"
		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd">
	<php>
		<ini name="memory_limit" value="4G"/>
	</php>
	<testsuite name='test LoginFlowV2'>
		<directory suffix=".php">./lib/User/SessionTest.php</directory>
		<directory suffix=".php">./lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php</directory>
		<directory suffix=".php">./Core/Controller/ClientFlowLoginV2ControllerTest.php</directory>
		<directory suffix=".php">./Core/Service/LoginFlowV2ServiceUnitTest.php</directory>
		<directory suffix=".php">./Core/Controller/AppPasswordControllerTest.php</directory>
		<directory suffix=".php">./Core/Controller/ClientFlowLoginControllerTest.php</directory>
		<directory suffix=".php">./Core/Controller/WipeControllerTest.php</directory>
		<directory suffix=".php">./Core/Controller/UserControllerTest.php</directory>
		<directory suffix=".php">./lib/Authentication/Token/RemoteWipeTest.php</directory>
		<directory suffix=".php">./lib/Authentication/Token/InvalidatorTest.php</directory>
	</testsuite>
	<coverage>
		<include>
			<directory suffix=".php">../core/*</directory>
			<directory suffix=".php">../lib/private/*</directory>
		</include>
		<exclude>
			<directory suffix=".js">../**/</directory>
			<directory suffix=".php">../3rdparty/**/*</directory>
			<directory suffix=".php">../apps/**/*</directory>
			<directory suffix=".php">../apps-custom/**/*</directory>
			<directory suffix=".php">../apps-external/**</directory>
			<directory suffix=".php">../apps-custom/**</directory>
			<directory suffix=".php">../build</directory>
			<directory suffix=".php">../IONOS/**/*</directory>
			<directory suffix=".php">../lib/composer</directory>
			<directory suffix=".php">../vendor/**/*</directory>
			<directory suffix=".php">../tests</directory>
		</exclude>
	</coverage>
	<listeners>
		<listener class="StartSessionListener" file="startsessionlistener.php" />
	</listeners>
</phpunit>
```

</details>



```shell
phpunit --configuration tests/phpunit-autotest-external-provisioning_api.xml
 ```

<details>
<summary>tests/phpunit-autotest-user-invalidate.xml</summary>
```xml
<?xml version="1.0" encoding="utf-8" ?>
<!--
 - SPDX-FileCopyrightText: 2014-2016 ownCloud, Inc.
 - SPDX-License-Identifier: AGPL-3.0-only
-->
<phpunit bootstrap="bootstrap.php"
		 verbose="true"
		 timeoutForSmallTests="900"
		 timeoutForMediumTests="900"
		 timeoutForLargeTests="900"
>
	<testsuite name='provisioning_api app external'>
		<directory suffix=".php">../apps/provisioning_api/tests</directory>
		<!-- exclude backends as they are called separately -->
<!--		<exclude>../apps/provisioning_api/tests/Storage/</exclude>-->
	</testsuite>
	<!-- filters for code coverage -->
	<filter>
		<!-- whitelist processUncoveredFilesFromWhitelist="true" -->
		<whitelist>
			<file>../lib/private/Files/Storage/DAV.php</file>
			<directory suffix=".php">../apps/provisioning_api</directory>
			<exclude>
				<directory suffix=".php">../apps/provisioning_api/l10n</directory>
				<directory suffix=".php">../apps/provisioning_api/3rdparty</directory>
				<directory suffix=".php">../apps/provisioning_api/tests</directory>
			</exclude>
		</whitelist>
	</filter>
</phpunit>
```
</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
