### PR TITLE
fix(LDAP): inlcude ldapExpertUsernameAttr in general attribute list

### DIFF
--- a/apps/user_ldap/lib/User/Manager.php
+++ b/apps/user_ldap/lib/User/Manager.php
@@ -109,6 +109,7 @@ class Manager {
 		$baseAttributes = array_merge(Access::UUID_ATTRIBUTES, ['dn', 'uid', 'samaccountname', 'memberof']);
 		$attributes = [
 			$this->access->getConnection()->ldapExpertUUIDUserAttr,
+			$this->access->getConnection()->ldapExpertUsernameAttr,
 			$this->access->getConnection()->ldapQuotaAttribute,
 			$this->access->getConnection()->ldapEmailAttribute,
 			$this->access->getConnection()->ldapUserDisplayName,


### PR DESCRIPTION
## Summary

fixes corner cases in which an LDAP record might be loaded and used, where the user is still not mapped - and then this information is missing though expected.

This was never an issue, until preferences started to throw `InvalidArgumentException` in `UserConfig::assertParams` although it's not documented.
