### PR TITLE
Optionally allow logging parameters to query log

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2513,6 +2513,28 @@ $CONFIG = [
 'query_log_file' => '',
 
 /**
+ * Prefix all queries with the requestid when set to `yes`
+ *
+ * Requires `query_log_file` to be set.
+ */
+'query_log_file_requestid' => '',
+
+/**
+ * Add all query parameters to the query log entry when set to `yes`
+ *
+ * Requires `query_log_file` to be set.
+ * Warning: This will log sensitive data into a plain text file.
+ */
+'query_log_file_parameters' => '',
+
+/**
+ * Add a backtrace to the query log entry when set to `yes`
+ *
+ * Requires `query_log_file` to be set.
+ */
+'query_log_file_backtrace' => '',
+
+/**
  * Log all redis requests into a file
  *
  * Warning: This heavily decreases the performance of the server and is only

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -414,7 +414,7 @@ class Connection extends PrimaryReadReplicaConnection {
 
 		$sql = $this->finishQuery($sql);
 		$this->queriesExecuted++;
-		$this->logQueryToFile($sql);
+		$this->logQueryToFile($sql, $params);
 		try {
 			return parent::executeQuery($sql, $params, $types, $qcp);
 		} catch (\Exception $e) {
@@ -461,7 +461,7 @@ class Connection extends PrimaryReadReplicaConnection {
 		}
 		$sql = $this->finishQuery($sql);
 		$this->queriesExecuted++;
-		$this->logQueryToFile($sql);
+		$this->logQueryToFile($sql, $params);
 		try {
 			return (int)parent::executeStatement($sql, $params, $types);
 		} catch (\Exception $e) {
@@ -470,14 +470,19 @@ class Connection extends PrimaryReadReplicaConnection {
 		}
 	}
 
-	protected function logQueryToFile(string $sql): void {
+	protected function logQueryToFile(string $sql, array $params): void {
 		$logFile = $this->systemConfig->getValue('query_log_file');
 		if ($logFile !== '' && is_writable(dirname($logFile)) && (!file_exists($logFile) || is_writable($logFile))) {
 			$prefix = '';
 			if ($this->systemConfig->getValue('query_log_file_requestid') === 'yes') {
 				$prefix .= Server::get(IRequestId::class)->getId() . "\t";
 			}
+
 			$postfix = '';
+			if ($this->systemConfig->getValue('query_log_file_parameters') === 'yes') {
+				$postfix .= '; ' . json_encode($params);
+			}
+
 			if ($this->systemConfig->getValue('query_log_file_backtrace') === 'yes') {
 				$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 				array_pop($trace);


### PR DESCRIPTION
## Summary

Adds the option to enable logging the query parameters to the query log as well. Also it updates `config.sample.php` to include all query log related options.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
