### PR TITLE
perf(UserMountCache): Use local cache for user mounts

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -215,6 +215,11 @@ class Application extends App {
 
 			$event->addMissingIndex(
 				'mounts',
+				'mounts_userid',
+				['user_id']
+			);
+			$event->addMissingIndex(
+				'mounts',
 				'mounts_class_index',
 				['mount_provider_class']
 			);

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -252,7 +252,7 @@ class UserMountCache implements IUserMountCache {
 	}
 
 	public function getInternalPathForMountInfo(CachedMountInfo $info): string {
-		$cached = $this->internalPathCache->get($info->getRootId());
+		$cached = $this->internalPathCache->get((string)$info->getRootId());
 		if ($cached !== null) {
 			return $cached;
 		}
@@ -260,7 +260,9 @@ class UserMountCache implements IUserMountCache {
 		$query = $builder->select('path')
 			->from('filecache')
 			->where($builder->expr()->eq('fileid', $builder->createNamedParameter($info->getRootId())));
-		return $query->executeQuery()->fetchOne() ?: '';
+		$path = $query->executeQuery()->fetchOne() ?: '';
+		$this->internalPathCache->set((string)$info->getRootId(), $path);
+		return $path;
 	}
 
 	/**

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -12,7 +12,6 @@ use OC\DB\QueryBuilder\Literal;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Storage;
 use OC\User\Manager;
-use OCP\Cache\CappedMemoryCache;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -117,10 +116,6 @@ class UserMountCacheTest extends TestCase {
 		return [$storage, $rootId];
 	}
 
-	private function clearCache() {
-		$this->invokePrivate($this->cache, 'mountsForUsers', [new CappedMemoryCache()]);
-	}
-
 	private function keyForMount(MountPoint $mount): string {
 		return $mount->getStorageRootId() . '::' . $mount->getMountPoint();
 	}
@@ -133,7 +128,7 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForUser($user);
 
@@ -153,11 +148,11 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForUser($user);
 
@@ -177,11 +172,11 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$this->cache->registerMounts($user, []);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForUser($user);
 
@@ -196,13 +191,13 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$mount = new MountPoint($storage, '/foo/');
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForUser($user);
 
@@ -219,13 +214,13 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$mount = new MountPoint($storage, '/foo/', null, null, null, 1);
 
 		$this->cache->registerMounts($user, [$mount]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForUser($user);
 
@@ -248,7 +243,7 @@ class UserMountCacheTest extends TestCase {
 		$this->cache->registerMounts($user2, [$mount2]);
 		$this->cache->registerMounts($user3, [$mount2]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$user3->delete();
 
@@ -283,7 +278,7 @@ class UserMountCacheTest extends TestCase {
 		$this->cache->registerMounts($user1, [$mount1, $mount2]);
 		$this->cache->registerMounts($user2, [$mount2]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForStorageId(2);
 		$this->sortMounts($cachedMounts);
@@ -313,7 +308,7 @@ class UserMountCacheTest extends TestCase {
 		$this->cache->registerMounts($user1, [$mount1, $mount2]);
 		$this->cache->registerMounts($user2, [$mount2]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForRootId($id2);
 		$this->sortMounts($cachedMounts);
@@ -383,7 +378,7 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user1, [$mount1]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForFileId($rootId);
 
@@ -405,7 +400,7 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user1, [$mount1]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForFileId($fileId);
 
@@ -438,7 +433,7 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user1, [$mount1]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForFileId($fileId);
 
@@ -473,7 +468,7 @@ class UserMountCacheTest extends TestCase {
 
 		$this->cache->registerMounts($user1, [$mount1]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForFileId($fileId);
 
@@ -490,7 +485,7 @@ class UserMountCacheTest extends TestCase {
 		$this->cache->registerMounts($user1, [$mount1]);
 
 		$user1->delete();
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForFileId($rootId);
 		$this->assertEmpty($cachedMounts);
@@ -535,7 +530,7 @@ class UserMountCacheTest extends TestCase {
 		$mount1 = new MountPoint($storage1, '/foo/');
 		$this->cache->registerMounts($user1, [$mount1]);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForUser($user1);
 		$this->assertCount(1, $cachedMounts);
@@ -544,7 +539,7 @@ class UserMountCacheTest extends TestCase {
 		$mount1 = new MountPoint($storage1, '/foo/', null, null, null, null, 'dummy');
 		$this->cache->registerMounts($user1, [$mount1], ['dummy']);
 
-		$this->clearCache();
+		$this->cache->clear();
 
 		$cachedMounts = $this->cache->getMountsForUser($user1);
 		$this->assertCount(1, $cachedMounts);

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -20,6 +20,7 @@ use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IUserManager;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 use Test\Util\User\Dummy;
@@ -67,7 +68,7 @@ class UserMountCacheTest extends TestCase {
 		$userBackend->createUser('u2', '');
 		$userBackend->createUser('u3', '');
 		$this->userManager->registerBackend($userBackend);
-		$this->cache = new \OC\Files\Config\UserMountCache($this->connection, $this->userManager, $this->createMock(LoggerInterface::class), $this->createMock(IEventLogger::class));
+		$this->cache = new \OC\Files\Config\UserMountCache($this->connection, $this->userManager, $this->createMock(LoggerInterface::class), $this->createMock(IEventLogger::class), Server::get(ICacheFactory::class));
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
## Summary

Currently the query causing the highest load for the DB of c.nc.c is
```sql
SELECT
  `storage_id`,
  `root_id`,
  `user_id`,
  `mount_point`,
  `mount_id`,
  `mount_provider_class`
FROM
  `oc_mounts` `m`
WHERE
  `user_id` = '';
```
and comes from `\OC\Files\Config\UserMountCache::getMountsForUser`.

Given that the UserMountCache tracks all changes to the oc_mounts table ( :crossed_fingers: ) it would be necessary to use a distributed cache for clustered setups which could live without (or very high) a TTL.
To decrease latency I opted to use a local cache and to avoid the mounts becoming out-of-sync between the nodes I used a low TTL.
It should always be fine to have a mount appear/disappear/modified up to one minute after the change in the DB.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)