### PR TITLE
fix(SFTP): infinite loop scanning directories with upward symlinks

### DIFF
--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -262,7 +262,7 @@ class SFTP extends Common {
 			$dirStream = [];
 			foreach ($list as $file => $stat) {
 				$fileAdded = ((int)$stat['type'] === NET_SFTP_TYPE_SYMLINK) &&
-                             str_contains($absPath, '/' . basename($absPath) . '/' . $file . '/');
+							 str_contains($absPath, '/' . basename($absPath) . '/' . $file . '/');
 
 				if ($file !== '.' && $file !== '..' && !$fileAdded) {
 					$dirStream[] = $file;

--- a/apps/files_external/lib/Lib/Storage/SFTP.php
+++ b/apps/files_external/lib/Lib/Storage/SFTP.php
@@ -252,15 +252,23 @@ class SFTP extends Common {
 
 	public function opendir(string $path) {
 		try {
-			$list = $this->getConnection()->nlist($this->absPath($path));
+			$absPath = $this->absPath($path);
+			$list = $this->getConnection()->nlist($absPath);
 			if ($list === false) {
 				return false;
 			}
 
+			$linkedPath = $this->getConnection()->readlink($absPath);
 			$id = md5('sftp:' . $path);
 			$dirStream = [];
 			foreach ($list as $file) {
-				if ($file !== '.' && $file !== '..') {
+				$fileAdded = false;
+
+				if (!empty($linkedPath)) {
+					$fileAdded = substr_count($absPath, basename($absPath) . '/' . $file) > 0;
+				}
+
+				if ($file !== '.' && $file !== '..' && !$fileAdded) {
 					$dirStream[] = $file;
 				}
 			}

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -139,33 +139,31 @@ class SftpTest extends \Test\Files\Storage\Storage {
 	}
 
 	public function testSymlinks(): void {
-		$this->instance->getConnection()->mkdir($this->config['root']);
-		$this->instance->getConnection()->mkdir($this->config['root'] . '/test');
-		$this->instance->getConnection()->touch($this->config['root'] . '/notes.txt');
-		$this->assertTrue($this->instance->getConnection()->is_dir($this->config['root'] . '/test'));
-		$this->assertTrue($this->instance->getConnection()->is_file($this->config['root'] . '/notes.txt'));
+        $this->instance->mkdir('test');
+        $this->instance->touch('notes.txt');
+		$this->assertTrue($this->instance->is_dir('test'));
+		$this->assertTrue($this->instance->is_file('notes.txt'));
 
-		$symlinkDir = $this->config['root'] . '/test/slink';
-		$symlinkFile = $this->config['root'] . '/foo.txt';
-		$this->instance->getConnection()->symlink($this->config['root'], $symlinkDir);
-		$this->instance->getConnection()->symlink($this->config['root'] . '/notes.txt', $symlinkFile);
+        $root = $this->instance->getRoot();
+		$symlinkDir = $root . '/test/slink';
+		$symlinkFile = $root . '/test/foo.txt';
+		$this->instance->getConnection()->symlink($root, $symlinkDir);
+		$this->instance->getConnection()->symlink($root . '/notes.txt', $symlinkFile);
 		$this->assertTrue($this->instance->getConnection()->is_link($symlinkDir), 'Symlink directory was not created');
 		$this->assertTrue($this->instance->getConnection()->is_link($symlinkFile), 'Symlink file was not created');
 
-		$dirHandle = $this->instance->opendir('test/slink');
+        $contents = $this->instance->getDirectoryContent('test/slink');
 		$files = [];
-		while (($file = readdir($dirHandle)) !== false) {
-			$files[] = $file;
+		foreach ($contents as $file) {
+			$files[] = $file['name'];
 		}
-		closedir($dirHandle);
 		$this->assertEquals(['test', 'notes.txt'], $files);
 
-		$dirHandle = $this->instance->opendir('test/slink/test');
+		$contents = $this->instance->getDirectoryContent('test/slink/test');
 		$files = [];
-		while (($file = readdir($dirHandle)) !== false) {
-			$files[] = $file;
+		foreach ($contents as $file) {
+			$files[] = $file['name'];
 		}
-		closedir($dirHandle);
-		$this->assertEquals([], $files, 'Symlink directory must not repeat itself');
+		$this->assertEquals(['foo.txt'], $files, 'Symlink directory must not repeat itself');
 	}
 }

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -6,7 +6,6 @@
  */
 namespace OCA\Files_External\Tests\Storage;
 
-use OC\Files\Filesystem;
 use OCA\Files_External\Lib\Storage\SFTP;
 
 /**
@@ -156,7 +155,7 @@ class SftpTest extends \Test\Files\Storage\Storage {
 		$dirHandle = $this->instance->opendir('test/slink');
 		$files = [];
 		while (($file = readdir($dirHandle)) !== false) {
-				$files[] = $file;
+			$files[] = $file;
 		}
 		closedir($dirHandle);
 		$this->assertEquals(['test', 'notes.txt'], $files);
@@ -164,7 +163,7 @@ class SftpTest extends \Test\Files\Storage\Storage {
 		$dirHandle = $this->instance->opendir('test/slink/test');
 		$files = [];
 		while (($file = readdir($dirHandle)) !== false) {
-				$files[] = $file;
+			$files[] = $file;
 		}
 		closedir($dirHandle);
 		$this->assertEquals([], $files, 'Symlink directory must not repeat itself');

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2019-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -139,12 +140,12 @@ class SftpTest extends \Test\Files\Storage\Storage {
 	}
 
 	public function testSymlinks(): void {
-        $this->instance->mkdir('test');
-        $this->instance->touch('notes.txt');
+		$this->instance->mkdir('test');
+		$this->instance->touch('notes.txt');
 		$this->assertTrue($this->instance->is_dir('test'));
 		$this->assertTrue($this->instance->is_file('notes.txt'));
 
-        $root = $this->instance->getRoot();
+		$root = $this->instance->getRoot();
 		$symlinkDir = $root . '/test/slink';
 		$symlinkFile = $root . '/test/foo.txt';
 		$this->instance->getConnection()->symlink($root, $symlinkDir);
@@ -152,7 +153,7 @@ class SftpTest extends \Test\Files\Storage\Storage {
 		$this->assertTrue($this->instance->getConnection()->is_link($symlinkDir), 'Symlink directory was not created');
 		$this->assertTrue($this->instance->getConnection()->is_link($symlinkFile), 'Symlink file was not created');
 
-        $contents = $this->instance->getDirectoryContent('test/slink');
+		$contents = $this->instance->getDirectoryContent('test/slink');
 		$files = [];
 		foreach ($contents as $file) {
 			$files[] = $file['name'];


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #52214 <!-- related github issue -->

## Summary
When a symlink is detected, check if the path already includes the file. If it does, ignore the file. This helps prevents the scanner from going into an infinite loop when the configured root contains a directory symlinked to a parent/grandparent/higher directory which eventually contains it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [X] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
