### PR TITLE
chore: revert "fix(deps): lock mdast-util-gfm-autolink-literal library"

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,9 +197,6 @@
     "npm": "^10.0.0"
   },
   "overrides": {
-    "colors": "1.4.0",
-    "mdast-util-gfm": {
-      "mdast-util-gfm-autolink-literal": "2.0.0"
-    }
+    "colors": "1.4.0"
   }
 }


### PR DESCRIPTION
## Summary
This reverts commit d028b61a40196ba41005ad7718b7936535e7bb6b.

Fixed with https://github.com/nextcloud/server/pull/52246

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
