### PR TITLE
fix(files_versions): wait for version to be created before setting metadata

### DIFF
--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -107,7 +107,8 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(BeforeNodeRenamedEvent::class, FileEventsListener::class);
 		$context->registerEventListener(BeforeNodeCopiedEvent::class, FileEventsListener::class);
 
-		$context->registerEventListener(NodeWrittenEvent::class, VersionAuthorListener::class);
+		// we add the version author listener with lower priority to make sure new versions already are created by FileEventsListener
+		$context->registerEventListener(NodeWrittenEvent::class, VersionAuthorListener::class, -1);
 
 		$context->registerEventListener(VersionRestoredEvent::class, LegacyRollbackListener::class);
 	}


### PR DESCRIPTION
* Partly related to https://github.com/nextcloud/server/issues/41174

## Summary
If a new file is created then:
1. a version is created
2. the author is set in the meta data

those two are done in separate event listeners with the same priority.
In some situations they are sorted in such a way that 2 is executed before 1 and causing an issue due to version not found for update.
As 2 always needs to be done **after** 1 we need to reduce the priority of the second event listener.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
