### PR TITLE
fix(metadata): set background job on fresh setup

### DIFF
--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -14,6 +14,7 @@ use Exception;
 use InvalidArgumentException;
 use OC\Authentication\Token\PublicKeyTokenProvider;
 use OC\Authentication\Token\TokenCleanupJob;
+use OC\Core\BackgroundJobs\GenerateMetadataJob;
 use OC\Log\Rotate;
 use OC\Preview\BackgroundCleanupJob;
 use OC\TextProcessing\RemoveOldTasksBackgroundJob;
@@ -495,6 +496,7 @@ class Setup {
 		$jobList->add(BackgroundCleanupJob::class);
 		$jobList->add(RemoveOldTasksBackgroundJob::class);
 		$jobList->add(CleanupDeletedUsers::class);
+		$jobList->add(GenerateMetadataJob::class);
 	}
 
 	/**


### PR DESCRIPTION
until now, only an upgrade will add the job to the list:

https://github.com/nextcloud/server/blob/master/lib/private/Repair/AddMetadataGenerationJob.php#L24

The background job is mainly to create metadata on files added previously to the upgrade that implemented the `FilesMetadata` feature.
This background job is useless on fresh setup that already implement the feature.
Adding the background job on fresh setup instead of waiting for the next execution of the Repair Step disable the huge process at first upgrade once the cloud and filesystem are filled with users+documents