### PR TITLE
fix(32bit): make `pack` compatible with 32bit PHP

### DIFF
--- a/lib/private/Security/Normalizer/IpAddress.php
+++ b/lib/private/Security/Normalizer/IpAddress.php
@@ -41,10 +41,14 @@ class IpAddress {
 		$config = \OCP\Server::get(IConfig::class);
 		$maskSize = min(64, $config->getSystemValueInt('security.ipv6_normalized_subnet_size', 56));
 		$maskSize = max(32, $maskSize);
-		$mask = pack('VVP', (1 << 32) - 1, (1 << $maskSize - 32) - 1, 0);
+		if (PHP_INT_SIZE === 4) {
+			// as long as we support 32bit PHP we cannot use the `P` pack formatter (and not overflow 32bit integer)
+			$mask = pack('VVVV', 0xFFFF, $maskSize === 64 ? 0xFFFF : ((1 << $maskSize - 32) - 1), 0, 0);
+		} else {
+			$mask = pack('VVP', (1 << 32) - 1, (1 << $maskSize - 32) - 1, 0);
+		}
 
 		$binary = \inet_pton($ip);
-
 		return inet_ntop($binary & $mask) . '/' . $maskSize;
 	}
 


### PR DESCRIPTION
* Regression from https://github.com/nextcloud/server/pull/52223

## Summary
The `P` formatter is 64bit only - we need to manually pack the 64bit.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
