### PR TITLE
fix(32bit): use `PHP_INT_MAX` where needed

### DIFF
--- a/lib/private/Security/Normalizer/IpAddress.php
+++ b/lib/private/Security/Normalizer/IpAddress.php
@@ -42,8 +42,15 @@ class IpAddress {
 		$maskSize = min(64, $config->getSystemValueInt('security.ipv6_normalized_subnet_size', 56));
 		$maskSize = max(32, $maskSize);
 		if (PHP_INT_SIZE === 4) {
+			if ($maskSize === 64) {
+				$value = -1;
+			} elseif ($maskSize === 63) {
+				$value = PHP_INT_MAX;
+			} else {
+				$value = (1 << $maskSize - 32) - 1;
+			}
 			// as long as we support 32bit PHP we cannot use the `P` pack formatter (and not overflow 32bit integer)
-			$mask = pack('VVVV', 0xFFFF, $maskSize === 64 ? 0xFFFF : ((1 << $maskSize - 32) - 1), 0, 0);
+			$mask = pack('VVVV', -1, $value, 0, 0);
 		} else {
 			$mask = pack('VVP', (1 << 32) - 1, (1 << $maskSize - 32) - 1, 0);
 		}


### PR DESCRIPTION
* Typo from https://github.com/nextcloud/server/pull/52392
* See also https://github.com/nextcloud/server/actions/runs/14636364753/job/41068278906

`0xFFFF` is only 2 bytes, but we need either `0xFFFFFFFF` or maybe a bit easier to read `PHP_INT_MAX`.
