### PR TITLE
fix(federation): Allow federation file sharing when federation app is…

### DIFF
--- a/apps/cloud_federation_api/lib/Config.php
+++ b/apps/cloud_federation_api/lib/Config.php
@@ -6,6 +6,7 @@
 namespace OCA\CloudFederationAPI;
 
 use OCP\Federation\ICloudFederationProviderManager;
+use Psr\Log\LoggerInterface;
 
 /**
  * Class config
@@ -18,6 +19,7 @@ class Config {
 
 	public function __construct(
 		private ICloudFederationProviderManager $cloudFederationProviderManager,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -32,6 +34,7 @@ class Config {
 			$provider = $this->cloudFederationProviderManager->getCloudFederationProvider($resourceType);
 			return $provider->getSupportedShareTypes();
 		} catch (\Exception $e) {
+			$this->logger->error('Failed to create federation provider', ['exception' => $e]);
 			return [];
 		}
 	}

--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -452,7 +452,7 @@ class RequestHandlerController extends Controller {
 	 */
 	private function getHostFromFederationId(string $entry): string {
 		if (!str_contains($entry, '@')) {
-			throw new IncomingRequestException('entry ' . $entry . ' does not contains @');
+			throw new IncomingRequestException('entry ' . $entry . ' does not contain @');
 		}
 		$rightPart = substr($entry, strrpos($entry, '@') + 1);
 

--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -67,7 +67,6 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 		private LoggerInterface $logger,
 		private IFilenameValidator $filenameValidator,
 		private readonly IProviderFactory $shareProviderFactory,
-		private TrustedServers $trustedServers,
 	) {
 	}
 
@@ -156,6 +155,17 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 				// get DisplayName about the owner of the share
 				$ownerDisplayName = $this->getUserDisplayName($ownerFederatedId);
 
+				$trustedServers = null;
+				if ($this->appManager->isEnabledForAnyone('federation')
+					&& class_exists(TrustedServers::class)) {
+					try {
+						$trustedServers = Server::get(TrustedServers::class);
+					} catch (\Throwable $e) {
+						$this->logger->debug('Failed to create TrustedServers', ['exception' => $e]);
+					}
+				}
+
+
 				if ($shareType === IShare::TYPE_USER) {
 					$event = $this->activityManager->generateEvent();
 					$event->setApp('files_sharing')
@@ -167,7 +177,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 					$this->notifyAboutNewShare($shareWith, $shareId, $ownerFederatedId, $sharedByFederatedId, $name, $ownerDisplayName);
 
 					// If auto-accept is enabled, accept the share
-					if ($this->federatedShareProvider->isFederatedTrustedShareAutoAccept() && $this->trustedServers->isTrustedServer($remote)) {
+					if ($this->federatedShareProvider->isFederatedTrustedShareAutoAccept() && $trustedServers?->isTrustedServer($remote) === true) {
 						$this->externalShareManager->acceptShare($shareId, $shareWith);
 					}
 				} else {
@@ -183,7 +193,7 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 						$this->notifyAboutNewShare($user->getUID(), $shareId, $ownerFederatedId, $sharedByFederatedId, $name, $ownerDisplayName);
 
 						// If auto-accept is enabled, accept the share
-						if ($this->federatedShareProvider->isFederatedTrustedShareAutoAccept() && $this->trustedServers->isTrustedServer($remote)) {
+						if ($this->federatedShareProvider->isFederatedTrustedShareAutoAccept() && $trustedServers?->isTrustedServer($remote) === true) {
 							$this->externalShareManager->acceptShare($shareId, $user->getUID());
 						}
 					}


### PR DESCRIPTION
… disabled

The app id might be misleading, the federation app is for syncing addressbooks with trusted servers. It is not always enabled and show not have to be.

- "Regression" from #49973 

## Steps

1. Disable app "federation" (description: "Federation allows you to connect with other trusted servers to exchange the account directory.")
2. Try to share a file federated
3. Sender log shows:
    ```
    Server error: POST https://nextcloudf32.local:442/index.php/ocm/shares resulted in a 501 Not Implemented response:␊{"message":"Share type "user" not implemented"}
    ```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
