### PR TITLE
fix(caldav): use direct.edit route in event activities

### DIFF
--- a/apps/dav/lib/CalDAV/Activity/Provider/Event.php
+++ b/apps/dav/lib/CalDAV/Activity/Provider/Event.php
@@ -78,14 +78,9 @@ class Event extends Base {
 					//       as seen from the affected user.
 					$objectId = base64_encode($this->url->getWebroot() . '/remote.php/dav/calendars/' . $affectedUser . '/' . $calendarUri . '_shared_by_' . $linkData['owner'] . '/' . $linkData['object_uri']);
 				}
-				$link = [
-					'view' => 'dayGridMonth',
-					'timeRange' => 'now',
-					'mode' => 'sidebar',
+				$params['link'] = $this->url->linkToRouteAbsolute('calendar.view.indexdirect.edit', [
 					'objectId' => $objectId,
-					'recurrenceId' => 'next'
-				];
-				$params['link'] = $this->url->linkToRouteAbsolute('calendar.view.indexview.timerange.edit', $link);
+				]);
 			} catch (\Exception $error) {
 				// Do nothing
 			}

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -75,11 +75,7 @@ class EventTest extends TestCase {
 		if ($link) {
 			$affectedUser = $link['owner'];
 			$generatedLink = [
-				'view' => 'dayGridMonth',
-				'timeRange' => 'now',
-				'mode' => 'sidebar',
 				'objectId' => base64_encode('/remote.php/dav/calendars/' . $link['owner'] . '/' . $link['calendar_uri'] . '/' . $link['object_uri']),
-				'recurrenceId' => 'next'
 			];
 			$this->appManager->expects($this->once())
 				->method('isEnabledForUser')
@@ -90,7 +86,7 @@ class EventTest extends TestCase {
 					->method('getWebroot');
 				$this->url->expects($this->once())
 					->method('linkToRouteAbsolute')
-					->with('calendar.view.indexview.timerange.edit', $generatedLink)
+					->with('calendar.view.indexdirect.edit', $generatedLink)
 					->willReturn('fullLink');
 			}
 		}
@@ -159,11 +155,7 @@ class EventTest extends TestCase {
 	 */
 	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId): void {
 		$generatedLink = [
-			'view' => 'dayGridMonth',
-			'timeRange' => 'now',
-			'mode' => 'sidebar',
 			'objectId' => $objectId,
-			'recurrenceId' => 'next'
 		];
 		$this->appManager->expects($this->once())
 			->method('isEnabledForUser')
@@ -173,7 +165,7 @@ class EventTest extends TestCase {
 			->method('getWebroot');
 		$this->url->expects($this->once())
 			->method('linkToRouteAbsolute')
-			->with('calendar.view.indexview.timerange.edit', $generatedLink)
+			->with('calendar.view.indexdirect.edit', $generatedLink)
 			->willReturn('fullLink');
 		$objectParameter = ['id' => 42, 'name' => 'calendar', 'link' => $link];
 		$result = [


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

There is no reason to force a view and timerange here. We can just use the simplified direct route as the object id is the only thing known in the activity.

```
['name' => 'view#index', 'url' => '/edit/{objectId}', 'verb' => 'GET', 'postfix' => 'direct.edit'],
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
