### PR TITLE
refactor(dav): refactor inline event listeners

### DIFF
--- a/apps/dav/lib/Listener/CalendarShareUpdateListener.php
+++ b/apps/dav/lib/Listener/CalendarShareUpdateListener.php
@@ -39,5 +39,7 @@ class CalendarShareUpdateListener implements IEventListener {
 			$event->getAdded(),
 			$event->getRemoved()
 		);
+
+		// Here we should recalculate if reminders should be sent to new or old sharees
 	}
 }

--- a/apps/dav/lib/Listener/UserEventsListener.php
+++ b/apps/dav/lib/Listener/UserEventsListener.php
@@ -13,6 +13,7 @@ use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\SyncService;
 use OCA\DAV\Service\DefaultContactService;
+use OCP\Accounts\UserUpdatedEvent;
 use OCP\Defaults;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -29,7 +30,7 @@ use OCP\User\Events\UserIdAssignedEvent;
 use OCP\User\Events\UserIdUnassignedEvent;
 use Psr\Log\LoggerInterface;
 
-/** @template-implements IEventListener<UserFirstTimeLoggedInEvent|UserIdAssignedEvent|BeforeUserIdUnassignedEvent|UserIdUnassignedEvent|BeforeUserDeletedEvent|UserDeletedEvent|UserCreatedEvent|UserChangedEvent> */
+/** @template-implements IEventListener<UserFirstTimeLoggedInEvent|UserIdAssignedEvent|BeforeUserIdUnassignedEvent|UserIdUnassignedEvent|BeforeUserDeletedEvent|UserDeletedEvent|UserCreatedEvent|UserChangedEvent|UserUpdatedEvent> */
 class UserEventsListener implements IEventListener {
 
 	/** @var IUser[] */
@@ -69,10 +70,16 @@ class UserEventsListener implements IEventListener {
 			$this->changeUser($event->getUser(), $event->getFeature());
 		} elseif ($event instanceof UserFirstTimeLoggedInEvent) {
 			$this->firstLogin($event->getUser());
+		} elseif ($event instanceof UserUpdatedEvent) {
+			$this->updateUser($event->getUser());
 		}
 	}
 
 	public function postCreateUser(IUser $user): void {
+		$this->syncService->updateUser($user);
+	}
+
+	public function updateUser(IUser $user): void {
 		$this->syncService->updateUser($user);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

1. Move inline listeners to existing listener classes.
2. Get rid of duplicated call to `$backend->onCalendarUpdateShares()` (once inline and once in the already existing listener class).

Based on https://github.com/nextcloud/server/pull/52427

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
