### PR TITLE
fix(navigation): Fix default app entry registered as closure

### DIFF
--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -77,7 +77,7 @@ class NavigationManager implements INavigationManager {
 			$this->closureEntries[] = $entry;
 			return;
 		}
-		$this->init();
+		$this->init(false);
 
 		$id = $entry['id'];
 
@@ -123,10 +123,6 @@ class NavigationManager implements INavigationManager {
 	 */
 	public function getAll(string $type = 'link'): array {
 		$this->init();
-		foreach ($this->closureEntries as $c) {
-			$this->add($c());
-		}
-		$this->closureEntries = [];
 
 		$result = $this->entries;
 		if ($type !== 'all') {
@@ -212,7 +208,13 @@ class NavigationManager implements INavigationManager {
 		return $this->activeEntry;
 	}
 
-	private function init() {
+	private function init(bool $resolveClosures = true): void {
+		if ($resolveClosures) {
+			while ($c = array_pop($this->closureEntries)) {
+				$this->add($c());
+			}
+		}
+
 		if ($this->init) {
 			return;
 		}
@@ -420,11 +422,6 @@ class NavigationManager implements INavigationManager {
 
 	public function get(string $id): ?array {
 		$this->init();
-		foreach ($this->closureEntries as $c) {
-			$this->add($c());
-		}
-		$this->closureEntries = [];
-
 		return $this->entries[$id];
 	}
 

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -304,6 +304,11 @@ class URLGenerator implements IURLGenerator {
 		if ($href === '') {
 			throw new \InvalidArgumentException('Default navigation entry is missing href: ' . $entryId);
 		}
+
+		if (str_starts_with($href, $this->getBaseUrl())) {
+			return $href;
+		}
+
 		if (str_starts_with($href, '/index.php/') && ($this->config->getSystemValueBool('htaccess.IgnoreFrontController', false) || getenv('front_controller_active') === 'true')) {
 			$href = substr($href, 10);
 		}

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -704,30 +704,64 @@ class NavigationManagerTest extends TestCase {
 				true,
 				'settings',
 			],
+			// closure navigation entries are also resolved
+			[
+				'closure2',
+				'',
+				'',
+				true,
+				'closure2',
+			],
+			[
+				'',
+				'closure2',
+				'',
+				true,
+				'closure2',
+			],
+			[
+				'',
+				'',
+				'{"closure2":{"order":1,"app":"closure2","href":"/closure2"}}',
+				true,
+				'closure2',
+			],
 		];
 	}
 
 	/**
 	 * @dataProvider provideDefaultEntries
 	 */
-	public function testGetDefaultEntryIdForUser($defaultApps, $userDefaultApps, $userApporder, $withFallbacks, $expectedApp): void {
+	public function testGetDefaultEntryIdForUser(string $defaultApps, string $userDefaultApps, string $userApporder, bool $withFallbacks, string $expectedApp): void {
 		$this->navigationManager->add([
 			'id' => 'files',
 		]);
 		$this->navigationManager->add([
 			'id' => 'settings',
 		]);
+		$this->navigationManager->add(static function (): array {
+			return [
+				'id' => 'closure1',
+				'href' => '/closure1',
+			];
+		});
+		$this->navigationManager->add(static function (): array {
+			return [
+				'id' => 'closure2',
+				'href' => '/closure2',
+			];
+		});
 
 		$this->appManager->method('getEnabledApps')->willReturn([]);
 
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('user1');
 
-		$this->userSession->expects($this->once())
+		$this->userSession->expects($this->atLeastOnce())
 			->method('getUser')
 			->willReturn($user);
 
-		$this->config->expects($this->once())
+		$this->config->expects($this->atLeastOnce())
 			->method('getSystemValueString')
 			->with('defaultapp', $this->anything())
 			->willReturn($defaultApps);


### PR DESCRIPTION
Fix #52420

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
