### PR TITLE
feat: add an option to filter what paths get checked for updates

### DIFF
--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -36,6 +36,8 @@ class Watcher implements IWatcher {
 	/** @var callable[] */
 	protected $onUpdate = [];
 
+	protected ?string $checkFilter = null;
+
 	/**
 	 * @param \OC\Files\Storage\Storage $storage
 	 */
@@ -50,6 +52,10 @@ class Watcher implements IWatcher {
 	 */
 	public function setPolicy($policy) {
 		$this->watchPolicy = $policy;
+	}
+
+	public function setCheckFilter(?string $filter): void {
+		$this->checkFilter = $filter;
 	}
 
 	/**
@@ -116,6 +122,12 @@ class Watcher implements IWatcher {
 	 * @return bool
 	 */
 	public function needsUpdate($path, $cachedData) {
+		if ($this->checkFilter !== null) {
+			if (!preg_match($this->checkFilter, $path)) {
+				return false;
+			}
+		}
+
 		if ($this->watchPolicy === self::CHECK_ALWAYS || ($this->watchPolicy === self::CHECK_ONCE && !in_array($path, $this->checkedPaths))) {
 			$this->checkedPaths[] = $path;
 			return $cachedData['storage_mtime'] === null || $this->storage->hasUpdated($path, $cachedData['storage_mtime']);

--- a/lib/private/Files/Cache/Watcher.php
+++ b/lib/private/Files/Cache/Watcher.php
@@ -7,8 +7,11 @@
  */
 namespace OC\Files\Cache;
 
+use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\Cache\IScanner;
 use OCP\Files\Cache\IWatcher;
+use OCP\Files\Storage\IStorage;
 
 /**
  * check the storage backends for updates and change the cache accordingly
@@ -19,17 +22,17 @@ class Watcher implements IWatcher {
 	protected $checkedPaths = [];
 
 	/**
-	 * @var \OC\Files\Storage\Storage $storage
+	 * @var IStorage $storage
 	 */
 	protected $storage;
 
 	/**
-	 * @var Cache $cache
+	 * @var ICache $cache
 	 */
 	protected $cache;
 
 	/**
-	 * @var Scanner $scanner ;
+	 * @var IScanner $scanner ;
 	 */
 	protected $scanner;
 
@@ -38,10 +41,7 @@ class Watcher implements IWatcher {
 
 	protected ?string $checkFilter = null;
 
-	/**
-	 * @param \OC\Files\Storage\Storage $storage
-	 */
-	public function __construct(\OC\Files\Storage\Storage $storage) {
+	public function __construct(IStorage $storage) {
 		$this->storage = $storage;
 		$this->cache = $storage->getCache();
 		$this->scanner = $storage->getScanner();

--- a/lib/private/Files/Storage/Common.php
+++ b/lib/private/Files/Storage/Common.php
@@ -331,6 +331,7 @@ abstract class Common implements Storage, ILockingStorage, IWriteStreamStorage, 
 			$this->watcher = new Watcher($storage);
 			$globalPolicy = Server::get(IConfig::class)->getSystemValueInt('filesystem_check_changes', Watcher::CHECK_NEVER);
 			$this->watcher->setPolicy((int)$this->getMountOption('filesystem_check_changes', $globalPolicy));
+			$this->watcher->setCheckFilter($this->getMountOption('filesystem_check_filter'));
 		}
 		return $this->watcher;
 	}

--- a/lib/public/Files/Cache/IWatcher.php
+++ b/lib/public/Files/Cache/IWatcher.php
@@ -35,6 +35,17 @@ interface IWatcher {
 	public function setPolicy($policy);
 
 	/**
+	 * Set a filter regex, only paths matching the regex will be checked for updates.
+	 *
+	 * When set to `null`, every path will be checked for updates
+	 *
+	 * @param ?string $filter
+	 * @return void
+	 * @since 33.0.0
+	 */
+	public function setCheckFilter(?string $filter): void;
+
+	/**
 	 * @return int either IWatcher::CHECK_NEVER, IWatcher::CHECK_ONCE, IWatcher::CHECK_ALWAYS
 	 * @since 9.0.0
 	 */

--- a/tests/lib/Files/Cache/WatcherTest.php
+++ b/tests/lib/Files/Cache/WatcherTest.php
@@ -8,9 +8,13 @@
 
 namespace Test\Files\Cache;
 
+use OC\Files\Cache\CacheEntry;
 use OC\Files\Cache\Watcher;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
+use OCP\Files\Cache\IWatcher;
+use OCP\Files\Storage\IStorage;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Class WatcherTest
@@ -191,5 +195,44 @@ class WatcherTest extends \Test\TestCase {
 		}
 		$this->storages[] = $storage;
 		return $storage;
+	}
+
+	public static function checkFilterProvider(): array {
+		return [
+			[null, [
+				'' => true,
+				'foo' => true,
+				'foo.txt' => true,
+			]],
+			['/^.+$/', [
+				'' => false,
+				'foo' => true,
+				'foo.txt' => true,
+			]],
+			['/^.+\..+$/', [
+				'' => false,
+				'foo' => false,
+				'foo.txt' => true,
+			]]
+		];
+	}
+
+	#[DataProvider('checkFilterProvider')]
+	public function testCheckFilter($filter, $paths) {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('hasUpdated')
+			->willReturn(true);
+		$watcher = new Watcher($storage);
+		$watcher->setPolicy(IWatcher::CHECK_ALWAYS);
+
+		$watcher->setCheckFilter($filter);
+
+		$entry = new CacheEntry([
+			'storage_mtime' => 0,
+		]);
+
+		foreach ($paths as $patch => $shouldUpdate) {
+			$this->assertEquals($shouldUpdate, $watcher->needsUpdate($patch, $entry));
+		}
 	}
 }


### PR DESCRIPTION
An example use case would be a external storage where the root contains a very large number of sub-directories but each sub-directory is fairly small.

Currently trying to browse the root of the external storage will be slow (since the "check for update" cost scales with the number of items in directory) leading to a bad user experience. Disabling the "check for update" on the storage would make it fast but will lead to the filecache being out of date over time.

This would allow an admin to configure the instance so only the sub-directories are being checked for updates, while an external process (such as a periodic shallow-scan) can check for any changes to the root directory. Leading to an improved browsing experience for the user at the cost of a possible delay for new items in the root directory.
(Though systems like `notify` could be used to help there)

Currently this can only be configured by setting the mount option manually, in the future we might want to provide some curated presets in the ui.

Example for configuring it to not check the root folder as in the scenario described above:

```bash
occ files_external:option <mount id> filesystem_check_filter '/^.+$/'
```