### PR TITLE
fix: don't check node access again for listing reminders in dav

### DIFF
--- a/apps/files_reminders/lib/Dav/PropFindPlugin.php
+++ b/apps/files_reminders/lib/Dav/PropFindPlugin.php
@@ -62,7 +62,7 @@ class PropFindPlugin extends ServerPlugin {
 				}
 
 				$fileId = $node->getId();
-				$reminder = $this->reminderService->getDueForUser($user, $fileId);
+				$reminder = $this->reminderService->getDueForUser($user, $fileId, false);
 				if ($reminder === null) {
 					return '';
 				}

--- a/apps/files_reminders/lib/Service/ReminderService.php
+++ b/apps/files_reminders/lib/Service/ReminderService.php
@@ -64,8 +64,10 @@ class ReminderService {
 	/**
 	 * @throws NodeNotFoundException
 	 */
-	public function getDueForUser(IUser $user, int $fileId): ?RichReminder {
-		$this->checkNode($user, $fileId);
+	public function getDueForUser(IUser $user, int $fileId, bool $checkNode = true): ?RichReminder {
+		if ($checkNode) {
+			$this->checkNode($user, $fileId);
+		}
 		/** @var null|false|Reminder $cachedReminder */
 		$cachedReminder = $this->cache->get("{$user->getUID()}-$fileId");
 		if ($cachedReminder === false) {


### PR DESCRIPTION
Fixes a performance regression from https://github.com/nextcloud/server/pull/50711#pullrequestreview-2794930246

The dav propfind will have already made sure we have access to the node.

The check is left in place for other callers