### PR TITLE
chore: Update config.sample.php to document new ffprobe path option

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1422,6 +1422,15 @@ $CONFIG = [
 'preview_ffmpeg_path' => '/usr/bin/ffmpeg',
 
 /**
+ * custom path for ffprobe binary
+ *
+ * Defaults to ``null`` and falls back to using the same path as ffmpeg.
+ * ffprobe is typically packaged with ffmpeg and is required for
+ * enhanced preview generation for HDR videos.
+ */
+'preview_ffprobe_path' => '/usr/bin/ffprobe',
+
+/**
  * Set the URL of the Imaginary service to send image previews to.
  * Also requires the ``OC\Preview\Imaginary`` provider to be enabled in the
  * ``enabledPreviewProviders`` array, to create previews for these mimetypes: bmp,


### PR DESCRIPTION
PR #51712 added new preview_ffprobe_path parameter. This PR updates config.sample.php to document this new optional parameter and the fallback behavior if the path is not set manually.

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
