### PR TITLE
fix(JSResourceLocator) fix incorrect parameter being used.

### DIFF
--- a/lib/private/Template/JSResourceLocator.php
+++ b/lib/private/Template/JSResourceLocator.php
@@ -69,7 +69,7 @@ class JSResourceLocator extends ResourceLocator {
 			|| $this->appendScriptIfExist($this->serverroot, "dist/$app-$scriptName")
 			|| $this->appendScriptIfExist($appRoot, $script, $appWebRoot)
 			|| $this->cacheAndAppendCombineJsonIfExist($this->serverroot, $script . '.json')
-			|| $this->cacheAndAppendCombineJsonIfExist($appRoot, $script . '.json', $appWebRoot)
+			|| $this->cacheAndAppendCombineJsonIfExist($appRoot, $script . '.json', $app)
 			|| $this->appendScriptIfExist($this->serverroot, $theme_dir . 'core/' . $script)
 			|| $this->appendScriptIfExist($this->serverroot, 'core/' . $script)
 			|| (strpos($scriptName, '/') === -1 && ($this->appendScriptIfExist($this->serverroot, $theme_dir . "dist/core-$scriptName")


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #52265 

## Summary

Fix incorrect parameter being passed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
