### PR TITLE
fix: don't log error when default contact template does not exist

### DIFF
--- a/apps/dav/lib/Service/DefaultContactService.php
+++ b/apps/dav/lib/Service/DefaultContactService.php
@@ -10,15 +10,14 @@ declare(strict_types=1);
 namespace OCA\DAV\Service;
 
 use OCA\DAV\CardDAV\CardDavBackend;
-use OCP\App\IAppManager;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\NotFoundException;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
 class DefaultContactService {
 	public function __construct(
 		private CardDavBackend $cardDav,
-		private IAppManager $appManager,
 		private IAppDataFactory $appDataFactory,
 		private LoggerInterface $logger,
 	) {
@@ -30,6 +29,8 @@ class DefaultContactService {
 			$folder = $appData->getFolder('defaultContact');
 			$defaultContactFile = $folder->getFile('defaultContact.vcf');
 			$data = $defaultContactFile->getContent();
+		} catch (NotFoundException $e) {
+			return;
 		} catch (\Exception $e) {
 			$this->logger->error('Couldn\'t get default contact file', ['exception' => $e]);
 			return;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/pull/50156#discussion_r2063079697

## Summary

Prevent error log spam.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
