### PR TITLE
fix: check if config is enabled before creating a default contact

### DIFF
--- a/apps/dav/lib/Service/DefaultContactService.php
+++ b/apps/dav/lib/Service/DefaultContactService.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Service;
 
+use OCA\DAV\AppInfo\Application;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCP\App\IAppManager;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\IAppConfig;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Uid\Uuid;
 
@@ -20,11 +22,16 @@ class DefaultContactService {
 		private CardDavBackend $cardDav,
 		private IAppManager $appManager,
 		private IAppDataFactory $appDataFactory,
+		private IAppConfig $config,
 		private LoggerInterface $logger,
 	) {
 	}
 
 	public function createDefaultContact(int $addressBookId): void {
+		$enableDefaultContact = $this->config->getValueString(Application::APP_ID, 'enableDefaultContact', 'no');
+		if ($enableDefaultContact !== 'yes') {
+			return;
+		}
 		$appData = $this->appDataFactory->get('dav');
 		try {
 			$folder = $appData->getFolder('defaultContact');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Ref: #52493 , https://github.com/nextcloud/server/pull/50156#discussion_r2063079697

## Summary
Check if config is enabled, file existing is not an enough indicator 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
