### PR TITLE
feat: Add preload.php script for opcache preloading

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -368,6 +368,9 @@ class OC {
 	}
 
 	public static function initSession(): void {
+		if (defined('PHP_PRELOAD')) {
+			return;
+		}
 		$request = Server::get(IRequest::class);
 
 		// TODO: Temporary disabled again to solve issues with CalDAV/CardDAV clients like DAVx5 that use cookies

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -202,7 +202,7 @@ class Config {
 			unset($CONFIG);
 
 			// Invalidate opcache (only if the timestamp changed)
-			if (function_exists('opcache_invalidate')) {
+			if (!defined('PHP_PRELOAD') && function_exists('opcache_invalidate')) {
 				@opcache_invalidate($file, false);
 			}
 
@@ -233,7 +233,7 @@ class Config {
 				fclose($filePointer);
 			}
 
-			if (!defined('PHPUNIT_RUN') && headers_sent()) {
+			if (!defined('PHP_PRELOAD') && !defined('PHPUNIT_RUN') && headers_sent()) {
 				// syntax issues in the config file like leading spaces causing PHP to send output
 				$errorMessage = sprintf('Config file has leading content, please remove everything before "<?php" in %s', basename($file));
 				if (!defined('OC_CONSOLE')) {

--- a/preload.php
+++ b/preload.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+define('PHP_PRELOAD', 1);
+$_SERVER['SCRIPT_FILENAME'] = __DIR__ . '/index.php';
+$_SERVER['SCRIPT_NAME'] = '/index.php';
+require_once __DIR__ . '/lib/base.php';
+
+function scanFolder(string $folder): void {
+	$files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator($folder),
+		RecursiveIteratorIterator::LEAVES_ONLY
+	);
+
+	// names to skip
+	$skip = [
+		'update.php',
+		'index.php',
+		'cron.php',
+		'console.php',
+		'command.php',
+		'routes.php',
+		'authpicker.php',
+		'grant.php',
+		'/templates',
+		'composer/',
+		'tests/',
+	];
+
+	// require all
+	foreach ($files as $file) {
+		// check skipping
+		foreach ($skip as $s) {
+			if (strpos($file->getPathname(), $s) !== false) {
+				continue 2;
+			}
+		}
+
+		if (substr($file->getFilename(), -4) === '.php') {
+			require_once $file;
+		}
+	}
+}
+
+scanFolder(__DIR__ . '/lib');
+scanFolder(__DIR__ . '/core');
+// scanFolder(__DIR__ . '/apps');


### PR DESCRIPTION
* Resolves: #18145 

## Summary

Adds a preload.php script to use with opcache preload feature added in PHP 7.4.

According to my tests so far, this does not help performances, I could not get a measurable improvement.

I’m still pushing this in case me or someone else wants to spend more time investigating on this.

The define trick is ugly, and for some reason autoloading apps was failing. Ideally the script would not call OC::init and only use the autoloader.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
