### PR TITLE
fix(cypress): Use visit instead of reload to avoid cypress error

### DIFF
--- a/cypress/e2e/files_sharing/note-to-recipient.cy.ts
+++ b/cypress/e2e/files_sharing/note-to-recipient.cy.ts
@@ -72,7 +72,7 @@ describe('files_sharing: Note to recipient', { testIsolation: true }, () => {
 		createShare('folder', sharee.userId, { read: true, download: true, note: 'Hello, this is the note.' })
 
 		// reload just to be sure
-		cy.reload()
+		cy.visit('/apps/files')
 
 		// open the sharing tab
 		openSharingPanel('folder')


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

cypress test `cypress/e2e/files_sharing/note-to-recipient.cy.ts` was failing a lot in CI. This is an attempt to fix that.

Not 100% clear why the reload makes it flaky, but it seems related. My only guess is that with reload the details panel is already opened maybe?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
