### PR TITLE
fix(files_sharing): bring back owner and ownerDisplayName initial state

### DIFF
--- a/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
+++ b/apps/files_sharing/lib/DefaultPublicShareTemplateProvider.php
@@ -70,8 +70,10 @@ class DefaultPublicShareTemplateProvider implements IPublicShareTemplateProvider
 
 			$ownerNameProperty = $ownerAccount->getProperty(IAccountManager::PROPERTY_DISPLAYNAME);
 			if ($ownerNameProperty->getScope() === IAccountManager::SCOPE_PUBLISHED) {
-				$ownerName = $owner->getDisplayName();
 				$ownerId = $owner->getUID();
+				$ownerName = $owner->getDisplayName();
+				$this->initialState->provideInitialState('owner', $ownerId);
+				$this->initialState->provideInitialState('ownerDisplayName', $ownerName);
 			}
 		}
 

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -330,6 +330,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'filename' => $filename,
 			'view' => $view,
 			'fileId' => 111,
+			'owner' => 'ownerUID',
+			'ownerDisplayName' => 'ownerDisplay',
 		];
 
 		$response = $this->shareController->showShare();
@@ -470,6 +472,8 @@ class ShareControllerTest extends \Test\TestCase {
 			'filename' => $filename,
 			'view' => 'public-file-drop',
 			'disclaimer' => 'My disclaimer text',
+			'owner' => 'ownerUID',
+			'ownerDisplayName' => 'ownerDisplay',
 		];
 
 		$response = $this->shareController->showShare();


### PR DESCRIPTION
Regression from https://github.com/nextcloud/server/pull/45652

It's still being used in https://github.com/nextcloud/server/blob/b27d76059e9b08a35d0aa0aa0c4c7eaee0543e6e/apps/files_sharing/src/views/PublicAuthPrompt.vue#L69-L73