### PR TITLE
perf(caldav): increase chunk size in RemoveOrphanEventsAndContacts repair step

### DIFF
--- a/apps/dav/lib/Migration/RemoveOrphanEventsAndContacts.php
+++ b/apps/dav/lib/Migration/RemoveOrphanEventsAndContacts.php
@@ -77,7 +77,7 @@ class RemoveOrphanEventsAndContacts implements IRepairStep {
 			$qb->delete($childTable)
 				->where($qb->expr()->in('id', $qb->createParameter('ids')));
 
-			$orphanItemsBatch = array_chunk($orphanItems, 200);
+			$orphanItemsBatch = array_chunk($orphanItems, 1000);
 			foreach ($orphanItemsBatch as $items) {
 				$qb->setParameter('ids', $items, IQueryBuilder::PARAM_INT_ARRAY);
 				$qb->executeStatement();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Ref https://github.com/nextcloud/server/issues/52505

## Summary

Should slightly reduce the memory footprint.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
