### PR TITLE
Use PHP 8.4 lazy ghosts for Dependency injection

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3450,53 +3450,9 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="lib/private/AppFramework/Utility/SimpleContainer.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$class->newInstance()]]></code>
-      <code><![CDATA[$class->newInstanceArgs(array_map(function (ReflectionParameter $parameter) {
-			$parameterType = $parameter->getType();
-
-			$resolveName = $parameter->getName();
-
-			// try to find out if it is a class or a simple parameter
-			if ($parameterType !== null && ($parameterType instanceof ReflectionNamedType) && !$parameterType->isBuiltin()) {
-				$resolveName = $parameterType->getName();
-			}
-
-			try {
-				$builtIn = $parameter->hasType() && ($parameter->getType() instanceof ReflectionNamedType)
-					&& $parameter->getType()->isBuiltin();
-				return $this->query($resolveName, !$builtIn);
-			} catch (QueryException $e) {
-				// Service not found, use the default value when available
-				if ($parameter->isDefaultValueAvailable()) {
-					return $parameter->getDefaultValue();
-				}
-
-				if ($parameterType !== null && ($parameterType instanceof ReflectionNamedType) && !$parameterType->isBuiltin()) {
-					$resolveName = $parameter->getName();
-					try {
-						return $this->query($resolveName);
-					} catch (QueryException $e2) {
-						// Pass null if typed and nullable
-						if ($parameter->allowsNull() && ($parameterType instanceof ReflectionNamedType)) {
-							return null;
-						}
-
-						// don't lose the error we got while trying to query by type
-						throw new QueryException($e->getMessage(), (int)$e->getCode(), $e);
-					}
-				}
-
-				throw $e;
-			}
-		}, $constructor->getParameters()))]]></code>
-    </LessSpecificReturnStatement>
     <MissingTemplateParam>
       <code><![CDATA[ArrayAccess]]></code>
     </MissingTemplateParam>
-    <MoreSpecificReturnType>
-      <code><![CDATA[\stdClass]]></code>
-    </MoreSpecificReturnType>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2743,4 +2743,12 @@ $CONFIG = [
  * Defaults to true.
  */
 'files.trash.delete' => true,
+
+/**
+ * Enable lazy objects feature from PHP 8.4 to be used in the Dependency Injection.
+ * Should improve performances by avoiding buiding unused objects.
+ *
+ * Defaults to false.
+ */
+'enable_lazy_objects' => false,
 ];

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2748,7 +2748,7 @@ $CONFIG = [
  * Enable lazy objects feature from PHP 8.4 to be used in the Dependency Injection.
  * Should improve performances by avoiding buiding unused objects.
  *
- * Defaults to false.
+ * Defaults to true.
  */
-'enable_lazy_objects' => false,
+'enable_lazy_objects' => true,
 ];

--- a/lib/base.php
+++ b/lib/base.php
@@ -618,6 +618,9 @@ class OC {
 		}
 		$loaderEnd = microtime(true);
 
+		// Enable lazy loading if activated
+		\OC\AppFramework\Utility\SimpleContainer::$useLazyObjects = (bool)self::$config->getValue('enable_lazy_objects');
+
 		// setup the basic server
 		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);
 		self::$server->boot();

--- a/lib/base.php
+++ b/lib/base.php
@@ -619,7 +619,7 @@ class OC {
 		$loaderEnd = microtime(true);
 
 		// Enable lazy loading if activated
-		\OC\AppFramework\Utility\SimpleContainer::$useLazyObjects = (bool)self::$config->getValue('enable_lazy_objects');
+		\OC\AppFramework\Utility\SimpleContainer::$useLazyObjects = (bool)self::$config->getValue('enable_lazy_objects', true);
 
 		// setup the basic server
 		self::$server = new \OC\Server(\OC::$WEBROOT, self::$config);

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -58,6 +58,7 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 			return $class->newInstance();
 		}
 		return $class->newLazyGhost(function (object $object) use ($constructor): void {
+			/** @psalm-suppress DirectConstructorCall For lazy ghosts we have to call the constructor directly */
 			$object->__construct(...array_map(function (ReflectionParameter $parameter) {
 				$parameterType = $parameter->getType();
 
@@ -69,8 +70,8 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 				}
 
 				try {
-					$builtIn = $parameter->hasType() && ($parameter->getType() instanceof ReflectionNamedType)
-						&& $parameter->getType()->isBuiltin();
+					$builtIn = $parameterType !== null && ($parameterType instanceof ReflectionNamedType)
+								&& $parameterType->isBuiltin();
 					return $this->query($resolveName, !$builtIn);
 				} catch (QueryException $e) {
 					// Service not found, use the default value when available

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -24,6 +24,8 @@ use function class_exists;
  * SimpleContainer is a simple implementation of a container on basis of Pimple
  */
 class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
+	public static bool $useLazyObjects = false;
+
 	private Container $container;
 
 	public function __construct() {
@@ -58,7 +60,7 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 			/* No constructor, return a instance directly */
 			return $class->newInstance();
 		}
-		if (PHP_VERSION_ID >= 80400) {
+		if (PHP_VERSION_ID >= 80400 && self::$useLazyObjects) {
 			/* For PHP>=8.4, use a lazy ghost to delay constructor and dependency resolving */
 			/** @psalm-suppress UndefinedMethod */
 			return $class->newLazyGhost(function (object $object) use ($constructor): void {

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -100,6 +100,9 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 						if ($parameter->allowsNull() && ($parameterType instanceof ReflectionNamedType)) {
 							return null;
 						}
+
+						// don't lose the error we got while trying to query by type
+						throw new QueryException($e->getMessage(), (int)$e->getCode(), $e);
 					}
 				}
 

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -69,6 +69,12 @@ class App {
 					$step['args'][1] === $classNameParts[1]) {
 					$setUpViaQuery = true;
 					break;
+				} elseif (isset($step['class'], $step['function'], $step['args'][0]) &&
+					$step['class'] === \ReflectionClass::class &&
+					$step['function'] === 'initializeLazyObject' &&
+					$step['args'][0] === $this) {
+					$setUpViaQuery = true;
+					break;
 				}
 			}
 

--- a/tests/lib/AppFramework/Utility/SimpleContainerTest.php
+++ b/tests/lib/AppFramework/Utility/SimpleContainerTest.php
@@ -36,7 +36,9 @@ class ClassComplexConstructor {
 }
 
 class ClassNullableUntypedConstructorArg {
+	public $class;
 	public function __construct($class) {
+		$this->class = $class;
 	}
 }
 class ClassNullableTypedConstructorArg {
@@ -217,6 +219,8 @@ class SimpleContainerTest extends \Test\TestCase {
 		$object = $this->container->query(
 			'Test\AppFramework\Utility\ClassComplexConstructor'
 		);
+		/* Use the object to trigger DI on PHP >= 8.4 */
+		get_object_vars($object);
 	}
 
 	public function testRegisterFactory(): void {
@@ -243,7 +247,11 @@ class SimpleContainerTest extends \Test\TestCase {
 	public function testQueryUntypedNullable(): void {
 		$this->expectException(\OCP\AppFramework\QueryException::class);
 
-		$this->container->query(ClassNullableUntypedConstructorArg::class);
+		$object = $this->container->query(
+			ClassNullableUntypedConstructorArg::class
+		);
+		/* Use the object to trigger DI on PHP >= 8.4 */
+		get_object_vars($object);
 	}
 
 	public function testQueryTypedNullable(): void {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/54156)

## Summary

Use the new feature from PHP 8.4 Lazy objects for our Dependency injections system.

It’s not possible to make a ghost for an interface, so it’s only after aliases and so on are resolved that this happens, directly on the class.
It’s active for all classes. It should improve performances either for classes doing stuff in the constructor, or for classes loading a lot of dependencies. Thanks to the lazy ghosts only services which are actually used will be built.
This is only enabled for classes relying on the autobuild, so declarations like:
```php
		$context->registerService(IAuditLogger::class, function (ContainerInterface $c) {
			return new AuditLogger($c->get(ILogFactory::class), $c->get(IConfig::class));
		});
```
will not benefit from it.
They should be replaced by:
```php
		$context->registerServiceAlias(IAuditLogger::class, AuditLogger::class);
```

I’ve seen a measurable improvement of performances on some request with this, I would be interested in a more detailed analysis.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
