### PR TITLE
fix: Forward 'extra' argument when optimizing query

### DIFF
--- a/lib/private/Files/Search/QueryOptimizer/OrEqualsToIn.php
+++ b/lib/private/Files/Search/QueryOptimizer/OrEqualsToIn.php
@@ -32,7 +32,7 @@ class OrEqualsToIn extends ReplacingOptimizerStep {
 						$value = $comparison->getValue();
 						return $value;
 					}, $group);
-					$in = new SearchComparison(ISearchComparison::COMPARE_IN, $field, $values);
+					$in = new SearchComparison(ISearchComparison::COMPARE_IN, $field, $values, $group[0]->getExtra());
 					$pathEqHash = array_reduce($group, function ($pathEqHash, ISearchComparison $comparison) {
 						return $comparison->getQueryHint(ISearchComparison::HINT_PATH_EQ_HASH, true) && $pathEqHash;
 					}, true);

--- a/lib/private/Files/Search/QueryOptimizer/SplitLargeIn.php
+++ b/lib/private/Files/Search/QueryOptimizer/SplitLargeIn.php
@@ -24,7 +24,7 @@ class SplitLargeIn extends ReplacingOptimizerStep {
 		) {
 			$chunks = array_chunk($operator->getValue(), 1000);
 			$chunkComparisons = array_map(function (array $values) use ($operator) {
-				return new SearchComparison(ISearchComparison::COMPARE_IN, $operator->getField(), $values);
+				return new SearchComparison(ISearchComparison::COMPARE_IN, $operator->getField(), $values, $operator->getExtra());
 			}, $chunks);
 
 			$operator = new SearchBinaryOperator(ISearchBinaryOperator::OPERATOR_OR, $chunkComparisons);


### PR DESCRIPTION
This allows DAV SEARCH queries containing optimizable comparisons on files metadata like:

```xml
<d:or>
	<d:eq>
		<d:prop>
			<nc:metadata-photos-place />
		</d:prop>
		<d:literal>La Valette-du-Var</d:literal>
	</d:eq>
	<d:eq>
		<d:prop>
			<nc:metadata-photos-place />
		</d:prop>
		<d:literal>Évenos</d:literal>
	</d:eq>
</d:or>
```
