### PR TITLE
fix(share): assume download enabled on federated share

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -2118,6 +2118,8 @@ class ShareAPIController extends OCSController {
 				$hideDownload = $hideDownload && $originalShare->getHideDownload();
 				// allow download if already allowed by previous share or when the current share allows downloading
 				$canDownload = $canDownload || $inheritedAttributes === null || $inheritedAttributes->getAttribute('permissions', 'download') !== false;
+			} elseif ($node->getStorage()->instanceOfStorage(Storage::class)) {
+				$canDownload = true; // in case of federation storage, we can expect the download to be activated by default
 			}
 		}
 


### PR DESCRIPTION
fix #52060

The logic behind this condition is that if the file originate from a remote instance (federated share), then we can assume that the file is set as downloadable. We only know that for sure when trying to access the remote document.

Meaning that if you reshare it, you can assume that the document is downloadable and enable the checkbox on the share interface. Then the $hideDownload kicks in and disable the download to the final recipient, in case download permission is not kept on the reshare