### PR TITLE
chore(IAccountManager): remove deprecated visibility constants

### DIFF
--- a/build/integration/features/contacts-menu.feature
+++ b/build/integration/features/contacts-menu.feature
@@ -71,8 +71,6 @@ Feature: contacts-menu
     And searched contact "1" is named "Test name"
     And searched contact "2" is named "user2"
 
-
-
   Scenario: users can not be found by display name if visibility is private
     Given user "user0" exists
     And user "user1" exists
@@ -80,11 +78,11 @@ Feature: contacts-menu
     And Logging in using web as "user1"
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
       | displayname | Test name |
-      | displaynameScope | private |
+      | displaynameScope | v2-private |
     And Logging in using web as "user2"
     And Sending a "PUT" to "/settings/users/user2/settings" with requesttoken
       | displayname | Another test name |
-      | displaynameScope | contacts |
+      | displaynameScope | v2-federated |
     When Logging in using web as "user0"
     And searching for contacts matching with "test"
     # Disabled because it regularly fails on drone:
@@ -98,11 +96,11 @@ Feature: contacts-menu
     And Logging in using web as "user1"
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
       | email | test@example.com |
-      | emailScope | private |
+      | emailScope | v2-private |
     And Logging in using web as "user2"
     And Sending a "PUT" to "/settings/users/user2/settings" with requesttoken
       | email | another_test@example.com |
-      | emailScope | contacts |
+      | emailScope | v2-federated |
     # Disabled because it regularly fails on drone:
     # When Logging in using web as "user0"
     # And searching for contacts matching with "test"
@@ -116,15 +114,15 @@ Feature: contacts-menu
     And Logging in using web as "user1"
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
       | displayname | Test name |
-      | displaynameScope | contacts |
+      | displaynameScope | v2-federated |
       | email | test@example.com |
-      | emailScope | private |
+      | emailScope | v2-private |
     And Logging in using web as "user2"
     And Sending a "PUT" to "/settings/users/user2/settings" with requesttoken
       | displayname | Another test name |
-      | displaynameScope | private |
+      | displaynameScope | v2-private |
       | email | another_test@example.com |
-      | emailScope | contacts |
+      | emailScope | v2-federated |
     When Logging in using web as "user0"
     And searching for contacts matching with "test"
     Then the list of searched contacts has "2" contacts
@@ -140,9 +138,9 @@ Feature: contacts-menu
     And Logging in using web as "user1"
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
       | displayname | Test name |
-      | displaynameScope | private |
+      | displaynameScope | v2-private |
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
-      | displaynameScope | contacts |
+      | displaynameScope | v2-federated |
     When Logging in using web as "user0"
     And searching for contacts matching with "test"
     Then the list of searched contacts has "1" contacts
@@ -154,9 +152,9 @@ Feature: contacts-menu
     And Logging in using web as "user1"
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
       | email | test@example.com |
-      | emailScope | private |
+      | emailScope | v2-private |
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
-      | emailScope | contacts |
+      | emailScope | v2-federated |
     # Disabled because it regularly fails on drone:
     # When Logging in using web as "user0"
     # And searching for contacts matching with "test"
@@ -170,7 +168,7 @@ Feature: contacts-menu
     And user "user1" exists
     And Logging in using web as "user1"
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
-      | displaynameScope | private |
+      | displaynameScope | v2-private |
     And As an "admin"
     And sending "PUT" to "/cloud/users/user1" with
       | key | displayname |
@@ -185,7 +183,7 @@ Feature: contacts-menu
     And user "user1" exists
     And Logging in using web as "user1"
     And Sending a "PUT" to "/settings/users/user1/settings" with requesttoken
-      | emailScope | private |
+      | emailScope | v2-private |
     And As an "admin"
     And sending "PUT" to "/cloud/users/user1" with
       | key | email |

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -210,21 +210,6 @@ Feature: provisioning
       | value | v2-published |
     Then the OCS status code should be "100"
     And the HTTP status code should be "200"
-    When sending "PUT" to "/cloud/users/brand-new-user" with
-      | key | websiteScope |
-      | value | public |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    When sending "PUT" to "/cloud/users/brand-new-user" with
-      | key | displaynameScope |
-      | value | contacts |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    When sending "PUT" to "/cloud/users/brand-new-user" with
-      | key | avatarScope |
-      | value | private |
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
     And sending "PUT" to "/cloud/users/brand-new-user" with
       | key | email |
       | value | no-reply@nextcloud.com |
@@ -253,9 +238,6 @@ Feature: provisioning
       | twitterScope | v2-local |
       | addressScope | v2-federated |
       | emailScope | v2-published |
-      | websiteScope | v2-published |
-      | displaynameScope | v2-federated |
-      | avatarScope | v2-local |
 
   Scenario: Edit a user account multivalue property scopes
     Given user "brand-new-user" exists

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -131,9 +131,7 @@ class AccountManager implements IAccountManager {
 				$property->setScope(self::SCOPE_LOCAL);
 			}
 		} else {
-			// migrate scope values to the new format
-			// invalid scopes are mapped to a default value
-			$property->setScope(AccountProperty::mapScopeToV2($property->getScope()));
+			$property->setScope($property->getScope());
 		}
 	}
 

--- a/lib/private/Accounts/AccountProperty.php
+++ b/lib/private/Accounts/AccountProperty.php
@@ -55,16 +55,11 @@ class AccountProperty implements IAccountProperty {
 	 * @since 15.0.0
 	 */
 	public function setScope(string $scope): IAccountProperty {
-		$newScope = $this->mapScopeToV2($scope);
-		if (!in_array($newScope, [
-			IAccountManager::SCOPE_LOCAL,
-			IAccountManager::SCOPE_FEDERATED,
-			IAccountManager::SCOPE_PRIVATE,
-			IAccountManager::SCOPE_PUBLISHED
-		])) {
+		if (!in_array($scope, IAccountManager::ALLOWED_SCOPES, )) {
 			throw new InvalidArgumentException('Invalid scope');
 		}
-		$this->scope = $newScope;
+		/** @var IAccountManager::SCOPE_* $scope */
+		$this->scope = $scope;
 		return $this;
 	}
 
@@ -103,19 +98,6 @@ class AccountProperty implements IAccountProperty {
 	 */
 	public function getScope(): string {
 		return $this->scope;
-	}
-
-	public static function mapScopeToV2(string $scope): string {
-		if (str_starts_with($scope, 'v2-')) {
-			return $scope;
-		}
-
-		return match ($scope) {
-			IAccountManager::VISIBILITY_PRIVATE, '' => IAccountManager::SCOPE_LOCAL,
-			IAccountManager::VISIBILITY_CONTACTS_ONLY => IAccountManager::SCOPE_FEDERATED,
-			IAccountManager::VISIBILITY_PUBLIC => IAccountManager::SCOPE_PUBLISHED,
-			default => $scope,
-		};
 	}
 
 	/**

--- a/lib/public/Accounts/IAccountManager.php
+++ b/lib/public/Accounts/IAccountManager.php
@@ -48,30 +48,6 @@ interface IAccountManager {
 	public const SCOPE_PUBLISHED = 'v2-published';
 
 	/**
-	 * Contact details only visible locally
-	 *
-	 * @since 15.0.0
-	 * @deprecated 21.0.1
-	 */
-	public const VISIBILITY_PRIVATE = 'private';
-
-	/**
-	 * Contact details visible on trusted federated servers.
-	 *
-	 * @since 15.0.0
-	 * @deprecated 21.0.1
-	 */
-	public const VISIBILITY_CONTACTS_ONLY = 'contacts';
-
-	/**
-	 * Contact details visible on trusted federated servers and in the public lookup server.
-	 *
-	 * @since 15.0.0
-	 * @deprecated 21.0.1
-	 */
-	public const VISIBILITY_PUBLIC = 'public';
-
-	/**
 	 * The list of allowed scopes
 	 *
 	 * @since 25.0.0
@@ -81,9 +57,6 @@ interface IAccountManager {
 		self::SCOPE_LOCAL,
 		self::SCOPE_FEDERATED,
 		self::SCOPE_PUBLISHED,
-		self::VISIBILITY_PRIVATE,
-		self::VISIBILITY_CONTACTS_ONLY,
-		self::VISIBILITY_PUBLIC,
 	];
 
 	/**
@@ -98,6 +71,7 @@ interface IAccountManager {
 
 	/**
 	 * @since 27.0.0
+	 * @deprecated 27.0.0 only added for backwards compatibility with provisioning_api UsersController::getCurrentUser
 	 */
 	public const PROPERTY_DISPLAYNAME_LEGACY = 'display-name';
 

--- a/tests/lib/Accounts/AccountPropertyTest.php
+++ b/tests/lib/Accounts/AccountPropertyTest.php
@@ -63,11 +63,6 @@ class AccountPropertyTest extends TestCase {
 			[IAccountManager::SCOPE_LOCAL, IAccountManager::SCOPE_LOCAL],
 			[IAccountManager::SCOPE_FEDERATED, IAccountManager::SCOPE_FEDERATED],
 			[IAccountManager::SCOPE_PUBLISHED, IAccountManager::SCOPE_PUBLISHED],
-			// legacy values
-			[IAccountManager::VISIBILITY_PRIVATE, IAccountManager::SCOPE_LOCAL],
-			[IAccountManager::VISIBILITY_CONTACTS_ONLY, IAccountManager::SCOPE_FEDERATED],
-			[IAccountManager::VISIBILITY_PUBLIC, IAccountManager::SCOPE_PUBLISHED],
-			['', IAccountManager::SCOPE_LOCAL],
 			// invalid values
 			['unknown', null],
 			['v2-unknown', null],


### PR DESCRIPTION
## Summary

Those constants are not used anywhere anymore and are deprecated for more than ten versions.
All legacy scopes should be already migrated as this was done since Nextcloud 21.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
