### PR TITLE
fix(WeatherStatus): Check if result is an array

### DIFF
--- a/apps/weather_status/lib/Service/WeatherStatusService.php
+++ b/apps/weather_status/lib/Service/WeatherStatusService.php
@@ -257,12 +257,19 @@ class WeatherStatusService {
 		];
 		$url = 'https://nominatim.openstreetmap.org/search';
 		$results = $this->requestJSON($url, $params);
-		if ($results['error'] !== null) {
-			return $results;
+
+		if (isset($results['error'])) {
+			return ['error' => (string)$results['error']];
 		}
-		if (count($results) > 0) {
-			return $results[0];
+
+		if (count($results) > 0 && is_array($results[0])) {
+			return [
+				'display_name' => (string)($results[0]['display_name'] ?? null),
+				'lat' => (string)($results[0]['lat'] ?? null),
+				'lon' => (string)($results[0]['lon'] ?? null),
+			];
 		}
+
 		return ['error' => $this->l10n->t('No result.')];
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fix:

```
{
  "reqId": "JbpwgXOXkV33ULwTfBku",
  "level": 3,
  "time": "2025-04-29T16:39:11+02:00",
  "remoteAddr": "6.17.12.8",
  "user": "ezdf",
  "app": "PHP",
  "method": "PUT",
  "url": "/ocs/v2.php/apps/weather_status/api/v1/location",
  "message": "Undefined array key \"error\" at /var/www/nextcloud/apps/weather_status/lib/Service/WeatherStatusService.php#260",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
  "version": "30.0.9.2",
  "data": {
    "app": "PHP"
  },
  "id": "6811b29447190"
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
