### PR TITLE
chore: ignore coding-standard PRs from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,4 +4,4 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 # Update to coding-standard 1.2.2
-98d8ae805eb6ff38e60237ad4b599605df981322
+832f79ac9388addeb2b22479c6da1ac46eea205c


### PR DESCRIPTION
Make git blame more useful by ignoring the correct git hash (show the real author instead of just the one that applied code style).