### PR TITLE
fix: Flaky samba kerberos tests

### DIFF
--- a/.github/workflows/files-external-smb-kerberos.yml
+++ b/.github/workflows/files-external-smb-kerberos.yml
@@ -83,6 +83,18 @@ jobs:
         run: |
           apps/files_external/tests/sso-setup/test-sso-smb.sh ${{ env.DC_IP }}
 
+      - name: Show logs DC
+        if: always()
+        run: |
+          docker logs dc
+          echo "------------"
+          docker exec dc cat /var/log/samba/log.samba
+
+      - name: Show logs Apache
+        if: always()
+        run: |
+          docker logs apache
+
       - name: Show logs
         if: always()
         run: |

--- a/apps/files_external/tests/sso-setup/start-apache.sh
+++ b/apps/files_external/tests/sso-setup/start-apache.sh
@@ -15,6 +15,9 @@ APACHE_IP=$(docker inspect apache --format '{{.NetworkSettings.IPAddress}}')
 docker exec apache chown 33 /var/www/html/config /var/www/html/data /var/www/html/extra-apps
 docker cp "$SCRIPT_DIR/apps.config.php" apache:/var/www/html/config/apps.config.php
 
+# ensure that samba is started (see https://github.com/icewind1991/samba-krb-test/pull/8)
+docker exec dc service samba-ad-dc status || docker exec dc service samba-ad-dc start
+
 # add the dns record for apache
 docker exec dc samba-tool dns add krb.domain.test domain.test httpd A $APACHE_IP -U administrator --password=passwOrd1 1>&2
 


### PR DESCRIPTION
 The samba kerberos tests have become flaky "lately". After some debugging, it became clear, that samba in the dc container is not running when the tests are failing. The reason is that on start / restart of samba, the port 389 is still being used which terminates samba.

See https://github.com/nextcloud/server/actions/runs/14765943837/job/41457286732#step:6:124 for a debug run.
So there's no problem with the test itself, but with the test environment. The real fix seems to be https://github.com/icewind1991/samba-krb-test/pull/8.

For now we can also ensure that samba is running to not fail the tests.
