### PR TITLE
fix(throttler): Always use the sleepDelayOrThrowOnMax instead of deprecated sleepDelay

### DIFF
--- a/apps/dav/lib/Direct/DirectHome.php
+++ b/apps/dav/lib/Direct/DirectHome.php
@@ -53,7 +53,7 @@ class DirectHome implements ICollection {
 		} catch (DoesNotExistException $e) {
 			// Since the token space is so huge only throttle on non-existing token
 			$this->throttler->registerAttempt('directlink', $this->request->getRemoteAddress());
-			$this->throttler->sleepDelay($this->request->getRemoteAddress(), 'directlink');
+			$this->throttler->sleepDelayOrThrowOnMax($this->request->getRemoteAddress(), 'directlink');
 
 			throw new NotFound();
 		}

--- a/apps/dav/lib/Files/BrowserErrorPagePlugin.php
+++ b/apps/dav/lib/Files/BrowserErrorPagePlugin.php
@@ -11,6 +11,7 @@ use OC\AppFramework\Http\Request;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
+use OCP\Security\Bruteforce\MaxDelayReached;
 use OCP\Template\ITemplateManager;
 use Sabre\DAV\Exception;
 use Sabre\DAV\Server;
@@ -60,6 +61,9 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 		if ($ex instanceof Exception) {
 			$httpCode = $ex->getHTTPCode();
 			$headers = $ex->getHTTPHeaders($this->server);
+		} elseif ($ex instanceof MaxDelayReached) {
+			$httpCode = 429;
+			$headers = [];
 		} else {
 			$httpCode = 500;
 			$headers = [];
@@ -81,7 +85,7 @@ class BrowserErrorPagePlugin extends ServerPlugin {
 		$request = \OCP\Server::get(IRequest::class);
 
 		$templateName = 'exception';
-		if ($httpCode === 403 || $httpCode === 404) {
+		if ($httpCode === 403 || $httpCode === 404 || $httpCode === 429) {
 			$templateName = (string)$httpCode;
 		}
 

--- a/apps/dav/tests/unit/Direct/DirectHomeTest.php
+++ b/apps/dav/tests/unit/Direct/DirectHomeTest.php
@@ -160,7 +160,7 @@ class DirectHomeTest extends TestCase {
 				'1.2.3.4'
 			);
 		$this->throttler->expects($this->once())
-			->method('sleepDelay')
+			->method('sleepDelayOrThrowOnMax')
 			->with(
 				'1.2.3.4',
 				'directlink'

--- a/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
+++ b/lib/private/AppFramework/Middleware/PublicShare/PublicShareMiddleware.php
@@ -120,7 +120,7 @@ class PublicShareMiddleware extends Middleware {
 
 	private function throttle($bruteforceProtectionAction, $token): void {
 		$ip = $this->request->getRemoteAddress();
-		$this->throttler->sleepDelay($ip, $bruteforceProtectionAction);
+		$this->throttler->sleepDelayOrThrowOnMax($ip, $bruteforceProtectionAction);
 		$this->throttler->registerAttempt($bruteforceProtectionAction, $ip, ['token' => $token]);
 	}
 }

--- a/lib/private/Security/Bruteforce/Throttler.php
+++ b/lib/private/Security/Bruteforce/Throttler.php
@@ -127,6 +127,13 @@ class Throttler implements IThrottler {
 	 */
 	public function getDelay(string $ip, string $action = ''): int {
 		$attempts = $this->getAttempts($ip, $action);
+		return $this->calculateDelay($attempts);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function calculateDelay(int $attempts): int {
 		if ($attempts === 0) {
 			return 0;
 		}
@@ -199,25 +206,29 @@ class Throttler implements IThrottler {
 	 * {@inheritDoc}
 	 */
 	public function sleepDelayOrThrowOnMax(string $ip, string $action = ''): int {
-		$delay = $this->getDelay($ip, $action);
-		if (($delay === self::MAX_DELAY_MS) && $this->getAttempts($ip, $action, 0.5) > $this->config->getSystemValueInt('auth.bruteforce.max-attempts', self::MAX_ATTEMPTS)) {
-			$this->logger->info('IP address blocked because it reached the maximum failed attempts in the last 30 minutes [action: {action}, ip: {ip}]', [
+		$attempts = $this->getAttempts($ip, $action, 0.5);
+		if ($attempts > $this->config->getSystemValueInt('auth.bruteforce.max-attempts', self::MAX_ATTEMPTS)) {
+			$this->logger->info('IP address blocked because it reached the maximum failed attempts in the last 30 minutes [action: {action}, attempts: {attempts}, ip: {ip}]', [
 				'action' => $action,
 				'ip' => $ip,
+				'attempts' => $attempts,
 			]);
 			// If the ip made too many attempts within the last 30 mins we don't execute anymore
 			throw new MaxDelayReached('Reached maximum delay');
 		}
-		if ($delay > 100) {
-			$this->logger->info('IP address throttled because it reached the attempts limit in the last 30 minutes [action: {action}, delay: {delay}, ip: {ip}]', [
+
+		$attempts = $this->getAttempts($ip, $action);
+		if ($attempts > 10) {
+			$this->logger->info('IP address throttled because it reached the attempts limit in the last 12 hours [action: {action}, attempts: {attempts}, ip: {ip}]', [
 				'action' => $action,
 				'ip' => $ip,
-				'delay' => $delay,
+				'attempts' => $attempts,
 			]);
 		}
-		if (!$this->config->getSystemValueBool('auth.bruteforce.protection.testing')) {
-			usleep($delay * 1000);
+		if ($attempts > 0) {
+			return $this->calculateDelay($attempts);
 		}
-		return $delay;
+
+		return 0;
 	}
 }


### PR DESCRIPTION
- Additionally removing the actual sleep when throwing method is used, as it is not adding benefit when it's being aborted with 429 in other cases anyway.
- Also fixes internal server error that was shown when being throttled on public sharing webdav endpoints

Before | After
---|---
![grafik](https://github.com/user-attachments/assets/923a8f94-3f64-441d-9162-42b9c79efc28) | ![grafik](https://github.com/user-attachments/assets/a2e5bbca-f850-4ab1-b803-aea419def0e4)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
