### PR TITLE
fix(loginflow): Fix type error when password could not be decrypted

### DIFF
--- a/core/Service/LoginFlowV2Service.php
+++ b/core/Service/LoginFlowV2Service.php
@@ -63,8 +63,12 @@ class LoginFlowV2Service {
 		try {
 			// Decrypt the apptoken
 			$privateKey = $this->crypto->decrypt($data->getPrivateKey(), $pollToken);
-			$appPassword = $this->decryptPassword($data->getAppPassword(), $privateKey);
-		} catch (\Exception $e) {
+		} catch (\Exception) {
+			throw new LoginFlowV2NotFoundException('Apptoken could not be decrypted');
+		}
+
+		$appPassword = $this->decryptPassword($data->getAppPassword(), $privateKey);
+		if ($appPassword === null) {
 			throw new LoginFlowV2NotFoundException('Apptoken could not be decrypted');
 		}
 
@@ -251,10 +255,10 @@ class LoginFlowV2Service {
 		return $encryptedPassword;
 	}
 
-	private function decryptPassword(string $encryptedPassword, string $privateKey): string {
+	private function decryptPassword(string $encryptedPassword, string $privateKey): ?string {
 		$encryptedPassword = base64_decode($encryptedPassword);
-		openssl_private_decrypt($encryptedPassword, $password, $privateKey, OPENSSL_PKCS1_OAEP_PADDING);
+		$success = openssl_private_decrypt($encryptedPassword, $password, $privateKey, OPENSSL_PKCS1_OAEP_PADDING);
 
-		return $password;
+		return $success ? $password : null;
 	}
 }

--- a/tests/Core/Service/LoginFlowV2ServiceUnitTest.php
+++ b/tests/Core/Service/LoginFlowV2ServiceUnitTest.php
@@ -128,10 +128,13 @@ class LoginFlowV2ServiceUnitTest extends TestCase {
 	/*
 	 * Tests for poll
 	 */
-
-	public function testPollApptokenCouldNotBeDecrypted(): void {
+	public function testPollPrivateKeyCouldNotBeDecrypted(): void {
 		$this->expectException(LoginFlowV2NotFoundException::class);
 		$this->expectExceptionMessage('Apptoken could not be decrypted');
+
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->willThrowException(new \Exception('HMAC mismatch'));
 
 		/*
 		 * Cannot be mocked, because functions like getLoginName are magic functions.
@@ -148,6 +151,32 @@ class LoginFlowV2ServiceUnitTest extends TestCase {
 			->willReturn($loginFlowV2);
 
 		$this->subjectUnderTest->poll('');
+	}
+
+	public function testPollApptokenCouldNotBeDecrypted(): void {
+		$this->expectException(LoginFlowV2NotFoundException::class);
+		$this->expectExceptionMessage('Apptoken could not be decrypted');
+
+		/*
+		 * Cannot be mocked, because functions like getLoginName are magic functions.
+		 * To be able to set internal properties, we have to use the real class here.
+		 */
+		[$encrypted, $privateKey,] = $this->getOpenSSLEncryptedPublicAndPrivateKey('test');
+		$loginFlowV2 = new LoginFlowV2();
+		$loginFlowV2->setLoginName('test');
+		$loginFlowV2->setServer('test');
+		$loginFlowV2->setAppPassword('broken#' . $encrypted);
+		$loginFlowV2->setPrivateKey('encrypted(test)');
+
+		$this->crypto->expects($this->once())
+			->method('decrypt')
+			->willReturn($privateKey);
+
+		$this->mapper->expects($this->once())
+			->method('getByPollToken')
+			->willReturn($loginFlowV2);
+
+		$this->subjectUnderTest->poll('test');
 	}
 
 	public function testPollInvalidToken(): void {


### PR DESCRIPTION
Seems to be only a theoretical problem when or when breaking things intentionally in the database. But better save then sorry. [`openssl_private_decrypt`](https://www.php.net/manual/en/function.openssl-private-decrypt.php) returns null, instead of throws, when it failed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
