### PR TITLE
add lexicon support to files_external

### DIFF
--- a/apps/files_external/composer/composer/autoload_classmap.php
+++ b/apps/files_external/composer/composer/autoload_classmap.php
@@ -22,6 +22,7 @@ return array(
     'OCA\\Files_External\\Command\\Scan' => $baseDir . '/../lib/Command/Scan.php',
     'OCA\\Files_External\\Command\\StorageAuthBase' => $baseDir . '/../lib/Command/StorageAuthBase.php',
     'OCA\\Files_External\\Command\\Verify' => $baseDir . '/../lib/Command/Verify.php',
+    'OCA\\Files_External\\ConfigLexicon' => $baseDir . '/../lib/ConfigLexicon.php',
     'OCA\\Files_External\\Config\\ConfigAdapter' => $baseDir . '/../lib/Config/ConfigAdapter.php',
     'OCA\\Files_External\\Config\\ExternalMountPoint' => $baseDir . '/../lib/Config/ExternalMountPoint.php',
     'OCA\\Files_External\\Config\\IConfigHandler' => $baseDir . '/../lib/Config/IConfigHandler.php',

--- a/apps/files_external/composer/composer/autoload_static.php
+++ b/apps/files_external/composer/composer/autoload_static.php
@@ -37,6 +37,7 @@ class ComposerStaticInitFiles_External
         'OCA\\Files_External\\Command\\Scan' => __DIR__ . '/..' . '/../lib/Command/Scan.php',
         'OCA\\Files_External\\Command\\StorageAuthBase' => __DIR__ . '/..' . '/../lib/Command/StorageAuthBase.php',
         'OCA\\Files_External\\Command\\Verify' => __DIR__ . '/..' . '/../lib/Command/Verify.php',
+        'OCA\\Files_External\\ConfigLexicon' => __DIR__ . '/..' . '/../lib/ConfigLexicon.php',
         'OCA\\Files_External\\Config\\ConfigAdapter' => __DIR__ . '/..' . '/../lib/Config/ConfigAdapter.php',
         'OCA\\Files_External\\Config\\ExternalMountPoint' => __DIR__ . '/..' . '/../lib/Config/ExternalMountPoint.php',
         'OCA\\Files_External\\Config\\IConfigHandler' => __DIR__ . '/..' . '/../lib/Config/IConfigHandler.php',

--- a/apps/files_external/lib/AppInfo/Application.php
+++ b/apps/files_external/lib/AppInfo/Application.php
@@ -9,6 +9,7 @@ namespace OCA\Files_External\AppInfo;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files_External\Config\ConfigAdapter;
 use OCA\Files_External\Config\UserPlaceholderHandler;
+use OCA\Files_External\ConfigLexicon;
 use OCA\Files_External\Lib\Auth\AmazonS3\AccessKey;
 use OCA\Files_External\Lib\Auth\Builtin;
 use OCA\Files_External\Lib\Auth\NullMechanism;
@@ -73,6 +74,7 @@ class Application extends App implements IBackendProvider, IAuthMechanismProvide
 		$context->registerEventListener(UserDeletedEvent::class, UserDeletedListener::class);
 		$context->registerEventListener(GroupDeletedEvent::class, GroupDeletedListener::class);
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, LoadAdditionalListener::class);
+		$context->registerConfigLexicon(ConfigLexicon::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/apps/files_external/lib/ConfigLexicon.php
+++ b/apps/files_external/lib/ConfigLexicon.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_External;
+
+use NCU\Config\Lexicon\ConfigLexiconEntry;
+use NCU\Config\Lexicon\ConfigLexiconStrictness;
+use NCU\Config\Lexicon\IConfigLexicon;
+use NCU\Config\ValueType;
+
+/**
+ * Config Lexicon for files_sharing.
+ *
+ * Please Add & Manage your Config Keys in that file and keep the Lexicon up to date!
+ *
+ * {@see IConfigLexicon}
+ */
+class ConfigLexicon implements IConfigLexicon {
+	public const ALLOW_USER_MOUNTING = 'allow_user_mounting';
+	public const USER_MOUNTING_BACKENDS = 'user_mounting_backends';
+
+	public function getStrictness(): ConfigLexiconStrictness {
+		return ConfigLexiconStrictness::NOTICE;
+	}
+
+	public function getAppConfigs(): array {
+		return [
+			new ConfigLexiconEntry(self::ALLOW_USER_MOUNTING, ValueType::BOOL, false, 'allow users to mount their own external filesystems', true),
+			new ConfigLexiconEntry(self::USER_MOUNTING_BACKENDS, ValueType::STRING, '', 'list of mounting backends available for users', true),
+		];
+	}
+
+	public function getUserConfigs(): array {
+		return [];
+	}
+}

--- a/apps/files_external/lib/Listener/LoadAdditionalListener.php
+++ b/apps/files_external/lib/Listener/LoadAdditionalListener.php
@@ -10,10 +10,11 @@ namespace OCA\Files_External\Listener;
 
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\Files_External\AppInfo\Application;
+use OCA\Files_External\ConfigLexicon;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Util;
 
 /**
@@ -22,7 +23,7 @@ use OCP\Util;
 class LoadAdditionalListener implements IEventListener {
 
 	public function __construct(
-		private IConfig $config,
+		private readonly IAppConfig $appConfig,
 		private IInitialState $initialState,
 	) {
 	}
@@ -32,7 +33,7 @@ class LoadAdditionalListener implements IEventListener {
 			return;
 		}
 
-		$allowUserMounting = $this->config->getAppValue('files_external', 'allow_user_mounting', 'no') === 'yes';
+		$allowUserMounting = $this->appConfig->getValueBool('files_external', ConfigLexicon::ALLOW_USER_MOUNTING);
 		$this->initialState->provideInitialState('allowUserMounting', $allowUserMounting);
 
 		Util::addInitScript(Application::APP_ID, 'init');

--- a/apps/files_external/lib/Service/BackendService.php
+++ b/apps/files_external/lib/Service/BackendService.php
@@ -7,14 +7,14 @@
 namespace OCA\Files_External\Service;
 
 use OCA\Files_External\Config\IConfigHandler;
+use OCA\Files_External\ConfigLexicon;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Backend\Backend;
-
 use OCA\Files_External\Lib\Config\IAuthMechanismProvider;
 use OCA\Files_External\Lib\Config\IBackendProvider;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IConfig;
+use OCP\IAppConfig;
 use OCP\Server;
 
 /**
@@ -56,19 +56,12 @@ class BackendService {
 
 	private $configHandlers = [];
 
-	/**
-	 * @param IConfig $config
-	 */
 	public function __construct(
-		protected IConfig $config,
+		protected IAppConfig $appConfig,
 	) {
 		// Load config values
-		if ($this->config->getAppValue('files_external', 'allow_user_mounting', 'yes') !== 'yes') {
-			$this->userMountingAllowed = false;
-		}
-		$this->userMountingBackends = explode(',',
-			$this->config->getAppValue('files_external', 'user_mounting_backends', '')
-		);
+		$this->userMountingAllowed = $appConfig->getValueBool('files_external', ConfigLexicon::ALLOW_USER_MOUNTING);
+		$this->userMountingBackends = explode(',', $appConfig->getValueString('files_external', ConfigLexicon::USER_MOUNTING_BACKENDS));
 
 		// if no backend is in the list an empty string is in the array and user mounting is disabled
 		if ($this->userMountingBackends === ['']) {


### PR DESCRIPTION
Add ConfigLexicon to files_external, notice is generated when using unknown config key 