### PR TITLE
iAppConfig: getValueType() get data from lexicon if available

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -488,6 +488,14 @@ class AppConfig implements IAppConfig {
 	 * @see VALUE_ARRAY
 	 */
 	public function getValueType(string $app, string $key, ?bool $lazy = null): int {
+		$type = self::VALUE_MIXED;
+		$ignorable = $lazy ?? false;
+		$this->matchAndApplyLexiconDefinition($app, $key, $ignorable, $type);
+		if ($type !== self::VALUE_MIXED) {
+			// a modified $type means config key is set in Lexicon
+			return $type;
+		}
+
 		$this->assertParams($app, $key);
 		$this->loadConfig($app, $lazy);
 


### PR DESCRIPTION
Enforce the correct value type when setting a config (via `occ`) defined in the Lexicon:

```
$ ./occ config:app:set my_app enable_something --value 'not_a_boolean'

In SetConfig.php line 194:
                                                        
  Value is not a boolean, please use 'true' or 'false'  
```                                                        

