### PR TITLE
test(comments): Make Comments test result output properly readable

### DIFF
--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -22,6 +24,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IInitialStateService;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -50,15 +53,9 @@ class ManagerTest extends TestCase {
 	}
 
 	protected function addDatabaseEntry($parentId, $topmostParentId, $creationDT = null, $latestChildDT = null, $objectId = null, $expireDate = null) {
-		if (is_null($creationDT)) {
-			$creationDT = new \DateTime();
-		}
-		if (is_null($latestChildDT)) {
-			$latestChildDT = new \DateTime('yesterday');
-		}
-		if (is_null($objectId)) {
-			$objectId = 'file64';
-		}
+		$creationDT ??= new \DateTime();
+		$latestChildDT ??= new \DateTime('yesterday');
+		$objectId ??= 'file64';
 
 		$qb = $this->connection->getQueryBuilder();
 		$qb
@@ -79,7 +76,7 @@ class ManagerTest extends TestCase {
 				'reference_id' => $qb->createNamedParameter('referenceId'),
 				'meta_data' => $qb->createNamedParameter(json_encode(['last_edit_actor_id' => 'admin'])),
 			])
-			->execute();
+			->executeStatement();
 
 		return $qb->getLastInsertId();
 	}
@@ -116,10 +113,10 @@ class ManagerTest extends TestCase {
 	public function testGetComment(): void {
 		$manager = $this->getManager();
 
-		$creationDT = new \DateTime();
-		$latestChildDT = new \DateTime('yesterday');
+		$creationDT = new \DateTime('yesterday');
+		$latestChildDT = new \DateTime();
 
-		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb = \OCP\Server::get(IDBConnection::class)->getQueryBuilder();
 		$qb
 			->insert('comments')
 			->values([
@@ -137,26 +134,26 @@ class ManagerTest extends TestCase {
 				'reference_id' => $qb->createNamedParameter('referenceId'),
 				'meta_data' => $qb->createNamedParameter(json_encode(['last_edit_actor_id' => 'admin'])),
 			])
-			->execute();
+			->executeStatement();
 
-		$id = strval($qb->getLastInsertId());
+		$id = (string)$qb->getLastInsertId();
 
 		$comment = $manager->get($id);
-		$this->assertTrue($comment instanceof IComment);
-		$this->assertSame($comment->getId(), $id);
-		$this->assertSame($comment->getParentId(), '2');
-		$this->assertSame($comment->getTopmostParentId(), '1');
-		$this->assertSame($comment->getChildrenCount(), 2);
-		$this->assertSame($comment->getActorType(), 'users');
-		$this->assertSame($comment->getActorId(), 'alice');
-		$this->assertSame($comment->getMessage(), 'nice one');
-		$this->assertSame($comment->getVerb(), 'comment');
-		$this->assertSame($comment->getObjectType(), 'files');
-		$this->assertSame($comment->getObjectId(), 'file64');
-		$this->assertEquals($comment->getCreationDateTime()->getTimestamp(), $creationDT->getTimestamp());
-		$this->assertEquals($comment->getLatestChildDateTime(), $latestChildDT);
-		$this->assertEquals($comment->getReferenceId(), 'referenceId');
-		$this->assertEquals($comment->getMetaData(), ['last_edit_actor_id' => 'admin']);
+		$this->assertInstanceOf(IComment::class, $comment);
+		$this->assertSame($id, $comment->getId());
+		$this->assertSame('2', $comment->getParentId());
+		$this->assertSame('1', $comment->getTopmostParentId());
+		$this->assertSame(2, $comment->getChildrenCount());
+		$this->assertSame('users', $comment->getActorType());
+		$this->assertSame('alice', $comment->getActorId());
+		$this->assertSame('nice one', $comment->getMessage());
+		$this->assertSame('comment', $comment->getVerb());
+		$this->assertSame('files', $comment->getObjectType());
+		$this->assertSame('file64', $comment->getObjectId());
+		$this->assertEquals($creationDT->getTimestamp(), $comment->getCreationDateTime()->getTimestamp());
+		$this->assertEquals($latestChildDT->getTimestamp(), $comment->getLatestChildDateTime()->getTimestamp());
+		$this->assertEquals('referenceId',  $comment->getReferenceId());
+		$this->assertEquals(['last_edit_actor_id' => 'admin'], $comment->getMetaData());
 	}
 
 
@@ -186,17 +183,17 @@ class ManagerTest extends TestCase {
 		$tree = $manager->getTree($headId);
 
 		// Verifying the root comment
-		$this->assertTrue(isset($tree['comment']));
-		$this->assertTrue($tree['comment'] instanceof IComment);
-		$this->assertSame($tree['comment']->getId(), strval($headId));
-		$this->assertTrue(isset($tree['replies']));
-		$this->assertSame(count($tree['replies']), 3);
+		$this->assertArrayHasKey('comment', $tree);
+		$this->assertInstanceOf(IComment::class, $tree['comment']);
+		$this->assertSame((string)$headId, $tree['comment']->getId());
+		$this->assertArrayHasKey('replies', $tree);
+		$this->assertCount(3, $tree['replies']);
 
 		// one level deep
 		foreach ($tree['replies'] as $reply) {
-			$this->assertTrue($reply['comment'] instanceof IComment);
-			$this->assertSame($reply['comment']->getId(), strval($id));
-			$this->assertSame(count($reply['replies']), 0);
+			$this->assertInstanceOf(IComment::class, $reply['comment']);
+			$this->assertSame((string)$id, $reply['comment']->getId());
+			$this->assertCount(0, $reply['replies']);
 			$id--;
 		}
 	}
@@ -208,16 +205,11 @@ class ManagerTest extends TestCase {
 		$tree = $manager->getTree($id);
 
 		// Verifying the root comment
-		$this->assertTrue(isset($tree['comment']));
-		$this->assertTrue($tree['comment'] instanceof IComment);
-		$this->assertSame($tree['comment']->getId(), strval($id));
-		$this->assertTrue(isset($tree['replies']));
-		$this->assertSame(count($tree['replies']), 0);
-
-		// one level deep
-		foreach ($tree['replies'] as $reply) {
-			throw new \Exception('This ain`t happen');
-		}
+		$this->assertArrayHasKey('comment', $tree);
+		$this->assertInstanceOf(IComment::class, $tree['comment']);
+		$this->assertSame((string)$id, $tree['comment']->getId());
+		$this->assertArrayHasKey('replies', $tree);
+		$this->assertCount(0, $tree['replies']);
 	}
 
 	public function testGetTreeWithLimitAndOffset(): void {
@@ -231,20 +223,20 @@ class ManagerTest extends TestCase {
 		$manager = $this->getManager();
 
 		for ($offset = 0; $offset < 3; $offset += 2) {
-			$tree = $manager->getTree(strval($headId), 2, $offset);
+			$tree = $manager->getTree((string)$headId, 2, $offset);
 
 			// Verifying the root comment
-			$this->assertTrue(isset($tree['comment']));
-			$this->assertTrue($tree['comment'] instanceof IComment);
-			$this->assertSame($tree['comment']->getId(), strval($headId));
-			$this->assertTrue(isset($tree['replies']));
-			$this->assertSame(count($tree['replies']), 2);
+			$this->assertArrayHasKey('comment', $tree);
+			$this->assertInstanceOf(IComment::class, $tree['comment']);
+			$this->assertSame((string)$headId, $tree['comment']->getId());
+			$this->assertArrayHasKey('replies', $tree);
+			$this->assertCount(2, $tree['replies']);
 
 			// one level deep
 			foreach ($tree['replies'] as $reply) {
-				$this->assertTrue($reply['comment'] instanceof IComment);
-				$this->assertSame($reply['comment']->getId(), strval($idToVerify));
-				$this->assertSame(count($reply['replies']), 0);
+				$this->assertInstanceOf(IComment::class, $reply['comment']);
+				$this->assertSame((string)$idToVerify, $reply['comment']->getId());
+				$this->assertCount(0, $reply['replies']);
 				$idToVerify--;
 			}
 		}
@@ -256,10 +248,10 @@ class ManagerTest extends TestCase {
 		$manager = $this->getManager();
 		$comments = $manager->getForObject('files', 'file64');
 
-		$this->assertTrue(is_array($comments));
-		$this->assertSame(count($comments), 1);
-		$this->assertTrue($comments[0] instanceof IComment);
-		$this->assertSame($comments[0]->getMessage(), 'nice one');
+		$this->assertIsArray($comments);
+		$this->assertCount(1, $comments);
+		$this->assertInstanceOf(IComment::class, $comments[0]);
+		$this->assertSame('nice one', $comments[0]->getMessage());
 	}
 
 	public function testGetForObjectWithLimitAndOffset(): void {
@@ -276,11 +268,11 @@ class ManagerTest extends TestCase {
 		do {
 			$comments = $manager->getForObject('files', 'file64', 3, $offset);
 
-			$this->assertTrue(is_array($comments));
-			foreach ($comments as $comment) {
-				$this->assertTrue($comment instanceof IComment);
-				$this->assertSame($comment->getMessage(), 'nice one');
-				$this->assertSame($comment->getId(), strval($idToVerify));
+			$this->assertIsArray($comments);
+			foreach ($comments as $key => $comment) {
+				$this->assertInstanceOf(IComment::class, $comment);
+				$this->assertSame('nice one', $comment->getMessage());
+				$this->assertSame((string)$idToVerify, $comment->getId(), 'ID wrong for comment ' . $key . ' on offset: ' . $offset);
 				$idToVerify--;
 			}
 			$offset += 3;
@@ -296,9 +288,9 @@ class ManagerTest extends TestCase {
 		$manager = $this->getManager();
 		$comments = $manager->getForObject('files', 'file64', 0, 0, new \DateTime('-4 hours'));
 
-		$this->assertSame(count($comments), 2);
-		$this->assertSame($comments[0]->getId(), strval($id2));
-		$this->assertSame($comments[1]->getId(), strval($id1));
+		$this->assertCount(2, $comments);
+		$this->assertSame((string)$id2, $comments[0]->getId());
+		$this->assertSame((string)$id1, $comments[1]->getId());
 	}
 
 	public function testGetForObjectWithLimitAndOffsetAndDateTimeConstraint(): void {
@@ -315,12 +307,12 @@ class ManagerTest extends TestCase {
 		do {
 			$comments = $manager->getForObject('files', 'file64', 3, $offset, new \DateTime('-4 hours'));
 
-			$this->assertTrue(is_array($comments));
+			$this->assertIsArray($comments);
 			foreach ($comments as $comment) {
-				$this->assertTrue($comment instanceof IComment);
-				$this->assertSame($comment->getMessage(), 'nice one');
-				$this->assertSame($comment->getId(), strval($idToVerify));
-				$this->assertTrue(intval($comment->getId()) >= 4);
+				$this->assertInstanceOf(IComment::class, $comment);
+				$this->assertSame('nice one', $comment->getMessage());
+				$this->assertSame((string)$idToVerify, $comment->getId());
+				$this->assertGreaterThanOrEqual(4, $comment->getId());
 				$idToVerify--;
 			}
 			$offset += 3;
@@ -335,10 +327,10 @@ class ManagerTest extends TestCase {
 		$manager = $this->getManager();
 
 		$amount = $manager->getNumberOfCommentsForObject('untype', '00');
-		$this->assertSame($amount, 0);
+		$this->assertSame(0, $amount);
 
 		$amount = $manager->getNumberOfCommentsForObject('files', 'file64');
-		$this->assertSame($amount, 4);
+		$this->assertSame(4, $amount);
 	}
 
 	public function testGetNumberOfUnreadCommentsForFolder(): void {
@@ -386,13 +378,8 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataGetForObjectSince
-	 * @param $lastKnown
-	 * @param $order
-	 * @param $limit
-	 * @param $resultFrom
-	 * @param $resultTo
 	 */
-	public function testGetForObjectSince($lastKnown, $order, $limit, $resultFrom, $resultTo): void {
+	public function testGetForObjectSince(?int $lastKnown, string $order, int $limit, int $resultFrom, int $resultTo): void {
 		$ids = [];
 		$ids[] = $this->addDatabaseEntry(0, 0);
 		$ids[] = $this->addDatabaseEntry(0, 0);
@@ -408,12 +395,10 @@ class ManagerTest extends TestCase {
 			$expected = array_reverse($expected);
 		}
 
-		$this->assertSame($expected, array_map(function (IComment $c) {
-			return (int)$c->getId();
-		}, $comments));
+		$this->assertSame($expected, array_map(static fn (IComment $c): int => (int)$c->getId(), $comments));
 	}
 
-	public function dataGetForObjectSince() {
+	public static function dataGetForObjectSince(): array {
 		return [
 			[null, 'asc', 20, 0, 4],
 			[null, 'asc', 2, 0, 1],
@@ -426,7 +411,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	public function invalidCreateArgsProvider() {
+	public static function invalidCreateArgsProvider(): array {
 		return [
 			['', 'aId-1', 'oType-1', 'oId-1'],
 			['aType-1', '', 'oType-1', 'oId-1'],
@@ -441,12 +426,8 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * @dataProvider invalidCreateArgsProvider
-	 * @param string $aType
-	 * @param string $aId
-	 * @param string $oType
-	 * @param string $oId
 	 */
-	public function testCreateCommentInvalidArguments($aType, $aId, $oType, $oId): void {
+	public function testCreateCommentInvalidArguments(string|int $aType, string|int $aId, string|int $oType, string|int $oId): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$manager = $this->getManager();
@@ -460,11 +441,11 @@ class ManagerTest extends TestCase {
 		$objectId = 'bielefeld';
 
 		$comment = $this->getManager()->create($actorType, $actorId, $objectType, $objectId);
-		$this->assertTrue($comment instanceof IComment);
-		$this->assertSame($comment->getActorType(), $actorType);
-		$this->assertSame($comment->getActorId(), $actorId);
-		$this->assertSame($comment->getObjectType(), $objectType);
-		$this->assertSame($comment->getObjectId(), $objectId);
+		$this->assertInstanceOf(IComment::class, $comment);
+		$this->assertSame($actorType, $comment->getActorType());
+		$this->assertSame($actorId, $comment->getActorId());
+		$this->assertSame($objectType, $comment->getObjectType());
+		$this->assertSame($objectId, $comment->getObjectId());
 	}
 
 
@@ -482,9 +463,9 @@ class ManagerTest extends TestCase {
 		$done = $manager->delete('');
 		$this->assertFalse($done);
 
-		$id = strval($this->addDatabaseEntry(0, 0));
+		$id = (string)$this->addDatabaseEntry(0, 0);
 		$comment = $manager->get($id);
-		$this->assertTrue($comment instanceof IComment);
+		$this->assertInstanceOf(IComment::class, $comment);
 		$done = $manager->delete($id);
 		$this->assertTrue($done);
 		$manager->get($id);
@@ -518,9 +499,9 @@ class ManagerTest extends TestCase {
 		return $comment;
 	}
 
-	public function providerTestSave(): array {
+	public static function providerTestSave(): array {
 		return [
-			['very beautiful, I am impressed!', 'alice', 'comment', null]
+			['very beautiful, I am impressed!', 'alice', 'comment', null],
 		];
 	}
 
@@ -570,8 +551,6 @@ class ManagerTest extends TestCase {
 
 
 	public function testSaveUpdateException(): void {
-		$this->expectException(\OCP\Comments\NotFoundException::class);
-
 		$manager = $this->getManager();
 		$comment = new Comment();
 		$comment
@@ -583,22 +562,25 @@ class ManagerTest extends TestCase {
 		$manager->save($comment);
 
 		$manager->delete($comment->getId());
+
 		$comment->setMessage('very beautiful, I am really so much impressed!');
+		$this->expectException(\OCP\Comments\NotFoundException::class);
 		$manager->save($comment);
 	}
 
 
 	public function testSaveIncomplete(): void {
-		$this->expectException(\UnexpectedValueException::class);
 
 		$manager = $this->getManager();
 		$comment = new Comment();
 		$comment->setMessage('from no one to nothing');
+
+		$this->expectException(\UnexpectedValueException::class);
 		$manager->save($comment);
 	}
 
 	public function testSaveAsChild(): void {
-		$id = $this->addDatabaseEntry(0, 0);
+		$id = (string)$this->addDatabaseEntry(0, 0);
 
 		$manager = $this->getManager();
 
@@ -607,7 +589,7 @@ class ManagerTest extends TestCase {
 			$comment
 				->setActor('users', 'alice')
 				->setObject('files', 'file64')
-				->setParentId(strval($id))
+				->setParentId($id)
 				->setMessage('full ack')
 				->setVerb('comment')
 				// setting the creation time avoids using sleep() while making sure to test with different timestamps
@@ -615,14 +597,14 @@ class ManagerTest extends TestCase {
 
 			$manager->save($comment);
 
-			$this->assertSame($comment->getTopmostParentId(), strval($id));
-			$parentComment = $manager->get(strval($id));
-			$this->assertSame($parentComment->getChildrenCount(), $i + 1);
-			$this->assertEquals($parentComment->getLatestChildDateTime()->getTimestamp(), $comment->getCreationDateTime()->getTimestamp());
+			$this->assertSame($id, $comment->getTopmostParentId());
+			$parentComment = $manager->get($id);
+			$this->assertSame($i + 1, $parentComment->getChildrenCount());
+			$this->assertEquals($comment->getCreationDateTime()->getTimestamp(), $parentComment->getLatestChildDateTime()->getTimestamp());
 		}
 	}
 
-	public function invalidActorArgsProvider() {
+	public static function invalidActorArgsProvider(): array {
 		return
 			[
 				['', ''],
@@ -633,10 +615,8 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * @dataProvider invalidActorArgsProvider
-	 * @param string $type
-	 * @param string $id
 	 */
-	public function testDeleteReferencesOfActorInvalidInput($type, $id): void {
+	public function testDeleteReferencesOfActorInvalidInput(string|int $type, string|int $id): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$manager = $this->getManager();
@@ -652,17 +632,17 @@ class ManagerTest extends TestCase {
 		$manager = $this->getManager();
 
 		// just to make sure they are really set, with correct actor data
-		$comment = $manager->get(strval($ids[1]));
-		$this->assertSame($comment->getActorType(), 'users');
-		$this->assertSame($comment->getActorId(), 'alice');
+		$comment = $manager->get((string)$ids[1]);
+		$this->assertSame('users', $comment->getActorType());
+		$this->assertSame('alice', $comment->getActorId());
 
 		$wasSuccessful = $manager->deleteReferencesOfActor('users', 'alice');
 		$this->assertTrue($wasSuccessful);
 
 		foreach ($ids as $id) {
-			$comment = $manager->get(strval($id));
-			$this->assertSame($comment->getActorType(), ICommentsManager::DELETED_USER);
-			$this->assertSame($comment->getActorId(), ICommentsManager::DELETED_USER);
+			$comment = $manager->get((string)$id);
+			$this->assertSame(ICommentsManager::DELETED_USER, $comment->getActorType());
+			$this->assertSame(ICommentsManager::DELETED_USER, $comment->getActorId());
 		}
 
 		// actor info is gone from DB, but when database interaction is alright,
@@ -672,10 +652,10 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testDeleteReferencesOfActorWithUserManagement(): void {
-		$user = \OC::$server->getUserManager()->createUser('xenia', 'NotAnEasyPassword123456+');
-		$this->assertTrue($user instanceof IUser);
+		$user = \OCP\Server::get(IUserManager::class)->createUser('xenia', 'NotAnEasyPassword123456+');
+		$this->assertInstanceOf(IUser::class, $user);
 
-		$manager = \OC::$server->get(ICommentsManager::class);
+		$manager = \OCP\Server::get(ICommentsManager::class);
 		$comment = $manager->create('users', $user->getUID(), 'files', 'file64');
 		$comment
 			->setMessage('Most important comment I ever left on the Internet.')
@@ -687,11 +667,11 @@ class ManagerTest extends TestCase {
 		$user->delete();
 
 		$comment = $manager->get($commentID);
-		$this->assertSame($comment->getActorType(), ICommentsManager::DELETED_USER);
-		$this->assertSame($comment->getActorId(), ICommentsManager::DELETED_USER);
+		$this->assertSame(ICommentsManager::DELETED_USER, $comment->getActorType());
+		$this->assertSame(ICommentsManager::DELETED_USER, $comment->getActorId());
 	}
 
-	public function invalidObjectArgsProvider() {
+	public static function invalidObjectArgsProvider(): array {
 		return
 			[
 				['', ''],
@@ -702,10 +682,8 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * @dataProvider invalidObjectArgsProvider
-	 * @param string $type
-	 * @param string $id
 	 */
-	public function testDeleteCommentsAtObjectInvalidInput($type, $id): void {
+	public function testDeleteCommentsAtObjectInvalidInput(string|int $type, string|int $id): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$manager = $this->getManager();
@@ -721,9 +699,9 @@ class ManagerTest extends TestCase {
 		$manager = $this->getManager();
 
 		// just to make sure they are really set, with correct actor data
-		$comment = $manager->get(strval($ids[1]));
-		$this->assertSame($comment->getObjectType(), 'files');
-		$this->assertSame($comment->getObjectId(), 'file64');
+		$comment = $manager->get((string)$ids[1]);
+		$this->assertSame('files', $comment->getObjectType());
+		$this->assertSame('file64', $comment->getObjectId());
 
 		$wasSuccessful = $manager->deleteCommentsAtObject('files', 'file64');
 		$this->assertTrue($wasSuccessful);
@@ -731,12 +709,12 @@ class ManagerTest extends TestCase {
 		$verified = 0;
 		foreach ($ids as $id) {
 			try {
-				$manager->get(strval($id));
-			} catch (NotFoundException $e) {
+				$manager->get((string)$id);
+			} catch (NotFoundException) {
 				$verified++;
 			}
 		}
-		$this->assertSame($verified, 3);
+		$this->assertSame(3, $verified);
 
 		// actor info is gone from DB, but when database interaction is alright,
 		// we still expect to get true back
@@ -766,8 +744,8 @@ class ManagerTest extends TestCase {
 
 		// just to make sure they are really set, with correct actor data
 		$comment = $manager->get((string)$ids[1]);
-		$this->assertSame($comment->getObjectType(), 'files');
-		$this->assertSame($comment->getObjectId(), 'file64');
+		$this->assertSame('files', $comment->getObjectType());
+		$this->assertSame('file64', $comment->getObjectId());
 
 		$deleted = $manager->deleteCommentsExpiredAtObject('files', 'file64');
 		$this->assertTrue($deleted);
@@ -778,12 +756,12 @@ class ManagerTest extends TestCase {
 			try {
 				$manager->get((string)$id);
 				$exists++;
-			} catch (NotFoundException $e) {
+			} catch (NotFoundException) {
 				$deleted++;
 			}
 		}
-		$this->assertSame($exists, 3);
-		$this->assertSame($deleted, 3);
+		$this->assertSame(3, $exists);
+		$this->assertSame(3, $deleted);
 
 		// actor info is gone from DB, but when database interaction is alright,
 		// we still expect to get true back
@@ -820,12 +798,12 @@ class ManagerTest extends TestCase {
 			try {
 				$manager->get((string)$id);
 				$exists++;
-			} catch (NotFoundException $e) {
+			} catch (NotFoundException) {
 				$deleted++;
 			}
 		}
-		$this->assertSame($exists, 0);
-		$this->assertSame($deleted, 6);
+		$this->assertSame(0, $exists);
+		$this->assertSame(6, $deleted);
 
 		// actor info is gone from DB, but when database interaction is alright,
 		// we still expect to get true back
@@ -847,7 +825,7 @@ class ManagerTest extends TestCase {
 
 		$dateTimeGet = $manager->getReadMark('robot', '36', $user);
 
-		$this->assertEquals($dateTimeGet->getTimestamp(), $dateTimeSet->getTimestamp());
+		$this->assertEquals($dateTimeSet->getTimestamp(), $dateTimeGet->getTimestamp());
 	}
 
 	public function testSetMarkReadUpdate(): void {
@@ -867,7 +845,7 @@ class ManagerTest extends TestCase {
 
 		$dateTimeGet = $manager->getReadMark('robot', '36', $user);
 
-		$this->assertEquals($dateTimeGet, $dateTimeSet);
+		$this->assertEquals($dateTimeSet, $dateTimeGet);
 	}
 
 	public function testReadMarkDeleteUser(): void {
@@ -907,11 +885,11 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testSendEvent(): void {
-		$handler1 = $this->getMockBuilder(ICommentsEventHandler::class)->getMock();
+		$handler1 = $this->createMock(ICommentsEventHandler::class);
 		$handler1->expects($this->exactly(4))
 			->method('handle');
 
-		$handler2 = $this->getMockBuilder(ICommentsEventHandler::class)->getMock();
+		$handler2 = $this->createMock(ICommentsEventHandler::class);
 		$handler1->expects($this->exactly(4))
 			->method('handle');
 
@@ -1006,10 +984,23 @@ class ManagerTest extends TestCase {
 		};
 
 		$manager->registerDisplayNameResolver('planet', $planetClosure);
-		$this->assertTrue(is_string($manager->resolveDisplayName('planet', 'neptune')));
+		$this->assertIsString($manager->resolveDisplayName('planet', 'neptune'));
 	}
 
-	private function skipIfNotSupport4ByteUTF() {
+	public function testResolveDisplayNameInvalidType(): void {
+
+		$manager = $this->getManager();
+
+		$planetClosure = function () {
+			return null;
+		};
+
+		$manager->registerDisplayNameResolver('planet', $planetClosure);
+		$this->expectException(\InvalidArgumentException::class);
+		$this->assertIsString($manager->resolveDisplayName(1337, 'neptune'));
+	}
+
+	private function skipIfNotSupport4ByteUTF(): void {
 		if (!$this->getManager()->supportReactions()) {
 			$this->markTestSkipped('MySQL doesn\'t support 4 byte UTF-8');
 		}
@@ -1017,10 +1008,6 @@ class ManagerTest extends TestCase {
 
 	/**
 	 * @dataProvider providerTestReactionAddAndDelete
-	 *
-	 * @param IComment[] $comments
-	 * @param array $reactionsExpected
-	 * @return void
 	 */
 	public function testReactionAddAndDelete(array $comments, array $reactionsExpected): void {
 		$this->skipIfNotSupport4ByteUTF();
@@ -1034,7 +1021,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
-	public function providerTestReactionAddAndDelete(): array {
+	public static function providerTestReactionAddAndDelete(): array {
 		return[
 			[
 				[
@@ -1081,25 +1068,12 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	public function testResolveDisplayNameInvalidType(): void {
-		$this->expectException(\InvalidArgumentException::class);
-
-		$manager = $this->getManager();
-
-		$planetClosure = function () {
-			return null;
-		};
-
-		$manager->registerDisplayNameResolver('planet', $planetClosure);
-		$this->assertTrue(is_string($manager->resolveDisplayName(1337, 'neptune')));
-	}
-
 	/**
 	 * @param array $data
-	 * @return IComment[]
+	 * @return array<string, IComment>
 	 */
 	private function proccessComments(array $data): array {
-		/** @var IComment[] */
+		/** @var array<string, IComment> $comments */
 		$comments = [];
 		foreach ($data as $comment) {
 			[$message, $actorId, $verb, $parentText] = $comment;
@@ -1126,17 +1100,17 @@ class ManagerTest extends TestCase {
 
 		$processedComments = $this->proccessComments($comments);
 		$comment = reset($processedComments);
-		$all = $manager->retrieveAllReactions($comment->getId());
-		$actual = array_map(function ($row) {
+		$all = $manager->retrieveAllReactions((int)$comment->getId());
+		$actual = array_map(static function (IComment $row): array {
 			return [
-				'message' => $row->getMessage(),
-				'actorId' => $row->getActorId(),
+				$row->getActorId(),
+				$row->getMessage(),
 			];
 		}, $all);
 		$this->assertEqualsCanonicalizing($expected, $actual);
 	}
 
-	public function providerTestRetrieveAllReactions(): array {
+	public static function providerTestRetrieveAllReactions(): array {
 		return [
 			[
 				[
@@ -2386,17 +2360,17 @@ class ManagerTest extends TestCase {
 
 		$processedComments = $this->proccessComments($comments);
 		$comment = reset($processedComments);
-		$all = $manager->retrieveAllReactionsWithSpecificReaction($comment->getId(), $reaction);
-		$actual = array_map(function ($row) {
+		$all = $manager->retrieveAllReactionsWithSpecificReaction((int)$comment->getId(), $reaction);
+		$actual = array_map(static function (IComment $row): array {
 			return [
-				'message' => $row->getMessage(),
-				'actorId' => $row->getActorId(),
+				$row->getActorId(),
+				$row->getMessage(),
 			];
 		}, $all);
 		$this->assertEqualsCanonicalizing($expected, $actual);
 	}
 
-	public function providerTestRetrieveAllReactionsWithSpecificReaction(): array {
+	public static function providerTestRetrieveAllReactionsWithSpecificReaction(): array {
 		return [
 			[
 				[
@@ -2448,7 +2422,7 @@ class ManagerTest extends TestCase {
 			$this->expectException(\OCP\Comments\NotFoundException::class);
 		}
 		$comment = $processedComments[$expected['message'] . '#' . $expected['actorId']];
-		$actual = $manager->getReactionComment($comment->getParentId(), $comment->getActorType(), $comment->getActorId(), $comment->getMessage());
+		$actual = $manager->getReactionComment((int)$comment->getParentId(), $comment->getActorType(), $comment->getActorId(), $comment->getMessage());
 		if (!$notFound) {
 			$this->assertEquals($expected['message'], $actual->getMessage());
 			$this->assertEquals($expected['actorId'], $actual->getActorId());
@@ -2457,7 +2431,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
-	public function providerTestGetReactionComment(): array {
+	public static function providerTestGetReactionComment(): array {
 		return [
 			[
 				[
@@ -2504,7 +2478,7 @@ class ManagerTest extends TestCase {
 	/**
 	 * @dataProvider providerTestReactionMessageSize
 	 */
-	public function testReactionMessageSize($reactionString, $valid): void {
+	public function testReactionMessageSize(string $reactionString, bool $valid): void {
 		$this->skipIfNotSupport4ByteUTF();
 		if (!$valid) {
 			$this->expectException(\UnexpectedValueException::class);
@@ -2520,7 +2494,7 @@ class ManagerTest extends TestCase {
 		$this->assertTrue($status);
 	}
 
-	public function providerTestReactionMessageSize(): array {
+	public static function providerTestReactionMessageSize(): array {
 		return [
 			['a', false],
 			['1', false],
@@ -2552,7 +2526,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
-	public function providerTestReactionsSummarizeOrdered(): array {
+	public static function providerTestReactionsSummarizeOrdered(): array {
 		return [
 			[
 				[

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -152,7 +152,7 @@ class ManagerTest extends TestCase {
 		$this->assertSame('file64', $comment->getObjectId());
 		$this->assertEquals($creationDT->getTimestamp(), $comment->getCreationDateTime()->getTimestamp());
 		$this->assertEquals($latestChildDT->getTimestamp(), $comment->getLatestChildDateTime()->getTimestamp());
-		$this->assertEquals('referenceId',  $comment->getReferenceId());
+		$this->assertEquals('referenceId', $comment->getReferenceId());
 		$this->assertEquals(['last_edit_actor_id' => 'admin'], $comment->getMetaData());
 	}
 


### PR DESCRIPTION
Instead of the many "false is not true" errors on flaky tests we see at the moment, this should give clearer hints as to what is wrong. Also in quite many asserts the argument order was swapped, so it was not clear what was expected and what was actual.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [X] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
