### PR TITLE
perf(Share20): Add interface to query all shares in a folder without filtering by user

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -778,6 +778,7 @@ return array(
     'OCP\\Share\\IShareHelper' => $baseDir . '/lib/public/Share/IShareHelper.php',
     'OCP\\Share\\IShareProvider' => $baseDir . '/lib/public/Share/IShareProvider.php',
     'OCP\\Share\\IShareProviderSupportsAccept' => $baseDir . '/lib/public/Share/IShareProviderSupportsAccept.php',
+    'OCP\\Share\\IShareProviderSupportsAllSharesInFolder' => $baseDir . '/lib/public/Share/IShareProviderSupportsAllSharesInFolder.php',
     'OCP\\Share\\IShareProviderWithNotification' => $baseDir . '/lib/public/Share/IShareProviderWithNotification.php',
     'OCP\\Share_Backend' => $baseDir . '/lib/public/Share_Backend.php',
     'OCP\\Share_Backend_Collection' => $baseDir . '/lib/public/Share_Backend_Collection.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -819,6 +819,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Share\\IShareHelper' => __DIR__ . '/../../..' . '/lib/public/Share/IShareHelper.php',
         'OCP\\Share\\IShareProvider' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProvider.php',
         'OCP\\Share\\IShareProviderSupportsAccept' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderSupportsAccept.php',
+        'OCP\\Share\\IShareProviderSupportsAllSharesInFolder' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderSupportsAllSharesInFolder.php',
         'OCP\\Share\\IShareProviderWithNotification' => __DIR__ . '/../../..' . '/lib/public/Share/IShareProviderWithNotification.php',
         'OCP\\Share_Backend' => __DIR__ . '/../../..' . '/lib/public/Share_Backend.php',
         'OCP\\Share_Backend_Collection' => __DIR__ . '/../../..' . '/lib/public/Share_Backend_Collection.php',

--- a/lib/public/Share/IShareProviderSupportsAllSharesInFolder.php
+++ b/lib/public/Share/IShareProviderSupportsAllSharesInFolder.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Share;
+
+use OCP\Files\Folder;
+
+/**
+ * Allows defining a IShareProvider with support for the getAllSharesInFolder method.
+ *
+ * @since 32.0.0
+ */
+interface IShareProviderSupportsAllSharesInFolder extends IShareProvider {
+	/**
+	 * Get all shares in a folder.
+	 *
+	 * @return array<int, list<IShare>>
+	 * @since 32.0.0
+	 */
+	public function getAllSharesInFolder(Folder $node): array;
+}

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -55,6 +55,7 @@ use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
+use OCP\Share\IShareProviderSupportsAllSharesInFolder;
 use PHPUnit\Framework\MockObject\MockBuilder;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
@@ -4551,7 +4552,7 @@ class ManagerTest extends \Test\TestCase {
 		$manager = $this->createManager($factory);
 
 		$factory->setProvider($this->defaultProvider);
-		$extraProvider = $this->createMock(IShareProvider::class);
+		$extraProvider = $this->createMock(IShareProviderSupportsAllSharesInFolder::class);
 		$factory->setSecondProvider($extraProvider);
 
 		$share1 = $this->createMock(IShare::class);
@@ -4559,28 +4560,20 @@ class ManagerTest extends \Test\TestCase {
 
 		$mount = $this->createMock(IShareOwnerlessMount::class);
 
-		$file = $this->createMock(File::class);
-		$file
-			->method('getId')
-			->willReturn(1);
-
 		$folder = $this->createMock(Folder::class);
 		$folder
 			->method('getMountPoint')
 			->willReturn($mount);
-		$folder
-			->method('getDirectoryListing')
-			->willReturn([$file]);
 
 		$this->defaultProvider
-			->method('getSharesByPath')
-			->with($file)
-			->willReturn([$share1]);
+			->method('getAllSharesInFolder')
+			->with($folder)
+			->willReturn([1 => [$share1]]);
 
 		$extraProvider
-			->method('getSharesByPath')
-			->with($file)
-			->willReturn([$share2]);
+			->method('getAllSharesInFolder')
+			->with($folder)
+			->willReturn([1 => [$share2]]);
 
 		$this->assertSame([
 			1 => [$share1, $share2],


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/52510

## Summary

The providers didn't have an efficient way to query all shares in a folder without filtering by user and the current solution which was doing it for each node in the folder caused performance issues.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
