### PR TITLE
test: add e2e tests for multiple-files download

### DIFF
--- a/cypress/e2e/files/files-download.cy.ts
+++ b/cypress/e2e/files/files-download.cy.ts
@@ -6,6 +6,9 @@
 import type { User } from '@nextcloud/cypress'
 import { getRowForFile, navigateToFolder, triggerActionForFile } from './FilesUtils'
 import { deleteDownloadsFolderBeforeEach } from 'cypress-delete-downloads-folder'
+import { zipFileContains } from '../../support/utils/assertions.ts'
+
+import randomString from 'crypto-random-string'
 
 describe('files: Download files using file actions', { testIsolation: true }, () => {
 	let user: User
@@ -32,6 +35,29 @@ describe('files: Download files using file actions', { testIsolation: true }, ()
 			.should('exist')
 			.and('have.length.gt', 8)
 			.and('equal', '<content>')
+	})
+
+	it('can download folder', () => {
+		cy.mkdir(user, '/subfolder')
+		cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/subfolder/file.txt')
+
+		cy.login(user)
+		cy.visit('/apps/files')
+		getRowForFile('subfolder')
+			.should('be.visible')
+
+		triggerActionForFile('subfolder', 'download')
+
+		// check a file is downloaded
+		const downloadsFolder = Cypress.config('downloadsFolder')
+		cy.readFile(`${downloadsFolder}/subfolder.zip`, null, { timeout: 15000 })
+			.should('exist')
+			.and('have.length.gt', 30)
+			// Check all files are included
+			.and(zipFileContains([
+				'subfolder/',
+				'subfolder/file.txt',
+			]))
 	})
 
 	/**
@@ -141,5 +167,185 @@ describe('files: Download files using default action', { testIsolation: true }, 
 			.should('exist')
 			.and('have.length.gt', 8)
 			.and('equal', '<content>')
+	})
+})
+
+describe('files: Download files using selection', () => {
+
+	deleteDownloadsFolderBeforeEach()
+
+	it('can download selected files', () => {
+		cy.createRandomUser().then((user) => {
+			cy.mkdir(user, '/subfolder')
+			cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/subfolder/file.txt')
+			cy.login(user)
+			cy.visit('/apps/files')
+		})
+
+		getRowForFile('subfolder')
+			.should('be.visible')
+
+		getRowForFile('subfolder')
+			.findByRole('checkbox')
+			.check({ force: true })
+
+		// see that two files are selected
+		cy.get('[data-cy-files-list]').within(() => {
+			cy.contains('1 selected').should('be.visible')
+		})
+
+		// click download
+		cy.get('[data-cy-files-list-selection-actions]')
+			.findByRole('button', { name: 'Actions' })
+			.click()
+		cy.findByRole('menuitem', { name: 'Download (selected)' })
+			.should('be.visible')
+			.click()
+
+		// check a file is downloaded
+		const downloadsFolder = Cypress.config('downloadsFolder')
+		cy.readFile(`${downloadsFolder}/subfolder.zip`, null, { timeout: 15000 })
+			.should('exist')
+			.and('have.length.gt', 30)
+			// Check all files are included
+			.and(zipFileContains([
+				'subfolder/',
+				'subfolder/file.txt',
+			]))
+	})
+
+	it('can download multiple selected files', () => {
+		cy.createRandomUser().then((user) => {
+			cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/file.txt')
+			cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/other file.txt')
+			cy.login(user)
+			cy.visit('/apps/files')
+		})
+
+		getRowForFile('file.txt')
+			.should('be.visible')
+			.findByRole('checkbox')
+			.check({ force: true })
+
+		getRowForFile('other file.txt')
+			.should('be.visible')
+			.findByRole('checkbox')
+			.check({ force: true })
+
+		cy.get('[data-cy-files-list]').within(() => {
+			// see that two files are selected
+			cy.contains('2 selected').should('be.visible')
+		})
+
+		// click download
+		cy.get('[data-cy-files-list-selection-actions]')
+			.findByRole('button', { name: 'Actions' })
+			.click()
+		cy.findByRole('menuitem', { name: 'Download (selected)' })
+			.click()
+
+		// check a file is downloaded
+		const downloadsFolder = Cypress.config('downloadsFolder')
+		cy.readFile(`${downloadsFolder}/download.zip`, null, { timeout: 15000 })
+			.should('exist')
+			.and('have.length.gt', 30)
+			// Check all files are included
+			.and(zipFileContains([
+				'file.txt',
+				'other file.txt',
+			]))
+	})
+
+	/**
+	 * Regression test of https://help.nextcloud.com/t/unable-to-download-files-on-nextcloud-when-multiple-files-selected/221327/5
+	 */
+	it('can download selected files with special characters', () => {
+		cy.createRandomUser().then((user) => {
+			cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/1+1.txt')
+			cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/some@other.txt')
+			cy.login(user)
+			cy.visit('/apps/files')
+		})
+
+		getRowForFile('some@other.txt')
+			.should('be.visible')
+			.findByRole('checkbox')
+			.check({ force: true })
+
+		getRowForFile('1+1.txt')
+			.should('be.visible')
+			.findByRole('checkbox')
+			.check({ force: true })
+
+		cy.get('[data-cy-files-list]').within(() => {
+			// see that two files are selected
+			cy.contains('2 selected').should('be.visible')
+		})
+
+		// click download
+		cy.get('[data-cy-files-list-selection-actions]')
+			.findByRole('button', { name: 'Actions' })
+			.click()
+		cy.findByRole('menuitem', { name: 'Download (selected)' })
+			.click()
+
+		// check a file is downloaded
+		const downloadsFolder = Cypress.config('downloadsFolder')
+		cy.readFile(`${downloadsFolder}/download.zip`, null, { timeout: 15000 })
+			.should('exist')
+			.and('have.length.gt', 30)
+			// Check all files are included
+			.and(zipFileContains([
+				'1+1.txt',
+				'some@other.txt',
+			]))
+	})
+
+	/**
+	 * Regression test of https://help.nextcloud.com/t/unable-to-download-files-on-nextcloud-when-multiple-files-selected/221327/5
+	 */
+	it('can download selected files with email uid', () => {
+		const name = `${randomString(5)}@${randomString(3)}`
+		const user: User = { userId: name, password: name, language: 'en' }
+
+		cy.createUser(user).then(() => {
+			cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/file.txt')
+			cy.uploadContent(user, new Blob(['<content>']), 'text/plain', '/other file.txt')
+			cy.login(user)
+			cy.visit('/apps/files')
+		})
+
+		getRowForFile('file.txt')
+			.should('be.visible')
+			.findByRole('checkbox')
+			.check({ force: true })
+
+		getRowForFile('other file.txt')
+			.should('be.visible')
+			.findByRole('checkbox')
+			.check({ force: true })
+
+		cy.get('[data-cy-files-list]').within(() => {
+			// see that two files are selected
+			cy.contains('2 selected').should('be.visible')
+		})
+
+		// click download
+		cy.get('[data-cy-files-list-selection-actions]')
+			.findByRole('button', { name: 'Actions' })
+			.click()
+		cy.findByRole('menuitem', { name: 'Download (selected)' })
+			.click()
+
+		// check a file is downloaded
+		const downloadsFolder = Cypress.config('downloadsFolder')
+		cy.readFile(`${downloadsFolder}/download.zip`, null, { timeout: 15000 })
+			.should('exist')
+			.and('have.length.gt', 30)
+			// Check all files are included
+			.and(zipFileContains([
+				'file.txt',
+				'other file.txt',
+			]))
 	})
 })


### PR DESCRIPTION
## Summary

Add some test coverage for files downloading

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
