### PR TITLE
fix: Do not require `samesite=strict` cookies for `public.php`

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -551,10 +551,10 @@ class OC {
 			$processingScript = explode('/', $requestUri);
 			$processingScript = $processingScript[count($processingScript) - 1];
 
-			// index.php routes are handled in the middleware
-			// and cron.php does not need any authentication at all
-			if ($processingScript === 'index.php'
-				|| $processingScript === 'cron.php') {
+			if ($processingScript === 'index.php' // index.php routes are handled in the middleware
+			|| $processingScript === 'cron.php' // and cron.php does not need any authentication at all
+				// || $processingScript === 'public.php' // public.php does not need any authentication at all
+			) {
 				return;
 			}
 


### PR DESCRIPTION
This currently prevent directly accessing a resource from a third party site.

Not sure whether `public.php` actually does not need auth. I am just not aware of any place where it is the case. 

- Fix https://github.com/nextcloud/server/issues/52482
- Similar to https://github.com/nextcloud/server/pull/49130
