### PR TITLE
fix: create mountpoint folder even if the user has a quota of 0

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Quota.php
+++ b/lib/private/Files/Storage/Wrapper/Quota.php
@@ -21,6 +21,7 @@ class Quota extends Wrapper {
 	protected string $sizeRoot;
 	private SystemConfig $config;
 	private bool $quotaIncludeExternalStorage;
+	private bool $enabled = true;
 
 	/**
 	 * @param array $parameters
@@ -46,6 +47,9 @@ class Quota extends Wrapper {
 	}
 
 	private function hasQuota(): bool {
+		if (!$this->enabled) {
+			return false;
+		}
 		return $this->getQuota() !== FileInfo::SPACE_UNLIMITED;
 	}
 
@@ -196,5 +200,9 @@ class Quota extends Wrapper {
 		}
 
 		return parent::touch($path, $mtime);
+	}
+
+	public function enableQuota(bool $enabled): void {
+		$this->enabled = $enabled;
 	}
 }

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -10,6 +10,7 @@ namespace OC\Files;
 use Icewind\Streams\CallbackWrapper;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\Storage\Storage;
+use OC\Files\Storage\Wrapper\Quota;
 use OC\Share\Share;
 use OC\User\LazyUser;
 use OC\User\Manager as UserManager;
@@ -1578,11 +1579,21 @@ class View {
 						// Create parent folders if the mountpoint is inside a subfolder that doesn't exist yet
 						if (!isset($files[$entryName])) {
 							try {
+								[$storage, ] = $this->resolvePath($path . '/' . $entryName);
+								// make sure we can create the mountpoint folder, even if the user has a quota of 0
+								if ($storage->instanceOfStorage(Quota::class)) {
+									$storage->enableQuota(false);
+								}
+
 								if ($this->mkdir($path . '/' . $entryName) !== false) {
 									$info = $this->getFileInfo($path . '/' . $entryName);
 									if ($info !== false) {
 										$files[$entryName] = $info;
 									}
+								}
+
+								if ($storage->instanceOfStorage(Quota::class)) {
+									$storage->enableQuota(true);
 								}
 							} catch (\Exception $e) {
 								// Creating the parent folder might not be possible, for example due to a lack of permissions.


### PR DESCRIPTION
A quota of 0 also blocks the user from creating folders in their home directory.

This conflicts issue with the mechanism that makes sure the folder that external storages are mounted at exists.

This adds some logic to disable the quota check when creating the folder.

To test:

- Create a user with a quota of 0
- Configure an external storage that is mounted in a subfolder (e.g. "foo/bar")
- Check if the external storage is accessible for the user