### PR TITLE
Improve init profiling

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1266,11 +1266,6 @@
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
-  <file src="lib/autoloader.php">
-    <RedundantCondition>
-      <code><![CDATA[$this->memoryCache]]></code>
-    </RedundantCondition>
-  </file>
   <file src="lib/base.php">
     <InvalidArgument>
       <code><![CDATA[$restrictions]]></code>

--- a/build/rector.php
+++ b/build/rector.php
@@ -52,6 +52,7 @@ class NextcloudNamespaceSkipVoter implements ClassNameImportSkipVoterInterface {
 $config = RectorConfig::configure()
 	->withPaths([
 		$nextcloudDir . '/apps',
+		$nextcloudDir . '/status.php',
 		// $nextcloudDir . '/config',
 		// $nextcloudDir . '/core',
 		// $nextcloudDir . '/lib',

--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -22,10 +22,8 @@ class Autoloader {
 
 	/**
 	 * Optional low-latency memory cache for class to path mapping.
-	 *
-	 * @var \OC\Memcache\Cache
 	 */
-	protected $memoryCache;
+	protected ?ICache $memoryCache = null;
 
 	/**
 	 * Autoloader constructor.
@@ -127,13 +125,13 @@ class Autoloader {
 	 * @throws AutoloadNotAllowedException
 	 */
 	public function load(string $class): bool {
+		if (class_exists($class, false)) {
+			return false;
+		}
+
 		$pathsToRequire = null;
 		if ($this->memoryCache) {
 			$pathsToRequire = $this->memoryCache->get($class);
-		}
-
-		if (class_exists($class, false)) {
-			return false;
 		}
 
 		if (!is_array($pathsToRequire)) {

--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -87,7 +87,8 @@ class Coordinator {
 					$this->eventLogger->start("bootstrap:register_app:$appId:application", "Load `Application` instance for $appId");
 					try {
 						/** @var IBootstrap&App $application */
-						$apps[$appId] = $application = $this->serverContainer->query($applicationClassName);
+						$application = $this->serverContainer->query($applicationClassName);
+						$apps[$appId] = $application;
 					} catch (QueryException $e) {
 						// Weird, but ok
 						$this->eventLogger->end("bootstrap:register_app:$appId");

--- a/lib/private/AppFramework/Bootstrap/Coordinator.php
+++ b/lib/private/AppFramework/Bootstrap/Coordinator.php
@@ -83,10 +83,10 @@ class Coordinator {
 			$appNameSpace = App::buildAppNamespace($appId);
 			$applicationClassName = $appNameSpace . '\\AppInfo\\Application';
 			try {
-				if (class_exists($applicationClassName) && in_array(IBootstrap::class, class_implements($applicationClassName), true)) {
+				if (class_exists($applicationClassName) && is_a($applicationClassName, IBootstrap::class, true)) {
 					$this->eventLogger->start("bootstrap:register_app:$appId:application", "Load `Application` instance for $appId");
 					try {
-						/** @var IBootstrap|App $application */
+						/** @var IBootstrap&App $application */
 						$apps[$appId] = $application = $this->serverContainer->query($applicationClassName);
 					} catch (QueryException $e) {
 						// Weird, but ok

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -153,13 +153,13 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 			return $closure($this);
 		};
 		$name = $this->sanitizeName($name);
-		if (isset($this[$name])) {
-			unset($this[$name]);
+		if (isset($this->container[$name])) {
+			unset($this->container[$name]);
 		}
 		if ($shared) {
-			$this[$name] = $wrapped;
+			$this->container[$name] = $wrapped;
 		} else {
-			$this[$name] = $this->container->factory($wrapped);
+			$this->container[$name] = $this->container->factory($wrapped);
 		}
 	}
 

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -54,9 +54,9 @@ class Router implements IRouter {
 		protected LoggerInterface $logger,
 		IRequest $request,
 		private IConfig $config,
-		private IEventLogger $eventLogger,
+		protected IEventLogger $eventLogger,
 		private ContainerInterface $container,
-		private IAppManager $appManager,
+		protected IAppManager $appManager,
 	) {
 		$baseUrl = \OC::$WEBROOT;
 		if (!($config->getSystemValue('htaccess.IgnoreFrontController', false) === true || getenv('front_controller_active') === 'true')) {
@@ -116,9 +116,11 @@ class Router implements IRouter {
 			$this->loaded = true;
 			$routingFiles = $this->getRoutingFiles();
 
+			$this->eventLogger->start('route:load:attributes', 'Loading Routes from attributes');
 			foreach (\OC_App::getEnabledApps() as $enabledApp) {
 				$this->loadAttributeRoutes($enabledApp);
 			}
+			$this->eventLogger->end('route:load:attributes');
 		} else {
 			if (isset($this->loadedApps[$app])) {
 				return;
@@ -140,6 +142,7 @@ class Router implements IRouter {
 			}
 		}
 
+		$this->eventLogger->start('route:load:files', 'Loading Routes from files');
 		foreach ($routingFiles as $app => $file) {
 			if (!isset($this->loadedApps[$app])) {
 				if (!$this->appManager->isAppLoaded($app)) {
@@ -160,6 +163,7 @@ class Router implements IRouter {
 				$this->root->addCollection($collection);
 			}
 		}
+		$this->eventLogger->end('route:load:files');
 
 		if (!isset($this->loadedApps['core'])) {
 			$this->loadedApps['core'] = true;
@@ -265,6 +269,7 @@ class Router implements IRouter {
 			$this->loadRoutes();
 		}
 
+		$this->eventLogger->start('route:url:match', 'Symfony url matcher call');
 		$matcher = new UrlMatcher($this->root, $this->context);
 		try {
 			$parameters = $matcher->match($url);
@@ -283,6 +288,7 @@ class Router implements IRouter {
 				throw $e;
 			}
 		}
+		$this->eventLogger->end('route:url:match');
 
 		$this->eventLogger->end('route:match');
 		return $parameters;

--- a/lib/private/ServerContainer.php
+++ b/lib/private/ServerContainer.php
@@ -128,18 +128,17 @@ class ServerContainer extends SimpleContainer {
 			} catch (QueryException $e) {
 				// Continue with general autoloading then
 			}
-		}
-
-		// In case the service starts with OCA\ we try to find the service in
-		// the apps container first.
-		if (($appContainer = $this->getAppContainerForService($name)) !== null) {
-			try {
-				return $appContainer->queryNoFallback($name);
-			} catch (QueryException $e) {
-				// Didn't find the service or the respective app container
-				// In this case the service won't be part of the core container,
-				// so we can throw directly
-				throw $e;
+			// In case the service starts with OCA\ we try to find the service in
+			// the apps container first.
+			if (($appContainer = $this->getAppContainerForService($name)) !== null) {
+				try {
+					return $appContainer->queryNoFallback($name);
+				} catch (QueryException $e) {
+					// Didn't find the service or the respective app container
+					// In this case the service won't be part of the core container,
+					// so we can throw directly
+					throw $e;
+				}
 			}
 		} elseif (str_starts_with($name, 'OC\\Settings\\') && substr_count($name, '\\') >= 3) {
 			$segments = explode('\\', $name);

--- a/status.php
+++ b/status.php
@@ -1,33 +1,42 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 require_once __DIR__ . '/lib/versioncheck.php';
 
+use OC\SystemConfig;
+use OCP\Defaults;
+use OCP\Server;
+use OCP\ServerVersion;
+use OCP\Util;
 use Psr\Log\LoggerInterface;
 
 try {
 	require_once __DIR__ . '/lib/base.php';
 
-	$systemConfig = \OC::$server->getSystemConfig();
+	$systemConfig = Server::get(SystemConfig::class);
 
 	$installed = (bool)$systemConfig->getValue('installed', false);
 	$maintenance = (bool)$systemConfig->getValue('maintenance', false);
 	# see core/lib/private/legacy/defaults.php and core/themes/example/defaults.php
 	# for description and defaults
-	$defaults = new \OCP\Defaults();
+	$defaults = new Defaults();
+	$serverVersion = Server::get(ServerVersion::class);
 	$values = [
 		'installed' => $installed,
 		'maintenance' => $maintenance,
-		'needsDbUpgrade' => \OCP\Util::needUpgrade(),
-		'version' => implode('.', \OCP\Util::getVersion()),
-		'versionstring' => \OCP\Server::get(\OCP\ServerVersion::class)->getVersionString(),
+		'needsDbUpgrade' => Util::needUpgrade(),
+		'version' => implode('.', $serverVersion->getVersion()),
+		'versionstring' => $serverVersion->getVersionString(),
 		'edition' => '',
 		'productname' => $defaults->getProductName(),
-		'extendedSupport' => \OCP\Util::hasExtendedSupport()
+		'extendedSupport' => Util::hasExtendedSupport()
 	];
 	if (OC::$CLI) {
 		print_r($values);
@@ -38,5 +47,5 @@ try {
 	}
 } catch (Exception $ex) {
 	http_response_code(500);
-	\OCP\Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'remote','exception' => $ex]);
+	Server::get(LoggerInterface::class)->error($ex->getMessage(), ['app' => 'remote','exception' => $ex]);
 }


### PR DESCRIPTION
## Summary

Add profiling steps to init and routing to get a better view of where we can gain performances.
Fix a few obvious perf lost (objects built too early, that kind of things).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
