### PR TITLE
fix(db): Store last insert id before reconnect

### DIFF
--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -28,11 +28,25 @@ class Adapter {
 	/**
 	 * @param string $table name
 	 *
-	 * @return int id of last insert statement
+	 * @return int id of last insert statement, 0 in case there was no INSERT before or it failed to get the ID
 	 * @throws Exception
 	 */
-	public function lastInsertId($table) {
-		return (int)$this->conn->realLastInsertId($table);
+	public function lastInsertId($table, bool $allowRetry = true): int {
+		$return = $this->conn->realLastInsertId($table);
+		if ($return === 0 && $allowRetry) {
+			/**
+			 * During a reconnect we are losing the connection and when the
+			 * realLastInsertId call is the one triggering the reconnect, it
+			 * does not return the ID. But inside the reconnect, we were able
+			 * to save the last insert id, so calling it a second time is going
+			 * to be successful.
+			 * We can not return the result on the initial call, as we are already
+			 * way deeper in the stack performing the actual database query on
+			 * the doctrine driver.
+			 */
+			return $this->lastInsertId($table, false);
+		}
+		return $return;
 	}
 
 	/**

--- a/lib/private/DB/AdapterOCI8.php
+++ b/lib/private/DB/AdapterOCI8.php
@@ -8,7 +8,7 @@
 namespace OC\DB;
 
 class AdapterOCI8 extends Adapter {
-	public function lastInsertId($table) {
+	public function lastInsertId($table, bool $allowRetry = true): int {
 		if (is_null($table)) {
 			throw new \InvalidArgumentException('Oracle requires a table name to be passed into lastInsertId()');
 		}

--- a/lib/private/DB/AdapterPgSql.php
+++ b/lib/private/DB/AdapterPgSql.php
@@ -9,7 +9,7 @@ namespace OC\DB;
 
 class AdapterPgSql extends Adapter {
 
-	public function lastInsertId($table) {
+	public function lastInsertId($table, bool $allowRetry = true): int {
 		$result = $this->conn->executeQuery('SELECT lastval()');
 		$val = $result->fetchOne();
 		$result->free();

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -92,6 +92,8 @@ class Connection extends PrimaryReadReplicaConnection {
 	protected ShardConnectionManager $shardConnectionManager;
 	protected AutoIncrementHandler $autoIncrementHandler;
 	protected bool $isShardingEnabled;
+	protected bool $disableReconnect = false;
+	protected int $lastInsertId = 0;
 
 	public const SHARD_PRESETS = [
 		'filecache' => [
@@ -510,9 +512,9 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * because the underlying database may not even support the notion of AUTO_INCREMENT/IDENTITY
 	 * columns or sequences.
 	 *
-	 * @param string $seqName Name of the sequence object from which the ID should be returned.
+	 * @param ?string $name Name of the sequence object from which the ID should be returned.
 	 *
-	 * @return int the last inserted ID.
+	 * @return int the last inserted ID, 0 in case there was no INSERT before or it failed to get the ID
 	 * @throws Exception
 	 */
 	public function lastInsertId($name = null): int {
@@ -526,8 +528,13 @@ class Connection extends PrimaryReadReplicaConnection {
 	 * @internal
 	 * @throws Exception
 	 */
-	public function realLastInsertId($seqName = null) {
-		return parent::lastInsertId($seqName);
+	public function realLastInsertId($seqName = null): int {
+		if ($this->lastInsertId !== 0) {
+			$lastInsertId = $this->lastInsertId;
+			$this->lastInsertId = 0;
+			return $lastInsertId;
+		}
+		return (int)parent::lastInsertId($seqName);
 	}
 
 	/**
@@ -896,9 +903,21 @@ class Connection extends PrimaryReadReplicaConnection {
 		if (
 			!isset($this->lastConnectionCheck[$this->getConnectionName()]) ||
 			time() <= $this->lastConnectionCheck[$this->getConnectionName()] + 30 ||
-			$this->isTransactionActive()
+			$this->isTransactionActive() ||
+			$this->disableReconnect
 		) {
 			return;
+		}
+
+		if ($this->getDatabaseProvider() === IDBConnection::PLATFORM_MYSQL) {
+			/**
+			 * Before reconnecting we save the lastInsertId, so that if the reconnect
+			 * happens between the INSERT executeStatement() and the getLastInsertId call
+			 * we are able to return the correct result after all.
+			 */
+			$this->disableReconnect = true;
+			$this->lastInsertId = (int)parent::lastInsertId();
+			$this->disableReconnect = false;
 		}
 
 		try {

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -1107,6 +1107,10 @@ class ManagerTest extends TestCase {
 				$row->getMessage(),
 			];
 		}, $all);
+
+		usort($actual, static fn (array $a, array $b): int => $a[1] <=> $b[1]);
+		usort($expected, static fn (array $a, array $b): int => $a[1] <=> $b[1]);
+
 		$this->assertEqualsCanonicalizing($expected, $actual);
 	}
 


### PR DESCRIPTION
## Debugging locally

With the following diff applied

<details>

```diff
diff --git a/composer.json b/composer.json
index 5e9b50e2771..a3463cbb61b 100644
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
                        "PHP_CLI_SERVER_WORKERS=${NEXTCLOUD_WORKERS:=4} php -S ${NEXTCLOUD_HOST:=localhost}:${NEXTCLOUD_PORT:=8080} -t ./"
                ],
                "test": "phpunit --configuration tests/phpunit-autotest.xml",
+               "test:reactions": "@composer run test -- tests/lib/Comments/ManagerTest.php --filter=testRetrieveAllReactions",
                "test:db": "@composer run test -- --group DB,SLOWDB",
                "test:files_external": "phpunit --configuration tests/phpunit-autotest-external.xml",
                "rector": "rector --config=build/rector.php && composer cs:fix",
diff --git a/lib/private/DB/Adapter.php b/lib/private/DB/Adapter.php
index 8f1b8e6d75f48..e5b4ea72d1300 100644
--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -32,7 +32,14 @@ public function __construct($conn) {
 	 * @throws Exception
 	 */
 	public function lastInsertId($table) {
-		return (int)$this->conn->realLastInsertId($table);
+		$return = $this->conn->realLastInsertId($table);
+		if (!is_string($return) && !is_int($return)) {
+			throw new \Exception('realLastInsertId errored? ' . json_encode($return));
+		}
+		if (!(int)$return) {
+			throw new \Exception('realLastInsertId returning falsy value ' . json_encode($return));
+		}
+		return (int)$return;
 	}
 
 	/**
diff --git a/tests/lib/Comments/ManagerTest.php b/tests/lib/Comments/ManagerTest.php
index c187f664215..25e870b976a 100644
--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -1075,18 +1075,20 @@ class ManagerTest extends TestCase {
        private function proccessComments(array $data): array {
                /** @var array<string, IComment> $comments */
                $comments = [];
-               foreach ($data as $comment) {
-                       [$message, $actorId, $verb, $parentText] = $comment;
-                       $parentId = null;
-                       if ($parentText) {
-                               $parentId = (string)$comments[$parentText]->getId();
+               for ($i = 0; $i < 20; $i++) {
+                       foreach ($data as $comment) {
+                               [$message, $actorId, $verb, $parentText] = $comment;
+                               $parentId = null;
+                               if ($parentText) {
+                                       $parentId = (string)$comments[$parentText]->getId();
+                               }
+                               $id = '';
+                               if ($verb === 'reaction_deleted') {
+                                       $id = $comments[$message . '#' . $actorId]->getId();
+                               }
+                               $comment = $this->testSave($message, $actorId, $verb, $parentId, $id);
+                               $comments[$comment->getMessage() . '#' . $comment->getActorId()] = $comment;
                        }
-                       $id = '';
-                       if ($verb === 'reaction_deleted') {
-                               $id = $comments[$message . '#' . $actorId]->getId();
-                       }
-                       $comment = $this->testSave($message, $actorId, $verb, $parentId, $id);
-                       $comments[$comment->getMessage() . '#' . $comment->getActorId()] = $comment;
                }
                return $comments;
        }
```

</details>

The following command gives a ~90% success rate to trigger the bug.
```sh
clear && composer run test:reactions
```

## :sweat: Summary

During a reconnect we are losing the connection and when the realLastInsertId call is the one triggering the reconnect, it does not return the ID. But inside the reconnect, we were able to save the last insert id, so calling it a second time is going to be successful.
We can not return the result on the initial call, as we are already way deeper in the stack performing the actual database query on the doctrine driver.

## :bulb: Thoughts

1. I think it would be better if triggering an insert after lets say 25 seconds would already trigger the reconnection, but I was unable to implement that, as information required and the action itself are on very different levels and reconnecting manually inside executeStatement send my Server away.
2. We could also "require" that if you rely on getLastInsertId, you have to run the insert + the getLastInsertId with in a transaction (as that will also avoid the reconnection check), but I'm not sure what the impact is performance wise, row/lock wise or in a clustered setup. cc @juliusknorr @ChristophWurst @icewind1991 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
