### PR TITLE
fix(files_external): Safely check if the timestamp is numeric

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Swift.php
+++ b/apps/files_external/lib/Lib/Storage/Swift.php
@@ -288,7 +288,6 @@ class Swift extends Common {
 
 	public function stat(string $path): array|false {
 		$path = $this->normalizePath($path);
-
 		if ($path === '.') {
 			$path = '';
 		} elseif ($this->is_dir($path)) {
@@ -308,22 +307,23 @@ class Swift extends Common {
 			return false;
 		}
 
-		$dateTime = $object->lastModified ? \DateTime::createFromFormat(\DateTime::RFC1123, $object->lastModified) : false;
-		$mtime = $dateTime ? $dateTime->getTimestamp() : null;
-		$objectMetadata = $object->getMetadata();
-		if (isset($objectMetadata['timestamp'])) {
-			$mtime = $objectMetadata['timestamp'];
+		$mtime = null;
+		if (!empty($object->lastModified)) {
+			$dateTime = \DateTime::createFromFormat(\DateTime::RFC1123, $object->lastModified);
+			if ($dateTime !== false) {
+				$mtime = $dateTime->getTimestamp();
+			}
 		}
 
-		if (!empty($mtime)) {
-			$mtime = floor($mtime);
+		if (is_numeric($object->getMetadata()['timestamp'] ?? null)) {
+			$mtime = (float)$object->getMetadata()['timestamp'];
 		}
 
-		$stat = [];
-		$stat['size'] = (int)$object->contentLength;
-		$stat['mtime'] = $mtime;
-		$stat['atime'] = time();
-		return $stat;
+		return [
+			'size' => (int)$object->contentLength,
+			'mtime' => isset($mtime) ? (int)floor($mtime) : null,
+			'atime' => time(),
+		];
 	}
 
 	public function filetype(string $path) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/52682

## Summary

- Reduces variable assignments by directly incorporating logic into the return statement
- Safely check if the timestamp is numeric, avoiding potential issues with invalid data

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
