### PR TITLE
fix(files_versions): Folder should not be hardcoded

### DIFF
--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -367,16 +367,20 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 	 * @inheritdoc
 	 */
 	public function clearVersionsForFile(IUser $user, Node $source, Node $target): void {
-		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$userId = $user->getUID();
+		$userFolder = $this->rootFolder->getUserFolder($userId);
 
 		$relativePath = $userFolder->getRelativePath($source->getPath());
 		if ($relativePath === null) {
 			throw new Exception('Relative path not found for node with path: ' . $source->getPath());
 		}
 
-		$versions = Storage::getVersions($user->getUID(), $relativePath);
-		/** @var Folder versionFolder */
-		$versionFolder = $this->rootFolder->get('admin/files_versions');
+		$versionFolder = $this->rootFolder->get($userId . '/files_versions');
+		if (!$versionFolder instanceof Folder) {
+			throw new Exception('User versions folder does not exist');
+		}
+
+		$versions = Storage::getVersions($userId, $relativePath);
 		foreach ($versions as $version) {
 			$versionFolder->get($version['path'] . '.v' . (int)$version['version'])->delete();
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Maybe I'm missing something, but folder should not be hardcoded? 🤔 

Fix:

```
{
  "reqId": "anA975K1WAxV3Frui1yJ",
  "level": 3,
  "time": "2025-05-07T11:55:22+02:00",
  "remoteAddr": "5.6.3.4",
  "user": "myUser",
  "app": "no app in context",
  "method": "MOVE",
  "url": "/remote.php/dav/files/myUser/userFolder/file.txt",
  "message": "Exception thrown: OCP\\Files\\NotFoundException",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118.0.0.0 Safari/537.36",
  "version": "30.0.9.2",
  "exception": {
    "Exception": "OCP\\Files\\NotFoundException",
    "Message": "/admin/files_versions",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/Files/Node/LazyFolder.php",
        "line": 141,
        "function": "get",
        "class": "OC\\Files\\Node\\Root",
        "type": "->",
        "args": [
          "/admin/files_versions"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Versions/LegacyVersionsBackend.php",
        "line": 374,
        "function": "get",
        "class": "OC\\Files\\Node\\LazyFolder",
        "type": "->",
        "args": [
          "admin/files_versions"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
        "line": 129,
        "function": "clearVersionsForFile",
        "class": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\User\\User"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
        "line": 102,
        "function": "handleMoveOrCopy",
        "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          {
            "__class__": "OC\\User\\User"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
          },
          {
            "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/VersionStorageMoveListener.php",
        "line": 74,
        "function": "recursivelyHandleMoveOrCopy",
        "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          {
            "__class__": "OC\\User\\User"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OC\\Files\\Node\\File"
          },
          {
            "__class__": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend"
          },
          {
            "__class__": "OCA\\GroupFolders\\Versions\\VersionsBackend"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 68,
        "function": "handle",
        "class": "OCA\\Files_Versions\\Listener\\VersionStorageMoveListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 220,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
          {
            "__class__": "Symfony\\Component\\EventDispatcher\\EventDispatcher"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 56,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          [
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            },
            {
              "__class__": "Closure"
            }
          ],
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 67,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          },
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 79,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          "OCP\\Files\\Events\\Node\\NodeRenamedEvent",
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Files/Node/HookConnector.php",
        "line": 169,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCP\\Files\\Events\\Node\\NodeRenamedEvent"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/legacy/OC_Hook.php",
        "line": 82,
        "function": "postRename",
        "class": "OC\\Files\\Node\\HookConnector",
        "type": "->",
        "args": [
          {
            "oldpath": "/userFolder/file.txt",
            "newpath": "/groupFolder/folder1/folder2/file.txt"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/lib/private/Files/View.php",
        "line": 833,
        "function": "emit",
        "class": "OC_Hook",
        "type": "::",
        "args": [
          "OC_Filesystem",
          "post_rename",
          {
            "oldpath": "/userFolder/file.txt",
            "newpath": "/groupFolder/folder1/folder2/file.txt"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Directory.php",
        "line": 416,
        "function": "rename",
        "class": "OC\\Files\\View",
        "type": "->",
        "args": [
          "/userFolder/file.txt",
          "/groupFolder/folder1/folder2/file.txt"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Tree.php",
        "line": 178,
        "function": "moveInto",
        "class": "OCA\\DAV\\Connector\\Sabre\\Directory",
        "type": "->",
        "args": [
          "file.txt",
          "files/myUser/userFolder/file.txt",
          {
            "__class__": "OCA\\DAV\\Connector\\Sabre\\File"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/CorePlugin.php",
        "line": 612,
        "function": "move",
        "class": "Sabre\\DAV\\Tree",
        "type": "->",
        "args": [
          "files/myUser/userFolder/file.txt",
          "files/myUser/groupFolder/folder1/folder2/file.txt"
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/event/lib/WildcardEmitterTrait.php",
        "line": 89,
        "function": "httpMove",
        "class": "Sabre\\DAV\\CorePlugin",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/3rdparty/sabre/dav/lib/DAV/Server.php",
        "line": 472,
        "function": "emit",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          "method:MOVE",
          [
            {
              "__class__": "Sabre\\HTTP\\Request"
            },
            {
              "__class__": "Sabre\\HTTP\\Response"
            }
          ]
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Connector/Sabre/Server.php",
        "line": 49,
        "function": "invokeMethod",
        "class": "Sabre\\DAV\\Server",
        "type": "->",
        "args": [
          {
            "__class__": "Sabre\\HTTP\\Request"
          },
          {
            "__class__": "Sabre\\HTTP\\Response"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/dav/lib/Server.php",
        "line": 375,
        "function": "start",
        "class": "OCA\\DAV\\Connector\\Sabre\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php",
        "line": 19,
        "function": "exec",
        "class": "OCA\\DAV\\Server",
        "type": "->",
        "args": []
      },
      {
        "file": "/var/www/nextcloud/remote.php",
        "line": 146,
        "args": [
          "/var/www/nextcloud/apps/dav/appinfo/v2/remote.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/nextcloud/lib/private/Files/Node/Root.php",
    "Line": 187,
    "CustomMessage": "Exception thrown: OCP\\Files\\NotFoundException"
  },
  "id": "681cce49d6ba6"
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
