### PR TITLE
fix(webhooks_listener): correctly set userId from event

### DIFF
--- a/apps/webhook_listeners/lib/BackgroundJobs/WebhookCall.php
+++ b/apps/webhook_listeners/lib/BackgroundJobs/WebhookCall.php
@@ -74,7 +74,8 @@ class WebhookCall extends QueuedJob {
 				} elseif (!$exApp['enabled']) {
 					throw new RuntimeException('ExApp ' . $exAppId . ' is disabled.');
 				}
-				$response = $appApiFunctions->exAppRequest($exAppId, $webhookUri, $webhookListener->getUserId(), $webhookListener->getHttpMethod(), [], $options);
+				$userId = ($data['user'] ?? [])['uid'] ?? null;
+				$response = $appApiFunctions->exAppRequest($exAppId, $webhookUri, $userId, $webhookListener->getHttpMethod(), [], $options);
 				if (is_array($response) && isset($response['error'])) {
 					throw new RuntimeException(sprintf('Error during request to ExApp(%s): %s', $exAppId, $response['error']));
 				}

--- a/apps/webhook_listeners/lib/Listener/WebhooksEventListener.php
+++ b/apps/webhook_listeners/lib/Listener/WebhooksEventListener.php
@@ -41,6 +41,7 @@ class WebhooksEventListener implements IEventListener {
 			// TODO add group membership to be able to filter on it
 			$data = [
 				'event' => $this->serializeEvent($event),
+				/* Do not remove 'user' from here, see BackgroundJobs/WebhookCall.php */
 				'user' => (is_null($user) ? null : JsonSerializer::serializeUser($user)),
 				'time' => time(),
 			];


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/app_api/issues/576

## Summary

In `$appApiFunctions->exAppRequest` we should pass the userID from which the event occurred, not the userID that registered the webhook.

This was a typo in the original code.

_This only affects AppAPI and ExApps, but we should backport this fix to Nextcloud 30/31._

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
