### PR TITLE
fix: throw a better error if we can't get the encrypted header size

### DIFF
--- a/apps/encryption/lib/Command/FixEncryptedVersion.php
+++ b/apps/encryption/lib/Command/FixEncryptedVersion.php
@@ -12,6 +12,7 @@ use OC\Files\Storage\Wrapper\Encryption;
 use OC\Files\View;
 use OC\ServerNotAvailableException;
 use OCA\Encryption\Util;
+use OCP\Encryption\Exceptions\InvalidHeaderException;
 use OCP\Files\IRootFolder;
 use OCP\HintException;
 use OCP\IConfig;
@@ -196,7 +197,7 @@ class FixEncryptedVersion extends Command {
 			\fclose($handle);
 
 			return true;
-		} catch (ServerNotAvailableException $e) {
+		} catch (ServerNotAvailableException|InvalidHeaderException $e) {
 			// not a "bad signature" error and likely "legacy cipher" exception
 			// this could mean that the file is maybe not encrypted but the encrypted version is set
 			if (!$this->supportLegacy && $ignoreCorrectEncVersionCall === true) {

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -320,6 +320,7 @@ return array(
     'OCP\\DirectEditing\\IToken' => $baseDir . '/lib/public/DirectEditing/IToken.php',
     'OCP\\DirectEditing\\RegisterDirectEditorEvent' => $baseDir . '/lib/public/DirectEditing/RegisterDirectEditorEvent.php',
     'OCP\\Encryption\\Exceptions\\GenericEncryptionException' => $baseDir . '/lib/public/Encryption/Exceptions/GenericEncryptionException.php',
+    'OCP\\Encryption\\Exceptions\\InvalidHeaderException' => $baseDir . '/lib/public/Encryption/Exceptions/InvalidHeaderException.php',
     'OCP\\Encryption\\IEncryptionModule' => $baseDir . '/lib/public/Encryption/IEncryptionModule.php',
     'OCP\\Encryption\\IFile' => $baseDir . '/lib/public/Encryption/IFile.php',
     'OCP\\Encryption\\IManager' => $baseDir . '/lib/public/Encryption/IManager.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -361,6 +361,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\DirectEditing\\IToken' => __DIR__ . '/../../..' . '/lib/public/DirectEditing/IToken.php',
         'OCP\\DirectEditing\\RegisterDirectEditorEvent' => __DIR__ . '/../../..' . '/lib/public/DirectEditing/RegisterDirectEditorEvent.php',
         'OCP\\Encryption\\Exceptions\\GenericEncryptionException' => __DIR__ . '/../../..' . '/lib/public/Encryption/Exceptions/GenericEncryptionException.php',
+        'OCP\\Encryption\\Exceptions\\InvalidHeaderException' => __DIR__ . '/../../..' . '/lib/public/Encryption/Exceptions/InvalidHeaderException.php',
         'OCP\\Encryption\\IEncryptionModule' => __DIR__ . '/../../..' . '/lib/public/Encryption/IEncryptionModule.php',
         'OCP\\Encryption\\IFile' => __DIR__ . '/../../..' . '/lib/public/Encryption/IFile.php',
         'OCP\\Encryption\\IManager' => __DIR__ . '/../../..' . '/lib/public/Encryption/IManager.php',

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -18,6 +18,7 @@ use OC\Files\Storage\Common;
 use OC\Files\Storage\LocalTempFileTrait;
 use OC\Memcache\ArrayCache;
 use OCP\Cache\CappedMemoryCache;
+use OCP\Encryption\Exceptions\InvalidHeaderException;
 use OCP\Encryption\IFile;
 use OCP\Encryption\IManager;
 use OCP\Encryption\Keys\IStorage;
@@ -344,6 +345,16 @@ class Encryption extends Wrapper {
 			if ($shouldEncrypt === true && $encryptionModule !== null) {
 				$this->encryptedPaths->set($this->util->stripPartialFileExtension($path), true);
 				$headerSize = $this->getHeaderSize($path);
+				if ($mode === 'r' && $headerSize === 0) {
+					$firstBlock = $this->readFirstBlock($path);
+					if (!$firstBlock) {
+						throw new InvalidHeaderException("Unable to get header block for $path");
+					} elseif (!str_starts_with($firstBlock, Util::HEADER_START)) {
+						throw new InvalidHeaderException("Unable to get header size for $path, file doesn't start with encryption header");
+					} else {
+						throw new InvalidHeaderException("Unable to get header size for $path, even though file does start with encryption header");
+					}
+				}
 				$source = $this->storage->fopen($path, $mode);
 				if (!is_resource($source)) {
 					return false;

--- a/lib/public/Encryption/Exceptions/InvalidHeaderException.php
+++ b/lib/public/Encryption/Exceptions/InvalidHeaderException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OCP\Encryption\Exceptions;
+
+use OCP\HintException;
+
+/**
+ * Class InvalidHeaderException
+ *
+ * @since 32.0.0
+ */
+class InvalidHeaderException extends HintException {
+}


### PR DESCRIPTION
Instead of erroring later down the line because of the header size of 0 with a cryptic "ValueError: fread(): Argument #2 ($length) must be greater than 0". Throw an error with a more meaningful message.