### PR TITLE
fix: use correct date format for expires, last-modified, and if-modified-since headers

### DIFF
--- a/apps/dav/lib/Provisioning/Apple/AppleProvisioningNode.php
+++ b/apps/dav/lib/Provisioning/Apple/AppleProvisioningNode.php
@@ -57,7 +57,7 @@ class AppleProvisioningNode implements INode, IProperties {
 
 		return [
 			'{DAV:}getcontentlength' => 42,
-			'{DAV:}getlastmodified' => $datetime->format(\DateTimeInterface::RFC2822),
+			'{DAV:}getlastmodified' => $datetime->format(\DateTimeInterface::RFC7231),
 		];
 	}
 

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
@@ -54,7 +54,7 @@ class AppleProvisioningNodeTest extends TestCase {
 
 		$this->assertEquals([
 			'{DAV:}getcontentlength' => 42,
-			'{DAV:}getlastmodified' => 'Sat, 01 Jan 2000 00:00:00 +0000',
+			'{DAV:}getlastmodified' => 'Sat, 01 Jan 2000 00:00:00 GMT',
 		], $this->node->getProperties([]));
 	}
 

--- a/lib/private/AppFramework/Middleware/NotModifiedMiddleware.php
+++ b/lib/private/AppFramework/Middleware/NotModifiedMiddleware.php
@@ -29,7 +29,7 @@ class NotModifiedMiddleware extends Middleware {
 		}
 
 		$modifiedSinceHeader = $this->request->getHeader('IF_MODIFIED_SINCE');
-		if ($modifiedSinceHeader !== '' && $response->getLastModified() !== null && trim($modifiedSinceHeader) === $response->getLastModified()->format(\DateTimeInterface::RFC2822)) {
+		if ($modifiedSinceHeader !== '' && $response->getLastModified() !== null && trim($modifiedSinceHeader) === $response->getLastModified()->format(\DateTimeInterface::RFC7231)) {
 			$response->setStatus(Http::STATUS_NOT_MODIFIED);
 			return $response;
 		}

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -96,7 +96,7 @@ class Response {
 			$time = \OCP\Server::get(ITimeFactory::class);
 			$expires->setTimestamp($time->getTime());
 			$expires->add(new \DateInterval('PT' . $cacheSeconds . 'S'));
-			$this->addHeader('Expires', $expires->format(\DateTimeInterface::RFC2822));
+			$this->addHeader('Expires', $expires->format(\DateTimeInterface::RFC7231));
 		} else {
 			$this->addHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
 			unset($this->headers['Expires']);
@@ -238,7 +238,7 @@ class Response {
 		];
 
 		if ($this->lastModified) {
-			$mergeWith['Last-Modified'] = $this->lastModified->format(\DateTimeInterface::RFC2822);
+			$mergeWith['Last-Modified'] = $this->lastModified->format(\DateTimeInterface::RFC7231);
 		}
 
 		if ($this->ETag) {

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -229,7 +229,7 @@ class ResponseTest extends \Test\TestCase {
 
 		$headers = $this->childResponse->getHeaders();
 		$this->assertEquals('private, max-age=33, must-revalidate', $headers['Cache-Control']);
-		$this->assertEquals('Thu, 15 Jan 1970 06:56:40 +0000', $headers['Expires']);
+		$this->assertEquals('Thu, 15 Jan 1970 06:56:40 GMT', $headers['Expires']);
 	}
 
 
@@ -239,7 +239,7 @@ class ResponseTest extends \Test\TestCase {
 		$lastModified->setTimestamp(1);
 		$this->childResponse->setLastModified($lastModified);
 		$headers = $this->childResponse->getHeaders();
-		$this->assertEquals('Thu, 01 Jan 1970 00:00:01 +0000', $headers['Last-Modified']);
+		$this->assertEquals('Thu, 01 Jan 1970 00:00:01 GMT', $headers['Last-Modified']);
 	}
 
 	public function testChainability(): void {
@@ -257,7 +257,7 @@ class ResponseTest extends \Test\TestCase {
 		$this->assertEquals('world', $headers['hello']);
 		$this->assertEquals(Http::STATUS_NOT_FOUND, $this->childResponse->getStatus());
 		$this->assertEquals('hi', $this->childResponse->getEtag());
-		$this->assertEquals('Thu, 01 Jan 1970 00:00:01 +0000', $headers['Last-Modified']);
+		$this->assertEquals('Thu, 01 Jan 1970 00:00:01 GMT', $headers['Last-Modified']);
 		$this->assertEquals('private, max-age=33, must-revalidate',
 			$headers['Cache-Control']);
 	}

--- a/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
@@ -43,13 +43,13 @@ class NotModifiedMiddlewareTest extends \Test\TestCase {
 			[null, '"etag"', null, '', false],
 			['etag', '"etag"', null, '', true],
 
-			[null, '', $now, $now->format(\DateTimeInterface::RFC2822), true],
+			[null, '', $now, $now->format(\DateTimeInterface::RFC7231), true],
 			[null, '', $now, $now->format(\DateTimeInterface::ATOM), false],
-			[null, '', null, $now->format(\DateTimeInterface::RFC2822), false],
+			[null, '', null, $now->format(\DateTimeInterface::RFC7231), false],
 			[null, '', $now, '', false],
 
 			['etag', '"etag"', $now, $now->format(\DateTimeInterface::ATOM), true],
-			['etag', '"etag"', $now, $now->format(\DateTimeInterface::RFC2822), true],
+			['etag', '"etag"', $now, $now->format(\DateTimeInterface::RFC7231), true],
 		];
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

| B | A |
| --- | --- |
| `Sat, 10 May 2025 18:17:41 +0000` | `Sat, 10 May 2025 18:17:41 GMT` |

RFC: https://httpwg.org/specs/rfc9110.html#http.date


Chrome and Firefox seem quite easy about the format of the headers. I couldn't see a difference in their behavior regarding caching the files, so I wouldn't backport it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
