### PR TITLE
feat(CertificateManager): Add option to specify the default certificates bundle path

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2877,4 +2877,13 @@ $CONFIG = [
 	 * Defaults to ``true``
 	 */
 	'enable_lazy_objects' => true,
+
+	/**
+	 * Change the default certificates bundle used for trusting certificates.
+	 *
+	 * Nextcloud ships its own up-to-date certificates bundle, but in certain cases admins may wish to specify a different bundle, for example the one shipped by their distro.
+	 *
+	 * Defaults to `\OC::$SERVERROOT . '/resources/config/ca-bundle.crt'`.
+	 */
+	'default_certificates_bundle_path' => \OC::$SERVERROOT . '/resources/config/ca-bundle.crt',
 ];

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -241,13 +241,13 @@ trait S3ConnectionTrait {
 
 	protected function getCertificateBundlePath(): ?string {
 		if ((int)($this->params['use_nextcloud_bundle'] ?? '0')) {
+			/** @var ICertificateManager $certManager */
+			$certManager = Server::get(ICertificateManager::class);
 			// since we store the certificate bundles on the primary storage, we can't get the bundle while setting up the primary storage
 			if (!isset($this->params['primary_storage'])) {
-				/** @var ICertificateManager $certManager */
-				$certManager = Server::get(ICertificateManager::class);
 				return $certManager->getAbsoluteBundlePath();
 			} else {
-				return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+				return $certManager->getDefaultCertificatesBundlePath();
 			}
 		} else {
 			return null;

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -105,7 +105,7 @@ class Client implements IClient {
 		// $this->certificateManager->getAbsoluteBundlePath() tries to instantiate
 		// a view
 		if (!$this->config->getSystemValueBool('installed', false)) {
-			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+			return $this->certificateManager->getDefaultCertificatesBundlePath();
 		}
 
 		return $this->certificateManager->getAbsoluteBundlePath();

--- a/lib/private/Security/CertificateManager.php
+++ b/lib/private/Security/CertificateManager.php
@@ -100,7 +100,7 @@ class CertificateManager implements ICertificateManager {
 			$this->view->mkdir($path);
 		}
 
-		$defaultCertificates = file_get_contents(\OC::$SERVERROOT . '/resources/config/ca-bundle.crt');
+		$defaultCertificates = file_get_contents($this->getDefaultCertificatesBundlePath());
 		if (strlen($defaultCertificates) < 1024) { // sanity check to verify that we have some content for our bundle
 			// log as exception so we have a stacktrace
 			$e = new \Exception('Shipped ca-bundle is empty, refusing to create certificate bundle');
@@ -204,7 +204,7 @@ class CertificateManager implements ICertificateManager {
 		try {
 			if ($this->bundlePath === null) {
 				if (!$this->hasCertificates()) {
-					$this->bundlePath = \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+					$this->bundlePath = $this->getDefaultCertificatesBundlePath();
 				} else {
 					if ($this->needsRebundling()) {
 						$this->createCertificateBundle();
@@ -221,7 +221,7 @@ class CertificateManager implements ICertificateManager {
 			return $this->bundlePath;
 		} catch (\Exception $e) {
 			$this->logger->error('Failed to get absolute bundle path. Fallback to default ca-bundle.crt', ['exception' => $e]);
-			return \OC::$SERVERROOT . '/resources/config/ca-bundle.crt';
+			return $this->getDefaultCertificatesBundlePath();
 		}
 	}
 
@@ -246,6 +246,10 @@ class CertificateManager implements ICertificateManager {
 	 * get mtime of ca-bundle shipped by Nextcloud
 	 */
 	protected function getFilemtimeOfCaBundle(): int {
-		return filemtime(\OC::$SERVERROOT . '/resources/config/ca-bundle.crt');
+		return filemtime($this->getDefaultCertificatesBundlePath());
+	}
+
+	public function getDefaultCertificatesBundlePath(): string {
+		return $this->config->getSystemValueString('default_certificates_bundle_path', \OC::$SERVERROOT . '/resources/config/ca-bundle.crt');
 	}
 }

--- a/lib/public/ICertificateManager.php
+++ b/lib/public/ICertificateManager.php
@@ -52,4 +52,11 @@ interface ICertificateManager {
 	 * @since 9.0.0
 	 */
 	public function getAbsoluteBundlePath(): string;
+
+	/**
+	 * Get the path of the default certificates bundle.
+	 *
+	 * @since 33.0.0
+	 */
+	public function getDefaultCertificatesBundlePath(): string;
 }

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -473,6 +473,10 @@ class ClientTest extends \Test\TestCase {
 		$this->certificateManager
 			->expects($this->never())
 			->method('listCertificates');
+		$this->certificateManager
+			->expects($this->once())
+			->method('getDefaultCertificatesBundlePath')
+			->willReturn(\OC::$SERVERROOT . '/resources/config/ca-bundle.crt');
 
 		$this->serverVersion->method('getVersionString')
 			->willReturn('123.45.6');

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -52,6 +52,11 @@ class CertificateManagerTest extends \Test\TestCase {
 		$config = $this->createMock(IConfig::class);
 		$config->expects($this->any())->method('getSystemValueBool')
 			->with('installed', false)->willReturn(true);
+		$config
+			->expects($this->any())
+			->method('getSystemValueString')
+			->with('default_certificates_bundle_path', \OC::$SERVERROOT . '/resources/config/ca-bundle.crt')
+			->willReturn(\OC::$SERVERROOT . '/resources/config/ca-bundle.crt');
 
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->random->method('generate')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Currently it's not possible for admins to reject certificates that are part of the default bundle shipped by Nextcloud.
This option allows specifying the default bundle which in turn allows admins to use the system bundle which they might customize to include self-signed certificates and which might also get faster security updates (without even updating Nextcloud).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
