### PR TITLE
fix(updatenotification): respect `updatechecker` config

### DIFF
--- a/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
+++ b/apps/updatenotification/lib/BackgroundJob/UpdateAvailableNotifications.php
@@ -64,9 +64,14 @@ class UpdateAvailableNotifications extends TimedJob {
 	}
 
 	/**
-	 * Check for ownCloud update
+	 * Check for Nextcloud server update
 	 */
 	protected function checkCoreUpdate() {
+		if (!$this->config->getSystemValueBool('updatechecker', true)) {
+			// update checker is disabled so no core update check!
+			return;
+		}
+
 		if (\in_array($this->serverVersion->getChannel(), ['daily', 'git'], true)) {
 			// "These aren't the update channels you're looking for." - Ben Obi-Wan Kenobi
 			return;

--- a/apps/updatenotification/lib/Settings/Admin.php
+++ b/apps/updatenotification/lib/Settings/Admin.php
@@ -130,7 +130,12 @@ class Admin implements ISettings {
 		return $result;
 	}
 
-	public function getSection(): string {
+	public function getSection(): ?string {
+		if (!$this->config->getSystemValueBool('updatechecker', true)) {
+			// update checker is disabled so we do not show the section at all
+			return null;
+		}
+
 		return 'overview';
 	}
 

--- a/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
@@ -25,7 +25,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class UpdateAvailableNotificationsTest extends TestCase {
-	private ServerVersion $serverVersion;
+	private ServerVersion&MockObject $serverVersion;
 	private IConfig|MockObject $config;
 	private IManager|MockObject $notificationManager;
 	private IGroupManager|MockObject $groupManager;
@@ -96,13 +96,12 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		$job->expects($this->once())
 			->method('checkAppUpdates');
 
-		$this->config->expects($this->exactly(2))
+		$this->config->expects(self::exactly(2))
 			->method('getSystemValueBool')
 			->willReturnMap([
-				['has_internet_connection', true, true],
 				['debug', false, true],
+				['has_internet_connection', true, true],
 			]);
-
 		self::invokePrivate($job, 'run', [null]);
 	}
 
@@ -117,7 +116,9 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		$job->expects($this->never())
 			->method('checkAppUpdates');
 
-		$this->config->method('getSystemValueBool')
+		$this->config
+			->expects(self::once())
+			->method('getSystemValueBool')
 			->with('has_internet_connection', true)
 			->willReturn(false);
 
@@ -211,6 +212,13 @@ class UpdateAvailableNotificationsTest extends TestCase {
 				->method('createNotifications')
 				->with('core', $version, $readableVersion);
 		}
+
+		$this->config->expects(self::any())
+			->method('getSystemValueBool')
+			->willReturnMap([
+				['updatechecker', true, true],
+				['has_internet_connection', true, true],
+			]);
 
 		self::invokePrivate($job, 'checkCoreUpdate');
 	}

--- a/apps/updatenotification/tests/Settings/AdminTest.php
+++ b/apps/updatenotification/tests/Settings/AdminTest.php
@@ -108,6 +108,11 @@ class AdminTest extends TestCase {
 				['updater.server.url', 'https://updates.nextcloud.com/updater_server/', 'https://updates.nextcloud.com/updater_server/'],
 				['upgrade.disable-web', false, false],
 			]);
+		$this->config
+			->expects(self::any())
+			->method('getSystemValueBool')
+			->with('updatechecker', true)
+			->willReturn(true);
 		$this->dateTimeFormatter
 			->expects($this->once())
 			->method('formatDateTime')
@@ -192,6 +197,11 @@ class AdminTest extends TestCase {
 			->method('getValueInt')
 			->with('core', 'lastupdatedat', 0)
 			->willReturn(12345);
+		$this->config
+			->expects(self::any())
+			->method('getSystemValueBool')
+			->with('updatechecker', true)
+			->willReturn(true);
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')
@@ -288,6 +298,11 @@ class AdminTest extends TestCase {
 			->with('core', 'lastupdatedat', 0)
 			->willReturn(12345);
 		$this->config
+			->expects(self::any())
+			->method('getSystemValueBool')
+			->with('updatechecker', true)
+			->willReturn(true);
+		$this->config
 			->expects($this->once())
 			->method('getAppValue')
 			->with('updatenotification', 'notify_groups', '["admin"]')
@@ -363,7 +378,23 @@ class AdminTest extends TestCase {
 
 
 	public function testGetSection(): void {
+		$this->config
+			->expects(self::atLeastOnce())
+			->method('getSystemValueBool')
+			->with('updatechecker', true)
+			->willReturn(true);
+
 		$this->assertSame('overview', $this->admin->getSection());
+	}
+
+	public function testGetSectionDisabled(): void {
+		$this->config
+			->expects(self::atLeastOnce())
+			->method('getSystemValueBool')
+			->with('updatechecker', true)
+			->willReturn(false);
+
+		$this->assertNull($this->admin->getSection());
 	}
 
 	public function testGetPriority(): void {


### PR DESCRIPTION
Close https://github.com/nextcloud/server/issues/52125

## Summary
If disabled:
- Hide admin settings
- Do not create Nextcloud server update notifications

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
