### PR TITLE
feat(cypress): add oracle to setup tests

### DIFF
--- a/cypress/dockerNode.ts
+++ b/cypress/dockerNode.ts
@@ -182,6 +182,7 @@ export const applyChangesToNextcloud = async function() {
 		'./ocs',
 		'./ocs-provider',
 		'./resources',
+		'./tests',
 		'./console.php',
 		'./cron.php',
 		'./index.php',

--- a/cypress/e2e/core/setup.ts
+++ b/cypress/e2e/core/setup.ts
@@ -85,6 +85,26 @@ describe('Can install Nextcloud', { testIsolation: true, retries: 0 }, () => {
 		sharedSetup()
 	})
 
+	it('Oracle', () => {
+		cy.runCommand('cp /var/www/html/tests/databases-all-config.php /var/www/html/config/config.php')
+		cy.visit('/')
+		cy.get('[data-cy-setup-form]').should('be.visible')
+		cy.get('[data-cy-setup-form-field="adminlogin"]').should('be.visible')
+		cy.get('[data-cy-setup-form-field="adminpass"]').should('be.visible')
+		cy.get('[data-cy-setup-form-field="directory"]').should('have.value', '/var/www/html/data')
+
+		// Select the SQLite database
+		cy.get('[data-cy-setup-form-field="dbtype-oci"] input').check({ force: true })
+
+		// Fill in the DB form
+		cy.get('[data-cy-setup-form-field="dbuser"]').type('{selectAll}system')
+		cy.get('[data-cy-setup-form-field="dbpass"]').type('{selectAll}oracle')
+		cy.get('[data-cy-setup-form-field="dbname"]').type('{selectAll}FREE')
+		cy.get('[data-cy-setup-form-field="dbhost"]').type('{selectAll}oracle:1521')
+
+		sharedSetup()
+	})
+
 })
 
 /**

--- a/tests/databases-all-config.php
+++ b/tests/databases-all-config.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+$CONFIG = [
+	'supportedDatabases' => [
+		'sqlite',
+		'mysql',
+		'pgsql',
+		'oci',
+	],
+];


### PR DESCRIPTION
- Followup #52703 
- [x] Needs https://github.com/nextcloud/docker-ci/pull/766
- [x] Release new `shallow-server`: https://github.com/nextcloud/docker-ci/actions/runs/14976683203/job/42070680964