### PR TITLE
fix unjailedroot of nested jails if there are other wrappers in between

### DIFF
--- a/apps/files_sharing/lib/Cache.php
+++ b/apps/files_sharing/lib/Cache.php
@@ -68,7 +68,7 @@ class Cache extends CacheJail {
 		return $this->root;
 	}
 
-	protected function getGetUnjailedRoot(): string {
+	public function getGetUnjailedRoot(): string {
 		return $this->sourceRootInfo->getPath();
 	}
 

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -50,7 +50,7 @@ class CacheJail extends CacheWrapper {
 	 *
 	 * @return string
 	 */
-	protected function getGetUnjailedRoot() {
+	public function getGetUnjailedRoot() {
 		return $this->unjailedRoot;
 	}
 

--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -31,10 +31,13 @@ class CacheJail extends CacheWrapper {
 	) {
 		parent::__construct($cache, $dependencies);
 
-		if ($cache instanceof CacheJail) {
-			$this->unjailedRoot = $cache->getSourcePath($root);
-		} else {
-			$this->unjailedRoot = $root;
+		$this->unjailedRoot = $root;
+		$parent = $cache;
+		while ($parent instanceof CacheWrapper) {
+			if ($parent instanceof CacheJail) {
+				$this->unjailedRoot = $parent->getSourcePath($this->unjailedRoot);
+			}
+			$parent = $parent->getCache();
 		}
 	}
 

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -8,6 +8,7 @@
 namespace Test\Files\Cache\Wrapper;
 
 use OC\Files\Cache\Wrapper\CacheJail;
+use OC\Files\Cache\Wrapper\CacheWrapper;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Jail;
@@ -251,5 +252,15 @@ class CacheJailTest extends CacheTest {
 		$this->assertFalse($this->cache->inCache('bar'));
 		$storage->getWatcher()->update('bar', ['mimetype' => 'text/plain']);
 		$this->assertTrue($this->cache->inCache('bar'));
+	}
+
+	public function testUnJailedRoot(): void {
+		$jail1 = new CacheJail($this->sourceCache, 'foo');
+		$jail2 = new CacheJail($jail1, 'bar');
+		$this->assertEquals('foo/bar', $jail2->getGetUnjailedRoot());
+
+		$middleWrapper = new CacheWrapper($jail1);
+		$jail3 = new CacheJail($middleWrapper, 'bar');
+		$this->assertEquals('foo/bar', $jail3->getGetUnjailedRoot());
 	}
 }


### PR DESCRIPTION
This breaks (probably among other things), search in subfolders in groupfolders.

Fixes https://github.com/nextcloud/groupfolders/issues/3712