### PR TITLE
feat: Cache compiled routes

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Print logs
         if: always()
         run: |
-          cat data/nextcloud.log
+          cat $(./occ log:file |grep "Log file"|cut -d" " -f3)
           docker ps -a
           docker ps -aq | while read container ; do IMAGE=$(docker inspect --format='{{.Config.Image}}' $container); echo $IMAGE; docker logs $container; echo "\n\n" ; done
 

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4336,9 +4336,6 @@
     </ParamNameMismatch>
   </file>
   <file src="lib/private/Route/Router.php">
-    <InvalidClass>
-      <code><![CDATA[\OC_APP]]></code>
-    </InvalidClass>
     <InvalidNullableReturnType>
       <code><![CDATA[string]]></code>
     </InvalidNullableReturnType>

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -135,6 +135,7 @@ class AppManager implements IAppManager {
 	 */
 	private function getEnabledAppsValues(): array {
 		if (!$this->enabledAppsCache) {
+			/** @var array<string,string> */
 			$values = $this->getAppConfig()->searchValues('enabled', false, IAppConfig::VALUE_STRING);
 
 			$alwaysEnabledApps = $this->getAlwaysEnabledApps();

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -18,6 +18,7 @@ use OCP\Collaboration\AutoComplete\IManager as IAutoCompleteManager;
 use OCP\Collaboration\Collaborators\ISearch as ICollaboratorSearch;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IGroup;
@@ -134,7 +135,7 @@ class AppManager implements IAppManager {
 	 */
 	private function getEnabledAppsValues(): array {
 		if (!$this->enabledAppsCache) {
-			$values = $this->getAppConfig()->getValues(false, 'enabled');
+			$values = $this->getAppConfig()->searchValues('enabled', false, IAppConfig::VALUE_STRING);
 
 			$alwaysEnabledApps = $this->getAlwaysEnabledApps();
 			foreach ($alwaysEnabledApps as $appId) {
@@ -784,8 +785,8 @@ class AppManager implements IAppManager {
 	 *
 	 * @return array<string, string>
 	 */
-	public function getAppInstalledVersions(): array {
-		return $this->getAppConfig()->getAppInstalledVersions();
+	public function getAppInstalledVersions(bool $onlyEnabled = false): array {
+		return $this->getAppConfig()->getAppInstalledVersions($onlyEnabled);
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1670,10 +1670,17 @@ class AppConfig implements IAppConfig {
 	 *
 	 * @return array<string, string>
 	 */
-	public function getAppInstalledVersions(): array {
+	public function getAppInstalledVersions(bool $onlyEnabled = false): array {
 		if ($this->appVersionsCache === null) {
 			/** @var array<string, string> */
 			$this->appVersionsCache = $this->searchValues('installed_version', false, IAppConfig::VALUE_STRING);
+		}
+		if ($onlyEnabled) {
+			return array_filter(
+				$this->appVersionsCache,
+				fn (string $app): bool => $this->getValueString($app, 'enabled', 'no') !== 'no',
+				ARRAY_FILTER_USE_KEY
+			);
 		}
 		return $this->appVersionsCache;
 	}

--- a/lib/private/AppFramework/Services/AppConfig.php
+++ b/lib/private/AppFramework/Services/AppConfig.php
@@ -343,7 +343,7 @@ class AppConfig implements IAppConfig {
 	 *
 	 * @return array<string, string>
 	 */
-	public function getAppInstalledVersions(): array {
-		return $this->appConfig->getAppInstalledVersions();
+	public function getAppInstalledVersions(bool $onlyEnabled = false): array {
+		return $this->appConfig->getAppInstalledVersions($onlyEnabled);
 	}
 }

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -15,6 +15,7 @@ use OCP\IConfig;
 use OCP\IRequest;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\RouteCollection;
 
 class CachingRouter extends Router {
 	protected ICache $cache;
@@ -53,5 +54,63 @@ class CachingRouter extends Router {
 			}
 			return $url;
 		}
+	}
+
+	private function serializeRouteCollection(RouteCollection $collection): array {
+		return array_map(
+			fn (Route $route) => [$route->getPath(), $route->getDefaults(), $route->getRequirements(), $route->getOptions(), $route->getHost(), $route->getSchemes(), $route->getMethods(), $route->getCondition()],
+			$collection->all(),
+		);
+	}
+
+	private function unserializeRouteCollection(array $data): RouteCollection {
+		$collection = new RouteCollection();
+		foreach ($data as $name => $details) {
+			$route = new Route(...$details);
+			$collection->add($name, $route);
+		}
+		return $collection;
+	}
+
+	/**
+	 * Loads the routes
+	 *
+	 * @param null|string $app
+	 */
+	public function loadRoutes($app = null): void {
+		$this->eventLogger->start('cacheroute:load:' . $app, 'Loading Routes (using cache) for ' . $app);
+		if (is_string($app)) {
+			$app = $this->appManager->cleanAppId($app);
+		}
+
+		$requestedApp = $app;
+		if ($this->loaded) {
+			$this->eventLogger->end('cacheroute:load:' . $app);
+			return;
+		}
+		if (is_null($app)) {
+			$cachedRoutes = $this->cache->get('root:');
+			if ($cachedRoutes) {
+				$this->root = $this->unserializeRouteCollection($cachedRoutes);
+				$this->loaded = true;
+				$this->eventLogger->end('cacheroute:load:' . $app);
+				return;
+			}
+		} else {
+			if (isset($this->loadedApps[$app])) {
+				$this->eventLogger->end('cacheroute:load:' . $app);
+				return;
+			}
+			$cachedRoutes = $this->cache->get('root:' . $requestedApp);
+			if ($cachedRoutes) {
+				$this->root = $this->unserializeRouteCollection($cachedRoutes);
+				$this->loadedApps[$app] = true;
+				$this->eventLogger->end('cacheroute:load:' . $app);
+				return;
+			}
+		}
+		parent::loadRoutes($app);
+		$this->cache->set('root:' . $requestedApp, $this->serializeRouteCollection($this->root), 3600);
+		$this->eventLogger->end('cacheroute:load:' . $app);
 	}
 }

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -74,7 +74,7 @@ class CachingRouter extends Router {
 	 * @return array
 	 */
 	public function findMatchingRoute(string $url): array {
-		$this->eventLogger->start('cacheroute:match');
+		$this->eventLogger->start('cacheroute:match', 'Match route');
 		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . '#rootCollection';
 		$cachedRoutes = $this->cache->get($key);
 		if (!$cachedRoutes) {
@@ -83,7 +83,7 @@ class CachingRouter extends Router {
 			$this->cache->set($key, $cachedRoutes, 3600);
 		}
 		$matcher = new CompiledUrlMatcher($cachedRoutes, $this->context);
-		$this->eventLogger->start('cacheroute:url:match');
+		$this->eventLogger->start('cacheroute:url:match', 'Symfony URL match call');
 		try {
 			$parameters = $matcher->match($url);
 		} catch (ResourceNotFoundException $e) {

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -73,11 +73,12 @@ class CachingRouter extends Router {
 	 */
 	public function findMatchingRoute(string $url): array {
 		$this->eventLogger->start('cacheroute:match');
-		$cachedRoutes = $this->cache->get('root:');
+		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . '#rootCollection';
+		$cachedRoutes = $this->cache->get($key);
 		if (!$cachedRoutes) {
 			parent::loadRoutes();
 			$cachedRoutes = $this->serializeRouteCollection($this->root);
-			$this->cache->set('root:', $cachedRoutes, 3600);
+			$this->cache->set($key, $cachedRoutes, 3600);
 		}
 		$matcher = new CompiledUrlMatcher($cachedRoutes, $this->context);
 		$this->eventLogger->start('cacheroute:url:match');

--- a/lib/private/Route/Route.php
+++ b/lib/private/Route/Route.php
@@ -124,15 +124,9 @@ class Route extends SymfonyRoute implements IRoute {
 	 * The action to execute when this route matches, includes a file like
 	 * it is called directly
 	 * @param string $file
-	 * @return void
 	 */
 	public function actionInclude($file) {
-		$function = function ($param) use ($file) {
-			unset($param['_route']);
-			$_GET = array_merge($_GET, $param);
-			unset($param);
-			require_once "$file";
-		} ;
-		$this->action($function);
+		$this->setDefault('file', $file);
+		return $this;
 	}
 }

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -322,6 +322,10 @@ class Router implements IRouter {
 			call_user_func($action, $parameters);
 			$this->eventLogger->end('route:run:call');
 		} elseif (isset($parameters['file'])) {
+			$param = $parameters;
+			unset($param['_route']);
+			$_GET = array_merge($_GET, $param);
+			unset($param);
 			include $parameters['file'];
 		} else {
 			throw new \Exception('no action available');

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -82,7 +82,7 @@ class Router implements IRouter {
 	public function getRoutingFiles() {
 		if ($this->routingFiles === null) {
 			$this->routingFiles = [];
-			foreach (\OC_APP::getEnabledApps() as $app) {
+			foreach ($this->appManager->getEnabledApps() as $app) {
 				try {
 					$appPath = $this->appManager->getAppPath($app);
 					$file = $appPath . '/appinfo/routes.php';
@@ -117,7 +117,7 @@ class Router implements IRouter {
 			$routingFiles = $this->getRoutingFiles();
 
 			$this->eventLogger->start('route:load:attributes', 'Loading Routes from attributes');
-			foreach (\OC_App::getEnabledApps() as $enabledApp) {
+			foreach ($this->appManager->getEnabledApps() as $enabledApp) {
 				$this->loadAttributeRoutes($enabledApp);
 			}
 			$this->eventLogger->end('route:load:attributes');

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -620,7 +620,7 @@ class Server extends ServerContainer implements IServerContainer {
 						];
 					}
 					$v['core'] = implode(',', $serverVersion->getVersion());
-					$version = implode(',', $v);
+					$version = implode(',', array_keys($v)) . implode(',', $v);
 					$instanceId = \OC_Util::getInstanceId();
 					$path = \OC::$SERVERROOT;
 					return md5($instanceId . '-' . $version . '-' . $path);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -605,7 +605,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$prefixClosure = function () use ($logQuery, $serverVersion): ?string {
 					if (!$logQuery) {
 						try {
-							$v = \OCP\Server::get(IAppConfig::class)->getAppInstalledVersions();
+							$v = \OCP\Server::get(IAppConfig::class)->getAppInstalledVersions(true);
 						} catch (\Doctrine\DBAL\Exception $e) {
 							// Database service probably unavailable
 							// Probably related to https://github.com/nextcloud/server/issues/37424

--- a/lib/private/TemplateLayout.php
+++ b/lib/private/TemplateLayout.php
@@ -201,7 +201,7 @@ class TemplateLayout {
 
 		if ($this->config->getSystemValueBool('installed', false)) {
 			if (empty(self::$versionHash)) {
-				$v = $this->appManager->getAppInstalledVersions();
+				$v = $this->appManager->getAppInstalledVersions(true);
 				$v['core'] = implode('.', $this->serverVersion->getVersion());
 				self::$versionHash = substr(md5(implode(',', $v)), 0, 8);
 			}

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -57,7 +57,7 @@ interface IAppManager {
 	 * @return array<string, string>
 	 * @since 32.0.0
 	 */
-	public function getAppInstalledVersions(): array;
+	public function getAppInstalledVersions(bool $onlyEnabled = false): array;
 
 	/**
 	 * Returns the app icon or null if none is found

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -514,5 +514,5 @@ interface IAppConfig {
 	 * @return array<string, string>
 	 * @since 32.0.0
 	 */
-	public function getAppInstalledVersions(): array;
+	public function getAppInstalledVersions(bool $onlyEnabled = false): array;
 }

--- a/lib/public/Route/IRoute.php
+++ b/lib/public/Route/IRoute.php
@@ -34,8 +34,9 @@ interface IRoute {
 	 * it is called directly
 	 *
 	 * @param string $file
-	 * @return void
+	 * @return $this
 	 * @since 7.0.0
+	 * @deprecated 32.0.0 Use a proper controller instead
 	 */
 	public function actionInclude($file);
 
@@ -70,6 +71,7 @@ interface IRoute {
 	 * This function is called with $class set to a callable or
 	 * to the class with $function
 	 * @since 7.0.0
+	 * @deprecated 32.0.0 Use a proper controller instead
 	 */
 	public function action($class, $function = null);
 

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -71,6 +71,17 @@ class AppManagerTest extends TestCase {
 					return $values;
 				}
 			});
+		$config->expects($this->any())
+			->method('searchValues')
+			->willReturnCallback(function ($key, $lazy, $type) use (&$appConfig) {
+				$values = [];
+				foreach ($appConfig as $appid => $appData) {
+					if (isset($appData[$key])) {
+						$values[$appid] = $appData[$key];
+					}
+				}
+				return $values;
+			});
 
 		return $config;
 	}

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -38,7 +38,7 @@ class AppConfigTest extends TestCase {
 	private static array $baseStruct =
 		[
 			'testapp' => [
-				'enabled' => ['enabled', 'true'],
+				'enabled' => ['enabled', 'yes'],
 				'installed_version' => ['installed_version', '1.2.3'],
 				'depends_on' => ['depends_on', 'someapp'],
 				'deletethis' => ['deletethis', 'deletethis'],
@@ -49,11 +49,12 @@ class AppConfigTest extends TestCase {
 				'otherkey' => ['otherkey', 'othervalue']
 			],
 			'123456' => [
-				'enabled' => ['enabled', 'true'],
+				'enabled' => ['enabled', 'yes'],
 				'key' => ['key', 'value']
 			],
 			'anotherapp' => [
-				'enabled' => ['enabled', 'false'],
+				'enabled' => ['enabled', 'no'],
+				'installed_version' => ['installed_version', '3.2.1'],
 				'key' => ['key', 'value']
 			],
 			'non-sensitive-app' => [
@@ -209,6 +210,19 @@ class AppConfigTest extends TestCase {
 		$config = $this->generateAppConfig(false);
 
 		$this->assertEqualsCanonicalizing(array_keys(self::$baseStruct), $config->getApps());
+	}
+
+	public function testGetAppInstalledVersions(): void {
+		$config = $this->generateAppConfig(false);
+
+		$this->assertEquals(
+			['testapp' => '1.2.3', 'anotherapp' => '3.2.1'],
+			$config->getAppInstalledVersions(false)
+		);
+		$this->assertEquals(
+			['testapp' => '1.2.3'],
+			$config->getAppInstalledVersions(true)
+		);
 	}
 
 	/**
@@ -410,7 +424,7 @@ class AppConfigTest extends TestCase {
 
 	public function testSearchValues(): void {
 		$config = $this->generateAppConfig();
-		$this->assertEqualsCanonicalizing(['testapp' => 'true', '123456' => 'true', 'anotherapp' => 'false'], $config->searchValues('enabled'));
+		$this->assertEqualsCanonicalizing(['testapp' => 'yes', '123456' => 'yes', 'anotherapp' => 'no'], $config->searchValues('enabled'));
 	}
 
 	public function testGetValueString(): void {
@@ -1322,7 +1336,7 @@ class AppConfigTest extends TestCase {
 		$config = $this->generateAppConfig();
 		$config->deleteKey('anotherapp', 'key');
 		$status = $config->statusCache();
-		$this->assertEqualsCanonicalizing(['enabled' => 'false'], $status['fastCache']['anotherapp']);
+		$this->assertEqualsCanonicalizing(['enabled' => 'no', 'installed_version' => '3.2.1'], $status['fastCache']['anotherapp']);
 	}
 
 	public function testDeleteKeyDatabase(): void {

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -485,7 +485,7 @@ class AppTest extends \Test\TestCase {
 		\OC_User::setUserId($user);
 
 		$this->setupAppConfigMock()->expects($this->once())
-			->method('getValues')
+			->method('searchValues')
 			->willReturn(
 				[
 					'app3' => 'yes',
@@ -495,7 +495,6 @@ class AppTest extends \Test\TestCase {
 					'appforgroup2' => '["group2"]',
 					'appforgroup12' => '["group2","group1"]',
 				]
-
 			);
 
 		$apps = \OC_App::getEnabledApps(false, $forceAll);
@@ -524,13 +523,12 @@ class AppTest extends \Test\TestCase {
 		\OC_User::setUserId(self::TEST_USER1);
 
 		$this->setupAppConfigMock()->expects($this->once())
-			->method('getValues')
+			->method('searchValues')
 			->willReturn(
 				[
 					'app3' => 'yes',
 					'app2' => 'no',
 				]
-
 			);
 
 		$apps = \OC_App::getEnabledApps();
@@ -550,7 +548,7 @@ class AppTest extends \Test\TestCase {
 	private function setupAppConfigMock() {
 		/** @var AppConfig|MockObject */
 		$appConfig = $this->getMockBuilder(AppConfig::class)
-			->onlyMethods(['getValues'])
+			->onlyMethods(['searchValues'])
 			->setConstructorArgs([\OCP\Server::get(IDBConnection::class)])
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
PR for https://github.com/nextcloud/server/issues/54155

* Follow-up of https://github.com/nextcloud/server/pull/52667

## Summary

1. Use symfony tools to compile all routes
2. Cache that in a local cache
3. Load from cache instead of parsing routes on each request
4. [x] ~Do the same for the generator~ postponed to follow-up if needed
5. [x] Check whether cache reset is needed in some situations

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
