### PR TITLE
fix: log requests exceeding the rate limiting

### DIFF
--- a/lib/private/Security/RateLimiting/Limiter.php
+++ b/lib/private/Security/RateLimiting/Limiter.php
@@ -13,10 +13,12 @@ use OC\Security\RateLimiting\Backend\IBackend;
 use OC\Security\RateLimiting\Exception\RateLimitExceededException;
 use OCP\IUser;
 use OCP\Security\RateLimiting\ILimiter;
+use Psr\Log\LoggerInterface;
 
 class Limiter implements ILimiter {
 	public function __construct(
 		private IBackend $backend,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -32,6 +34,11 @@ class Limiter implements ILimiter {
 	): void {
 		$existingAttempts = $this->backend->getAttempts($methodIdentifier, $userIdentifier);
 		if ($existingAttempts >= $limit) {
+			$this->logger->info('Request blocked because it exceeds the rate limit [method: {method}, limit: {limit}, period: {period}]', [
+				'method' => $methodIdentifier,
+				'limit' => $limit,
+				'period' => $period,
+			]);
 			throw new RateLimitExceededException();
 		}
 

--- a/tests/lib/Security/RateLimiting/LimiterTest.php
+++ b/tests/lib/Security/RateLimiting/LimiterTest.php
@@ -12,21 +12,26 @@ namespace Test\Security\RateLimiting;
 use OC\Security\RateLimiting\Backend\IBackend;
 use OC\Security\RateLimiting\Limiter;
 use OCP\IUser;
+use OCP\Security\RateLimiting\ILimiter;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class LimiterTest extends TestCase {
-	/** @var IBackend|\PHPUnit\Framework\MockObject\MockObject */
-	private $backend;
-	/** @var Limiter */
-	private $limiter;
+
+	private IBackend&MockObject $backend;
+	private ILimiter $limiter;
+	private LoggerInterface $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->backend = $this->createMock(IBackend::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		$this->limiter = new Limiter(
-			$this->backend
+			$this->backend,
+			$this->logger,
 		);
 	}
 
@@ -43,6 +48,8 @@ class LimiterTest extends TestCase {
 				'4664f0d9c88dcb7552be47b37bb52ce35977b2e60e1ac13757cf625f31f87050a41f3da064887fa87d49fd042e4c8eb20de8f10464877d3959677ab011b73a47'
 			)
 			->willReturn(101);
+		$this->logger->expects($this->once())
+			->method('info');
 
 		$this->limiter->registerAnonRequest('MyIdentifier', 100, 100, '127.0.0.1');
 	}
@@ -64,6 +71,8 @@ class LimiterTest extends TestCase {
 				'4664f0d9c88dcb7552be47b37bb52ce35977b2e60e1ac13757cf625f31f87050a41f3da064887fa87d49fd042e4c8eb20de8f10464877d3959677ab011b73a47',
 				100
 			);
+		$this->logger->expects($this->never())
+			->method('info');
 
 		$this->limiter->registerAnonRequest('MyIdentifier', 100, 100, '127.0.0.1');
 	}
@@ -87,6 +96,8 @@ class LimiterTest extends TestCase {
 				'ddb2ec50fa973fd49ecf3d816f677c8095143e944ad10485f30fb3dac85c13a346dace4dae2d0a15af91867320957bfd38a43d9eefbb74fe6919e15119b6d805'
 			)
 			->willReturn(101);
+		$this->logger->expects($this->once())
+			->method('info');
 
 		$this->limiter->registerUserRequest('MyIdentifier', 100, 100, $user);
 	}
@@ -115,6 +126,8 @@ class LimiterTest extends TestCase {
 				'ddb2ec50fa973fd49ecf3d816f677c8095143e944ad10485f30fb3dac85c13a346dace4dae2d0a15af91867320957bfd38a43d9eefbb74fe6919e15119b6d805',
 				100
 			);
+		$this->logger->expects($this->never())
+			->method('info');
 
 		$this->limiter->registerUserRequest('MyIdentifier', 100, 100, $user);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary

Makes it a bit easier to find blocked requests due to rate limiting, similar to what we do for the bfp throttle.

Example user:

```json
{
  "reqId": "HPn5tPcQdhZCCs7LjQ9P",
  "level": 1,
  "time": "2025-05-13T16:59:00+00:00",
  "remoteAddr": "172.18.0.1",
  "user": "bob",
  "app": "no app in context",
  "method": "POST",
  "url": "/ocs/v2.php/apps/files_sharing/api/v1/shares",
  "message": "Request blocked because it exceeds the rate limit [method: OCA\\Files_Sharing\\Controller\\ShareAPIController::createShare, limit: 20, period: 600]",
  "userAgent": "IntelliJ HTTP Client/PhpStorm 2025.1.0.1",
  "version": "32.0.0.0",
  "data": []
}
```

Example anon:

```json
{
  "reqId": "2kWZvzMS0ECmcf2HdmW8",
  "level": 1,
  "time": "2025-05-13T17:02:06+00:00",
  "remoteAddr": "172.18.0.1",
  "user": "--",
  "app": "no app in context",
  "method": "GET",
  "url": "/index.php/u/alice",
  "message": "Request blocked because it exceeds the rate limit [method: OCA\\Profile\\Controller\\ProfilePageController::index, limit: 5, period: 120]",
  "userAgent": "IntelliJ HTTP Client/PhpStorm 2025.1.0.1",
  "version": "32.0.0.0",
  "data": []
}
```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
