### PR TITLE
fix: do not crash the event emitting parent process if on listener fails

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1554,6 +1554,7 @@ return array(
     'OC\\Encryption\\Manager' => $baseDir . '/lib/private/Encryption/Manager.php',
     'OC\\Encryption\\Update' => $baseDir . '/lib/private/Encryption/Update.php',
     'OC\\Encryption\\Util' => $baseDir . '/lib/private/Encryption/Util.php',
+    'OC\\EventDispatcher\\CoreDispatcher' => $baseDir . '/lib/private/EventDispatcher/CoreDispatcher.php',
     'OC\\EventDispatcher\\EventDispatcher' => $baseDir . '/lib/private/EventDispatcher/EventDispatcher.php',
     'OC\\EventDispatcher\\ServiceEventListener' => $baseDir . '/lib/private/EventDispatcher/ServiceEventListener.php',
     'OC\\EventSource' => $baseDir . '/lib/private/EventSource.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1595,6 +1595,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Encryption\\Manager' => __DIR__ . '/../../..' . '/lib/private/Encryption/Manager.php',
         'OC\\Encryption\\Update' => __DIR__ . '/../../..' . '/lib/private/Encryption/Update.php',
         'OC\\Encryption\\Util' => __DIR__ . '/../../..' . '/lib/private/Encryption/Util.php',
+        'OC\\EventDispatcher\\CoreDispatcher' => __DIR__ . '/../../..' . '/lib/private/EventDispatcher/CoreDispatcher.php',
         'OC\\EventDispatcher\\EventDispatcher' => __DIR__ . '/../../..' . '/lib/private/EventDispatcher/EventDispatcher.php',
         'OC\\EventDispatcher\\ServiceEventListener' => __DIR__ . '/../../..' . '/lib/private/EventDispatcher/ServiceEventListener.php',
         'OC\\EventSource' => __DIR__ . '/../../..' . '/lib/private/EventSource.php',

--- a/lib/private/EventDispatcher/CoreDispatcher.php
+++ b/lib/private/EventDispatcher/CoreDispatcher.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\EventDispatcher;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * Symfony Event Dispatcher Override
+ */
+class CoreDispatcher extends EventDispatcher {
+
+	public function __construct(
+		private LoggerInterface $logger
+	) {
+		parent::__construct();
+	}
+
+	/**
+     * Triggers the listeners of an event.
+     *
+     * This method can be overridden to add functionality that is executed
+     * for each listener.
+     *
+     * @param callable[] $listeners The event listeners
+     * @param string     $eventName The name of the event to dispatch
+     * @param object     $event     The event object to pass to the event handlers/listeners
+     *
+     * @return void
+     */
+    protected function callListeners(iterable $listeners, string $eventName, object $event)
+    {
+        $stoppable = $event instanceof StoppableEventInterface;
+
+        foreach ($listeners as $listener) {
+            if ($stoppable && $event->isPropagationStopped()) {
+                break;
+            }
+			// execute the listener and catch any exceptions to prevent an error in a listener from breaking the emitting process
+			try {
+				$listener($event, $eventName, $this);
+			} catch (\Throwable $e) {
+				$this->logger->error('Error occurred while executing an event listener ' . get_class($event), ['exception' => $e]);
+			}
+        }
+    }
+	
+}

--- a/lib/private/EventDispatcher/EventDispatcher.php
+++ b/lib/private/EventDispatcher/EventDispatcher.php
@@ -16,12 +16,11 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IServerContainer;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyDispatcher;
 use function get_class;
 
 class EventDispatcher implements IEventDispatcher {
 	public function __construct(
-		private SymfonyDispatcher $dispatcher,
+		private CoreDispatcher $dispatcher,
 		private IServerContainer $container,
 		private LoggerInterface $logger,
 	) {
@@ -80,10 +79,10 @@ class EventDispatcher implements IEventDispatcher {
 	}
 
 	/**
-	 * @return SymfonyDispatcher
+	 * @return CoreDispatcher
 	 * @deprecated 20.0.0
 	 */
-	public function getSymfonyDispatcher(): SymfonyDispatcher {
+	public function getSymfonyDispatcher(): CoreDispatcher {
 		return $this->dispatcher;
 	}
 }


### PR DESCRIPTION
## Resolves
Currently when a miss behaving event listener errors with out proper error catching this causes the emitting process to error also.

The issue here is that at this causes data loss and loss of functionality in unrelated apps. For instance, when saving a Calendar Appointment we emit a create calendar object event for every attendee that the event is saved to.

E.g.
Attendee 1 (Save Object) -> Emit Event ->Attendee 2 (Save Object) -> Emit Event -> Organizer (Save Object) -> Emit Event

So when a event listener errors after the first emit the entire process crashes and we lose data, even though the emitting process experienced no errors. As event listeners can be implemented by any app, there is no way to make sure that the code being executes is safe.

Some example of recent issues that causes user confusion and data loss..

#### Constructor errors
TypeError: OCA\Talk\Listener\CalDavEventListener::__construct(): Argument #6 ($userId) must be of type string, null given
#26 /spreed/lib/Listener/CalDavEventListener.php(32): OCA\Talk\Listener\CalDavEventListener::__construct

#### Runtime errors
ErrorException: Warning: Attempt to read property "LOCATION" on null
#17 /spreed/lib/Listener/CalDavEventListener.php(68): OCA\Talk\Listener\CalDavEventListener::handle

## Summary
- extends the symfony event dispatcher to catch errors in event listeners, to prevent the emitting process crashing in the event that a event listener errors without handling the exception  

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
