### PR TITLE
fix: annotate possible exceptions

### DIFF
--- a/lib/private/Files/SimpleFS/SimpleFile.php
+++ b/lib/private/Files/SimpleFS/SimpleFile.php
@@ -6,9 +6,11 @@
 namespace OC\Files\SimpleFS;
 
 use OCP\Files\File;
+use OCP\Files\GenericFileException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFile;
+use OCP\Lock\LockedException;
 
 class SimpleFile implements ISimpleFile {
 	private File $file;
@@ -48,8 +50,10 @@ class SimpleFile implements ISimpleFile {
 	/**
 	 * Get the content
 	 *
-	 * @throws NotPermittedException
+	 * @throws GenericFileException
+	 * @throws LockedException
 	 * @throws NotFoundException
+	 * @throws NotPermittedException
 	 */
 	public function getContent(): string {
 		$result = $this->file->getContent();
@@ -65,8 +69,10 @@ class SimpleFile implements ISimpleFile {
 	 * Overwrite the file
 	 *
 	 * @param string|resource $data
-	 * @throws NotPermittedException
+	 * @throws GenericFileException
+	 * @throws LockedException
 	 * @throws NotFoundException
+	 * @throws NotPermittedException
 	 */
 	public function putContent($data): void {
 		try {

--- a/lib/public/Files/SimpleFS/ISimpleFile.php
+++ b/lib/public/Files/SimpleFS/ISimpleFile.php
@@ -5,8 +5,10 @@
  */
 namespace OCP\Files\SimpleFS;
 
+use OCP\Files\GenericFileException;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\Lock\LockedException;
 
 /**
  * This interface allows to manage simple files.
@@ -49,8 +51,10 @@ interface ISimpleFile {
 	/**
 	 * Get the content
 	 *
-	 * @throws NotPermittedException
+	 * @throws GenericFileException
+	 * @throws LockedException
 	 * @throws NotFoundException
+	 * @throws NotPermittedException
 	 * @since 11.0.0
 	 */
 	public function getContent(): string;
@@ -59,8 +63,10 @@ interface ISimpleFile {
 	 * Overwrite the file
 	 *
 	 * @param string|resource $data
-	 * @throws NotPermittedException
+	 * @throws GenericFileException
+	 * @throws LockedException
 	 * @throws NotFoundException
+	 * @throws NotPermittedException
 	 * @since 11.0.0
 	 */
 	public function putContent($data): void;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

File.getContent can throw a GenericFileException since https://github.com/nextcloud/server/pull/37943.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
