### PR TITLE
chore: replace legacy OC_Helper calls with OCP\Util

### DIFF
--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -96,7 +96,7 @@ class CleanUp extends Command {
 			$node = $this->rootFolder->get($path);
 
 			if ($verbose) {
-				$output->writeln('Deleting <info>' . \OC_Helper::humanFileSize($node->getSize()) . "</info> in trash for <info>$uid</info>.");
+				$output->writeln('Deleting <info>' . \OCP\Util::humanFileSize($node->getSize()) . "</info> in trash for <info>$uid</info>.");
 			}
 			$node->delete();
 			if ($this->rootFolder->nodeExists($path)) {

--- a/apps/files_trashbin/lib/Command/Size.php
+++ b/apps/files_trashbin/lib/Command/Size.php
@@ -45,7 +45,7 @@ class Size extends Base {
 		$size = $input->getArgument('size');
 
 		if ($size) {
-			$parsedSize = \OC_Helper::computerFileSize($size);
+			$parsedSize = \OCP\Util::computerFileSize($size);
 			if ($parsedSize === false) {
 				$output->writeln('<error>Failed to parse input size</error>');
 				return -1;
@@ -70,7 +70,7 @@ class Size extends Base {
 		if ($globalSize < 0) {
 			$globalHumanSize = 'default (50% of available space)';
 		} else {
-			$globalHumanSize = \OC_Helper::humanFileSize($globalSize);
+			$globalHumanSize = \OCP\Util::humanFileSize($globalSize);
 		}
 
 		if ($user) {
@@ -79,7 +79,7 @@ class Size extends Base {
 			if ($userSize < 0) {
 				$userHumanSize = ($globalSize < 0) ? $globalHumanSize : "default($globalHumanSize)";
 			} else {
-				$userHumanSize = \OC_Helper::humanFileSize($userSize);
+				$userHumanSize = \OCP\Util::humanFileSize($userSize);
 			}
 
 			if ($input->getOption('output') == self::OUTPUT_FORMAT_PLAIN) {
@@ -106,7 +106,7 @@ class Size extends Base {
 				if (count($userValues)) {
 					$output->writeln('Per-user sizes:');
 					$this->writeArrayInOutputFormat($input, $output, array_map(function ($size) {
-						return \OC_Helper::humanFileSize($size);
+						return \OCP\Util::humanFileSize($size);
 					}, $userValues));
 				} else {
 					$output->writeln('No per-user sizes configured');

--- a/apps/settings/lib/Settings/Personal/PersonalInfo.php
+++ b/apps/settings/lib/Settings/Personal/PersonalInfo.php
@@ -71,7 +71,7 @@ class PersonalInfo implements ISettings {
 		if ($storageInfo['quota'] === FileInfo::SPACE_UNLIMITED) {
 			$totalSpace = $this->l->t('Unlimited');
 		} else {
-			$totalSpace = \OC_Helper::humanFileSize($storageInfo['total']);
+			$totalSpace = \OCP\Util::humanFileSize($storageInfo['total']);
 		}
 
 		$messageParameters = $this->getMessageParameters($account);
@@ -88,7 +88,7 @@ class PersonalInfo implements ISettings {
 			'groups' => $this->getGroups($user),
 			'quota' => $storageInfo['quota'],
 			'totalSpace' => $totalSpace,
-			'usage' => \OC_Helper::humanFileSize($storageInfo['used']),
+			'usage' => \OCP\Util::humanFileSize($storageInfo['used']),
 			'usageRelative' => round($storageInfo['relative']),
 			'displayName' => $this->getProperty($account, IAccountManager::PROPERTY_DISPLAYNAME),
 			'emailMap' => $this->getEmailMap($account),

--- a/apps/user_ldap/lib/User/User.php
+++ b/apps/user_ldap/lib/User/User.php
@@ -515,7 +515,7 @@ class User {
 	 * fetch all the user's attributes in one call and use the fetched values in this function.
 	 * The expected value for that parameter is a string describing the quota for the user. Valid
 	 * values are 'none' (unlimited), 'default' (the Nextcloud's default quota), '1234' (quota in
-	 * bytes), '1234 MB' (quota in MB - check the \OC_Helper::computerFileSize method for more info)
+	 * bytes), '1234 MB' (quota in MB - check the \OCP\Util::computerFileSize method for more info)
 	 *
 	 * fetches the quota from LDAP and stores it as Nextcloud user value
 	 * @param ?string $valueFromLDAP the quota attribute's value can be passed,
@@ -563,7 +563,7 @@ class User {
 	}
 
 	private function verifyQuotaValue(string $quotaValue): bool {
-		return $quotaValue === 'none' || $quotaValue === 'default' || \OC_Helper::computerFileSize($quotaValue) !== false;
+		return $quotaValue === 'none' || $quotaValue === 'default' || \OCP\Util::computerFileSize($quotaValue) !== false;
 	}
 
 	/**

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -11,7 +11,6 @@ use InvalidArgumentException;
 use OC\Accounts\AccountManager;
 use OC\Avatar\AvatarManager;
 use OC\Hooks\Emitter;
-use OC_Helper;
 use OCP\Accounts\IAccountManager;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -570,11 +569,11 @@ class User implements IUser {
 	public function setQuota($quota) {
 		$oldQuota = $this->config->getUserValue($this->uid, 'files', 'quota', '');
 		if ($quota !== 'none' and $quota !== 'default') {
-			$bytesQuota = OC_Helper::computerFileSize($quota);
+			$bytesQuota = \OCP\Util::computerFileSize($quota);
 			if ($bytesQuota === false) {
 				throw new InvalidArgumentException('Failed to set quota to invalid value ' . $quota);
 			}
-			$quota = OC_Helper::humanFileSize($bytesQuota);
+			$quota = \OCP\Util::humanFileSize($bytesQuota);
 		}
 		if ($quota !== $oldQuota) {
 			$this->config->setUserValue($this->uid, 'files', 'quota', $quota);

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -39,75 +39,26 @@ class OC_Helper {
 	 * Make a human file size
 	 * @param int|float $bytes file size in bytes
 	 * @return string a human readable file size
+	 * @deprecated 4.0.0 replaced with \OCP\Util::humanFileSize
 	 *
 	 * Makes 2048 to 2 kB.
 	 */
 	public static function humanFileSize(int|float $bytes): string {
-		if ($bytes < 0) {
-			return '?';
-		}
-		if ($bytes < 1024) {
-			return "$bytes B";
-		}
-		$bytes = round($bytes / 1024, 0);
-		if ($bytes < 1024) {
-			return "$bytes KB";
-		}
-		$bytes = round($bytes / 1024, 1);
-		if ($bytes < 1024) {
-			return "$bytes MB";
-		}
-		$bytes = round($bytes / 1024, 1);
-		if ($bytes < 1024) {
-			return "$bytes GB";
-		}
-		$bytes = round($bytes / 1024, 1);
-		if ($bytes < 1024) {
-			return "$bytes TB";
-		}
-
-		$bytes = round($bytes / 1024, 1);
-		return "$bytes PB";
+		return \OCP\Util::humanFileSize($bytes);
 	}
 
 	/**
 	 * Make a computer file size
 	 * @param string $str file size in human readable format
 	 * @return false|int|float a file size in bytes
+	 * @deprecated 4.0.0 Use \OCP\Util::computerFileSize
 	 *
 	 * Makes 2kB to 2048.
 	 *
 	 * Inspired by: https://www.php.net/manual/en/function.filesize.php#92418
 	 */
 	public static function computerFileSize(string $str): false|int|float {
-		$str = strtolower($str);
-		if (is_numeric($str)) {
-			return Util::numericToNumber($str);
-		}
-
-		$bytes_array = [
-			'b' => 1,
-			'k' => 1024,
-			'kb' => 1024,
-			'mb' => 1024 * 1024,
-			'm' => 1024 * 1024,
-			'gb' => 1024 * 1024 * 1024,
-			'g' => 1024 * 1024 * 1024,
-			'tb' => 1024 * 1024 * 1024 * 1024,
-			't' => 1024 * 1024 * 1024 * 1024,
-			'pb' => 1024 * 1024 * 1024 * 1024 * 1024,
-			'p' => 1024 * 1024 * 1024 * 1024 * 1024,
-		];
-
-		$bytes = (float)$str;
-
-		if (preg_match('#([kmgtp]?b?)$#si', $str, $matches) && isset($bytes_array[$matches[1]])) {
-			$bytes *= $bytes_array[$matches[1]];
-		} else {
-			return false;
-		}
-
-		return Util::numericToNumber(round($bytes));
+		return \OCP\Util::computerFileSize($str);
 	}
 
 	/**

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -107,7 +107,7 @@ class OC_Util {
 		if ($userQuota === 'none') {
 			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
 		}
-		return OC_Helper::computerFileSize($userQuota);
+		return \OCP\Util::computerFileSize($userQuota);
 	}
 
 	/**

--- a/lib/public/Template.php
+++ b/lib/public/Template.php
@@ -77,7 +77,7 @@ class Template extends \OC_Template implements ITemplate {
 	}
 
 	/**
-	 * Make OC_Helper::humanFileSize available as a simple function
+	 * Make \OCP\Util::humanFileSize available as a simple function
 	 * Example: 2048 to 2 kB.
 	 *
 	 * @param int $bytes in bytes

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -332,19 +332,70 @@ class Util {
 	 * @since 4.0.0
 	 */
 	public static function humanFileSize(int|float $bytes): string {
-		return \OC_Helper::humanFileSize($bytes);
+		if ($bytes < 0) {
+			return '?';
+		}
+		if ($bytes < 1024) {
+			return "$bytes B";
+		}
+		$bytes = round($bytes / 1024, 0);
+		if ($bytes < 1024) {
+			return "$bytes KB";
+		}
+		$bytes = round($bytes / 1024, 1);
+		if ($bytes < 1024) {
+			return "$bytes MB";
+		}
+		$bytes = round($bytes / 1024, 1);
+		if ($bytes < 1024) {
+			return "$bytes GB";
+		}
+		$bytes = round($bytes / 1024, 1);
+		if ($bytes < 1024) {
+			return "$bytes TB";
+		}
+
+		$bytes = round($bytes / 1024, 1);
+		return "$bytes PB";
 	}
 
 	/**
 	 * Make a computer file size (2 kB to 2048)
+	 * Inspired by: https://www.php.net/manual/en/function.filesize.php#92418
+	 *
 	 * @param string $str file size in a fancy format
 	 * @return false|int|float a file size in bytes
-	 *
-	 * Inspired by: https://www.php.net/manual/en/function.filesize.php#92418
 	 * @since 4.0.0
 	 */
 	public static function computerFileSize(string $str): false|int|float {
-		return \OC_Helper::computerFileSize($str);
+		$str = strtolower($str);
+		if (is_numeric($str)) {
+			return Util::numericToNumber($str);
+		}
+
+		$bytes_array = [
+			'b' => 1,
+			'k' => 1024,
+			'kb' => 1024,
+			'mb' => 1024 * 1024,
+			'm' => 1024 * 1024,
+			'gb' => 1024 * 1024 * 1024,
+			'g' => 1024 * 1024 * 1024,
+			'tb' => 1024 * 1024 * 1024 * 1024,
+			't' => 1024 * 1024 * 1024 * 1024,
+			'pb' => 1024 * 1024 * 1024 * 1024 * 1024,
+			'p' => 1024 * 1024 * 1024 * 1024 * 1024,
+		];
+
+		$bytes = (float)$str;
+
+		if (preg_match('#([kmgtp]?b?)$#si', $str, $matches) && isset($bytes_array[$matches[1]])) {
+			$bytes *= $bytes_array[$matches[1]];
+		} else {
+			return false;
+		}
+
+		return Util::numericToNumber(round($bytes));
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Replace legacy calls with OCP\Util
- Add missing deprecation notices
- Inline implementation in OCP\Util and call it from OC_Helper

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
