### PR TITLE
chore: deprecate \OC_Helper::canExecute

### DIFF
--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\Files\Type;
 
 use OCP\Files\IMimeTypeDetector;
+use OCP\IBinaryFinder;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
 use Psr\Log\LoggerInterface;
@@ -225,11 +226,13 @@ class Detection implements IMimeTypeDetector {
 			}
 		}
 
-		if (\OC_Helper::canExecute('file')) {
+		$binaryFinder = \OCP\Server::get(IBinaryFinder::class);
+		$program = $binaryFinder->findBinaryPath('file');
+		if ($program !== false) {
 			// it looks like we have a 'file' command,
 			// lets see if it does have mime support
 			$path = escapeshellarg($path);
-			$fp = popen("test -f $path && file -b --mime-type $path", 'r');
+			$fp = popen("test -f $path && $program -b --mime-type $path", 'r');
 			if ($fp !== false) {
 				$mimeType = fgets($fp);
 				pclose($fp);

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -196,6 +196,7 @@ class OC_Helper {
 	 * @internal param string $program name
 	 * @internal param string $optional search path, defaults to $PATH
 	 * @return bool true if executable program found in path
+	 * @deprecated 32.0.0 use the \OCP\IBinaryFinder
 	 */
 	public static function canExecute($name, $path = false) {
 		// path defaults to PATH from environment if not set


### PR DESCRIPTION
## Summary

replace this legacy method with just the IBinaryFinder.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
