### PR TITLE
fix: use current user principal instead of the user session

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -42,6 +42,7 @@ $authBackend = new Auth(
 	Server::get(IThrottler::class),
 	'principals/'
 );
+$authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);
 $principalBackend = new Principal(
 	Server::get(IUserManager::class),
 	Server::get(IGroupManager::class),
@@ -53,6 +54,7 @@ $principalBackend = new Principal(
 	Server::get(KnownUserService::class),
 	Server::get(IConfig::class),
 	\OC::$server->getL10NFactory(),
+	$authPlugin,
 	'principals/'
 );
 $db = Server::get(IDBConnection::class);
@@ -97,7 +99,7 @@ $server->setBaseUri($baseuri);
 
 // Add plugins
 $server->addPlugin(new MaintenancePlugin(Server::get(IConfig::class), \OC::$server->getL10N('dav')));
-$server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend));
+$server->addPlugin($authPlugin);
 $server->addPlugin(new \Sabre\CalDAV\Plugin());
 
 $server->addPlugin(new LegacyDAVACL());

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -44,6 +44,7 @@ $authBackend = new Auth(
 	Server::get(IThrottler::class),
 	'principals/'
 );
+$authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);
 $principalBackend = new Principal(
 	Server::get(IUserManager::class),
 	Server::get(IGroupManager::class),
@@ -55,6 +56,7 @@ $principalBackend = new Principal(
 	Server::get(KnownUserService::class),
 	Server::get(IConfig::class),
 	\OC::$server->getL10NFactory(),
+	$authPlugin,
 	'principals/'
 );
 $db = Server::get(IDBConnection::class);
@@ -88,7 +90,7 @@ $server->httpRequest->setUrl(Server::get(IRequest::class)->getRequestUri());
 $server->setBaseUri($baseuri);
 // Add plugins
 $server->addPlugin(new MaintenancePlugin(Server::get(IConfig::class), \OC::$server->getL10N('dav')));
-$server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend));
+$server->addPlugin($authPlugin);
 $server->addPlugin(new Plugin());
 
 $server->addPlugin(new LegacyDAVACL());

--- a/apps/dav/lib/CalDAV/Auth/PublicPrincipalPlugin.php
+++ b/apps/dav/lib/CalDAV/Auth/PublicPrincipalPlugin.php
@@ -14,7 +14,9 @@ use Sabre\DAV\Auth\Plugin;
  * Defines the public facing principal option
  */
 class PublicPrincipalPlugin extends Plugin {
+	public const PUBLIC_PRINCIPAL = 'principals/system/public';
+
 	public function getCurrentPrincipal(): ?string {
-		return 'principals/system/public';
+		return self::PUBLIC_PRINCIPAL;
 	}
 }

--- a/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
+++ b/apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php
@@ -40,7 +40,12 @@ class InvitationResponseServer {
 		$logger = Server::get(LoggerInterface::class);
 		$dispatcher = Server::get(IEventDispatcher::class);
 
-		$root = new RootCollection();
+		// allow custom principal uri option
+		if ($public) {
+			$root = new RootCollection(new PublicPrincipalPlugin());
+		} else {
+			$root = new RootCollection(new CustomPrincipalPlugin());
+		}
 		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
 
 		// Add maintenance plugin
@@ -55,13 +60,6 @@ class InvitationResponseServer {
 			Server::get(ThemingDefaults::class),
 		));
 		$this->server->addPlugin(new AnonymousOptionsPlugin());
-
-		// allow custom principal uri option
-		if ($public) {
-			$this->server->addPlugin(new PublicPrincipalPlugin());
-		} else {
-			$this->server->addPlugin(new CustomPrincipalPlugin());
-		}
 
 		// allow setup of additional auth backends
 		$event = new SabrePluginAuthInitEvent($this->server);

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Command;
 
 use OC\KnownUser\KnownUserService;
+use OCA\DAV\CalDAV\Auth\CustomPrincipalPlugin;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\CalDAV\Sharing\Backend;
@@ -54,6 +55,10 @@ class CreateCalendar extends Command {
 		if (!$this->userManager->userExists($user)) {
 			throw new \InvalidArgumentException("User <$user> in unknown.");
 		}
+
+		$principalUri = "principals/users/$user";
+		$authPlugin = new CustomPrincipalPlugin();
+		$authPlugin->setCurrentPrincipal($principalUri);
 		$principalBackend = new Principal(
 			$this->userManager,
 			$this->groupManager,
@@ -65,6 +70,7 @@ class CreateCalendar extends Command {
 			Server::get(KnownUserService::class),
 			Server::get(IConfig::class),
 			\OC::$server->getL10NFactory(),
+			$authPlugin,
 		);
 		$random = Server::get(ISecureRandom::class);
 		$logger = Server::get(LoggerInterface::class);
@@ -81,7 +87,7 @@ class CreateCalendar extends Command {
 			$config,
 			Server::get(Backend::class),
 		);
-		$caldav->createCalendar("principals/users/$user", $name, []);
+		$caldav->createCalendar($principalUri, $name, []);
 		return self::SUCCESS;
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -10,6 +10,7 @@ use OC\KnownUser\KnownUserService;
 use OCA\Circles\Api\v1\Circles;
 use OCA\Circles\Exceptions\CircleNotFoundException;
 use OCA\Circles\Model\Circle;
+use OCA\DAV\CalDAV\Auth\PublicPrincipalPlugin;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\Traits\PrincipalProxyTrait;
 use OCP\Accounts\IAccountManager;
@@ -26,6 +27,7 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Share\IManager as IShareManager;
+use Sabre\DAV\Auth\Plugin as AuthPlugin;
 use Sabre\DAV\Exception;
 use Sabre\DAV\PropPatch;
 use Sabre\DAVACL\PrincipalBackend\BackendInterface;
@@ -57,7 +59,8 @@ class Principal implements BackendInterface {
 		ProxyMapper $proxyMapper,
 		KnownUserService $knownUserService,
 		private IConfig $config,
-		private IFactory $languageFactory,
+		private IFactory$languageFactory,
+		private AuthPlugin $authPlugin,
 		string $principalPrefix = 'principals/users/',
 	) {
 		$this->principalPrefix = trim($principalPrefix, '/');
@@ -68,6 +71,25 @@ class Principal implements BackendInterface {
 
 	use PrincipalProxyTrait {
 		getGroupMembership as protected traitGetGroupMembership;
+	}
+
+	private function getUserForCurrentPrincipal(): ?IUser {
+		$currentPrincipal = $this->authPlugin->getCurrentPrincipal();
+		if ($currentPrincipal === PublicPrincipalPlugin::PUBLIC_PRINCIPAL) {
+			return null;
+		}
+
+		$parts = explode('/', $currentPrincipal);
+		if (count($parts) !== 3) {
+			return null;
+		}
+
+		[, $collection, $userId] = $parts;
+		if ($collection !== 'users') {
+			return null;
+		}
+
+		return $this->userManager->get($userId);
 	}
 
 	/**
@@ -133,7 +155,7 @@ class Principal implements BackendInterface {
 				return $this->userToPrincipal($user);
 			}
 		} elseif ($prefix === 'principals/circles') {
-			if ($this->userSession->getUser() !== null) {
+			if ($this->getUserForCurrentPrincipal() !== null) {
 				// At the time of writing - 2021-01-19 — a mixed state is possible.
 				// The second condition can be removed when this is fixed.
 				return $this->circleToPrincipal($decodedName)
@@ -237,7 +259,7 @@ class Principal implements BackendInterface {
 		// If sharing is restricted to group members only,
 		// return only members that have groups in common
 		$restrictGroups = false;
-		$currentUser = $this->userSession->getUser();
+		$currentUser = $this->getUserForCurrentPrincipal();
 		if ($this->shareManager->shareWithGroupMembersOnly()) {
 			if (!$currentUser instanceof IUser) {
 				return [];
@@ -427,7 +449,7 @@ class Principal implements BackendInterface {
 		// return only members that have groups in common
 		$restrictGroups = false;
 		if ($this->shareManager->shareWithGroupMembersOnly()) {
-			$user = $this->userSession->getUser();
+			$user = $this->getUserForCurrentPrincipal();
 			if (!$user) {
 				return null;
 			}

--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -24,7 +24,6 @@ use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Share\IManager as IShareManager;
 use Sabre\DAV\Auth\Plugin as AuthPlugin;
@@ -54,7 +53,6 @@ class Principal implements BackendInterface {
 		private IGroupManager $groupManager,
 		private IAccountManager $accountManager,
 		private IShareManager $shareManager,
-		private IUserSession $userSession,
 		private IAppManager $appManager,
 		ProxyMapper $proxyMapper,
 		KnownUserService $knownUserService,

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -116,7 +116,7 @@ class ServerFactory {
 		}
 
 		// wait with registering these until auth is handled and the filesystem is setup
-		$server->on('beforeMethod:*', function () use ($server, $tree, $viewCallBack, $isPublicShare, $rootCollection): void {
+		$server->on('beforeMethod:*', function () use ($server, $tree, $viewCallBack, $isPublicShare, $rootCollection, $authPlugin): void {
 			// ensure the skeleton is copied
 			$userFolder = \OC::$server->getUserFolder();
 
@@ -147,6 +147,7 @@ class ServerFactory {
 					\OCP\Server::get(KnownUserService::class),
 					\OCP\Server::get(IConfig::class),
 					\OC::$server->getL10NFactory(),
+					$authPlugin,
 				);
 
 				// Mount the share collection at /public.php/dav/shares/<share token>

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -68,7 +68,6 @@ class RootCollection extends SimpleCollection {
 			$groupManager,
 			Server::get(IAccountManager::class),
 			$shareManager,
-			Server::get(IUserSession::class),
 			Server::get(IAppManager::class),
 			$proxyMapper,
 			Server::get(KnownUserService::class),

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -43,10 +43,13 @@ use OCP\Server;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use Psr\Log\LoggerInterface;
+use Sabre\DAV\Auth\Plugin as AuthPlugin;
 use Sabre\DAV\SimpleCollection;
 
 class RootCollection extends SimpleCollection {
-	public function __construct() {
+	public function __construct(
+		AuthPlugin $authPlugin,
+	) {
 		$l10n = \OC::$server->getL10N('dav');
 		$random = Server::get(ISecureRandom::class);
 		$logger = Server::get(LoggerInterface::class);
@@ -70,7 +73,8 @@ class RootCollection extends SimpleCollection {
 			$proxyMapper,
 			Server::get(KnownUserService::class),
 			Server::get(IConfig::class),
-			\OC::$server->getL10NFactory()
+			\OC::$server->getL10NFactory(),
+			$authPlugin,
 		);
 
 		$groupPrincipalBackend = new GroupPrincipalBackend($groupManager, $userSession, $shareManager, $config);

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -117,15 +117,6 @@ class Server {
 		$logger = \OCP\Server::get(LoggerInterface::class);
 		$eventDispatcher = \OCP\Server::get(IEventDispatcher::class);
 
-		$root = new RootCollection();
-		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
-
-		// Add maintenance plugin
-		$this->server->addPlugin(new MaintenancePlugin(\OCP\Server::get(IConfig::class), \OC::$server->getL10N('dav')));
-
-		$this->server->addPlugin(new AppleQuirksPlugin());
-
-		// Backends
 		$authBackend = new Auth(
 			\OCP\Server::get(ISession::class),
 			\OCP\Server::get(IUserSession::class),
@@ -133,6 +124,15 @@ class Server {
 			\OCP\Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
 			\OCP\Server::get(IThrottler::class)
 		);
+		$authPlugin = new Plugin();
+
+		$root = new RootCollection($authPlugin);
+		$this->server = new \OCA\DAV\Connector\Sabre\Server(new CachingTree($root));
+
+		// Add maintenance plugin
+		$this->server->addPlugin(new MaintenancePlugin(\OCP\Server::get(IConfig::class), \OC::$server->getL10N('dav')));
+
+		$this->server->addPlugin(new AppleQuirksPlugin());
 
 		// Set URL explicitly due to reverse-proxy situations
 		$this->server->httpRequest->setUrl($this->request->getRequestUri());
@@ -144,7 +144,6 @@ class Server {
 			\OCP\Server::get(ThemingDefaults::class),
 		));
 		$this->server->addPlugin(new AnonymousOptionsPlugin());
-		$authPlugin = new Plugin();
 		$authPlugin->addBackend(new PublicAuth());
 		$this->server->addPlugin($authPlugin);
 

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -22,7 +22,6 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Security\ISecureRandom;
 use OCP\Server;
@@ -30,6 +29,7 @@ use OCP\Share\IManager as ShareManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
+use Sabre\DAV\Auth\Plugin as AuthPlugin;
 use Sabre\DAV\Xml\Property\Href;
 use Test\TestCase;
 
@@ -70,12 +70,12 @@ abstract class AbstractCalDavBackend extends TestCase {
 				$this->groupManager,
 				$this->createMock(IAccountManager::class),
 				$this->createMock(ShareManager::class),
-				$this->createMock(IUserSession::class),
 				$this->createMock(IAppManager::class),
 				$this->createMock(ProxyMapper::class),
 				$this->createMock(KnownUserService::class),
 				$this->createMock(IConfig::class),
-				$this->createMock(IFactory::class)
+				$this->createMock(IFactory::class),
+				$this->createMock(AuthPlugin::class),
 			])
 			->setMethods(['getPrincipalByPath', 'getGroupMembership', 'findByUri'])
 			->getMock();

--- a/apps/files_versions/lib/AppInfo/Application.php
+++ b/apps/files_versions/lib/AppInfo/Application.php
@@ -62,26 +62,6 @@ class Application extends App implements IBootstrap {
 		 */
 		$context->registerCapability(Capabilities::class);
 
-		/**
-		 * Register $principalBackend for the DAV collection
-		 */
-		$context->registerService('principalBackend', function (ContainerInterface $c) {
-			/** @var IServerContainer $server */
-			$server = $c->get(IServerContainer::class);
-			return new Principal(
-				$server->get(IUserManager::class),
-				$server->get(IGroupManager::class),
-				Server::get(IAccountManager::class),
-				$server->get(IShareManager::class),
-				$server->get(IUserSession::class),
-				$server->get(IAppManager::class),
-				$server->get(ProxyMapper::class),
-				$server->get(KnownUserService::class),
-				$server->get(IConfig::class),
-				$server->get(IFactory::class),
-			);
-		});
-
 		$context->registerServiceAlias(IVersionManager::class, VersionManager::class);
 
 		/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

The principal backend should not rely on the user session as a DAV server is sometimes used in a context without a user session. Instead, it should rely on the current user principal. This is is the case, for example, in a background job or in a call to a OCP API in which the current user principal is overwritten deliberately.

Ref https://github.com/nextcloud/mail/issues/10811#issuecomment-2876819469

## TODO

- [ ] Fix unit tests
- [ ] Fix integration tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
