### PR TITLE
chore: move `rmdirr` implementation from OC legacy to OCP\Files

### DIFF
--- a/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
+++ b/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php
@@ -10,6 +10,7 @@ namespace OC\Core\BackgroundJobs;
 
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\QueuedJob;
+use OCP\Files;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
@@ -70,7 +71,7 @@ class BackgroundCleanupUpdaterBackupsJob extends QueuedJob {
 
 			foreach ($dirList as $dir) {
 				$this->log->info("Removing $dir ...");
-				$result = \OC_Helper::rmdirr($dir);
+				$result = Files::rmdirr($dir);
 				if (!$result) {
 					$this->log->error('Could not remove updater backup folder $dir');
 				}

--- a/lib/private/Files/Storage/Temporary.php
+++ b/lib/private/Files/Storage/Temporary.php
@@ -7,16 +7,20 @@
  */
 namespace OC\Files\Storage;
 
+use OCP\Files;
+use OCP\ITempManager;
+use OCP\Server;
+
 /**
  * local storage backend in temporary folder for testing purpose
  */
 class Temporary extends Local {
 	public function __construct(array $parameters = []) {
-		parent::__construct(['datadir' => \OC::$server->getTempManager()->getTemporaryFolder()]);
+		parent::__construct(['datadir' => Server::get(ITempManager::class)->getTemporaryFolder()]);
 	}
 
 	public function cleanUp(): void {
-		\OC_Helper::rmdirr($this->datadir);
+		Files::rmdirr($this->datadir);
 	}
 
 	public function __destruct() {

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -19,6 +19,7 @@ use OC\DB\MigrationService;
 use OC_App;
 use OC_Helper;
 use OCP\App\IAppManager;
+use OCP\Files;
 use OCP\HintException;
 use OCP\Http\Client\IClientService;
 use OCP\IConfig;
@@ -324,14 +325,14 @@ class Installer {
 
 					$baseDir = OC_App::getInstallPath() . '/' . $appId;
 					// Remove old app with the ID if existent
-					OC_Helper::rmdirr($baseDir);
+					Files::rmdirr($baseDir);
 					// Move to app folder
 					if (@mkdir($baseDir)) {
 						$extractDir .= '/' . $folders[0];
 						OC_Helper::copyr($extractDir, $baseDir);
 					}
 					OC_Helper::copyr($extractDir, $baseDir);
-					OC_Helper::rmdirr($extractDir);
+					Files::rmdirr($extractDir);
 					return;
 				}
 				// Signature does not match
@@ -450,7 +451,7 @@ class Installer {
 				return false;
 			}
 			$appDir = OC_App::getInstallPath() . '/' . $appId;
-			OC_Helper::rmdirr($appDir);
+			Files::rmdirr($appDir);
 			return true;
 		} else {
 			$this->logger->error('can\'t remove app ' . $appId . '. It is not installed.');

--- a/lib/private/Repair/MoveUpdaterStepFile.php
+++ b/lib/private/Repair/MoveUpdaterStepFile.php
@@ -5,6 +5,7 @@
  */
 namespace OC\Repair;
 
+use OCP\Files;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
@@ -40,7 +41,7 @@ class MoveUpdaterStepFile implements IRepairStep {
 
 			// cleanup
 			if (file_exists($previousStepFile)) {
-				if (\OC_Helper::rmdirr($previousStepFile)) {
+				if (Files::rmdirr($previousStepFile)) {
 					$output->info('.step-previous-update removed');
 				} else {
 					$output->info('.step-previous-update can\'t be removed - abort move of .step file');

--- a/lib/private/TempManager.php
+++ b/lib/private/TempManager.php
@@ -8,6 +8,7 @@
 namespace OC;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OCP\Files;
 use OCP\IConfig;
 use OCP\ITempManager;
 use OCP\Security\ISecureRandom;
@@ -99,7 +100,7 @@ class TempManager implements ITempManager {
 		foreach ($files as $file) {
 			if (file_exists($file)) {
 				try {
-					\OC_Helper::rmdirr($file);
+					Files::rmdirr($file);
 				} catch (\UnexpectedValueException $ex) {
 					$this->log->warning(
 						'Error deleting temporary file/folder: {file} - Reason: {error}',

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -144,37 +144,10 @@ class OC_Helper {
 	 * @param string $dir path to the folder
 	 * @param bool $deleteSelf if set to false only the content of the folder will be deleted
 	 * @return bool
+	 * @deprecated 5.0.0 use \OCP\Files::rmdirr instead
 	 */
 	public static function rmdirr($dir, $deleteSelf = true) {
-		if (is_dir($dir)) {
-			$files = new RecursiveIteratorIterator(
-				new RecursiveDirectoryIterator($dir, RecursiveDirectoryIterator::SKIP_DOTS),
-				RecursiveIteratorIterator::CHILD_FIRST
-			);
-
-			foreach ($files as $fileInfo) {
-				/** @var SplFileInfo $fileInfo */
-				if ($fileInfo->isLink()) {
-					unlink($fileInfo->getPathname());
-				} elseif ($fileInfo->isDir()) {
-					rmdir($fileInfo->getRealPath());
-				} else {
-					unlink($fileInfo->getRealPath());
-				}
-			}
-			if ($deleteSelf) {
-				rmdir($dir);
-			}
-		} elseif (file_exists($dir)) {
-			if ($deleteSelf) {
-				unlink($dir);
-			}
-		}
-		if (!$deleteSelf) {
-			return true;
-		}
-
-		return !file_exists($dir);
+		return \OCP\Files::rmdirr($dir, $deleteSelf);
 	}
 
 	/**

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -18,12 +18,44 @@ namespace OCP;
 class Files {
 	/**
 	 * Recursive deletion of folders
+	 *
+	 * @param string $dir path to the folder
+	 * @param bool $deleteSelf if set to false only the content of the folder will be deleted
 	 * @return bool
 	 * @since 5.0.0
+	 * @since 32.0.0 added the $deleteSelf parameter
 	 * @deprecated 14.0.0
 	 */
-	public static function rmdirr($dir) {
-		return \OC_Helper::rmdirr($dir);
+	public static function rmdirr($dir, bool $deleteSelf = true) {
+		if (is_dir($dir)) {
+			$files = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+				\RecursiveIteratorIterator::CHILD_FIRST
+			);
+
+			foreach ($files as $fileInfo) {
+				/** @var \SplFileInfo $fileInfo */
+				if ($fileInfo->isLink()) {
+					unlink($fileInfo->getPathname());
+				} elseif ($fileInfo->isDir()) {
+					rmdir($fileInfo->getRealPath());
+				} else {
+					unlink($fileInfo->getRealPath());
+				}
+			}
+			if ($deleteSelf) {
+				rmdir($dir);
+			}
+		} elseif (file_exists($dir)) {
+			if ($deleteSelf) {
+				unlink($dir);
+			}
+		}
+		if (!$deleteSelf) {
+			return true;
+		}
+
+		return !file_exists($dir);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- move implementation to the OCP variant that called the legacy before
- add the missing deprecation notice
- add missing parameter to align both signatures
- use OCP\Files where this method is still used

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
