### PR TITLE
fix(dav): handle uploading folders with names of existing file for file drop plugin

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -104,11 +104,9 @@ $server = $serverFactory->createServer(false, $baseuri, $requestUri, $authPlugin
 	if (!$isReadable) {
 		$filesDropPlugin->enable();
 	}
-
-	$view = new View($node->getPath());
-	$filesDropPlugin->setView($view);
 	$filesDropPlugin->setShare($share);
 
+	$view = new View($node->getPath());
 	return $view;
 });
 

--- a/apps/dav/appinfo/v2/publicremote.php
+++ b/apps/dav/appinfo/v2/publicremote.php
@@ -131,11 +131,9 @@ $server = $serverFactory->createServer(true, $baseuri, $requestUri, $authPlugin,
 	if (!$isReadable) {
 		$filesDropPlugin->enable();
 	}
-
-	$view = new View($node->getPath());
-	$filesDropPlugin->setView($view);
 	$filesDropPlugin->setShare($share);
 
+	$view = new View($node->getPath());
 	return $view;
 });
 

--- a/build/integration/filesdrop_features/filesdrop.feature
+++ b/build/integration/filesdrop_features/filesdrop.feature
@@ -99,6 +99,47 @@ Feature: FilesDrop
     And Downloading file "/drop/Alice/folder/a.txt"
     Then Downloaded content should be "abc"
 
+  Scenario: File drop uploading folder with name of file
+    Given user "user0" exists
+    And As an "user0"
+    And user "user0" created a folder "/drop"
+    And as "user0" creating a share with
+      | path | drop |
+      | shareType | 4 |
+      | permissions | 4 |
+      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+      | shareWith |  |
+    When Dropping file "/folder" with "its a file" as "Alice"
+    Then the HTTP status code should be "201"
+    When Dropping file "/folder/a.txt" with "abc" as "Alice"
+    Then the HTTP status code should be "201"
+    When Downloading file "/drop/Alice/folder"
+    Then the HTTP status code should be "200"
+    And Downloaded content should be "its a file"
+    When Downloading file "/drop/Alice/folder (2)/a.txt"
+    Then Downloaded content should be "abc"
+
+  Scenario: File drop uploading file with name of folder
+    Given user "user0" exists
+    And As an "user0"
+    And user "user0" created a folder "/drop"
+    And as "user0" creating a share with
+      | path | drop |
+      | shareType | 4 |
+      | permissions | 4 |
+      | attributes | [{"scope":"fileRequest","key":"enabled","value":true}] |
+      | shareWith |  |
+    When Dropping file "/folder/a.txt" with "abc" as "Alice"
+    Then the HTTP status code should be "201"
+    When Dropping file "/folder" with "its a file" as "Alice"
+    Then the HTTP status code should be "201"
+    When Downloading file "/drop/Alice/folder/a.txt"
+    Then the HTTP status code should be "200"
+    And Downloaded content should be "abc"
+    When Downloading file "/drop/Alice/folder (2)"
+    Then the HTTP status code should be "200"
+    And Downloaded content should be "its a file"
+    
   Scenario: Put file same file multiple times via files drop
     Given user "user0" exists
     And As an "user0"


### PR DESCRIPTION
* follow up for https://github.com/nextcloud/server/pull/52785

## Summary

This PR does two things:
1. Migrate from private file view API to the File Node API
2. Fix an issue if you upload first a file (e.g. "file") and afterwards a folder (called "files) with the same name.
   In this case the folder needs to get a new unique name as we cannot rename the file (missing permission).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
