### PR TITLE
fix(files_versions): Remove routes leading to deleted ajax files

### DIFF
--- a/apps/files_versions/appinfo/routes.php
+++ b/apps/files_versions/appinfo/routes.php
@@ -6,16 +6,6 @@
  */
 namespace OCA\Files_Versions\AppInfo;
 
-use OCP\Route\IRouter;
-
-/** @var IRouter $this */
-$this->create('files_versions_download', 'apps/files_versions/download.php')
-	->actionInclude('files_versions/download.php');
-$this->create('files_versions_ajax_getVersions', 'apps/files_versions/ajax/getVersions.php')
-	->actionInclude('files_versions/ajax/getVersions.php');
-$this->create('files_versions_ajax_rollbackVersion', 'apps/files_versions/ajax/rollbackVersion.php')
-	->actionInclude('files_versions/ajax/rollbackVersion.php');
-
 return [
 	'routes' => [
 		[

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -966,11 +966,6 @@
       <code><![CDATA[$timestamp]]></code>
     </InvalidArgument>
   </file>
-  <file src="apps/files_versions/appinfo/routes.php">
-    <InvalidScope>
-      <code><![CDATA[$this->create('files_versions_download', 'apps/files_versions/download.php')]]></code>
-    </InvalidScope>
-  </file>
   <file src="apps/files_versions/lib/Sabre/RestoreFolder.php">
     <InvalidNullableReturnType>
       <code><![CDATA[getChild]]></code>


### PR DESCRIPTION
* Follow up of https://github.com/nextcloud/server/pull/11778

## Summary

I suppose 6 years after deleting the files it’s safe to remove the routes as well.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
