### PR TITLE
chore: remove reviewers from dependendabot - its deprecated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,11 +16,9 @@
 *.ts                                          @nextcloud/server-frontend
 
 # dependency management
-package.json                                  @nextcloud/server-dependabot
+package.json                                  @nextcloud/server-dependabot @nextcloud/server-frontend
 package-lock.json                             @nextcloud/server-dependabot
-
-# Compiled assets only - no owner set to not spam on automated dependency updates
-/dist                                         
+/dist                                         @nextcloud/server-dependabot
 
 # App maintainers
 /apps/admin_audit/appinfo/info.xml            @luka-nextcloud @blizzz

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,6 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
-  reviewers:
-    - "nextcloud/server-dependabot"
 
 # Main composer (linting, testing, openapi)
 - package-ecosystem: composer
@@ -37,8 +35,6 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
-  reviewers:
-    - "nextcloud/server-dependabot"
 
 # Main master npm frontend dependencies
 - package-ecosystem: npm
@@ -52,8 +48,6 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
-  reviewers:
-    - "nextcloud/server-dependabot"
   # Disable automatic rebasing because without a build CI will likely fail anyway
   rebase-strategy: "disabled"
 
@@ -76,8 +70,6 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
-  reviewers:
-    - "nextcloud/server-dependabot"
   ignore:
     # only patch updates on stable branches
     - dependency-name: "*"
@@ -97,8 +89,6 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
-  reviewers:
-    - "nextcloud/server-dependabot"
   # Disable automatic rebasing because without a build CI will likely fail anyway
   rebase-strategy: "disabled"
   ignore:
@@ -126,8 +116,6 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
-  reviewers:
-    - "nextcloud/server-dependabot"
   ignore:
     # only patch updates on stable branches
     - dependency-name: "*"
@@ -146,8 +134,6 @@ updates:
   labels:
     - "3. to review"
     - "feature: dependencies"
-  reviewers:
-    - "nextcloud/server-dependabot"
   # Disable automatic rebasing because without a build CI will likely fail anyway
   rebase-strategy: "disabled"
   ignore:


### PR DESCRIPTION
## Summary
Instead make sure all PRs get a reviewer assigned. Also fixed an issue with the `dist/` folder as there is no automated PR adding dist files - it needs to be manually updated, so that a PR containing changes has to be reviewed properly!

> The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
