### PR TITLE
refactor: cleanup public code and clean psalm baseline

### DIFF
--- a/build/psalm-baseline-ocp.xml
+++ b/build/psalm-baseline-ocp.xml
@@ -1,67 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
-  <file src="lib/public/AppFramework/ApiController.php">
-    <NoInterfaceProperties>
-      <code><![CDATA[$this->request->server]]></code>
-    </NoInterfaceProperties>
-  </file>
   <file src="lib/public/AppFramework/App.php">
     <UndefinedClass>
-      <code><![CDATA[\OC]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/public/AppFramework/Http/RedirectToDefaultAppResponse.php">
-    <UndefinedClass>
-      <code><![CDATA[\OC]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/public/AppFramework/Http/Response.php">
-    <UndefinedClass>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/public/Defaults.php">
-    <UndefinedClass>
-      <code><![CDATA[\OC]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/public/Diagnostics/IQueryLogger.php">
-    <LessSpecificImplementedReturnType>
-      <code><![CDATA[mixed]]></code>
-    </LessSpecificImplementedReturnType>
-  </file>
-  <file src="lib/public/EventDispatcher/GenericEvent.php">
-    <MissingTemplateParam>
-      <code><![CDATA[ArrayAccess]]></code>
-      <code><![CDATA[IteratorAggregate]]></code>
-    </MissingTemplateParam>
-  </file>
-  <file src="lib/public/Files.php">
-    <UndefinedClass>
-      <code><![CDATA[\OC]]></code>
-    </UndefinedClass>
-  </file>
-  <file src="lib/public/L10N/ILanguageIterator.php">
-    <MissingTemplateParam>
-      <code><![CDATA[\Iterator]]></code>
-    </MissingTemplateParam>
-  </file>
-  <file src="lib/public/Util.php">
-    <UndefinedClass>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
-      <code><![CDATA[\OC]]></code>
       <code><![CDATA[\OC]]></code>
     </UndefinedClass>
   </file>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3780,9 +3780,6 @@
     <InvalidArgument>
       <code><![CDATA[microtime(true)]]></code>
     </InvalidArgument>
-    <InvalidReturnType>
-      <code><![CDATA[stopQuery]]></code>
-    </InvalidReturnType>
   </file>
   <file src="lib/private/DirectEditing/Manager.php">
     <InvalidReturnType>
@@ -4679,11 +4676,6 @@
       <code><![CDATA[\Test\Util\User\Dummy]]></code>
     </UndefinedClass>
   </file>
-  <file src="lib/public/AppFramework/ApiController.php">
-    <NoInterfaceProperties>
-      <code><![CDATA[$this->request->server]]></code>
-    </NoInterfaceProperties>
-  </file>
   <file src="lib/public/AppFramework/Http/Response.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[array_merge($mergeWith, $this->headers)]]></code>
@@ -4699,22 +4691,6 @@
     <MoreSpecificReturnType>
       <code><![CDATA[array{0: int, 1: int, 2: int}]]></code>
     </MoreSpecificReturnType>
-  </file>
-  <file src="lib/public/Diagnostics/IQueryLogger.php">
-    <LessSpecificImplementedReturnType>
-      <code><![CDATA[mixed]]></code>
-    </LessSpecificImplementedReturnType>
-  </file>
-  <file src="lib/public/EventDispatcher/GenericEvent.php">
-    <MissingTemplateParam>
-      <code><![CDATA[ArrayAccess]]></code>
-      <code><![CDATA[IteratorAggregate]]></code>
-    </MissingTemplateParam>
-  </file>
-  <file src="lib/public/L10N/ILanguageIterator.php">
-    <MissingTemplateParam>
-      <code><![CDATA[\Iterator]]></code>
-    </MissingTemplateParam>
   </file>
   <file src="lib/public/Preview/BeforePreviewFetchedEvent.php">
     <LessSpecificReturnStatement>

--- a/lib/public/AppFramework/ApiController.php
+++ b/lib/public/AppFramework/ApiController.php
@@ -58,9 +58,8 @@ abstract class ApiController extends Controller {
 	#[PublicPage]
 	#[NoAdminRequired]
 	public function preflightedCors() {
-		if (isset($this->request->server['HTTP_ORIGIN'])) {
-			$origin = $this->request->server['HTTP_ORIGIN'];
-		} else {
+		$origin = $this->request->getHeader('origin');
+		if ($origin === '') {
 			$origin = '*';
 		}
 

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace OCP\AppFramework;
 
 use OC\ServerContainer;
+use OCP\IConfig;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -44,7 +46,7 @@ class App {
 	 * @since 6.0.0
 	 */
 	public function __construct(string $appName, array $urlParams = []) {
-		$runIsSetupDirectly = \OC::$server->getConfig()->getSystemValueBool('debug')
+		$runIsSetupDirectly = Server::get(IConfig::class)->getSystemValueBool('debug')
 			&& !ini_get('zend.exception_ignore_args');
 
 		if ($runIsSetupDirectly) {
@@ -71,7 +73,7 @@ class App {
 			}
 
 			if (!$setUpViaQuery && $applicationClassName !== \OCP\AppFramework\App::class) {
-				\OCP\Server::get(LoggerInterface::class)->error($e->getMessage(), [
+				Server::get(LoggerInterface::class)->error($e->getMessage(), [
 					'app' => $appName,
 					'exception' => $e,
 				]);

--- a/lib/public/AppFramework/Http/RedirectToDefaultAppResponse.php
+++ b/lib/public/AppFramework/Http/RedirectToDefaultAppResponse.php
@@ -30,8 +30,7 @@ class RedirectToDefaultAppResponse extends RedirectResponse {
 	 * @deprecated 23.0.0 Use RedirectResponse() with IURLGenerator::linkToDefaultPageUrl() instead
 	 */
 	public function __construct(int $status = Http::STATUS_SEE_OTHER, array $headers = []) {
-		/** @var IURLGenerator $urlGenerator */
-		$urlGenerator = \OC::$server->get(IURLGenerator::class);
+		$urlGenerator = \OCP\Server::get(IURLGenerator::class);
 		parent::__construct($urlGenerator->linkToDefaultPageUrl(), $status, $headers);
 	}
 }

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -93,7 +93,6 @@ class Response {
 
 			// Set expires header
 			$expires = new \DateTime();
-			/** @var ITimeFactory $time */
 			$time = \OCP\Server::get(ITimeFactory::class);
 			$expires->setTimestamp($time->getTime());
 			$expires->add(new \DateInterval('PT' . $cacheSeconds . 'S'));
@@ -184,10 +183,10 @@ class Response {
 		if ($this->status === Http::STATUS_NOT_MODIFIED
 			&& stripos($name, 'x-') === 0) {
 			/** @var IConfig $config */
-			$config = \OC::$server->get(IConfig::class);
+			$config = \OCP\Server::get(IConfig::class);
 
 			if ($config->getSystemValueBool('debug', false)) {
-				\OC::$server->get(LoggerInterface::class)->error('Setting custom header on a 304 is not supported (Header: {header})', [
+				\OCP\Server::get(LoggerInterface::class)->error('Setting custom header on a 304 is not supported (Header: {header})', [
 					'header' => $name,
 				]);
 			}
@@ -229,7 +228,7 @@ class Response {
 		/**
 		 * @psalm-suppress UndefinedClass
 		 */
-		$request = \OC::$server->get(IRequest::class);
+		$request = \OCP\Server::get(IRequest::class);
 		$mergeWith = [
 			'X-Request-Id' => $request->getId(),
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',

--- a/lib/public/Defaults.php
+++ b/lib/public/Defaults.php
@@ -29,7 +29,7 @@ class Defaults {
 	 */
 	public function __construct(?\OC_Defaults $defaults = null) {
 		if ($defaults === null) {
-			$defaults = \OC::$server->get('ThemingDefaults');
+			$defaults = \OCP\Server::get('ThemingDefaults');
 		}
 		$this->defaults = $defaults;
 	}

--- a/lib/public/Diagnostics/IQueryLogger.php
+++ b/lib/public/Diagnostics/IQueryLogger.php
@@ -31,7 +31,7 @@ interface IQueryLogger extends SQLLogger {
 	 * Mark the end of the current active query. Ending query should store \OCP\Diagnostics\IQuery to
 	 * be returned with getQueries() method.
 	 *
-	 * @return mixed
+	 * @return void
 	 * @since 8.0.0
 	 */
 	public function stopQuery();

--- a/lib/public/EventDispatcher/GenericEvent.php
+++ b/lib/public/EventDispatcher/GenericEvent.php
@@ -18,10 +18,12 @@ use function array_key_exists;
 /**
  * Class GenericEvent
  *
- * convenience reimplementation of \Symfony\Component\GenericEvent against
+ * convenience re-implementation of \Symfony\Component\GenericEvent against
  * \OCP\EventDispatcher\Event
  *
  * @since 18.0.0
+ * @template-implements ArrayAccess<array-key, mixed>
+ * @template-implements IteratorAggregate<array-key, mixed>
  * @deprecated 22.0.0 use \OCP\EventDispatcher\Event
  */
 class GenericEvent extends Event implements ArrayAccess, IteratorAggregate {

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -9,6 +9,8 @@
 
 namespace OCP;
 
+use OCP\Files\IMimeTypeDetector;
+
 /**
  * This class provides access to the internal filesystem abstraction layer. Use
  * this class exclusively if you want to access files
@@ -67,7 +69,7 @@ class Files {
 	 * @deprecated 14.0.0
 	 */
 	public static function getMimeType($path) {
-		return \OC::$server->getMimeTypeDetector()->detect($path);
+		return Server::get(IMimeTypeDetector::class)->detect($path);
 	}
 
 	/**

--- a/lib/public/Files_FullTextSearch/Model/AFilesDocument.php
+++ b/lib/public/Files_FullTextSearch/Model/AFilesDocument.php
@@ -16,7 +16,7 @@ use OCP\FullTextSearch\Model\IIndexDocument;
  * This is mostly used by 3rd party apps that want to complete the IIndexDocument
  * with more information about a file before its index:
  *
- *    \OC::$server->getEventDispatcher()->addListener(
+ *    \OCP\Server::get(IEventDispatcher::class)->addListener(
  *        '\OCA\Files_FullTextSearch::onFileIndexing',
  *        function(GenericEvent $e) {
  *            //@var \OCP\Files\Node $file

--- a/lib/public/L10N/ILanguageIterator.php
+++ b/lib/public/L10N/ILanguageIterator.php
@@ -21,7 +21,7 @@ namespace OCP\L10N;
  * if settings are not present or truncating is not applicable, the iterator
  * skips to the next valid item itself
  *
- *
+ * @template-extends \Iterator<int, string>
  * @since 14.0.0
  */
 interface ILanguageIterator extends \Iterator {
@@ -36,22 +36,20 @@ interface ILanguageIterator extends \Iterator {
 	 * Move forward to next element
 	 *
 	 * @since 14.0.0
-	 * @return void
 	 */
-	#[\ReturnTypeWillChange]
-	public function next();
+	public function next(): void;
 
 	/**
 	 * Return the key of the current element
 	 *
 	 * @since 14.0.0
 	 */
-	public function key():int;
+	public function key(): int;
 
 	/**
 	 * Checks if current position is valid
 	 *
 	 * @since 14.0.0
 	 */
-	public function valid():bool;
+	public function valid(): bool;
 }

--- a/lib/public/Mail/IMailer.php
+++ b/lib/public/Mail/IMailer.php
@@ -14,7 +14,7 @@ namespace OCP\Mail;
  *
  * Example usage:
  *
- * 	$mailer = \OC::$server->get(\OCP\Mail\IMailer::class);
+ * 	$mailer = \OCP\Server::get(\OCP\Mail\IMailer::class);
  * 	$message = $mailer->createMessage();
  * 	$message->setSubject('Your Subject');
  * 	$message->setFrom(['cloud@domain.org' => 'Nextcloud Notifier']);

--- a/lib/public/Profiler/IProfile.php
+++ b/lib/public/Profiler/IProfile.php
@@ -17,7 +17,7 @@ use OCP\DataCollector\IDataCollector;
  *
  * ```php
  * <?php
- * $profiler = \OC::$server->get(IProfiler::class);
+ * $profiler = \OCP\Server::get(IProfiler::class);
  * $profiles = $profiler->find('/settings/users', 10);
  * ```
  *

--- a/lib/public/Security/ICrypto.php
+++ b/lib/public/Security/ICrypto.php
@@ -13,8 +13,8 @@ namespace OCP\Security;
  * it will use the secret defined in config.php as key. Additionally the message will be HMAC'd.
  *
  * Usage:
- * $encryptWithDefaultPassword = \OC::$server->getCrypto()->encrypt('EncryptedText');
- * $encryptWithCustomPassword = \OC::$server->getCrypto()->encrypt('EncryptedText', 'password');
+ * $encryptWithDefaultPassword = \OCP\Server::get(ICrypto::class)->encrypt('EncryptedText');
+ * $encryptWithCustomPassword = \OCP\Server::get(ICrypto::class)->encrypt('EncryptedText', 'password');
  *
  * @since 8.0.0
  */

--- a/lib/public/Security/IHasher.php
+++ b/lib/public/Security/IHasher.php
@@ -19,10 +19,10 @@ namespace OCP\Security;
  *
  * Usage:
  * // Hashing a message
- * $hash = \OC::$server->get(\OCP\Security\IHasher::class)->hash('MessageToHash');
+ * $hash = \OCP\Server::get(\OCP\Security\IHasher::class)->hash('MessageToHash');
  * // Verifying a message - $newHash will contain the newly calculated hash
  * $newHash = null;
- * var_dump(\OC::$server->get(\OCP\Security\IHasher::class)->verify('a', '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8', $newHash));
+ * var_dump(\OCP\Server::get(\OCP\Security\IHasher::class)->verify('a', '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8', $newHash));
  * var_dump($newHash);
  *
  * @since 8.0.0

--- a/lib/public/Security/ISecureRandom.php
+++ b/lib/public/Security/ISecureRandom.php
@@ -14,7 +14,7 @@ namespace OCP\Security;
  * use a fallback.
  *
  * Usage:
- * \OC::$server->get(ISecureRandom::class)->generate(10);
+ * \OCP\Server::get(ISecureRandom::class)->generate(10);
  *
  * @since 8.0.0
  */

--- a/lib/public/Util.php
+++ b/lib/public/Util.php
@@ -51,7 +51,7 @@ class Util {
 			return $subscriptionRegistry->delegateHasExtendedSupport();
 		} catch (ContainerExceptionInterface $e) {
 		}
-		return \OC::$server->getConfig()->getSystemValueBool('extendedSupport', false);
+		return \OCP\Server::get(IConfig::class)->getSystemValueBool('extendedSupport', false);
 	}
 
 	/**
@@ -60,7 +60,7 @@ class Util {
 	 * @since 8.1.0
 	 */
 	public static function setChannel($channel) {
-		\OC::$server->getConfig()->setSystemValue('updater.release.channel', $channel);
+		\OCP\Server::get(IConfig::class)->setSystemValue('updater.release.channel', $channel);
 	}
 
 	/**
@@ -182,7 +182,7 @@ class Util {
 	 */
 	public static function getScripts(): array {
 		// Sort scriptDeps into sortedScriptDeps
-		$scriptSort = \OC::$server->get(AppScriptSort::class);
+		$scriptSort = \OCP\Server::get(AppScriptSort::class);
 		$sortedScripts = $scriptSort->sort(self::$scripts, self::$scriptDeps);
 
 		// Flatten array and remove duplicates
@@ -209,7 +209,7 @@ class Util {
 	 */
 	public static function addTranslations($application, $languageCode = null, $init = false) {
 		if (is_null($languageCode)) {
-			$languageCode = \OC::$server->get(IFactory::class)->findLanguage($application);
+			$languageCode = \OCP\Server::get(IFactory::class)->findLanguage($application);
 		}
 		if (!empty($application)) {
 			$path = "$application/l10n/$languageCode";
@@ -247,7 +247,7 @@ class Util {
 	 * @since 4.0.0 - parameter $args was added in 4.5.0
 	 */
 	public static function linkToAbsolute($app, $file, $args = []) {
-		$urlGenerator = \OC::$server->getURLGenerator();
+		$urlGenerator = \OCP\Server::get(IURLGenerator::class);
 		return $urlGenerator->getAbsoluteURL(
 			$urlGenerator->linkTo($app, $file, $args)
 		);
@@ -260,7 +260,7 @@ class Util {
 	 * @since 4.0.0
 	 */
 	public static function linkToRemote($service) {
-		$urlGenerator = \OC::$server->getURLGenerator();
+		$urlGenerator = \OCP\Server::get(IURLGenerator::class);
 		$remoteBase = $urlGenerator->linkTo('', 'remote.php') . '/' . $service;
 		return $urlGenerator->getAbsoluteURL(
 			$remoteBase . (($service[strlen($service) - 1] != '/') ? '/' : '')
@@ -273,7 +273,7 @@ class Util {
 	 * @since 5.0.0
 	 */
 	public static function getServerHostName() {
-		$host_name = \OC::$server->getRequest()->getServerHost();
+		$host_name = \OCP\Server::get(IRequest::class)->getServerHost();
 		// strip away port number (if existing)
 		$colon_pos = strpos($host_name, ':');
 		if ($colon_pos != false) {
@@ -299,13 +299,13 @@ class Util {
 	 * @since 5.0.0
 	 */
 	public static function getDefaultEmailAddress(string $user_part): string {
-		$config = \OC::$server->getConfig();
+		$config = \OCP\Server::get(IConfig::class);
 		$user_part = $config->getSystemValueString('mail_from_address', $user_part);
 		$host_name = self::getServerHostName();
 		$host_name = $config->getSystemValueString('mail_domain', $host_name);
 		$defaultEmailAddress = $user_part . '@' . $host_name;
 
-		$mailer = \OC::$server->get(IMailer::class);
+		$mailer = \OCP\Server::get(IMailer::class);
 		if ($mailer->validateMailAddress($defaultEmailAddress)) {
 			return $defaultEmailAddress;
 		}
@@ -447,7 +447,7 @@ class Util {
 	 */
 	public static function callRegister() {
 		if (self::$token === '') {
-			self::$token = \OC::$server->get(CsrfTokenManager::class)->getToken()->getEncryptedValue();
+			self::$token = \OCP\Server::get(CsrfTokenManager::class)->getToken()->getEncryptedValue();
 		}
 		return self::$token;
 	}
@@ -582,7 +582,7 @@ class Util {
 	 */
 	public static function needUpgrade() {
 		if (!isset(self::$needUpgradeCache)) {
-			self::$needUpgradeCache = \OC_Util::needUpgrade(\OC::$server->getSystemConfig());
+			self::$needUpgradeCache = \OC_Util::needUpgrade(\OCP\Server::get(\OC\SystemConfig::class));
 		}
 		return self::$needUpgradeCache;
 	}


### PR DESCRIPTION
## Summary

- Add missing template implements
- Use OCP in public interfaces instead of OC

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
