### PR TITLE
chore!: remove deprecated `\OCP\AppFramework\App::registerRoutes`

### DIFF
--- a/build/psalm-baseline-ocp.xml
+++ b/build/psalm-baseline-ocp.xml
@@ -6,9 +6,6 @@
     </NoInterfaceProperties>
   </file>
   <file src="lib/public/AppFramework/App.php">
-    <InternalMethod>
-      <code><![CDATA[new RouteConfig($this->container, $router, $routes)]]></code>
-    </InternalMethod>
     <UndefinedClass>
       <code><![CDATA[\OC]]></code>
     </UndefinedClass>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2579,11 +2579,6 @@
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
-  <file src="lib/public/AppFramework/App.php">
-    <InternalMethod>
-      <code><![CDATA[new RouteConfig($this->container, $router, $routes)]]></code>
-    </InternalMethod>
-  </file>
   <file src="lib/public/AppFramework/Http/Response.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[array_merge($mergeWith, $this->headers)]]></code>

--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -97,35 +97,6 @@ class App {
 	}
 
 	/**
-	 * This function is to be called to create single routes and restful routes based on the given $routes array.
-	 *
-	 * Example code in routes.php of tasks app (it will register two restful resources):
-	 * $routes = array(
-	 *		'resources' => array(
-	 *		'lists' => array('url' => '/tasklists'),
-	 *		'tasks' => array('url' => '/tasklists/{listId}/tasks')
-	 *	)
-	 *	);
-	 *
-	 * $a = new TasksApp();
-	 * $a->registerRoutes($this, $routes);
-	 *
-	 * @param \OCP\Route\IRouter $router
-	 * @param array $routes
-	 * @since 6.0.0
-	 * @suppress PhanAccessMethodInternal
-	 * @deprecated 20.0.0 Just return an array from your routes.php
-	 */
-	public function registerRoutes(IRouter $router, array $routes) {
-		if (!($router instanceof Router)) {
-			throw new \RuntimeException('Can only setup routes with real router');
-		}
-
-		$routeConfig = new RouteConfig($this->container, $router, $routes);
-		$routeConfig->register();
-	}
-
-	/**
 	 * This function is called by the routing component to fire up the frameworks dispatch mechanism.
 	 *
 	 * Example code in routes.php of the task app:


### PR DESCRIPTION
## Summary

deprecated since Nextcloud 20, not used by any active app and causes usage of private API within OCP.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
