### PR TITLE
fix: Remove deprecated getters in IServerContainer

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4379,8 +4379,6 @@
   </file>
   <file src="lib/private/Server.php">
     <ImplementedReturnTypeMismatch>
-      <code><![CDATA[\OCP\Calendar\Resource\IManager]]></code>
-      <code><![CDATA[\OCP\Calendar\Room\IManager]]></code>
       <code><![CDATA[\OCP\Files\Folder|null]]></code>
     </ImplementedReturnTypeMismatch>
     <LessSpecificReturnStatement>
@@ -4468,39 +4466,13 @@
     </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/Share20/ProviderFactory.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[FederatedShareProvider]]></code>
-      <code><![CDATA[ShareByMailProvider]]></code>
-    </InvalidNullableReturnType>
     <InvalidReturnStatement>
       <code><![CDATA[$provider]]></code>
       <code><![CDATA[$provider]]></code>
-      <code><![CDATA[$this->shareByCircleProvider]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[getProviderForType]]></code>
     </InvalidReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-      <code><![CDATA[null]]></code>
-    </NullableReturnStatement>
-    <ParamNameMismatch>
-      <code><![CDATA[$shareProviderClass]]></code>
-    </ParamNameMismatch>
-    <UndefinedClass>
-      <code><![CDATA[\OCA\Circles\ShareByCircleProvider]]></code>
-    </UndefinedClass>
-    <UndefinedDocblockClass>
-      <code><![CDATA[RoomShareProvider]]></code>
-      <code><![CDATA[\OCA\Circles\ShareByCircleProvider]]></code>
-      <code><![CDATA[\OCA\Talk\Share\RoomShareProvider]]></code>
-      <code><![CDATA[private $roomShareProvider = null;]]></code>
-      <code><![CDATA[private $shareByCircleProvider = null;]]></code>
-    </UndefinedDocblockClass>
   </file>
   <file src="lib/private/Share20/Share.php">
     <LessSpecificReturnStatement>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4384,7 +4384,6 @@
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->get(IFile::class)]]></code>
       <code><![CDATA[$this->get(IGroupManager::class)]]></code>
-      <code><![CDATA[$this->get(INavigationManager::class)]]></code>
       <code><![CDATA[$this->get(IUserManager::class)]]></code>
       <code><![CDATA[$this->get(IUserSession::class)]]></code>
       <code><![CDATA[$this->get(\OCP\Encryption\IManager::class)]]></code>
@@ -4393,13 +4392,9 @@
       <code><![CDATA[\OC\Encryption\File]]></code>
       <code><![CDATA[\OC\Encryption\Manager]]></code>
       <code><![CDATA[\OC\Group\Manager]]></code>
-      <code><![CDATA[\OC\NavigationManager]]></code>
       <code><![CDATA[\OC\User\Manager]]></code>
       <code><![CDATA[\OC\User\Session]]></code>
     </MoreSpecificReturnType>
-    <UndefinedDocblockClass>
-      <code><![CDATA[\OC\OCSClient]]></code>
-    </UndefinedDocblockClass>
   </file>
   <file src="lib/private/ServerContainer.php">
     <InvalidPropertyAssignmentValue>

--- a/build/rector.php
+++ b/build/rector.php
@@ -63,6 +63,7 @@ $config = RectorConfig::configure()
 		$nextcloudDir . '/remote.php',
 		$nextcloudDir . '/status.php',
 		$nextcloudDir . '/version.php',
+		$nextcloudDir . '/lib/private/Share20/ProviderFactory.php',
 		// $nextcloudDir . '/config',
 		// $nextcloudDir . '/lib',
 		// $nextcloudDir . '/tests',

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -124,10 +124,6 @@ use OC\User\DisplayNameCache;
 use OC\User\Listeners\BeforeUserDeletedListener;
 use OC\User\Listeners\UserChangedListener;
 use OC\User\Session;
-use OCA\Files_External\Service\BackendService;
-use OCA\Files_External\Service\GlobalStoragesService;
-use OCA\Files_External\Service\UserGlobalStoragesService;
-use OCA\Files_External\Service\UserStoragesService;
 use OCA\Theming\ImageManager;
 use OCA\Theming\Service\BackgroundService;
 use OCA\Theming\ThemingDefaults;
@@ -138,7 +134,6 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\LoginCredentials\IStore;
 use OCP\Authentication\Token\IProvider as OCPIProvider;
 use OCP\BackgroundJob\IJobList;
-use OCP\Collaboration\AutoComplete\IManager;
 use OCP\Collaboration\Reference\IReferenceManager;
 use OCP\Command\IBus;
 use OCP\Comments\ICommentsManager;
@@ -189,7 +184,6 @@ use OCP\IRequest;
 use OCP\IRequestId;
 use OCP\IServerContainer;
 use OCP\ISession;
-use OCP\ITagManager;
 use OCP\ITempManager;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
@@ -212,7 +206,6 @@ use OCP\RichObjectStrings\IRichTextFormatter;
 use OCP\RichObjectStrings\IValidator;
 use OCP\Route\IRouter;
 use OCP\Security\Bruteforce\IThrottler;
-use OCP\Security\IContentSecurityPolicyManager;
 use OCP\Security\ICredentialsManager;
 use OCP\Security\ICrypto;
 use OCP\Security\IHasher;
@@ -1305,30 +1298,6 @@ class Server extends ServerContainer implements IServerContainer {
 		$hookConnector->viewToNode();
 	}
 
-	/**
-	 * @return \OCP\Calendar\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCalendarManager() {
-		return $this->get(\OC\Calendar\Manager::class);
-	}
-
-	/**
-	 * @return \OCP\Calendar\Resource\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCalendarResourceBackendManager() {
-		return $this->get(\OC\Calendar\Resource\Manager::class);
-	}
-
-	/**
-	 * @return \OCP\Calendar\Room\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCalendarRoomBackendManager() {
-		return $this->get(\OC\Calendar\Room\Manager::class);
-	}
-
 	private function connectDispatcher(): void {
 		/** @var IEventDispatcher $eventDispatcher */
 		$eventDispatcher = $this->get(IEventDispatcher::class);
@@ -1366,14 +1335,6 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return \OCP\Encryption\Keys\IStorage
-	 * @deprecated 20.0.0
-	 */
-	public function getEncryptionKeyStorage() {
-		return $this->get(IStorage::class);
-	}
-
-	/**
 	 * The current request object holding all information about the request
 	 * currently being processed is returned from this method.
 	 * In case the current execution was not initiated by a web request null is returned
@@ -1383,61 +1344,6 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getRequest() {
 		return $this->get(IRequest::class);
-	}
-
-	/**
-	 * Returns the preview manager which can create preview images for a given file
-	 *
-	 * @return IPreview
-	 * @deprecated 20.0.0
-	 */
-	public function getPreviewManager() {
-		return $this->get(IPreview::class);
-	}
-
-	/**
-	 * Returns the tag manager which can get and set tags for different object types
-	 *
-	 * @see \OCP\ITagManager::load()
-	 * @return ITagManager
-	 * @deprecated 20.0.0
-	 */
-	public function getTagManager() {
-		return $this->get(ITagManager::class);
-	}
-
-	/**
-	 * Returns the system-tag manager
-	 *
-	 * @return ISystemTagManager
-	 *
-	 * @since 9.0.0
-	 * @deprecated 20.0.0
-	 */
-	public function getSystemTagManager() {
-		return $this->get(ISystemTagManager::class);
-	}
-
-	/**
-	 * Returns the system-tag object mapper
-	 *
-	 * @return ISystemTagObjectMapper
-	 *
-	 * @since 9.0.0
-	 * @deprecated 20.0.0
-	 */
-	public function getSystemTagObjectMapper() {
-		return $this->get(ISystemTagObjectMapper::class);
-	}
-
-	/**
-	 * Returns the avatar manager, used for avatar functionality
-	 *
-	 * @return IAvatarManager
-	 * @deprecated 20.0.0
-	 */
-	public function getAvatarManager() {
-		return $this->get(IAvatarManager::class);
 	}
 
 	/**
@@ -1524,22 +1430,6 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return \OC\Authentication\TwoFactorAuth\Manager
-	 * @deprecated 20.0.0
-	 */
-	public function getTwoFactorAuthManager() {
-		return $this->get(\OC\Authentication\TwoFactorAuth\Manager::class);
-	}
-
-	/**
-	 * @return \OC\NavigationManager
-	 * @deprecated 20.0.0
-	 */
-	public function getNavigationManager() {
-		return $this->get(INavigationManager::class);
-	}
-
-	/**
 	 * @return \OCP\IConfig
 	 * @deprecated 20.0.0
 	 */
@@ -1553,16 +1443,6 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getSystemConfig() {
 		return $this->get(SystemConfig::class);
-	}
-
-	/**
-	 * Returns the app config manager
-	 *
-	 * @return IAppConfig
-	 * @deprecated 20.0.0
-	 */
-	public function getAppConfig() {
-		return $this->get(IAppConfig::class);
 	}
 
 	/**
@@ -1594,14 +1474,6 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return AppFetcher
-	 * @deprecated 20.0.0
-	 */
-	public function getAppFetcher() {
-		return $this->get(AppFetcher::class);
-	}
-
-	/**
 	 * Returns an ICache instance. Since 8.1.0 it returns a fake cache. Use
 	 * getMemCacheFactory() instead.
 	 *
@@ -1621,17 +1493,6 @@ class Server extends ServerContainer implements IServerContainer {
 	public function getMemCacheFactory() {
 		return $this->get(ICacheFactory::class);
 	}
-
-	/**
-	 * Returns an \OC\RedisFactory instance
-	 *
-	 * @return \OC\RedisFactory
-	 * @deprecated 20.0.0
-	 */
-	public function getGetRedisFactory() {
-		return $this->get('RedisFactory');
-	}
-
 
 	/**
 	 * Returns the current session
@@ -1661,25 +1522,6 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getJobList() {
 		return $this->get(IJobList::class);
-	}
-
-	/**
-	 * @return ILogFactory
-	 * @throws \OCP\AppFramework\QueryException
-	 * @deprecated 20.0.0
-	 */
-	public function getLogFactory() {
-		return $this->get(ILogFactory::class);
-	}
-
-	/**
-	 * Returns a router for generating and matching urls
-	 *
-	 * @return IRouter
-	 * @deprecated 20.0.0
-	 */
-	public function getRouter() {
-		return $this->get(IRouter::class);
 	}
 
 	/**
@@ -1713,56 +1555,12 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * Returns a CredentialsManager instance
-	 *
-	 * @return ICredentialsManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCredentialsManager() {
-		return $this->get(ICredentialsManager::class);
-	}
-
-	/**
 	 * Get the certificate manager
 	 *
 	 * @return \OCP\ICertificateManager
 	 */
 	public function getCertificateManager() {
 		return $this->get(ICertificateManager::class);
-	}
-
-	/**
-	 * Returns an instance of the HTTP client service
-	 *
-	 * @return IClientService
-	 * @deprecated 20.0.0
-	 */
-	public function getHTTPClientService() {
-		return $this->get(IClientService::class);
-	}
-
-	/**
-	 * Get the active event logger
-	 *
-	 * The returned logger only logs data when debug mode is enabled
-	 *
-	 * @return IEventLogger
-	 * @deprecated 20.0.0
-	 */
-	public function getEventLogger() {
-		return $this->get(IEventLogger::class);
-	}
-
-	/**
-	 * Get the active query logger
-	 *
-	 * The returned logger only logs data when debug mode is enabled
-	 *
-	 * @return IQueryLogger
-	 * @deprecated 20.0.0
-	 */
-	public function getQueryLogger() {
-		return $this->get(IQueryLogger::class);
 	}
 
 	/**
@@ -1806,66 +1604,6 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return \OC\OCSClient
-	 * @deprecated 20.0.0
-	 */
-	public function getOcsClient() {
-		return $this->get('OcsClient');
-	}
-
-	/**
-	 * @return IDateTimeZone
-	 * @deprecated 20.0.0
-	 */
-	public function getDateTimeZone() {
-		return $this->get(IDateTimeZone::class);
-	}
-
-	/**
-	 * @return IDateTimeFormatter
-	 * @deprecated 20.0.0
-	 */
-	public function getDateTimeFormatter() {
-		return $this->get(IDateTimeFormatter::class);
-	}
-
-	/**
-	 * @return IMountProviderCollection
-	 * @deprecated 20.0.0
-	 */
-	public function getMountProviderCollection() {
-		return $this->get(IMountProviderCollection::class);
-	}
-
-	/**
-	 * Get the IniWrapper
-	 *
-	 * @return IniGetWrapper
-	 * @deprecated 20.0.0
-	 */
-	public function getIniWrapper() {
-		return $this->get(IniGetWrapper::class);
-	}
-
-	/**
-	 * @return \OCP\Command\IBus
-	 * @deprecated 20.0.0
-	 */
-	public function getCommandBus() {
-		return $this->get(IBus::class);
-	}
-
-	/**
-	 * Get the trusted domain helper
-	 *
-	 * @return TrustedDomainHelper
-	 * @deprecated 20.0.0
-	 */
-	public function getTrustedDomainHelper() {
-		return $this->get(TrustedDomainHelper::class);
-	}
-
-	/**
 	 * Get the locking provider
 	 *
 	 * @return ILockingProvider
@@ -1874,22 +1612,6 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getLockingProvider() {
 		return $this->get(ILockingProvider::class);
-	}
-
-	/**
-	 * @return IMountManager
-	 * @deprecated 20.0.0
-	 **/
-	public function getMountManager() {
-		return $this->get(IMountManager::class);
-	}
-
-	/**
-	 * @return IUserMountCache
-	 * @deprecated 20.0.0
-	 */
-	public function getUserMountCache() {
-		return $this->get(IUserMountCache::class);
 	}
 
 	/**
@@ -1913,16 +1635,6 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * Get the manager of all the capabilities
-	 *
-	 * @return CapabilitiesManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCapabilitiesManager() {
-		return $this->get(CapabilitiesManager::class);
-	}
-
-	/**
 	 * Get the Notification Manager
 	 *
 	 * @return \OCP\Notification\IManager
@@ -1931,14 +1643,6 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getNotificationManager() {
 		return $this->get(\OCP\Notification\IManager::class);
-	}
-
-	/**
-	 * @return ICommentsManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCommentsManager() {
-		return $this->get(ICommentsManager::class);
 	}
 
 	/**
@@ -1958,14 +1662,6 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return \OC\Session\CryptoWrapper
-	 * @deprecated 20.0.0
-	 */
-	public function getSessionCryptoWrapper() {
-		return $this->get('CryptoWrapper');
-	}
-
-	/**
 	 * @return CsrfTokenManager
 	 * @deprecated 20.0.0
 	 */
@@ -1974,101 +1670,11 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return IThrottler
-	 * @deprecated 20.0.0
-	 */
-	public function getBruteForceThrottler() {
-		return $this->get(Throttler::class);
-	}
-
-	/**
-	 * @return IContentSecurityPolicyManager
-	 * @deprecated 20.0.0
-	 */
-	public function getContentSecurityPolicyManager() {
-		return $this->get(ContentSecurityPolicyManager::class);
-	}
-
-	/**
 	 * @return ContentSecurityPolicyNonceManager
 	 * @deprecated 20.0.0
 	 */
 	public function getContentSecurityPolicyNonceManager() {
 		return $this->get(ContentSecurityPolicyNonceManager::class);
-	}
-
-	/**
-	 * Not a public API as of 8.2, wait for 9.0
-	 *
-	 * @return \OCA\Files_External\Service\BackendService
-	 * @deprecated 20.0.0
-	 */
-	public function getStoragesBackendService() {
-		return $this->get(BackendService::class);
-	}
-
-	/**
-	 * Not a public API as of 8.2, wait for 9.0
-	 *
-	 * @return \OCA\Files_External\Service\GlobalStoragesService
-	 * @deprecated 20.0.0
-	 */
-	public function getGlobalStoragesService() {
-		return $this->get(GlobalStoragesService::class);
-	}
-
-	/**
-	 * Not a public API as of 8.2, wait for 9.0
-	 *
-	 * @return \OCA\Files_External\Service\UserGlobalStoragesService
-	 * @deprecated 20.0.0
-	 */
-	public function getUserGlobalStoragesService() {
-		return $this->get(UserGlobalStoragesService::class);
-	}
-
-	/**
-	 * Not a public API as of 8.2, wait for 9.0
-	 *
-	 * @return \OCA\Files_External\Service\UserStoragesService
-	 * @deprecated 20.0.0
-	 */
-	public function getUserStoragesService() {
-		return $this->get(UserStoragesService::class);
-	}
-
-	/**
-	 * @return \OCP\Share\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getShareManager() {
-		return $this->get(\OCP\Share\IManager::class);
-	}
-
-	/**
-	 * @return \OCP\Collaboration\Collaborators\ISearch
-	 * @deprecated 20.0.0
-	 */
-	public function getCollaboratorSearch() {
-		return $this->get(\OCP\Collaboration\Collaborators\ISearch::class);
-	}
-
-	/**
-	 * @return \OCP\Collaboration\AutoComplete\IManager
-	 * @deprecated 20.0.0
-	 */
-	public function getAutoCompleteManager() {
-		return $this->get(IManager::class);
-	}
-
-	/**
-	 * Returns the LDAP Provider
-	 *
-	 * @return \OCP\LDAP\ILDAPProvider
-	 * @deprecated 20.0.0
-	 */
-	public function getLDAPProvider() {
-		return $this->get('LDAPProvider');
 	}
 
 	/**
@@ -2090,78 +1696,11 @@ class Server extends ServerContainer implements IServerContainer {
 	}
 
 	/**
-	 * @return \OCP\Lockdown\ILockdownManager
-	 * @deprecated 20.0.0
-	 */
-	public function getLockdownManager() {
-		return $this->get('LockdownManager');
-	}
-
-	/**
 	 * @return \OCP\Federation\ICloudIdManager
 	 * @deprecated 20.0.0
 	 */
 	public function getCloudIdManager() {
 		return $this->get(ICloudIdManager::class);
-	}
-
-	/**
-	 * @return \OCP\GlobalScale\IConfig
-	 * @deprecated 20.0.0
-	 */
-	public function getGlobalScaleConfig() {
-		return $this->get(IConfig::class);
-	}
-
-	/**
-	 * @return \OCP\Federation\ICloudFederationProviderManager
-	 * @deprecated 20.0.0
-	 */
-	public function getCloudFederationProviderManager() {
-		return $this->get(ICloudFederationProviderManager::class);
-	}
-
-	/**
-	 * @return \OCP\Remote\Api\IApiFactory
-	 * @deprecated 20.0.0
-	 */
-	public function getRemoteApiFactory() {
-		return $this->get(IApiFactory::class);
-	}
-
-	/**
-	 * @return \OCP\Federation\ICloudFederationFactory
-	 * @deprecated 20.0.0
-	 */
-	public function getCloudFederationFactory() {
-		return $this->get(ICloudFederationFactory::class);
-	}
-
-	/**
-	 * @return \OCP\Remote\IInstanceFactory
-	 * @deprecated 20.0.0
-	 */
-	public function getRemoteInstanceFactory() {
-		return $this->get(IInstanceFactory::class);
-	}
-
-	/**
-	 * @return IStorageFactory
-	 * @deprecated 20.0.0
-	 */
-	public function getStorageFactory() {
-		return $this->get(IStorageFactory::class);
-	}
-
-	/**
-	 * Get the Preview GeneratorHelper
-	 *
-	 * @return GeneratorHelper
-	 * @since 17.0.0
-	 * @deprecated 20.0.0
-	 */
-	public function getGeneratorHelper() {
-		return $this->get(\OC\Preview\GeneratorHelper::class);
 	}
 
 	private function registerDeprecatedAlias(string $alias, string $target) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1125,7 +1125,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$config = $c->get(\OCP\IConfig::class);
 			$factoryClass = $config->getSystemValue('sharing.managerFactory', ProviderFactory::class);
 			/** @var \OCP\Share\IProviderFactory $factory */
-			return new $factoryClass($this);
+			return $c->get($factoryClass);
 		});
 
 		$this->registerAlias(\OCP\Share\IManager::class, \OC\Share20\Manager::class);

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace OC\Share20;
 
 use OC\Share20\Exception\ProviderException;
-use OCA\Circles\ShareByCircleProvider;
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\ShareByMail\ShareByMailProvider;
 use OCA\Talk\Share\RoomShareProvider;
@@ -185,7 +184,7 @@ class ProviderFactory implements IProviderFactory {
 		} elseif ($shareType === IShare::TYPE_EMAIL) {
 			$provider = $this->getShareByMailProvider();
 		} elseif ($shareType === IShare::TYPE_CIRCLE) {
-			$provider = $this->getProvider(ShareByCircleProvider::IDENTIFIER);
+			$provider = $this->getProvider('ocCircleShare');
 		} elseif ($shareType === IShare::TYPE_ROOM) {
 			$provider = $this->getRoomShareProvider();
 		} elseif ($shareType === IShare::TYPE_DECK) {

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -1,32 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OC\Share20;
 
 use OC\Share20\Exception\ProviderException;
-use OCA\FederatedFileSharing\AddressHandler;
+use OCA\Circles\ShareByCircleProvider;
 use OCA\FederatedFileSharing\FederatedShareProvider;
-use OCA\FederatedFileSharing\Notifications;
-use OCA\FederatedFileSharing\TokenHandler;
-use OCA\ShareByMail\Settings\SettingsManager;
 use OCA\ShareByMail\ShareByMailProvider;
 use OCA\Talk\Share\RoomShareProvider;
-use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\Defaults;
-use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Federation\ICloudFederationFactory;
-use OCP\Files\IRootFolder;
-use OCP\Http\Client\IClientService;
-use OCP\IServerContainer;
-use OCP\L10N\IFactory;
-use OCP\Mail\IMailer;
-use OCP\Security\IHasher;
-use OCP\Security\ISecureRandom;
-use OCP\Share\IManager;
+use OCP\App\IAppManager;
+use OCP\Server;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
 use OCP\Share\IShareProvider;
@@ -38,30 +28,28 @@ use Psr\Log\LoggerInterface;
  * @package OC\Share20
  */
 class ProviderFactory implements IProviderFactory {
-	/** @var DefaultShareProvider */
-	private $defaultProvider = null;
-	/** @var FederatedShareProvider */
-	private $federatedProvider = null;
-	/** @var ShareByMailProvider */
-	private $shareByMailProvider;
-	/** @var \OCA\Circles\ShareByCircleProvider */
+	private ?DefaultShareProvider $defaultProvider = null;
+	private ?FederatedShareProvider $federatedProvider = null;
+	private ?ShareByMailProvider $shareByMailProvider = null;
+	/**
+	 * @psalm-suppress UndefinedDocblockClass
+	 * @var ?ShareByCircleProvider
+	 */
 	private $shareByCircleProvider = null;
-	/** @var bool */
-	private $circlesAreNotAvailable = false;
-	/** @var \OCA\Talk\Share\RoomShareProvider */
+	private bool $circlesAreNotAvailable = false;
+	/**
+	 * @psalm-suppress UndefinedDocblockClass
+	 * @var ?RoomShareProvider
+	 */
 	private $roomShareProvider = null;
 
-	private $registeredShareProviders = [];
+	private array $registeredShareProviders = [];
 
-	private $shareProviders = [];
+	private array $shareProviders = [];
 
-	/**
-	 * IProviderFactory constructor.
-	 *
-	 * @param IServerContainer $serverContainer
-	 */
 	public function __construct(
-		private IServerContainer $serverContainer,
+		protected IAppManager $appManager,
+		protected LoggerInterface $logger,
 	) {
 	}
 
@@ -71,81 +59,24 @@ class ProviderFactory implements IProviderFactory {
 
 	/**
 	 * Create the default share provider.
-	 *
-	 * @return DefaultShareProvider
 	 */
-	protected function defaultShareProvider() {
-		if ($this->defaultProvider === null) {
-			$this->defaultProvider = new DefaultShareProvider(
-				$this->serverContainer->getDatabaseConnection(),
-				$this->serverContainer->getUserManager(),
-				$this->serverContainer->getGroupManager(),
-				$this->serverContainer->get(IRootFolder::class),
-				$this->serverContainer->get(IMailer::class),
-				$this->serverContainer->get(Defaults::class),
-				$this->serverContainer->get(IFactory::class),
-				$this->serverContainer->getURLGenerator(),
-				$this->serverContainer->get(ITimeFactory::class),
-				$this->serverContainer->get(LoggerInterface::class),
-				$this->serverContainer->get(IManager::class),
-			);
-		}
-
-		return $this->defaultProvider;
+	protected function defaultShareProvider(): DefaultShareProvider {
+		return Server::get(DefaultShareProvider::class);
 	}
 
 	/**
 	 * Create the federated share provider
-	 *
-	 * @return FederatedShareProvider
 	 */
-	protected function federatedShareProvider() {
+	protected function federatedShareProvider(): ?FederatedShareProvider {
 		if ($this->federatedProvider === null) {
 			/*
 			 * Check if the app is enabled
 			 */
-			$appManager = $this->serverContainer->getAppManager();
-			if (!$appManager->isEnabledForUser('federatedfilesharing')) {
+			if (!$this->appManager->isEnabledForUser('federatedfilesharing')) {
 				return null;
 			}
 
-			/*
-			 * TODO: add factory to federated sharing app
-			 */
-			$l = $this->serverContainer->getL10N('federatedfilesharing');
-			$addressHandler = new AddressHandler(
-				$this->serverContainer->getURLGenerator(),
-				$l,
-				$this->serverContainer->getCloudIdManager()
-			);
-			$notifications = new Notifications(
-				$addressHandler,
-				$this->serverContainer->get(IClientService::class),
-				$this->serverContainer->get(\OCP\OCS\IDiscoveryService::class),
-				$this->serverContainer->getJobList(),
-				\OC::$server->getCloudFederationProviderManager(),
-				\OC::$server->get(ICloudFederationFactory::class),
-				$this->serverContainer->get(IEventDispatcher::class),
-				$this->serverContainer->get(LoggerInterface::class),
-			);
-			$tokenHandler = new TokenHandler(
-				$this->serverContainer->get(ISecureRandom::class)
-			);
-
-			$this->federatedProvider = new FederatedShareProvider(
-				$this->serverContainer->getDatabaseConnection(),
-				$addressHandler,
-				$notifications,
-				$tokenHandler,
-				$l,
-				$this->serverContainer->get(IRootFolder::class),
-				$this->serverContainer->getConfig(),
-				$this->serverContainer->getUserManager(),
-				$this->serverContainer->getCloudIdManager(),
-				$this->serverContainer->getGlobalScaleConfig(),
-				$this->serverContainer->getCloudFederationProviderManager(),
-				$this->serverContainer->get(LoggerInterface::class),
-			);
+			$this->federatedProvider = Server::get(FederatedShareProvider::class);
 		}
 
 		return $this->federatedProvider;
@@ -153,38 +84,17 @@ class ProviderFactory implements IProviderFactory {
 
 	/**
 	 * Create the federated share provider
-	 *
-	 * @return ShareByMailProvider
 	 */
-	protected function getShareByMailProvider() {
+	protected function getShareByMailProvider(): ?ShareByMailProvider {
 		if ($this->shareByMailProvider === null) {
 			/*
 			 * Check if the app is enabled
 			 */
-			$appManager = $this->serverContainer->getAppManager();
-			if (!$appManager->isEnabledForUser('sharebymail')) {
+			if (!$this->appManager->isEnabledForUser('sharebymail')) {
 				return null;
 			}
 
-			$settingsManager = new SettingsManager($this->serverContainer->getConfig());
-
-			$this->shareByMailProvider = new ShareByMailProvider(
-				$this->serverContainer->getConfig(),
-				$this->serverContainer->getDatabaseConnection(),
-				$this->serverContainer->get(ISecureRandom::class),
-				$this->serverContainer->getUserManager(),
-				$this->serverContainer->get(IRootFolder::class),
-				$this->serverContainer->getL10N('sharebymail'),
-				$this->serverContainer->get(LoggerInterface::class),
-				$this->serverContainer->get(IMailer::class),
-				$this->serverContainer->getURLGenerator(),
-				$this->serverContainer->getActivityManager(),
-				$settingsManager,
-				$this->serverContainer->get(Defaults::class),
-				$this->serverContainer->get(IHasher::class),
-				$this->serverContainer->get(IEventDispatcher::class),
-				$this->serverContainer->get(IManager::class)
-			);
+			$this->shareByMailProvider = Server::get(ShareByMailProvider::class);
 		}
 
 		return $this->shareByMailProvider;
@@ -194,16 +104,15 @@ class ProviderFactory implements IProviderFactory {
 	/**
 	 * Create the circle share provider
 	 *
-	 * @return FederatedShareProvider
-	 *
-	 * @suppress PhanUndeclaredClassMethod
+	 * @psalm-suppress UndefinedDocblockClass
+	 * @return ?ShareByCircleProvider
 	 */
 	protected function getShareByCircleProvider() {
 		if ($this->circlesAreNotAvailable) {
 			return null;
 		}
 
-		if (!$this->serverContainer->getAppManager()->isEnabledForUser('circles') ||
+		if (!$this->appManager->isEnabledForUser('circles') ||
 			!class_exists('\OCA\Circles\ShareByCircleProvider')
 		) {
 			$this->circlesAreNotAvailable = true;
@@ -211,15 +120,8 @@ class ProviderFactory implements IProviderFactory {
 		}
 
 		if ($this->shareByCircleProvider === null) {
-			$this->shareByCircleProvider = new \OCA\Circles\ShareByCircleProvider(
-				$this->serverContainer->getDatabaseConnection(),
-				$this->serverContainer->get(ISecureRandom::class),
-				$this->serverContainer->getUserManager(),
-				$this->serverContainer->get(IRootFolder::class),
-				$this->serverContainer->getL10N('circles'),
-				$this->serverContainer->get(LoggerInterface::class),
-				$this->serverContainer->getURLGenerator()
-			);
+			/** @psalm-suppress UndefinedClass */
+			$this->shareByCircleProvider = Server::get(ShareByCircleProvider::class);
 		}
 
 		return $this->shareByCircleProvider;
@@ -228,15 +130,15 @@ class ProviderFactory implements IProviderFactory {
 	/**
 	 * Create the room share provider
 	 *
-	 * @return RoomShareProvider
+	 * @psalm-suppress UndefinedDocblockClass
+	 * @return ?RoomShareProvider
 	 */
 	protected function getRoomShareProvider() {
 		if ($this->roomShareProvider === null) {
 			/*
 			 * Check if the app is enabled
 			 */
-			$appManager = $this->serverContainer->getAppManager();
-			if (!$appManager->isEnabledForUser('spreed')) {
+			if (!$this->appManager->isEnabledForUser('spreed')) {
 				return null;
 			}
 
@@ -244,9 +146,9 @@ class ProviderFactory implements IProviderFactory {
 				/**
 				 * @psalm-suppress UndefinedClass
 				 */
-				$this->roomShareProvider = $this->serverContainer->get(RoomShareProvider::class);
+				$this->roomShareProvider = Server::get(RoomShareProvider::class);
 			} catch (\Throwable $e) {
-				$this->serverContainer->get(LoggerInterface::class)->error(
+				$this->logger->error(
 					$e->getMessage(),
 					['exception' => $e]
 				);
@@ -281,10 +183,10 @@ class ProviderFactory implements IProviderFactory {
 		foreach ($this->registeredShareProviders as $shareProvider) {
 			try {
 				/** @var IShareProvider $instance */
-				$instance = $this->serverContainer->get($shareProvider);
+				$instance = Server::get($shareProvider);
 				$this->shareProviders[$instance->identifier()] = $instance;
 			} catch (\Throwable $e) {
-				$this->serverContainer->get(LoggerInterface::class)->error(
+				$this->logger->error(
 					$e->getMessage(),
 					['exception' => $e]
 				);
@@ -353,9 +255,9 @@ class ProviderFactory implements IProviderFactory {
 		foreach ($this->registeredShareProviders as $shareProvider) {
 			try {
 				/** @var IShareProvider $instance */
-				$instance = $this->serverContainer->get($shareProvider);
+				$instance = Server::get($shareProvider);
 			} catch (\Throwable $e) {
-				$this->serverContainer->get(LoggerInterface::class)->error(
+				$this->logger->error(
 					$e->getMessage(),
 					['exception' => $e]
 				);

--- a/lib/private/Share20/ProviderFactory.php
+++ b/lib/private/Share20/ProviderFactory.php
@@ -33,12 +33,6 @@ class ProviderFactory implements IProviderFactory {
 	private ?ShareByMailProvider $shareByMailProvider = null;
 	/**
 	 * @psalm-suppress UndefinedDocblockClass
-	 * @var ?ShareByCircleProvider
-	 */
-	private $shareByCircleProvider = null;
-	private bool $circlesAreNotAvailable = false;
-	/**
-	 * @psalm-suppress UndefinedDocblockClass
 	 * @var ?RoomShareProvider
 	 */
 	private $roomShareProvider = null;
@@ -100,33 +94,6 @@ class ProviderFactory implements IProviderFactory {
 		return $this->shareByMailProvider;
 	}
 
-
-	/**
-	 * Create the circle share provider
-	 *
-	 * @psalm-suppress UndefinedDocblockClass
-	 * @return ?ShareByCircleProvider
-	 */
-	protected function getShareByCircleProvider() {
-		if ($this->circlesAreNotAvailable) {
-			return null;
-		}
-
-		if (!$this->appManager->isEnabledForUser('circles') ||
-			!class_exists('\OCA\Circles\ShareByCircleProvider')
-		) {
-			$this->circlesAreNotAvailable = true;
-			return null;
-		}
-
-		if ($this->shareByCircleProvider === null) {
-			/** @psalm-suppress UndefinedClass */
-			$this->shareByCircleProvider = Server::get(ShareByCircleProvider::class);
-		}
-
-		return $this->shareByCircleProvider;
-	}
-
 	/**
 	 * Create the room share provider
 	 *
@@ -174,8 +141,6 @@ class ProviderFactory implements IProviderFactory {
 			$provider = $this->federatedShareProvider();
 		} elseif ($id === 'ocMailShare') {
 			$provider = $this->getShareByMailProvider();
-		} elseif ($id === 'ocCircleShare') {
-			$provider = $this->getShareByCircleProvider();
 		} elseif ($id === 'ocRoomShare') {
 			$provider = $this->getRoomShareProvider();
 		}
@@ -220,7 +185,7 @@ class ProviderFactory implements IProviderFactory {
 		} elseif ($shareType === IShare::TYPE_EMAIL) {
 			$provider = $this->getShareByMailProvider();
 		} elseif ($shareType === IShare::TYPE_CIRCLE) {
-			$provider = $this->getShareByCircleProvider();
+			$provider = $this->getProvider(ShareByCircleProvider::IDENTIFIER);
 		} elseif ($shareType === IShare::TYPE_ROOM) {
 			$provider = $this->getRoomShareProvider();
 		} elseif ($shareType === IShare::TYPE_DECK) {
@@ -242,10 +207,6 @@ class ProviderFactory implements IProviderFactory {
 		$shareByMail = $this->getShareByMailProvider();
 		if ($shareByMail !== null) {
 			$shares[] = $shareByMail;
-		}
-		$shareByCircle = $this->getShareByCircleProvider();
-		if ($shareByCircle !== null) {
-			$shares[] = $shareByCircle;
 		}
 		$roomShare = $this->getRoomShareProvider();
 		if ($roomShare !== null) {

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -8,9 +8,7 @@ declare(strict_types=1);
  */
 namespace OCP;
 
-use OCP\Federation\ICloudFederationFactory;
 use OCP\Federation\ICloudFederationProviderManager;
-use OCP\Log\ILogFactory;
 use OCP\Security\IContentSecurityPolicyManager;
 use Psr\Container\ContainerInterface;
 
@@ -26,35 +24,6 @@ use Psr\Container\ContainerInterface;
  * @since 6.0.0
  */
 interface IServerContainer extends ContainerInterface, IContainer {
-	/**
-	 * The calendar manager will act as a broker between consumers for calendar information and
-	 * providers which actual deliver the calendar information.
-	 *
-	 * @return \OCP\Calendar\IManager
-	 * @since 13.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCalendarManager();
-
-	/**
-	 * The calendar resource backend manager will act as a broker between consumers
-	 * for calendar resource information an providers which actual deliver the room information.
-	 *
-	 * @return \OCP\Calendar\Resource\IBackend
-	 * @since 14.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCalendarResourceBackendManager();
-
-	/**
-	 * The calendar room backend manager will act as a broker between consumers
-	 * for calendar room information an providers which actual deliver the room information.
-	 *
-	 * @return \OCP\Calendar\Room\IBackend
-	 * @since 14.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCalendarRoomBackendManager();
 
 	/**
 	 * The contacts manager will act as a broker between consumers for contacts information and
@@ -76,25 +45,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getRequest();
-
-	/**
-	 * Returns the preview manager which can create preview images for a given file
-	 *
-	 * @return \OCP\IPreview
-	 * @since 6.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getPreviewManager();
-
-	/**
-	 * Returns the tag manager which can get and set tags for different object types
-	 *
-	 * @see \OCP\ITagManager::load()
-	 * @return \OCP\ITagManager
-	 * @since 6.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getTagManager();
 
 	/**
 	 * Returns the root folder of ownCloud's data directory
@@ -189,15 +139,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getSecureRandom();
 
 	/**
-	 * Returns a CredentialsManager instance
-	 *
-	 * @return \OCP\Security\ICredentialsManager
-	 * @since 9.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCredentialsManager();
-
-	/**
 	 * Returns the app config manager
 	 *
 	 * @return \OCP\IAppConfig
@@ -236,13 +177,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getEncryptionFilesHelper();
-
-	/**
-	 * @return \OCP\Encryption\Keys\IStorage
-	 * @since 8.1.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getEncryptionKeyStorage();
 
 	/**
 	 * Returns the URL generator
@@ -299,15 +233,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getDatabaseConnection();
 
 	/**
-	 * Returns an avatar manager, used for avatar functionality
-	 *
-	 * @return \OCP\IAvatarManager
-	 * @since 6.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getAvatarManager();
-
-	/**
 	 * Returns an job list for controlling background jobs
 	 *
 	 * @return \OCP\BackgroundJob\IJobList
@@ -315,24 +240,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getJobList();
-
-	/**
-	 * returns a log factory instance
-	 *
-	 * @return ILogFactory
-	 * @since 14.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getLogFactory();
-
-	/**
-	 * Returns a router for generating and matching urls
-	 *
-	 * @return \OCP\Route\IRouter
-	 * @since 7.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getRouter();
 
 	/**
 	 * Get the certificate manager
@@ -351,26 +258,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getHTTPClientService();
-
-	/**
-	 * Get the active event logger
-	 *
-	 * @return \OCP\Diagnostics\IEventLogger
-	 * @since 8.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getEventLogger();
-
-	/**
-	 * Get the active query logger
-	 *
-	 * The returned logger only logs data when debug mode is enabled
-	 *
-	 * @return \OCP\Diagnostics\IQueryLogger
-	 * @since 8.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getQueryLogger();
 
 	/**
 	 * Get the manager for temporary files and folders
@@ -398,28 +285,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getWebRoot();
-
-	/**
-	 * @return \OCP\Files\Config\IMountProviderCollection
-	 * @since 8.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getMountProviderCollection();
-
-	/**
-	 * Get the IniWrapper
-	 *
-	 * @return \bantu\IniGetWrapper\IniGetWrapper
-	 * @since 8.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getIniWrapper();
-	/**
-	 * @return \OCP\Command\IBus
-	 * @since 8.1.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCommandBus();
 
 	/**
 	 * Creates a new mailer
@@ -474,61 +339,11 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getNotificationManager();
 
 	/**
-	 * @return \OCP\Comments\ICommentsManager
-	 * @since 9.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCommentsManager();
-
-	/**
-	 * Returns the system-tag manager
-	 *
-	 * @return \OCP\SystemTag\ISystemTagManager
-	 *
-	 * @since 9.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getSystemTagManager();
-
-	/**
-	 * Returns the system-tag object mapper
-	 *
-	 * @return \OCP\SystemTag\ISystemTagObjectMapper
-	 *
-	 * @since 9.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getSystemTagObjectMapper();
-
-	/**
-	 * Returns the share manager
-	 *
-	 * @return \OCP\Share\IManager
-	 * @since 9.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getShareManager();
-
-	/**
 	 * @return IContentSecurityPolicyManager
 	 * @since 9.0.0
 	 * @deprecated 17.0.0 Use the AddContentSecurityPolicyEvent
 	 */
 	public function getContentSecurityPolicyManager();
-
-	/**
-	 * @return \OCP\IDateTimeZone
-	 * @since 8.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getDateTimeZone();
-
-	/**
-	 * @return \OCP\IDateTimeFormatter
-	 * @since 8.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getDateTimeFormatter();
 
 	/**
 	 * @return \OCP\Federation\ICloudIdManager
@@ -545,37 +360,9 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getGlobalScaleConfig();
 
 	/**
-	 * @return ICloudFederationFactory
-	 * @since 14.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCloudFederationFactory();
-
-	/**
 	 * @return ICloudFederationProviderManager
 	 * @since 14.0.0
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getCloudFederationProviderManager();
-
-	/**
-	 * @return \OCP\Remote\Api\IApiFactory
-	 * @since 13.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getRemoteApiFactory();
-
-	/**
-	 * @return \OCP\Remote\IInstanceFactory
-	 * @since 13.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getRemoteInstanceFactory();
-
-	/**
-	 * @return \OCP\Files\Storage\IStorageFactory
-	 * @since 15.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getStorageFactory();
 }

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
  */
 namespace OCP;
 
-use OCP\Federation\ICloudFederationProviderManager;
-use OCP\Security\IContentSecurityPolicyManager;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -94,15 +92,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getUserSession();
 
 	/**
-	 * Returns the navigation manager
-	 *
-	 * @return \OCP\INavigationManager
-	 * @since 6.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getNavigationManager();
-
-	/**
 	 * Returns the config manager
 	 *
 	 * @return \OCP\IConfig
@@ -137,15 +126,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getSecureRandom();
-
-	/**
-	 * Returns the app config manager
-	 *
-	 * @return \OCP\IAppConfig
-	 * @since 7.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getAppConfig();
 
 	/**
 	 * @return \OCP\L10N\IFactory
@@ -251,15 +231,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getCertificateManager();
 
 	/**
-	 * Returns an instance of the HTTP client service
-	 *
-	 * @return \OCP\Http\Client\IClientService
-	 * @since 8.1.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getHTTPClientService();
-
-	/**
 	 * Get the manager for temporary files and folders
 	 *
 	 * @return \OCP\ITempManager
@@ -305,13 +276,6 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getLockingProvider();
 
 	/**
-	 * @return \OCP\Files\Mount\IMountManager
-	 * @since 8.2.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getMountManager();
-
-	/**
 	 * Get the MimeTypeDetector
 	 *
 	 * @return \OCP\Files\IMimeTypeDetector
@@ -339,30 +303,9 @@ interface IServerContainer extends ContainerInterface, IContainer {
 	public function getNotificationManager();
 
 	/**
-	 * @return IContentSecurityPolicyManager
-	 * @since 9.0.0
-	 * @deprecated 17.0.0 Use the AddContentSecurityPolicyEvent
-	 */
-	public function getContentSecurityPolicyManager();
-
-	/**
 	 * @return \OCP\Federation\ICloudIdManager
 	 * @since 12.0.0
 	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
 	 */
 	public function getCloudIdManager();
-
-	/**
-	 * @return \OCP\GlobalScale\IConfig
-	 * @since 14.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getGlobalScaleConfig();
-
-	/**
-	 * @return ICloudFederationProviderManager
-	 * @since 14.0.0
-	 * @deprecated 20.0.0 have it injected or fetch it through \Psr\Container\ContainerInterface::get
-	 */
-	public function getCloudFederationProviderManager();
 }

--- a/lib/public/Security/IContentSecurityPolicyManager.php
+++ b/lib/public/Security/IContentSecurityPolicyManager.php
@@ -24,7 +24,7 @@ interface IContentSecurityPolicyManager {
 	 * Note that the adjustment is only applied to applications that use AppFramework
 	 * controllers.
 	 *
-	 * To use this from your `app.php` use `\OC::$server->getContentSecurityPolicyManager()->addDefaultPolicy($policy)`,
+	 * To use this from your `app.php` use `\OCP\Server::get(IContentSecurityPolicyManager::class)->addDefaultPolicy($policy)`,
 	 * $policy has to be of type `\OCP\AppFramework\Http\ContentSecurityPolicy`.
 	 *
 	 * WARNING: Using this API incorrectly may make the instance more insecure.

--- a/lib/public/Share/IProviderFactory.php
+++ b/lib/public/Share/IProviderFactory.php
@@ -39,7 +39,8 @@ interface IProviderFactory {
 
 	/**
 	 * @since 21.0.0
-	 * @param string $shareProvier
+	 * @since 32.0.0 Fix typo in parameter name
+	 * @param string $shareProviderClass
 	 */
-	public function registerProvider(string $shareProvier): void;
+	public function registerProvider(string $shareProviderClass): void;
 }

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -393,7 +393,7 @@ class CacheTest extends \Test\TestCase {
 		$id4 = $this->cache->put($file4, $fileData['foo2']);
 		$id5 = $this->cache->put($file5, $fileData['foo3']);
 
-		$tagManager = \OC::$server->getTagManager()->load('files', [], false, $userId);
+		$tagManager = \OCP\Server::get(\OCP\ITagManager::class)->load('files', [], false, $userId);
 		$this->assertTrue($tagManager->tagAs($id1, 'tag1'));
 		$this->assertTrue($tagManager->tagAs($id1, 'tag2'));
 		$this->assertTrue($tagManager->tagAs($id2, 'tag2'));

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -472,7 +472,7 @@ class FilesystemTest extends \Test\TestCase {
 		$this->assertEquals('/', \OC\Files\Filesystem::getMountPoint('/foo/bar'));
 		$mount = new MountPoint(new Temporary([]), '/foo/bar');
 		$mountProvider = new DummyMountProvider([self::TEST_FILESYSTEM_USER2 => [$mount]]);
-		\OC::$server->getMountProviderCollection()->registerProvider($mountProvider);
+		\OCP\Server::get(\OCP\Files\Config\IMountProviderCollection::class)->registerProvider($mountProvider);
 		$this->assertEquals('/foo/bar/', \OC\Files\Filesystem::getMountPoint('/foo/bar'));
 	}
 }

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -80,7 +80,7 @@ class HookConnectorTest extends TestCase {
 			Filesystem::getMountManager(),
 			$this->view,
 			\OC::$server->getUserManager()->get($this->userId),
-			\OC::$server->getUserMountCache(),
+			\OCP\Server::get(\OCP\Files\Config\IUserMountCache::class),
 			$this->createMock(LoggerInterface::class),
 			$this->createMock(IUserManager::class),
 			$this->createMock(IEventDispatcher::class),

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -124,7 +124,7 @@ class ScannerTest extends \Test\TestCase {
 				}
 			});
 
-		\OC::$server->getMountProviderCollection()->registerProvider($mountProvider);
+		\OCP\Server::get(\OCP\Files\Config\IMountProviderCollection::class)->registerProvider($mountProvider);
 		$cache = $storage->getCache();
 
 		$storage->mkdir('folder');

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -155,7 +155,7 @@ class ViewTest extends \Test\TestCase {
 		$this->userObject->delete();
 		$this->groupObject->delete();
 
-		$mountProviderCollection = \OC::$server->getMountProviderCollection();
+		$mountProviderCollection = \OCP\Server::get(\OCP\Files\Config\IMountProviderCollection::class);
 		self::invokePrivate($mountProviderCollection, 'providers', [[]]);
 
 		parent::tearDown();
@@ -1626,7 +1626,7 @@ class ViewTest extends \Test\TestCase {
 			->method('getMountsForUser')
 			->willReturn($mounts);
 
-		$mountProviderCollection = \OC::$server->getMountProviderCollection();
+		$mountProviderCollection = \OCP\Server::get(\OCP\Files\Config\IMountProviderCollection::class);
 		$mountProviderCollection->registerProvider($mountProvider);
 
 		return $mounts;

--- a/tests/lib/Traits/MountProviderTrait.php
+++ b/tests/lib/Traits/MountProviderTrait.php
@@ -58,6 +58,6 @@ trait MountProviderTrait {
 					return [];
 				}
 			}));
-		\OC::$server->getMountProviderCollection()->registerProvider($this->mountProvider);
+		\OCP\Server::get(\OCP\Files\Config\IMountProviderCollection::class)->registerProvider($this->mountProvider);
 	}
 }


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Remove deprecated getters from IServerContainer which are unused in current known code.
Remove those from Server class implementation, along with some that were already gone from the interface.
Cleaned up share provider factory as it was using some of those.

## TODO

- [x] Fix remaining calls (with rector?)
- [x] Remove the others
- [x] Remove the implementation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
