### PR TITLE
fix: Throw exception in PreviewManager when preview is not available

### DIFF
--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -154,7 +154,7 @@ class PreviewManager implements IPreview {
 		$mimeType = null,
 		bool $cacheResult = true,
 	): ISimpleFile {
-		$this->throwIfPreviewsDisabled();
+		$this->throwIfPreviewsDisabled($file);
 		$previewConcurrency = $this->getGenerator()->getNumConcurrentPreviews('preview_concurrency_all');
 		$sem = Generator::guardWithSemaphore(Generator::SEMAPHORE_ID_ALL, $previewConcurrency);
 		try {
@@ -178,7 +178,7 @@ class PreviewManager implements IPreview {
 	 * @since 19.0.0
 	 */
 	public function generatePreviews(File $file, array $specifications, $mimeType = null) {
-		$this->throwIfPreviewsDisabled();
+		$this->throwIfPreviewsDisabled($file);
 		return $this->getGenerator()->generatePreviews($file, $specifications, $mimeType);
 	}
 
@@ -455,8 +455,8 @@ class PreviewManager implements IPreview {
 	/**
 	 * @throws NotFoundException if preview generation is disabled
 	 */
-	private function throwIfPreviewsDisabled(): void {
-		if (!$this->enablePreviews) {
+	private function throwIfPreviewsDisabled(File $file): void {
+		if (!$this->isAvailable($file)) {
 			throw new NotFoundException('Previews disabled');
 		}
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/52858

## Summary

- The exception thrown doesn't actually check if previews are disabled at storage or  provider level; I fix that in this PR so that storage level disabling of preview works as expected

### Before:

- For an external storage mount with previews disabled
![image](https://github.com/user-attachments/assets/5eb6dc30-22a4-4702-9b40-20038383afd1)


### After:
![image](https://github.com/user-attachments/assets/d322086c-0943-474d-bd4c-a0b6e240f56e)



## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
