### PR TITLE
feat(psalm): Mark all usage of deprecated code as error

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -44,17 +44,158 @@
       <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
   </file>
+  <file src="apps/admin_audit/lib/AppInfo/Application.php">
+    <DeprecatedClass>
+      <code><![CDATA[Share::class]]></code>
+      <code><![CDATA[Share::class]]></code>
+      <code><![CDATA[Share::class]]></code>
+      <code><![CDATA[Share::class]]></code>
+    </DeprecatedClass>
+    <DeprecatedConstant>
+      <code><![CDATA[ManagerEvent::EVENT_CREATE]]></code>
+    </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[Util::connectHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', $trashActions, 'restore')]]></code>
+      <code><![CDATA[Util::connectHook('\OCP\Trashbin', 'preDelete', $trashActions, 'delete')]]></code>
+      <code><![CDATA[Util::connectHook('\OCP\Versions', 'delete', $versionsActions, 'delete')]]></code>
+      <code><![CDATA[Util::connectHook(Share::class, 'post_set_expiration_date', $shareActions, 'updateExpirationDate')]]></code>
+      <code><![CDATA[Util::connectHook(Share::class, 'post_update_password', $shareActions, 'updatePassword')]]></code>
+      <code><![CDATA[Util::connectHook(Share::class, 'post_update_permissions', $shareActions, 'updatePermissions')]]></code>
+      <code><![CDATA[Util::connectHook(Share::class, 'share_link_access', $shareActions, 'shareAccessed')]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/admin_audit/lib/AuditLogger.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/admin_audit/lib/BackgroundJobs/Rotate.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/cloud_federation_api/lib/Controller/RequestHandlerController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::emitHook(
+			'\OCA\Files_Sharing\API\Server2Server',
+			'preLoginNameUsedAsUserName',
+			['uid' => &$uid]
+		)]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/comments/lib/Activity/Listener.php">
+    <DeprecatedConstant>
+      <code><![CDATA[CommentsEvent::EVENT_ADD]]></code>
+    </DeprecatedConstant>
+  </file>
+  <file src="apps/comments/lib/Listener/CommentsEventListener.php">
+    <DeprecatedConstant>
+      <code><![CDATA[CommentsEvent::EVENT_ADD]]></code>
+      <code><![CDATA[CommentsEvent::EVENT_DELETE]]></code>
+      <code><![CDATA[CommentsEvent::EVENT_PRE_UPDATE]]></code>
+      <code><![CDATA[CommentsEvent::EVENT_UPDATE]]></code>
+    </DeprecatedConstant>
+  </file>
+  <file src="apps/comments/lib/MaxAutoCompleteResultsInitialState.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/comments/lib/Notification/Listener.php">
+    <DeprecatedConstant>
+      <code><![CDATA[CommentsEvent::EVENT_DELETE]]></code>
+      <code><![CDATA[CommentsEvent::EVENT_PRE_UPDATE]]></code>
+    </DeprecatedConstant>
+  </file>
+  <file src="apps/comments/lib/Search/CommentsSearchProvider.php">
+    <DeprecatedClass>
+      <code><![CDATA[Result]]></code>
+    </DeprecatedClass>
+    <DeprecatedProperty>
+      <code><![CDATA[$result->authorId]]></code>
+      <code><![CDATA[$result->authorId]]></code>
+      <code><![CDATA[$result->authorId]]></code>
+      <code><![CDATA[$result->name]]></code>
+      <code><![CDATA[$result->path]]></code>
+    </DeprecatedProperty>
+  </file>
+  <file src="apps/comments/lib/Search/LegacyProvider.php">
+    <DeprecatedClass>
+      <code><![CDATA[Provider]]></code>
+      <code><![CDATA[new Result($query,
+						$comment,
+						$displayName,
+						$file->getPath()
+					)]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[Provider]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/comments/lib/Search/Result.php">
+    <DeprecatedClass>
+      <code><![CDATA[BaseResult]]></code>
+      <code><![CDATA[parent::__construct(
+			$comment->getId(),
+			$comment->getMessage()
+			/* @todo , [link to file] */
+		)]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[parent::__construct(
+			$comment->getId(),
+			$comment->getMessage()
+			/* @todo , [link to file] */
+		)]]></code>
+    </DeprecatedMethod>
+    <DeprecatedProperty>
+      <code><![CDATA[$this->authorId]]></code>
+      <code><![CDATA[$this->comment]]></code>
+      <code><![CDATA[$this->fileName]]></code>
+      <code><![CDATA[$this->path]]></code>
+    </DeprecatedProperty>
+  </file>
+  <file src="apps/dashboard/lib/Controller/DashboardApiController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dashboard/lib/Service/DashboardService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/appinfo/v1/caldav.php">
+    <DeprecatedMethod>
+      <code><![CDATA[exec]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getL10N]]></code>
+      <code><![CDATA[getL10NFactory]]></code>
+    </DeprecatedMethod>
     <UndefinedGlobalVariable>
       <code><![CDATA[$baseuri]]></code>
     </UndefinedGlobalVariable>
   </file>
   <file src="apps/dav/appinfo/v1/carddav.php">
+    <DeprecatedMethod>
+      <code><![CDATA[exec]]></code>
+      <code><![CDATA[getL10N]]></code>
+      <code><![CDATA[getL10NFactory]]></code>
+    </DeprecatedMethod>
     <UndefinedGlobalVariable>
       <code><![CDATA[$baseuri]]></code>
     </UndefinedGlobalVariable>
   </file>
   <file src="apps/dav/appinfo/v1/publicwebdav.php">
+    <DeprecatedClass>
+      <code><![CDATA[OC_Util::obEnd()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[OC_App::loadApps($RUNTIME_APPTYPES)]]></code>
+      <code><![CDATA[exec]]></code>
+      <code><![CDATA[getL10N]]></code>
+    </DeprecatedMethod>
     <InternalMethod>
       <code><![CDATA[Filesystem::logWarningWhenAddingStorageWrapper($previousLog)]]></code>
       <code><![CDATA[Filesystem::logWarningWhenAddingStorageWrapper(false)]]></code>
@@ -64,26 +205,99 @@
     </UndefinedGlobalVariable>
   </file>
   <file src="apps/dav/appinfo/v1/webdav.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::obEnd()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+      <code><![CDATA[exec]]></code>
+      <code><![CDATA[getL10N]]></code>
+    </DeprecatedMethod>
     <UndefinedGlobalVariable>
       <code><![CDATA[$baseuri]]></code>
     </UndefinedGlobalVariable>
   </file>
   <file src="apps/dav/appinfo/v2/direct.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::obEnd()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[exec]]></code>
+    </DeprecatedMethod>
     <UndefinedGlobalVariable>
       <code><![CDATA[$baseuri]]></code>
     </UndefinedGlobalVariable>
   </file>
+  <file src="apps/dav/appinfo/v2/publicremote.php">
+    <DeprecatedClass>
+      <code><![CDATA[OC_Util::obEnd()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[OC_App::loadApps($RUNTIME_APPTYPES)]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/appinfo/v2/remote.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::obEnd()]]></code>
+    </DeprecatedClass>
     <UndefinedGlobalVariable>
       <code><![CDATA[$baseuri]]></code>
     </UndefinedGlobalVariable>
   </file>
   <file src="apps/dav/lib/AppInfo/Application.php">
+    <DeprecatedInterface>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_App::loadApps(['dav'])]]></code>
+      <code><![CDATA[getServer]]></code>
+      <code><![CDATA[getServer]]></code>
+      <code><![CDATA[getURLGenerator]]></code>
+      <code><![CDATA[getURLGenerator]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[register]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[registerEventListener]]></code>
     </InvalidArgument>
   </file>
+  <file src="apps/dav/lib/BackgroundJob/CleanupInvitationTokenJob.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/EventReminderJob.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/GenerateBirthdayCalendarBackgroundJob.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/PruneOutdatedSyncTokensJob.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/BackgroundJob/RefreshWebcalJob.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/CalDAV/BirthdayService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <UndefinedMethod>
       <code><![CDATA[setDateTime]]></code>
       <code><![CDATA[setDateTime]]></code>
@@ -105,6 +319,10 @@
     </ParamNameMismatch>
   </file>
   <file src="apps/dav/lib/CalDAV/CalDavBackend.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidNullableReturnType>
       <code><![CDATA[array]]></code>
     </InvalidNullableReturnType>
@@ -124,6 +342,9 @@
     </NullableReturnStatement>
   </file>
   <file src="apps/dav/lib/CalDAV/CalendarHome.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getL10N]]></code>
+    </DeprecatedMethod>
     <InvalidNullableReturnType>
       <code><![CDATA[INode]]></code>
     </InvalidNullableReturnType>
@@ -137,10 +358,30 @@
       <code><![CDATA[calendarSearch]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/CalDAV/CalendarManager.php">
+    <DeprecatedMethod>
+      <code><![CDATA[registerCalendar]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/CalDAV/CalendarRoot.php">
     <ParamNameMismatch>
       <code><![CDATA[$principal]]></code>
     </ParamNameMismatch>
+  </file>
+  <file src="apps/dav/lib/CalDAV/ICSExportPlugin/ICSExportPlugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/CalDAV/InvitationResponse/InvitationResponseServer.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getL10N]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Outbox.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Plugin.php">
     <ImplementedReturnTypeMismatch>
@@ -156,6 +397,13 @@
     <MoreSpecificImplementedParamType>
       <code><![CDATA[$paths]]></code>
     </MoreSpecificImplementedParamType>
+  </file>
+  <file src="apps/dav/lib/CalDAV/Publishing/PublishPlugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Reminder/NotificationProvider/AbstractProvider.php">
     <LessSpecificReturnStatement>
@@ -180,6 +428,11 @@
       <code><![CDATA[isFloating]]></code>
     </UndefinedMethod>
   </file>
+  <file src="apps/dav/lib/CalDAV/Reminder/NotificationProvider/PushProvider.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/CalDAV/Reminder/NotificationProviderManager.php">
     <UndefinedConstant>
       <code><![CDATA[$provider::NOTIFICATION_TYPE]]></code>
@@ -191,6 +444,9 @@
     </TypeDoesNotContainType>
   </file>
   <file src="apps/dav/lib/CalDAV/Reminder/ReminderService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <LessSpecificReturnStatement>
       <code><![CDATA[$vevents]]></code>
       <code><![CDATA[VObject\Reader::read($calendarData,
@@ -209,6 +465,18 @@
     </UndefinedPropertyFetch>
   </file>
   <file src="apps/dav/lib/CalDAV/ResourceBooking/AbstractPrincipalBackend.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
     <InvalidNullableReturnType>
       <code><![CDATA[array]]></code>
     </InvalidNullableReturnType>
@@ -223,6 +491,11 @@
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/dav/lib/CalDAV/RetentionService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipPlugin.php">
     <RedundantCast>
       <code><![CDATA[(string)$iTipMessage->recipientName]]></code>
@@ -233,12 +506,18 @@
     </RedundantCondition>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/IMipService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <UndefinedMethod>
       <code><![CDATA[getNormalizedValue]]></code>
       <code><![CDATA[getNormalizedValue]]></code>
     </UndefinedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Schedule/Plugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getPropertiesForPath]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[[$aclPlugin, 'propFind']]]></code>
       <code><![CDATA[[$aclPlugin, 'propFind']]]></code>
@@ -258,6 +537,9 @@
     </UndefinedMethod>
   </file>
   <file src="apps/dav/lib/CalDAV/Search/SearchPlugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getPropertiesForPath]]></code>
+    </DeprecatedMethod>
     <InvalidNullableReturnType>
       <code><![CDATA[bool]]></code>
     </InvalidNullableReturnType>
@@ -329,16 +611,65 @@
       <code><![CDATA[string|null]]></code>
     </ImplementedReturnTypeMismatch>
   </file>
+  <file src="apps/dav/lib/CardDAV/SystemAddressbook.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/CardDAV/UserAddressBooks.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getL10N]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$this->principalUri]]></code>
       <code><![CDATA[$this->principalUri]]></code>
     </InvalidArgument>
   </file>
+  <file src="apps/dav/lib/Command/CreateCalendar.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getL10NFactory]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Command/SendEventReminders.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Command/SyncBirthdayCalendar.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Command/SyncSystemAddressBook.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/Comments/CommentsPlugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getPropertiesForPath]]></code>
+    </DeprecatedMethod>
     <UndefinedFunction>
       <code><![CDATA[\Sabre\HTTP\toDate($value)]]></code>
     </UndefinedFunction>
+  </file>
+  <file src="apps/dav/lib/Comments/RootCollection.php">
+    <DeprecatedConstant>
+      <code><![CDATA[CommentsEntityEvent::EVENT_ENTITY]]></code>
+    </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/AnonymousOptionsPlugin.php">
     <InvalidNullableReturnType>
@@ -354,6 +685,10 @@
     </MoreSpecificReturnType>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/BearerAuth.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($userId)]]></code>
+      <code><![CDATA[\OC_Util::setupFS()]]></code>
+    </DeprecatedClass>
     <UndefinedInterfaceMethod>
       <code><![CDATA[tryTokenLogin]]></code>
     </UndefinedInterfaceMethod>
@@ -408,6 +743,11 @@
       <code><![CDATA[getPath]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/Connector/Sabre/MaintenancePlugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getL10N]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/Connector/Sabre/Node.php">
     <InvalidNullableReturnType>
       <code><![CDATA[int]]></code>
@@ -448,6 +788,10 @@
     </UndefinedClass>
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ServerFactory.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getL10NFactory]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+    </DeprecatedMethod>
     <TooManyArguments>
       <code><![CDATA[new QuotaPlugin($view, true)]]></code>
     </TooManyArguments>
@@ -470,12 +814,28 @@
       <code><![CDATA[getId]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/dav/lib/Controller/BirthdayCalendarController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Controller/ExampleContentController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/Controller/InvitationResponseController.php">
     <UndefinedPropertyAssignment>
       <code><![CDATA[$vEvent->DTSTAMP]]></code>
     </UndefinedPropertyAssignment>
   </file>
   <file src="apps/dav/lib/DAV/CustomPropertiesBackend.php">
+    <DeprecatedMethod>
+      <code><![CDATA[closeCursor]]></code>
+      <code><![CDATA[closeCursor]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$whereValues]]></code>
     </InvalidArgument>
@@ -503,6 +863,11 @@
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
+  </file>
+  <file src="apps/dav/lib/DAV/Sharing/Plugin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/DAV/SystemPrincipalBackend.php">
     <InvalidNullableReturnType>
@@ -543,15 +908,97 @@
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
   </file>
+  <file src="apps/dav/lib/Files/RootCollection.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserFolder]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/BuildCalendarSearchIndex.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/Migration/BuildCalendarSearchIndexBackgroundJob.php">
     <ParamNameMismatch>
       <code><![CDATA[$arguments]]></code>
     </ParamNameMismatch>
   </file>
+  <file src="apps/dav/lib/Migration/BuildSocialSearchIndex.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/Migration/BuildSocialSearchIndexBackgroundJob.php">
     <ParamNameMismatch>
       <code><![CDATA[$arguments]]></code>
     </ParamNameMismatch>
+  </file>
+  <file src="apps/dav/lib/Migration/ChunkCleanup.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/RefreshWebcalJobRegistrar.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/RegenerateBirthdayCalendars.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/RegisterBuildReminderIndexBackgroundJob.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/RemoveDeletedUsersCalendarSubscriptions.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1004Date20170825134824.php">
+    <DeprecatedMethod>
+      <code><![CDATA[changeColumn]]></code>
+      <code><![CDATA[changeColumn]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181105104826.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1008Date20181105110300.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1025Date20240308063933.php">
+    <DeprecatedMethod>
+      <code><![CDATA[fetchColumn]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Migration/Version1027Date20230504122946.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/RootCollection.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getL10N]]></code>
+      <code><![CDATA[getL10NFactory]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/Search/ContactsSearchProvider.php">
     <InvalidOperand>
@@ -595,6 +1042,33 @@
       <code><![CDATA[hasTime]]></code>
     </UndefinedMethod>
   </file>
+  <file src="apps/dav/lib/Server.php">
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+      <code><![CDATA[dispatch]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getL10N]]></code>
+      <code><![CDATA[getL10N]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Settings/CalDAVSettings.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/Settings/ExampleContentSettings.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/dav/lib/SetupChecks/NeedsSystemAddressBookSync.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/dav/lib/SystemTag/SystemTagsObjectMappingCollection.php">
     <ParamNameMismatch>
       <code><![CDATA[$tagId]]></code>
@@ -605,6 +1079,14 @@
     <ParamNameMismatch>
       <code><![CDATA[$objectName]]></code>
     </ParamNameMismatch>
+  </file>
+  <file src="apps/dav/lib/SystemTag/SystemTagsRelationsCollection.php">
+    <DeprecatedConstant>
+      <code><![CDATA[SystemTagsEntityEvent::EVENT_ENTITY]]></code>
+    </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/dav/lib/Traits/PrincipalProxyTrait.php">
     <MoreSpecificImplementedParamType>
@@ -651,15 +1133,67 @@
       <code><![CDATA[array{name: string, displayName: string, description: ?string, vCards: VCard[]}]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/encryption/lib/Command/DisableMasterKey.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/encryption/lib/Command/DropLegacyFileKey.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/encryption/lib/Command/EnableMasterKey.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/encryption/lib/Command/FixEncryptedVersion.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/encryption/lib/Command/FixKeyLocation.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user->getUID())]]></code>
+    </DeprecatedClass>
     <MoreSpecificReturnType>
       <code><![CDATA[\Generator<File>]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/encryption/lib/Command/ScanLegacyFormat.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/encryption/lib/Crypto/Crypt.php">
+    <DeprecatedMethod>
+      <code><![CDATA[opensslSeal]]></code>
+    </DeprecatedMethod>
     <TypeDoesNotContainType>
       <code><![CDATA[get_class($res) === 'OpenSSLAsymmetricKey']]></code>
     </TypeDoesNotContainType>
+  </file>
+  <file src="apps/encryption/lib/Crypto/EncryptAll.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/encryption/lib/Crypto/Encryption.php">
     <ImplementedParamTypeMismatch>
@@ -667,14 +1201,72 @@
     </ImplementedParamTypeMismatch>
   </file>
   <file src="apps/encryption/lib/KeyManager.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidThrow>
       <code><![CDATA[throw $exception;]]></code>
     </InvalidThrow>
+  </file>
+  <file src="apps/encryption/lib/Migration/SetMasterKeyStatus.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/encryption/lib/Recovery.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/encryption/lib/Session.php">
     <TooManyArguments>
       <code><![CDATA[new PrivateKeyMissingException('please try to log-out and log-in again', 0)]]></code>
     </TooManyArguments>
+  </file>
+  <file src="apps/encryption/lib/Settings/Admin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/encryption/lib/Settings/Personal.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/encryption/lib/Util.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/federatedfilesharing/lib/AddressHandler.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::emitHook(
+				'\OCA\Files_Sharing\API\Server2Server',
+				'preLoginNameUsedAsUserName',
+				['uid' => &$user1]
+			)]]></code>
+      <code><![CDATA[Util::emitHook(
+				'\OCA\Files_Sharing\API\Server2Server',
+				'preLoginNameUsedAsUserName',
+				['uid' => &$user2]
+			)]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/federatedfilesharing/lib/AppInfo/Application.php">
+    <DeprecatedInterface>
+      <code><![CDATA[IAppContainer]]></code>
+    </DeprecatedInterface>
   </file>
   <file src="apps/federatedfilesharing/lib/Controller/RequestHandlerController.php">
     <InvalidArgument>
@@ -688,6 +1280,15 @@
     </InvalidArgument>
   </file>
   <file src="apps/federatedfilesharing/lib/FederatedShareProvider.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$shareId]]></code>
       <code><![CDATA[$shareId]]></code>
@@ -696,7 +1297,19 @@
       <code><![CDATA[(int)$data['id']]]></code>
     </InvalidArgument>
   </file>
+  <file src="apps/federatedfilesharing/lib/Migration/Version1011Date20201120125158.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getName]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/federatedfilesharing/lib/Notifications.php">
+    <DeprecatedMethod>
+      <code><![CDATA[sendNotification]]></code>
+      <code><![CDATA[sendNotification]]></code>
+      <code><![CDATA[sendNotification]]></code>
+      <code><![CDATA[sendShare]]></code>
+    </DeprecatedMethod>
     <InvalidReturnType>
       <code><![CDATA[bool]]></code>
       <code><![CDATA[bool]]></code>
@@ -704,6 +1317,21 @@
     </InvalidReturnType>
   </file>
   <file src="apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($shareWith)]]></code>
+      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[Util::emitHook(
+					'\OCA\Files_Sharing\API\Server2Server',
+					'preLoginNameUsedAsUserName',
+					['uid' => &$shareWith]
+				)]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[lastInsertId]]></code>
+      <code><![CDATA[sendNotification]]></code>
+      <code><![CDATA[sendNotification]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$id]]></code>
       <code><![CDATA[$id]]></code>
@@ -753,7 +1381,49 @@
       <code><![CDATA[$this->fileIsEncrypted]]></code>
     </TypeDoesNotContainType>
   </file>
+  <file src="apps/files/lib/AppInfo/Application.php">
+    <DeprecatedInterface>
+      <code><![CDATA[$server]]></code>
+      <code><![CDATA[$server]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[Util::connectHook('\OCP\Config', 'js', '\OCA\Files\App', 'extendJsConfig')]]></code>
+      <code><![CDATA[\OC_Helper::getFileTemplateManager()]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files/lib/BackgroundJob/ScanFiles.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files/lib/Command/RepairTree.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files/lib/Command/Scan.php">
+    <DeprecatedMethod>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files/lib/Command/ScanAppData.php">
+    <DeprecatedMethod>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+    </DeprecatedMethod>
     <NullArgument>
       <code><![CDATA[null]]></code>
       <code><![CDATA[null]]></code>
@@ -777,15 +1447,57 @@
       <code><![CDATA[$i]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/files/lib/Migration/Version2003Date20241021095629.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files/lib/Service/OwnershipTransferService.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($destinationUser->getUID())]]></code>
+      <code><![CDATA[\OC_Util::setupFS($destinationUser->getUID())]]></code>
+      <code><![CDATA[\OC_Util::setupFS($sourceUser->getUID())]]></code>
+    </DeprecatedClass>
     <UndefinedInterfaceMethod>
       <code><![CDATA[isReadyForUser]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/files_external/ajax/applicable.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('files_external')]]></code>
+      <code><![CDATA[\OC_JSON::success($results)]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_external/ajax/oauth2.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('files_external')]]></code>
+      <code><![CDATA[\OC_JSON::checkLoggedIn()]]></code>
+      <code><![CDATA[getL10N]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files_external/appinfo/routes.php">
     <InvalidScope>
       <code><![CDATA[$this]]></code>
     </InvalidScope>
+  </file>
+  <file src="apps/files_external/lib/Command/Notify.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::normalizeUnicode($parent)]]></code>
+      <code><![CDATA[\OC_Util::normalizeUnicode($path)]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_external/lib/Command/Scan.php">
+    <DeprecatedMethod>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files_external/lib/Controller/StoragesController.php">
     <RedundantCast>
@@ -800,6 +1512,11 @@
     <MoreSpecificReturnType>
       <code><![CDATA[class-string<IStorage>]]></code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="apps/files_external/lib/Lib/Backend/SMB.php">
+    <DeprecatedClass>
+      <code><![CDATA[new KerberosApacheAuth()]]></code>
+    </DeprecatedClass>
   </file>
   <file src="apps/files_external/lib/Lib/Storage/SFTP.php">
     <InternalMethod>
@@ -831,6 +1548,18 @@
       <code><![CDATA[login]]></code>
     </InvalidReturnType>
   </file>
+  <file src="apps/files_external/lib/Migration/Version1011Date20200630192246.php">
+    <DeprecatedMethod>
+      <code><![CDATA[changeColumn]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_external/lib/Migration/Version1015Date20211104103506.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files_external/lib/MountConfig.php">
     <InternalMethod>
       <code><![CDATA[decrypt]]></code>
@@ -843,13 +1572,79 @@
       <code><![CDATA[test]]></code>
     </TooManyArguments>
   </file>
+  <file src="apps/files_external/lib/Service/BackendService.php">
+    <DeprecatedClass>
+      <code><![CDATA[new GenericEvent()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+      <code><![CDATA[registerAuthMechanism]]></code>
+      <code><![CDATA[registerAuthMechanisms]]></code>
+      <code><![CDATA[registerBackend]]></code>
+      <code><![CDATA[registerBackends]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_external/lib/Service/DBConfigService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_external/lib/Service/StoragesService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::emitHook(
+				Filesystem::CLASSNAME,
+				$signal,
+				[
+					Filesystem::signal_param_path => $mountPoint,
+					Filesystem::signal_param_mount_type => $mountType,
+					Filesystem::signal_param_users => $applicable,
+				]
+			)]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files_reminders/lib/Model/RichReminder.php">
     <ConstructorSignatureMismatch>
       <code><![CDATA[public function __construct(]]></code>
       <code><![CDATA[public function __construct(]]></code>
     </ConstructorSignatureMismatch>
   </file>
+  <file src="apps/files_sharing/lib/AppInfo/Application.php">
+    <DeprecatedMethod>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Capabilities.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Controller/DeletedShareAPIController.php">
+    <DeprecatedClass>
+      <code><![CDATA[new QueryException()]]></code>
+      <code><![CDATA[new QueryException()]]></code>
+      <code><![CDATA[new QueryException()]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+  </file>
   <file src="apps/files_sharing/lib/Controller/ShareAPIController.php">
+    <DeprecatedClass>
+      <code><![CDATA[new QueryException()]]></code>
+      <code><![CDATA[new QueryException()]]></code>
+      <code><![CDATA[new QueryException()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <RedundantCast>
       <code><![CDATA[(int)$code]]></code>
       <code><![CDATA[(int)$code]]></code>
@@ -865,7 +1660,40 @@
       <code><![CDATA[\OCA\Talk\Share\Helper\ShareAPIController]]></code>
     </UndefinedDocblockClass>
   </file>
+  <file src="apps/files_sharing/lib/Controller/ShareController.php">
+    <DeprecatedClass>
+      <code><![CDATA[Share::class]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[emitAccessShareHook]]></code>
+      <code><![CDATA[emitAccessShareHook]]></code>
+      <code><![CDATA[emitAccessShareHook]]></code>
+      <code><![CDATA[emitAccessShareHook]]></code>
+      <code><![CDATA[emitAccessShareHook]]></code>
+      <code><![CDATA[emitAccessShareHook]]></code>
+      <code><![CDATA[emitAccessShareHook]]></code>
+      <code><![CDATA[emitAccessShareHook]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files_sharing/lib/External/Manager.php">
+    <DeprecatedClass>
+      <code><![CDATA[Files::buildNotExistingFileName($shareFolder, $share['name'])]]></code>
+      <code><![CDATA[Files::buildNotExistingFileName('/', $name)]]></code>
+      <code><![CDATA[Share::RESPONSE_FORMAT]]></code>
+      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[Files::buildNotExistingFileName($shareFolder, $share['name'])]]></code>
+      <code><![CDATA[Files::buildNotExistingFileName('/', $name)]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[insertIfNotExist]]></code>
+      <code><![CDATA[sendNotification]]></code>
+      <code><![CDATA[sendNotification]]></code>
+    </DeprecatedMethod>
     <LessSpecificReturnStatement>
       <code><![CDATA[$mount]]></code>
     </LessSpecificReturnStatement>
@@ -873,10 +1701,71 @@
       <code><![CDATA[Mount]]></code>
     </MoreSpecificReturnType>
   </file>
+  <file src="apps/files_sharing/lib/External/Scanner.php">
+    <DeprecatedInterface>
+      <code><![CDATA[Scanner]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/files_sharing/lib/External/Storage.php">
+    <DeprecatedInterface>
+      <code><![CDATA[Storage]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[Util::isSharingDisabledForUser()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Helper.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::connectHook('OC_Filesystem', 'post_delete', '\OCA\Files_Sharing\Hooks', 'unshareChildren')]]></code>
+      <code><![CDATA[Util::connectHook('OC_Filesystem', 'post_rename', '\OCA\Files_Sharing\Updater', 'renameHook')]]></code>
+      <code><![CDATA[Util::connectHook('OC_User', 'post_deleteUser', '\OCA\Files_Sharing\Hooks', 'deleteUser')]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Middleware/SharingCheckMiddleware.php">
+    <DeprecatedInterface>
+      <code><![CDATA[protected]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[hasAnnotation]]></code>
+      <code><![CDATA[hasAnnotation]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Migration/OwncloudGuestShareType.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Migration/SetAcceptedStatus.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Migration/SetPasswordColumn.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_sharing/lib/Migration/Version11300Date20201120141438.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getName]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files_sharing/lib/MountProvider.php">
     <RedundantFunctionCall>
       <code><![CDATA[array_values]]></code>
     </RedundantFunctionCall>
+  </file>
+  <file src="apps/files_sharing/lib/Scanner.php">
+    <DeprecatedInterface>
+      <code><![CDATA[Scanner]]></code>
+    </DeprecatedInterface>
   </file>
   <file src="apps/files_sharing/lib/ShareBackend/File.php">
     <InvalidArgument>
@@ -888,6 +1777,10 @@
     </MoreSpecificImplementedParamType>
   </file>
   <file src="apps/files_sharing/lib/ShareBackend/Folder.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
     <UndefinedInterfaceMethod>
       <code><![CDATA[fetchRow]]></code>
     </UndefinedInterfaceMethod>
@@ -898,6 +1791,15 @@
     </InvalidReturnType>
   </file>
   <file src="apps/files_sharing/lib/SharedStorage.php">
+    <DeprecatedInterface>
+      <code><![CDATA[SharedStorage]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[Util::emitHook('\OC\Files\Storage\Shared', 'file_get_contents', $info)]]></code>
+      <code><![CDATA[Util::emitHook('\OC\Files\Storage\Shared', 'file_put_contents', $info)]]></code>
+      <code><![CDATA[Util::emitHook('\OC\Files\Storage\Shared', 'fopen', $info)]]></code>
+      <code><![CDATA[Util::isSharingDisabledForUser()]]></code>
+    </DeprecatedMethod>
     <FalsableReturnStatement>
       <code><![CDATA[$this->sourceRootInfo]]></code>
     </FalsableReturnStatement>
@@ -908,7 +1810,18 @@
       <code><![CDATA[$this->sourceRootInfo]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/files_sharing/lib/SharesReminderJob.php">
+    <DeprecatedConstant>
+      <code><![CDATA[IQueryBuilder::PARAM_DATE]]></code>
+      <code><![CDATA[IQueryBuilder::PARAM_DATE]]></code>
+      <code><![CDATA[IQueryBuilder::PARAM_DATE]]></code>
+      <code><![CDATA[IQueryBuilder::PARAM_DATE]]></code>
+    </DeprecatedConstant>
+  </file>
   <file src="apps/files_sharing/lib/Updater.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getUserFolder]]></code>
+    </DeprecatedMethod>
     <UndefinedMethod>
       <code><![CDATA[moveMount]]></code>
     </UndefinedMethod>
@@ -918,6 +1831,63 @@
       <code><![CDATA[$_['hideFileList'] !== true]]></code>
       <code><![CDATA[isset($_['hideFileList']) && $_['hideFileList'] !== true]]></code>
     </RedundantCondition>
+  </file>
+  <file src="apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/CleanUp.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/Expire.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($this->user)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/ExpireTrash.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/RestoreAllFiles.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_trashbin/lib/Command/Size.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files_trashbin/lib/Sabre/AbstractTrash.php">
     <InvalidNullableReturnType>
@@ -956,15 +1926,67 @@
       <code><![CDATA[ITrash]]></code>
     </InvalidReturnType>
   </file>
+  <file src="apps/files_trashbin/lib/Storage.php">
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files_trashbin/lib/Trash/LegacyTrashBackend.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[$file]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="apps/files_trashbin/lib/Trashbin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
+				'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))])]]></code>
+      <code><![CDATA[Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', ['filePath' => $targetPath, 'trashPath' => $sourcePath])]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+      <code><![CDATA[getUserFolder]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$timestamp]]></code>
     </InvalidArgument>
+  </file>
+  <file src="apps/files_versions/lib/AppInfo/Application.php">
+    <DeprecatedClass>
+      <code><![CDATA[LegacyRollbackListener::class]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[$server]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/files_versions/lib/BackgroundJob/ExpireVersions.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_versions/lib/Command/CleanUp.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/files_versions/lib/Command/ExpireVersions.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/files_versions/lib/Sabre/RestoreFolder.php">
     <InvalidNullableReturnType>
@@ -974,12 +1996,24 @@
       <code><![CDATA[null]]></code>
     </NullableReturnStatement>
   </file>
+  <file src="apps/files_versions/lib/Sabre/VersionFile.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getLabel]]></code>
+      <code><![CDATA[setVersionLabel]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/files_versions/lib/Sabre/VersionHome.php">
     <InvalidNullableReturnType>
       <code><![CDATA[getChild]]></code>
     </InvalidNullableReturnType>
   </file>
   <file src="apps/files_versions/lib/Storage.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
     <RedundantCondition>
       <code><![CDATA[$storage1->instanceOfStorage('\OC\Files\ObjectStore\ObjectStoreStorage')]]></code>
     </RedundantCondition>
@@ -989,31 +2023,239 @@
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
   </file>
+  <file src="apps/provisioning_api/lib/Controller/AUserDataOCSController.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user->getUID())]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedConstant>
+      <code><![CDATA[IAccountManager::PROPERTY_DISPLAYNAME_LEGACY]]></code>
+    </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/provisioning_api/lib/Controller/UsersController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[implementsActions]]></code>
+      <code><![CDATA[setEMailAddress]]></code>
+      <code><![CDATA[setEMailAddress]]></code>
+    </DeprecatedMethod>
     <TypeDoesNotContainNull>
       <code><![CDATA[$groupid === null]]></code>
       <code><![CDATA[$groupid === null]]></code>
     </TypeDoesNotContainNull>
   </file>
+  <file src="apps/provisioning_api/lib/FederatedShareProviderFactory.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/provisioning_api/lib/Middleware/ProvisioningApiMiddleware.php">
+    <DeprecatedInterface>
+      <code><![CDATA[IControllerMethodReflector]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[hasAnnotation]]></code>
+      <code><![CDATA[hasAnnotation]]></code>
+    </DeprecatedMethod>
     <InvalidReturnType>
       <code><![CDATA[Response]]></code>
     </InvalidReturnType>
   </file>
   <file src="apps/settings/lib/AppInfo/Application.php">
+    <DeprecatedInterface>
+      <code><![CDATA[$serverContainer]]></code>
+      <code><![CDATA[$serverContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[Util::connectHook('OC_User', 'changeUser', $this, 'onChangeInfo')]]></code>
+      <code><![CDATA[Util::connectHook('OC_User', 'post_setPassword', $this, 'onChangePassword')]]></code>
+      <code><![CDATA[getConfig]]></code>
+      <code><![CDATA[getCrypto]]></code>
+      <code><![CDATA[getL10NFactory]]></code>
+      <code><![CDATA[getMailer]]></code>
+      <code><![CDATA[getSecureRandom]]></code>
+      <code><![CDATA[getURLGenerator]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
     <UndefinedInterfaceMethod>
       <code><![CDATA[getSettingsManager]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="apps/settings/lib/Controller/AISettingsController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/Controller/AppSettingsController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getSupportedApps]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/Controller/MailSettingsController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/Controller/UsersController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/Controller/WebAuthnController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[PublicKeyCredentialCreationOptions::createFromArray($this->session->get(self::WEBAUTHN_REGISTRATION))]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/settings/lib/Hooks.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidArrayOffset>
       <code><![CDATA[[$user->getEMailAddress() => $user->getDisplayName()]]]></code>
     </InvalidArrayOffset>
+  </file>
+  <file src="apps/settings/lib/Settings/Admin/ArtificialIntelligence.php">
+    <DeprecatedInterface>
+      <code><![CDATA[$taskProcessingSettings]]></code>
+      <code><![CDATA[$textProcessingSettings]]></code>
+      <code><![CDATA[private]]></code>
+      <code><![CDATA[private]]></code>
+      <code><![CDATA[private]]></code>
+      <code><![CDATA[private]]></code>
+      <code><![CDATA[try {
+				$taskType = $this->container->get($taskTypeClass);
+			} catch (NotFoundExceptionInterface $e) {
+				continue;
+			} catch (ContainerExceptionInterface $e) {
+				continue;
+			}]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/settings/lib/Settings/Admin/Security.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[isReady]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/settings/lib/Settings/Admin/Server.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/Settings/Admin/Sharing.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/PersonalInfo.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user->getUID())]]></code>
+    </DeprecatedClass>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/Security/Authtokens.php">
+    <DeprecatedClass>
+      <code><![CDATA[IToken::WIPE_TOKEN]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[IToken]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/Security/WebAuthn.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[provideInitialState]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/Settings/Personal/ServerDevNotice.php">
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/CheckUserCertificates.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/CronErrors.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/EmailTestSuccessful.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/PushService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/settings/lib/SetupChecks/SupportedDatabase.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getDatabasePlatform]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/sharebymail/lib/Settings/SettingsManager.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/sharebymail/lib/ShareByMailProvider.php">
     <InvalidArgument>
@@ -1022,12 +2264,200 @@
     </InvalidArgument>
   </file>
   <file src="apps/systemtags/lib/Activity/Listener.php">
+    <DeprecatedConstant>
+      <code><![CDATA[ManagerEvent::EVENT_CREATE]]></code>
+      <code><![CDATA[ManagerEvent::EVENT_CREATE]]></code>
+      <code><![CDATA[ManagerEvent::EVENT_DELETE]]></code>
+      <code><![CDATA[ManagerEvent::EVENT_UPDATE]]></code>
+      <code><![CDATA[ManagerEvent::EVENT_UPDATE]]></code>
+      <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
+      <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
+      <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
+      <code><![CDATA[MapperEvent::EVENT_UNASSIGN]]></code>
+      <code><![CDATA[MapperEvent::EVENT_UNASSIGN]]></code>
+    </DeprecatedConstant>
     <InvalidArgument>
       <code><![CDATA[$event->getObjectId()]]></code>
       <code><![CDATA[$event->getObjectId()]]></code>
     </InvalidArgument>
   </file>
+  <file src="apps/systemtags/lib/AppInfo/Application.php">
+    <DeprecatedConstant>
+      <code><![CDATA[ManagerEvent::EVENT_CREATE]]></code>
+      <code><![CDATA[ManagerEvent::EVENT_DELETE]]></code>
+      <code><![CDATA[ManagerEvent::EVENT_UPDATE]]></code>
+      <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
+      <code><![CDATA[MapperEvent::EVENT_UNASSIGN]]></code>
+    </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/AlternativeHomeUserBackend.php">
+    <DeprecatedInterface>
+      <code><![CDATA[AlternativeHomeUserBackend]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/testing/lib/AppInfo/Application.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getConfig]]></code>
+      <code><![CDATA[getUserManager]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/Controller/ConfigController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/Controller/LockingController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[getAppKeys]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/Locking/FakeDBLockingProvider.php">
+    <DeprecatedMethod>
+      <code><![CDATA[executeUpdate]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/testing/lib/Provider/FakeText2ImageProvider.php">
+    <DeprecatedInterface>
+      <code><![CDATA[FakeText2ImageProvider]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/testing/lib/Provider/FakeTextProcessingProvider.php">
+    <DeprecatedClass>
+      <code><![CDATA[FakeTextProcessingProvider]]></code>
+      <code><![CDATA[FreePromptTaskType::class]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[FakeTextProcessingProvider]]></code>
+      <code><![CDATA[FakeTextProcessingProvider]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/testing/lib/Provider/FakeTextProcessingProviderSync.php">
+    <DeprecatedClass>
+      <code><![CDATA[FakeTextProcessingProviderSync]]></code>
+      <code><![CDATA[FreePromptTaskType::class]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[FakeTextProcessingProviderSync]]></code>
+      <code><![CDATA[FakeTextProcessingProviderSync]]></code>
+      <code><![CDATA[FakeTextProcessingProviderSync]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/testing/lib/Provider/FakeTranslationProvider.php">
+    <DeprecatedClass>
+      <code><![CDATA[new LanguageTuple('de', 'German', 'en', 'English')]]></code>
+      <code><![CDATA[new LanguageTuple('en', 'English', 'de', 'German')]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[FakeTranslationProvider]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="apps/theming/lib/Capabilities.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Command/UpdateConfig.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Controller/ThemingController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/ImageManager.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Settings/Admin.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Settings/Personal.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/Themes/CommonThemeTrait.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/theming/lib/ThemingDefaults.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[deleteAppValues]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/theming/lib/Util.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidReturnStatement>
       <code><![CDATA[array_values($color->getRgb())]]></code>
     </InvalidReturnStatement>
@@ -1035,12 +2465,117 @@
       <code><![CDATA[array{0: int, 1: int, 2: int}]]></code>
     </InvalidReturnType>
   </file>
+  <file src="apps/twofactor_backupcodes/lib/Db/BackupCodeMapper.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Migration/Version1002Date20170607113030.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Migration/Version1002Date20170919123342.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getName]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/twofactor_backupcodes/lib/Provider/BackupCodesProvider.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[provideInitialState]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/ajax/clearMappings.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $e->getMessage()])]]></code>
+      <code><![CDATA[\OC_JSON::success()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/ajax/deleteConfiguration.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('Failed to delete the server configuration')])]]></code>
+      <code><![CDATA[\OC_JSON::success()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/ajax/getConfiguration.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
+      <code><![CDATA[\OC_JSON::success(['configuration' => $configuration])]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/ajax/getNewServerConfigPrefix.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
+      <code><![CDATA[\OC_JSON::success($resultData)]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/ajax/setConfiguration.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
+      <code><![CDATA[\OC_JSON::success()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/ajax/testConfiguration.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
+      <code><![CDATA[\OC_JSON::error(['message'
+			=> $l->t('Valid configuration, but binding failed. Please check the server settings and credentials.')])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message'
+		=> $l->t('Invalid configuration: %s', $configurationError)])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $e->getMessage()])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('Invalid configuration: Anonymous binding is not allowed.')])]]></code>
+      <code><![CDATA[\OC_JSON::success(['message'
+			=> $l->t('Valid configuration, connection established!')])]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/ajax/wizard.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_JSON::callCheck()]]></code>
+      <code><![CDATA[\OC_JSON::checkAdminUser()]]></code>
+      <code><![CDATA[\OC_JSON::checkAppEnabled('user_ldap')]]></code>
+      <code><![CDATA[\OC_JSON::error()]]></code>
+      <code><![CDATA[\OC_JSON::error()]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $e->getMessage(), 'code' => $e->getCode()])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $e->getMessage()])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('Action does not exist')])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('Could not set configuration %1$s to %2$s', [$key, $setParameters[0]])])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('Invalid data specified')])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('No action specified')])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('No configuration specified')])]]></code>
+      <code><![CDATA[\OC_JSON::error(['message' => $l->t('No data specified')])]]></code>
+      <code><![CDATA[\OC_JSON::success($result->getResultArray())]]></code>
+      <code><![CDATA[\OC_JSON::success($result->getResultArray())]]></code>
+      <code><![CDATA[\OC_JSON::success()]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/user_ldap/appinfo/routes.php">
     <InvalidScope>
       <code><![CDATA[$this]]></code>
     </InvalidScope>
   </file>
   <file src="apps/user_ldap/lib/Access.php">
+    <DeprecatedMethod>
+      <code><![CDATA[emit]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidReturnStatement>
       <code><![CDATA[$uuid]]></code>
       <code><![CDATA[$values]]></code>
@@ -1051,6 +2586,37 @@
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
+  </file>
+  <file src="apps/user_ldap/lib/AppInfo/Application.php">
+    <DeprecatedInterface>
+      <code><![CDATA[$server]]></code>
+      <code><![CDATA[$server]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+      <code><![CDATA[IAppContainer]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[Util::connectHook(
+			'\OCA\Files_Sharing\API\Server2Server',
+			'preLoginNameUsedAsUserName',
+			'\OCA\User_LDAP\Helper',
+			'loginName2UserName'
+		)]]></code>
+      <code><![CDATA[dispatch]]></code>
+      <code><![CDATA[getConfig]]></code>
+      <code><![CDATA[getConfig]]></code>
+      <code><![CDATA[getRequest]]></code>
+      <code><![CDATA[getURLGenerator]]></code>
+      <code><![CDATA[registerService]]></code>
+      <code><![CDATA[registerService]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/Configuration.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/user_ldap/lib/Connection.php">
     <NoValue>
@@ -1072,12 +2638,65 @@
       <code><![CDATA[$gid]]></code>
     </ParamNameMismatch>
   </file>
+  <file src="apps/user_ldap/lib/Helper.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getAppKeys]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/Jobs/CleanUp.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/user_ldap/lib/Jobs/Sync.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppKeys]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidOperand>
       <code><![CDATA[$i]]></code>
     </InvalidOperand>
   </file>
+  <file src="apps/user_ldap/lib/Jobs/UpdateGroups.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/LDAPProvider.php">
+    <DeprecatedInterface>
+      <code><![CDATA[IServerContainer]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[getGroupManager]]></code>
+      <code><![CDATA[getUserManager]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/LDAPProviderFactory.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+  </file>
   <file src="apps/user_ldap/lib/Mapping/AbstractMapping.php">
+    <DeprecatedClass>
+      <code><![CDATA[\Doctrine\DBAL\FetchMode::ASSOCIATIVE]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[getDatabasePlatform]]></code>
+      <code><![CDATA[insertIfNotExist]]></code>
+    </DeprecatedMethod>
     <RedundantCondition>
       <code><![CDATA[isset($qb)]]></code>
     </RedundantCondition>
@@ -1085,12 +2704,42 @@
       <code><![CDATA[isset($qb)]]></code>
     </TypeDoesNotContainNull>
   </file>
+  <file src="apps/user_ldap/lib/Migration/RemoveRefreshTime.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/UUIDFixInsert.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1120Date20210917155206.php">
+    <DeprecatedMethod>
+      <code><![CDATA[emit]]></code>
+      <code><![CDATA[emit]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_ldap/lib/Migration/Version1130Date20211102154716.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getDatabasePlatform]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/user_ldap/lib/User/Manager.php">
     <InvalidDocblock>
       <code><![CDATA[public function setLdapAccess(Access $access) {]]></code>
     </InvalidDocblock>
   </file>
+  <file src="apps/user_ldap/lib/User/User.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::connectHook('OC_User', 'post_login', $this, 'handlePasswordExpiry')]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="apps/user_ldap/lib/User_LDAP.php">
+    <DeprecatedInterface>
+      <code><![CDATA[User_LDAP]]></code>
+    </DeprecatedInterface>
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[string|false]]></code>
     </ImplementedReturnTypeMismatch>
@@ -1107,6 +2756,9 @@
     </RedundantCondition>
   </file>
   <file src="apps/user_ldap/lib/User_Proxy.php">
+    <DeprecatedInterface>
+      <code><![CDATA[User_Proxy]]></code>
+    </DeprecatedInterface>
     <ParamNameMismatch>
       <code><![CDATA[$uid]]></code>
     </ParamNameMismatch>
@@ -1117,9 +2769,44 @@
     </InvalidArrayOffset>
   </file>
   <file src="apps/user_status/lib/AppInfo/Application.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
     <UndefinedInterfaceMethod>
       <code><![CDATA[registerProvider]]></code>
     </UndefinedInterfaceMethod>
+  </file>
+  <file src="apps/user_status/lib/Listener/BeforeTemplateRenderedListener.php">
+    <DeprecatedInterface>
+      <code><![CDATA[IInitialStateService]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[provideLazyInitialState]]></code>
+      <code><![CDATA[provideLazyInitialState]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/user_status/lib/Service/PredefinedStatusService.php">
+    <DeprecatedConstant>
+      <code><![CDATA[self::CALL]]></code>
+      <code><![CDATA[self::CALL]]></code>
+      <code><![CDATA[self::CALL]]></code>
+      <code><![CDATA[self::CALL]]></code>
+    </DeprecatedConstant>
+  </file>
+  <file src="apps/user_status/lib/Service/StatusService.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/workflowengine/lib/BackgroundJobs/Rotate.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="apps/workflowengine/lib/Check/AbstractStringCheck.php">
     <NullArgument>
@@ -1154,11 +2841,43 @@
     </InvalidArgument>
   </file>
   <file src="apps/workflowengine/lib/Entity/File.php">
+    <DeprecatedConstant>
+      <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
+      <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
+      <code><![CDATA[MapperEvent::EVENT_ASSIGN]]></code>
+    </DeprecatedConstant>
+    <DeprecatedMethod>
+      <code><![CDATA[getSubject]]></code>
+      <code><![CDATA[getSubject]]></code>
+    </DeprecatedMethod>
     <InvalidReturnType>
       <code><![CDATA[string]]></code>
     </InvalidReturnType>
   </file>
   <file src="apps/workflowengine/lib/Manager.php">
+    <DeprecatedInterface>
+      <code><![CDATA[protected]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[$missingCheck]]></code>
     </InvalidArgument>
@@ -1172,7 +2891,55 @@
       <code><![CDATA[bool]]></code>
     </InvalidReturnType>
   </file>
+  <file src="apps/workflowengine/lib/Migration/Version2200Date20210805101925.php">
+    <DeprecatedMethod>
+      <code><![CDATA[changeColumn]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/workflowengine/lib/Service/Logger.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/workflowengine/lib/Service/RuleMatcher.php">
+    <DeprecatedInterface>
+      <code><![CDATA[protected]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[query]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="apps/workflowengine/lib/Settings/ASettings.php">
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Application.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getServer]]></code>
+      <code><![CDATA[registerService]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php">
+    <DeprecatedClass>
+      <code><![CDATA[Files::rmdirr($dir)]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[Files::rmdirr($dir)]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="core/BackgroundJobs/CheckForUserCertificates.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($userId)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
     <ParamNameMismatch>
       <code><![CDATA[$arguments]]></code>
     </ParamNameMismatch>
@@ -1182,13 +2949,32 @@
       <code><![CDATA[array]]></code>
     </LessSpecificImplementedReturnType>
   </file>
+  <file src="core/Command/Broadcast/Test.php">
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Check.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::checkServer($this->config)]]></code>
+    </DeprecatedClass>
+  </file>
   <file src="core/Command/Config/Import.php">
+    <DeprecatedMethod>
+      <code><![CDATA[deleteAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
     <InvalidScalarArgument>
       <code><![CDATA[0]]></code>
       <code><![CDATA[1]]></code>
     </InvalidScalarArgument>
   </file>
   <file src="core/Command/Config/ListConfigs.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_App::getAllApps()]]></code>
+      <code><![CDATA[getFilteredValues]]></code>
+      <code><![CDATA[getValues]]></code>
+    </DeprecatedMethod>
     <FalsableReturnStatement>
       <code><![CDATA[$this->appConfig->getValues($app, false)]]></code>
     </FalsableReturnStatement>
@@ -1196,16 +2982,97 @@
       <code><![CDATA[getFilteredValues]]></code>
     </TooManyArguments>
   </file>
+  <file src="core/Command/Db/AddMissingPrimaryKeys.php">
+    <DeprecatedMethod>
+      <code><![CDATA[hasPrimaryKey]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Db/ConvertFilecacheBigInt.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getName]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="core/Command/Db/ConvertType.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_App::getAllApps()]]></code>
+      <code><![CDATA[\OC_App::loadApp($app)]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[getName]]></code>
+      <code><![CDATA[getPrimaryKeyColumns]]></code>
+    </DeprecatedMethod>
     <InvalidScalarArgument>
       <code><![CDATA[0]]></code>
       <code><![CDATA[1]]></code>
     </InvalidScalarArgument>
   </file>
+  <file src="core/Command/Db/ExportSchema.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getDatabasePlatform]]></code>
+      <code><![CDATA[getDatabasePlatform]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Db/Migrations/ExecuteCommand.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_App::getAllApps()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Db/Migrations/GenerateCommand.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::getVersion()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Db/Migrations/MigrateCommand.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_App::getAllApps()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Db/Migrations/StatusCommand.php">
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_App::getAllApps()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Encryption/ChangeKeyStorageRoot.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Encryption/DecryptAll.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Encryption/Disable.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="core/Command/Encryption/Enable.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
     <NullArgument>
       <code><![CDATA[null]]></code>
     </NullArgument>
+  </file>
+  <file src="core/Command/Encryption/MigrateKeyStorage.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="core/Command/Log/File.php">
     <InvalidReturnStatement>
@@ -1236,6 +3103,96 @@
       <code><![CDATA[[]]]></code>
     </InvalidReturnStatement>
   </file>
+  <file src="core/Command/Security/BruteforceAttempts.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAttempts]]></code>
+      <code><![CDATA[getDelay]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Security/BruteforceResetAttempts.php">
+    <DeprecatedMethod>
+      <code><![CDATA[resetDelayForIP]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/TaskProcessing/EnabledCommand.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+      <code><![CDATA[setAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/Upgrade.php">
+    <DeprecatedMethod>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/User/AuthTokens/Add.php">
+    <DeprecatedClass>
+      <code><![CDATA[IToken::DO_NOT_REMEMBER]]></code>
+      <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
+    </DeprecatedClass>
+  </file>
+  <file src="core/Command/User/AuthTokens/ListCommand.php">
+    <DeprecatedClass>
+      <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
+      <code><![CDATA[IToken::TEMPORARY_TOKEN]]></code>
+      <code><![CDATA[IToken::WIPE_TOKEN]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[IToken]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="core/Command/User/Info.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($user->getUID())]]></code>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Command/User/Setting.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setEMailAddress]]></code>
+      <code><![CDATA[setEMailAddress]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Controller/AppPasswordController.php">
+    <DeprecatedClass>
+      <code><![CDATA[IToken::DO_NOT_REMEMBER]]></code>
+      <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
+    </DeprecatedClass>
+  </file>
+  <file src="core/Controller/AutoCompleteController.php">
+    <DeprecatedClass>
+      <code><![CDATA[new AutoCompleteEvent([
+			'search' => $search,
+			'results' => $results,
+			'itemType' => $itemType,
+			'itemId' => $itemId,
+			'sorter' => $sorter,
+			'shareTypes' => $shareTypes,
+			'limit' => $limit,
+		])]]></code>
+    </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[dispatch]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="core/Controller/ClientFlowLoginV2Controller.php">
     <TypeDoesNotContainType>
       <code><![CDATA[!is_string($stateToken)]]></code>
@@ -1246,20 +3203,173 @@
       <code><![CDATA[searchCollections]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="core/Controller/LoginController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getDelay]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="core/Controller/LostController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[Util::emitHook(
+			'\OCA\Files_Sharing\API\Server2Server',
+			'preLoginNameUsedAsUserName',
+			['uid' => &$user]
+		)]]></code>
+    </DeprecatedMethod>
     <RedundantCast>
       <code><![CDATA[(int)$e->getCode()]]></code>
     </RedundantCast>
   </file>
+  <file src="core/Controller/OCJSController.php">
+    <DeprecatedInterface>
+      <code><![CDATA[IInitialStateService]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="core/Controller/RecommendedAppsController.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[provideInitialState]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Controller/SetupController.php">
+    <DeprecatedInterface>
+      <code><![CDATA[protected]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[provideInitialState]]></code>
+      <code><![CDATA[provideInitialState]]></code>
+      <code><![CDATA[provideInitialState]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Controller/TaskProcessingApiController.php">
+    <DeprecatedClass>
+      <code><![CDATA[\OC_Util::setupFS($task->getUserId())]]></code>
+    </DeprecatedClass>
+  </file>
+  <file src="core/Controller/TextProcessingApiController.php">
+    <DeprecatedClass>
+      <code><![CDATA[Task]]></code>
+      <code><![CDATA[new Task($type, $input, $appId, $this->userId, $identifier)]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[$object]]></code>
+      <code><![CDATA[Task]]></code>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="core/Controller/TextToImageApiController.php">
+    <DeprecatedClass>
+      <code><![CDATA[Task]]></code>
+      <code><![CDATA[new Task($input, $appId, $numberOfImages, $this->userId, $identifier)]]></code>
+    </DeprecatedClass>
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+  </file>
+  <file src="core/Controller/TranslationApiController.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+  </file>
   <file src="core/Controller/UnifiedSearchController.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
     <UndefinedInterfaceMethod>
       <code><![CDATA[findMatchingRoute]]></code>
     </UndefinedInterfaceMethod>
   </file>
+  <file src="core/Controller/WebAuthnController.php">
+    <DeprecatedMethod>
+      <code><![CDATA[PublicKeyCredentialRequestOptions::createFromString($this->session->get(self::WEBAUTHN_LOGIN))]]></code>
+      <code><![CDATA[Util::emitHook(
+			'\OCA\Files_Sharing\API\Server2Server',
+			'preLoginNameUsedAsUserName',
+			['uid' => &$uid]
+		)]]></code>
+    </DeprecatedMethod>
+  </file>
   <file src="core/Middleware/TwoFactorMiddleware.php">
+    <DeprecatedInterface>
+      <code><![CDATA[private]]></code>
+    </DeprecatedInterface>
+    <DeprecatedMethod>
+      <code><![CDATA[hasAnnotation]]></code>
+      <code><![CDATA[hasAnnotation]]></code>
+    </DeprecatedMethod>
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>
     </NoInterfaceProperties>
+  </file>
+  <file src="core/Migrations/Version13000Date20170718121200.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Migrations/Version14000Date20180404140050.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Migrations/Version16000Date20190427105638.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Migrations/Version18000Date20190920085628.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Migrations/Version20000Date20201109081918.php">
+    <DeprecatedMethod>
+      <code><![CDATA[execute]]></code>
+      <code><![CDATA[execute]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Migrations/Version21000Date20201120141228.php">
+    <DeprecatedMethod>
+      <code><![CDATA[changeColumn]]></code>
+      <code><![CDATA[changeColumn]]></code>
+      <code><![CDATA[changeColumn]]></code>
+      <code><![CDATA[changeColumn]]></code>
+      <code><![CDATA[changeColumn]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="core/Service/LoginFlowV2Service.php">
+    <DeprecatedClass>
+      <code><![CDATA[IToken::DO_NOT_REMEMBER]]></code>
+      <code><![CDATA[IToken::PERMANENT_TOKEN]]></code>
+    </DeprecatedClass>
+  </file>
+  <file src="core/ajax/update.php">
+    <DeprecatedMethod>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+      <code><![CDATA[listen]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="cron.php">
+    <DeprecatedMethod>
+      <code><![CDATA[OC_JSON::error(['data' => ['message' => 'Background jobs disabled!']])]]></code>
+      <code><![CDATA[OC_JSON::error(['data' => ['message' => 'Backgroundjobs are using system cron!']])]]></code>
+      <code><![CDATA[OC_JSON::success()]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="lib/base.php">
     <InvalidArgument>
@@ -2628,5 +4738,30 @@
     <MoreSpecificReturnType>
       <code><![CDATA[null|IPreview::MODE_FILL|IPreview::MODE_COVER]]></code>
     </MoreSpecificReturnType>
+  </file>
+  <file src="ocs-provider/index.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppManager]]></code>
+      <code><![CDATA[getRequest]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="ocs/v1.php">
+    <DeprecatedMethod>
+      <code><![CDATA[OC_App::loadApps()]]></code>
+      <code><![CDATA[OC_App::loadApps(['authentication'])]]></code>
+      <code><![CDATA[OC_App::loadApps(['extended_authentication'])]]></code>
+      <code><![CDATA[OC_App::loadApps(['session'])]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="public.php">
+    <DeprecatedMethod>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
+  </file>
+  <file src="remote.php">
+    <DeprecatedMethod>
+      <code><![CDATA[exec]]></code>
+      <code><![CDATA[getAppValue]]></code>
+    </DeprecatedMethod>
   </file>
 </files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -161,5 +161,40 @@
 				<referencedConstant name="OC\Memcache\LoggerWrapperCache::DEFAULT_TTL" />
 			</errorLevel>
 		</AmbiguousConstantInheritance>
+		<DeprecatedClass>
+			<errorLevel type="suppress">
+				<directory name="lib" />
+			</errorLevel>
+		</DeprecatedClass>
+		<DeprecatedConstant>
+			<errorLevel type="suppress">
+				<directory name="lib" />
+			</errorLevel>
+		</DeprecatedConstant>
+		<DeprecatedFunction>
+			<errorLevel type="suppress">
+				<directory name="lib" />
+			</errorLevel>
+		</DeprecatedFunction>
+		<DeprecatedInterface>
+			<errorLevel type="suppress">
+				<directory name="lib" />
+			</errorLevel>
+		</DeprecatedInterface>
+		<DeprecatedMethod>
+			<errorLevel type="suppress">
+				<directory name="lib" />
+			</errorLevel>
+		</DeprecatedMethod>
+		<DeprecatedProperty>
+			<errorLevel type="suppress">
+				<directory name="lib" />
+			</errorLevel>
+		</DeprecatedProperty>
+		<DeprecatedTrait>
+			<errorLevel type="suppress">
+				<directory name="lib" />
+			</errorLevel>
+		</DeprecatedTrait>
 	</issueHandlers>
 </psalm>


### PR DESCRIPTION
## Summary

Based on https://github.com/nextcloud/server/pull/52853.

The idea is to prevent any new code to use already deprecated stuff. It will not be possible everywhere since we sometimes have no replacement, but then it should just be added to the baseline.
This change adds a lot to the baseline, but it's basically just a todo list for technical debt cleanups :)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
