### PR TITLE
chore!(\OCP\Files): remove deprecated static `getStorage` method

### DIFF
--- a/build/psalm-baseline-ocp.xml
+++ b/build/psalm-baseline-ocp.xml
@@ -41,9 +41,6 @@
     </MissingTemplateParam>
   </file>
   <file src="lib/public/Files.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[\OC_App::getStorage($app)]]></code>
-    </FalsableReturnStatement>
     <UndefinedClass>
       <code><![CDATA[\OC]]></code>
     </UndefinedClass>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4721,11 +4721,6 @@
       <code><![CDATA[IteratorAggregate]]></code>
     </MissingTemplateParam>
   </file>
-  <file src="lib/public/Files.php">
-    <FalsableReturnStatement>
-      <code><![CDATA[\OC_App::getStorage($app)]]></code>
-    </FalsableReturnStatement>
-  </file>
   <file src="lib/public/L10N/ILanguageIterator.php">
     <MissingTemplateParam>
       <code><![CDATA[\Iterator]]></code>

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -768,28 +768,6 @@ class OC_App {
 		}
 	}
 
-	/**
-	 * @param string $appId
-	 * @return \OC\Files\View|false
-	 */
-	public static function getStorage(string $appId) {
-		if (\OC::$server->getAppManager()->isEnabledForUser($appId)) { //sanity check
-			if (\OC::$server->getUserSession()->isLoggedIn()) {
-				$view = new \OC\Files\View('/' . OC_User::getUser());
-				if (!$view->file_exists($appId)) {
-					$view->mkdir($appId);
-				}
-				return new \OC\Files\View('/' . OC_User::getUser() . '/' . $appId);
-			} else {
-				\OCP\Server::get(LoggerInterface::class)->error('Can\'t get app storage, app ' . $appId . ', user not logged in', ['app' => 'core']);
-				return false;
-			}
-		} else {
-			\OCP\Server::get(LoggerInterface::class)->error('Can\'t get app storage, app ' . $appId . ' not enabled', ['app' => 'core']);
-			return false;
-		}
-	}
-
 	protected static function findBestL10NOption(array $options, string $lang): string {
 		// only a single option
 		if (isset($options['@value'])) {

--- a/lib/public/Files.php
+++ b/lib/public/Files.php
@@ -105,16 +105,4 @@ class Files {
 	public static function buildNotExistingFileName($path, $filename) {
 		return \OC_Helper::buildNotExistingFileName($path, $filename);
 	}
-
-	/**
-	 * Gets the Storage for an app - creates the needed folder if they are not
-	 * existent
-	 * @param string $app
-	 * @return \OC\Files\View
-	 * @since 5.0.0
-	 * @deprecated 14.0.0 use IAppData instead
-	 */
-	public static function getStorage($app) {
-		return \OC_App::getStorage($app);
-	}
 }


### PR DESCRIPTION
## Summary
Was deprecated since Nextcloud 14 and is not used anymore. Removing allows us to clean the OCP psalm baseline.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
