### PR TITLE
fix: improve error message when cache rename source can't be found

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -663,7 +663,7 @@ class Cache implements ICache {
 
 			$sourceData = $sourceCache->get($sourcePath);
 			if (!$sourceData) {
-				throw new \Exception('Invalid source storage path: ' . $sourcePath);
+				throw new \Exception('Source path not found in cache: ' . $sourcePath);
 			}
 
 			$shardDefinition = $this->connection->getShardDefinition('filecache');


### PR DESCRIPTION
The existing error is very misleading