### PR TITLE
fix(files_sharing): remove queueUpdate and auto-saving behavior

### DIFF
--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -820,11 +820,6 @@ export default {
 
 			// reset password state after sync
 			this.$delete(this.share, 'newPassword')
-
-			// only update if valid share.
-			if (this.share.id) {
-				this.queueUpdate('password')
-			}
 		},
 
 		/**
@@ -839,7 +834,6 @@ export default {
 		onPasswordSubmit() {
 			if (this.hasUnsavedPassword) {
 				this.share.password = this.share.newPassword.trim()
-				this.queueUpdate('password')
 			}
 		},
 
@@ -855,8 +849,6 @@ export default {
 			if (this.hasUnsavedPassword) {
 				this.share.password = this.share.newPassword.trim()
 			}
-
-			this.queueUpdate('sendPasswordByTalk', 'password')
 		},
 
 		/**

--- a/apps/files_sharing/src/components/SharingEntryQuickShareSelect.vue
+++ b/apps/files_sharing/src/components/SharingEntryQuickShareSelect.vue
@@ -164,7 +164,6 @@ export default {
 				this.$emit('open-sharing-details')
 			} else {
 				this.share.permissions = this.dropDownPermissionValue
-				this.queueUpdate('permissions')
 				// TODO: Add a focus method to NcActions or configurable returnFocus enabling to NcActionButton with closeAfterClick
 				this.$refs.quickShareActions.$refs.menuButton.$el.focus()
 			}

--- a/apps/files_sharing/src/views/SharingDetailsTab.vue
+++ b/apps/files_sharing/src/views/SharingDetailsTab.vue
@@ -165,8 +165,7 @@
 						@input="onExpirationChange" />
 					<NcCheckboxRadioSwitch v-if="isPublicShare"
 						:disabled="canChangeHideDownload"
-						:checked.sync="share.hideDownload"
-						@update:checked="queueUpdate('hideDownload')">
+						:checked.sync="share.hideDownload">
 						{{ t('files_sharing', 'Hide download') }}
 					</NcCheckboxRadioSwitch>
 					<NcCheckboxRadioSwitch v-else
@@ -1015,7 +1014,6 @@ export default {
 
 				// ugly hack to make code work - we need the id to be set but at the same time we need to keep values we want to update
 				this.share._share.id = share.id
-				await this.queueUpdate(...permissionsAndAttributes)
 				// Also a ugly hack to update the updated permissions
 				for (const prop of permissionsAndAttributes) {
 					if (prop in share && prop in this.share) {
@@ -1034,7 +1032,6 @@ export default {
 				// Let's update after creation as some attrs are only available after creation
 				this.$emit('update:share', this.share)
 				emit('update:share', this.share)
-				this.queueUpdate(...permissionsAndAttributes)
 			}
 
 			await this.getNode()
@@ -1114,8 +1111,6 @@ export default {
 			if (this.hasUnsavedPassword) {
 				this.share.password = this.share.newPassword.trim()
 			}
-
-			this.queueUpdate('sendPasswordByTalk', 'password')
 		},
 		isValidShareAttribute(value) {
 			if ([null, undefined].includes(value)) {


### PR DESCRIPTION
- Removed queueUpdate method from SharesMixin
- Removed all auto-saving calls to queueUpdate across components
- Ensured share modifications are only saved on explicit user action
- Updated components to handle share state changes locally until save
- Cleaned up related code and comments

This change makes the share modification behavior more predictable by requiring explicit save actions instead of auto-saving on every change.

Resolves: https://github.com/nextcloud/server/issues/52795