### PR TITLE
Add command to clear dav's photo cache

### DIFF
--- a/apps/dav/appinfo/info.xml
+++ b/apps/dav/appinfo/info.xml
@@ -56,6 +56,7 @@
 
 	<commands>
 		<command>OCA\DAV\Command\ClearCalendarUnshares</command>
+		<command>OCA\DAV\Command\ClearContactsPhotoCache</command>
 		<command>OCA\DAV\Command\CreateAddressBook</command>
 		<command>OCA\DAV\Command\CreateCalendar</command>
 		<command>OCA\DAV\Command\CreateSubscription</command>

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -23,7 +23,6 @@ use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\AppData\IAppDataFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -98,10 +97,7 @@ if ($debugging) {
 
 $server->addPlugin(new \Sabre\DAV\Sync\Plugin());
 $server->addPlugin(new \Sabre\CardDAV\VCFExportPlugin());
-$server->addPlugin(new ImageExportPlugin(new PhotoCache(
-	Server::get(IAppDataFactory::class)->get('dav-photocache'),
-	Server::get(LoggerInterface::class)
-)));
+$server->addPlugin(new ImageExportPlugin(Server::get(PhotoCache::class)));
 $server->addPlugin(new ExceptionLoggerPlugin('carddav', Server::get(LoggerInterface::class)));
 $server->addPlugin(Server::get(CardDavRateLimitingPlugin::class));
 $server->addPlugin(Server::get(CardDavValidatePlugin::class));

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -156,6 +156,7 @@ return array(
     'OCA\\DAV\\CardDAV\\Validation\\CardDavValidatePlugin' => $baseDir . '/../lib/CardDAV/Validation/CardDavValidatePlugin.php',
     'OCA\\DAV\\CardDAV\\Xml\\Groups' => $baseDir . '/../lib/CardDAV/Xml/Groups.php',
     'OCA\\DAV\\Command\\ClearCalendarUnshares' => $baseDir . '/../lib/Command/ClearCalendarUnshares.php',
+    'OCA\\DAV\\Command\\ClearContactsPhotoCache' => $baseDir . '/../lib/Command/ClearContactsPhotoCache.php',
     'OCA\\DAV\\Command\\CreateAddressBook' => $baseDir . '/../lib/Command/CreateAddressBook.php',
     'OCA\\DAV\\Command\\CreateCalendar' => $baseDir . '/../lib/Command/CreateCalendar.php',
     'OCA\\DAV\\Command\\CreateSubscription' => $baseDir . '/../lib/Command/CreateSubscription.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -171,6 +171,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CardDAV\\Validation\\CardDavValidatePlugin' => __DIR__ . '/..' . '/../lib/CardDAV/Validation/CardDavValidatePlugin.php',
         'OCA\\DAV\\CardDAV\\Xml\\Groups' => __DIR__ . '/..' . '/../lib/CardDAV/Xml/Groups.php',
         'OCA\\DAV\\Command\\ClearCalendarUnshares' => __DIR__ . '/..' . '/../lib/Command/ClearCalendarUnshares.php',
+        'OCA\\DAV\\Command\\ClearContactsPhotoCache' => __DIR__ . '/..' . '/../lib/Command/ClearContactsPhotoCache.php',
         'OCA\\DAV\\Command\\CreateAddressBook' => __DIR__ . '/..' . '/../lib/Command/CreateAddressBook.php',
         'OCA\\DAV\\Command\\CreateCalendar' => __DIR__ . '/..' . '/../lib/Command/CreateCalendar.php',
         'OCA\\DAV\\Command\\CreateSubscription' => __DIR__ . '/..' . '/../lib/Command/CreateSubscription.php',

--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -20,7 +20,6 @@ use OCA\DAV\CalDAV\Reminder\NotificationProviderManager;
 use OCA\DAV\CalDAV\Reminder\Notifier;
 use OCA\DAV\Capabilities;
 use OCA\DAV\CardDAV\ContactsManager;
-use OCA\DAV\CardDAV\PhotoCache;
 use OCA\DAV\CardDAV\SyncService;
 use OCA\DAV\Events\AddressBookCreatedEvent;
 use OCA\DAV\Events\AddressBookDeletedEvent;
@@ -82,7 +81,6 @@ use OCP\Config\BeforePreferenceSetEvent;
 use OCP\Contacts\IManager as IContactsManager;
 use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\Federation\Events\TrustedServerRemovedEvent;
-use OCP\Files\AppData\IAppDataFactory;
 use OCP\IUserSession;
 use OCP\Server;
 use OCP\Settings\Events\DeclarativeSettingsGetValueEvent;
@@ -112,12 +110,6 @@ class Application extends App implements IBootstrap {
 
 	public function register(IRegistrationContext $context): void {
 		$context->registerServiceAlias('CardDAVSyncService', SyncService::class);
-		$context->registerService(PhotoCache::class, function (ContainerInterface $c) {
-			return new PhotoCache(
-				$c->get(IAppDataFactory::class)->get('dav-photocache'),
-				$c->get(LoggerInterface::class)
-			);
-		});
 		$context->registerService(AppCalendarPlugin::class, function (ContainerInterface $c) {
 			return new AppCalendarPlugin(
 				$c->get(ICalendarManager::class),

--- a/apps/dav/lib/CardDAV/PhotoCache.php
+++ b/apps/dav/lib/CardDAV/PhotoCache.php
@@ -3,8 +3,10 @@
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\DAV\CardDAV;
 
+use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
@@ -19,6 +21,7 @@ use Sabre\VObject\Property\Binary;
 use Sabre\VObject\Reader;
 
 class PhotoCache {
+	private ?IAppData $photoCacheAppData = null;
 
 	/** @var array */
 	public const ALLOWED_CONTENT_TYPES = [
@@ -30,12 +33,9 @@ class PhotoCache {
 		'image/avif' => 'avif',
 	];
 
-	/**
-	 * PhotoCache constructor.
-	 */
 	public function __construct(
-		protected IAppData $appData,
-		protected LoggerInterface $logger,
+		private IAppDataFactory $appDataFactory,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -142,13 +142,12 @@ class PhotoCache {
 	private function getFolder(int $addressBookId, string $cardUri, bool $createIfNotExists = true): ISimpleFolder {
 		$hash = md5($addressBookId . ' ' . $cardUri);
 		try {
-			return $this->appData->getFolder($hash);
+			return $this->getPhotoCacheAppData()->getFolder($hash);
 		} catch (NotFoundException $e) {
 			if ($createIfNotExists) {
-				return $this->appData->newFolder($hash);
-			} else {
-				throw $e;
+				return $this->getPhotoCacheAppData()->newFolder($hash);
 			}
+			throw $e;
 		}
 	}
 
@@ -264,5 +263,12 @@ class PhotoCache {
 		} catch (NotFoundException $e) {
 			// that's OK, nothing to do
 		}
+	}
+
+	private function getPhotoCacheAppData(): IAppData {
+		if ($this->photoCacheAppData === null) {
+			$this->photoCacheAppData = $this->appDataFactory->get('dav-photocache');
+		}
+		return $this->photoCacheAppData;
 	}
 }

--- a/apps/dav/lib/Command/ClearContactsPhotoCache.php
+++ b/apps/dav/lib/Command/ClearContactsPhotoCache.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Command;
+
+use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\NotPermittedException;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+#[AsCommand(
+	name: 'dav:clear-contacts-photo-cache',
+	description: 'Clear cached contact photos',
+	hidden: false,
+)]
+class ClearContactsPhotoCache extends Command {
+
+	public function __construct(
+		private IAppDataFactory $appDataFactory,
+	) {
+		parent::__construct();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$photoCacheAppData = $this->appDataFactory->get('dav-photocache');
+
+		$folders = $photoCacheAppData->getDirectoryListing();
+		$countFolders = count($folders);
+
+		if ($countFolders === 0) {
+			$output->writeln('No cached contact photos found.');
+			return self::SUCCESS;
+		}
+
+		$output->writeln('Found ' . count($folders) . ' cached contact photos.');
+
+		/** @var QuestionHelper $helper */
+		$helper = $this->getHelper('question');
+		$question = new ConfirmationQuestion('Please confirm to clear the contacts photo cache [y/n] ', true);
+
+		if ($helper->ask($input, $output, $question) === false) {
+			$output->writeln('Clearing the contacts photo cache aborted.');
+			return self::SUCCESS;
+		}
+
+		$progressBar = new ProgressBar($output, $countFolders);
+		$progressBar->start();
+
+		foreach ($folders as $folder) {
+			try {
+				$folder->delete();
+			} catch (NotPermittedException) {
+			}
+			$progressBar->advance();
+		}
+
+		$progressBar->finish();
+
+		$output->writeln('');
+		$output->writeln('Contacts photo cache cleared.');
+
+		return self::SUCCESS;
+	}
+}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -72,7 +72,6 @@ use OCP\Comments\ICommentsManager;
 use OCP\Defaults;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\AppData\IAppDataFactory;
 use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\FilesMetadata\IFilesMetadataManager;
@@ -216,10 +215,7 @@ class Server {
 			$this->server->addPlugin(new VCFExportPlugin());
 			$this->server->addPlugin(new MultiGetExportPlugin());
 			$this->server->addPlugin(new HasPhotoPlugin());
-			$this->server->addPlugin(new ImageExportPlugin(new PhotoCache(
-				\OCP\Server::get(IAppDataFactory::class)->get('dav-photocache'),
-				$logger)
-			));
+			$this->server->addPlugin(new ImageExportPlugin(\OCP\Server::get(PhotoCache::class)));
 
 			$this->server->addPlugin(\OCP\Server::get(CardDavRateLimitingPlugin::class));
 			$this->server->addPlugin(\OCP\Server::get(CardDavValidatePlugin::class));

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -61,6 +61,7 @@ use OCP\AppFramework\QueryException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Collaboration\Resources\IManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\AppData\IAppDataFactory;
 use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -173,7 +174,7 @@ class Repair implements IOutput {
 			\OCP\Server::get(ClearGeneratedAvatarCache::class),
 			new AddPreviewBackgroundCleanupJob(\OC::$server->getJobList()),
 			new AddCleanupUpdaterBackupsJob(\OC::$server->getJobList()),
-			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OC::$server->getAppDataDir('dav-photocache'), \OC::$server->get(LoggerInterface::class)),
+			new CleanupCardDAVPhotoCache(\OC::$server->getConfig(), \OCP\Server::get(IAppDataFactory::class), \OC::$server->get(LoggerInterface::class)),
 			new AddClenupLoginFlowV2BackgroundJob(\OC::$server->getJobList()),
 			new RemoveLinkShares(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig(), \OC::$server->getGroupManager(), \OC::$server->get(INotificationManager::class), \OCP\Server::get(ITimeFactory::class)),
 			new ClearCollectionsAccessCache(\OC::$server->getConfig(), \OCP\Server::get(IManager::class)),


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Contacts is using a request like below to fetch the photo for a user from the vcard.

`/remote.php/dav/addressbooks/users/alice/z-server-generated--system/Database:jane.vcf?photo`

As fetching and parsing vcards might be expensive there's a cache for the photos in app-data. While there are event listeners in place to reset the cache for a vcard on update or delete, there might be still cases where it's helpful to clear the cache.

**How to test:**

- Make sure you have some contacts
- Open contacts
- Check oc_filecache for paths like `'%dav-photocache%'`
- Run the occ command
- Check oc_filecache for paths like `'%dav-photocache%'`
- Open contacts
- Check oc_filecache for paths like `'%dav-photocache%'`

**Backports:**

Only the command, refactoring is for 32. 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
