### PR TITLE
fix(CalDav): use old event information if new is missing

### DIFF
--- a/apps/dav/lib/CalDAV/TipBroker.php
+++ b/apps/dav/lib/CalDAV/TipBroker.php
@@ -101,7 +101,11 @@ class TipBroker extends Broker {
 				$message->method = $icalMsg->METHOD = 'CANCEL';
 				$message->significantChange = true;
 				// clone base event
-				$event = clone $eventInfo['instances']['master'];
+				if (isset($eventInfo['instances']['master'])) {
+					$event = clone $eventInfo['instances']['master'];
+				} else {
+					$event = clone $oldEventInfo['instances']['master'];
+				}
 				// alter some properties
 				unset($event->ATTENDEE);
 				$event->add('ATTENDEE', $attendee['href'], ['CN' => $attendee['name'],]);


### PR DESCRIPTION
## Issue

* Resolves: https://github.com/nextcloud/calendar/issues/6838

## Resolution
- added check to use old event information, when a user removes all attendees the new information is blank

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
