### PR TITLE
fix(OCP\Color): use correct doc block type

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4684,14 +4684,6 @@
       <code><![CDATA[array{X-Request-Id: string, Cache-Control: string, Content-Security-Policy: string, Feature-Policy: string, X-Robots-Tag: string, Last-Modified?: string, ETag?: string, ...H}]]></code>
     </MoreSpecificReturnType>
   </file>
-  <file src="lib/public/Color.php">
-    <LessSpecificReturnStatement>
-      <code><![CDATA[$step]]></code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType>
-      <code><![CDATA[array{0: int, 1: int, 2: int}]]></code>
-    </MoreSpecificReturnType>
-  </file>
   <file src="lib/public/Preview/BeforePreviewFetchedEvent.php">
     <LessSpecificReturnStatement>
       <code><![CDATA[$this->mode]]></code>

--- a/lib/public/Color.php
+++ b/lib/public/Color.php
@@ -125,7 +125,7 @@ class Color {
 	 * Calculate steps between two Colors
 	 * @param int $steps start color
 	 * @param Color[] $ends end color
-	 * @return array{0: int, 1: int, 2: int} [r,g,b] steps for each color to go from $steps to $ends
+	 * @return array{0: float, 1: float, 2: float} [r,g,b] steps for each color to go from $steps to $ends
 	 * @since 25.0.0
 	 */
 	private static function stepCalc(int $steps, array $ends): array {


### PR DESCRIPTION
## Summary

Should be float as its returned.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
