### PR TITLE
chore(files): remove dead code from the helper class

### DIFF
--- a/apps/files/tests/HelperTest.php
+++ b/apps/files/tests/HelperTest.php
@@ -2,8 +2,6 @@
 
 use OC\Files\FileInfo;
 use OCA\Files\Helper;
-use OCP\ITagManager;
-use OCP\ITags;
 
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
@@ -93,37 +91,5 @@ class HelperTest extends \Test\TestCase {
 			$expectedOrder,
 			$fileNames
 		);
-	}
-
-	public function testPopulateTags(): void {
-		$tagManager = $this->createMock(ITagManager::class);
-		$tagger = $this->createMock(ITags::class);
-
-		$tagManager->method('load')
-			->with('files')
-			->willReturn($tagger);
-
-		$data = [
-			['file_source' => 10],
-			['file_source' => 22, 'foo' => 'bar'],
-			['file_source' => 42, 'x' => 'y'],
-		];
-
-		$tags = [
-			10 => ['tag3'],
-			42 => ['tag1', 'tag2'],
-		];
-
-		$tagger->method('getTagsForObjects')
-			->with([10, 22, 42])
-			->willReturn($tags);
-
-		$result = Helper::populateTags($data, $tagManager);
-
-		$this->assertSame([
-			['file_source' => 10, 'tags' => ['tag3']],
-			['file_source' => 22, 'foo' => 'bar', 'tags' => []],
-			['file_source' => 42, 'x' => 'y', 'tags' => ['tag1', 'tag2']],
-		], $result);
 	}
 }

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -26,6 +26,7 @@ use OCP\IGroupManager;
 use OCP\IL10N;
 use OCP\IPreview;
 use OCP\IRequest;
+use OCP\ITagManager;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\Mail\IMailer;
@@ -111,6 +112,7 @@ class ApiTest extends TestCase {
 		$logger = $this->createMock(LoggerInterface::class);
 		$providerFactory = $this->createMock(IProviderFactory::class);
 		$mailer = $this->createMock(IMailer::class);
+		$tagManager = $this->createMock(ITagManager::class);
 		$dateTimeZone->method('getTimeZone')->willReturn(new \DateTimeZone(date_default_timezone_get()));
 
 		return new ShareAPIController(
@@ -131,6 +133,7 @@ class ApiTest extends TestCase {
 			$logger,
 			$providerFactory,
 			$mailer,
+			$tagManager,
 			$userId,
 		);
 	}

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1396,7 +1396,6 @@
   </file>
   <file src="apps/files/lib/Helper.php">
     <UndefinedInterfaceMethod>
-      <code><![CDATA[$file]]></code>
       <code><![CDATA[$i]]></code>
       <code><![CDATA[$i]]></code>
       <code><![CDATA[$i]]></code>


### PR DESCRIPTION
## Summary

Most is not used or only by files sharing, so inline it in files sharing and cleanup the files code :broom:

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
