### PR TITLE
test: restore .htaccess file after running unit tests

### DIFF
--- a/autotest.sh
+++ b/autotest.sh
@@ -146,6 +146,9 @@ function cleanup_config {
 	fi
 	# Remove mysqlmb4.config.php
 	rm -f config/mysqlmb4.config.php
+
+	# restore .htaccess
+	git restore .htaccess
 }
 
 # restore config on exit


### PR DESCRIPTION
## Summary

Its always annoying to have the file changed after running unit tests :pensive: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
