### PR TITLE
feat(integrity): Allow to run check for all apps

### DIFF
--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -40,31 +40,58 @@ class CheckApp extends Base {
 		$this
 			->setName('integrity:check-app')
 			->setDescription('Check integrity of an app using a signature.')
-			->addArgument('appid', InputArgument::REQUIRED, 'Application to check')
-			->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Path to application. If none is given it will be guessed.');
+			->addArgument('appid', InputArgument::OPTIONAL, 'Application to check')
+			->addOption('path', null, InputOption::VALUE_OPTIONAL, 'Path to application. If none is given it will be guessed.')
+			->addOption('all', null, InputOption::VALUE_NONE, 'Check integrity of all apps.');
 	}
 
 	/**
 	 * {@inheritdoc }
 	 */
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$appid = $input->getArgument('appid');
-		$path = (string)$input->getOption('path');
-		if ($path === '') {
-			$path = $this->appLocator->getAppPath($appid);
+		if ($input->getOption('all') && $input->getArgument('appid')) {
+			$output->writeln('<error>Option "--all" cannot be combined with an appid</error>');
+			return 1;
 		}
-		if ($this->appManager->isShipped($appid) || $this->fileAccessHelper->file_exists($path . '/appinfo/signature.json')) {
-			// Only verify if the application explicitly ships a signature.json file
-			$result = $this->checker->verifyAppSignature($appid, $path, true);
-			$this->writeArrayInOutputFormat($input, $output, $result);
-			if (count($result) > 0) {
-				$output->writeln('<error>' . count($result) . ' errors found</error>', OutputInterface::VERBOSITY_VERBOSE);
-				return 1;
-			}
-			$output->writeln('<info>No errors found</info>', OutputInterface::VERBOSITY_VERBOSE);
+
+		if (!$input->getArgument('appid') && !$input->getOption('all')) {
+			$output->writeln('<error>Please specify an appid, or "--all" to verify all apps</error>');
+			return 1;
+		}
+
+		if ($input->getArgument('appid')) {
+			$appIds = [$input->getArgument('appid')];
 		} else {
-			$output->writeln('<comment>App signature not found, skipping app integrity check</comment>');
+			$appIds = $this->appManager->getAllAppsInAppsFolders();
 		}
-		return 0;
+
+		$errorsFound = false;
+
+		foreach ($appIds as $appId) {
+			$path = (string)$input->getOption('path');
+			if ($path === '') {
+				$path = $this->appLocator->getAppPath($appId);
+			}
+
+			if ($this->appManager->isShipped($appId) || $this->fileAccessHelper->file_exists($path . '/appinfo/signature.json')) {
+				// Only verify if the application explicitly ships a signature.json file
+				$result = $this->checker->verifyAppSignature($appId, $path, true);
+
+				if (count($result) > 0) {
+					$output->writeln('<error>' . $appId . ': ' . count($result) . ' errors found:</error>');
+					$this->writeArrayInOutputFormat($input, $output, $result);
+					$errorsFound = true;
+				}
+			} else {
+				$output->writeln('<comment>' . $appId . ': ' . 'App signature not found, skipping app integrity check</comment>');
+			}
+		}
+
+		if (!$errorsFound) {
+			$output->writeln('<info>No errors found</info>', OutputInterface::VERBOSITY_VERBOSE);
+			return 0;
+		}
+
+		return 1;
 	}
 }


### PR DESCRIPTION
## Summary

Example:

```
✗ occ integrity:check-app --all
encryption: 1 errors found:
  - EXCEPTION:
    - class: OC\IntegrityCheck\Exceptions\InvalidSignatureException
    - message: Signature data not found.
settings: 1 errors found:
  - EXCEPTION:
    - class: OC\IntegrityCheck\Exceptions\InvalidSignatureException
    - message: Signature data not found.
comments: 1 errors found:
  - EXCEPTION:
    - class: OC\IntegrityCheck\Exceptions\InvalidSignatureException
    - message: Signature data not found.
activity_back: App signature not found, skipping app integrity check
...
```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
