### PR TITLE
chore!: remove legacy functions from `OC_Helper` deprecated before v10

### DIFF
--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -12,6 +12,7 @@ use OCP\Files\Mount\IMountPoint;
 use OCP\IBinaryFinder;
 use OCP\ICacheFactory;
 use OCP\IUser;
+use OCP\Server;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 
@@ -34,32 +35,6 @@ class OC_Helper {
 	private static $templateManager;
 	private static ?ICacheFactory $cacheFactory = null;
 	private static ?bool $quotaIncludeExternalStorage = null;
-
-	/**
-	 * Make a human file size
-	 * @param int|float $bytes file size in bytes
-	 * @return string a human readable file size
-	 * @deprecated 4.0.0 replaced with \OCP\Util::humanFileSize
-	 *
-	 * Makes 2048 to 2 kB.
-	 */
-	public static function humanFileSize(int|float $bytes): string {
-		return \OCP\Util::humanFileSize($bytes);
-	}
-
-	/**
-	 * Make a computer file size
-	 * @param string $str file size in human readable format
-	 * @return false|int|float a file size in bytes
-	 * @deprecated 4.0.0 Use \OCP\Util::computerFileSize
-	 *
-	 * Makes 2kB to 2048.
-	 *
-	 * Inspired by: https://www.php.net/manual/en/function.filesize.php#92418
-	 */
-	public static function computerFileSize(string $str): false|int|float {
-		return \OCP\Util::computerFileSize($str);
-	}
 
 	/**
 	 * Recursive copying of folders
@@ -89,17 +64,6 @@ class OC_Helper {
 				copy($src, $dest);
 			}
 		}
-	}
-
-	/**
-	 * Recursive deletion of folders
-	 * @param string $dir path to the folder
-	 * @param bool $deleteSelf if set to false only the content of the folder will be deleted
-	 * @return bool
-	 * @deprecated 5.0.0 use \OCP\Files::rmdirr instead
-	 */
-	public static function rmdirr($dir, $deleteSelf = true) {
-		return \OCP\Files::rmdirr($dir, $deleteSelf);
 	}
 
 	/**
@@ -246,73 +210,12 @@ class OC_Helper {
 	}
 
 	/**
-	 * Returns an array with all keys from input lowercased or uppercased. Numbered indices are left as is.
-	 * Based on https://www.php.net/manual/en/function.array-change-key-case.php#107715
-	 *
-	 * @param array $input The array to work on
-	 * @param int $case Either MB_CASE_UPPER or MB_CASE_LOWER (default)
-	 * @param string $encoding The encoding parameter is the character encoding. Defaults to UTF-8
-	 * @return array
-	 * @deprecated 4.5.0 use \OCP\Util::mb_array_change_key_case instead
-	 */
-	public static function mb_array_change_key_case($input, $case = MB_CASE_LOWER, $encoding = 'UTF-8') {
-		return \OCP\Util::mb_array_change_key_case($input, $case, $encoding);
-	}
-
-	/**
-	 * Performs a search in a nested array.
-	 * Taken from https://www.php.net/manual/en/function.array-search.php#97645
-	 *
-	 * @param array $haystack the array to be searched
-	 * @param string $needle the search string
-	 * @param mixed $index optional, only search this key name
-	 * @return mixed the key of the matching field, otherwise false
-	 * @deprecated 4.5.0 - use \OCP\Util::recursiveArraySearch
-	 */
-	public static function recursiveArraySearch($haystack, $needle, $index = null) {
-		return \OCP\Util::recursiveArraySearch($haystack, $needle, $index);
-	}
-
-	/**
-	 * calculates the maximum upload size respecting system settings, free space and user quota
-	 *
-	 * @param string $dir the current folder where the user currently operates
-	 * @param int|float $freeSpace the number of bytes free on the storage holding $dir, if not set this will be received from the storage directly
-	 * @return int|float number of bytes representing
-	 * @deprecated 5.0.0 - use \OCP\Util::maxUploadFilesize
-	 */
-	public static function maxUploadFilesize($dir, $freeSpace = null) {
-		return \OCP\Util::maxUploadFilesize($dir, $freeSpace);
-	}
-
-	/**
-	 * Calculate free space left within user quota
-	 *
-	 * @param string $dir the current folder where the user currently operates
-	 * @return int|float number of bytes representing
-	 * @deprecated 7.0.0 - use \OCP\Util::freeSpace
-	 */
-	public static function freeSpace($dir) {
-		return \OCP\Util::freeSpace($dir);
-	}
-
-	/**
-	 * Calculate PHP upload limit
-	 *
-	 * @return int|float PHP upload file size limit
-	 * @deprecated 7.0.0 - use \OCP\Util::uploadLimit
-	 */
-	public static function uploadLimit() {
-		return \OCP\Util::uploadLimit();
-	}
-
-	/**
 	 * Checks if a function is available
 	 *
 	 * @deprecated 25.0.0 use \OCP\Util::isFunctionEnabled instead
 	 */
 	public static function is_function_enabled(string $function_name): bool {
-		return \OCP\Util::isFunctionEnabled($function_name);
+		return Util::isFunctionEnabled($function_name);
 	}
 
 	/**
@@ -320,7 +223,7 @@ class OC_Helper {
 	 * @deprecated 25.0.0 Use \OC\BinaryFinder directly
 	 */
 	public static function findBinaryPath(string $program): ?string {
-		$result = \OCP\Server::get(IBinaryFinder::class)->findBinaryPath($program);
+		$result = Server::get(IBinaryFinder::class)->findBinaryPath($program);
 		return $result !== false ? $result : null;
 	}
 
@@ -340,7 +243,7 @@ class OC_Helper {
 	 */
 	public static function getStorageInfo($path, $rootInfo = null, $includeMountPoints = true, $useCache = true) {
 		if (!self::$cacheFactory) {
-			self::$cacheFactory = \OC::$server->get(ICacheFactory::class);
+			self::$cacheFactory = Server::get(ICacheFactory::class);
 		}
 		$memcache = self::$cacheFactory->createLocal('storage_info');
 

--- a/lib/public/Template.php
+++ b/lib/public/Template.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/../private/Template/functions.php';
  */
 class Template extends \OC_Template implements ITemplate {
 	/**
-	 * Make OC_Helper::imagePath available as a simple function
+	 * Make \OCP\IURLGenerator::imagePath available as a simple function
 	 *
 	 * @see \OCP\IURLGenerator::imagePath
 	 *
@@ -39,7 +39,7 @@ class Template extends \OC_Template implements ITemplate {
 
 
 	/**
-	 * Make OC_Helper::mimetypeIcon available as a simple function
+	 * Make IMimeTypeDetector->mimeTypeIcon available as a simple function
 	 *
 	 * @param string $mimetype
 	 * @return string to the image of this file type.

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -10,6 +10,7 @@ namespace Test\Files;
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\Temporary;
 use OC\User\NoUserException;
+use OCP\Files;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IUser;
@@ -74,7 +75,7 @@ class FilesystemTest extends \Test\TestCase {
 
 	protected function tearDown(): void {
 		foreach ($this->tmpDirs as $dir) {
-			\OC_Helper::rmdirr($dir);
+			Files::rmdirr($dir);
 		}
 
 		$this->logout();

--- a/tests/lib/Files/Storage/CommonTest.php
+++ b/tests/lib/Files/Storage/CommonTest.php
@@ -9,6 +9,7 @@ namespace Test\Files\Storage;
 
 use OC\Files\Storage\Wrapper\Jail;
 use OC\Files\Storage\Wrapper\Wrapper;
+use OCP\Files;
 use OCP\Files\IFilenameValidator;
 use OCP\Files\InvalidCharacterInPathException;
 use OCP\Files\InvalidPathException;
@@ -37,7 +38,7 @@ class CommonTest extends Storage {
 	}
 
 	protected function tearDown(): void {
-		\OC_Helper::rmdirr($this->tmpDir);
+		Files::rmdirr($this->tmpDir);
 		$this->restoreService(IFilenameValidator::class);
 		parent::tearDown();
 	}

--- a/tests/lib/Files/Storage/HomeTest.php
+++ b/tests/lib/Files/Storage/HomeTest.php
@@ -8,6 +8,7 @@
 namespace Test\Files\Storage;
 
 use OC\User\User;
+use OCP\Files;
 
 class DummyUser extends User {
 	private $home;
@@ -62,7 +63,7 @@ class HomeTest extends Storage {
 	}
 
 	protected function tearDown(): void {
-		\OC_Helper::rmdirr($this->tmpDir);
+		Files::rmdirr($this->tmpDir);
 		parent::tearDown();
 	}
 

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -8,6 +8,7 @@
 namespace Test\Files\Storage;
 
 use OC\Files\Storage\Wrapper\Jail;
+use OCP\Files;
 
 /**
  * Class LocalTest
@@ -30,7 +31,7 @@ class LocalTest extends Storage {
 	}
 
 	protected function tearDown(): void {
-		\OC_Helper::rmdirr($this->tmpDir);
+		Files::rmdirr($this->tmpDir);
 		parent::tearDown();
 	}
 

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -10,6 +10,7 @@ namespace Test\Files\Storage\Wrapper;
 //ensure the constants are loaded
 use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\Local;
+use OCP\Files;
 
 \OC::$loader->load('\OC\Files\Filesystem');
 
@@ -35,7 +36,7 @@ class QuotaTest extends \Test\Files\Storage\Storage {
 	}
 
 	protected function tearDown(): void {
-		\OC_Helper::rmdirr($this->tmpDir);
+		Files::rmdirr($this->tmpDir);
 		parent::tearDown();
 	}
 

--- a/tests/lib/Files/Storage/Wrapper/WrapperTest.php
+++ b/tests/lib/Files/Storage/Wrapper/WrapperTest.php
@@ -7,6 +7,8 @@
 
 namespace Test\Files\Storage\Wrapper;
 
+use OCP\Files;
+
 class WrapperTest extends \Test\Files\Storage\Storage {
 	/**
 	 * @var string tmpDir
@@ -22,7 +24,7 @@ class WrapperTest extends \Test\Files\Storage\Storage {
 	}
 
 	protected function tearDown(): void {
-		\OC_Helper::rmdirr($this->tmpDir);
+		Files::rmdirr($this->tmpDir);
 		parent::tearDown();
 	}
 

--- a/tests/lib/FilesTest.php
+++ b/tests/lib/FilesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test;
+
+use OCP\Files;
+use OCP\ITempManager;
+use OCP\Server;
+
+class FilesTest extends TestCase {
+
+	/**
+	 * Tests recursive folder deletion with rmdirr()
+	 */
+	public function testRecursiveFolderDeletion(): void {
+		$baseDir = Server::get(ITempManager::class)->getTemporaryFolder() . '/';
+		mkdir($baseDir . 'a/b/c/d/e', 0777, true);
+		mkdir($baseDir . 'a/b/c1/d/e', 0777, true);
+		mkdir($baseDir . 'a/b/c2/d/e', 0777, true);
+		mkdir($baseDir . 'a/b1/c1/d/e', 0777, true);
+		mkdir($baseDir . 'a/b2/c1/d/e', 0777, true);
+		mkdir($baseDir . 'a/b3/c1/d/e', 0777, true);
+		mkdir($baseDir . 'a1/b', 0777, true);
+		mkdir($baseDir . 'a1/c', 0777, true);
+		file_put_contents($baseDir . 'a/test.txt', 'Hello file!');
+		file_put_contents($baseDir . 'a/b1/c1/test one.txt', 'Hello file one!');
+		file_put_contents($baseDir . 'a1/b/test two.txt', 'Hello file two!');
+		Files::rmdirr($baseDir . 'a');
+
+		$this->assertFalse(file_exists($baseDir . 'a'));
+		$this->assertTrue(file_exists($baseDir . 'a1'));
+
+		Files::rmdirr($baseDir);
+		$this->assertFalse(file_exists($baseDir));
+	}
+}

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -94,6 +94,7 @@ class HelperStorageTest extends \Test\TestCase {
 		$this->assertEquals(5, $storageInfo['used']);
 		$this->assertEquals(17, $storageInfo['total']);
 	}
+
 	private function getIncludeExternalStorage(): bool {
 		$class = new \ReflectionClass(\OC_Helper::class);
 		$prop = $class->getProperty('quotaIncludeExternalStorage');

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -23,85 +23,6 @@ class LegacyHelperTest extends \Test\TestCase {
 		\OC::$WEBROOT = $this->originalWebRoot;
 	}
 
-	/**
-	 * @dataProvider humanFileSizeProvider
-	 */
-	public function testHumanFileSize($expected, $input): void {
-		$result = OC_Helper::humanFileSize($input);
-		$this->assertEquals($expected, $result);
-	}
-
-	public static function humanFileSizeProvider(): array {
-		return [
-			['0 B', 0],
-			['1 KB', 1024],
-			['9.5 MB', 10000000],
-			['1.3 GB', 1395864371],
-			['465.7 GB', 500000000000],
-			['454.7 TB', 500000000000000],
-			['444.1 PB', 500000000000000000],
-		];
-	}
-
-	/**
-	 * @dataProvider providesComputerFileSize
-	 */
-	public function testComputerFileSize($expected, $input): void {
-		$result = OC_Helper::computerFileSize($input);
-		$this->assertEquals($expected, $result);
-	}
-
-	public static function providesComputerFileSize(): array {
-		return [
-			[0.0, '0 B'],
-			[1024.0, '1 KB'],
-			[1395864371.0, '1.3 GB'],
-			[9961472.0, '9.5 MB'],
-			[500041567437.0, '465.7 GB'],
-			[false, '12 GB etfrhzui']
-		];
-	}
-
-	public function testMb_array_change_key_case(): void {
-		$arrayStart = [
-			'Foo' => 'bar',
-			'Bar' => 'foo',
-		];
-		$arrayResult = [
-			'foo' => 'bar',
-			'bar' => 'foo',
-		];
-		$result = OC_Helper::mb_array_change_key_case($arrayStart);
-		$expected = $arrayResult;
-		$this->assertEquals($result, $expected);
-
-		$arrayStart = [
-			'foo' => 'bar',
-			'bar' => 'foo',
-		];
-		$arrayResult = [
-			'FOO' => 'bar',
-			'BAR' => 'foo',
-		];
-		$result = OC_Helper::mb_array_change_key_case($arrayStart, MB_CASE_UPPER);
-		$expected = $arrayResult;
-		$this->assertEquals($result, $expected);
-	}
-
-	public function testRecursiveArraySearch(): void {
-		$haystack = [
-			'Foo' => 'own',
-			'Bar' => 'Cloud',
-		];
-
-		$result = OC_Helper::recursiveArraySearch($haystack, 'own');
-		$expected = 'Foo';
-		$this->assertEquals($result, $expected);
-
-		$result = OC_Helper::recursiveArraySearch($haystack, 'NotFound');
-		$this->assertFalse($result);
-	}
-
 	public function testBuildNotExistingFileNameForView(): void {
 		$viewMock = $this->createMock(View::class);
 		$this->assertEquals('/filename', OC_Helper::buildNotExistingFileNameForView('/', 'filename', $viewMock));
@@ -226,30 +147,5 @@ class LegacyHelperTest extends \Test\TestCase {
 			[filesize(\OC::$SERVERROOT . '/tests/data/lorem.txt'), true, \OC::$SERVERROOT . '/tests/data/lorem.txt', \OC::$SERVERROOT . '/tests/data/lorem-copy.txt'],
 			[3670, true, \OC::$SERVERROOT . '/tests/data/testimage.png', \OC::$SERVERROOT . '/tests/data/testimage-copy.png'],
 		];
-	}
-
-	/**
-	 * Tests recursive folder deletion with rmdirr()
-	 */
-	public function testRecursiveFolderDeletion(): void {
-		$baseDir = \OC::$server->getTempManager()->getTemporaryFolder() . '/';
-		mkdir($baseDir . 'a/b/c/d/e', 0777, true);
-		mkdir($baseDir . 'a/b/c1/d/e', 0777, true);
-		mkdir($baseDir . 'a/b/c2/d/e', 0777, true);
-		mkdir($baseDir . 'a/b1/c1/d/e', 0777, true);
-		mkdir($baseDir . 'a/b2/c1/d/e', 0777, true);
-		mkdir($baseDir . 'a/b3/c1/d/e', 0777, true);
-		mkdir($baseDir . 'a1/b', 0777, true);
-		mkdir($baseDir . 'a1/c', 0777, true);
-		file_put_contents($baseDir . 'a/test.txt', 'Hello file!');
-		file_put_contents($baseDir . 'a/b1/c1/test one.txt', 'Hello file one!');
-		file_put_contents($baseDir . 'a1/b/test two.txt', 'Hello file two!');
-		\OC_Helper::rmdirr($baseDir . 'a');
-
-		$this->assertFalse(file_exists($baseDir . 'a'));
-		$this->assertTrue(file_exists($baseDir . 'a1'));
-
-		\OC_Helper::rmdirr($baseDir);
-		$this->assertFalse(file_exists($baseDir));
 	}
 }

--- a/tests/lib/Preview/OfficeTest.php
+++ b/tests/lib/Preview/OfficeTest.php
@@ -7,6 +7,9 @@
 
 namespace Test\Preview;
 
+use OCP\IBinaryFinder;
+use OCP\Server;
+
 /**
  * Class OfficeTest
  *
@@ -16,10 +19,11 @@ namespace Test\Preview;
  */
 class OfficeTest extends Provider {
 	protected function setUp(): void {
-		$libreofficeBinary = \OC_Helper::findBinaryPath('libreoffice');
-		$openofficeBinary = ($libreofficeBinary) ? null : \OC_Helper::findBinaryPath('openoffice');
+		$binaryFinder = Server::get(IBinaryFinder::class);
+		$libreofficeBinary = $binaryFinder->findBinaryPath('libreoffice');
+		$openofficeBinary = $libreofficeBinary === false ? $binaryFinder->findBinaryPath('openoffice') : false;
 
-		if ($libreofficeBinary || $openofficeBinary) {
+		if ($libreofficeBinary !== false || $openofficeBinary !== false) {
 			parent::setUp();
 
 			$fileName = 'testimage.odt';

--- a/tests/lib/TempManagerTest.php
+++ b/tests/lib/TempManagerTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OCP\Files;
 use OCP\IConfig;
 use Psr\Log\LoggerInterface;
 
@@ -26,7 +27,7 @@ class TempManagerTest extends \Test\TestCase {
 
 	protected function tearDown(): void {
 		if ($this->baseDir !== null) {
-			\OC_Helper::rmdirr($this->baseDir);
+			Files::rmdirr($this->baseDir);
 		}
 		$this->baseDir = null;
 		parent::tearDown();

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -334,4 +334,84 @@ class UtilTest extends \Test\TestCase {
 		// each of the characters is 12 bytes
 		$this->assertEquals('🙈', Util::shortenMultibyteString('🙈🙊🙉', 16, 2));
 	}
+
+	/**
+	 * @dataProvider humanFileSizeProvider
+	 */
+	public function testHumanFileSize($expected, $input): void {
+		$result = Util::humanFileSize($input);
+		$this->assertEquals($expected, $result);
+	}
+
+	public static function humanFileSizeProvider(): array {
+		return [
+			['0 B', 0],
+			['1 KB', 1024],
+			['9.5 MB', 10000000],
+			['1.3 GB', 1395864371],
+			['465.7 GB', 500000000000],
+			['454.7 TB', 500000000000000],
+			['444.1 PB', 500000000000000000],
+		];
+	}
+
+	/**
+	 * @dataProvider providesComputerFileSize
+	 */
+	public function testComputerFileSize($expected, $input): void {
+		$result = Util::computerFileSize($input);
+		$this->assertEquals($expected, $result);
+	}
+
+	public static function providesComputerFileSize(): array {
+		return [
+			[0.0, '0 B'],
+			[1024.0, '1 KB'],
+			[1395864371.0, '1.3 GB'],
+			[9961472.0, '9.5 MB'],
+			[500041567437.0, '465.7 GB'],
+			[false, '12 GB etfrhzui']
+		];
+	}
+
+	public function testMb_array_change_key_case(): void {
+		$arrayStart = [
+			'Foo' => 'bar',
+			'Bar' => 'foo',
+		];
+		$arrayResult = [
+			'foo' => 'bar',
+			'bar' => 'foo',
+		];
+		$result = Util::mb_array_change_key_case($arrayStart);
+		$expected = $arrayResult;
+		$this->assertEquals($result, $expected);
+
+		$arrayStart = [
+			'foo' => 'bar',
+			'bar' => 'foo',
+		];
+		$arrayResult = [
+			'FOO' => 'bar',
+			'BAR' => 'foo',
+		];
+		$result = Util::mb_array_change_key_case($arrayStart, MB_CASE_UPPER);
+		$expected = $arrayResult;
+		$this->assertEquals($result, $expected);
+	}
+
+	public function testRecursiveArraySearch(): void {
+		$haystack = [
+			'Foo' => 'own',
+			'Bar' => 'Cloud',
+		];
+
+		$result = Util::recursiveArraySearch($haystack, 'own');
+		$expected = 'Foo';
+		$this->assertEquals($result, $expected);
+
+		$result = Util::recursiveArraySearch($haystack, 'NotFound');
+		$this->assertFalse($result);
+	}
+
 }


### PR DESCRIPTION
## Summary

Quite old stuff I could not find any using app for.
All of it has alternatives, so should be safe.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
