### PR TITLE
fix: hide guests group from principal backend

### DIFF
--- a/apps/dav/lib/DAV/GroupPrincipalBackend.php
+++ b/apps/dav/lib/DAV/GroupPrincipalBackend.php
@@ -50,8 +50,10 @@ class GroupPrincipalBackend implements BackendInterface {
 		$principals = [];
 
 		if ($prefixPath === self::PRINCIPAL_PREFIX) {
-			foreach ($this->groupManager->search('') as $user) {
-				$principals[] = $this->groupToPrincipal($user);
+			foreach ($this->groupManager->search('') as $group) {
+				if (!$group->hideFromCollaboration()) {
+					$principals[] = $this->groupToPrincipal($group);
+				}
 			}
 		}
 
@@ -77,7 +79,7 @@ class GroupPrincipalBackend implements BackendInterface {
 		$name = urldecode($elements[2]);
 		$group = $this->groupManager->get($name);
 
-		if (!is_null($group)) {
+		if ($group !== null && !$group->hideFromCollaboration()) {
 			return $this->groupToPrincipal($group);
 		}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #52958

## Summary

Make the GroupPrincipalBackend respect hideFromCollaboration

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
