### PR TITLE
test: Migrate settings and provisioning_api to PHPUnit10

### DIFF
--- a/apps/provisioning_api/tests/CapabilitiesTest.php
+++ b/apps/provisioning_api/tests/CapabilitiesTest.php
@@ -1,9 +1,11 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Provisioning_API\Tests\unit;
+namespace OCA\Provisioning_API\Tests;
 
 use OCA\FederatedFileSharing\FederatedShareProvider;
 use OCA\Provisioning_API\Capabilities;
@@ -21,11 +23,8 @@ use Test\TestCase;
  */
 class CapabilitiesTest extends TestCase {
 
-	/** @var Capabilities */
-	protected $capabilities;
-
-	/** @var IAppManager|MockObject */
-	protected $appManager;
+	protected IAppManager&MockObject $appManager;
+	protected Capabilities $capabilities;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -38,7 +37,7 @@ class CapabilitiesTest extends TestCase {
 			->willReturn('1.12');
 	}
 
-	public function getCapabilitiesProvider() {
+	public static function getCapabilitiesProvider(): array {
 		return [
 			[true, false, false, true, false],
 			[true, true, false, true, false],
@@ -52,7 +51,7 @@ class CapabilitiesTest extends TestCase {
 	/**
 	 * @dataProvider getCapabilitiesProvider
 	 */
-	public function testGetCapabilities($federationAppEnabled, $federatedFileSharingAppEnabled, $lookupServerEnabled, $expectedFederatedScopeEnabled, $expectedPublishedScopeEnabled): void {
+	public function testGetCapabilities(bool $federationAppEnabled, bool $federatedFileSharingAppEnabled, bool $lookupServerEnabled, bool $expectedFederatedScopeEnabled, bool $expectedPublishedScopeEnabled): void {
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')
 			->will($this->returnValueMap([

--- a/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -30,7 +32,6 @@ use function json_encode;
  * @package OCA\Provisioning_API\Tests
  */
 class AppConfigControllerTest extends TestCase {
-
 	private IAppConfig&MockObject $appConfig;
 	private IUserSession&MockObject $userSession;
 	private IL10N&MockObject $l10n;
@@ -51,7 +52,7 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @param string[] $methods
-	 * @return AppConfigController|\PHPUnit\Framework\MockObject\MockObject
+	 * @return AppConfigController|MockObject
 	 */
 	protected function getInstance(array $methods = []) {
 		$request = $this->createMock(IRequest::class);
@@ -79,7 +80,7 @@ class AppConfigControllerTest extends TestCase {
 					$this->settingManager,
 					$this->appManager,
 				])
-				->setMethods($methods)
+				->onlyMethods($methods)
 				->getMock();
 		}
 	}
@@ -95,7 +96,7 @@ class AppConfigControllerTest extends TestCase {
 		$this->assertEquals(['data' => ['apps']], $result->getData());
 	}
 
-	public function dataGetKeys() {
+	public static function dataGetKeys(): array {
 		return [
 			['app1 ', null, new \InvalidArgumentException('error'), Http::STATUS_FORBIDDEN],
 			['app2', ['keys'], null, Http::STATUS_OK],
@@ -104,12 +105,8 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataGetKeys
-	 * @param string $app
-	 * @param array|null $keys
-	 * @param \Exception|null $throws
-	 * @param int $status
 	 */
-	public function testGetKeys($app, $keys, $throws, $status): void {
+	public function testGetKeys(string $app, ?array $keys, ?\Throwable $throws, int $status): void {
 		$api = $this->getInstance(['verifyAppId']);
 		if ($throws instanceof \Exception) {
 			$api->expects($this->once())
@@ -140,7 +137,7 @@ class AppConfigControllerTest extends TestCase {
 		}
 	}
 
-	public function dataGetValue() {
+	public static function dataGetValue(): array {
 		return [
 			['app1', 'key', 'default', null, new \InvalidArgumentException('error'), Http::STATUS_FORBIDDEN],
 			['app2', 'key', 'default', 'return', null, Http::STATUS_OK],
@@ -149,14 +146,8 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataGetValue
-	 * @param string $app
-	 * @param string|null $key
-	 * @param string|null $default
-	 * @param string|null $return
-	 * @param \Exception|null $throws
-	 * @param int $status
 	 */
-	public function testGetValue($app, $key, $default, $return, $throws, $status): void {
+	public function testGetValue(string $app, string $key, string $default, ?string $return, ?\Throwable $throws, int $status): void {
 		$api = $this->getInstance(['verifyAppId']);
 		if ($throws instanceof \Exception) {
 			$api->expects($this->once())
@@ -184,7 +175,7 @@ class AppConfigControllerTest extends TestCase {
 		}
 	}
 
-	public function dataSetValue() {
+	public static function dataSetValue(): array {
 		return [
 			['app1', 'key', 'default', new \InvalidArgumentException('error1'), null, Http::STATUS_FORBIDDEN],
 			['app2', 'key', 'default', null, new \InvalidArgumentException('error2'), Http::STATUS_FORBIDDEN],
@@ -201,14 +192,8 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataSetValue
-	 * @param string $app
-	 * @param string|null $key
-	 * @param string|null $value
-	 * @param \Exception|null $appThrows
-	 * @param \Exception|null $keyThrows
-	 * @param int|\Throwable $status
 	 */
-	public function testSetValue($app, $key, $value, $appThrows, $keyThrows, $status, int|\Throwable $type = IAppConfig::VALUE_MIXED): void {
+	public function testSetValue(string $app, string $key, string $value, ?\Throwable $appThrows, ?\Throwable $keyThrows, int $status, int|\Throwable $type = IAppConfig::VALUE_MIXED): void {
 		$adminUser = $this->createMock(IUser::class);
 		$adminUser->expects($this->once())
 			->method('getUid')
@@ -297,7 +282,7 @@ class AppConfigControllerTest extends TestCase {
 		}
 	}
 
-	public function dataDeleteValue() {
+	public static function dataDeleteValue(): array {
 		return [
 			['app1', 'key', new \InvalidArgumentException('error1'), null, Http::STATUS_FORBIDDEN],
 			['app2', 'key', null, new \InvalidArgumentException('error2'), Http::STATUS_FORBIDDEN],
@@ -307,13 +292,8 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataDeleteValue
-	 * @param string $app
-	 * @param string|null $key
-	 * @param \Exception|null $appThrows
-	 * @param \Exception|null $keyThrows
-	 * @param int $status
 	 */
-	public function testDeleteValue($app, $key, $appThrows, $keyThrows, $status): void {
+	public function testDeleteValue(string $app, string $key, ?\Throwable $appThrows, ?\Throwable $keyThrows, int $status): void {
 		$api = $this->getInstance(['verifyAppId', 'verifyConfigKey']);
 		if ($appThrows instanceof \Exception) {
 			$api->expects($this->once())
@@ -367,7 +347,7 @@ class AppConfigControllerTest extends TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	public function dataVerifyAppIdThrows() {
+	public static function dataVerifyAppIdThrows(): array {
 		return [
 			['activity..'],
 			['activity/'],
@@ -378,16 +358,15 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataVerifyAppIdThrows
-	 * @param string $app
 	 */
-	public function testVerifyAppIdThrows($app): void {
+	public function testVerifyAppIdThrows(string $app): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$api = $this->getInstance();
 		$this->invokePrivate($api, 'verifyAppId', [$app]);
 	}
 
-	public function dataVerifyConfigKey() {
+	public static function dataVerifyConfigKey(): array {
 		return [
 			['activity', 'abc', ''],
 			['dav', 'public_route', ''],
@@ -398,17 +377,14 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataVerifyConfigKey
-	 * @param string $app
-	 * @param string $key
-	 * @param string $value
 	 */
-	public function testVerifyConfigKey($app, $key, $value): void {
+	public function testVerifyConfigKey(string $app, string $key, string $value): void {
 		$api = $this->getInstance();
 		$this->invokePrivate($api, 'verifyConfigKey', [$app, $key, $value]);
 		$this->addToAssertionCount(1);
 	}
 
-	public function dataVerifyConfigKeyThrows() {
+	public static function dataVerifyConfigKeyThrows(): array {
 		return [
 			['activity', 'installed_version', ''],
 			['calendar', 'enabled', ''],
@@ -424,11 +400,8 @@ class AppConfigControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataVerifyConfigKeyThrows
-	 * @param string $app
-	 * @param string $key
-	 * @param string $value
 	 */
-	public function testVerifyConfigKeyThrows($app, $key, $value): void {
+	public function testVerifyConfigKeyThrows(string $app, string $key, string $value): void {
 		$this->expectException(\InvalidArgumentException::class);
 
 		$api = $this->getInstance();

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -24,12 +24,9 @@ use OCP\Server;
  * @package OCA\Provisioning_API\Tests
  */
 class AppsControllerTest extends TestCase {
-	/** @var IAppManager */
-	private $appManager;
-	/** @var AppsController */
-	private $api;
-	/** @var IUserSession */
-	private $userSession;
+	private IAppManager $appManager;
+	private AppsController $api;
+	private IUserSession $userSession;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -38,9 +35,7 @@ class AppsControllerTest extends TestCase {
 		$this->groupManager = Server::get(IGroupManager::class);
 		$this->userSession = Server::get(IUserSession::class);
 
-		$request = $this->getMockBuilder(IRequest::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(IRequest::class);
 
 		$this->api = new AppsController(
 			'provisioning_api',
@@ -96,7 +91,7 @@ class AppsControllerTest extends TestCase {
 		$this->assertEquals(count($disabled), count($data['apps']));
 	}
 
-	
+
 	public function testGetAppsInvalidFilter(): void {
 		$this->expectException(OCSException::class);
 		$this->expectExceptionCode(101);

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -22,30 +22,20 @@ use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\UserInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 class GroupsControllerTest extends \Test\TestCase {
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	protected $request;
-	/** @var IUserManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $userManager;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $config;
-	/** @var Manager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $groupManager;
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	protected $userSession;
-	/** @var IAccountManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $accountManager;
-	/** @var ISubAdmin|\PHPUnit\Framework\MockObject\MockObject */
-	protected $subAdminManager;
-	/** @var IFactory|\PHPUnit\Framework\MockObject\MockObject */
-	protected $l10nFactory;
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	protected $logger;
-
-	/** @var GroupsController|\PHPUnit\Framework\MockObject\MockObject */
-	protected $api;
+	protected IRequest&MockObject $request;
+	protected IUserManager&MockObject $userManager;
+	protected IConfig&MockObject $config;
+	protected Manager&MockObject $groupManager;
+	protected IUserSession&MockObject $userSession;
+	protected IAccountManager&MockObject $accountManager;
+	protected ISubAdmin&MockObject $subAdminManager;
+	protected IFactory&MockObject $l10nFactory;
+	protected LoggerInterface&MockObject $logger;
+	protected GroupsController&MockObject $api;
 
 	private IRootFolder $rootFolder;
 
@@ -82,16 +72,12 @@ class GroupsControllerTest extends \Test\TestCase {
 				$this->rootFolder,
 				$this->logger
 			])
-			->setMethods(['fillStorageInfo'])
+			->onlyMethods(['fillStorageInfo'])
 			->getMock();
 	}
 
-	/**
-	 * @param string $gid
-	 * @return IGroup|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function createGroup($gid) {
-		$group = $this->getMockBuilder('\OCP\IGroup')->disableOriginalConstructor()->getMock();
+	private function createGroup(string $gid): IGroup&MockObject {
+		$group = $this->createMock(\OCP\IGroup::class);
 		$group
 			->method('getGID')
 			->willReturn($gid);
@@ -116,7 +102,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 	/**
 	 * @param string $uid
-	 * @return IUser|\PHPUnit\Framework\MockObject\MockObject
+	 * @return IUser&MockObject
 	 */
 	private function createUser($uid) {
 		$user = $this->getMockBuilder(IUser::class)->disableOriginalConstructor()->getMock();
@@ -165,7 +151,7 @@ class GroupsControllerTest extends \Test\TestCase {
 			});
 	}
 
-	public function dataGetGroups() {
+	public static function dataGetGroups(): array {
 		return [
 			[null, 0, 0],
 			['foo', 0, 0],
@@ -177,12 +163,8 @@ class GroupsControllerTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider dataGetGroups
-	 *
-	 * @param string|null $search
-	 * @param int|null $limit
-	 * @param int|null $offset
 	 */
-	public function testGetGroups($search, $limit, $offset): void {
+	public function testGetGroups(?string $search, int $limit, int $offset): void {
 		$groups = [$this->createGroup('group1'), $this->createGroup('group2')];
 
 		$search = $search === null ? '' : $search;
@@ -509,7 +491,7 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('getUserGroups')
 			->willReturn([$group]);
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject */
+		/** @var MockObject */
 		$this->subAdminManager->expects($this->any())
 			->method('isSubAdminOfGroup')
 			->willReturn(false);
@@ -554,7 +536,7 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('getUserGroups')
 			->willReturn([$group]);
 
-		/** @var \PHPUnit\Framework\MockObject\MockObject */
+		/** @var MockObject */
 		$this->subAdminManager->expects($this->any())
 			->method('isSubAdminOfGroup')
 			->willReturn(false);

--- a/apps/provisioning_api/tests/Middleware/ProvisioningApiMiddlewareTest.php
+++ b/apps/provisioning_api/tests/Middleware/ProvisioningApiMiddlewareTest.php
@@ -24,34 +24,29 @@ class ProvisioningApiMiddlewareTest extends TestCase {
 		$this->reflector = $this->createMock(IControllerMethodReflector::class);
 	}
 
-	public function dataAnnotation() {
+	public static function dataAnnotation(): array {
 		return [
 			[false, false, false, false, false],
-			[false, false,  true, false, false],
-			[false,  true,  true, false, false],
-			[ true, false, false, false, true],
-			[ true, false,  true, false, false],
-			[ true,  true, false, false, false],
-			[ true,  true,  true, false, false],
+			[false, false, true, false, false],
+			[false, true, true, false, false],
+			[true, false, false, false, true],
+			[true, false, true, false, false],
+			[true, true, false, false, false],
+			[true, true, true, false, false],
 			[false, false, false, true, false],
-			[false, false,  true, true, false],
-			[false,  true,  true, true, false],
-			[ true, false, false, true, false],
-			[ true, false,  true, true, false],
-			[ true,  true, false, true, false],
-			[ true,  true,  true, true, false],
+			[false, false, true, true, false],
+			[false, true, true, true, false],
+			[true, false, false, true, false],
+			[true, false, true, true, false],
+			[true, true, false, true, false],
+			[true, true, true, true, false],
 		];
 	}
 
 	/**
 	 * @dataProvider dataAnnotation
-	 *
-	 * @param bool $subadminRequired
-	 * @param bool $isAdmin
-	 * @param bool $isSubAdmin
-	 * @param bool $shouldThrowException
 	 */
-	public function testBeforeController($subadminRequired, $isAdmin, $isSubAdmin, $hasSettingAuthorizationAnnotation, $shouldThrowException): void {
+	public function testBeforeController(bool $subadminRequired, bool $isAdmin, bool $isSubAdmin, bool $hasSettingAuthorizationAnnotation, bool $shouldThrowException): void {
 		$middleware = new ProvisioningApiMiddleware(
 			$this->reflector,
 			$isAdmin,
@@ -80,7 +75,7 @@ class ProvisioningApiMiddlewareTest extends TestCase {
 		}
 	}
 
-	public function dataAfterException() {
+	public static function dataAfterException(): array {
 		return [
 			[new NotSubAdminException(), false],
 			[new \Exception('test', 42), true],
@@ -89,11 +84,8 @@ class ProvisioningApiMiddlewareTest extends TestCase {
 
 	/**
 	 * @dataProvider dataAfterException
-	 *
-	 * @param \Exception $e
-	 * @param bool $forwared
 	 */
-	public function testAfterException(\Exception $exception, $forwared): void {
+	public function testAfterException(\Exception $exception, bool $forwared): void {
 		$middleware = new ProvisioningApiMiddleware(
 			$this->reflector,
 			false,

--- a/apps/settings/tests/Activity/SecurityFilterTest.php
+++ b/apps/settings/tests/Activity/SecurityFilterTest.php
@@ -12,15 +12,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SecurityFilterTest extends TestCase {
-
-	/** @var IURLGenerator|MockObject */
-	private $urlGenerator;
-
-	/** @var IL10N|MockObject */
-	private $l10n;
-
-	/** @var SecurityFilter */
-	private $filter;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IL10N&MockObject $l10n;
+	private SecurityFilter $filter;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/settings/tests/Activity/SecurityProviderTest.php
+++ b/apps/settings/tests/Activity/SecurityProviderTest.php
@@ -16,27 +16,19 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SecurityProviderTest extends TestCase {
-
-	/** @var IFactory|MockObject */
-	private $l10n;
-
-	/** @var IURLGenerator|MockObject */
-	private $urlGenerator;
-
-	/** @var IManager|MockObject */
-	private $activityManager;
-
-	/** @var SecurityProvider */
-	private $provider;
+	private IFactory&MockObject $l10nFactory;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IManager&MockObject $activityManager;
+	private SecurityProvider $provider;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->createMock(IFactory::class);
+		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->activityManager = $this->createMock(IManager::class);
 
-		$this->provider = new SecurityProvider($this->l10n, $this->urlGenerator, $this->activityManager);
+		$this->provider = new SecurityProvider($this->l10nFactory, $this->urlGenerator, $this->activityManager);
 	}
 
 	public function testParseUnrelated(): void {
@@ -50,7 +42,7 @@ class SecurityProviderTest extends TestCase {
 		$this->provider->parse($lang, $event);
 	}
 
-	public function subjectData() {
+	public static function subjectData(): array {
 		return [
 			['twofactor_success'],
 			['twofactor_failed'],
@@ -60,7 +52,7 @@ class SecurityProviderTest extends TestCase {
 	/**
 	 * @dataProvider subjectData
 	 */
-	public function testParse($subject): void {
+	public function testParse(string $subject): void {
 		$lang = 'ru';
 		$event = $this->createMock(IEvent::class);
 		$l = $this->createMock(IL10N::class);
@@ -68,7 +60,7 @@ class SecurityProviderTest extends TestCase {
 		$event->expects($this->once())
 			->method('getType')
 			->willReturn('security');
-		$this->l10n->expects($this->once())
+		$this->l10nFactory->expects($this->once())
 			->method('get')
 			->with('settings', $lang)
 			->willReturn($l);
@@ -104,7 +96,7 @@ class SecurityProviderTest extends TestCase {
 		$event->expects($this->once())
 			->method('getType')
 			->willReturn('security');
-		$this->l10n->expects($this->once())
+		$this->l10nFactory->expects($this->once())
 			->method('get')
 			->with('settings', $lang)
 			->willReturn($l);

--- a/apps/settings/tests/Activity/SecuritySettingTest.php
+++ b/apps/settings/tests/Activity/SecuritySettingTest.php
@@ -12,8 +12,8 @@ use Test\TestCase;
 class SecuritySettingTest extends TestCase {
 	private $l10n;
 
-	/** @var SecuritySetting */
-	private $setting;
+	/** @var  */
+	private SecuritySetting $setting;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/settings/tests/AppInfo/ApplicationTest.php
+++ b/apps/settings/tests/AppInfo/ApplicationTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -26,11 +28,8 @@ use Test\TestCase;
  * @group DB
  */
 class ApplicationTest extends TestCase {
-	/** @var Application */
-	protected $app;
-
-	/** @var IAppContainer */
-	protected $container;
+	protected Application $app;
+	protected IAppContainer $container;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,7 +42,7 @@ class ApplicationTest extends TestCase {
 		$this->assertEquals('settings', $this->container->getAppName());
 	}
 
-	public function dataContainerQuery() {
+	public static function dataContainerQuery(): array {
 		return [
 			[AdminSettingsController::class, Controller::class],
 			[AppSettingsController::class, Controller::class],
@@ -59,10 +58,8 @@ class ApplicationTest extends TestCase {
 
 	/**
 	 * @dataProvider dataContainerQuery
-	 * @param string $service
-	 * @param string $expected
 	 */
-	public function testContainerQuery($service, $expected): void {
+	public function testContainerQuery(string $service, string $expected): void {
 		$this->assertTrue($this->container->query($service) instanceof $expected);
 	}
 }

--- a/apps/settings/tests/Controller/AppSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AppSettingsControllerTest.php
@@ -37,39 +37,23 @@ use Test\TestCase;
  * @group DB
  */
 class AppSettingsControllerTest extends TestCase {
-	/** @var AppSettingsController */
-	private $appSettingsController;
-	/** @var IRequest|MockObject */
-	private $request;
-	/** @var IL10N|MockObject */
-	private $l10n;
-	/** @var IConfig|MockObject */
-	private $config;
-	/** @var INavigationManager|MockObject */
-	private $navigationManager;
+	private IRequest&MockObject $request;
+	private IL10N&MockObject $l10n;
+	private IConfig&MockObject $config;
+	private INavigationManager&MockObject $navigationManager;
 	private AppManager&MockObject $appManager;
-	/** @var CategoryFetcher|MockObject */
-	private $categoryFetcher;
-	/** @var AppFetcher|MockObject */
-	private $appFetcher;
-	/** @var IFactory|MockObject */
-	private $l10nFactory;
-	/** @var BundleFetcher|MockObject */
-	private $bundleFetcher;
-	/** @var Installer|MockObject */
-	private $installer;
-	/** @var IURLGenerator|MockObject */
-	private $urlGenerator;
-	/** @var LoggerInterface|MockObject */
-	private $logger;
-	/** @var IInitialState|MockObject */
-	private $initialState;
-	/** @var IAppDataFactory|MockObject */
-	private $appDataFactory;
-	/** @var AppDiscoverFetcher|MockObject */
-	private $discoverFetcher;
-	/** @var IClientService|MockObject */
-	private $clientService;
+	private CategoryFetcher&MockObject $categoryFetcher;
+	private AppFetcher&MockObject $appFetcher;
+	private IFactory&MockObject $l10nFactory;
+	private BundleFetcher&MockObject $bundleFetcher;
+	private Installer&MockObject $installer;
+	private IURLGenerator&MockObject $urlGenerator;
+	private LoggerInterface&MockObject $logger;
+	private IInitialState&MockObject $initialState;
+	private IAppDataFactory&MockObject $appDataFactory;
+	private AppDiscoverFetcher&MockObject $discoverFetcher;
+	private IClientService&MockObject $clientService;
+	private AppSettingsController $appSettingsController;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/settings/tests/Controller/AuthSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AuthSettingsControllerTest.php
@@ -28,24 +28,15 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class AuthSettingsControllerTest extends TestCase {
-
-	/** @var AuthSettingsController */
-	private $controller;
-	/** @var IRequest|MockObject */
-	private $request;
-	/** @var IProvider|MockObject */
-	private $tokenProvider;
-	/** @var ISession|MockObject */
-	private $session;
-	/** @var IUserSession|MockObject */
-	private $userSession;
-	/** @var ISecureRandom|MockObject */
-	private $secureRandom;
-	/** @var IManager|MockObject */
-	private $activityManager;
-	/** @var RemoteWipe|MockObject */
-	private $remoteWipe;
-	private $uid = 'jane';
+	private IRequest&MockObject $request;
+	private IProvider&MockObject $tokenProvider;
+	private ISession&MockObject $session;
+	private IUserSession&MockObject $userSession;
+	private ISecureRandom&MockObject $secureRandom;
+	private IManager&MockObject $activityManager;
+	private RemoteWipe&MockObject $remoteWipe;
+	private string $uid = 'jane';
+	private AuthSettingsController $controller;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -57,7 +48,7 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->secureRandom = $this->createMock(ISecureRandom::class);
 		$this->activityManager = $this->createMock(IManager::class);
 		$this->remoteWipe = $this->createMock(RemoteWipe::class);
-		/** @var LoggerInterface|MockObject $logger */
+		/** @var LoggerInterface&MockObject $logger */
 		$logger = $this->createMock(LoggerInterface::class);
 
 		$this->controller = new AuthSettingsController(
@@ -214,7 +205,7 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->assertSame(\OCP\AppFramework\Http::STATUS_NOT_FOUND, $response->getStatus());
 	}
 
-	public function dataRenameToken(): array {
+	public static function dataRenameToken(): array {
 		return [
 			'App password => Other token name' => ['App password', 'Other token name'],
 			'Other token name => App password' => ['Other token name', 'App password'],
@@ -223,9 +214,6 @@ class AuthSettingsControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataRenameToken
-	 *
-	 * @param string $name
-	 * @param string $newName
 	 */
 	public function testUpdateRename(string $name, string $newName): void {
 		$tokenId = 42;
@@ -257,7 +245,7 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->assertSame([], $this->controller->update($tokenId, [IToken::SCOPE_FILESYSTEM => true], $newName));
 	}
 
-	public function dataUpdateFilesystemScope(): array {
+	public static function dataUpdateFilesystemScope(): array {
 		return [
 			'Grant filesystem access' => [false, true],
 			'Revoke filesystem access' => [true, false],
@@ -266,9 +254,6 @@ class AuthSettingsControllerTest extends TestCase {
 
 	/**
 	 * @dataProvider dataUpdateFilesystemScope
-	 *
-	 * @param bool $filesystem
-	 * @param bool $newFilesystem
 	 */
 	public function testUpdateFilesystemScope(bool $filesystem, bool $newFilesystem): void {
 		$tokenId = 42;

--- a/apps/settings/tests/Controller/CheckSetupControllerTest.php
+++ b/apps/settings/tests/Controller/CheckSetupControllerTest.php
@@ -29,59 +29,40 @@ use Test\TestCase;
  * @package Tests\Settings\Controller
  */
 class CheckSetupControllerTest extends TestCase {
-	/** @var CheckSetupController | \PHPUnit\Framework\MockObject\MockObject */
-	private $checkSetupController;
-	/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject */
-	private $request;
-	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
-	private $urlGenerator;
-	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
-	private $l10n;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var Checker|\PHPUnit\Framework\MockObject\MockObject */
-	private $checker;
-	/** @var ISetupCheckManager|MockObject */
-	private $setupCheckManager;
+	private IRequest&MockObject $request;
+	private IConfig&MockObject $config;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IL10N&MockObject $l10n;
+	private LoggerInterface&MockObject $logger;
+	private Checker&MockObject $checker;
+	private ISetupCheckManager&MockObject $setupCheckManager;
+	private CheckSetupController $checkSetupController;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->request = $this->getMockBuilder(IRequest::class)
-			->disableOriginalConstructor()->getMock();
-		$this->config = $this->getMockBuilder(IConfig::class)
-			->disableOriginalConstructor()->getMock();
-		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)
-			->disableOriginalConstructor()->getMock();
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->request = $this->createMock(IRequest::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {
 				return vsprintf($message, $replace);
 			});
-		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
-			->disableOriginalConstructor()->getMock();
-		$this->logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+		$this->checker = $this->createMock(Checker::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->setupCheckManager = $this->createMock(ISetupCheckManager::class);
-		$this->checkSetupController = $this->getMockBuilder(CheckSetupController::class)
-			->setConstructorArgs([
-				'settings',
-				$this->request,
-				$this->config,
-				$this->urlGenerator,
-				$this->l10n,
-				$this->checker,
-				$this->logger,
-				$this->setupCheckManager,
-			])
-			->setMethods([
-				'getCurlVersion',
-				'isPhpOutdated',
-				'isPHPMailerUsed',
-			])->getMock();
+		$this->checkSetupController = new CheckSetupController(
+			'settings',
+			$this->request,
+			$this->config,
+			$this->urlGenerator,
+			$this->l10n,
+			$this->checker,
+			$this->logger,
+			$this->setupCheckManager,
+		);
 	}
 
 	public function testCheck(): void {

--- a/apps/settings/tests/Controller/DelegationControllerTest.php
+++ b/apps/settings/tests/Controller/DelegationControllerTest.php
@@ -10,23 +10,18 @@ use OC\Settings\AuthorizedGroup;
 use OCA\Settings\Controller\AuthorizedGroupController;
 use OCA\Settings\Service\AuthorizedGroupService;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class DelegationControllerTest extends TestCase {
-
-	/** @var AuthorizedGroupService */
-	private $service;
-
-	/** @var IRequest */
-	private $request;
-
-	/** @var AuthorizedGroupController */
-	private $controller;
+	private AuthorizedGroupService&MockObject $service;
+	private IRequest&MockObject $request;
+	private AuthorizedGroupController $controller;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->request = $this->getMockBuilder(IRequest::class)->getMock();
-		$this->service = $this->getMockBuilder(AuthorizedGroupService::class)->disableOriginalConstructor()->getMock();
+		$this->request = $this->createMock(IRequest::class);
+		$this->service = $this->createMock(AuthorizedGroupService::class);
 		$this->controller = new AuthorizedGroupController(
 			'settings', $this->request, $this->service
 		);
@@ -41,7 +36,7 @@ class DelegationControllerTest extends TestCase {
 		$this->service->expects($this->once())
 			->method('findExistingGroupsForClass')
 			->with('MySecretSetting')
-			->will($this->returnValue($oldGroups));
+			->willReturn($oldGroups);
 
 		$this->service->expects($this->once())
 			->method('delete')
@@ -50,7 +45,7 @@ class DelegationControllerTest extends TestCase {
 		$this->service->expects($this->once())
 			->method('create')
 			->with('world', 'MySecretSetting')
-			->will($this->returnValue(AuthorizedGroup::fromParams(['groupId' => 'world', 'class' => $setting])));
+			->willReturn(AuthorizedGroup::fromParams(['groupId' => 'world', 'class' => $setting]));
 
 		$result = $this->controller->saveSettings([['gid' => 'hello'], ['gid' => 'world']], 'MySecretSetting');
 

--- a/apps/settings/tests/Controller/MailSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/MailSettingsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -16,25 +18,18 @@ use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @package Tests\Settings\Controller
  */
 class MailSettingsControllerTest extends \Test\TestCase {
-
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	private $userSession;
-	/** @var IMailer|\PHPUnit\Framework\MockObject\MockObject */
-	private $mailer;
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l;
-	/** @var IURLGenerator */
-	private $urlGenerator;
-
-	/** @var MailSettingsController */
-	private $mailController;
+	private IConfig&MockObject $config;
+	private IUserSession&MockObject $userSession;
+	private IMailer&MockObject $mailer;
+	private IL10N&MockObject $l;
+	private IURLGenerator&MockObject $urlGenerator;
+	private MailSettingsController $mailController;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -44,7 +39,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->mailer = $this->createMock(IMailer::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
-		/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject $request */
+		/** @var IRequest&MockObject $request */
 		$request = $this->createMock(IRequest::class);
 		$this->mailController = new MailSettingsController(
 			'settings',
@@ -54,37 +49,40 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			$this->userSession,
 			$this->urlGenerator,
 			$this->mailer,
-			'no-reply@nextcloud.com'
 		);
 	}
 
 	public function testSetMailSettings(): void {
+		$calls = [
+			[[
+				'mail_domain' => 'nextcloud.com',
+				'mail_from_address' => 'demo@nextcloud.com',
+				'mail_smtpmode' => 'smtp',
+				'mail_smtpsecure' => 'ssl',
+				'mail_smtphost' => 'mx.nextcloud.org',
+				'mail_smtpauth' => 1,
+				'mail_smtpport' => '25',
+				'mail_sendmailmode' => 'smtp',
+			]],
+			[[
+				'mail_domain' => 'nextcloud.com',
+				'mail_from_address' => 'demo@nextcloud.com',
+				'mail_smtpmode' => 'smtp',
+				'mail_smtpsecure' => 'ssl',
+				'mail_smtphost' => 'mx.nextcloud.org',
+				'mail_smtpauth' => null,
+				'mail_smtpport' => '25',
+				'mail_smtpname' => null,
+				'mail_smtppassword' => null,
+				'mail_sendmailmode' => 'smtp',
+			]],
+		];
 		$this->config->expects($this->exactly(2))
 			->method('setSystemValues')
-			->withConsecutive(
-				[[
-					'mail_domain' => 'nextcloud.com',
-					'mail_from_address' => 'demo@nextcloud.com',
-					'mail_smtpmode' => 'smtp',
-					'mail_smtpsecure' => 'ssl',
-					'mail_smtphost' => 'mx.nextcloud.org',
-					'mail_smtpauth' => 1,
-					'mail_smtpport' => '25',
-					'mail_sendmailmode' => 'smtp',
-				]],
-				[[
-					'mail_domain' => 'nextcloud.com',
-					'mail_from_address' => 'demo@nextcloud.com',
-					'mail_smtpmode' => 'smtp',
-					'mail_smtpsecure' => 'ssl',
-					'mail_smtphost' => 'mx.nextcloud.org',
-					'mail_smtpauth' => null,
-					'mail_smtpport' => '25',
-					'mail_smtpname' => null,
-					'mail_smtppassword' => null,
-					'mail_sendmailmode' => 'smtp',
-				]]
-			);
+			->willReturnCallback(function () use (&$calls) {
+				$expected = array_shift($calls);
+				$this->assertEquals($expected, func_get_args());
+			});
 
 		// With authentication
 		$response = $this->mailController->setMailSettings(
@@ -93,7 +91,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'smtp',
 			'ssl',
 			'mx.nextcloud.org',
-			1,
+			'1',
 			'25',
 			'smtp'
 		);
@@ -106,7 +104,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 			'smtp',
 			'ssl',
 			'mx.nextcloud.org',
-			0,
+			'0',
 			'25',
 			'smtp'
 		);

--- a/apps/settings/tests/Controller/TwoFactorSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/TwoFactorSettingsControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -14,15 +16,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class TwoFactorSettingsControllerTest extends TestCase {
-
-	/** @var IRequest|MockObject */
-	private $request;
-
-	/** @var MandatoryTwoFactor|MockObject */
-	private $mandatoryTwoFactor;
-
-	/** @var TwoFactorSettingsController */
-	private $controller;
+	private IRequest&MockObject $request;
+	private MandatoryTwoFactor&MockObject $mandatoryTwoFactor;
+	private TwoFactorSettingsController $controller;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2019-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2014-2015 ownCloud, Inc.
@@ -40,38 +42,22 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @package Tests\Settings\Controller
  */
 class UsersControllerTest extends \Test\TestCase {
-	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $groupManager;
-	/** @var UserManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $userManager;
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	private $userSession;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-	/** @var IMailer|\PHPUnit\Framework\MockObject\MockObject */
-	private $mailer;
-	/** @var IFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10nFactory;
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $appManager;
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l;
-	/** @var AccountManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $accountManager;
-	/** @var IJobList | \PHPUnit\Framework\MockObject\MockObject */
-	private $jobList;
-	/** @var \OC\Security\IdentityProof\Manager|\PHPUnit\Framework\MockObject\MockObject */
-	private $securityManager;
-	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $encryptionManager;
-	/** @var KnownUserService|\PHPUnit\Framework\MockObject\MockObject */
-	private $knownUserService;
-	/** @var IEncryptionModule|\PHPUnit\Framework\MockObject\MockObject */
-	private $encryptionModule;
-	/** @var IEventDispatcher|\PHPUnit\Framework\MockObject\MockObject */
-	private $dispatcher;
-	/** @var IInitialState|\PHPUnit\Framework\MockObject\MockObject */
-	private $initialState;
+	private IGroupManager&MockObject $groupManager;
+	private UserManager&MockObject $userManager;
+	private IUserSession&MockObject $userSession;
+	private IConfig&MockObject $config;
+	private IMailer&MockObject $mailer;
+	private IFactory&MockObject $l10nFactory;
+	private IAppManager&MockObject $appManager;
+	private IL10N&MockObject $l;
+	private AccountManager&MockObject $accountManager;
+	private IJobList&MockObject $jobList;
+	private \OC\Security\IdentityProof\Manager&MockObject $securityManager;
+	private IManager&MockObject $encryptionManager;
+	private KnownUserService&MockObject $knownUserService;
+	private IEncryptionModule&MockObject $encryptionModule;
+	private IEventDispatcher&MockObject $dispatcher;
+	private IInitialState&MockObject $initialState;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -85,7 +71,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->l10nFactory = $this->createMock(IFactory::class);
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->accountManager = $this->createMock(AccountManager::class);
-		$this->securityManager = $this->getMockBuilder(\OC\Security\IdentityProof\Manager::class)->disableOriginalConstructor()->getMock();
+		$this->securityManager = $this->createMock(\OC\Security\IdentityProof\Manager::class);
 		$this->jobList = $this->createMock(IJobList::class);
 		$this->encryptionManager = $this->createMock(IManager::class);
 		$this->knownUserService = $this->createMock(KnownUserService::class);
@@ -106,9 +92,9 @@ class UsersControllerTest extends \Test\TestCase {
 
 	/**
 	 * @param bool $isAdmin
-	 * @return UsersController | \PHPUnit\Framework\MockObject\MockObject
+	 * @return UsersController|MockObject
 	 */
-	protected function getController($isAdmin = false, $mockedMethods = []) {
+	protected function getController(bool $isAdmin = false, array $mockedMethods = []) {
 		$this->groupManager->expects($this->any())
 			->method('isAdmin')
 			->willReturn($isAdmin);
@@ -155,7 +141,9 @@ class UsersControllerTest extends \Test\TestCase {
 						$this->dispatcher,
 						$this->initialState,
 					]
-				)->onlyMethods($mockedMethods)->getMock();
+				)
+				->onlyMethods($mockedMethods)
+				->getMock();
 		}
 	}
 
@@ -177,7 +165,7 @@ class UsersControllerTest extends \Test\TestCase {
 		return $property;
 	}
 
-	protected function getDefaultAccountMock(bool $useDefaultValues = true): MockObject {
+	protected function getDefaultAccountMock(): MockObject {
 		$propertyMocks = [
 			IAccountManager::PROPERTY_DISPLAYNAME => $this->buildPropertyMock(
 				IAccountManager::PROPERTY_DISPLAYNAME,
@@ -249,12 +237,8 @@ class UsersControllerTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider dataTestSetUserSettings
-	 *
-	 * @param string $email
-	 * @param bool $validEmail
-	 * @param $expectedStatus
 	 */
-	public function testSetUserSettings($email, $validEmail, $expectedStatus): void {
+	public function testSetUserSettings(string $email, bool $validEmail, int $expectedStatus): void {
 		$controller = $this->getController(false, ['saveUserSettings']);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('johndoe');
@@ -305,7 +289,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertSame($expectedStatus, $result->getStatus());
 	}
 
-	public function dataTestSetUserSettings() {
+	public static function dataTestSetUserSettings(): array {
 		return [
 			['', true, Http::STATUS_OK],
 			['', false, Http::STATUS_OK],
@@ -515,18 +499,15 @@ class UsersControllerTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider dataTestSetUserSettingsSubset
-	 *
-	 * @param string $property
-	 * @param string $propertyValue
 	 */
-	public function testSetUserSettingsSubset($property, $propertyValue): void {
+	public function testSetUserSettingsSubset(string $property, string $propertyValue): void {
 		$controller = $this->getController(false, ['saveUserSettings']);
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('johndoe');
 
 		$this->userSession->method('getUser')->willReturn($user);
 
-		/** @var IAccount|MockObject $userAccount */
+		/** @var IAccount&MockObject $userAccount */
 		$userAccount = $this->getDefaultAccountMock();
 
 		$this->accountManager->expects($this->once())
@@ -554,9 +535,9 @@ class UsersControllerTest extends \Test\TestCase {
 		$pronouns = ($property === 'pronouns') ? $propertyValue : null;
 		$pronounsScope = ($property === 'pronounsScope') ? $propertyValue : null;
 
-		/** @var IAccountProperty[]|MockObject[] $expectedProperties */
+		/** @var IAccountProperty[]&MockObject[] $expectedProperties */
 		$expectedProperties = $userAccount->getProperties();
-		$isScope = strrpos($property, 'Scope') === strlen($property) - strlen(5);
+		$isScope = strrpos($property, 'Scope') === strlen($property) - strlen('5');
 		switch ($property) {
 			case 'avatarScope':
 				$propertyId = IAccountManager::PROPERTY_AVATAR;
@@ -636,7 +617,7 @@ class UsersControllerTest extends \Test\TestCase {
 		);
 	}
 
-	public function dataTestSetUserSettingsSubset() {
+	public static function dataTestSetUserSettingsSubset(): array {
 		return [
 			['avatarScope', IAccountManager::SCOPE_PUBLISHED],
 			['displayName', 'Display name'],
@@ -662,15 +643,8 @@ class UsersControllerTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider dataTestSaveUserSettings
-	 *
-	 * @param array $data
-	 * @param ?string $oldEmailAddress
-	 * @param ?string $oldDisplayName
 	 */
-	public function testSaveUserSettings($data,
-		$oldEmailAddress,
-		$oldDisplayName,
-	): void {
+	public function testSaveUserSettings(array $data, ?string $oldEmailAddress, ?string $oldDisplayName): void {
 		$controller = $this->getController();
 		$user = $this->createMock(IUser::class);
 
@@ -722,7 +696,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->invokePrivate($controller, 'saveUserSettings', [$account]);
 	}
 
-	public function dataTestSaveUserSettings() {
+	public static function dataTestSaveUserSettings(): array {
 		return [
 			[
 				[
@@ -833,7 +807,7 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 
-	public function dataTestSaveUserSettingsException() {
+	public static function dataTestSaveUserSettingsException(): array {
 		return [
 			[
 				[
@@ -870,14 +844,9 @@ class UsersControllerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @param string $account
-	 * @param string $type
-	 * @param array $dataBefore
-	 * @param array $expectedData
-	 *
 	 * @dataProvider dataTestGetVerificationCode
 	 */
-	public function testGetVerificationCode($account, $type, $dataBefore, $expectedData, $onlyVerificationCode): void {
+	public function testGetVerificationCode(string $account, string $type, array $dataBefore, array $expectedData, bool $onlyVerificationCode): void {
 		$message = 'Use my Federated Cloud ID to share with me: user@nextcloud.com';
 		$signature = 'theSignature';
 
@@ -936,7 +905,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertSame($code, $data['code']);
 	}
 
-	public function dataTestGetVerificationCode() {
+	public static function dataTestGetVerificationCode(): array {
 		$accountDataBefore = [
 			IAccountManager::PROPERTY_WEBSITE => ['value' => 'https://nextcloud.com', 'verified' => IAccountManager::NOT_VERIFIED],
 			IAccountManager::PROPERTY_TWITTER => ['value' => '@nextclouders', 'verified' => IAccountManager::NOT_VERIFIED, 'signature' => 'theSignature'],
@@ -973,16 +942,13 @@ class UsersControllerTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider dataTestCanAdminChangeUserPasswords
-	 *
-	 * @param bool $encryptionEnabled
-	 * @param bool $encryptionModuleLoaded
-	 * @param bool $masterKeyEnabled
-	 * @param bool $expected
 	 */
-	public function testCanAdminChangeUserPasswords($encryptionEnabled,
-		$encryptionModuleLoaded,
-		$masterKeyEnabled,
-		$expected): void {
+	public function testCanAdminChangeUserPasswords(
+		bool $encryptionEnabled,
+		bool $encryptionModuleLoaded,
+		bool $masterKeyEnabled,
+		bool $expected,
+	): void {
 		$controller = $this->getController();
 
 		$this->encryptionManager->expects($this->any())
@@ -1005,7 +971,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertSame($expected, $result);
 	}
 
-	public function dataTestCanAdminChangeUserPasswords() {
+	public static function dataTestCanAdminChangeUserPasswords(): array {
 		return [
 			// encryptionEnabled, encryptionModuleLoaded, masterKeyEnabled, expectedResult
 			[true, true, true, true],

--- a/apps/settings/tests/Mailer/NewUserMailHelperTest.php
+++ b/apps/settings/tests/Mailer/NewUserMailHelperTest.php
@@ -20,29 +20,20 @@ use OCP\Mail\IEMailTemplate;
 use OCP\Mail\IMailer;
 use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class NewUserMailHelperTest extends TestCase {
-	/** @var Defaults|\PHPUnit\Framework\MockObject\MockObject */
-	private $defaults;
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	private $urlGenerator;
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10n;
-	/** @var IFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10nFactory;
-	/** @var IMailer|\PHPUnit\Framework\MockObject\MockObject */
-	private $mailer;
-	/** @var ISecureRandom|\PHPUnit\Framework\MockObject\MockObject */
-	private $secureRandom;
-	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $timeFactory;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-	/** @var ICrypto|\PHPUnit\Framework\MockObject\MockObject */
-	private $crypto;
-	/** @var NewUserMailHelper */
-	private $newUserMailHelper;
+	private Defaults&MockObject $defaults;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IL10N&MockObject $l10n;
+	private IFactory&MockObject $l10nFactory;
+	private IMailer&MockObject $mailer;
+	private ISecureRandom&MockObject $secureRandom;
+	private ITimeFactory&MockObject $timeFactory;
+	private IConfig&MockObject $config;
+	private ICrypto&MockObject $crypto;
+	private NewUserMailHelper $newUserMailHelper;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -113,7 +104,7 @@ class NewUserMailHelperTest extends TestCase {
 			->expects($this->once())
 			->method('getTime')
 			->willReturn(12345);
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser&MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->any())
@@ -371,7 +362,7 @@ EOF;
 				['myLogo',''],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser&MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->any())
@@ -611,7 +602,7 @@ EOF;
 				['myLogo', ''],
 			]);
 
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser&MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->any())
@@ -830,7 +821,7 @@ EOF;
 	}
 
 	public function testSendMail(): void {
-		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var IUser&MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user
 			->expects($this->once())
@@ -840,7 +831,7 @@ EOF;
 			->expects($this->once())
 			->method('getDisplayName')
 			->willReturn('John Doe');
-		/** @var IEMailTemplate|\PHPUnit\Framework\MockObject\MockObject $emailTemplate */
+		/** @var IEMailTemplate&MockObject $emailTemplate */
 		$emailTemplate = $this->createMock(IEMailTemplate::class);
 		$message = $this->createMock(Message::class);
 		$message

--- a/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
+++ b/apps/settings/tests/Middleware/SubadminMiddlewareTest.php
@@ -29,7 +29,6 @@ use PHPUnit\Framework\MockObject\MockObject;
  */
 class SubadminMiddlewareTest extends \Test\TestCase {
 	private SubadminMiddleware $subadminMiddleware;
-
 	private IUserSession&MockObject $userSession;
 	private ISubAdmin&MockObject $subAdminManager;
 	private ControllerMethodReflector&MockObject $reflector;
@@ -38,8 +37,7 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->reflector = $this->getMockBuilder(ControllerMethodReflector::class)
-			->disableOriginalConstructor()->getMock();
+		$this->reflector = $this->createMock(ControllerMethodReflector::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->subAdminManager = $this->createMock(ISubAdmin::class);
 		$this->l10n = $this->createMock(IL10N::class);
@@ -51,8 +49,7 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 			$this->l10n,
 		);
 
-		$this->controller = $this->getMockBuilder(Controller::class)
-			->disableOriginalConstructor()->getMock();
+		$this->controller = $this->createMock(Controller::class);
 
 		$this->userSession
 			->expects(self::any())
@@ -67,10 +64,10 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 		$this->reflector
 			->expects($this->exactly(2))
 			->method('hasAnnotation')
-			->withConsecutive(
-				['NoSubAdminRequired'],
-				['AuthorizedAdminSetting'],
-			)->willReturn(false);
+			->willReturnMap([
+				['NoSubAdminRequired', false],
+				['AuthorizedAdminSetting', false],
+			]);
 
 		$this->subAdminManager
 			->expects(self::once())
@@ -99,10 +96,10 @@ class SubadminMiddlewareTest extends \Test\TestCase {
 		$this->reflector
 			->expects($this->exactly(2))
 			->method('hasAnnotation')
-			->withConsecutive(
-				['NoSubAdminRequired'],
-				['AuthorizedAdminSetting'],
-			)->willReturn(false);
+			->willReturnMap([
+				['NoSubAdminRequired', false],
+				['AuthorizedAdminSetting', false],
+			]);
 
 		$this->subAdminManager
 			->expects(self::once())

--- a/apps/settings/tests/Settings/Admin/MailTest.php
+++ b/apps/settings/tests/Settings/Admin/MailTest.php
@@ -21,8 +21,8 @@ class MailTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
 
 		$this->admin = new Mail(
 			$this->config,

--- a/apps/settings/tests/Settings/Admin/SecurityTest.php
+++ b/apps/settings/tests/Settings/Admin/SecurityTest.php
@@ -16,21 +16,16 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SecurityTest extends TestCase {
-	/** @var Security */
-	private $admin;
-	/** @var Manager */
-	private $manager;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var MandatoryTwoFactor|MockObject */
-	private $mandatoryTwoFactor;
-	/** @var IInitialState|MockObject */
-	private $initialState;
+	private Manager $manager;
+	private IUserManager $userManager;
+	private MandatoryTwoFactor&MockObject $mandatoryTwoFactor;
+	private IInitialState&MockObject $initialState;
+	private Security $admin;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->manager = $this->getMockBuilder(Manager::class)->disableOriginalConstructor()->getMock();
-		$this->userManager = $this->getMockBuilder(IUserManager::class)->getMock();
+		$this->manager = $this->createMock(Manager::class);
+		$this->userManager = $this->createMock(IUserManager::class);
 		$this->mandatoryTwoFactor = $this->createMock(MandatoryTwoFactor::class);
 		$this->initialState = $this->createMock(IInitialState::class);
 
@@ -43,10 +38,7 @@ class SecurityTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @return array
-	 */
-	public function encryptionSettingsProvider() {
+	public static function encryptionSettingsProvider(): array {
 		return [
 			[true],
 			[false],
@@ -55,9 +47,8 @@ class SecurityTest extends TestCase {
 
 	/**
 	 * @dataProvider encryptionSettingsProvider
-	 * @param bool $enabled
 	 */
-	public function testGetFormWithOnlyOneBackend($enabled): void {
+	public function testGetFormWithOnlyOneBackend(bool $enabled): void {
 		$this->manager
 			->expects($this->once())
 			->method('isEnabled')

--- a/apps/settings/tests/Settings/Admin/ServerTest.php
+++ b/apps/settings/tests/Settings/Admin/ServerTest.php
@@ -25,24 +25,15 @@ use Test\TestCase;
  * @group DB
  */
 class ServerTest extends TestCase {
-	/** @var IDBConnection */
-	private $connection;
-	/** @var Server&MockObject */
-	private $admin;
-	/** @var IInitialState&MockObject */
-	private $initialStateService;
-	/** @var ProfileManager&MockObject */
-	private $profileManager;
-	/** @var ITimeFactory&MockObject */
-	private $timeFactory;
-	/** @var IConfig&MockObject */
-	private $config;
-	/** @var IAppConfig&MockObject */
-	private $appConfig;
-	/** @var IL10N&MockObject */
-	private $l10n;
-	/** @var IUrlGenerator&MockObject */
-	private $urlGenerator;
+	private IDBConnection $connection;
+	private Server&MockObject $admin;
+	private IInitialState&MockObject $initialStateService;
+	private ProfileManager&MockObject $profileManager;
+	private ITimeFactory&MockObject $timeFactory;
+	private IConfig&MockObject $config;
+	private IAppConfig&MockObject $appConfig;
+	private IL10N&MockObject $l10n;
+	private IUrlGenerator&MockObject $urlGenerator;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/settings/tests/Settings/Admin/SharingTest.php
+++ b/apps/settings/tests/Settings/Admin/SharingTest.php
@@ -18,34 +18,22 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SharingTest extends TestCase {
-	/** @var Sharing */
-	private $admin;
-	/** @var IConfig&MockObject */
-	private $config;
-	/** @var IL10N&MockObject */
-	private $l10n;
-	/** @var IManager|MockObject */
-	private $shareManager;
-	/** @var IAppManager|MockObject */
-	private $appManager;
-	/** @var IURLGenerator|MockObject */
-	private $urlGenerator;
-	/** @var IInitialState|MockObject */
-	private $initialState;
+	private IConfig&MockObject $config;
+	private IL10N&MockObject $l10n;
+	private IManager&MockObject $shareManager;
+	private IAppManager&MockObject $appManager;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IInitialState&MockObject $initialState;
+	private Sharing $admin;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
-
-		/** @var IManager|MockObject */
-		$this->shareManager = $this->getMockBuilder(IManager::class)->getMock();
-		/** @var IAppManager|MockObject */
-		$this->appManager = $this->getMockBuilder(IAppManager::class)->getMock();
-		/** @var IURLGenerator|MockObject */
-		$this->urlGenerator = $this->getMockBuilder(IURLGenerator::class)->getMock();
-		/** @var IInitialState|MockObject */
-		$this->initialState = $this->getMockBuilder(IInitialState::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->shareManager = $this->createMock(IManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->initialState = $this->createMock(IInitialState::class);
 
 		$this->admin = new Sharing(
 			$this->config,
@@ -104,7 +92,7 @@ class SharingTest extends TestCase {
 			->willReturnCallback(function (string $key) use (&$initialStateCalls): void {
 				$initialStateCalls[$key] = func_get_args();
 			});
-		
+
 		$expectedInitialStateCalls = [
 			'sharingAppEnabled' => false,
 			'sharingDocumentation' => '',

--- a/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
+++ b/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
@@ -20,24 +20,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class AuthtokensTest extends TestCase {
-
-	/** @var IAuthTokenProvider|MockObject */
-	private $authTokenProvider;
-
-	/** @var ISession|MockObject */
-	private $session;
-
-	/** @var IUserSession|MockObject */
-	private $userSession;
-
-	/** @var IInitialState|MockObject */
-	private $initialState;
-
-	/** @var string */
-	private $uid;
-
-	/** @var Authtokens */
-	private $section;
+	private IAuthTokenProvider&MockObject $authTokenProvider;
+	private ISession&MockObject $session;
+	private IUserSession&MockObject $userSession;
+	private IInitialState&MockObject $initialState;
+	private string $uid;
+	private Authtokens $section;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -80,34 +68,39 @@ class AuthtokensTest extends TestCase {
 			->method('getToken')
 			->with('session123')
 			->willReturn($sessionToken);
+
+		$calls = [
+			[
+				'app_tokens', [
+					[
+						'id' => 100,
+						'name' => null,
+						'lastActivity' => 0,
+						'type' => 0,
+						'canDelete' => false,
+						'current' => true,
+						'scope' => [IToken::SCOPE_FILESYSTEM => true],
+						'canRename' => false,
+					],
+					[
+						'id' => 200,
+						'name' => null,
+						'lastActivity' => 0,
+						'type' => 0,
+						'canDelete' => true,
+						'scope' => [IToken::SCOPE_FILESYSTEM => true],
+						'canRename' => true,
+					],
+				]
+			],
+			['can_create_app_token', true],
+		];
 		$this->initialState->expects($this->exactly(2))
 			->method('provideInitialState')
-			->withConsecutive(
-				[
-					'app_tokens', [
-						[
-							'id' => 100,
-							'name' => null,
-							'lastActivity' => 0,
-							'type' => 0,
-							'canDelete' => false,
-							'current' => true,
-							'scope' => [IToken::SCOPE_FILESYSTEM => true],
-							'canRename' => false,
-						],
-						[
-							'id' => 200,
-							'name' => null,
-							'lastActivity' => 0,
-							'type' => 0,
-							'canDelete' => true,
-							'scope' => [IToken::SCOPE_FILESYSTEM => true],
-							'canRename' => true,
-						],
-					]
-				],
-				['can_create_app_token', true],
-			);
+			->willReturnCallback(function () use (&$calls) {
+				$expected = array_shift($calls);
+				$this->assertEquals($expected, func_get_args());
+			});
 
 		$form = $this->section->getForm();
 

--- a/apps/settings/tests/Settings/Personal/Security/PasswordTest.php
+++ b/apps/settings/tests/Settings/Personal/Security/PasswordTest.php
@@ -16,15 +16,9 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class PasswordTest extends TestCase {
-
-	/** @var IUserManager|MockObject */
-	private $userManager;
-
-	/** @var string */
-	private $uid;
-
-	/** @var Password */
-	private $section;
+	private IUserManager&MockObject $userManager;
+	private string $uid;
+	private Password $section;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/settings/tests/SetupChecks/AppDirsWithDifferentOwnerTest.php
+++ b/apps/settings/tests/SetupChecks/AppDirsWithDifferentOwnerTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\AppDirsWithDifferentOwner;
 use OCP\IL10N;
@@ -26,8 +26,7 @@ class AppDirsWithDifferentOwnerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {

--- a/apps/settings/tests/SetupChecks/CodeIntegrityTest.php
+++ b/apps/settings/tests/SetupChecks/CodeIntegrityTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OC\IntegrityCheck\Checker;
 use OCA\Settings\SetupChecks\CodeIntegrity;
@@ -17,7 +17,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class CodeIntegrityTest extends TestCase {
-	
+
 	private IL10N&MockObject $l10n;
 	private IURLGenerator&MockObject $urlGenerator;
 	private Checker&MockObject $checker;
@@ -25,8 +25,7 @@ class CodeIntegrityTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {

--- a/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
+++ b/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\DataDirectoryProtected;
 use OCP\Http\Client\IClientService;
@@ -30,9 +30,7 @@ class DataDirectoryProtectedTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		/** @var IL10N&MockObject */
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {

--- a/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\ForwardedForHeaders;
 use OCP\IConfig;
@@ -26,8 +26,7 @@ class ForwardedForHeadersTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {
@@ -68,7 +67,7 @@ class ForwardedForHeadersTest extends TestCase {
 		);
 	}
 
-	public function dataForwardedForHeadersWorking(): array {
+	public static function dataForwardedForHeadersWorking(): array {
 		return [
 			// description => trusted proxies, getHeader('REMOTE_ADDR'), getRemoteAddr, expected result
 			'no trusted proxies' => [[], '2.2.2.2', '2.2.2.2', SetupResult::SUCCESS],

--- a/apps/settings/tests/SetupChecks/LoggingLevelTest.php
+++ b/apps/settings/tests/SetupChecks/LoggingLevelTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\LoggingLevel;
 use OCP\IConfig;
@@ -60,7 +60,7 @@ class LoggingLevelTest extends TestCase {
 	}
 
 	/** @dataProvider dataRun */
-	public function testRun(mixed $value, string $expected): void {
+	public function testRun(string|int $value, string $expected): void {
 		$this->urlGenerator->method('linkToDocs')->willReturn('admin-logging');
 
 		$this->config->expects(self::once())

--- a/apps/settings/tests/SetupChecks/OcxProvicersTest.php
+++ b/apps/settings/tests/SetupChecks/OcxProvicersTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\OcxProviders;
 use OCP\Http\Client\IClientService;
@@ -30,9 +30,7 @@ class OcxProvicersTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		/** @var IL10N|MockObject */
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {

--- a/apps/settings/tests/SetupChecks/PhpDefaultCharsetTest.php
+++ b/apps/settings/tests/SetupChecks/PhpDefaultCharsetTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\PhpDefaultCharset;
 use OCP\IL10N;
@@ -21,8 +21,7 @@ class PhpDefaultCharsetTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {

--- a/apps/settings/tests/SetupChecks/PhpOutputBufferingTest.php
+++ b/apps/settings/tests/SetupChecks/PhpOutputBufferingTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\PhpOutputBuffering;
 use OCP\IL10N;
@@ -21,8 +21,7 @@ class PhpOutputBufferingTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {

--- a/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\SecurityHeaders;
 use OCP\Http\Client\IClientService;
@@ -20,19 +20,17 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class SecurityHeadersTest extends TestCase {
-	private IL10N|MockObject $l10n;
-	private IConfig|MockObject $config;
-	private IURLGenerator|MockObject $urlGenerator;
-	private IClientService|MockObject $clientService;
-	private LoggerInterface|MockObject $logger;
-	private SecurityHeaders|MockObject $setupcheck;
+	private IL10N&MockObject $l10n;
+	private IConfig&MockObject $config;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IClientService&MockObject $clientService;
+	private LoggerInterface&MockObject $logger;
+	private SecurityHeaders&MockObject $setupcheck;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		/** @var IL10N|MockObject */
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {
@@ -92,7 +90,7 @@ class SecurityHeadersTest extends TestCase {
 		$this->assertEquals(SetupResult::WARNING, $result->getSeverity());
 	}
 
-	public function dataSuccess(): array {
+	public static function dataSuccess(): array {
 		return [
 			// description => modifiedHeaders
 			'basic' => [[]],
@@ -112,7 +110,7 @@ class SecurityHeadersTest extends TestCase {
 	/**
 	 * @dataProvider dataSuccess
 	 */
-	public function testSuccess($headers): void {
+	public function testSuccess(array $headers): void {
 		$headers = array_merge(
 			[
 				'X-XSS-Protection' => '1; mode=block',
@@ -138,7 +136,7 @@ class SecurityHeadersTest extends TestCase {
 		$this->assertEquals(SetupResult::SUCCESS, $result->getSeverity());
 	}
 
-	public function dataFailure(): array {
+	public static function dataFailure(): array {
 		return [
 			// description => modifiedHeaders
 			'x-robots-none' => [['X-Robots-Tag' => 'none'], "- The `X-Robots-Tag` HTTP header is not set to `noindex,nofollow`. This is a potential security or privacy risk, as it is recommended to adjust this setting accordingly.\n"],

--- a/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
+++ b/apps/settings/tests/SetupChecks/SupportedDatabaseTest.php
@@ -6,12 +6,12 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\SupportedDatabase;
 use OCP\IDBConnection;
 use OCP\IL10N;
-use OCP\IUrlGenerator;
+use OCP\IURLGenerator;
 use OCP\Server;
 use OCP\SetupCheck\SetupResult;
 use Test\TestCase;
@@ -29,8 +29,8 @@ class SupportedDatabaseTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
-		$this->urlGenerator = $this->getMockBuilder(IUrlGenerator::class)->getMock();
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->connection = Server::get(IDBConnection::class);
 
 		$this->check = new SupportedDatabase(

--- a/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
+++ b/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\Settings\Tests;
+namespace OCA\Settings\Tests\SetupChecks;
 
 use OCA\Settings\SetupChecks\WellKnownUrls;
 use OCP\Http\Client\IClientService;
@@ -20,19 +20,18 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class WellKnownUrlsTest extends TestCase {
-	private IL10N|MockObject $l10n;
-	private IConfig|MockObject $config;
-	private IURLGenerator|MockObject $urlGenerator;
-	private IClientService|MockObject $clientService;
-	private LoggerInterface|MockObject $logger;
-	private WellKnownUrls|MockObject $setupcheck;
+	private IL10N&MockObject $l10n;
+	private IConfig&MockObject $config;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IClientService&MockObject $clientService;
+	private LoggerInterface&MockObject $logger;
+	private WellKnownUrls&MockObject $setupcheck;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		/** @var IL10N|MockObject */
-		$this->l10n = $this->getMockBuilder(IL10N::class)
-			->disableOriginalConstructor()->getMock();
+		/** @var IL10N&MockObject */
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->l10n->expects($this->any())
 			->method('t')
 			->willReturnCallback(function ($message, array $replace) {
@@ -116,7 +115,7 @@ class WellKnownUrlsTest extends TestCase {
 	}
 
 	public function dataTestResponses(): array {
-		$createResponse = function (int $statuscode, array $header = []): IResponse|MockObject {
+		$createResponse = function (int $statuscode, array $header = []): IResponse&MockObject {
 			$response = $this->createMock(IResponse::class);
 			$response->expects($this->any())
 				->method('getStatusCode')

--- a/apps/settings/tests/UserMigration/AccountMigratorTest.php
+++ b/apps/settings/tests/UserMigration/AccountMigratorTest.php
@@ -27,21 +27,12 @@ use Test\TestCase;
  * @group DB
  */
 class AccountMigratorTest extends TestCase {
-
 	private IUserManager $userManager;
-
 	private IAvatarManager $avatarManager;
-
 	private AccountMigrator $migrator;
-
-	/** @var IImportSource|MockObject */
-	private $importSource;
-
-	/** @var IExportDestination|MockObject */
-	private $exportDestination;
-
-	/** @var OutputInterface|MockObject */
-	private $output;
+	private IImportSource&MockObject $importSource;
+	private IExportDestination&MockObject $exportDestination;
+	private OutputInterface&MockObject $output;
 
 	private const ASSETS_DIR = __DIR__ . '/assets/';
 
@@ -72,9 +63,9 @@ class AccountMigratorTest extends TestCase {
 		parent::tearDown();
 	}
 
-	public function dataImportExportAccount(): array {
+	public static function dataImportExportAccount(): array {
 		return array_map(
-			function (string $filename) {
+			static function (string $filename): array {
 				$dataPath = static::ASSETS_DIR . $filename;
 				// For each account json file there is an avatar image and a config json file with the same basename
 				$basename = pathinfo($filename, PATHINFO_FILENAME);
@@ -111,17 +102,18 @@ class AccountMigratorTest extends TestCase {
 			->with($this->migrator->getId())
 			->willReturn(1);
 
+		$calls = [
+			[static::REGEX_ACCOUNT_FILE, json_encode($importData)],
+			[static::REGEX_CONFIG_FILE, json_encode($importConfig)],
+		];
 		$this->importSource
 			->expects($this->exactly(2))
 			->method('getFileContents')
-			->withConsecutive(
-				[$this->matchesRegularExpression(static::REGEX_ACCOUNT_FILE)],
-				[$this->matchesRegularExpression(static::REGEX_CONFIG_FILE)],
-			)
-			->willReturnOnConsecutiveCalls(
-				json_encode($importData),
-				json_encode($importConfig),
-			);
+			->willReturnCallback(function ($path) use (&$calls) {
+				$expected = array_shift($calls);
+				$this->assertMatchesRegularExpression($expected[0], $path);
+				return $expected[1];
+			});
 
 		$this->importSource
 			->expects($this->once())
@@ -152,13 +144,18 @@ class AccountMigratorTest extends TestCase {
 			);
 		}
 
+		$calls = [
+			[static::REGEX_ACCOUNT_FILE, new JsonMatches(json_encode($importData))],
+			[static::REGEX_CONFIG_FILE,new JsonMatches(json_encode($importConfig))],
+		];
 		$this->exportDestination
 			->expects($this->exactly(2))
 			->method('addFileContents')
-			->withConsecutive(
-				[$this->matchesRegularExpression(static::REGEX_ACCOUNT_FILE), new JsonMatches(json_encode($exportData))],
-				[$this->matchesRegularExpression(static::REGEX_CONFIG_FILE), new JsonMatches(json_encode($exportConfig))],
-			);
+			->willReturnCallback(function ($path) use (&$calls) {
+				$expected = array_shift($calls);
+				$this->assertMatchesRegularExpression($expected[0], $path);
+				return $expected[1];
+			});
 
 		$this->exportDestination
 			->expects($this->once())


### PR DESCRIPTION
- Ref #48210 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
