### PR TITLE
feat: add OCC command to list all routes (incl. fixing the Router)

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4335,14 +4335,6 @@
       <code><![CDATA[$out]]></code>
     </ParamNameMismatch>
   </file>
-  <file src="lib/private/Route/Router.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[string]]></code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->collectionName]]></code>
-    </NullableReturnStatement>
-  </file>
   <file src="lib/private/Security/CSP/ContentSecurityPolicyNonceManager.php">
     <NoInterfaceProperties>
       <code><![CDATA[$this->request->server]]></code>

--- a/core/Command/Router/ListRoutes.php
+++ b/core/Command/Router/ListRoutes.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Command\Router;
+
+use OC\Core\Command\Base;
+use OC\Route\Route;
+use OC\Route\Router;
+use OCP\App\IAppManager;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListRoutes extends Base {
+
+	private InputInterface $input;
+
+	public function __construct(
+		private IAppManager $appManager,
+		private Router $router,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setName('router:list')
+			->setDescription('List registered routes')
+			->addArgument('appId', InputArgument::OPTIONAL, 'Limit routes to specific app', '')
+			->addOption('grouped', 'g', InputOption::VALUE_NONE, 'Group routes by app');
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$this->input = $input;
+
+		$app = (string)$input->getArgument('appId');
+		$apps = $app === '' ? $this->appManager->getEnabledApps() : [$app];
+
+		$this->router->loadRoutes();
+		$allRoutes = [];
+		foreach ($apps as $appId) {
+			$routes = $this->router->getCollection($appId)->all();
+			$routes = array_merge($routes, $this->router->getCollection("$appId.ocs")->all());
+			$allRoutes = array_merge($allRoutes, $routes);
+
+			if (!empty($routes) && $input->getOption('grouped')) {
+				$output->writeln("\nRoutes of $appId:");
+				$rows = $this->formatRoutes($routes);
+				$this->writeTableInOutputFormat($input, $output, $rows);
+			}
+		}
+		if (!$input->getOption('grouped')) {
+			$rows = $this->formatRoutes($allRoutes);
+			$this->writeTableInOutputFormat($input, $output, $rows);
+		}
+		return 0;
+	}
+
+	/**
+	 * @param Route[] $routes
+	 */
+	private function formatRoutes(array $routes): array {
+		$rows = [];
+		foreach ($routes as $route) {
+			[$realApp, $controller, $function] = $route->getDefault('caller');
+			//print_r($route->__serialize());
+			$rows[] = [
+				'app' => $realApp,
+				'controller' => $controller,
+				'function' => $function,
+				'method' => $route->getMethods()[0],
+				'path' => str_replace('/ocsapp', '/ocs/v2.php', $route->getPath()),
+				'defaults' => $this->formatDefaults($route->getDefaults()),
+				'requirements' => $this->formatArray($route->getRequirements()),
+			];
+		}
+		return $rows;
+	}
+
+	private function formatDefaults(array $defaults): array|string {
+		$defaults = array_filter($defaults, fn (string $name) => !in_array($name, ['action', 'caller']), ARRAY_FILTER_USE_KEY);
+		return $this->formatArray($defaults);
+	}
+
+	private function formatArray(array $value): array|string {
+		if (str_starts_with($this->input->getOption('output'), self::OUTPUT_FORMAT_JSON)) {
+			return $value;
+		}
+		return empty($value) ? '' : json_encode($value);
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -71,6 +71,7 @@ use OC\Core\Command\Maintenance\UpdateTheme;
 use OC\Core\Command\Memcache\RedisCommand;
 use OC\Core\Command\Preview\Generate;
 use OC\Core\Command\Preview\ResetRenderedTexts;
+use OC\Core\Command\Router\ListRoutes;
 use OC\Core\Command\Security\BruteforceAttempts;
 use OC\Core\Command\Security\BruteforceResetAttempts;
 use OC\Core\Command\Security\ExportCertificates;
@@ -243,6 +244,8 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(Statistics::class));
 
 	$application->add(Server::get(RedisCommand::class));
+
+	$application->add(Server::get(ListRoutes::class));
 } else {
 	$application->add(Server::get(Command\Maintenance\Install::class));
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1295,6 +1295,7 @@ return array(
     'OC\\Core\\Command\\Preview\\Generate' => $baseDir . '/core/Command/Preview/Generate.php',
     'OC\\Core\\Command\\Preview\\Repair' => $baseDir . '/core/Command/Preview/Repair.php',
     'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => $baseDir . '/core/Command/Preview/ResetRenderedTexts.php',
+    'OC\\Core\\Command\\Router\\ListRoutes' => $baseDir . '/core/Command/Router/ListRoutes.php',
     'OC\\Core\\Command\\Security\\BruteforceAttempts' => $baseDir . '/core/Command/Security/BruteforceAttempts.php',
     'OC\\Core\\Command\\Security\\BruteforceResetAttempts' => $baseDir . '/core/Command/Security/BruteforceResetAttempts.php',
     'OC\\Core\\Command\\Security\\ExportCertificates' => $baseDir . '/core/Command/Security/ExportCertificates.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1336,6 +1336,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Preview\\Generate' => __DIR__ . '/../../..' . '/core/Command/Preview/Generate.php',
         'OC\\Core\\Command\\Preview\\Repair' => __DIR__ . '/../../..' . '/core/Command/Preview/Repair.php',
         'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => __DIR__ . '/../../..' . '/core/Command/Preview/ResetRenderedTexts.php',
+        'OC\\Core\\Command\\Router\\ListRoutes' => __DIR__ . '/../../..' . '/core/Command/Router/ListRoutes.php',
         'OC\\Core\\Command\\Security\\BruteforceAttempts' => __DIR__ . '/../../..' . '/core/Command/Security/BruteforceAttempts.php',
         'OC\\Core\\Command\\Security\\BruteforceResetAttempts' => __DIR__ . '/../../..' . '/core/Command/Security/BruteforceResetAttempts.php',
         'OC\\Core\\Command\\Security\\ExportCertificates' => __DIR__ . '/../../..' . '/core/Command/Security/ExportCertificates.php',

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -43,10 +43,12 @@ class CachingRouter extends Router {
 	 *
 	 * @param string $name Name of the route to use.
 	 * @param array $parameters Parameters for the route
-	 * @param bool $absolute
-	 * @return string
 	 */
-	public function generate($name, $parameters = [], $absolute = false) {
+	public function generate(
+		string $name,
+		array $parameters = [],
+		bool $absolute = false,
+	): string {
 		asort($parameters);
 		$key = $this->context->getHost() . '#' . $this->context->getBaseUrl() . $name . sha1(json_encode($parameters)) . (int)$absolute;
 		$cachedKey = $this->cache->get($key);

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -117,7 +117,6 @@ class CachingRouter extends Router {
 		 * Closures cannot be serialized to cache, so for legacy routes calling an action we have to include the routes.php file again
 		 */
 		$app = $parameters['app'];
-		$this->useCollection($app);
 		parent::requireRouteFile($parameters['route-file'], $app);
 		$collection = $this->getCollection($app);
 		$parameters['action'] = $collection->get($parameters['_route'])?->getDefault('action');

--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -145,7 +145,7 @@ class CachingRouter extends Router {
 		$this->legacyCreatedRoutes = [];
 		parent::requireRouteFile($file, $appName);
 		foreach ($this->legacyCreatedRoutes as $routeName) {
-			$route = $this->collection?->get($routeName);
+			$route = $this->getCollection($appName)->get($routeName);
 			if ($route === null) {
 				/* Should never happen */
 				throw new \Exception("Could not find route $routeName");

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -478,7 +478,7 @@ class Router implements IRouter {
 	 * @param string $file the route file location to include
 	 * @param string $appName
 	 */
-	private function requireRouteFile(string $file, string $appName): void {
+	protected function requireRouteFile(string $file, string $appName): void {
 		try {
 			$this->setupRoutes(include $file, $appName);
 		} catch (\TypeError) {

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -136,19 +136,21 @@ class Router implements IRouter {
 		}
 
 		$this->eventLogger->start('route:load:files', 'Loading Routes from files');
-		foreach ($routingFiles as $app => $file) {
-			if (isset($this->loadedApps[$app])) {
+		foreach ($routingFiles as $appId => $file) {
+			if (isset($this->loadedApps[$appId])) {
 				continue;
 			}
-			if (!$this->appManager->isAppLoaded($app)) {
+			if (!$this->appManager->isAppLoaded($appId)) {
 				// app MUST be loaded before app routes
 				// try again next time loadRoutes() is called
 				$this->loaded = false;
 				continue;
 			}
-
-			$this->loadedApps[$app] = true;
-			$this->requireRouteFile($file, $app);
+			$this->requireRouteFile($file, $appId);
+			// mark fully loaded app as loaded (route file + annotation)
+			if ($app === null || $app === $appId) {
+				$this->loadedApps[$appId] = true;
+			}
 		}
 		$this->eventLogger->end('route:load:files');
 

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -105,7 +105,7 @@ class Router implements IRouter {
 		}
 
 		// already loaded so we skip
-		if ($this->loaded || ($app !== null && in_array($app, $this->loadedApps))) {
+		if ($this->loaded || ($app !== null && isset($this->loadedApps[$app]))) {
 			return;
 		}
 
@@ -155,9 +155,9 @@ class Router implements IRouter {
 		$this->eventLogger->end('route:load:files');
 
 		if (!isset($this->loadedApps['core'])) {
-			$this->loadedApps['core'] = true;
 			$this->setupRoutes($this->getAttributeRoutes('core'), 'core');
 			$this->requireRouteFile(__DIR__ . '/../../../core/routes.php', 'core');
+			$this->loadedApps['core'] = true;
 		}
 
 		$this->eventLogger->end('route:load:' . $requestedApp);

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -482,6 +482,7 @@ class Router implements IRouter {
 	 */
 	protected function requireRouteFile(string $file, string $appName): void {
 		try {
+			$this->useCollection($appName);
 			$this->setupRoutes(include $file, $appName);
 		} catch (\TypeError) {
 			$this->logger->debug('Routes should only be registered by returning an array of routes from the routes.php');

--- a/tests/lib/Route/RouterTest.php
+++ b/tests/lib/Route/RouterTest.php
@@ -66,6 +66,12 @@ class RouterTest extends TestCase {
 		$this->appManager->expects(self::atLeastOnce())
 			->method('isAppLoaded')
 			->willReturn(true);
+		$this->appManager->expects(self::atLeastOnce())
+			->method('isEnabledForUser')
+			->willReturn(true);
+		$this->appManager->expects(self::exactly(2))
+			->method('getEnabledApps')
+			->willReturn(['files', 'dav']);
 
 		$this->assertEquals('/index.php/apps/files/', $this->router->generate('files.view.index'));
 


### PR DESCRIPTION
## Summary

Main idea was to add a command to list all registered routes, to make the annotation more usable.
But when doing so I noticed the Router is broken as retrieving individual collections of routes was broken,
so this also contains a fix for it:
- Add routes to individual collections for each app
  and then merge them for the root collection holding all routes for the
  URL generator.
- Short cut route loading with already loaded apps
- Simplify active collection handling
- Remove deprecated `OC_App` usage
- Fully type Router methods

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
