### PR TITLE
Taking back major version to its 31 value

### DIFF
--- a/version.php
+++ b/version.php
@@ -9,15 +9,15 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [32, 0, 0, 0];
+$OC_Version = [31, 0, 0, 5];
 
 // The human-readable string
-$OC_VersionString = '32.0.0 dev';
+$OC_VersionString = '31.0.0 dev';
 
 $OC_VersionCanBeUpgradedFrom = [
 	'nextcloud' => [
+		'30.0' => true,
 		'31.0' => true,
-		'32.0' => true,
 	],
 	'owncloud' => [
 		'10.13' => true,


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
I am not sure if this pull request is going to make sense or not, maybe it would be a better idea for me if I have created an issue first. If this ends being a major burden to review please disregard it.

I have installed Nextcloud Server, but I wasn't able to install any application due to the fact that these applications require the server to be in its version 31 but the methods were reading major version 32 from the version.php file instead. Following is an image depicting the issue.
![CalendarUnableToInstall](https://github.com/user-attachments/assets/3b7739f0-0839-43fe-8a90-79e1243f4026)
I also noticed the URLs weren't resolving to any existing resource, take this for example: https://docs.nextcloud.com/server/32/go.php?to=developer-manual

I have performed another installation, this time around changing the major version to its previous value, I tried to figure it out from the commit history of this file first. And now the applications are able to get installed and the constructed URLs are working as expected (https://docs.nextcloud.com/server/31/go.php?to=developer-manual).
![CalendarEnabled](https://github.com/user-attachments/assets/9e9e7844-ba80-4fed-a7f2-3345050b35ae)

If I missed something obvious in some other configuration file to avoid this change, I will feel very appreciative of your guidance.

Thanks!

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
