### PR TITLE
chore: deprecate `OC_Helper::isReadOnlyConfigEnabled`

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -196,7 +196,8 @@ class OC {
 
 		// Check if config is writable
 		$configFileWritable = is_writable($configFilePath);
-		if (!$configFileWritable && !OC_Helper::isReadOnlyConfigEnabled()
+		$configReadOnly = Server::get(IConfig::class)->getSystemValueBool('config_is_read_only');
+		if (!$configFileWritable && !$configReadOnly
 			|| !$configFileWritable && \OCP\Util::needUpgrade()) {
 			$urlGenerator = Server::get(IURLGenerator::class);
 			$l = Server::get(\OCP\L10N\IFactory::class)->get('lib');

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -199,7 +199,7 @@ class OC_Helper {
 
 	/**
 	 * Try to find a program
-	 * @deprecated 25.0.0 Use \OC\BinaryFinder directly
+	 * @deprecated 25.0.0 Use \OCP\IBinaryFinder directly
 	 */
 	public static function findBinaryPath(string $program): ?string {
 		$result = Server::get(IBinaryFinder::class)->findBinaryPath($program);
@@ -415,6 +415,7 @@ class OC_Helper {
 	/**
 	 * Returns whether the config file is set manually to read-only
 	 * @return bool
+	 * @deprecated 32.0.0 use the `config_is_read_only` system config directly
 	 */
 	public static function isReadOnlyConfigEnabled() {
 		return \OC::$server->getConfig()->getSystemValueBool('config_is_read_only', false);

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -98,6 +98,7 @@ class OC_Util {
 	 *
 	 * @param IUser|null $user
 	 * @return int|\OCP\Files\FileInfo::SPACE_UNLIMITED|false|float Quota bytes
+	 * @deprecated 9.0.0 - Use \OCP\IUser::getQuota
 	 */
 	public static function getUserQuota(?IUser $user) {
 		if (is_null($user)) {
@@ -331,7 +332,7 @@ class OC_Util {
 		}
 
 		// Check if config folder is writable.
-		if (!OC_Helper::isReadOnlyConfigEnabled()) {
+		if (!(bool)$config->getValue('config_is_read_only', false)) {
 			if (!is_writable(OC::$configDir) or !is_readable(OC::$configDir)) {
 				$errors[] = [
 					'error' => $l->t('Cannot write into "config" directory.'),


### PR DESCRIPTION
## Summary

Legacy class and pretty useless helper as its one line getter from the config.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
