### PR TITLE
fix(files_versions): only close stream if still open, fixing S3

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -430,11 +430,17 @@ class Storage {
 					} else {
 						$target = $storage2->fopen($internalPath2, 'w');
 						$result = $target !== false;
-						if ($target !== false) {
+						if ($result) {
 							[, $result] = Files::streamCopy($source, $target, true);
+						}
+						// explicit check as S3 library closes streams already
+						if (is_resource($target)) {
 							fclose($target);
 						}
 					}
+				}
+				// explicit check as S3 library closes streams already
+				if (is_resource($source)) {
 					fclose($source);
 				}
 


### PR DESCRIPTION
## Summary

> streams get closed automatically when dropped, and in some cases the stream seems to be already closed by the S3 library, in which case trying to close it again will raise an error.

* https://github.com/nextcloud/server/pull/26072

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
