### PR TITLE
fix(tests): Register mount in loginHelper as well

### DIFF
--- a/apps/files_sharing/tests/EncryptedSizePropagationTest.php
+++ b/apps/files_sharing/tests/EncryptedSizePropagationTest.php
@@ -24,14 +24,19 @@ class EncryptedSizePropagationTest extends SizePropagationTest {
 
 	protected function setupUser($name, $password = '') {
 		$this->createUser($name, $password);
-		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
-		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
+		$this->registerMountForUser($name);
 		$this->setupForUser($name, $password);
 		$this->loginWithEncryption($name);
 		return new View('/' . $name . '/files');
 	}
 
+	private function registerMountForUser($user): void {
+		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
+		$this->registerMount($user, '\OC\Files\Storage\Local', '/' . $user, ['datadir' => $tmpFolder]);
+	}
+
 	protected function loginHelper($user, $create = false, $password = false) {
+		$this->registerMountForUser($user);
 		$this->setupForUser($user, $password);
 		parent::loginHelper($user, $create, $password);
 	}


### PR DESCRIPTION
## Fixes

```
1) OCA\Files_Sharing\Tests\EncryptedSizePropagationTest::testSizePropagationWhenOwnerChangesFile
openssl_public_encrypt(): key parameter is not a valid public key

/home/runner/actions-runner/_work/server/server/apps/encryption/lib/Crypto/Crypt.php:655
/home/runner/actions-runner/_work/server/server/apps/encryption/lib/Crypto/Encryption.php:228
/home/runner/actions-runner/_work/server/server/lib/private/Files/Stream/Encryption.php:396
/home/runner/actions-runner/_work/server/server/lib/private/Files/View.php:634
/home/runner/actions-runner/_work/server/server/lib/private/Files/Node/File.php:52
/home/runner/actions-runner/_work/server/server/lib/private/legacy/OC_Util.php:196
/home/runner/actions-runner/_work/server/server/lib/private/legacy/OC_Util.php:155
/home/runner/actions-runner/_work/server/server/lib/private/User/Session.php:521
/home/runner/actions-runner/_work/server/server/lib/private/User/Session.php:357
/home/runner/actions-runner/_work/server/server/lib/private/User/Session.php:585
/home/runner/actions-runner/_work/server/server/lib/private/User/Session.php:307
/home/runner/actions-runner/_work/server/server/apps/files_sharing/tests/TestCase.php:197
/home/runner/actions-runner/_work/server/server/apps/files_sharing/tests/EncryptedSizePropagationTest.php:36
/home/runner/actions-runner/_work/server/server/apps/files_sharing/tests/TestCase.php:[111](https://github.com/nextcloud/server/actions/runs/15105747424/job/42454147053#step:7:112)
/home/runner/actions-runner/_work/server/server/apps/files_sharing/tests/EncryptedSizePropagationTest.php:21
```

Minimal repro case:

* Setup NC with Minio (as is done on CI)
* Run `phpunit --configuration tests/phpunit-autotest.xml --group DB,SLOWDB --filter 'testSizePropagationWhenOwnerChangesFile' --debug`

Still not sure why only running the encrypted test works:

`phpunit --configuration tests/phpunit-autotest.xml --group DB,SLOWDB --filter 'EncryptedSizePropagationTest::testSizePropagationWhenOwnerChangesFile' --debug`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
