### PR TITLE
chore: Remove useless legacy autoloader for tests

### DIFF
--- a/lib/autoloader.php
+++ b/lib/autoloader.php
@@ -95,10 +95,6 @@ class Autoloader {
 			} catch (AppPathNotFoundException) {
 				// App not found, ignore
 			}
-		} elseif ($class === 'Test\\TestCase') {
-			// This File is considered public API, so we make sure that the class
-			// can still be loaded, although the PSR-4 paths have not been loaded.
-			$paths[] = \OC::$SERVERROOT . '/tests/lib/TestCase.php';
 		}
 		return $paths;
 	}

--- a/lib/base.php
+++ b/lib/base.php
@@ -601,9 +601,6 @@ class OC {
 		self::$loader = new \OC\Autoloader([
 			OC::$SERVERROOT . '/lib/private/legacy',
 		]);
-		if (defined('PHPUNIT_RUN')) {
-			self::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-		}
 		spl_autoload_register([self::$loader, 'load']);
 		$loaderEnd = microtime(true);
 

--- a/tests/lib/AutoLoaderTest.php
+++ b/tests/lib/AutoLoaderTest.php
@@ -24,12 +24,6 @@ class AutoLoaderTest extends TestCase {
 		], $this->loader->findClass('OC_JSON'));
 	}
 
-	public function testLoadTestTestCase(): void {
-		$this->assertEquals([
-			\OC::$SERVERROOT . '/tests/lib/TestCase.php'
-		], $this->loader->findClass('Test\TestCase'));
-	}
-
 	public function testLoadCore(): void {
 		$this->assertEquals([
 			\OC::$SERVERROOT . '/lib/private/legacy/foo/bar.php',

--- a/tests/lib/Files/Storage/Wrapper/QuotaTest.php
+++ b/tests/lib/Files/Storage/Wrapper/QuotaTest.php
@@ -12,8 +12,6 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Storage\Local;
 use OCP\Files;
 
-\OC::$loader->load('\OC\Files\Filesystem');
-
 /**
  * Class QuotaTest
  *


### PR DESCRIPTION
## Summary

We do not need the legacy autoloader for the TestCase, because we have PSR-4 loading added in https://github.com/nextcloud/server/commit/54250ed06554cb59683f5c03a1e4529660febc52

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
