### PR TITLE
Fix: [Preview] Generator::getPreviewFolder fails to create preview folder in empty preview-structure

### DIFF
--- a/lib/private/Preview/Generator.php
+++ b/lib/private/Preview/Generator.php
@@ -582,16 +582,11 @@ class Generator {
 	 * @throws NotPermittedException
 	 */
 	private function getPreviewFolder(File $file) {
-		// Obtain file id outside of try catch block to prevent the creation of an existing folder
-		$fileId = (string)$file->getId();
-
-		try {
-			$folder = $this->appData->getFolder($fileId);
-		} catch (NotFoundException $e) {
-			$folder = $this->appData->newFolder($fileId);
+		try{
+			return $this->appData->newFolder((string)$file->getId());
+		} catch (NotPermittedException $e) {
+			throw new NotFoundException('Creation or access of preview directory not permitted!');
 		}
-
-		return $folder;
 	}
 
 	/**


### PR DESCRIPTION
Problem:
Generator fails to create preview-structure and files in an empty preview-structure (e.g. after occ preview:clean)

Cause:
Changed iFolder getFolder/ newFolder logic: getFolder(string path) throws unhandled NotPermittedException if an not existing path is supplied, which is regularly the case in an empty preview-dir structure. Anyway it's usage is obsolete here:
https://github.com/nextcloud/server/blob/249e33fcd67034b63aafdc7c3debd84982eb3cb3/lib/private/Files/SimpleFS/SimpleFolder.php#L75
https://github.com/nextcloud/server/blob/249e33fcd67034b63aafdc7c3debd84982eb3cb3/lib/private/Files/Node/Folder.php#L48
Fix:
newFolder(string name) already implements the needed behaviour: It checks for an existing directory prior creating the new one and throws only if a folder with the new name does not already exist AND could not be created. 
https://github.com/nextcloud/server/blob/249e33fcd67034b63aafdc7c3debd84982eb3cb3/lib/private/Files/Node/Folder.php#L124

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- As most (dev-)installation come with already filled preview-folder structures,  a test might be helpful to verify ability to create preview(-folder)s from scratch.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
