### PR TITLE
chore: Add an autoload.php file for tests relying on core class

### DIFF
--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+require_once __DIR__ . '/../lib/base.php';
+
+/**
+ * This is a file that applications can require to be able to autoload the class Test\TestCase from Nextcloud tests
+ */
+
+\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,8 +12,8 @@ if ($configDir) {
 }
 
 require_once __DIR__ . '/../lib/base.php';
+require_once __DIR__ . '/autoload.php';
 
-\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);
 \OC::$composerAutoloader->addPsr4('Tests\\', OC::$SERVERROOT . '/tests/', true);
 
 // load all enabled apps


### PR DESCRIPTION
## Summary

Some applications are directly referring to `OC::$loader` in their tests bootstrap.php to be able to load `Test\TestCase` class.

This adds an autoload.php file that they can use instead, to allow core to refactor TestCase autoloading without breaking apps.

Pre-requisite for https://github.com/nextcloud/server/pull/52945
 
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
