### PR TITLE
fix(files_versions): Log error instead of crashing when event listeners get called on non-existing files

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -125,6 +125,22 @@ class FileEventsListener implements IEventListener {
 	}
 
 	public function touch_hook(Node $node): void {
+		// Do not handle folders.
+		if ($node instanceof Folder) {
+			return;
+		}
+
+		if ($node instanceof NonExistingFile) {
+			$this->logger->error(
+				'Failed to create or update version for {path}, node does not exist',
+				[
+					'path' => $node->getPath(),
+				]
+			);
+
+			return;
+		}
+
 		$previousNode = $this->nodesTouched[$node->getId()] ?? null;
 
 		if ($previousNode === null) {
@@ -152,7 +168,22 @@ class FileEventsListener implements IEventListener {
 
 	public function created(Node $node): void {
 		// Do not handle folders.
-		if ($node instanceof File && $this->versionManager instanceof INeedSyncVersionBackend) {
+		if (!($node instanceof File)) {
+			return;
+		}
+
+		if ($node instanceof NonExistingFile) {
+			$this->logger->error(
+				'Failed to create version for {path}, node does not exist',
+				[
+					'path' => $node->getPath(),
+				]
+			);
+
+			return;
+		}
+
+		if ($this->versionManager instanceof INeedSyncVersionBackend) {
 			$this->versionManager->createVersionEntity($node);
 		}
 	}
@@ -187,6 +218,17 @@ class FileEventsListener implements IEventListener {
 	public function post_write_hook(Node $node): void {
 		// Do not handle folders.
 		if ($node instanceof Folder) {
+			return;
+		}
+
+		if ($node instanceof NonExistingFile) {
+			$this->logger->error(
+				'Failed to create or update version for {path}, node does not exist',
+				[
+					'path' => $node->getPath(),
+				]
+			);
+
 			return;
 		}
 


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
