### PR TITLE
Add integration tests for deleting a file copied from a share

### DIFF
--- a/build/integration/dav_features/webdav-related.feature
+++ b/build/integration/dav_features/webdav-related.feature
@@ -169,6 +169,40 @@ Feature: webdav-related
 		Then the HTTP status code should be "403"
 		And Downloaded content when downloading file "/testshare/overwritethis.txt" with range "bytes=0-6" should be "Welcome"
 
+	Scenario: Deleting a file copied from a received share
+		Given using old dav path
+		And user "user0" exists
+		And user "user1" exists
+		And User "user0" uploads file "data/textfile.txt" to "/test.txt"
+		And As an "user0"
+		And creating a share with
+		  | path | /test.txt |
+		  | shareType | 0 |
+		  | shareWith | user1 |
+		And As an "user1"
+		And accepting last share
+		When User "user1" copies file "/test.txt" to "/copied.txt"
+		And User "user1" deletes file "/copied.txt"
+		Then the HTTP status code should be "204"
+
+	Scenario: Deleting a file copied from a received shared folder without delete permission
+		Given using old dav path
+		And user "user0" exists
+		And user "user1" exists
+		And User "user0" created a folder "/Test"
+		And User "user0" uploads file "data/textfile.txt" to "/Test/test.txt"
+		And As an "user0"
+		And creating a share with
+		  | path | /Test |
+		  | shareType | 0 |
+		  | shareWith | user1 |
+		  | permissions | 23 |
+		And As an "user1"
+		And accepting last share
+		When User "user1" copies file "/Test/test.txt" to "/copied.txt"
+		And User "user1" deletes file "/copied.txt"
+		Then the HTTP status code should be "204"
+
 	Scenario: download a file with range
 		Given using old dav path
 		And As an "admin"


### PR DESCRIPTION
See #51846

:warning: :warning: :warning: So far **only the tests were added**, the bug still needs to be fixed (and I would need someone to take over :shrug: Maybe @icewind1991 or @artonge ? Thanks!) :warning: :warning: :warning:

After https://github.com/nextcloud/server/pull/48651/commits/199b0bd4d9d32bab41c308515a23facd38c8331e if a received share was copied, or if a file was copied from a received shared folder without delete permissions, the copied file could not be deleted. The problem seems to be that the cache of the files copied from a storage (like a share) is also copied, so the permissions of the copied file are the same as the permissions of the original file. The regression appeared only for files copied to a local storage; files copied to an object store retained their permissions already before that commit, unless [it was explicitly disabled by setting `handleCopiesAsOwned`](https://github.com/nextcloud/server/pull/41565).

Note that [single file shares do not have the delete permission](https://github.com/nextcloud/server/blob/4a9dc6c64dc29599126576e0b925492119ae4424/apps/files_sharing/lib/Controller/ShareAPIController.php#L627-L628), so it happened even without explicitly disabling it (and, in fact, it is not even possible to explicitly enable it, it is always disabled).

For reference, both when copying a received share and when copying a file from a received shared folder if the file is copied in a local storage the permissions can be fixed by rescanning it with `occ files:scan` (or `occ groupfolders:scan` if it is copied into a group folder). On the other hand, this has no effect when using an object store.

In the case of single file shares the bug was fixed (or, at least, the first test passes, maybe there are other cases) with https://github.com/nextcloud/server/pull/48769/commits/88c685f27c39e39f05da231968c53117a97aedfb when using an object store, and with https://github.com/nextcloud/server/pull/48769/commits/6419de7accfdb0d870aeb5cf48ae9ce0ad3cfb43 when using local storage, but it is still present in both cases when copying files from a received shared folder without delete permissions (second test).

As the scenarios were added to _dav_features/webdav-related.feature_ they are also [run with an object store as primary storage in CI](https://github.com/nextcloud/server/blob/ce26d5450ac5124beada0522d60847a85bc49f54/.github/workflows/integration-s3-primary.yml#L99). Note that `handleCopiesAsOwned` is not [set](https://github.com/nextcloud/server/issues/46248#issuecomment-2213664923)), but as mentioned the first test passes nevertheless after https://github.com/nextcloud/server/pull/48769/commits/88c685f27c39e39f05da231968c53117a97aedfb.
