### PR TITLE
perf: Skip photos related properties in custom properties

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -92,6 +92,11 @@ class CustomPropertiesBackend implements BackendInterface {
 		'{http://nextcloud.org/ns}lock-time',
 		'{http://nextcloud.org/ns}lock-timeout',
 		'{http://nextcloud.org/ns}lock-token',
+		// photos
+		'{http://nextcloud.org/ns}realpath',
+		'{http://nextcloud.org/ns}nbItems',
+		'{http://nextcloud.org/ns}face-detections',
+		'{http://nextcloud.org/ns}face-preview-image',
 	];
 
 	/**


### PR DESCRIPTION
We probably should think about better ways to generally exclude known ones (maybe we can even just skip any in the oc or nc namespace, but this saves 1 query per file in WebDAV search requests that the photos app is doing:

https://blackfire.io/profiles/compare/53aede2e-4560-4dff-8dcc-80e925e2fc4a/graph