### PR TITLE
perf(files): Move cache garbage collection to a background job

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 // Backends
+use OC\Files\SetupManager;
 use OC\KnownUser\KnownUserService;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\CalendarRoot;
@@ -40,6 +41,7 @@ $authBackend = new Auth(
 	Server::get(IRequest::class),
 	Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
 	Server::get(IThrottler::class),
+	Server::get(SetupManager::class),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/carddav.php
+++ b/apps/dav/appinfo/v1/carddav.php
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 // Backends
+use OC\Files\SetupManager;
 use OC\KnownUser\KnownUserService;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
@@ -41,6 +42,7 @@ $authBackend = new Auth(
 	Server::get(IRequest::class),
 	Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
 	Server::get(IThrottler::class),
+	Server::get(SetupManager::class),
 	'principals/'
 );
 $principalBackend = new Principal(

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 use OC\Files\Filesystem;
+use OC\Files\SetupManager;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\BearerAuth;
 use OCA\DAV\Connector\Sabre\ServerFactory;
@@ -55,6 +56,7 @@ $authBackend = new Auth(
 	Server::get(IRequest::class),
 	Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
 	Server::get(IThrottler::class),
+	Server::get(SetupManager::class),
 	'principals/'
 );
 $authPlugin = new \Sabre\DAV\Auth\Plugin($authBackend);

--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Connector\Sabre;
 use Exception;
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\TwoFactorAuth\Manager;
+use OC\Files\SetupManager;
 use OC\User\Session;
 use OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden;
 use OCA\DAV\Connector\Sabre\Exception\TooManyRequests;
@@ -37,6 +38,7 @@ class Auth extends AbstractBasic {
 		private IRequest $request,
 		private Manager $twoFactorManager,
 		private IThrottler $throttler,
+		private SetupManager $setupManager,
 		string $principalPrefix = 'principals/users/',
 	) {
 		$this->principalPrefix = $principalPrefix;
@@ -118,7 +120,7 @@ class Auth extends AbstractBasic {
 	 * Checks whether a CSRF check is required on the request
 	 */
 	private function requiresCSRFCheck(): bool {
-		
+
 		$methodsWithoutCsrf = ['GET', 'HEAD', 'OPTIONS'];
 		if (in_array($this->request->getMethod(), $methodsWithoutCsrf)) {
 			return false;
@@ -183,10 +185,13 @@ class Auth extends AbstractBasic {
 				($this->userSession->isLoggedIn() && $this->session->get(self::DAV_AUTHENTICATED) === $this->userSession->getUser()->getUID() && empty($request->getHeader('Authorization'))) ||
 				\OC_User::handleApacheAuth()
 			) {
-				$user = $this->userSession->getUser()->getUID();
-				$this->currentUser = $user;
+				$user = $this->userSession->getUser();
+				$this->setupManager->setupForUser($user);
+
+				$uid = $user->getUID();
+				$this->currentUser = $uid;
 				$this->session->close();
-				return [true, $this->principalPrefix . $user];
+				return [true, $this->principalPrefix . $uid];
 			}
 		}
 
@@ -201,6 +206,12 @@ class Auth extends AbstractBasic {
 			$response->setStatus(Http::STATUS_UNAUTHORIZED);
 			throw new \Sabre\DAV\Exception\NotAuthenticated('Cannot authenticate over ajax calls');
 		}
+
+		$user = $this->userSession->getUser();
+		if ($user !== null) {
+			$this->setupManager->setupForUser($user);
+		}
+
 		return $data;
 	}
 }

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -7,6 +7,7 @@
 namespace OCA\DAV;
 
 use OC\Files\Filesystem;
+use OC\Files\SetupManager;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\BulkUpload\BulkUploadPlugin;
 use OCA\DAV\CalDAV\BirthdayCalendar\EnablePlugin;
@@ -130,7 +131,8 @@ class Server {
 			\OCP\Server::get(IUserSession::class),
 			\OCP\Server::get(IRequest::class),
 			\OCP\Server::get(\OC\Authentication\TwoFactorAuth\Manager::class),
-			\OCP\Server::get(IThrottler::class)
+			\OCP\Server::get(IThrottler::class),
+			\OCP\Server::get(SetupManager::class),
 		);
 
 		// Set URL explicitly due to reverse-proxy situations

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -9,6 +9,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OC\Authentication\Exceptions\PasswordLoginForbiddenException;
 use OC\Authentication\TwoFactorAuth\Manager;
+use OC\Files\SetupManager;
 use OC\User\Session;
 use OCA\DAV\Connector\Sabre\Auth;
 use OCA\DAV\Connector\Sabre\Exception\PasswordLoginForbidden;
@@ -41,6 +42,7 @@ class AuthTest extends TestCase {
 	private $twoFactorManager;
 	/** @var IThrottler&MockObject */
 	private $throttler;
+	private SetupManager&MockObject $setupManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -56,12 +58,16 @@ class AuthTest extends TestCase {
 		$this->throttler = $this->getMockBuilder(IThrottler::class)
 			->disableOriginalConstructor()
 			->getMock();
+		$this->setupManager = $this->getMockBuilder(SetupManager::class)
+			->disableOriginalConstructor()
+			->getMock();
 		$this->auth = new Auth(
 			$this->session,
 			$this->userSession,
 			$this->request,
 			$this->twoFactorManager,
-			$this->throttler
+			$this->throttler,
+			$this->setupManager,
 		);
 	}
 
@@ -670,7 +676,7 @@ class AuthTest extends TestCase {
 			->method('getUID')
 			->willReturn('MyTestUser');
 		$this->userSession
-			->expects($this->exactly(3))
+			->expects($this->exactly(4))
 			->method('getUser')
 			->willReturn($user);
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);

--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -33,6 +33,7 @@
 		<job>OCA\Files\BackgroundJob\CleanupFileLocks</job>
 		<job>OCA\Files\BackgroundJob\CleanupDirectEditingTokens</job>
 		<job>OCA\Files\BackgroundJob\DeleteExpiredOpenLocalEditor</job>
+		<job>OCA\Files\BackgroundJob\CacheGarbageCollection</job>
 	</background-jobs>
 
 	<commands>

--- a/apps/files/composer/composer/autoload_classmap.php
+++ b/apps/files/composer/composer/autoload_classmap.php
@@ -19,6 +19,7 @@ return array(
     'OCA\\Files\\AdvancedCapabilities' => $baseDir . '/../lib/AdvancedCapabilities.php',
     'OCA\\Files\\App' => $baseDir . '/../lib/App.php',
     'OCA\\Files\\AppInfo\\Application' => $baseDir . '/../lib/AppInfo/Application.php',
+    'OCA\\Files\\BackgroundJob\\CacheGarbageCollection' => $baseDir . '/../lib/BackgroundJob/CacheGarbageCollection.php',
     'OCA\\Files\\BackgroundJob\\CleanupDirectEditingTokens' => $baseDir . '/../lib/BackgroundJob/CleanupDirectEditingTokens.php',
     'OCA\\Files\\BackgroundJob\\CleanupFileLocks' => $baseDir . '/../lib/BackgroundJob/CleanupFileLocks.php',
     'OCA\\Files\\BackgroundJob\\DeleteExpiredOpenLocalEditor' => $baseDir . '/../lib/BackgroundJob/DeleteExpiredOpenLocalEditor.php',

--- a/apps/files/composer/composer/autoload_static.php
+++ b/apps/files/composer/composer/autoload_static.php
@@ -34,6 +34,7 @@ class ComposerStaticInitFiles
         'OCA\\Files\\AdvancedCapabilities' => __DIR__ . '/..' . '/../lib/AdvancedCapabilities.php',
         'OCA\\Files\\App' => __DIR__ . '/..' . '/../lib/App.php',
         'OCA\\Files\\AppInfo\\Application' => __DIR__ . '/..' . '/../lib/AppInfo/Application.php',
+        'OCA\\Files\\BackgroundJob\\CacheGarbageCollection' => __DIR__ . '/..' . '/../lib/BackgroundJob/CacheGarbageCollection.php',
         'OCA\\Files\\BackgroundJob\\CleanupDirectEditingTokens' => __DIR__ . '/..' . '/../lib/BackgroundJob/CleanupDirectEditingTokens.php',
         'OCA\\Files\\BackgroundJob\\CleanupFileLocks' => __DIR__ . '/..' . '/../lib/BackgroundJob/CleanupFileLocks.php',
         'OCA\\Files\\BackgroundJob\\DeleteExpiredOpenLocalEditor' => __DIR__ . '/..' . '/../lib/BackgroundJob/DeleteExpiredOpenLocalEditor.php',

--- a/apps/files/lib/BackgroundJob/CacheGarbageCollection.php
+++ b/apps/files/lib/BackgroundJob/CacheGarbageCollection.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files\BackgroundJob;
+
+use Exception;
+use OC\Cache\File;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\IUser;
+use OCP\IUserManager;
+use Psr\Log\LoggerInterface;
+
+class CacheGarbageCollection extends TimedJob {
+	public function __construct(
+		ITimeFactory $time,
+		private IUserManager $userManager,
+		private LoggerInterface $logger,
+	) {
+		parent::__construct($time);
+
+		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		$this->setInterval(24 * 60 * 60);
+	}
+
+	protected function run(mixed $argument): void {
+		$cache = new File();
+
+		$this->userManager->callForSeenUsers(function (IUser $user) use ($cache): void {
+			$userId = $user->getUID();
+
+			try {
+				$cache->gc($userId);
+			} catch (Exception $e) {
+				$this->logger->warning('Exception when running cache gc.', [
+					'app' => 'files',
+					'user' => $userId,
+					'exception' => $e,
+				]);
+			}
+		});
+	}
+}

--- a/lib/base.php
+++ b/lib/base.php
@@ -889,23 +889,6 @@ class OC {
 					$throttler = Server::get(IThrottler::class);
 					$throttler->resetDelay($request->getRemoteAddress(), 'login', ['user' => $uid]);
 				}
-
-				try {
-					$cache = new \OC\Cache\File();
-					$cache->gc();
-				} catch (\OC\ServerNotAvailableException $e) {
-					// not a GC exception, pass it on
-					throw $e;
-				} catch (\OC\ForbiddenException $e) {
-					// filesystem blocked for this request, ignore
-				} catch (\Exception $e) {
-					// a GC exception should not prevent users from using OC,
-					// so log the exception
-					Server::get(LoggerInterface::class)->warning('Exception when running cache gc.', [
-						'app' => 'core',
-						'exception' => $e,
-					]);
-				}
 			});
 		}
 	}

--- a/lib/private/Cache/File.php
+++ b/lib/private/Cache/File.php
@@ -26,14 +26,20 @@ class File implements ICache {
 	 * @throws \OC\ForbiddenException
 	 * @throws \OC\User\NoUserException
 	 */
-	protected function getStorage() {
+	protected function getStorage(?string $userId = null) {
 		if ($this->storage !== null) {
 			return $this->storage;
 		}
-		$session = Server::get(IUserSession::class);
-		if ($session->isLoggedIn()) {
+
+		if ($userId === null) {
+			$session = Server::get(IUserSession::class);
+			if ($session->isLoggedIn()) {
+				$userId = $session->getUser()->getUID();
+			}
+		}
+
+		if ($userId !== null) {
 			$rootView = new View();
-			$userId = $session->getUser()->getUID();
 			Filesystem::initMountPoints($userId);
 			if (!$rootView->file_exists('/' . $userId . '/cache')) {
 				$rootView->mkdir('/' . $userId . '/cache');
@@ -154,8 +160,8 @@ class File implements ICache {
 	 * Runs GC
 	 * @throws \OC\ForbiddenException
 	 */
-	public function gc() {
-		$storage = $this->getStorage();
+	public function gc(?string $userId = null) {
+		$storage = $this->getStorage($userId);
 		if ($storage) {
 			// extra hour safety, in case of stray part chunks that take longer to write,
 			// because touch() is only called after the chunk was finished


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/31357

## Summary

Unlike previous attempts I did not try to change much of the logic, just stopped calling the GC in each request from base.php and moved that to a background job.
This brings down the base query count when calling /index.php/204 with basic auth credentials via curl from 22 to 14, because the FS doesn't need to be setup anymore before the controller is even called.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
