### PR TITLE
perf(dav): Preload dav search with tags/favorites

### DIFF
--- a/apps/dav/lib/Connector/Sabre/TagsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/TagsPlugin.php
@@ -94,6 +94,7 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 		$this->server = $server;
 		$this->server->on('propFind', [$this, 'handleGetProperties']);
 		$this->server->on('propPatch', [$this, 'handleUpdateProperties']);
+		$this->server->on('preloadProperties', [$this, 'handlePreloadProperties']);
 	}
 
 	/**
@@ -150,6 +151,24 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 	}
 
 	/**
+	 * Prefetches tags for a list of file IDs and caches the results
+	 *
+	 * @param array $fileIds List of file IDs to prefetch tags for
+	 * @return void
+	 */
+	private function prefetchTagsForFileIds(array $fileIds) {
+		$tags = $this->getTagger()->getTagsForObjects($fileIds);
+		if ($tags === false) {
+			// the tags API returns false on error...
+			$tags = [];
+		}
+
+		foreach ($fileIds as $fileId) {
+			$this->cachedTags[$fileId] = $tags[$fileId] ?? [];
+		}
+	}
+
+	/**
 	 * Updates the tags of the given file id
 	 *
 	 * @param int $fileId
@@ -199,22 +218,11 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 			)) {
 			// note: pre-fetching only supported for depth <= 1
 			$folderContent = $node->getChildren();
-			$fileIds[] = (int)$node->getId();
+			$fileIds = [(int)$node->getId()];
 			foreach ($folderContent as $info) {
 				$fileIds[] = (int)$info->getId();
 			}
-			$tags = $this->getTagger()->getTagsForObjects($fileIds);
-			if ($tags === false) {
-				// the tags API returns false on error...
-				$tags = [];
-			}
-
-			$this->cachedTags = $this->cachedTags + $tags;
-			$emptyFileIds = array_diff($fileIds, array_keys($tags));
-			// also cache the ones that were not found
-			foreach ($emptyFileIds as $fileId) {
-				$this->cachedTags[$fileId] = [];
-			}
+			$this->prefetchTagsForFileIds($fileIds);
 		}
 
 		$isFav = null;
@@ -269,5 +277,15 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 
 			return 200;
 		});
+	}
+
+	public function handlePreloadProperties(array $nodes, array $requestProperties): void {
+		if (
+			!in_array(self::FAVORITE_PROPERTYNAME, $requestProperties, true) &&
+			!in_array(self::TAGS_PROPERTYNAME, $requestProperties, true)
+		) {
+			return;
+		}
+		$this->prefetchTagsForFileIds(array_map(fn ($node) => $node->getId(), $nodes));
 	}
 }

--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -15,6 +15,7 @@ use OCA\DAV\Connector\Sabre\CachingTree;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
+use OCA\DAV\Connector\Sabre\Server;
 use OCA\DAV\Connector\Sabre\TagsPlugin;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Folder;
@@ -44,6 +45,7 @@ class FileSearchBackend implements ISearchBackend {
 	public const OPERATOR_LIMIT = 100;
 
 	public function __construct(
+		private Server $server,
 		private CachingTree $tree,
 		private IUser $user,
 		private IRootFolder $rootFolder,
@@ -133,6 +135,7 @@ class FileSearchBackend implements ISearchBackend {
 	 * @param string[] $requestProperties
 	 */
 	public function preloadPropertyFor(array $nodes, array $requestProperties): void {
+		$this->server->emit('preloadProperties', [$nodes, $requestProperties]);
 	}
 
 	private function getFolderForPath(?string $path = null): Folder {

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -354,6 +354,7 @@ class Server {
 						\OCP\Server::get(IAppManager::class)
 					));
 					$lazySearchBackend->setBackend(new FileSearchBackend(
+						$this->server,
 						$this->server->tree,
 						$user,
 						\OCP\Server::get(IRootFolder::class),


### PR DESCRIPTION
Save one query per file for aggregating tags/favorites on SEARCH requests by using the existing reload logic from propFinds.

This also introduces an event so it may be useful in other plugins in the future

https://blackfire.io/profiles/compare/1605ef6c-6a3d-4a77-aecd-69331df2b476/graph