### PR TITLE
chore: Set correct version for new UserMount events

### DIFF
--- a/lib/public/Files/Config/Event/UserMountAddedEvent.php
+++ b/lib/public/Files/Config/Event/UserMountAddedEvent.php
@@ -16,7 +16,7 @@ use OCP\Files\Mount\IMountPoint;
 /**
  * Event emitted when a user mount was added.
  *
- * @since 31.0.0
+ * @since 32.0.0
  */
 class UserMountAddedEvent extends Event {
 	public function __construct(

--- a/lib/public/Files/Config/Event/UserMountRemovedEvent.php
+++ b/lib/public/Files/Config/Event/UserMountRemovedEvent.php
@@ -16,7 +16,7 @@ use OCP\Files\Mount\IMountPoint;
 /**
  * Event emitted when a user mount was removed.
  *
- * @since 31.0.0
+ * @since 32.0.0
  */
 class UserMountRemovedEvent extends Event {
 	public function __construct(

--- a/lib/public/Files/Config/Event/UserMountUpdatedEvent.php
+++ b/lib/public/Files/Config/Event/UserMountUpdatedEvent.php
@@ -16,7 +16,7 @@ use OCP\Files\Mount\IMountPoint;
 /**
  * Event emitted when a user mount was moved.
  *
- * @since 31.0.0
+ * @since 32.0.0
  */
 class UserMountUpdatedEvent extends Event {
 	public function __construct(


### PR DESCRIPTION
## Summary

PR https://github.com/nextcloud/server/pull/50157 was opened before 31 was released and merged yesterday, but the since version was not correct anymore.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
