### PR TITLE
fix(node): emit hooks on `Node::copy()`

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -938,7 +938,7 @@ class View {
 
 			try {
 				$exists = $this->file_exists($target);
-				if ($this->shouldEmitHooks()) {
+				if ($this->shouldEmitHooks($target)) {
 					\OC_Hook::emit(
 						Filesystem::CLASSNAME,
 						Filesystem::signal_copy,
@@ -978,7 +978,7 @@ class View {
 					$this->changeLock($target, ILockingProvider::LOCK_SHARED);
 					$lockTypePath2 = ILockingProvider::LOCK_SHARED;
 
-					if ($this->shouldEmitHooks() && $result !== false) {
+					if ($this->shouldEmitHooks($target) && $result !== false) {
 						\OC_Hook::emit(
 							Filesystem::CLASSNAME,
 							Filesystem::signal_post_copy,


### PR DESCRIPTION
When calling `Files\Node\Node::copy()`, `Files\View::copy()` gets called, but `Files\View::fakeRoot` is empty so the hooks are not emitted if no path is given to `Files\View::shouldEmitHooks()`.

This results in node-related events like `NodeCopiedEvent` not being fired when copying files via `Files\Node\Node::copy()`.

`Files\View::shouldEmitHooks()` is given a path as parameter in almost all places except when called from the `copy()` function. This commit changes it and passes the copy target path.

Fixes: nextcloud/collectives#1756

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
