### PR TITLE
feat: Forward sizeDifference on update

### DIFF
--- a/lib/private/Files/Cache/Scanner.php
+++ b/lib/private/Files/Cache/Scanner.php
@@ -228,7 +228,6 @@ class Scanner extends BasicEmitter implements IScanner {
 				}
 
 				if ($cacheData !== false) {
-					$data['oldSize'] = $cacheData['size'] ?? 0;
 					$data['encrypted'] = $cacheData['encrypted'] ?? false;
 				}
 

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -111,10 +111,6 @@ class Updater implements IUpdater {
 
 		$data = $this->scanner->scan($path, Scanner::SCAN_SHALLOW, -1, false);
 
-		if (isset($data['oldSize']) && isset($data['size'])) {
-			$sizeDifference = $data['size'] - $data['oldSize'];
-		}
-
 		// encryption is a pita and touches the cache itself
 		if (isset($data['encrypted']) && (bool)$data['encrypted']) {
 			$sizeDifference = null;


### PR DESCRIPTION
And remove unneeded `oldSize` hack.

## Reason

This will speed up update operations on S3 as primary storage by preventing the recomputation of the size of each folder higher up in the hierarchy.

## Rational

When using S3 as primary storage, the `Scanner` is replaced with the `ObjectStoreScanner`. This means that we are not able to benefit from the `oldSize` property set in the `Scanner`.


- `Scanner` sets the `oldSize` property on the cache object:
https://github.com/nextcloud/server/blob/21526501d3df6e81c3e7f1f1cb486f0010255e2d/lib/private/Files/Cache/Scanner.php#L248

- `Updater` tries to access the `oldSize` property
https://github.com/nextcloud/server/blob/21526501d3df6e81c3e7f1f1cb486f0010255e2d/lib/private/Files/Cache/Updater.php#L134-L136

- `ObjectStoreScanner` just does nothing:
https://github.com/nextcloud/server/blob/21526501d3df6e81c3e7f1f1cb486f0010255e2d/lib/private/Files/ObjectStore/ObjectStoreScanner.php#L38-L40