### PR TITLE
fix(theming): Instead of expecting a warning handle it properly

### DIFF
--- a/apps/theming/lib/IconBuilder.php
+++ b/apps/theming/lib/IconBuilder.php
@@ -90,18 +90,17 @@ class IconBuilder {
 	 * Render app icon on themed background color
 	 * fallback to logo
 	 *
-	 * @param $app string app name
-	 * @param $size int size of the icon in px
+	 * @param string $app app name
+	 * @param int $size size of the icon in px
 	 * @return Imagick|false
 	 */
 	public function renderAppIcon($app, $size) {
 		$appIcon = $this->util->getAppIcon($app);
-		if ($appIcon === false) {
-			return false;
-		}
 		if ($appIcon instanceof ISimpleFile) {
 			$appIconContent = $appIcon->getContent();
 			$mime = $appIcon->getMimeType();
+		} elseif (!file_exists($appIcon)) {
+			return false;
 		} else {
 			$appIconContent = file_get_contents($appIcon);
 			$mime = mime_content_type($appIcon);
@@ -187,13 +186,13 @@ class IconBuilder {
 	}
 
 	/**
-	 * @param $app string app name
-	 * @param $image string relative path to svg file in app directory
+	 * @param string $app app name
+	 * @param string $image relative path to svg file in app directory
 	 * @return string|false content of a colorized svg file
 	 */
 	public function colorSvg($app, $image) {
 		$imageFile = $this->util->getAppImage($app, $image);
-		if ($imageFile === false || $imageFile === '') {
+		if ($imageFile === false || $imageFile === '' || !file_exists($imageFile)) {
 			return false;
 		}
 		$svg = file_get_contents($imageFile);

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -14,7 +14,6 @@ use OCP\App\IAppManager;
 use OCP\Files\NotFoundException;
 use OCP\IConfig;
 use OCP\ServerVersion;
-use PHPUnit\Framework\Error\Warning;
 use Test\TestCase;
 
 class IconBuilderTest extends TestCase {
@@ -165,8 +164,7 @@ class IconBuilderTest extends TestCase {
 
 	public function testGetFaviconNotFound(): void {
 		$this->checkImagick();
-		$this->expectWarning(Warning::class);
-		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
+		$util = $this->createMock(Util::class);
 		$iconBuilder = new IconBuilder($this->themingDefaults, $util, $this->imageManager);
 		$this->imageManager->expects($this->once())
 			->method('shouldReplaceIcons')
@@ -179,8 +177,7 @@ class IconBuilderTest extends TestCase {
 
 	public function testGetTouchIconNotFound(): void {
 		$this->checkImagick();
-		$this->expectWarning(Warning::class);
-		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
+		$util = $this->createMock(Util::class);
 		$iconBuilder = new IconBuilder($this->themingDefaults, $util, $this->imageManager);
 		$util->expects($this->once())
 			->method('getAppIcon')
@@ -190,8 +187,7 @@ class IconBuilderTest extends TestCase {
 
 	public function testColorSvgNotFound(): void {
 		$this->checkImagick();
-		$this->expectWarning(Warning::class);
-		$util = $this->getMockBuilder(Util::class)->disableOriginalConstructor()->getMock();
+		$util = $this->createMock(Util::class);
 		$iconBuilder = new IconBuilder($this->themingDefaults, $util, $this->imageManager);
 		$util->expects($this->once())
 			->method('getAppImage')


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
