### PR TITLE
feat(IUser): add `getQuotaBytes` method to get machine readable quota

### DIFF
--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -23,7 +23,6 @@ use OC\Share\Share;
 use OC\Share20\ShareDisableChecker;
 use OC_App;
 use OC_Hook;
-use OC_Util;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCA\Files_Sharing\External\Mount;
 use OCA\Files_Sharing\ISharedMountPoint;
@@ -157,7 +156,7 @@ class SetupManager {
 			if ($mount instanceof HomeMountPoint) {
 				$user = $mount->getUser();
 				return new Quota(['storage' => $storage, 'quotaCallback' => function () use ($user) {
-					return OC_Util::getUserQuota($user);
+					return $user->getQuotaBytes();
 				}, 'root' => 'files', 'include_external_storage' => $quotaIncludeExternal]);
 			}
 

--- a/lib/private/User/LazyUser.php
+++ b/lib/private/User/LazyUser.php
@@ -160,6 +160,10 @@ class LazyUser implements IUser {
 		return $this->getUser()->getQuota();
 	}
 
+	public function getQuotaBytes(): int|float {
+		return $this->getUser()->getQuotaBytes();
+	}
+
 	public function setQuota($quota) {
 		$this->getUser()->setQuota($quota);
 	}

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -558,6 +558,19 @@ class User implements IUser {
 		return $quota;
 	}
 
+	public function getQuotaBytes(): int|float {
+		$quota = $this->getQuota();
+		if ($quota === 'none') {
+			return \OCP\Files\FileInfo::SPACE_UNLIMITED;
+		}
+
+		$bytes = \OCP\Util::computerFileSize($quota);
+		if ($bytes === false) {
+			return \OCP\Files\FileInfo::SPACE_UNKNOWN;
+		}
+		return $bytes;
+	}
+
 	/**
 	 * set the users' quota
 	 *

--- a/lib/private/legacy/OC_Helper.php
+++ b/lib/private/legacy/OC_Helper.php
@@ -272,7 +272,7 @@ class OC_Helper {
 			} else {
 				$user = \OC::$server->getUserSession()->getUser();
 			}
-			$quota = OC_Util::getUserQuota($user);
+			$quota = $user?->getQuotaBytes() ?? \OCP\Files\FileInfo::SPACE_UNKNOWN;
 			if ($quota !== \OCP\Files\FileInfo::SPACE_UNLIMITED) {
 				// always get free space / total space from root + mount points
 				return self::getGlobalStorageInfo($quota, $user, $mount);

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -98,7 +98,7 @@ class OC_Util {
 	 *
 	 * @param IUser|null $user
 	 * @return int|\OCP\Files\FileInfo::SPACE_UNLIMITED|false|float Quota bytes
-	 * @deprecated 9.0.0 - Use \OCP\IUser::getQuota
+	 * @deprecated 9.0.0 - Use \OCP\IUser::getQuota or \OCP\IUser::getQuotaBytes
 	 */
 	public static function getUserQuota(?IUser $user) {
 		if (is_null($user)) {

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -281,6 +281,15 @@ interface IUser {
 	public function getQuota();
 
 	/**
+	 * Get the users' quota in machine readable form. If a specific quota is set
+	 * for the user, then the quota is returned in bytes. Otherwise the default value is returned.
+	 * If a default setting was not set, it is return as `\OCP\Files\FileInfo::SPACE_UNLIMITED`, i.e. quota is not limited.
+	 *
+	 * @since 32.0.0
+	 */
+	public function getQuotaBytes(): int|float;
+
+	/**
 	 * set the users' quota
 	 *
 	 * @param string $quota

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -14,6 +14,7 @@ use OC\Hooks\PublicEmitter;
 use OC\User\User;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\FileInfo;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\IURLGenerator;
@@ -834,8 +835,8 @@ class UserTest extends TestCase {
 		$config->method('getAppValue')
 			->will($this->returnValueMap($appValueMap));
 
-		$quota = $user->getQuota();
-		$this->assertEquals('none', $quota);
+		$this->assertEquals('none', $user->getQuota());
+		$this->assertEquals(FileInfo::SPACE_UNLIMITED, $user->getQuotaBytes());
 	}
 
 	public function testGetDefaultUnlimitedQuotaForbidden(): void {
@@ -868,8 +869,8 @@ class UserTest extends TestCase {
 		$config->method('getAppValue')
 			->will($this->returnValueMap($appValueMap));
 
-		$quota = $user->getQuota();
-		$this->assertEquals('1 GB', $quota);
+		$this->assertEquals('1 GB', $user->getQuota());
+		$this->assertEquals(1024 * 1024 * 1024, $user->getQuotaBytes());
 	}
 
 	public function testSetQuotaAddressNoChange(): void {


### PR DESCRIPTION
## Summary

Proper replacement for deprecated `OC_Util::getUserQuota`. Also we still use this in some cases we can now replace, moreover it just makes sense to have a machine readable format in the API instead of only the human readable format which is less precise. Aligns also with `getQuota` of the quota storage, which already returned the machine readable format.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
