### PR TITLE
feat: auto-generate changelog on release

### DIFF
--- a/.github/workflows/generate-release-changelog.yml
+++ b/.github/workflows/generate-release-changelog.yml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
+name: Generate changelog on release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  changelog_generate:
+    runs-on: ubuntu-latest
+
+    # Only allowed to be run on nextcloud-releases repositories
+    if: ${{ github.repository_owner == 'nextcloud-releases' }}
+
+    steps:
+      - name: Check actor permission
+        uses: skjnldsv/check-actor-permission@69e92a3c4711150929bca9fcf34448c5bf5526e7 # v3.0
+        with:
+          require: write
+
+      - name: Checkout github_helper
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          repository: nextcloud/github_helper
+          path: github_helper
+
+      - name: Checkout server
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          path: server
+          fetch-depth: 0
+
+      - name: Get previous tag
+        shell: bash
+        run: |
+          cd server
+          # Print all tags
+          git log --decorate --oneline | egrep '^[0-9a-f]+ \((HEAD, )?tag: ' | sed -r 's/^.+tag: ([^ ]+)[,\)].+$/\1/g'
+          # Get the current tag
+          TAGS=$(git log --decorate --oneline | egrep '^[0-9a-f]+ \((HEAD, )?tag: ' | sed -r 's/^.+tag: ([^ ]+)[,\)].+$/\1/g')
+          CURRENT_TAG=$(echo "$TAGS" | head -n 1)
+          # Get the previous tag that is not an rc, beta or alpha
+          PREVIOUS_TAG=$(echo "$TAGS" | grep -v 'rc\|beta\|alpha' | sed -n '2p')
+          echo "CURRENT_TAG=$CURRENT_TAG" >> $GITHUB_ENV
+          echo "PREVIOUS_TAG=$PREVIOUS_TAG" >> $GITHUB_ENV
+          
+      - name: Verify current tag
+        run: |
+         if [ "${{ github.ref_name }}" != "${{ env.CURRENT_TAG }}" ]; then
+           echo "Current tag does not match the release tag. Exiting."
+           exit 1
+         fi
+
+      - name: Set up php 8.2
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2.33.0
+        with:
+          php-version: 8.2
+          coverage: none
+          ini-file: development
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set credentials
+        run: |
+          echo '{"username": "github-actions"}' > github_helper/credentials.json
+
+      - name: Generate changelog between ${{ env.PREVIOUS_TAG }} and ${{ github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd github_helper/changelog
+          composer install
+          php index.php generate:changelog --no-bots --format=forum server ${{ env.PREVIOUS_TAG }} ${{ github.ref_name }} > changelog.md
+
+      - name: Set changelog to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+         cd server
+         gh release edit ${{ github.ref_name }} --notes-file "../github_helper/changelog/changelog.md" --title "${{ github.ref_name }}"


### PR DESCRIPTION
Needs https://github.com/nextcloud/github_helper/pull/126

First step towards moving nc releases to https://github.com/nextcloud-releases/server

Example run:
1. https://github.com/nextcloud-releases/server/releases/tag/v30.0.11
2. https://github.com/nextcloud-releases/server/actions/runs/15184415512/job/42701384467