### PR TITLE
fix(autoloader): Fix location of class to be autoloadable

### DIFF
--- a/core/Listener/FeedBackHandler.php
+++ b/core/Listener/FeedBackHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OC\Core\Listener;
+
+use OC\Repair\Events\RepairAdvanceEvent;
+use OC\Repair\Events\RepairErrorEvent;
+use OC\Repair\Events\RepairFinishEvent;
+use OC\Repair\Events\RepairInfoEvent;
+use OC\Repair\Events\RepairStartEvent;
+use OC\Repair\Events\RepairStepEvent;
+use OC\Repair\Events\RepairWarningEvent;
+use OCP\EventDispatcher\Event;
+use OCP\IEventSource;
+use OCP\IL10N;
+
+class FeedBackHandler {
+	private int $progressStateMax = 100;
+	private int $progressStateStep = 0;
+	private string $currentStep = '';
+
+	public function __construct(
+		private IEventSource $eventSource,
+		private IL10N $l10n,
+	) {
+	}
+
+	public function handleRepairFeedback(Event $event): void {
+		if ($event instanceof RepairStartEvent) {
+			$this->progressStateMax = $event->getMaxStep();
+			$this->progressStateStep = 0;
+			$this->currentStep = $event->getCurrentStepName();
+		} elseif ($event instanceof RepairAdvanceEvent) {
+			$this->progressStateStep += $event->getIncrement();
+			$desc = $event->getDescription();
+			if (empty($desc)) {
+				$desc = $this->currentStep;
+			}
+			$this->eventSource->send('success', $this->l10n->t('[%d / %d]: %s', [$this->progressStateStep, $this->progressStateMax, $desc]));
+		} elseif ($event instanceof RepairFinishEvent) {
+			$this->progressStateMax = $this->progressStateStep;
+			$this->eventSource->send('success', $this->l10n->t('[%d / %d]: %s', [$this->progressStateStep, $this->progressStateMax, $this->currentStep]));
+		} elseif ($event instanceof RepairStepEvent) {
+			$this->eventSource->send('success', $this->l10n->t('Repair step:') . ' ' . $event->getStepName());
+		} elseif ($event instanceof RepairInfoEvent) {
+			$this->eventSource->send('success', $this->l10n->t('Repair info:') . ' ' . $event->getMessage());
+		} elseif ($event instanceof RepairWarningEvent) {
+			$this->eventSource->send('notice', $this->l10n->t('Repair warning:') . ' ' . $event->getMessage());
+		} elseif ($event instanceof RepairErrorEvent) {
+			$this->eventSource->send('error', $this->l10n->t('Repair error:') . ' ' . $event->getMessage());
+		}
+	}
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1387,6 +1387,7 @@ return array(
     'OC\\Core\\Exception\\ResetPasswordException' => $baseDir . '/core/Exception/ResetPasswordException.php',
     'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => $baseDir . '/core/Listener/BeforeMessageLoggedEventListener.php',
     'OC\\Core\\Listener\\BeforeTemplateRenderedListener' => $baseDir . '/core/Listener/BeforeTemplateRenderedListener.php',
+    'OC\\Core\\Listener\\FeedBackHandler' => $baseDir . '/core/Listener/FeedBackHandler.php',
     'OC\\Core\\Middleware\\TwoFactorMiddleware' => $baseDir . '/core/Middleware/TwoFactorMiddleware.php',
     'OC\\Core\\Migrations\\Version13000Date20170705121758' => $baseDir . '/core/Migrations/Version13000Date20170705121758.php',
     'OC\\Core\\Migrations\\Version13000Date20170718121200' => $baseDir . '/core/Migrations/Version13000Date20170718121200.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1428,6 +1428,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Exception\\ResetPasswordException' => __DIR__ . '/../../..' . '/core/Exception/ResetPasswordException.php',
         'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => __DIR__ . '/../../..' . '/core/Listener/BeforeMessageLoggedEventListener.php',
         'OC\\Core\\Listener\\BeforeTemplateRenderedListener' => __DIR__ . '/../../..' . '/core/Listener/BeforeTemplateRenderedListener.php',
+        'OC\\Core\\Listener\\FeedBackHandler' => __DIR__ . '/../../..' . '/core/Listener/FeedBackHandler.php',
         'OC\\Core\\Middleware\\TwoFactorMiddleware' => __DIR__ . '/../../..' . '/core/Middleware/TwoFactorMiddleware.php',
         'OC\\Core\\Migrations\\Version13000Date20170705121758' => __DIR__ . '/../../..' . '/core/Migrations/Version13000Date20170705121758.php',
         'OC\\Core\\Migrations\\Version13000Date20170718121200' => __DIR__ . '/../../..' . '/core/Migrations/Version13000Date20170718121200.php',


### PR DESCRIPTION
> Class FeedBackHandler located in ./core/ajax/update.php does not comply with psr-4 autoloading standard (rule: OC\Core\ => ./core). Skipping.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
