### PR TITLE
chore(codeowners): add codeowners for calendar and contacts api

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,8 +92,10 @@ ResponseDefinitions.php             @provokateurin @nextcloud/server-backend
 /lib/public/UserStatus              @nickvergessen @nextcloud/talk-backend
 
 # Groupware
-/build/integration/dav_features/caldav.feature    @st3iny @SebastianKrupinski
-/build/integration/dav_features/carddav.feature   @st3iny @SebastianKrupinski
+/build/integration/dav_features/caldav.feature		@st3iny @SebastianKrupinski @tcitworld
+/build/integration/dav_features/carddav.feature		@hamza221 @SebastianKrupinski
+/lib/public/Calendar					@st3iny @SebastianKrupinski @tcitworld
+/lib/public/Contacts					@hamza221 @SebastianKrupinski
 
 # Personal interest
 */Activity/*                        @nickvergessen @nextcloud/server-backend


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Requesting a review from gw when changing the public api.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
