### PR TITLE
fix(settings): change Mastodon only URI to webfinger

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -620,6 +620,7 @@
  - szaimen <szaimen@e.mail.de>
  - tbartenstein <tbartenstein@users.noreply.github.com>
  - tbelau666 <thomas.belau@gmx.de>
+ - TechnicalSuwako <suwako@076.moe>
  - tgrant <tom.grant760@gmail.com>
  - timm2k <timm2k@gmx.de>
  - tux-rampage <tux-rampage@users.noreply.github.com>

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -746,6 +746,23 @@ class AccountManager implements IAccountManager {
 					if (!is_array($decoded) || ($decoded['subject'] ?? '') !== "acct:{$username}@{$instance}") {
 						throw new InvalidArgumentException();
 					}
+					// check for activitypub link
+					if (is_array($decoded['links']) && isset($decoded['links'])) {
+						$found = false;
+						foreach ($decoded['links'] as $link) {
+							// have application/activity+json or application/ld+json
+							if (isset($link['type']) && (
+								$link['type'] === 'application/activity+json' ||
+								$link['type'] === 'application/ld+json; profile="https://www.w3.org/ns/activitystreams"'
+							)) {
+								$found = true;
+								break;
+							}
+						}
+						if (!$found) {
+							throw new InvalidArgumentException();
+						}
+					}
 				} catch (InvalidArgumentException) {
 					throw new InvalidArgumentException(self::PROPERTY_FEDIVERSE);
 				} catch (\Exception $error) {

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -734,7 +734,7 @@ class AccountManager implements IAccountManager {
 
 				try {
 					// try the public account lookup API of mastodon
-					$response = $client->get("https://{$instance}/api/v1/accounts/lookup?acct={$username}@{$instance}");
+					$response = $client->get("https://{$instance}/.well-known/webfinger?resource=acct:{$username}@{$instance}");
 					// should be a json response with account information
 					$data = $response->getBody();
 					if (is_resource($data)) {
@@ -743,7 +743,7 @@ class AccountManager implements IAccountManager {
 					$decoded = json_decode($data, true);
 					// ensure the username is the same the user passed
 					// in this case we can assume this is a valid fediverse server and account
-					if (!is_array($decoded) || ($decoded['username'] ?? '') !== $username) {
+					if (!is_array($decoded) || ($decoded['subject'] ?? '') !== "acct:{$username}@{$instance}") {
 						throw new InvalidArgumentException();
 					}
 				} catch (InvalidArgumentException) {

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -839,12 +839,12 @@ class AccountManagerTest extends TestCase {
 					->willReturn($serverResponse);
 				$client->expects(self::once())
 					->method('get')
-					->with('https://example.com/api/v1/accounts/lookup?acct=foo@example.com')
+					->with('https://example.com/.well-known/webfinger?resource=acct:foo@example.com')
 					->willReturn($response);
 			} else {
 				$client->expects(self::once())
 					->method('get')
-					->with('https://example.com/api/v1/accounts/lookup?acct=foo@example.com')
+					->with('https://example.com/.well-known/webfinger?resource=acct:foo@example.com')
 					->willThrowException(new \Exception('404'));
 			}
 

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -792,20 +792,41 @@ class AccountManagerTest extends TestCase {
 				'@foo@example.com',
 				'foo@example.com',
 				true,
-				json_encode(['username' => 'foo']),
+				json_encode([
+					'subject' => 'acct:foo@example.com',
+					'links' => [
+						[
+							'rel' => 'self',
+							'type' => 'application/activity+json',
+							'href' => 'https://example.com/users/foo',
+						],
+					],
+				]),
 			],
 			'valid response - no at' => [
 				'foo@example.com',
 				'foo@example.com',
 				true,
-				json_encode(['username' => 'foo']),
+				json_encode([
+					'subject' => 'acct:foo@example.com',
+					'links' => [
+						[
+							'rel' => 'self',
+							'type' => 'application/activity+json',
+							'href' => 'https://example.com/users/foo',
+						],
+					],
+				]),
 			],
 			// failures
 			'invalid response' => [
 				'@foo@example.com',
 				null,
 				true,
-				json_encode(['not found']),
+				json_encode([
+					'subject' => 'acct:foo@example.com',
+					'links' => [],
+				]),
 			],
 			'no response' => [
 				'@foo@example.com',
@@ -817,7 +838,9 @@ class AccountManagerTest extends TestCase {
 				'@foo@example.com',
 				null,
 				true,
-				json_encode(['username' => 'foo@other.example.com']),
+				json_encode([
+					'links' => [],
+				]),
 			],
 		];
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #53107

## Summary
The URI for Mastodon only has been changed to the URI used for all Fediverse servers.
`https://{$instance}/api/v1/accounts/lookup?acct={$username}@{$instance}` → `https://{$instance}.well-known/webfinger?resource=acct:{$username}@{$instance}`

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
