### PR TITLE
feat(settings): let group admins add any existing account to a managed group

### DIFF
--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -5,8 +5,6 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-
-//  comment for shits and giggles
 return [
 	'ocs' => [
 		// Apps

--- a/apps/provisioning_api/appinfo/routes.php
+++ b/apps/provisioning_api/appinfo/routes.php
@@ -5,6 +5,8 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
+//  comment for shits and giggles
 return [
 	'ocs' => [
 		// Apps
@@ -27,6 +29,7 @@ return [
 		// Users
 		['root' => '/cloud', 'name' => 'Users#getUsers', 'url' => '/users', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#getUsersDetails', 'url' => '/users/details', 'verb' => 'GET'],
+		['root' => '/cloud', 'name' => 'Users#searchAllUsers', 'url' => '/users/search', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#getDisabledUsersDetails', 'url' => '/users/disabled', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#getLastLoggedInUsers', 'url' => '/users/recent', 'verb' => 'GET'],
 		['root' => '/cloud', 'name' => 'Users#searchByPhoneNumbers', 'url' => '/users/search/by-phone', 'verb' => 'POST'],

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -8,8 +8,6 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-//  comment for shits and giggles
-
 namespace OCA\Provisioning_API\Controller;
 
 use InvalidArgumentException;

--- a/apps/provisioning_api/lib/Controller/UsersController.php
+++ b/apps/provisioning_api/lib/Controller/UsersController.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+//  comment for shits and giggles
+
 namespace OCA\Provisioning_API\Controller;
 
 use InvalidArgumentException;
@@ -336,6 +338,45 @@ class UsersController extends AUserDataOCSController {
 		return new DataResponse([
 			'users' => $usersDetails
 		]);
+	}
+
+
+	/**
+	* Search all users by id or display name
+	*
+	* Allows subadmins to look up existing users that are not yet part of
+	* their groups so they can add them.
+	*
+	* @param string $search Text to search for
+	* @param ?int $limit Limit the amount of users returned
+	* @param int $offset Offset for searching for users
+	* @return DataResponse<Http::STATUS_OK, array{users: array<string, string>}, array{}>
+	*
+	* 200: Users returned
+	*/
+	#[NoAdminRequired]
+	public function searchAllUsers(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
+			$currentUser = $this->userSession->getUser();
+
+			$uid = $currentUser->getUID();
+			$subAdminManager = $this->groupManager->getSubAdmin();
+			$isAdmin = $this->groupManager->isAdmin($uid);
+			$isDelegatedAdmin = $this->groupManager->isDelegatedAdmin($uid);
+
+			if ($isAdmin || $isDelegatedAdmin || $subAdminManager->isSubAdmin($currentUser)) {
+					$users = $this->userManager->searchDisplayName($search, $limit, $offset);
+					$result = [];
+					foreach ($users as $user) {
+							/** @var IUser $user */
+							$result[$user->getUID()] = $user->getDisplayName();
+					}
+
+					return new DataResponse([
+							'users' => $result,
+					]);
+			}
+
+			throw new OCSForbiddenException();
 	}
 
 

--- a/apps/settings/src/components/UserList.vue
+++ b/apps/settings/src/components/UserList.vue
@@ -3,14 +3,20 @@
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
+<!-- comment for shits and giggles -->
+
 <template>
 	<Fragment>
+
 		<NewUserDialog v-if="showConfig.showNewUserForm"
-			:loading="loading"
-			:new-user="newUser"
-			:quota-options="quotaOptions"
-			@reset="resetForm"
-			@closing="closeDialog" />
+                        :loading="loading"
+                        :new-user="newUser"
+                        :quota-options="quotaOptions"
+                        @reset="resetForm"
+                        @closing="closeDialog" />
+		<AddExistingUserDialog v-if="showConfig.showAddExistingUserForm"
+				:group="currentGroup"
+				@closing="closeAddExistingDialog" />
 
 		<NcEmptyContent v-if="filteredUsers.length === 0"
 			class="empty"
@@ -70,6 +76,7 @@ import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 
 import VirtualList from './Users/VirtualList.vue'
 import NewUserDialog from './Users/NewUserDialog.vue'
+import AddExistingUserDialog from './Users/AddExistingUserDialog.vue'
 import UserListFooter from './Users/UserListFooter.vue'
 import UserListHeader from './Users/UserListHeader.vue'
 import UserRow from './Users/UserRow.vue'
@@ -101,6 +108,7 @@ export default {
 		NcIconSvgWrapper,
 		NcLoadingIcon,
 		NewUserDialog,
+		AddExistingUserDialog,
 		UserListFooter,
 		UserListHeader,
 		VirtualList,
@@ -171,8 +179,16 @@ export default {
 		},
 
 		groups() {
-			return this.$store.getters.getSortedGroups
-				.filter(group => group.id !== '__nc_internal_recent' && group.id !== 'disabled')
+                        return this.$store.getters.getSortedGroups
+                                .filter(group => group.id !== '__nc_internal_recent' && group.id !== 'disabled')
+		},
+
+		currentGroup() {
+				const gid = this.selectedGroup
+				if (!gid) {
+						return null
+				}
+				return this.groups.find(g => g.id === gid) || null
 		},
 
 		quotaOptions() {
@@ -309,10 +325,17 @@ export default {
 		},
 
 		closeDialog() {
-			this.$store.commit('setShowConfig', {
-				key: 'showNewUserForm',
-				value: false,
-			})
+                       this.$store.commit('setShowConfig', {
+                               key: 'showNewUserForm',
+                               value: false,
+                       })
+		},
+
+		closeAddExistingDialog() {
+				this.$store.commit('setShowConfig', {
+						key: 'showAddExistingUserForm',
+						value: false,
+				})
 		},
 
 		async search({ query }) {

--- a/apps/settings/src/components/UserList.vue
+++ b/apps/settings/src/components/UserList.vue
@@ -2,9 +2,6 @@
   - SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-
-<!-- comment for shits and giggles -->
-
 <template>
 	<Fragment>
 

--- a/apps/settings/src/components/Users/AddExistingUserDialog.vue
+++ b/apps/settings/src/components/Users/AddExistingUserDialog.vue
@@ -1,0 +1,180 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<!-- comment for shits and giggles -->
+<template>
+    <NcDialog
+      class="dialog"
+      size="small"
+      :name="t('settings', 'Add existing account')"
+      out-transition
+      v-on="$listeners"
+    >
+      <form
+        id="add-existing-user-form"
+        class="dialog__form"
+        @submit.prevent="submit"
+      >
+        <NcSelect
+          v-model="selectedUser"
+          class="dialog__select"
+          :options="possibleUsers"
+          :placeholder="t('settings', 'Search accounts')"
+          :user-select="true"
+          :dropdown-should-open="dropdownShouldOpen"
+          label="displayname"
+          @search="searchUsers"
+        />
+        <NcSelect
+          v-model="selectedGroup"
+          class="dialog__select"
+          :options="availableGroups"
+          :placeholder="t('settings', 'Select group')"
+          label="name"
+          :disabled="preselectedGroup"
+          :clearable="false"
+        />
+      </form>
+      <template #actions>
+        <NcButton
+          class="dialog__submit"
+          form="add-existing-user-form"
+          type="primary"
+          native-type="submit"
+        >
+          {{ t('settings', 'Add to group') }}
+        </NcButton>
+      </template>
+    </NcDialog>
+  </template>
+  
+  <script>
+  import { t } from '@nextcloud/l10n'
+  import NcDialog from '@nextcloud/vue/components/NcDialog'
+  import NcSelect from '@nextcloud/vue/components/NcSelect'
+  import NcButton from '@nextcloud/vue/components/NcButton'
+  import { showError } from '@nextcloud/dialogs'
+  import { confirmPassword } from '@nextcloud/password-confirmation'
+  import logger from '../../logger.ts'
+  
+  export default {
+    name: 'AddExistingUserDialog',
+    components: { NcDialog, NcSelect, NcButton },
+    props: {
+      group: {
+        type: Object,
+        default: null,
+      },
+    },
+    data() {
+      return {
+        possibleUsers: [],
+        selectedUser: null,
+        availableGroups: [],
+        selectedGroup: null,
+        preselectedGroup: false,
+        promise: null,
+      }
+    },
+    mounted() {
+      // only subadmins see a filtered list
+      this.availableGroups = this.$store.getters.getSubAdminGroups
+      if (this.group) {
+        this.selectedGroup = this.group
+        this.preselectedGroup = true
+      }
+    },
+    methods: {
+      t,
+      async searchUsers(query) {
+        if (this.promise) {
+          this.promise.cancel?.()
+        }
+        try {
+          this.promise = this.$store.dispatch('searchUsers', {
+            offset: 0,
+            limit: 10,
+            search: query,
+          })
+          const resp = await this.promise
+          this.possibleUsers = resp?.data
+            ? Object.values(resp.data.ocs.data.users)
+            : []
+        } catch (error) {
+          logger.error(t('settings', 'Failed to search accounts'), { error })
+        } finally {
+          this.promise = null
+        }
+      },
+        /**
+         * Only open the dropdown once there's some text in the search-box.
+         * @param {object} vm  the vue-select instance
+         * @returns {boolean}
+         */
+        dropdownShouldOpen(vm) {
+            return vm.search && vm.search.length > 0;
+        },
+      async submit() {
+        if (!this.selectedUser || !this.selectedGroup) {
+          return
+        }
+  
+        // require the admin to re-enter their password
+        try {
+          await confirmPassword()
+        } catch {
+          showError(t('settings', 'Password confirmation is required'))
+          return
+        }
+  
+        try {
+          // now that we've confirmed, call the action (it will include the
+          // proper header automatically)
+          await this.$store.dispatch('addUserGroup', {
+            userid: this.selectedUser.id,
+            gid: this.selectedGroup.id,
+          })
+          // if this user wasn’t in the list yet, fetch their details
+          if (
+            !this.$store.getters
+              .getUsers.find((u) => u.id === this.selectedUser.id)
+          ) {
+            const resp = await this.$store.dispatch(
+              'getUser',
+              this.selectedUser.id
+            )
+            if (resp) {
+              this.$store.commit('addUserData', resp)
+            }
+          }
+          this.$emit('closing')
+        } catch (error) {
+          logger.error(t('settings', 'Failed to add user to group'), { error })
+          showError(t('settings', 'Failed to add user to group'))
+        }
+      },
+    },
+  }
+  </script>
+  
+  <style scoped lang="scss">
+  .dialog {
+    &__form {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 0 8px;
+      gap: 4px 0;
+    }
+    &__select {
+      width: 100%;
+    }
+    &__submit {
+      margin-top: 4px;
+      margin-bottom: 8px;
+    }
+  }
+  </style>
+  

--- a/apps/settings/src/components/Users/AddExistingUserDialog.vue
+++ b/apps/settings/src/components/Users/AddExistingUserDialog.vue
@@ -2,8 +2,6 @@
   - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
   - SPDX-License-Identifier: AGPL-3.0-or-later
 -->
-
-<!-- comment for shits and giggles -->
 <template>
     <NcDialog
       class="dialog"

--- a/apps/settings/src/store/users.js
+++ b/apps/settings/src/store/users.js
@@ -2,9 +2,6 @@
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-
-// comment for shits and giggles
-
 import { getBuilder } from '@nextcloud/browser-storage'
 import { getCapabilities } from '@nextcloud/capabilities'
 import { parseFileSize } from '@nextcloud/files'


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/).
-->

* Resolves: #11334

## Summary

This PR adds two related features:

1. **Frontend**  
   - A new **“Add existing account”** button in the User Management navigation.  
   - A modal dialog (`AddExistingUserDialog.vue`) that lets group-admins search for existing users and assign them to the currently selected group.  
   - Vuex state (`showAddExistingUserForm`) persisted alongside the “New account” form flag to open/close the dialog.

2. **Backend**  
   - A new **Provisioning API** endpoint:  
     ```
     GET /ocs/v2.php/cloud/users/search?search=<query>
     ```  
     Returns a JSON map of `userId => displayName` for all Nextcloud users matching the search string.  
   - Access restricted to admins, delegated admins, and subadmins (throws 403 otherwise).

## Screenshots


<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img width="299" alt="Before Image" src="https://github.com/user-attachments/assets/5ef6cc98-585b-45a7-b050-2415590543e1" /></td>
    <td><img width="297" alt="After" src="https://github.com/user-attachments/assets/fb785d8d-659d-4d49-9d50-dd6ec9f3ba6a" /></td>
  </tr>
</table>

## TODO

- [ ] **Unit tests**  
  - Frontend: tests for `AddExistingUserDialog.vue` (rendering, search behavior, submit).  
  - Backend: tests for `UsersController::searchAllUsers()` (success and 403 cases).
- [ ] **Integration/API tests** for the new `/users/search` endpoint.
- [X] **Screenshots** (before/after) of the new “Add existing account” button and dialog.
- [ ] **Documentation**  
  - Update the Admin Manual / Provisioning API docs to include `/users/search`.
  - Add a note in the “Groups” section of the User docs about this UI change.
- [ ] **Backport** request to the 32 and 31 branches if this lands post-release.

## Checklist

- [X] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [X] All commits carry a valid DCO sign-off
- [ ] Tests (unit, integration, API) are included
- [X] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) updated or noted “not required”
- [ ] Backports requested for stable branches where applicable

## Note

I just wanted to quickly note that I didn't update the documentation yet, since I wasn't sure if that should only be updated after this pull-request is potentially accepted!