### PR TITLE
fix: broken password reset form

### DIFF
--- a/core/Controller/LostController.php
+++ b/core/Controller/LostController.php
@@ -64,7 +64,7 @@ class LostController extends Controller {
 		private Defaults $defaults,
 		private IL10N $l10n,
 		private IConfig $config,
-		protected string $from,
+		protected string $defaultMailAddress,
 		private IManager $encryptionManager,
 		private IMailer $mailer,
 		private LoggerInterface $logger,
@@ -281,7 +281,7 @@ class LostController extends Controller {
 		try {
 			$message = $this->mailer->createMessage();
 			$message->setTo([$email => $user->getDisplayName()]);
-			$message->setFrom([$this->from => $this->defaults->getName()]);
+			$message->setFrom([$this->defaultMailAddress => $this->defaults->getName()]);
 			$message->useTemplate($emailTemplate);
 			$this->mailer->send($message);
 		} catch (Exception $e) {


### PR DESCRIPTION
Broke in https://github.com/nextcloud/server/pull/52820

From sermo:

```json
{
    "reqId": "Y8hD0xfuKQ9AbI9JCiTz",
    "level": 3,
    "time": "2025-05-26T15:42:16+00:00",
    "remoteAddr": "116.202.53.135",
    "user": "--",
    "app": "index",
    "method": "HEAD",
    "url": "/lostpassword/reset/form/dsjfjkldsfjkdsj/dsjfjkldsfjkdsj",
    "message": "Could not resolve from!",
    "userAgent": "Nextcloud Server Crawler",
    "version": "32.0.0.0",
    "exception": {
        "Exception": "OC\\AppFramework\\Utility\\QueryNotFoundException",
        "Message": "Could not resolve from!",
        "Code": 0,
        "Trace": [
            {
                "file": "/var/www/html/lib/private/ServerContainer.php",
                "line": 154,
                "function": "query",
                "class": "OC\\AppFramework\\Utility\\SimpleContainer",
                "type": "->",
                "args": [
                    "from",
                    false
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/DependencyInjection/DIContainer.php",
                "line": 415,
                "function": "query",
                "class": "OC\\ServerContainer",
                "type": "->",
                "args": [
                    "from",
                    false
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/Utility/SimpleContainer.php",
                "line": 74,
                "function": "query",
                "class": "OC\\AppFramework\\DependencyInjection\\DIContainer",
                "type": "->",
                "args": [
                    "from",
                    false
                ]
            },
            {
                "function": "OC\\AppFramework\\Utility\\{closure}",
                "class": "OC\\AppFramework\\Utility\\SimpleContainer",
                "type": "->",
                "args": [
                    "*** sensitive parameters replaced ***"
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/Utility/SimpleContainer.php",
                "line": 61,
                "function": "array_map",
                "args": [
                    {
                        "__class__": "Closure"
                    },
                    [
                        {
                            "__class__": "ReflectionParameter",
                            "name": "appName"
                        },
                        {
                            "__class__": "ReflectionParameter",
                            "name": "request"
                        },
                        {
                            "__class__": "ReflectionParameter",
                            "name": "urlGenerator"
                        },
                        {
                            "__class__": "ReflectionParameter",
                            "name": "userManager"
                        },
                        {
                            "__class__": "ReflectionParameter",
                            "name": "defaults"
                        },
                        "And 11 more entries, set log level to debug to see all entries"
                    ]
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/Utility/SimpleContainer.php",
                "line": 106,
                "function": "buildClass",
                "class": "OC\\AppFramework\\Utility\\SimpleContainer",
                "type": "->",
                "args": [
                    {
                        "__class__": "ReflectionClass",
                        "name": "OC\\Core\\Controller\\LostController"
                    }
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/Utility/SimpleContainer.php",
                "line": 124,
                "function": "resolve",
                "class": "OC\\AppFramework\\Utility\\SimpleContainer",
                "type": "->",
                "args": [
                    "OC\\Core\\Controller\\LostController"
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/DependencyInjection/DIContainer.php",
                "line": 438,
                "function": "query",
                "class": "OC\\AppFramework\\Utility\\SimpleContainer",
                "type": "->",
                "args": [
                    "OC\\Core\\Controller\\LostController"
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/DependencyInjection/DIContainer.php",
                "line": 412,
                "function": "queryNoFallback",
                "class": "OC\\AppFramework\\DependencyInjection\\DIContainer",
                "type": "->",
                "args": [
                    "OC\\Core\\Controller\\LostController"
                ]
            },
            {
                "file": "/var/www/html/lib/private/AppFramework/App.php",
                "line": 140,
                "function": "query",
                "class": "OC\\AppFramework\\DependencyInjection\\DIContainer",
                "type": "->",
                "args": [
                    "OC\\Core\\Controller\\LostController"
                ]
            },
            {
                "file": "/var/www/html/lib/private/Route/Router.php",
                "line": 313,
                "function": "main",
                "class": "OC\\AppFramework\\App",
                "type": "::",
                "args": [
                    "OC\\Core\\Controller\\LostController",
                    "resetform",
                    {
                        "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
                    },
                    {
                        "token": "f1xLLnCz0Q2jAVZNGE1tP",
                        "userId": "dsjfjkldsfjkdsj",
                        "_route": "core.lost.resetform"
                    }
                ]
            },
            {
                "file": "/var/www/html/lib/base.php",
                "line": 1063,
                "function": "match",
                "class": "OC\\Route\\Router",
                "type": "->",
                "args": [
                    "/lostpassword/reset/form/dshflsdhjsdhfshjdf/dsjfjkldsfjkdsj"
                ]
            },
            {
                "file": "/var/www/html/index.php",
                "line": 25,
                "function": "handleRequest",
                "class": "OC",
                "type": "::",
                "args": []
            }
        ],
        "File": "/var/www/html/lib/private/AppFramework/Utility/SimpleContainer.php",
        "Line": 131,
        "message": "Could not resolve from!",
        "exception": {},
        "CustomMessage": "Could not resolve from!"
    }
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
