### PR TITLE
test: Migrate DAV Systemtags tests to PHPUnit 10

### DIFF
--- a/apps/dav/tests/unit/CapabilitiesTest.php
+++ b/apps/dav/tests/unit/CapabilitiesTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -22,7 +23,7 @@ class ServerTest extends \Test\TestCase {
 	/**
 	 * @dataProvider providesUris
 	 */
-	public function test($uri, array $plugins): void {
+	public function test(string $uri, array $plugins): void {
 		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $r */
 		$r = $this->createMock(IRequest::class);
 		$r->expects($this->any())->method('getRequestUri')->willReturn($uri);
@@ -33,7 +34,7 @@ class ServerTest extends \Test\TestCase {
 			$this->assertNotNull($s->server->getPlugin($plugin));
 		}
 	}
-	public function providesUris() {
+	public static function providesUris(): array {
 		return [
 			'principals' => ['principals/users/admin', ['caldav', 'oc-resource-sharing', 'carddav']],
 			'calendars' => ['calendars/admin', ['caldav', 'oc-resource-sharing']],

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -15,19 +17,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class CalDAVSettingsTest extends TestCase {
-
-	/** @var IConfig|MockObject */
-	private $config;
-
-	/** @var IInitialState|MockObject */
-	private $initialState;
-
-	/** @var IURLGenerator|MockObject */
-	private $urlGenerator;
-
-	/** @var IAppManager|MockObject */
-	private $appManager;
-
+	private IConfig&MockObject $config;
+	private IInitialState&MockObject $initialState;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IAppManager&MockObject $appManager;
 	private CalDAVSettings $settings;
 
 	protected function setUp(): void {
@@ -42,28 +35,32 @@ class CalDAVSettingsTest extends TestCase {
 
 	public function testGetForm(): void {
 		$this->config->method('getAppValue')
-			->withConsecutive(
-				['dav', 'sendInvitations', 'yes'],
-				['dav', 'generateBirthdayCalendar', 'yes'],
-				['dav', 'sendEventReminders', 'yes'],
-				['dav', 'sendEventRemindersToSharedUsers', 'yes'],
-				['dav', 'sendEventRemindersPush', 'yes'],
-			)
-			->will($this->onConsecutiveCalls('yes', 'no', 'yes', 'yes', 'yes'));
+			->willReturnMap([
+				['dav', 'sendInvitations', 'yes', 'yes'],
+				['dav', 'generateBirthdayCalendar', 'yes', 'no'],
+				['dav', 'sendEventReminders', 'yes', 'yes'],
+				['dav', 'sendEventRemindersToSharedUsers', 'yes', 'yes'],
+				['dav', 'sendEventRemindersPush', 'yes', 'yes'],
+			]);
 		$this->urlGenerator
 			->expects($this->once())
 			->method('linkToDocs')
 			->with('user-sync-calendars')
 			->willReturn('Some docs URL');
+
+		$calls = [
+			['userSyncCalendarsDocUrl', 'Some docs URL'],
+			['sendInvitations', true],
+			['generateBirthdayCalendar', false],
+			['sendEventReminders', true],
+			['sendEventRemindersToSharedUsers', true],
+			['sendEventRemindersPush', true],
+		];
 		$this->initialState->method('provideInitialState')
-			->withConsecutive(
-				['userSyncCalendarsDocUrl', 'Some docs URL'],
-				['sendInvitations', true],
-				['generateBirthdayCalendar', false],
-				['sendEventReminders', true],
-				['sendEventRemindersToSharedUsers', true],
-				['sendEventRemindersPush', true],
-			);
+			->willReturnCallback(function () use (&$calls) {
+				$expected = array_shift($calls);
+				$this->assertEquals($expected, func_get_args());
+			});
 		$result = $this->settings->getForm();
 
 		$this->assertInstanceOf(TemplateResponse::class, $result);
@@ -88,5 +85,4 @@ class CalDAVSettingsTest extends TestCase {
 	public function testGetPriority(): void {
 		$this->assertEquals(10, $this->settings->getPriority());
 	}
-
 }

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -14,30 +15,28 @@ use OCP\SystemTag\ISystemTag;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\SystemTag\TagNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class SystemTagMappingNodeTest extends \Test\TestCase {
-	private ISystemTagManager $tagManager;
-	private ISystemTagObjectMapper $tagMapper;
-	private IUser $user;
+	private ISystemTagManager&MockObject $tagManager;
+	private ISystemTagObjectMapper&MockObject $tagMapper;
+	private IUser&MockObject $user;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tagManager = $this->getMockBuilder(ISystemTagManager::class)
-			->getMock();
-		$this->tagMapper = $this->getMockBuilder(ISystemTagObjectMapper::class)
-			->getMock();
-		$this->user = $this->getMockBuilder(IUser::class)
-			->getMock();
+		$this->tagManager = $this->createMock(ISystemTagManager::class);
+		$this->tagMapper = $this->createMock(ISystemTagObjectMapper::class);
+		$this->user = $this->createMock(IUser::class);
 	}
 
 	public function getMappingNode($tag = null, array $writableNodeIds = []) {
 		if ($tag === null) {
-			$tag = new SystemTag(1, 'Test', true, true);
+			$tag = new SystemTag('1', 'Test', true, true);
 		}
 		return new SystemTagMappingNode(
 			$tag,
-			123,
+			'123',
 			'files',
 			$this->user,
 			$this->tagManager,
@@ -47,7 +46,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 	}
 
 	public function testGetters(): void {
-		$tag = new SystemTag(1, 'Test', true, false);
+		$tag = new SystemTag('1', 'Test', true, false);
 		$node = $this->getMappingNode($tag);
 		$this->assertEquals('1', $node->getName());
 		$this->assertEquals($tag, $node->getSystemTag());
@@ -93,16 +92,16 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 		$node->delete();
 	}
 
-	public function tagNodeDeleteProviderPermissionException() {
+	public static function tagNodeDeleteProviderPermissionException(): array {
 		return [
 			[
 				// cannot unassign invisible tag
-				new SystemTag(1, 'Original', false, true),
+				new SystemTag('1', 'Original', false, true),
 				'Sabre\DAV\Exception\NotFound',
 			],
 			[
 				// cannot unassign non-assignable tag
-				new SystemTag(1, 'Original', true, false),
+				new SystemTag('1', 'Original', true, false),
 				'Sabre\DAV\Exception\Forbidden',
 			],
 		];
@@ -141,7 +140,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 
 		// assuming the tag existed at the time the node was created,
 		// but got deleted concurrently in the database
-		$tag = new SystemTag(1, 'Test', true, true);
+		$tag = new SystemTag('1', 'Test', true, true);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
 			->with($tag)

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -13,27 +14,24 @@ use OCP\IUser;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
 use OCP\SystemTag\TagNotFoundException;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
-	private ISystemTagManager $tagManager;
-	private ISystemTagObjectMapper $tagMapper;
-	private IUser $user;
+	private ISystemTagManager&MockObject $tagManager;
+	private ISystemTagObjectMapper&MockObject $tagMapper;
+	private IUser&MockObject $user;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tagManager = $this->getMockBuilder(ISystemTagManager::class)
-			->getMock();
-		$this->tagMapper = $this->getMockBuilder(ISystemTagObjectMapper::class)
-			->getMock();
-
-		$this->user = $this->getMockBuilder(IUser::class)
-			->getMock();
+		$this->tagManager = $this->createMock(ISystemTagManager::class);
+		$this->tagMapper = $this->createMock(ISystemTagObjectMapper::class);
+		$this->user = $this->createMock(IUser::class);
 	}
 
-	public function getNode(array $writableNodeIds = []) {
+	public function getNode(array $writableNodeIds = []): SystemTagsObjectMappingCollection {
 		return new SystemTagsObjectMappingCollection(
-			111,
+			'111',
 			'files',
 			$this->user,
 			$this->tagManager,
@@ -86,7 +84,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->getNode()->createFile('555');
 	}
 
-	public function permissionsProvider() {
+	public static function permissionsProvider(): array {
 		return [
 			// invisible, tag does not exist for user
 			[false, true, '\Sabre\DAV\Exception\PreconditionFailed'],
@@ -98,7 +96,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	/**
 	 * @dataProvider permissionsProvider
 	 */
-	public function testAssignTagNoPermission($userVisible, $userAssignable, $expectedException): void {
+	public function testAssignTagNoPermission(bool $userVisible, bool $userAssignable, string $expectedException): void {
 		$tag = new SystemTag('1', 'Test', $userVisible, $userAssignable);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -146,7 +144,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	public function testGetChild(): void {
-		$tag = new SystemTag(555, 'TheTag', true, false);
+		$tag = new SystemTag('555', 'TheTag', true, false);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
 			->with($tag)
@@ -172,7 +170,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	public function testGetChildNonVisible(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
-		$tag = new SystemTag(555, 'TheTag', false, false);
+		$tag = new SystemTag('555', 'TheTag', false, false);
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
 			->with($tag)
@@ -228,9 +226,9 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	public function testGetChildren(): void {
-		$tag1 = new SystemTag(555, 'TagOne', true, false);
-		$tag2 = new SystemTag(556, 'TagTwo', true, true);
-		$tag3 = new SystemTag(557, 'InvisibleTag', false, true);
+		$tag1 = new SystemTag('555', 'TagOne', true, false);
+		$tag2 = new SystemTag('556', 'TagTwo', true, true);
+		$tag3 = new SystemTag('557', 'InvisibleTag', false, true);
 
 		$this->tagMapper->expects($this->once())
 			->method('getTagIdsForObjects')
@@ -265,7 +263,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	public function testChildExistsWithVisibleTag(): void {
-		$tag = new SystemTag(555, 'TagOne', true, false);
+		$tag = new SystemTag('555', 'TagOne', true, false);
 
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')
@@ -286,7 +284,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 	}
 
 	public function testChildExistsWithInvisibleTag(): void {
-		$tag = new SystemTag(555, 'TagOne', false, false);
+		$tag = new SystemTag('555', 'TagOne', false, false);
 
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectTypeCollectionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -15,60 +16,39 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class SystemTagsObjectTypeCollectionTest extends \Test\TestCase {
-
-	/**
-	 * @var SystemTagsObjectTypeCollection
-	 */
-	private $node;
-
-	/**
-	 * @var ISystemTagManager
-	 */
-	private $tagManager;
-
-	/**
-	 * @var ISystemTagObjectMapper
-	 */
-	private $tagMapper;
-
-	/**
-	 * @var Folder
-	 */
-	private $userFolder;
+	private ISystemTagManager&MockObject $tagManager;
+	private ISystemTagObjectMapper&MockObject $tagMapper;
+	private Folder&MockObject $userFolder;
+	private SystemTagsObjectTypeCollection $node;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->tagManager = $this->getMockBuilder(ISystemTagManager::class)
-			->getMock();
-		$this->tagMapper = $this->getMockBuilder(ISystemTagObjectMapper::class)
-			->getMock();
+		$this->tagManager = $this->createMock(ISystemTagManager::class);
+		$this->tagMapper = $this->createMock(ISystemTagObjectMapper::class);
 
-		$user = $this->getMockBuilder(IUser::class)
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('testuser');
-		$userSession = $this->getMockBuilder(IUserSession::class)
-			->getMock();
+		$userSession = $this->createMock(IUserSession::class);
 		$userSession->expects($this->any())
 			->method('getUser')
 			->willReturn($user);
-		$groupManager = $this->getMockBuilder(IGroupManager::class)
-			->getMock();
+		$groupManager = $this->createMock(IGroupManager::class);
 		$groupManager->expects($this->any())
 			->method('isAdmin')
 			->with('testuser')
 			->willReturn(true);
 
-		$this->userFolder = $this->getMockBuilder(Folder::class)
-			->getMock();
+		$this->userFolder = $this->createMock(Folder::class);
 		$userFolder = $this->userFolder;
 
 		$closure = function ($name) use ($userFolder) {
-			$node = $userFolder->getFirstNodeById(intval($name));
+			$node = $userFolder->getFirstNodeById((int)$name);
 			return $node !== null;
 		};
 		$writeAccessClosure = function ($name) use ($userFolder) {

--- a/apps/dav/tests/unit/Upload/FutureFileTest.php
+++ b/apps/dav/tests/unit/Upload/FutureFileTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -45,7 +46,7 @@ class FutureFileTest extends \Test\TestCase {
 	public function testDelete(): void {
 		$d = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
-			->setMethods(['delete'])
+			->onlyMethods(['delete'])
 			->getMock();
 
 		$d->expects($this->once())
@@ -55,7 +56,7 @@ class FutureFileTest extends \Test\TestCase {
 		$f->delete();
 	}
 
-	
+
 	public function testPut(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -63,7 +64,7 @@ class FutureFileTest extends \Test\TestCase {
 		$f->put('');
 	}
 
-	
+
 	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -71,13 +72,10 @@ class FutureFileTest extends \Test\TestCase {
 		$f->setName('');
 	}
 
-	/**
-	 * @return FutureFile
-	 */
-	private function mockFutureFile() {
+	private function mockFutureFile(): FutureFile {
 		$d = $this->getMockBuilder(Directory::class)
 			->disableOriginalConstructor()
-			->setMethods(['getETag', 'getLastModified', 'getChildren'])
+			->onlyMethods(['getETag', 'getLastModified', 'getChildren'])
 			->getMock();
 
 		$d->expects($this->any())


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
