### PR TITLE
fix(log): map all warnings to warn log level, notice to info

### DIFF
--- a/lib/private/Log/ErrorHandler.php
+++ b/lib/private/Log/ErrorHandler.php
@@ -72,9 +72,9 @@ class ErrorHandler {
 
 	private static function errnoToLogLevel(int $errno): int {
 		return match ($errno) {
-			E_USER_WARNING => ILogger::WARN,
+			E_WARNING, E_USER_WARNING => ILogger::WARN,
 			E_DEPRECATED, E_USER_DEPRECATED => ILogger::DEBUG,
-			E_USER_NOTICE => ILogger::INFO,
+			E_NOTICE, E_USER_NOTICE => ILogger::INFO,
 			default => ILogger::ERROR,
 		};
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: wrong log levels reported by @tobiasKaminsky 

## Summary

Log PHP warnings at warn log level, notices at info. This was also done for deprecations in https://github.com/nextcloud/server/commit/4c8ec6dc8992e13ba4dbb831ac865a41377ec86f.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
