### PR TITLE
fix(FileReferenceEventListener): Invalidate cache after node was renamed

### DIFF
--- a/lib/private/Collaboration/Reference/File/FileReferenceEventListener.php
+++ b/lib/private/Collaboration/Reference/File/FileReferenceEventListener.php
@@ -15,6 +15,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeDeletedEvent;
+use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareDeletedEvent;
 
@@ -27,6 +28,7 @@ class FileReferenceEventListener implements IEventListener {
 
 	public static function register(IEventDispatcher $eventDispatcher): void {
 		$eventDispatcher->addServiceListener(NodeDeletedEvent::class, FileReferenceEventListener::class);
+		$eventDispatcher->addServiceListener(NodeRenamedEvent::class, FileReferenceEventListener::class);
 		$eventDispatcher->addServiceListener(ShareDeletedEvent::class, FileReferenceEventListener::class);
 		$eventDispatcher->addServiceListener(ShareCreatedEvent::class, FileReferenceEventListener::class);
 	}
@@ -41,6 +43,9 @@ class FileReferenceEventListener implements IEventListener {
 			}
 
 			$this->manager->invalidateCache((string)$event->getNode()->getId());
+		}
+		if ($event instanceof NodeRenamedEvent) {
+			$this->manager->invalidateCache((string)$event->getTarget()->getId());
 		}
 		if ($event instanceof ShareDeletedEvent) {
 			$this->manager->invalidateCache((string)$event->getShare()->getNodeId());


### PR DESCRIPTION
Fixes: nextcloud/collectives#1527

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
