### PR TITLE
fix: log error when writing stream to dav file

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -216,7 +216,9 @@ class File extends Node implements IFile {
 					try {
 						/** @var IWriteStreamStorage $partStorage */
 						$count = $partStorage->writeStream($internalPartPath, $wrappedData);
-					} catch (GenericFileException) {
+					} catch (GenericFileException $e) {
+						$logger = Server::get(LoggerInterface::class);
+						$logger->error('Error while writing stream to storage: ' . $e->getMessage(), ['exception' => $e, 'app' => 'webdav']);
 						$result = $isEOF;
 						if (is_resource($wrappedData)) {
 							$result = feof($wrappedData);


### PR DESCRIPTION
Log the actual error instead of just triggering the "copied count mismatch" error later down.