### PR TITLE
test: Migrate remaining DAV tests to PHPUnit 10

### DIFF
--- a/apps/dav/lib/BulkUpload/MultipartRequestParser.php
+++ b/apps/dav/lib/BulkUpload/MultipartRequestParser.php
@@ -57,7 +57,13 @@ class MultipartRequestParser {
 	 */
 	private function parseBoundaryFromHeaders(string $contentType): string {
 		try {
+			if (!str_contains($contentType, ';')) {
+				throw new \InvalidArgumentException('No semicolon in header');
+			}
 			[$mimeType, $boundary] = explode(';', $contentType);
+			if (!str_contains($boundary, '=')) {
+				throw new \InvalidArgumentException('No equal in boundary header');
+			}
 			[$boundaryKey, $boundaryValue] = explode('=', $boundary);
 		} catch (\Exception $e) {
 			throw new BadRequest('Error while parsing boundary in Content-Type header.', Http::STATUS_BAD_REQUEST, $e);

--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2017 ownCloud GmbH
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-namespace OCA\DAV\Tests\Unit\Avatars;
+namespace OCA\DAV\Tests\unit\Avatars;
 
 use OCA\DAV\Avatars\AvatarHome;
 use OCA\DAV\Avatars\AvatarNode;

--- a/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarNodeTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2017 ownCloud GmbH
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-namespace OCA\DAV\Tests\Unit\Avatars;
+namespace OCA\DAV\Tests\unit\Avatars;
 
 use OCA\DAV\Avatars\AvatarNode;
 use OCP\IAvatar;

--- a/apps/dav/tests/unit/Command/DeleteCalendarTest.php
+++ b/apps/dav/tests/unit/Command/DeleteCalendarTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Command;
+namespace OCA\DAV\Tests\unit\Command;
 
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;

--- a/apps/dav/tests/unit/Command/ListAddressbooksTest.php
+++ b/apps/dav/tests/unit/Command/ListAddressbooksTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Command;
+namespace OCA\DAV\Tests\unit\Command;
 
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\Command\ListAddressbooks;

--- a/apps/dav/tests/unit/Command/ListCalendarSharesTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarSharesTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Command;
+namespace OCA\DAV\Tests\unit\Command;
 
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\Command\ListCalendarShares;

--- a/apps/dav/tests/unit/Command/ListCalendarsTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Command;
+namespace OCA\DAV\Tests\unit\Command;
 
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Command;
+namespace OCA\DAV\Tests\unit\Command;
 
 use InvalidArgumentException;
 use OCA\DAV\CalDAV\CalDavBackend;

--- a/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
+++ b/apps/dav/tests/unit/Command/RemoveInvalidSharesTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2018 ownCloud GmbH
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-namespace OCA\DAV\Tests\Unit\Command;
+namespace OCA\DAV\Tests\unit\Command;
 
 use OCA\DAV\Command\RemoveInvalidShares;
 use OCA\DAV\Connector\Sabre\Principal;

--- a/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/LegacyPublicAuthTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -14,6 +15,7 @@ use OCP\Security\Bruteforce\IThrottler;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class LegacyPublicAuthTest
@@ -23,36 +25,20 @@ use OCP\Share\IShare;
  * @package OCA\DAV\Tests\unit\Connector
  */
 class LegacyPublicAuthTest extends \Test\TestCase {
-
-	/** @var ISession|\PHPUnit\Framework\MockObject\MockObject */
-	private $session;
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $request;
-	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $shareManager;
-	/** @var LegacyPublicAuth */
-	private $auth;
-	/** @var IThrottler|\PHPUnit\Framework\MockObject\MockObject */
-	private $throttler;
-
-	/** @var string */
-	private $oldUser;
+	private ISession&MockObject $session;
+	private IRequest&MockObject $request;
+	private IManager&MockObject $shareManager;
+	private IThrottler&MockObject $throttler;
+	private LegacyPublicAuth $auth;
+	private string|false $oldUser;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->session = $this->getMockBuilder(ISession::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->request = $this->getMockBuilder(IRequest::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->shareManager = $this->getMockBuilder(IManager::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->throttler = $this->getMockBuilder(IThrottler::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->session = $this->createMock(ISession::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->shareManager = $this->createMock(IManager::class);
+		$this->throttler = $this->createMock(IThrottler::class);
 
 		$this->auth = new LegacyPublicAuth(
 			$this->request,
@@ -70,7 +56,9 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 
 		// Set old user
 		\OC_User::setUserId($this->oldUser);
-		\OC_Util::setupFS($this->oldUser);
+		if ($this->oldUser !== false) {
+			\OC_Util::setupFS($this->oldUser);
+		}
 
 		parent::tearDown();
 	}
@@ -86,9 +74,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 	}
 
 	public function testShareNoPassword(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn(null);
 
 		$this->shareManager->expects($this->once())
@@ -101,9 +87,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 	}
 
 	public function testSharePasswordFancyShareType(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
 		$share->method('getShareType')->willReturn(42);
 
@@ -118,9 +102,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 
 
 	public function testSharePasswordRemote(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
 		$share->method('getShareType')->willReturn(IShare::TYPE_REMOTE);
 
@@ -134,9 +116,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 	}
 
 	public function testSharePasswordLinkValidPassword(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
 		$share->method('getShareType')->willReturn(IShare::TYPE_LINK);
 
@@ -156,9 +136,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 	}
 
 	public function testSharePasswordMailValidPassword(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
 		$share->method('getShareType')->willReturn(IShare::TYPE_EMAIL);
 
@@ -178,9 +156,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 	}
 
 	public function testInvalidSharePasswordLinkValidSession(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
 		$share->method('getShareType')->willReturn(IShare::TYPE_LINK);
 		$share->method('getId')->willReturn('42');
@@ -204,9 +180,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 	}
 
 	public function testSharePasswordLinkInvalidSession(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
 		$share->method('getShareType')->willReturn(IShare::TYPE_LINK);
 		$share->method('getId')->willReturn('42');
@@ -231,9 +205,7 @@ class LegacyPublicAuthTest extends \Test\TestCase {
 
 
 	public function testSharePasswordMailInvalidSession(): void {
-		$share = $this->getMockBuilder(IShare::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$share = $this->createMock(IShare::class);
 		$share->method('getPassword')->willReturn('password');
 		$share->method('getShareType')->willReturn(IShare::TYPE_EMAIL);
 		$share->method('getId')->willReturn('42');

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -29,33 +30,20 @@ use Test\TestCase;
  * @group DB
  */
 class AuthTest extends TestCase {
-	/** @var ISession&MockObject */
-	private $session;
-	/** @var Auth */
-	private $auth;
-	/** @var Session&MockObject */
-	private $userSession;
-	/** @var IRequest&MockObject */
-	private $request;
-	/** @var Manager&MockObject */
-	private $twoFactorManager;
-	/** @var IThrottler&MockObject */
-	private $throttler;
+	private ISession&MockObject $session;
+	private Session&MockObject $userSession;
+	private IRequest&MockObject $request;
+	private Manager&MockObject $twoFactorManager;
+	private IThrottler&MockObject $throttler;
+	private Auth $auth;
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->session = $this->getMockBuilder(ISession::class)
-			->disableOriginalConstructor()->getMock();
-		$this->userSession = $this->getMockBuilder(Session::class)
-			->disableOriginalConstructor()->getMock();
-		$this->request = $this->getMockBuilder(IRequest::class)
-			->disableOriginalConstructor()->getMock();
-		$this->twoFactorManager = $this->getMockBuilder(Manager::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->throttler = $this->getMockBuilder(IThrottler::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->session = $this->createMock(ISession::class);
+		$this->userSession = $this->createMock(Session::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->twoFactorManager = $this->createMock(Manager::class);
+		$this->throttler = $this->createMock(IThrottler::class);
 		$this->auth = new Auth(
 			$this->session,
 			$this->userSession,
@@ -72,7 +60,7 @@ class AuthTest extends TestCase {
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn(null);
 
-		$this->assertFalse($this->invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
+		$this->assertFalse(self::invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
 	}
 
 	public function testIsDavAuthenticatedWithWrongDavSession(): void {
@@ -82,7 +70,7 @@ class AuthTest extends TestCase {
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn('AnotherUser');
 
-		$this->assertFalse($this->invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
+		$this->assertFalse(self::invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
 	}
 
 	public function testIsDavAuthenticatedWithCorrectDavSession(): void {
@@ -92,13 +80,11 @@ class AuthTest extends TestCase {
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn('MyTestUser');
 
-		$this->assertTrue($this->invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
+		$this->assertTrue(self::invokePrivate($this->auth, 'isDavAuthenticated', ['MyTestUser']));
 	}
 
 	public function testValidateUserPassOfAlreadyDAVAuthenticatedUser(): void {
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->exactly(1))
 			->method('getUID')
 			->willReturn('MyTestUser');
@@ -119,13 +105,11 @@ class AuthTest extends TestCase {
 			->expects($this->once())
 			->method('close');
 
-		$this->assertTrue($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
+		$this->assertTrue(self::invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
 	public function testValidateUserPassOfInvalidDAVAuthenticatedUser(): void {
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())
 			->method('getUID')
 			->willReturn('MyTestUser');
@@ -146,13 +130,11 @@ class AuthTest extends TestCase {
 			->expects($this->once())
 			->method('close');
 
-		$this->assertFalse($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
+		$this->assertFalse(self::invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
 	public function testValidateUserPassOfInvalidDAVAuthenticatedUserWithValidPassword(): void {
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('MyTestUser');
@@ -182,7 +164,7 @@ class AuthTest extends TestCase {
 			->expects($this->once())
 			->method('close');
 
-		$this->assertTrue($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
+		$this->assertTrue(self::invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
 	public function testValidateUserPassWithInvalidPassword(): void {
@@ -199,7 +181,7 @@ class AuthTest extends TestCase {
 			->expects($this->once())
 			->method('close');
 
-		$this->assertFalse($this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
+		$this->assertFalse(self::invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']));
 	}
 
 
@@ -219,16 +201,12 @@ class AuthTest extends TestCase {
 			->expects($this->once())
 			->method('close');
 
-		$this->invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']);
+		self::invokePrivate($this->auth, 'validateUserPass', ['MyTestUser', 'MyTestPassword']);
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGet(): void {
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -242,9 +220,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn(null);
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('MyWrongDavUser');
@@ -266,12 +242,8 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenAndCorrectlyDavAuthenticated(): void {
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -289,9 +261,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn('LoggedInUser');
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('LoggedInUser');
@@ -311,12 +281,8 @@ class AuthTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('2FA challenge not passed.');
 
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -334,9 +300,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn('LoggedInUser');
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('LoggedInUser');
@@ -360,12 +324,8 @@ class AuthTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\NotAuthenticated::class);
 		$this->expectExceptionMessage('CSRF check not passed.');
 
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -383,9 +343,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn('AnotherUser');
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('LoggedInUser');
@@ -401,12 +359,8 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForNonGetAndDesktopClient(): void {
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -424,9 +378,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn(null);
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('MyWrongDavUser');
@@ -443,12 +395,8 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithoutCsrfTokenForGet(): void {
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -458,9 +406,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn(null);
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('MyWrongDavUser');
@@ -478,12 +424,8 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateAlreadyLoggedInWithCsrfTokenForGet(): void {
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -493,9 +435,7 @@ class AuthTest extends TestCase {
 			->method('get')
 			->with('AUTHENTICATED_TO_DAV_BACKEND')
 			->willReturn(null);
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('MyWrongDavUser');
@@ -513,15 +453,9 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateNoBasicAuthenticateHeadersProvided(): void {
-		$server = $this->getMockBuilder(Server::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$server->httpRequest = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$server->httpResponse = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$server = $this->createMock(Server::class);
+		$server->httpRequest = $this->createMock(RequestInterface::class);
+		$server->httpResponse = $this->createMock(ResponseInterface::class);
 		$response = $this->auth->check($server->httpRequest, $server->httpResponse);
 		$this->assertEquals([false, 'No \'Authorization: Basic\' header found. Either the client didn\'t send one, or the server is misconfigured'], $response);
 	}
@@ -532,13 +466,9 @@ class AuthTest extends TestCase {
 		$this->expectExceptionMessage('Cannot authenticate over ajax calls');
 
 		/** @var \Sabre\HTTP\RequestInterface&MockObject $httpRequest */
-		$httpRequest = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$httpRequest = $this->createMock(RequestInterface::class);
 		/** @var \Sabre\HTTP\ResponseInterface&MockObject $httpResponse */
-		$httpResponse = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$httpResponse = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->any())
 			->method('isLoggedIn')
@@ -562,13 +492,9 @@ class AuthTest extends TestCase {
 			->willReturn(false);
 
 		/** @var \Sabre\HTTP\RequestInterface&MockObject $httpRequest */
-		$httpRequest = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$httpRequest = $this->createMock(RequestInterface::class);
 		/** @var \Sabre\HTTP\ResponseInterface&MockObject $httpResponse */
-		$httpResponse = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$httpResponse = $this->createMock(ResponseInterface::class);
 		$httpRequest
 			->expects($this->any())
 			->method('getHeader')
@@ -577,9 +503,7 @@ class AuthTest extends TestCase {
 				['Authorization', 'basic dXNlcm5hbWU6cGFzc3dvcmQ='],
 			]);
 
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->any())
 			->method('getUID')
 			->willReturn('MyDavUser');
@@ -602,17 +526,10 @@ class AuthTest extends TestCase {
 
 	public function testAuthenticateNoBasicAuthenticateHeadersProvidedWithAjaxButUserIsStillLoggedIn(): void {
 		/** @var \Sabre\HTTP\RequestInterface $httpRequest */
-		$httpRequest = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$httpRequest = $this->createMock(RequestInterface::class);
 		/** @var \Sabre\HTTP\ResponseInterface $httpResponse */
-		$httpResponse = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		/** @var IUser */
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$httpResponse = $this->createMock(ResponseInterface::class);
+		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('MyTestUser');
 		$this->userSession
 			->expects($this->any())
@@ -643,29 +560,21 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateValidCredentials(): void {
-		$server = $this->getMockBuilder(Server::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$server->httpRequest = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$server = $this->createMock(Server::class);
+		$server->httpRequest = $this->createMock(RequestInterface::class);
 		$server->httpRequest
 			->expects($this->once())
 			->method('getHeader')
 			->with('Authorization')
 			->willReturn('basic dXNlcm5hbWU6cGFzc3dvcmQ=');
 
-		$server->httpResponse = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$server->httpResponse = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->once())
 			->method('logClientIn')
 			->with('username', 'password')
 			->willReturn(true);
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->exactly(2))
 			->method('getUID')
 			->willReturn('MyTestUser');
@@ -678,12 +587,8 @@ class AuthTest extends TestCase {
 	}
 
 	public function testAuthenticateInvalidCredentials(): void {
-		$server = $this->getMockBuilder(Server::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$server->httpRequest = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$server = $this->createMock(Server::class);
+		$server->httpRequest = $this->createMock(RequestInterface::class);
 		$server->httpRequest
 			->expects($this->exactly(2))
 			->method('getHeader')
@@ -691,9 +596,7 @@ class AuthTest extends TestCase {
 				['Authorization', 'basic dXNlcm5hbWU6cGFzc3dvcmQ='],
 				['X-Requested-With', null],
 			]);
-		$server->httpResponse = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$server->httpResponse = $this->createMock(ResponseInterface::class);
 		$this->userSession
 			->expects($this->once())
 			->method('logClientIn')

--- a/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BearerAuthTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -21,14 +23,10 @@ use Test\TestCase;
  * @group DB
  */
 class BearerAuthTest extends TestCase {
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	private $userSession;
-	/** @var ISession|\PHPUnit\Framework\MockObject\MockObject */
-	private $session;
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $request;
-	/** @var BearerAuth */
-	private $bearerAuth;
+	private IUserSession&MockObject $userSession;
+	private ISession&MockObject $session;
+	private IRequest&MockObject $request;
+	private BearerAuth $bearerAuth;
 
 	private IConfig&MockObject $config;
 
@@ -74,9 +72,9 @@ class BearerAuthTest extends TestCase {
 	}
 
 	public function testChallenge(): void {
-		/** @var \PHPUnit\Framework\MockObject\MockObject|RequestInterface $request */
+		/** @var RequestInterface&MockObject $request */
 		$request = $this->createMock(RequestInterface::class);
-		/** @var \PHPUnit\Framework\MockObject\MockObject|ResponseInterface $response */
+		/** @var ResponseInterface&MockObject $response */
 		$response = $this->createMock(ResponseInterface::class);
 		$result = $this->bearerAuth->challenge($request, $response);
 		$this->assertEmpty($result);

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -83,7 +83,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		}
 
 		/** @var RequestInterface|MockObject $request */
-		$request = $this->createMock('\Sabre\HTTP\RequestInterface');
+		$request = $this->createMock(RequestInterface::class);
 		$request
 			->expects($this->once())
 			->method('getHeader')

--- a/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CopyEtagHeaderPluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -15,12 +16,8 @@ use Sabre\DAV\Tree;
 use Test\TestCase;
 
 class CopyEtagHeaderPluginTest extends TestCase {
-
-	/** @var CopyEtagHeaderPlugin */
-	private $plugin;
-
-	/** @var Server */
-	private $server;
+	private CopyEtagHeaderPlugin $plugin;
+	private Server $server;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -62,15 +59,11 @@ class CopyEtagHeaderPluginTest extends TestCase {
 	}
 
 	public function testAfterMove(): void {
-		$node = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$node = $this->createMock(File::class);
 		$node->expects($this->once())
 			->method('getETag')
 			->willReturn('123456');
-		$tree = $this->getMockBuilder(Tree::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$tree = $this->createMock(Tree::class);
 		$tree->expects($this->once())
 			->method('getNodeForPath')
 			->with('test.txt')

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -25,42 +26,21 @@ use Sabre\DAV\Tree;
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
 class CustomPropertiesBackendTest extends \Test\TestCase {
-
-	/**
-	 * @var \Sabre\DAV\Server
-	 */
-	private $server;
-
-	/**
-	 * @var \Sabre\DAV\Tree
-	 */
-	private $tree;
-
-	/**
-	 * @var CustomPropertiesBackend
-	 */
-	private $plugin;
-
-	/**
-	 * @var IUser
-	 */
-	private $user;
-
-	/** @property MockObject|DefaultCalendarValidator */
-	private $defaultCalendarValidator;
+	private \Sabre\DAV\Server $server;
+	private \Sabre\DAV\Tree&MockObject $tree;
+	private IUser&MockObject $user;
+	private DefaultCalendarValidator&MockObject $defaultCalendarValidator;
+	private CustomPropertiesBackend $plugin;
 
 	protected function setUp(): void {
 		parent::setUp();
+
 		$this->server = new \Sabre\DAV\Server();
-		$this->tree = $this->getMockBuilder(Tree::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->tree = $this->createMock(Tree::class);
 
-		$userId = $this->getUniqueID('testcustompropertiesuser');
+		$userId = self::getUniqueID('testcustompropertiesuser');
 
-		$this->user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->user = $this->createMock(IUser::class);
 		$this->user->expects($this->any())
 			->method('getUID')
 			->willReturn($userId);
@@ -88,12 +68,12 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 			]
 		);
 		$deleteStatement->closeCursor();
+
+		parent::tearDown();
 	}
 
-	private function createTestNode($class) {
-		$node = $this->getMockBuilder($class)
-			->disableOriginalConstructor()
-			->getMock();
+	private function createTestNode(string $class) {
+		$node = $this->createMock($class);
 		$node->expects($this->any())
 			->method('getId')
 			->willReturn(123);

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -1,11 +1,12 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-namespace OCA\DAV\Tests\Unit\Connector\Sabre;
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
 
 use OC\Files\FileInfo;
 use OC\Files\Filesystem;
@@ -21,6 +22,7 @@ use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\StorageNotAvailableException;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
 
 class TestViewDirectory extends View {
@@ -43,7 +45,7 @@ class TestViewDirectory extends View {
 		return $this->deletables[$path];
 	}
 
-	public function rename($path1, $path2, array $options = []) {
+	public function rename($source, $target, array $options = []) {
 		return $this->canRename;
 	}
 
@@ -59,16 +61,14 @@ class TestViewDirectory extends View {
 class DirectoryTest extends \Test\TestCase {
 	use UserTrait;
 
-	/** @var View|\PHPUnit\Framework\MockObject\MockObject */
-	private $view;
-	/** @var FileInfo|\PHPUnit\Framework\MockObject\MockObject */
-	private $info;
+	private View&MockObject $view;
+	private FileInfo&MockObject $info;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->view = $this->createMock('OC\Files\View');
-		$this->info = $this->createMock('OC\Files\FileInfo');
+		$this->view = $this->createMock(View::class);
+		$this->info = $this->createMock(FileInfo::class);
 		$this->info->method('isReadable')
 			->willReturn(true);
 		$this->info->method('getType')
@@ -81,7 +81,7 @@ class DirectoryTest extends \Test\TestCase {
 			->willReturn(Constants::PERMISSION_READ);
 	}
 
-	private function getDir($path = '/') {
+	private function getDir(string $path = '/'): Directory {
 		$this->view->expects($this->once())
 			->method('getRelativePath')
 			->willReturn($path);
@@ -174,12 +174,8 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 	public function testGetChildren(): void {
-		$info1 = $this->getMockBuilder(FileInfo::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$info2 = $this->getMockBuilder(FileInfo::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$info1 = $this->createMock(FileInfo::class);
+		$info2 = $this->createMock(FileInfo::class);
 		$info1->method('getName')
 			->willReturn('first');
 		$info1->method('getPath')
@@ -214,7 +210,7 @@ class DirectoryTest extends \Test\TestCase {
 		$dir = new Directory($this->view, $this->info);
 		$nodes = $dir->getChildren();
 
-		$this->assertEquals(2, count($nodes));
+		$this->assertCount(2, $nodes);
 
 		// calling a second time just returns the cached values,
 		// does not call getDirectoryContents again
@@ -273,12 +269,10 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 	public function testGetQuotaInfoUnlimited(): void {
-		self::createUser('user', 'password');
+		$this->createUser('user', 'password');
 		self::loginAsUser('user');
 		$mountPoint = $this->createMock(IMountPoint::class);
-		$storage = $this->getMockBuilder(Quota::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$storage = $this->createMock(Quota::class);
 		$mountPoint->method('getStorage')
 			->willReturn($storage);
 
@@ -329,12 +323,10 @@ class DirectoryTest extends \Test\TestCase {
 	}
 
 	public function testGetQuotaInfoSpecific(): void {
-		self::createUser('user', 'password');
+		$this->createUser('user', 'password');
 		self::loginAsUser('user');
 		$mountPoint = $this->createMock(IMountPoint::class);
-		$storage = $this->getMockBuilder(Quota::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$storage = $this->createMock(Quota::class);
 		$mountPoint->method('getStorage')
 			->willReturn($storage);
 
@@ -384,7 +376,7 @@ class DirectoryTest extends \Test\TestCase {
 	/**
 	 * @dataProvider moveFailedProvider
 	 */
-	public function testMoveFailed($source, $destination, $updatables, $deletables): void {
+	public function testMoveFailed(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->moveTest($source, $destination, $updatables, $deletables);
@@ -393,7 +385,7 @@ class DirectoryTest extends \Test\TestCase {
 	/**
 	 * @dataProvider moveSuccessProvider
 	 */
-	public function testMoveSuccess($source, $destination, $updatables, $deletables): void {
+	public function testMoveSuccess(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->moveTest($source, $destination, $updatables, $deletables);
 		$this->addToAssertionCount(1);
 	}
@@ -401,19 +393,19 @@ class DirectoryTest extends \Test\TestCase {
 	/**
 	 * @dataProvider moveFailedInvalidCharsProvider
 	 */
-	public function testMoveFailedInvalidChars($source, $destination, $updatables, $deletables): void {
+	public function testMoveFailedInvalidChars(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->expectException(InvalidPath::class);
 
 		$this->moveTest($source, $destination, $updatables, $deletables);
 	}
 
-	public function moveFailedInvalidCharsProvider() {
+	public static function moveFailedInvalidCharsProvider(): array {
 		return [
 			['a/valid', "a/i\nvalid", ['a' => true, 'a/valid' => true, 'a/c*' => false], []],
 		];
 	}
 
-	public function moveFailedProvider() {
+	public static function moveFailedProvider(): array {
 		return [
 			['a/b', 'a/c', ['a' => false, 'a/b' => false, 'a/c' => false], []],
 			['a/b', 'b/b', ['a' => false, 'a/b' => false, 'b' => false, 'b/b' => false], []],
@@ -424,7 +416,7 @@ class DirectoryTest extends \Test\TestCase {
 		];
 	}
 
-	public function moveSuccessProvider() {
+	public static function moveSuccessProvider(): array {
 		return [
 			['a/b', 'b/b', ['a' => true, 'a/b' => true, 'b' => true, 'b/b' => false], ['a/b' => true]],
 			// older files with special chars can still be renamed to valid names
@@ -432,12 +424,7 @@ class DirectoryTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @param $source
-	 * @param $destination
-	 * @param $updatables
-	 */
-	private function moveTest($source, $destination, $updatables, $deletables): void {
+	private function moveTest(string $source, string $destination, array $updatables, array $deletables): void {
 		$view = new TestViewDirectory($updatables, $deletables);
 
 		$sourceInfo = new FileInfo($source, null, null, [
@@ -449,7 +436,7 @@ class DirectoryTest extends \Test\TestCase {
 
 		$sourceNode = new Directory($view, $sourceInfo);
 		$targetNode = $this->getMockBuilder(Directory::class)
-			->setMethods(['childExists'])
+			->onlyMethods(['childExists'])
 			->setConstructorArgs([$view, $targetInfo])
 			->getMock();
 		$targetNode->expects($this->any())->method('childExists')

--- a/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DummyGetResponsePluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -19,8 +20,7 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
 class DummyGetResponsePluginTest extends TestCase {
-	/** @var DummyGetResponsePlugin */
-	private $dummyGetResponsePlugin;
+	private DummyGetResponsePlugin $dummyGetResponsePlugin;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -29,10 +29,7 @@ class DummyGetResponsePluginTest extends TestCase {
 	}
 
 	public function testInitialize(): void {
-		/** @var Server $server */
-		$server = $this->getMockBuilder(Server::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$server = $this->createMock(Server::class);
 		$server
 			->expects($this->once())
 			->method('on')
@@ -44,13 +41,9 @@ class DummyGetResponsePluginTest extends TestCase {
 
 	public function testHttpGet(): void {
 		/** @var \Sabre\HTTP\RequestInterface $request */
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(RequestInterface::class);
 		/** @var \Sabre\HTTP\ResponseInterface $response */
-		$response = $server = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$response = $this->createMock(ResponseInterface::class);
 		$response
 			->expects($this->once())
 			->method('setBody');

--- a/apps/dav/tests/unit/Connector/Sabre/Exception/ForbiddenTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/Exception/ForbiddenTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -8,6 +9,7 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre\Exception;
 
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
+use Sabre\DAV\Server;
 
 class ForbiddenTest extends \Test\TestCase {
 	public function testSerialization(): void {
@@ -32,9 +34,7 @@ class ForbiddenTest extends \Test\TestCase {
 EOD;
 
 		$ex = new Forbidden($message, $retry);
-		$server = $this->getMockBuilder('Sabre\DAV\Server')
-			->disableOriginalConstructor()
-			->getMock();
+		$server = $this->createMock(Server::class);
 		$ex->serialize($server, $error);
 
 		// assert

--- a/apps/dav/tests/unit/Connector/Sabre/Exception/InvalidPathTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/Exception/InvalidPathTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -8,6 +9,7 @@
 namespace OCA\DAV\Tests\unit\Connector\Sabre\Exception;
 
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use Sabre\DAV\Server;
 
 class InvalidPathTest extends \Test\TestCase {
 	public function testSerialization(): void {
@@ -32,9 +34,7 @@ class InvalidPathTest extends \Test\TestCase {
 EOD;
 
 		$ex = new InvalidPath($message, $retry);
-		$server = $this->getMockBuilder('Sabre\DAV\Server')
-			->disableOriginalConstructor()
-			->getMock();
+		$server = $this->createMock(Server::class);
 		$ex->serialize($server, $error);
 
 		// assert

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -11,21 +12,16 @@ use OC\SystemConfig;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Exception\ServerMaintenanceMode;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Server;
 use Test\TestCase;
 
 class ExceptionLoggerPluginTest extends TestCase {
-
-	/** @var Server */
-	private $server;
-
-	/** @var ExceptionLoggerPlugin */
-	private $plugin;
-
-	/** @var LoggerInterface | \PHPUnit\Framework\MockObject\MockObject */
-	private $logger;
+	private Server $server;
+	private ExceptionLoggerPlugin $plugin;
+	private LoggerInterface&MockObject $logger;
 
 	private function init(): void {
 		$config = $this->createMock(SystemConfig::class);
@@ -59,7 +55,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 		$this->plugin->logException($e);
 	}
 
-	public function providesExceptions() {
+	public static function providesExceptions(): array {
 		return [
 			['debug', new NotFound()],
 			['debug', new ServerMaintenanceMode('System is in maintenance mode.')],

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -53,16 +54,9 @@ class FileTest extends TestCase {
 	use MountProviderTrait;
 	use UserTrait;
 
-	/**
-	 * @var string
-	 */
-	private $user;
-
-	/** @var IConfig|MockObject */
-	protected $config;
-
-	/** @var IRequestId|MockObject */
-	protected $requestId;
+	private string $user;
+	protected IConfig&MockObject $config;
+	protected IRequestId&MockObject $requestId;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -72,7 +66,7 @@ class FileTest extends TestCase {
 		$this->user = 'test_user';
 		$this->createUser($this->user, 'pass');
 
-		$this->loginAsUser($this->user);
+		self::loginAsUser($this->user);
 
 		$this->config = $this->createMock(IConfig::class);
 		$this->requestId = $this->createMock(IRequestId::class);
@@ -86,9 +80,7 @@ class FileTest extends TestCase {
 	}
 
 	private function getMockStorage(): MockObject&IStorage {
-		$storage = $this->getMockBuilder(IStorage::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$storage = $this->createMock(IStorage::class);
 		$storage->method('getId')
 			->willReturn('home::someuser');
 		return $storage;
@@ -102,7 +94,7 @@ class FileTest extends TestCase {
 	}
 
 
-	public function fopenFailuresProvider() {
+	public static function fopenFailuresProvider(): array {
 		return [
 			[
 				// return false
@@ -161,14 +153,14 @@ class FileTest extends TestCase {
 	/**
 	 * @dataProvider fopenFailuresProvider
 	 */
-	public function testSimplePutFails($thrownException, $expectedException, $checkPreviousClass = true): void {
+	public function testSimplePutFails(?\Throwable $thrownException, string $expectedException, bool $checkPreviousClass = true): void {
 		// setup
 		$storage = $this->getMockBuilder(Local::class)
 			->onlyMethods(['writeStream'])
 			->setConstructorArgs([['datadir' => Server::get(ITempManager::class)->getTemporaryFolder()]])
 			->getMock();
 		Filesystem::mount($storage, [], $this->user . '/');
-		/** @var View | MockObject $view */
+		/** @var View&MockObject $view */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['getRelativePath', 'resolvePath'])
 			->getMock();
@@ -221,12 +213,12 @@ class FileTest extends TestCase {
 	 * Simulate putting a file to the given path.
 	 *
 	 * @param string $path path to put the file into
-	 * @param string $viewRoot root to use for the view
+	 * @param ?string $viewRoot root to use for the view
 	 * @param null|Request $request the HTTP request
 	 *
 	 * @return null|string of the PUT operation which is usually the etag
 	 */
-	private function doPut($path, $viewRoot = null, ?Request $request = null) {
+	private function doPut(string $path, ?string $viewRoot = null, ?Request $request = null) {
 		$view = Filesystem::getView();
 		if (!is_null($viewRoot)) {
 			$view = new View($viewRoot);
@@ -245,7 +237,7 @@ class FileTest extends TestCase {
 			null
 		);
 
-		/** @var File|MockObject $file */
+		/** @var File&MockObject $file */
 		$file = $this->getMockBuilder(File::class)
 			->setConstructorArgs([$view, $info, null, $request])
 			->onlyMethods(['header'])
@@ -269,55 +261,55 @@ class FileTest extends TestCase {
 		$this->assertNotEmpty($this->doPut('/foo.txt'));
 	}
 
-	public function legalMtimeProvider() {
+	public static function legalMtimeProvider(): array {
 		return [
 			'string' => [
-				'HTTP_X_OC_MTIME' => 'string',
-				'expected result' => null
+				'requestMtime' => 'string',
+				'resultMtime' => null
 			],
 			'castable string (int)' => [
-				'HTTP_X_OC_MTIME' => '987654321',
-				'expected result' => 987654321
+				'requestMtime' => '987654321',
+				'resultMtime' => 987654321
 			],
 			'castable string (float)' => [
-				'HTTP_X_OC_MTIME' => '123456789.56',
-				'expected result' => 123456789
+				'requestMtime' => '123456789.56',
+				'resultMtime' => 123456789
 			],
 			'float' => [
-				'HTTP_X_OC_MTIME' => 123456789.56,
-				'expected result' => 123456789
+				'requestMtime' => 123456789.56,
+				'resultMtime' => 123456789
 			],
 			'zero' => [
-				'HTTP_X_OC_MTIME' => 0,
-				'expected result' => null
+				'requestMtime' => 0,
+				'resultMtime' => null
 			],
 			'zero string' => [
-				'HTTP_X_OC_MTIME' => '0',
-				'expected result' => null
+				'requestMtime' => '0',
+				'resultMtime' => null
 			],
 			'negative zero string' => [
-				'HTTP_X_OC_MTIME' => '-0',
-				'expected result' => null
+				'requestMtime' => '-0',
+				'resultMtime' => null
 			],
 			'string starting with number following by char' => [
-				'HTTP_X_OC_MTIME' => '2345asdf',
-				'expected result' => null
+				'requestMtime' => '2345asdf',
+				'resultMtime' => null
 			],
 			'string castable hex int' => [
-				'HTTP_X_OC_MTIME' => '0x45adf',
-				'expected result' => null
+				'requestMtime' => '0x45adf',
+				'resultMtime' => null
 			],
 			'string that looks like invalid hex int' => [
-				'HTTP_X_OC_MTIME' => '0x123g',
-				'expected result' => null
+				'requestMtime' => '0x123g',
+				'resultMtime' => null
 			],
 			'negative int' => [
-				'HTTP_X_OC_MTIME' => -34,
-				'expected result' => null
+				'requestMtime' => -34,
+				'resultMtime' => null
 			],
 			'negative float' => [
-				'HTTP_X_OC_MTIME' => -34.43,
-				'expected result' => null
+				'requestMtime' => -34.43,
+				'resultMtime' => null
 			],
 		];
 	}
@@ -326,7 +318,7 @@ class FileTest extends TestCase {
 	 * Test putting a file with string Mtime
 	 * @dataProvider legalMtimeProvider
 	 */
-	public function testPutSingleFileLegalMtime($requestMtime, $resultMtime): void {
+	public function testPutSingleFileLegalMtime(mixed $requestMtime, ?int $resultMtime): void {
 		$request = new Request([
 			'server' => [
 				'HTTP_X_OC_MTIME' => (string)$requestMtime,
@@ -482,7 +474,7 @@ class FileTest extends TestCase {
 	 */
 	public function testSimplePutFailsSizeCheck(): void {
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['rename', 'getRelativePath', 'filesize'])
 			->getMock();
@@ -569,7 +561,7 @@ class FileTest extends TestCase {
 	 */
 	public function testSimplePutInvalidChars(): void {
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['getRelativePath'])
 			->getMock();
@@ -609,7 +601,7 @@ class FileTest extends TestCase {
 		$this->expectException(InvalidPath::class);
 
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['getRelativePath'])
 			->getMock();
@@ -630,7 +622,7 @@ class FileTest extends TestCase {
 
 	public function testUploadAbort(): void {
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['rename', 'getRelativePath', 'filesize'])
 			->getMock();
@@ -680,7 +672,7 @@ class FileTest extends TestCase {
 
 	public function testDeleteWhenAllowed(): void {
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
@@ -704,7 +696,7 @@ class FileTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
@@ -724,7 +716,7 @@ class FileTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
@@ -749,7 +741,7 @@ class FileTest extends TestCase {
 		$this->expectException(Forbidden::class);
 
 		// setup
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->getMock();
 
@@ -923,7 +915,7 @@ class FileTest extends TestCase {
 	public function testGetFopenFails(): void {
 		$this->expectException(\Sabre\DAV\Exception\ServiceUnavailable::class);
 
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['fopen'])
 			->getMock();
@@ -945,7 +937,7 @@ class FileTest extends TestCase {
 	public function testGetFopenThrows(): void {
 		$this->expectException(Forbidden::class);
 
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['fopen'])
 			->getMock();
@@ -967,7 +959,7 @@ class FileTest extends TestCase {
 	public function testGetThrowsIfNoPermission(): void {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 
-		/** @var View|MockObject */
+		/** @var View&MockObject */
 		$view = $this->getMockBuilder(View::class)
 			->onlyMethods(['fopen'])
 			->getMock();

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -73,23 +74,15 @@ class FilesPluginTest extends TestCase {
 			$this->accountManager,
 		);
 
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$response = $this->createMock(ResponseInterface::class);
 		$this->server->httpResponse = $response;
 		$this->server->xml = new Service();
 
 		$this->plugin->initialize($this->server);
 	}
 
-	/**
-	 * @param string $class
-	 * @return \PHPUnit\Framework\MockObject\MockObject
-	 */
-	private function createTestNode($class, $path = '/dummypath') {
-		$node = $this->getMockBuilder($class)
-			->disableOriginalConstructor()
-			->getMock();
+	private function createTestNode(string $class, string $path = '/dummypath'): MockObject {
+		$node = $this->createMock($class);
 
 		$node->expects($this->any())
 			->method('getId')
@@ -129,8 +122,8 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForFile(): void {
-		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		/** @var File&MockObject $node */
+		$node = $this->createTestNode(File::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',
@@ -149,8 +142,7 @@ class FilesPluginTest extends TestCase {
 			0
 		);
 
-		$user = $this->getMockBuilder(User::class)
-			->disableOriginalConstructor()->getMock();
+		$user = $this->createMock(User::class);
 		$user
 			->expects($this->once())
 			->method('getUID')
@@ -160,8 +152,7 @@ class FilesPluginTest extends TestCase {
 			->method('getDisplayName')
 			->willReturn('M. Foo');
 
-		$owner = $this->getMockBuilder(Account::class)
-			->disableOriginalConstructor()->getMock();
+		$owner = $this->createMock(Account::class);
 		$this->accountManager->expects($this->once())
 			->method('getAccount')
 			->with($user)
@@ -174,8 +165,7 @@ class FilesPluginTest extends TestCase {
 			->method('getOwner')
 			->willReturn($user);
 
-		$displayNameProp = $this->getMockBuilder(AccountProperty::class)
-			->disableOriginalConstructor()->getMock();
+		$displayNameProp = $this->createMock(AccountProperty::class);
 		$owner
 			->expects($this->once())
 			->method('getProperty')
@@ -205,9 +195,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetDisplayNamePropertyWhenNotPublished(): void {
-		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
-
+		$node = $this->createTestNode(File::class);
 		$propFind = new PropFind(
 			'/dummyPath',
 			[
@@ -220,15 +208,12 @@ class FilesPluginTest extends TestCase {
 			->method('getUser')
 			->willReturn(null);
 
-		$user = $this->getMockBuilder(User::class)
-			->disableOriginalConstructor()->getMock();
+		$user = $this->createMock(User::class);
 
-		$user
-			->expects($this->never())
+		$user->expects($this->never())
 			->method('getDisplayName');
 
-		$owner = $this->getMockBuilder(Account::class)
-			->disableOriginalConstructor()->getMock();
+		$owner = $this->createMock(Account::class);
 		$this->accountManager->expects($this->once())
 			->method('getAccount')
 			->with($user)
@@ -238,8 +223,7 @@ class FilesPluginTest extends TestCase {
 			->method('getOwner')
 			->willReturn($user);
 
-		$displayNameProp = $this->getMockBuilder(AccountProperty::class)
-			->disableOriginalConstructor()->getMock();
+		$displayNameProp = $this->createMock(AccountProperty::class);
 		$owner
 			->expects($this->once())
 			->method('getProperty')
@@ -257,10 +241,9 @@ class FilesPluginTest extends TestCase {
 
 		$this->assertEquals(null, $propFind->get(FilesPlugin::OWNER_DISPLAY_NAME_PROPERTYNAME));
 	}
-	
+
 	public function testGetDisplayNamePropertyWhenNotPublishedButLoggedIn(): void {
-		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		$node = $this->createTestNode(File::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',
@@ -270,15 +253,13 @@ class FilesPluginTest extends TestCase {
 			0
 		);
 
-		$user = $this->getMockBuilder(User::class)
-			->disableOriginalConstructor()->getMock();
+		$user = $this->createMock(User::class);
 
 		$node->expects($this->once())
 			->method('getOwner')
 			->willReturn($user);
 
-		$loggedInUser = $this->getMockBuilder(User::class)
-			->disableOriginalConstructor()->getMock();
+		$loggedInUser = $this->createMock(User::class);
 		$this->userSession->expects($this->once())
 			->method('getUser')
 			->willReturn($loggedInUser);
@@ -300,8 +281,8 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesStorageNotAvailable(): void {
-		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		/** @var File&MockObject $node */
+		$node = $this->createTestNode(File::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',
@@ -325,9 +306,7 @@ class FilesPluginTest extends TestCase {
 
 	public function testGetPublicPermissions(): void {
 		/** @var IRequest&MockObject */
-		$request = $this->getMockBuilder(IRequest::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$request = $this->createMock(IRequest::class);
 		$this->plugin = new FilesPlugin(
 			$this->tree,
 			$this->config,
@@ -348,8 +327,8 @@ class FilesPluginTest extends TestCase {
 			0
 		);
 
-		/** @var File|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		/** @var File&MockObject $node */
+		$node = $this->createTestNode(File::class);
 		$node->expects($this->any())
 			->method('getDavPermissions')
 			->willReturn('DWCKMSR');
@@ -363,8 +342,8 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForDirectory(): void {
-		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
+		/** @var Directory&MockObject $node */
+		$node = $this->createTestNode(Directory::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',
@@ -398,10 +377,8 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testGetPropertiesForRootDirectory(): void {
-		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->getMockBuilder(Directory::class)
-			->disableOriginalConstructor()
-			->getMock();
+		/** @var Directory&MockObject $node */
+		$node = $this->createMock(Directory::class);
 		$node->expects($this->any())->method('getPath')->willReturn('/');
 
 		$fileInfo = $this->createMock(FileInfo::class);
@@ -433,10 +410,8 @@ class FilesPluginTest extends TestCase {
 		// No read permissions can be caused by files access control.
 		// But we still want to load the directory list, so this is okay for us.
 		// $this->expectException(\Sabre\DAV\Exception\NotFound::class);
-		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->getMockBuilder(Directory::class)
-			->disableOriginalConstructor()
-			->getMock();
+		/** @var Directory&MockObject $node */
+		$node = $this->createMock(Directory::class);
 		$node->expects($this->any())->method('getPath')->willReturn('/');
 
 		$fileInfo = $this->createMock(FileInfo::class);
@@ -465,7 +440,7 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testUpdateProps(): void {
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\File');
+		$node = $this->createTestNode(File::class);
 
 		$testDate = 'Fri, 13 Feb 2015 00:01:02 GMT';
 		$testCreationDate = '2007-08-31T16:47+00:00';
@@ -549,16 +524,12 @@ class FilesPluginTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 		$this->expectExceptionMessage('FolderA/test.txt cannot be deleted');
 
-		$fileInfoFolderATestTXT = $this->getMockBuilder(FileInfo::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$fileInfoFolderATestTXT = $this->createMock(FileInfo::class);
 		$fileInfoFolderATestTXT->expects($this->once())
 			->method('isDeletable')
 			->willReturn(false);
 
-		$node = $this->getMockBuilder(Node::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$node = $this->createMock(Node::class);
 		$node->expects($this->atLeastOnce())
 			->method('getFileInfo')
 			->willReturn($fileInfoFolderATestTXT);
@@ -571,16 +542,12 @@ class FilesPluginTest extends TestCase {
 	}
 
 	public function testMoveSrcDeletable(): void {
-		$fileInfoFolderATestTXT = $this->getMockBuilder(FileInfo::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$fileInfoFolderATestTXT = $this->createMock(FileInfo::class);
 		$fileInfoFolderATestTXT->expects($this->once())
 			->method('isDeletable')
 			->willReturn(true);
 
-		$node = $this->getMockBuilder(Node::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$node = $this->createMock(Node::class);
 		$node->expects($this->atLeastOnce())
 			->method('getFileInfo')
 			->willReturn($fileInfoFolderATestTXT);
@@ -596,9 +563,7 @@ class FilesPluginTest extends TestCase {
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 		$this->expectExceptionMessage('FolderA/test.txt does not exist');
 
-		$node = $this->getMockBuilder(Node::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$node = $this->createMock(Node::class);
 		$node->expects($this->atLeastOnce())
 			->method('getFileInfo')
 			->willReturn(null);
@@ -674,7 +639,7 @@ class FilesPluginTest extends TestCase {
 		$this->plugin->checkCopy('FolderA/test.txt', 'invalid\\path.txt');
 	}
 
-	public function downloadHeadersProvider() {
+	public static function downloadHeadersProvider(): array {
 		return [
 			[
 				false,
@@ -690,22 +655,16 @@ class FilesPluginTest extends TestCase {
 	/**
 	 * @dataProvider downloadHeadersProvider
 	 */
-	public function testDownloadHeaders($isClumsyAgent, $contentDispositionHeader): void {
-		$request = $this->getMockBuilder(RequestInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$response = $this->getMockBuilder(ResponseInterface::class)
-			->disableOriginalConstructor()
-			->getMock();
+	public function testDownloadHeaders(bool $isClumsyAgent, string $contentDispositionHeader): void {
+		$request = $this->createMock(RequestInterface::class);
+		$response = $this->createMock(ResponseInterface::class);
 
 		$request
 			->expects($this->once())
 			->method('getPath')
 			->willReturn('test/somefile.xml');
 
-		$node = $this->getMockBuilder(File::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$node = $this->createMock(File::class);
 		$node
 			->expects($this->once())
 			->method('getName')
@@ -722,20 +681,24 @@ class FilesPluginTest extends TestCase {
 			->method('isUserAgent')
 			->willReturn($isClumsyAgent);
 
+		$calls = [
+			['Content-Disposition', $contentDispositionHeader],
+			['X-Accel-Buffering', 'no'],
+		];
 		$response
-			->expects($this->exactly(2))
+			->expects($this->exactly(count($calls)))
 			->method('addHeader')
-			->withConsecutive(
-				['Content-Disposition', $contentDispositionHeader],
-				['X-Accel-Buffering', 'no']
-			);
+			->willReturnCallback(function () use (&$calls) {
+				$expected = array_shift($calls);
+				$this->assertSame($expected, func_get_args());
+			});
 
 		$this->plugin->httpGet($request, $response);
 	}
 
 	public function testHasPreview(): void {
-		/** @var Directory|\PHPUnit\Framework\MockObject\MockObject $node */
-		$node = $this->createTestNode('\OCA\DAV\Connector\Sabre\Directory');
+		/** @var Directory&MockObject $node */
+		$node = $this->createTestNode(Directory::class);
 
 		$propFind = new PropFind(
 			'/dummyPath',

--- a/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/MaintenancePluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -10,6 +11,7 @@ namespace OCA\DAV\Tests\unit\Connector\Sabre;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCP\IConfig;
 use OCP\IL10N;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 /**
@@ -18,18 +20,15 @@ use Test\TestCase;
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
 class MaintenancePluginTest extends TestCase {
-	/** @var IConfig */
-	private $config;
-	/** @var \PHPUnit\Framework\MockObject\Builder\InvocationMocker|\PHPUnit_Framework_MockObject_Builder_InvocationMocker|IL10N */
-	private $l10n;
-	/** @var MaintenancePlugin */
-	private $maintenancePlugin;
+	private IConfig&MockObject $config;
+	private IL10N&MockObject $l10n;
+	private MaintenancePlugin $maintenancePlugin;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder(IConfig::class)->getMock();
-		$this->l10n = $this->getMockBuilder(IL10N::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
 		$this->maintenancePlugin = new MaintenancePlugin($this->config, $this->l10n);
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -32,7 +33,7 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @package OCA\DAV\Tests\unit\Connector\Sabre
  */
 class NodeTest extends \Test\TestCase {
-	public function davPermissionsProvider() {
+	public static function davPermissionsProvider(): array {
 		return [
 			[Constants::PERMISSION_ALL, 'file', false, Constants::PERMISSION_ALL, false, 'test', 'RGDNVW'],
 			[Constants::PERMISSION_ALL, 'dir', false, Constants::PERMISSION_ALL, false, 'test', 'RGDNVCK'],
@@ -53,7 +54,7 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider davPermissionsProvider
 	 */
-	public function testDavPermissions($permissions, $type, $shared, $shareRootPermissions, $mounted, $internalPath, $expected): void {
+	public function testDavPermissions(int $permissions, string $type, bool $shared, int $shareRootPermissions, bool $mounted, string $internalPath, string $expected): void {
 		$info = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()
 			->onlyMethods(['getPermissions', 'isShared', 'isMounted', 'getType', 'getInternalPath', 'getStorage', 'getMountPoint'])
@@ -94,15 +95,13 @@ class NodeTest extends \Test\TestCase {
 		}
 		$info->method('getStorage')
 			->willReturn($storage);
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->createMock(View::class);
 
 		$node = new  File($view, $info);
 		$this->assertEquals($expected, $node->getDavPermissions());
 	}
 
-	public function sharePermissionsProvider() {
+	public static function sharePermissionsProvider(): array {
 		return [
 			[\OCP\Files\FileInfo::TYPE_FILE, null, 1, 1],
 			[\OCP\Files\FileInfo::TYPE_FILE, null, 3, 3],
@@ -145,18 +144,14 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sharePermissionsProvider
 	 */
-	public function testSharePermissions($type, $user, $permissions, $expected): void {
-		$storage = $this->getMockBuilder(IStorage::class)
-			->disableOriginalConstructor()
-			->getMock();
+	public function testSharePermissions(string $type, ?string $user, int $permissions, int $expected): void {
+		$storage = $this->createMock(IStorage::class);
 		$storage->method('getPermissions')->willReturn($permissions);
 
-		$mountpoint = $this->getMockBuilder(IMountPoint::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$mountpoint = $this->createMock(IMountPoint::class);
 		$mountpoint->method('getMountPoint')->willReturn('myPath');
-		$shareManager = $this->getMockBuilder(IManager::class)->disableOriginalConstructor()->getMock();
-		$share = $this->getMockBuilder(IShare::class)->disableOriginalConstructor()->getMock();
+		$shareManager = $this->createMock(IManager::class);
+		$share = $this->createMock(IShare::class);
 
 		if ($user === null) {
 			$shareManager->expects($this->never())->method('getShareByToken');
@@ -169,7 +164,7 @@ class NodeTest extends \Test\TestCase {
 
 		$info = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()
-			->setMethods(['getStorage', 'getType', 'getMountPoint', 'getPermissions'])
+			->onlyMethods(['getStorage', 'getType', 'getMountPoint', 'getPermissions'])
 			->getMock();
 
 		$info->method('getStorage')->willReturn($storage);
@@ -177,9 +172,7 @@ class NodeTest extends \Test\TestCase {
 		$info->method('getMountPoint')->willReturn($mountpoint);
 		$info->method('getPermissions')->willReturn($permissions);
 
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->createMock(View::class);
 
 		$node = new File($view, $info);
 		$this->invokePrivate($node, 'shareManager', [$shareManager]);
@@ -189,11 +182,11 @@ class NodeTest extends \Test\TestCase {
 	public function testShareAttributes(): void {
 		$storage = $this->getMockBuilder(SharedStorage::class)
 			->disableOriginalConstructor()
-			->setMethods(['getShare'])
+			->onlyMethods(['getShare'])
 			->getMock();
 
-		$shareManager = $this->getMockBuilder(IManager::class)->disableOriginalConstructor()->getMock();
-		$share = $this->getMockBuilder(IShare::class)->disableOriginalConstructor()->getMock();
+		$shareManager = $this->createMock(IManager::class);
+		$share = $this->createMock(IShare::class);
 
 		$storage->expects($this->once())
 			->method('getShare')
@@ -214,9 +207,7 @@ class NodeTest extends \Test\TestCase {
 		$info->method('getType')->willReturn(FileInfo::TYPE_FOLDER);
 
 		/** @var View&MockObject $view */
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->createMock(View::class);
 
 		$node = new File($view, $info);
 		$this->invokePrivate($node, 'shareManager', [$shareManager]);
@@ -224,11 +215,8 @@ class NodeTest extends \Test\TestCase {
 	}
 
 	public function testShareAttributesNonShare(): void {
-		$storage = $this->getMockBuilder(IStorage::class)
-			->disableOriginalConstructor()
-			->getMock();
-
-		$shareManager = $this->getMockBuilder(IManager::class)->disableOriginalConstructor()->getMock();
+		$storage = $this->createMock(IStorage::class);
+		$shareManager = $this->createMock(IManager::class);
 
 		/** @var Folder&MockObject */
 		$info = $this->getMockBuilder(Folder::class)
@@ -240,16 +228,14 @@ class NodeTest extends \Test\TestCase {
 		$info->method('getType')->willReturn(FileInfo::TYPE_FOLDER);
 
 		/** @var View&MockObject */
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->createMock(View::class);
 
 		$node = new File($view, $info);
 		$this->invokePrivate($node, 'shareManager', [$shareManager]);
 		$this->assertEquals([], $node->getShareAttributes());
 	}
 
-	public function sanitizeMtimeProvider() {
+	public static function sanitizeMtimeProvider(): array {
 		return [
 			[123456789, 123456789],
 			['987654321', 987654321],
@@ -259,7 +245,7 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sanitizeMtimeProvider
 	 */
-	public function testSanitizeMtime($mtime, $expected): void {
+	public function testSanitizeMtime(string|int $mtime, int $expected): void {
 		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
 			->getMock();
@@ -272,7 +258,7 @@ class NodeTest extends \Test\TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
-	public function invalidSanitizeMtimeProvider() {
+	public static function invalidSanitizeMtimeProvider(): array {
 		return [
 			[-1337], [0], ['abcdef'], ['-1337'], ['0'], [12321], [24 * 60 * 60 - 1],
 		];
@@ -281,17 +267,13 @@ class NodeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider invalidSanitizeMtimeProvider
 	 */
-	public function testInvalidSanitizeMtime($mtime): void {
+	public function testInvalidSanitizeMtime(int|string $mtime): void {
 		$this->expectException(\InvalidArgumentException::class);
 
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$info = $this->getMockBuilder(FileInfo::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$view = $this->createMock(View::class);
+		$info = $this->createMock(FileInfo::class);
 
 		$node = new File($view, $info);
-		$result = $this->invokePrivate($node, 'sanitizeMtime', [$mtime]);
+		self::invokePrivate($node, 'sanitizeMtime', [$mtime]);
 	}
 }

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -27,7 +28,7 @@ use OCP\Files\Mount\IMountManager;
  * @package OCA\DAV\Tests\Unit\Connector\Sabre
  */
 class ObjectTreeTest extends \Test\TestCase {
-	public function copyDataProvider() {
+	public static function copyDataProvider(): array {
 		return [
 			// copy into same dir
 			['a', 'b', ''],
@@ -41,7 +42,7 @@ class ObjectTreeTest extends \Test\TestCase {
 	/**
 	 * @dataProvider copyDataProvider
 	 */
-	public function testCopy($sourcePath, $targetPath, $targetParent): void {
+	public function testCopy(string $sourcePath, string $targetPath, string $targetParent): void {
 		$view = $this->createMock(View::class);
 		$view->expects($this->once())
 			->method('verifyPath')
@@ -67,7 +68,7 @@ class ObjectTreeTest extends \Test\TestCase {
 
 		$rootDir = new Directory($view, $info);
 		$objectTree = $this->getMockBuilder(ObjectTree::class)
-			->setMethods(['nodeExists', 'getNodeForPath'])
+			->onlyMethods(['nodeExists', 'getNodeForPath'])
 			->setConstructorArgs([$rootDir, $view])
 			->getMock();
 
@@ -110,7 +111,7 @@ class ObjectTreeTest extends \Test\TestCase {
 
 		$rootDir = new Directory($view, $info);
 		$objectTree = $this->getMockBuilder(ObjectTree::class)
-			->setMethods(['nodeExists', 'getNodeForPath'])
+			->onlyMethods(['nodeExists', 'getNodeForPath'])
 			->setConstructorArgs([$rootDir, $view])
 			->getMock();
 
@@ -127,23 +128,15 @@ class ObjectTreeTest extends \Test\TestCase {
 	 * @dataProvider nodeForPathProvider
 	 */
 	public function testGetNodeForPath(
-		$inputFileName,
-		$fileInfoQueryPath,
-		$outputFileName,
-		$type,
+		string $inputFileName,
+		string $fileInfoQueryPath,
+		string $outputFileName,
+		string $type,
 	): void {
-		$rootNode = $this->getMockBuilder(Directory::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$mountManager = $this->getMockBuilder(Manager::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$view = $this->getMockBuilder(View::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$fileInfo = $this->getMockBuilder(FileInfo::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$rootNode = $this->createMock(Directory::class);
+		$mountManager = $this->createMock(Manager::class);
+		$view = $this->createMock(View::class);
+		$fileInfo = $this->createMock(FileInfo::class);
 		$fileInfo->method('getType')
 			->willReturn($type);
 		$fileInfo->method('getName')
@@ -164,13 +157,13 @@ class ObjectTreeTest extends \Test\TestCase {
 		$this->assertEquals($outputFileName, $node->getName());
 
 		if ($type === 'file') {
-			$this->assertTrue($node instanceof File);
+			$this->assertInstanceOf(File::class, $node);
 		} else {
-			$this->assertTrue($node instanceof Directory);
+			$this->assertInstanceOf(Directory::class, $node);
 		}
 	}
 
-	public function nodeForPathProvider() {
+	public static function nodeForPathProvider(): array {
 		return [
 			// regular file
 			[
@@ -213,7 +206,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$storage = new Temporary([]);
 
 		$view = $this->getMockBuilder(View::class)
-			->setMethods(['resolvePath'])
+			->onlyMethods(['resolvePath'])
 			->getMock();
 		$view->expects($this->once())
 			->method('resolvePath')
@@ -221,9 +214,7 @@ class ObjectTreeTest extends \Test\TestCase {
 				return [$storage, ltrim($path, '/')];
 			});
 
-		$rootNode = $this->getMockBuilder(Directory::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$rootNode = $this->createMock(Directory::class);
 		$mountManager = $this->createMock(IMountManager::class);
 
 		$tree = new ObjectTree();
@@ -239,7 +230,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$storage = new Temporary([]);
 
 		$view = $this->getMockBuilder(View::class)
-			->setMethods(['resolvePath'])
+			->onlyMethods(['resolvePath'])
 			->getMock();
 		$view->expects($this->any())
 			->method('resolvePath')
@@ -247,9 +238,7 @@ class ObjectTreeTest extends \Test\TestCase {
 				return [$storage, ltrim($path, '/')];
 			});
 
-		$rootNode = $this->getMockBuilder(Directory::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$rootNode = $this->createMock(Directory::class);
 		$mountManager = $this->createMock(IMountManager::class);
 
 		$tree = new ObjectTree();

--- a/apps/dav/tests/unit/Connector/Sabre/PropfindCompressionPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PropfindCompressionPluginTest.php
@@ -14,8 +14,7 @@ use Sabre\HTTP\Response;
 use Test\TestCase;
 
 class PropfindCompressionPluginTest extends TestCase {
-	/** @var PropfindCompressionPlugin */
-	private $plugin;
+	private PropfindCompressionPlugin $plugin;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/Auth.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/Auth.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -18,7 +19,7 @@ use OCP\AppFramework\Http;
  */
 class DeleteTest extends RequestTestCase {
 	public function testBasicUpload(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
 		$view->file_put_contents('foo.txt', 'asd');
@@ -29,7 +30,7 @@ class DeleteTest extends RequestTestCase {
 		$mount->getStorage()->unlink($mount->getInternalPath($internalPath));
 
 		// cache entry still exists
-		$this->assertInstanceOf('\OCP\Files\FileInfo', $view->getFileInfo('foo.txt'));
+		$this->assertInstanceOf(\OCP\Files\FileInfo::class, $view->getFileInfo('foo.txt'));
 
 		$response = $this->request($view, $user, 'pass', 'DELETE', '/foo.txt');
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DownloadTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -19,7 +20,7 @@ use OCP\Lock\ILockingProvider;
  */
 class DownloadTest extends RequestTestCase {
 	public function testDownload(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
 		$view->file_put_contents('foo.txt', 'bar');
@@ -30,7 +31,7 @@ class DownloadTest extends RequestTestCase {
 	}
 
 	public function testDownloadWriteLocked(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
 		$view->file_put_contents('foo.txt', 'bar');
@@ -42,7 +43,7 @@ class DownloadTest extends RequestTestCase {
 	}
 
 	public function testDownloadReadLocked(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
 		$view->file_put_contents('foo.txt', 'bar');

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionMasterKeyUploadTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -23,7 +24,7 @@ use Test\Traits\EncryptionTrait;
 class EncryptionMasterKeyUploadTest extends UploadTest {
 	use EncryptionTrait;
 
-	protected function setupUser($name, $password) {
+	protected function setupUser($name, $password): View {
 		$this->createUser($name, $password);
 		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/EncryptionUploadTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -23,7 +24,7 @@ use Test\Traits\EncryptionTrait;
 class EncryptionUploadTest extends UploadTest {
 	use EncryptionTrait;
 
-	protected function setupUser($name, $password) {
+	protected function setupUser($name, $password): View {
 		$this->createUser($name, $password);
 		$tmpFolder = Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/ExceptionPlugin.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/PartFileInRootUploadTest.php
@@ -21,9 +21,7 @@ use OCP\Server;
 class PartFileInRootUploadTest extends UploadTest {
 	protected function setUp(): void {
 		$config = Server::get(IConfig::class);
-		$mockConfig = $this->getMockBuilder(IConfig::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$mockConfig = $this->createMock(IConfig::class);
 		$mockConfig->expects($this->any())
 			->method('getSystemValue')
 			->willReturnCallback(function ($key, $default) use ($config) {

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/RequestTestCase.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -20,6 +21,7 @@ use OCP\IRequestId;
 use OCP\ITagManager;
 use OCP\ITempManager;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use Psr\Log\LoggerInterface;
 use Sabre\HTTP\Request;
 use Test\TestCase;
@@ -29,11 +31,7 @@ use Test\Traits\UserTrait;
 abstract class RequestTestCase extends TestCase {
 	use UserTrait;
 	use MountProviderTrait;
-
-	/**
-	 * @var ServerFactory
-	 */
-	protected $serverFactory;
+	protected ServerFactory $serverFactory;
 
 	protected function getStream($string) {
 		$stream = fopen('php://temp', 'r+');
@@ -52,20 +50,18 @@ abstract class RequestTestCase extends TestCase {
 			\OCP\Server::get(IUserSession::class),
 			\OCP\Server::get(IMountManager::class),
 			\OCP\Server::get(ITagManager::class),
-			$this->getMockBuilder(IRequest::class)
-				->disableOriginalConstructor()
-				->getMock(),
+			$this->createMock(IRequest::class),
 			\OCP\Server::get(IPreview::class),
 			\OCP\Server::get(IEventDispatcher::class),
-			\OC::$server->getL10N('dav')
+			\OCP\Server::get(IFactory::class)->get('dav'),
 		);
 	}
 
-	protected function setupUser($name, $password) {
+	protected function setupUser($name, $password): View {
 		$this->createUser($name, $password);
 		$tmpFolder = \OCP\Server::get(ITempManager::class)->getTemporaryFolder();
 		$this->registerMount($name, '\OC\Files\Storage\Local', '/' . $name, ['datadir' => $tmpFolder]);
-		$this->loginAsUser($name);
+		self::loginAsUser($name);
 		return new View('/' . $name . '/files');
 	}
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/Sapi.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/Sapi.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/UploadTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -19,7 +20,7 @@ use OCP\Lock\ILockingProvider;
  */
 class UploadTest extends RequestTestCase {
 	public function testBasicUpload(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
 		$this->assertFalse($view->file_exists('foo.txt'));
@@ -35,7 +36,7 @@ class UploadTest extends RequestTestCase {
 	}
 
 	public function testUploadOverWrite(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
 		$view->file_put_contents('foo.txt', 'foobar');
@@ -51,7 +52,7 @@ class UploadTest extends RequestTestCase {
 	}
 
 	public function testUploadOverWriteReadLocked(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 
 		$view->file_put_contents('foo.txt', 'bar');
@@ -63,7 +64,7 @@ class UploadTest extends RequestTestCase {
 	}
 
 	public function testUploadOverWriteWriteLocked(): void {
-		$user = $this->getUniqueID();
+		$user = self::getUniqueID();
 		$view = $this->setupUser($user, 'pass');
 		$this->loginAsUser($user);
 

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -17,35 +18,17 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Tree;
 
 class SharesPluginTest extends \Test\TestCase {
 	public const SHARETYPES_PROPERTYNAME = SharesPlugin::SHARETYPES_PROPERTYNAME;
 
-	/**
-	 * @var \Sabre\DAV\Server
-	 */
-	private $server;
-
-	/**
-	 * @var \Sabre\DAV\Tree
-	 */
-	private $tree;
-
-	/**
-	 * @var \OCP\Share\IManager
-	 */
-	private $shareManager;
-
-	/**
-	 * @var Folder
-	 */
-	private $userFolder;
-
-	/**
-	 * @var SharesPlugin
-	 */
-	private $plugin;
+	private \Sabre\DAV\Server $server;
+	private \Sabre\DAV\Tree&MockObject $tree;
+	private \OCP\Share\IManager&MockObject $shareManager;
+	private Folder&MockObject $userFolder;
+	private SharesPlugin $plugin;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -74,10 +57,8 @@ class SharesPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sharesGetPropertiesDataProvider
 	 */
-	public function testGetProperties($shareTypes): void {
-		$sabreNode = $this->getMockBuilder(Node::class)
-			->disableOriginalConstructor()
-			->getMock();
+	public function testGetProperties(array $shareTypes): void {
+		$sabreNode = $this->createMock(Node::class);
 		$sabreNode->expects($this->any())
 			->method('getId')
 			->willReturn(123);
@@ -86,9 +67,7 @@ class SharesPluginTest extends \Test\TestCase {
 			->willReturn('/subdir');
 
 		// node API nodes
-		$node = $this->getMockBuilder(Folder::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$node = $this->createMock(Folder::class);
 
 		$sabreNode->method('getNode')
 			->willReturn($node);
@@ -143,7 +122,7 @@ class SharesPluginTest extends \Test\TestCase {
 	/**
 	 * @dataProvider sharesGetPropertiesDataProvider
 	 */
-	public function testPreloadThenGetProperties($shareTypes): void {
+	public function testPreloadThenGetProperties(array $shareTypes): void {
 		$sabreNode1 = $this->createMock(File::class);
 		$sabreNode1->method('getId')
 			->willReturn(111);
@@ -182,7 +161,7 @@ class SharesPluginTest extends \Test\TestCase {
 			->willReturn($node2);
 
 		$dummyShares = array_map(function ($type) {
-			$share = $this->getMockBuilder(IShare::class)->getMock();
+			$share = $this->createMock(IShare::class);
 			$share->expects($this->any())
 				->method('getShareType')
 				->willReturn($type);
@@ -268,7 +247,7 @@ class SharesPluginTest extends \Test\TestCase {
 		$this->assertEquals($shareTypes, $result[200][self::SHARETYPES_PROPERTYNAME]->getShareTypes());
 	}
 
-	public function sharesGetPropertiesDataProvider() {
+	public static function sharesGetPropertiesDataProvider(): array {
 		return [
 			[[]],
 			[[IShare::TYPE_USER]],
@@ -287,9 +266,7 @@ class SharesPluginTest extends \Test\TestCase {
 	}
 
 	public function testGetPropertiesSkipChunks(): void {
-		$sabreNode = $this->getMockBuilder(UploadFile::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$sabreNode = $this->createMock(UploadFile::class);
 
 		$propFind = new \Sabre\DAV\PropFind(
 			'/dummyPath',

--- a/apps/dav/tests/unit/Controller/DirectControllerTest.php
+++ b/apps/dav/tests/unit/Controller/DirectControllerTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Unit\DAV\Controller;
+namespace OCA\DAV\Tests\unit\DAV\Controller;
 
 use OCA\DAV\Controller\DirectController;
 use OCA\DAV\Db\Direct;
@@ -20,29 +20,18 @@ use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IRequest;
-use OCP\IUrlGenerator;
+use OCP\IURLGenerator;
 use OCP\Security\ISecureRandom;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class DirectControllerTest extends TestCase {
-
-	/** @var IRootFolder|\PHPUnit\Framework\MockObject\MockObject */
-	private $rootFolder;
-
-	/** @var DirectMapper|\PHPUnit\Framework\MockObject\MockObject */
-	private $directMapper;
-
-	/** @var ISecureRandom|\PHPUnit\Framework\MockObject\MockObject */
-	private $random;
-
-	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $timeFactory;
-
-	/** @var IUrlGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	private $urlGenerator;
-
-	/** @var IEventDispatcher|\PHPUnit\Framework\MockObject\MockObject */
-	private $eventDispatcher;
+	private IRootFolder&MockObject $rootFolder;
+	private DirectMapper&MockObject $directMapper;
+	private ISecureRandom&MockObject $random;
+	private ITimeFactory&MockObject $timeFactory;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IEventDispatcher&MockObject $eventDispatcher;
 
 	private DirectController $controller;
 
@@ -53,7 +42,7 @@ class DirectControllerTest extends TestCase {
 		$this->directMapper = $this->createMock(DirectMapper::class);
 		$this->random = $this->createMock(ISecureRandom::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->urlGenerator = $this->createMock(IUrlGenerator::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 
 		$this->controller = new DirectController(

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Unit\DAV\Controller;
+namespace OCA\DAV\Tests\unit\DAV\Controller;
 
 use OCA\DAV\CalDAV\InvitationResponse\InvitationResponseServer;
 use OCA\DAV\Controller\InvitationResponseController;
@@ -18,24 +18,16 @@ use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\VObject\ITip\Message;
 use Test\TestCase;
 
 class InvitationResponseControllerTest extends TestCase {
-	/** @var InvitationResponseController */
-	private $controller;
-
-	/** @var IDBConnection|\PHPUnit\Framework\MockObject\MockObject */
-	private $dbConnection;
-
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $request;
-
-	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $timeFactory;
-
-	/** @var InvitationResponseServer|\PHPUnit\Framework\MockObject\MockObject */
-	private $responseServer;
+	private IDBConnection&MockObject $dbConnection;
+	private IRequest&MockObject $request;
+	private ITimeFactory&MockObject $timeFactory;
+	private InvitationResponseServer&MockObject $responseServer;
+	private InvitationResponseController $controller;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,9 +35,7 @@ class InvitationResponseControllerTest extends TestCase {
 		$this->dbConnection = $this->createMock(IDBConnection::class);
 		$this->request = $this->createMock(IRequest::class);
 		$this->timeFactory = $this->createMock(ITimeFactory::class);
-		$this->responseServer = $this->getMockBuilder(InvitationResponseServer::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$this->responseServer = $this->createMock(InvitationResponseServer::class);
 
 		$this->controller = new InvitationResponseController(
 			'appName',
@@ -56,7 +46,7 @@ class InvitationResponseControllerTest extends TestCase {
 		);
 	}
 
-	public function attendeeProvider(): array {
+	public static function attendeeProvider(): array {
 		return [
 			'local attendee' => [false],
 			'external attendee' => [true]
@@ -424,7 +414,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	private function buildQueryExpects($token, $return, $time): void {
+	private function buildQueryExpects(string $token, ?array $return, int $time): void {
 		$queryBuilder = $this->createMock(IQueryBuilder::class);
 		$stmt = $this->createMock(IResult::class);
 		$expr = $this->createMock(IExpressionBuilder::class);

--- a/apps/dav/tests/unit/Controller/UpcomingEventsControllerTest.php
+++ b/apps/dav/tests/unit/Controller/UpcomingEventsControllerTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Unit\DAV\Service;
+namespace OCA\DAV\Tests\unit\DAV\Service;
 
 use OCA\DAV\CalDAV\UpcomingEvent;
 use OCA\DAV\CalDAV\UpcomingEventsService;
@@ -17,9 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class UpcomingEventsControllerTest extends TestCase {
-
-	private IRequest|MockObject $request;
-	private UpcomingEventsService|MockObject $service;
+	private IRequest&MockObject $request;
+	private UpcomingEventsService&MockObject $service;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
+++ b/apps/dav/tests/unit/DAV/AnonymousOptionsTest.php
@@ -1,9 +1,11 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\tests\unit\DAV;
+namespace OCA\DAV\Tests\unit\DAV;
 
 use OCA\DAV\Connector\Sabre\AnonymousOptionsPlugin;
 use Sabre\DAV\Auth\Backend\BasicCallBack;
@@ -14,7 +16,7 @@ use Sabre\HTTP\Sapi;
 use Test\TestCase;
 
 class AnonymousOptionsTest extends TestCase {
-	private function sendRequest($method, $path, $userAgent = '') {
+	private function sendRequest(string $method, string $path, string $userAgent = '') {
 		$server = new Server();
 		$server->addPlugin(new AnonymousOptionsPlugin());
 		$server->addPlugin(new Plugin(new BasicCallBack(function () {

--- a/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
+++ b/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -8,6 +9,7 @@
 namespace OCA\DAV\Tests\unit\DAV;
 
 use OCA\DAV\Files\BrowserErrorPagePlugin;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\HTTP\Response;
 
@@ -15,18 +17,16 @@ class BrowserErrorPagePluginTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider providesExceptions
-	 * @param $expectedCode
-	 * @param $exception
 	 */
-	public function test($expectedCode, $exception): void {
-		/** @var BrowserErrorPagePlugin | \PHPUnit\Framework\MockObject\MockObject $plugin */
-		$plugin = $this->getMockBuilder(BrowserErrorPagePlugin::class)->setMethods(['sendResponse', 'generateBody'])->getMock();
+	public function test(int $expectedCode, \Throwable $exception): void {
+		/** @var BrowserErrorPagePlugin&MockObject $plugin */
+		$plugin = $this->getMockBuilder(BrowserErrorPagePlugin::class)->onlyMethods(['sendResponse', 'generateBody'])->getMock();
 		$plugin->expects($this->once())->method('generateBody')->willReturn(':boom:');
 		$plugin->expects($this->once())->method('sendResponse');
-		/** @var \Sabre\DAV\Server | \PHPUnit\Framework\MockObject\MockObject $server */
-		$server = $this->getMockBuilder('Sabre\DAV\Server')->disableOriginalConstructor()->getMock();
+		/** @var \Sabre\DAV\Server&MockObject $server */
+		$server = $this->createMock('Sabre\DAV\Server');
 		$server->expects($this->once())->method('on');
-		$httpResponse = $this->getMockBuilder(Response::class)->disableOriginalConstructor()->getMock();
+		$httpResponse = $this->createMock(Response::class);
 		$httpResponse->expects($this->once())->method('addHeaders');
 		$httpResponse->expects($this->once())->method('setStatus')->with($expectedCode);
 		$httpResponse->expects($this->once())->method('setBody')->with(':boom:');
@@ -35,7 +35,7 @@ class BrowserErrorPagePluginTest extends \Test\TestCase {
 		$plugin->logException($exception);
 	}
 
-	public function providesExceptions() {
+	public static function providesExceptions(): array {
 		return [
 			[ 404, new NotFound()],
 			[ 500, new \RuntimeException()],

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\DAV;
+namespace OCA\DAV\Tests\unit\DAV;
 
 use OCA\DAV\CalDAV\Calendar;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
@@ -12,6 +13,7 @@ use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\PropPatch;
@@ -28,23 +30,12 @@ use Test\TestCase;
 class CustomPropertiesBackendTest extends TestCase {
 	private const BASE_URI = '/remote.php/dav/';
 
-	/** @var Server | \PHPUnit\Framework\MockObject\MockObject */
-	private $server;
-
-	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
-	private $tree;
-
-	/** @var IDBConnection */
-	private $dbConnection;
-
-	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
-	private $user;
-
-	/** @var CustomPropertiesBackend | \PHPUnit\Framework\MockObject\MockObject */
-	private $backend;
-
-	/** @property DefaultCalendarValidator | \PHPUnit\Framework\MockObject\MockObject */
-	private $defaultCalendarValidator;
+	private Server&MockObject $server;
+	private Tree&MockObject $tree;
+	private IDBConnection $dbConnection;
+	private IUser&MockObject $user;
+	private DefaultCalendarValidator&MockObject $defaultCalendarValidator;
+	private CustomPropertiesBackend $backend;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -85,13 +76,13 @@ class CustomPropertiesBackendTest extends TestCase {
 		}
 	}
 
-	protected function insertProps(string $user, string $path, array $props) {
+	protected function insertProps(string $user, string $path, array $props): void {
 		foreach ($props as $name => $value) {
 			$this->insertProp($user, $path, $name, $value);
 		}
 	}
 
-	protected function insertProp(string $user, string $path, string $name, mixed $value) {
+	protected function insertProp(string $user, string $path, string $name, mixed $value): void {
 		$type = CustomPropertiesBackend::PROPERTY_TYPE_STRING;
 		if ($value instanceof Href) {
 			$value = $value->getHref();
@@ -110,7 +101,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$query->execute();
 	}
 
-	protected function getProps(string $user, string $path) {
+	protected function getProps(string $user, string $path): array {
 		$query = $this->dbConnection->getQueryBuilder();
 		$query->select('propertyname', 'propertyvalue', 'valuetype')
 			->from('properties')
@@ -245,7 +236,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals($props, $setProps);
 	}
 
-	public function propFindPrincipalScheduleDefaultCalendarProviderUrlProvider(): array {
+	public static function propFindPrincipalScheduleDefaultCalendarProviderUrlProvider(): array {
 		// [ user, nodes, existingProps, requestedProps, returnedProps ]
 		return [
 			[ // Exists
@@ -373,7 +364,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals($result, $storedProps);
 	}
 
-	public function propPatchProvider() {
+	public static function propPatchProvider(): array {
 		$longPath = str_repeat('long_path', 100);
 		return [
 			['foo_bar_path_1337', [], ['{DAV:}displayname' => 'anything'], ['{DAV:}displayname' => 'anything']],
@@ -436,7 +427,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals([], $this->getProps('dummy_user_42', $path));
 	}
 
-	public function deleteProvider() {
+	public static function deleteProvider(): array {
 		return [
 			['foo_bar_path_1337'],
 			[str_repeat('long_path', 100)]
@@ -453,7 +444,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals(['foo' => 'bar'], $this->getProps('dummy_user_42', $target));
 	}
 
-	public function moveProvider() {
+	public static function moveProvider(): array {
 		return [
 			['foo_bar_path_1337', 'foo_bar_path_7333'],
 			[str_repeat('long_path1', 100), str_repeat('long_path2', 100)]
@@ -475,5 +466,4 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertInstanceOf(\Sabre\CalDAV\Xml\Property\ScheduleCalendarTransp::class, $decodeValue);
 		$this->assertEquals('opaque', $decodeValue->getValue());
 	}
-
 }

--- a/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
+++ b/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -18,20 +20,11 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\PropPatch;
 
 class GroupPrincipalTest extends \Test\TestCase {
-	/** @var IConfig|MockObject */
-	private $config;
-
-	/** @var IGroupManager | MockObject */
-	private $groupManager;
-
-	/** @var IUserSession | MockObject */
-	private $userSession;
-
-	/** @var IManager | MockObject */
-	private $shareManager;
-
-	/** @var GroupPrincipalBackend */
-	private $connector;
+	private IConfig&MockObject $config;
+	private IGroupManager&MockObject $groupManager;
+	private IUserSession&MockObject $userSession;
+	private IManager&MockObject $shareManager;
+	private GroupPrincipalBackend $connector;
 
 	protected function setUp(): void {
 		$this->groupManager = $this->createMock(IGroupManager::class);
@@ -201,11 +194,6 @@ class GroupPrincipalTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider searchPrincipalsDataProvider
-	 * @param bool $sharingEnabled
-	 * @param bool $groupSharingEnabled
-	 * @param bool $groupsOnly
-	 * @param string $test
-	 * @param array $result
 	 */
 	public function testSearchPrincipals(bool $sharingEnabled, bool $groupSharingEnabled, bool $groupsOnly, string $test, array $result): void {
 		$this->shareManager->expects($this->once())
@@ -264,7 +252,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 			['{DAV:}displayname' => 'Foo'], $test));
 	}
 
-	public function searchPrincipalsDataProvider() {
+	public static function searchPrincipalsDataProvider(): array {
 		return [
 			[true, true, false, 'allof', ['principals/groups/group1', 'principals/groups/group2', 'principals/groups/group3', 'principals/groups/group4', 'principals/groups/group5']],
 			[true, true, false, 'anyof', ['principals/groups/group1', 'principals/groups/group2', 'principals/groups/group3', 'principals/groups/group4', 'principals/groups/group5']],
@@ -279,11 +267,6 @@ class GroupPrincipalTest extends \Test\TestCase {
 
 	/**
 	 * @dataProvider findByUriDataProvider
-	 * @param bool $sharingEnabled
-	 * @param bool $groupSharingEnabled
-	 * @param bool $groupsOnly
-	 * @param string $findUri
-	 * @param string|null $result
 	 */
 	public function testFindByUri(bool $sharingEnabled, bool $groupSharingEnabled, bool $groupsOnly, string $findUri, ?string $result): void {
 		$this->shareManager->expects($this->once())
@@ -320,7 +303,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		$this->assertEquals($result, $this->connector->findByUri($findUri, 'principals/groups'));
 	}
 
-	public function findByUriDataProvider() {
+	public static function findByUriDataProvider(): array {
 		return [
 			[false, false, false, 'principal:principals/groups/group1', null],
 			[false, false, false, 'principal:principals/groups/group3', null],
@@ -337,10 +320,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @return Group|MockObject
-	 */
-	private function mockGroup($gid) {
+	private function mockGroup(string $gid): Group&MockObject {
 		$fooGroup = $this->createMock(Group::class);
 		$fooGroup
 			->expects($this->exactly(1))

--- a/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
+++ b/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
@@ -51,9 +51,7 @@ class UserEventsListenerTest extends TestCase {
 	}
 
 	public function test(): void {
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
 		$this->defaults->expects($this->once())->method('getColorPrimary')->willReturn('#745bca');
@@ -76,9 +74,7 @@ class UserEventsListenerTest extends TestCase {
 	}
 
 	public function testWithExisting(): void {
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
 		$this->calDavBackend->expects($this->once())->method('getCalendarsForUserCount')->willReturn(1);
@@ -91,9 +87,7 @@ class UserEventsListenerTest extends TestCase {
 	}
 
 	public function testWithBirthdayCalendar(): void {
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
 		$this->defaults->expects($this->once())->method('getColorPrimary')->willReturn('#745bca');
@@ -116,9 +110,7 @@ class UserEventsListenerTest extends TestCase {
 	}
 
 	public function testDeleteCalendar(): void {
-		$user = $this->getMockBuilder(IUser::class)
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
 		$this->syncService->expects($this->once())

--- a/apps/dav/tests/unit/DAV/Sharing/BackendTest.php
+++ b/apps/dav/tests/unit/DAV/Sharing/BackendTest.php
@@ -24,14 +24,14 @@ use Test\TestCase;
 
 class BackendTest extends TestCase {
 
-	private IDBConnection|MockObject $db;
-	private IUserManager|MockObject $userManager;
-	private IGroupManager|MockObject $groupManager;
-	private MockObject|Principal $principalBackend;
-	private MockObject|ICache $shareCache;
-	private LoggerInterface|MockObject $logger;
-	private MockObject|ICacheFactory $cacheFactory;
-	private Service|MockObject $calendarService;
+	private IDBConnection&MockObject $db;
+	private IUserManager&MockObject $userManager;
+	private IGroupManager&MockObject $groupManager;
+	private Principal&MockObject $principalBackend;
+	private ICache&MockObject $shareCache;
+	private LoggerInterface&MockObject $logger;
+	private ICacheFactory&MockObject $cacheFactory;
+	private Service&MockObject $calendarService;
 	private CalendarSharingBackend $backend;
 
 	protected function setUp(): void {

--- a/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
+++ b/apps/dav/tests/unit/DAV/Sharing/PluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -12,6 +13,7 @@ use OCA\DAV\DAV\Sharing\IShareable;
 use OCA\DAV\DAV\Sharing\Plugin;
 use OCP\IConfig;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Server;
 use Sabre\DAV\SimpleCollection;
 use Sabre\HTTP\Request;
@@ -19,32 +21,24 @@ use Sabre\HTTP\Response;
 use Test\TestCase;
 
 class PluginTest extends TestCase {
-
-	/** @var Plugin */
-	private $plugin;
-	/** @var Server */
-	private $server;
-	/** @var IShareable | \PHPUnit\Framework\MockObject\MockObject */
-	private $book;
+	private Plugin $plugin;
+	private Server $server;
+	private IShareable&MockObject $book;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		/** @var Auth | \PHPUnit\Framework\MockObject\MockObject $authBackend */
-		$authBackend = $this->getMockBuilder(Auth::class)->disableOriginalConstructor()->getMock();
+		$authBackend = $this->createMock(Auth::class);
 		$authBackend->method('isDavAuthenticated')->willReturn(true);
 
-		/** @var IRequest $request */
-		$request = $this->getMockBuilder(IRequest::class)->disableOriginalConstructor()->getMock();
+		$request = $this->createMock(IRequest::class);
 		$config = $this->createMock(IConfig::class);
 		$this->plugin = new Plugin($authBackend, $request, $config);
 
 		$root = new SimpleCollection('root');
 		$this->server = new \Sabre\DAV\Server($root);
 		/** @var SimpleCollection $node */
-		$this->book = $this->getMockBuilder(IShareable::class)->
-			disableOriginalConstructor()->
-			getMock();
+		$this->book = $this->createMock(IShareable::class);
 		$this->book->method('getName')->willReturn('addressbook1.vcf');
 		$root->addChild($this->book);
 		$this->plugin->initialize($this->server);

--- a/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -8,22 +9,21 @@
 namespace OCA\DAV\Tests\unit\DAV;
 
 use OCA\DAV\DAV\SystemPrincipalBackend;
+use Sabre\DAV\Exception;
 use Test\TestCase;
 
 class SystemPrincipalBackendTest extends TestCase {
 
 	/**
 	 * @dataProvider providesPrefix
-	 * @param $expected
-	 * @param $prefix
 	 */
-	public function testGetPrincipalsByPrefix($expected, $prefix): void {
+	public function testGetPrincipalsByPrefix(array $expected, string $prefix): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalsByPrefix($prefix);
 		$this->assertEquals($expected, $result);
 	}
 
-	public function providesPrefix() {
+	public static function providesPrefix(): array {
 		return [
 			[[], ''],
 			[[[
@@ -40,16 +40,14 @@ class SystemPrincipalBackendTest extends TestCase {
 
 	/**
 	 * @dataProvider providesPath
-	 * @param $expected
-	 * @param $path
 	 */
-	public function testGetPrincipalByPath($expected, $path): void {
+	public function testGetPrincipalByPath(?array $expected, string $path): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalByPath($path);
 		$this->assertEquals($expected, $result);
 	}
 
-	public function providesPath() {
+	public static function providesPath(): array {
 		return [
 			[null, ''],
 			[null, 'principals'],
@@ -63,28 +61,22 @@ class SystemPrincipalBackendTest extends TestCase {
 
 	/**
 	 * @dataProvider providesPrincipalForGetGroupMemberSet
-	 *
-	 * @param string $principal
-	 * @throws \Sabre\DAV\Exception
 	 */
-	public function testGetGroupMemberSetExceptional($principal): void {
-		$this->expectException(\Sabre\DAV\Exception::class);
+	public function testGetGroupMemberSetExceptional(?string $principal): void {
+		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Principal not found');
 
 		$backend = new SystemPrincipalBackend();
 		$backend->getGroupMemberSet($principal);
 	}
 
-	public function providesPrincipalForGetGroupMemberSet() {
+	public static function providesPrincipalForGetGroupMemberSet(): array {
 		return [
 			[null],
 			['principals/system'],
 		];
 	}
 
-	/**
-	 * @throws \Sabre\DAV\Exception
-	 */
 	public function testGetGroupMemberSet(): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getGroupMemberSet('principals/system/system');
@@ -93,27 +85,21 @@ class SystemPrincipalBackendTest extends TestCase {
 
 	/**
 	 * @dataProvider providesPrincipalForGetGroupMembership
-	 *
-	 * @param string $principal
-	 * @throws \Sabre\DAV\Exception
 	 */
-	public function testGetGroupMembershipExceptional($principal): void {
-		$this->expectException(\Sabre\DAV\Exception::class);
+	public function testGetGroupMembershipExceptional(string $principal): void {
+		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Principal not found');
 
 		$backend = new SystemPrincipalBackend();
 		$backend->getGroupMembership($principal);
 	}
 
-	public function providesPrincipalForGetGroupMembership() {
+	public static function providesPrincipalForGetGroupMembership(): array {
 		return [
 			['principals/system/a'],
 		];
 	}
 
-	/**
-	 * @throws \Sabre\DAV\Exception
-	 */
 	public function testGetGroupMembership(): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getGroupMembership('principals/system/system');

--- a/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2019 ownCloud GmbH
@@ -20,30 +21,29 @@ use OCP\Files\Storage\IStorage;
 use OCP\IUser;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Server;
 use Sabre\DAV\Tree;
 use Sabre\HTTP\RequestInterface;
 use Test\TestCase;
 
 class ViewOnlyPluginTest extends TestCase {
-
+	private Tree&MockObject $tree;
+	private RequestInterface&MockObject $request;
+	private Folder&MockObject $userFolder;
 	private ViewOnlyPlugin $plugin;
-	/** @var Tree | \PHPUnit\Framework\MockObject\MockObject */
-	private $tree;
-	/** @var RequestInterface | \PHPUnit\Framework\MockObject\MockObject */
-	private $request;
-	/** @var Folder | \PHPUnit\Framework\MockObject\MockObject */
-	private $userFolder;
 
 	public function setUp(): void {
+		parent::setUp();
+
 		$this->userFolder = $this->createMock(Folder::class);
+		$this->request = $this->createMock(RequestInterface::class);
+		$this->tree = $this->createMock(Tree::class);
+		$server = $this->createMock(Server::class);
+
 		$this->plugin = new ViewOnlyPlugin(
 			$this->userFolder,
 		);
-		$this->request = $this->createMock(RequestInterface::class);
-		$this->tree = $this->createMock(Tree::class);
-
-		$server = $this->createMock(Server::class);
 		$server->tree = $this->tree;
 
 		$this->plugin->initialize($server);
@@ -71,7 +71,7 @@ class ViewOnlyPluginTest extends TestCase {
 		$this->assertTrue($this->plugin->checkViewOnly($this->request));
 	}
 
-	public function providesDataForCanGet(): array {
+	public static function providesDataForCanGet(): array {
 		return [
 			// has attribute permissions-download enabled - can get file
 			[false, true, true],

--- a/apps/dav/tests/unit/Direct/DirectFileTest.php
+++ b/apps/dav/tests/unit/Direct/DirectFileTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Unit\Direct;
+namespace OCA\DAV\Tests\unit\Direct;
 
 use OCA\DAV\Db\Direct;
 use OCA\DAV\Direct\DirectFile;
@@ -14,28 +14,17 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\Forbidden;
 use Test\TestCase;
 
 class DirectFileTest extends TestCase {
-
-	/** @var Direct */
-	private $direct;
-
-	/** @var IRootFolder|\PHPUnit\Framework\MockObject\MockObject */
-	private $rootFolder;
-
-	/** @var Folder|\PHPUnit\Framework\MockObject\MockObject */
-	private $userFolder;
-
-	/** @var File|\PHPUnit\Framework\MockObject\MockObject */
-	private $file;
-
-	/** @var DirectFile */
-	private $directFile;
-
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
+	private Direct $direct;
+	private IRootFolder&MockObject $rootFolder;
+	private Folder&MockObject $userFolder;
+	private File&MockObject $file;
+	private IEventDispatcher&MockObject $eventDispatcher;
+	private DirectFile $directFile;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/dav/tests/unit/Direct/DirectHomeTest.php
+++ b/apps/dav/tests/unit/Direct/DirectHomeTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Unit\Direct;
+namespace OCA\DAV\Tests\unit\Direct;
 
 use OCA\DAV\Db\Direct;
 use OCA\DAV\Db\DirectMapper;
@@ -18,33 +18,20 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
 use OCP\IRequest;
 use OCP\Security\Bruteforce\IThrottler;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\MethodNotAllowed;
 use Sabre\DAV\Exception\NotFound;
 use Test\TestCase;
 
 class DirectHomeTest extends TestCase {
-
-	/** @var DirectMapper|\PHPUnit\Framework\MockObject\MockObject */
-	private $directMapper;
-
-	/** @var IRootFolder|\PHPUnit\Framework\MockObject\MockObject */
-	private $rootFolder;
-
-	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $timeFactory;
-
-	/** @var IThrottler|\PHPUnit\Framework\MockObject\MockObject */
-	private $throttler;
-
-	/** @var IRequest */
-	private $request;
-
-	/** @var DirectHome */
-	private $directHome;
-
-	/** @var IEventDispatcher */
-	private $eventDispatcher;
+	private DirectMapper&MockObject $directMapper;
+	private IRootFolder&MockObject $rootFolder;
+	private ITimeFactory&MockObject $timeFactory;
+	private IThrottler&MockObject $throttler;
+	private IRequest&MockObject $request;
+	private IEventDispatcher&MockObject $eventDispatcher;
+	private DirectHome $directHome;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/dav/tests/unit/Files/FileSearchBackendTest.php
+++ b/apps/dav/tests/unit/Files/FileSearchBackendTest.php
@@ -1,10 +1,12 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Files;
+namespace OCA\DAV\Tests\unit\Files;
 
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
@@ -23,42 +25,26 @@ use OCP\Files\Search\ISearchQuery;
 use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IUser;
 use OCP\Share\IManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use SearchDAV\Backend\SearchPropertyDefinition;
 use SearchDAV\Query\Limit;
+use SearchDAV\Query\Literal;
 use SearchDAV\Query\Operator;
 use SearchDAV\Query\Query;
+use SearchDAV\Query\Scope;
 use Test\TestCase;
 
 class FileSearchBackendTest extends TestCase {
-	/** @var ObjectTree|\PHPUnit\Framework\MockObject\MockObject */
-	private $tree;
-
-	/** @var IUser */
-	private $user;
-
-	/** @var IRootFolder|\PHPUnit\Framework\MockObject\MockObject */
-	private $rootFolder;
-
-	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $shareManager;
-
-	/** @var View|\PHPUnit\Framework\MockObject\MockObject */
-	private $view;
-
-	/** @var Folder|\PHPUnit\Framework\MockObject\MockObject */
-	private $searchFolder;
-
-	/** @var FileSearchBackend */
-	private $search;
-
-	/** @var Directory|\PHPUnit\Framework\MockObject\MockObject */
-	private $davFolder;
+	private ObjectTree&MockObject $tree;
+	private IUser&MockObject $user;
+	private IRootFolder&MockObject $rootFolder;
+	private IManager&MockObject $shareManager;
+	private View&MockObject $view;
+	private Folder&MockObject $searchFolder;
+	private Directory&MockObject $davFolder;
+	private FileSearchBackend $search;
 
 	protected function setUp(): void {
-		if (PHP_VERSION_ID >= 80400) {
-			$this->markTestSkipped('SearchDAV is not yet PHP 8.4 compatible');
-		}
-
 		parent::setUp();
 
 		$this->user = $this->createMock(IUser::class);
@@ -66,11 +52,13 @@ class FileSearchBackendTest extends TestCase {
 			->method('getUID')
 			->willReturn('test');
 
-		$this->tree = $this->getMockBuilder(ObjectTree::class)
-			->disableOriginalConstructor()
-			->getMock();
-
+		$this->tree = $this->createMock(ObjectTree::class);
 		$this->view = $this->createMock(View::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+		$this->shareManager = $this->createMock(IManager::class);
+		$this->searchFolder = $this->createMock(Folder::class);
+		$fileInfo = $this->createMock(FileInfo::class);
+		$this->davFolder = $this->createMock(Directory::class);
 
 		$this->view->expects($this->any())
 			->method('getRoot')
@@ -79,16 +67,6 @@ class FileSearchBackendTest extends TestCase {
 		$this->view->expects($this->any())
 			->method('getRelativePath')
 			->willReturnArgument(0);
-
-		$this->rootFolder = $this->createMock(IRootFolder::class);
-
-		$this->shareManager = $this->createMock(IManager::class);
-
-		$this->searchFolder = $this->createMock(Folder::class);
-
-		$fileInfo = $this->createMock(FileInfo::class);
-
-		$this->davFolder = $this->createMock(Directory::class);
 
 		$this->davFolder->expects($this->any())
 			->method('getFileInfo')
@@ -263,8 +241,8 @@ class FileSearchBackendTest extends TestCase {
 		$this->search->search($query);
 	}
 
-	private function getBasicQuery($type, $property, $value = null) {
-		$scope = new \SearchDAV\Query\Scope('/', 'infinite');
+	private function getBasicQuery(string $type, string $property, int|string|null $value = null) {
+		$scope = new Scope('/', 'infinite');
 		$scope->path = '/';
 		$from = [$scope];
 		$orderBy = [];
@@ -272,12 +250,12 @@ class FileSearchBackendTest extends TestCase {
 		if (is_null($value)) {
 			$where = new Operator(
 				$type,
-				[new \SearchDAV\Query\Literal($property)]
+				[new Literal($property)]
 			);
 		} else {
 			$where = new Operator(
 				$type,
-				[new SearchPropertyDefinition($property, true, true, true), new \SearchDAV\Query\Literal($value)]
+				[new SearchPropertyDefinition($property, true, true, true), new Literal($value)]
 			);
 		}
 		$limit = new Limit();
@@ -350,11 +328,11 @@ class FileSearchBackendTest extends TestCase {
 			[
 				new Operator(
 					Operator::OPERATION_EQUAL,
-					[new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true), new \SearchDAV\Query\Literal('image/png')]
+					[new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true), new Literal('image/png')]
 				),
 				new Operator(
 					Operator::OPERATION_EQUAL,
-					[new SearchPropertyDefinition(FilesPlugin::OWNER_ID_PROPERTYNAME, true, true, true), new \SearchDAV\Query\Literal($this->user->getUID())]
+					[new SearchPropertyDefinition(FilesPlugin::OWNER_ID_PROPERTYNAME, true, true, true), new Literal($this->user->getUID())]
 				),
 			]
 		);
@@ -383,7 +361,7 @@ class FileSearchBackendTest extends TestCase {
 
 		$innerOperator = new Operator(
 			Operator::OPERATION_EQUAL,
-			[new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true), new \SearchDAV\Query\Literal('image/png')]
+			[new SearchPropertyDefinition('{DAV:}getcontenttype', true, true, true), new Literal('image/png')]
 		);
 		// 5 child operators
 		$level1Operator = new Operator(

--- a/apps/dav/tests/unit/Files/MultipartRequestParserTest.php
+++ b/apps/dav/tests/unit/Files/MultipartRequestParserTest.php
@@ -1,10 +1,12 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-namespace OCA\DAV\Tests\unit\DAV;
+namespace OCA\DAV\Tests\unit\Files;
 
 use OCA\DAV\BulkUpload\MultipartRequestParser;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -17,10 +19,11 @@ class MultipartRequestParserTest extends TestCase {
 	protected LoggerInterface&MockObject $logger;
 
 	protected function setUp(): void {
+		parent::setUp();
 		$this->logger = $this->createMock(LoggerInterface::class);
 	}
 
-	private function getValidBodyObject() {
+	private static function getValidBodyObject(): array {
 		return [
 			[
 				'headers' => [
@@ -99,7 +102,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * - valid file path
 	 */
 	public function testValidRequest(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		unset($bodyObject['0']['headers']['X-File-MD5']);
 
 		$multipartParser = $this->getMultipartParser($bodyObject);
@@ -122,7 +125,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * - valid file path
 	 */
 	public function testValidRequestWithMd5(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		unset($bodyObject['0']['headers']['OC-Checksum']);
 
 		$multipartParser = $this->getMultipartParser($bodyObject);
@@ -140,7 +143,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with invalid hash.
 	 */
 	public function testInvalidHash(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$bodyObject['0']['headers']['OC-Checksum'] = 'md5:f2377b4d911f7ec46325fe603c3af03';
 		unset($bodyObject['0']['headers']['X-File-MD5']);
 		$multipartParser = $this->getMultipartParser(
@@ -155,7 +158,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with invalid md5 hash.
 	 */
 	public function testInvalidMd5Hash(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		unset($bodyObject['0']['headers']['OC-Checksum']);
 		$bodyObject['0']['headers']['X-File-MD5'] = 'f2377b4d911f7ec46325fe603c3af03';
 		$multipartParser = $this->getMultipartParser(
@@ -170,7 +173,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a null hash headers.
 	 */
 	public function testNullHash(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		unset($bodyObject['0']['headers']['OC-Checksum']);
 		unset($bodyObject['0']['headers']['X-File-MD5']);
 		$multipartParser = $this->getMultipartParser(
@@ -185,7 +188,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a null Content-Length.
 	 */
 	public function testNullContentLength(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		unset($bodyObject['0']['headers']['Content-Length']);
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject
@@ -199,7 +202,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a lower Content-Length.
 	 */
 	public function testLowerContentLength(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$bodyObject['0']['headers']['Content-Length'] = 6;
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject
@@ -213,7 +216,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a higher Content-Length.
 	 */
 	public function testHigherContentLength(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$bodyObject['0']['headers']['Content-Length'] = 8;
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject
@@ -227,7 +230,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with wrong boundary in body.
 	 */
 	public function testWrongBoundary(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject,
 			['Content-Type' => 'multipart/related; boundary=boundary_poiuytreza']
@@ -241,7 +244,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with no boundary in request headers.
 	 */
 	public function testNoBoundaryInHeader(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$this->expectExceptionMessage('Error while parsing boundary in Content-Type header.');
 		$this->getMultipartParser(
 			$bodyObject,
@@ -253,7 +256,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with no boundary in the request's headers.
 	 */
 	public function testNoBoundaryInBody(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject,
 			['Content-Type' => 'multipart/related; boundary=boundary_azertyuiop'],
@@ -268,7 +271,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a boundary with quotes in the request's headers.
 	 */
 	public function testBoundaryWithQuotes(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$multipartParser = $this->getMultipartParser(
 			$bodyObject,
 			['Content-Type' => 'multipart/related; boundary="boundary_azertyuiop"'],
@@ -284,7 +287,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a wrong Content-Type in the request's headers.
 	 */
 	public function testWrongContentType(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$this->expectExceptionMessage('Content-Type must be multipart/related');
 		$this->getMultipartParser(
 			$bodyObject,
@@ -296,7 +299,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a wrong key after the content type in the request's headers.
 	 */
 	public function testWrongKeyInContentType(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$this->expectExceptionMessage('Boundary is invalid');
 		$this->getMultipartParser(
 			$bodyObject,
@@ -308,7 +311,7 @@ class MultipartRequestParserTest extends TestCase {
 	 * Test with a null Content-Type in the request's headers.
 	 */
 	public function testNullContentType(): void {
-		$bodyObject = $this->getValidBodyObject();
+		$bodyObject = self::getValidBodyObject();
 		$this->expectExceptionMessage('Content-Type can not be null');
 		$this->getMultipartParser(
 			$bodyObject,

--- a/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
+++ b/apps/dav/tests/unit/Files/Sharing/FilesDropPluginTest.php
@@ -1,9 +1,11 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Files\Sharing;
+namespace OCA\DAV\Tests\unit\Files\Sharing;
 
 use OCA\DAV\Files\Sharing\FilesDropPlugin;
 use OCP\Files\Folder;
@@ -205,7 +207,7 @@ class FilesDropPluginTest extends TestCase {
 		$this->request->method('getHeader')
 			->with('X-NC-Nickname')
 			->willReturn('nickname');
-		
+
 		$this->request->method('getPath')
 			->willReturn('/files/token/folder/subfolder/file.txt');
 		$this->request->method('getBaseUrl')

--- a/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
+++ b/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Unit\Listener;
+namespace OCA\DAV\Tests\unit\Listener;
 
 use OCA\DAV\CalDAV\Activity\Backend as ActivityBackend;
 use OCA\DAV\CalDAV\Activity\Provider\Event;
@@ -20,10 +20,8 @@ use Test\TestCase;
 
 class ActivityUpdaterListenerTest extends TestCase {
 
-	/** @var ActivityBackend|MockObject */
-	private $activityBackend;
-	/** @var LoggerInterface|MockObject */
-	private $logger;
+	private ActivityBackend&MockObject $activityBackend;
+	private LoggerInterface&MockObject $logger;
 	private ActivityUpdaterListener $listener;
 
 	protected function setUp(): void {
@@ -55,7 +53,7 @@ class ActivityUpdaterListenerTest extends TestCase {
 		$this->listener->handle($event);
 	}
 
-	public function dataForTestHandleCalendarObjectDeletedEvent(): array {
+	public static function dataForTestHandleCalendarObjectDeletedEvent(): array {
 		return [
 			[1, [], [], [], true],
 			[1, [], [], ['{' . SharingPlugin::NS_NEXTCLOUD . '}deleted-at' => 120], false],
@@ -77,7 +75,7 @@ class ActivityUpdaterListenerTest extends TestCase {
 		$this->listener->handle($event);
 	}
 
-	public function dataForTestHandleCalendarDeletedEvent(): array {
+	public static function dataForTestHandleCalendarDeletedEvent(): array {
 		return [
 			[1, [], [], true],
 			[1, ['{' . SharingPlugin::NS_NEXTCLOUD . '}deleted-at' => 120], [], false],

--- a/apps/dav/tests/unit/Listener/CalendarContactInteractionListenerTest.php
+++ b/apps/dav/tests/unit/Listener/CalendarContactInteractionListenerTest.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Unit\Listener;
+namespace OCA\DAV\Tests\unit\Listener;
 
 use OCA\DAV\Connector\Sabre\Principal;
 use OCA\DAV\Events\CalendarShareUpdatedEvent;
@@ -23,24 +23,12 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class CalendarContactInteractionListenerTest extends TestCase {
-
-	/** @var IEventDispatcher|MockObject */
-	private $eventDispatcher;
-
-	/** @var IUserSession|MockObject */
-	private $userSession;
-
-	/** @var Principal|MockObject */
-	private $principalConnector;
-
-	/** @var LoggerInterface|MockObject */
-	private $logger;
-
-	/** @var IMailer|MockObject */
-	private $mailer;
-
-	/** @var CalendarContactInteractionListener */
-	private $listener;
+	private IEventDispatcher&MockObject $eventDispatcher;
+	private IUserSession&MockObject $userSession;
+	private Principal&MockObject $principalConnector;
+	private LoggerInterface&MockObject $logger;
+	private IMailer&MockObject $mailer;
+	private CalendarContactInteractionListener $listener;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/dav/tests/unit/Listener/OutOfOfficeListenerTest.php
+++ b/apps/dav/tests/unit/Listener/OutOfOfficeListenerTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Unit\Listener;
+namespace OCA\DAV\Tests\unit\Listener;
 
 use DateTimeImmutable;
 use InvalidArgumentException;
@@ -27,7 +27,6 @@ use OCP\User\Events\OutOfOfficeChangedEvent;
 use OCP\User\Events\OutOfOfficeClearedEvent;
 use OCP\User\Events\OutOfOfficeScheduledEvent;
 use OCP\User\IOutOfOfficeData;
-use OCP\UserStatus\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Exception\NotFound;
@@ -42,11 +41,10 @@ use Test\TestCase;
  */
 class OutOfOfficeListenerTest extends TestCase {
 
-	private ServerFactory|MockObject $serverFactory;
-	private IConfig|MockObject $appConfig;
-	private LoggerInterface|MockObject $loggerInterface;
-	private MockObject|TimezoneService $timezoneService;
-	private IManager|MockObject $manager;
+	private ServerFactory&MockObject $serverFactory;
+	private IConfig&MockObject $appConfig;
+	private LoggerInterface&MockObject $loggerInterface;
+	private TimezoneService&MockObject $timezoneService;
 	private OutOfOfficeListener $listener;
 
 	protected function setUp(): void {
@@ -56,14 +54,12 @@ class OutOfOfficeListenerTest extends TestCase {
 		$this->appConfig = $this->createMock(IConfig::class);
 		$this->timezoneService = $this->createMock(TimezoneService::class);
 		$this->loggerInterface = $this->createMock(LoggerInterface::class);
-		$this->manager = $this->createMock(IManager::class);
 
 		$this->listener = new OutOfOfficeListener(
 			$this->serverFactory,
 			$this->appConfig,
 			$this->timezoneService,
 			$this->loggerInterface,
-			$this->manager
 		);
 	}
 
@@ -453,8 +449,6 @@ class OutOfOfficeListenerTest extends TestCase {
 			->method('getPlugin')
 			->with('caldav')
 			->willReturn($caldavPlugin);
-		$this->manager->expects(self::never())
-			->method('revertUserStatus');
 		$event = new OutOfOfficeClearedEvent($data);
 
 		$this->listener->handle($event);
@@ -483,8 +477,6 @@ class OutOfOfficeListenerTest extends TestCase {
 			->method('getNodeForPath')
 			->with('/home/calendar')
 			->willThrowException(new NotFound('nope'));
-		$this->manager->expects(self::never())
-			->method('revertUserStatus');
 		$event = new OutOfOfficeClearedEvent($data);
 
 		$this->listener->handle($event);
@@ -522,8 +514,6 @@ class OutOfOfficeListenerTest extends TestCase {
 			->method('getChild')
 			->with('personal-1')
 			->willThrowException(new NotFound('nope'));
-		$this->manager->expects(self::never())
-			->method('revertUserStatus');
 		$event = new OutOfOfficeClearedEvent($data);
 
 		$this->listener->handle($event);
@@ -565,8 +555,6 @@ class OutOfOfficeListenerTest extends TestCase {
 		$calendar->expects(self::once())
 			->method('getChild')
 			->willThrowException(new NotFound());
-		$this->manager->expects(self::never())
-			->method('revertUserStatus');
 		$event = new OutOfOfficeClearedEvent($data);
 
 		$this->listener->handle($event);

--- a/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
+++ b/apps/dav/tests/unit/Migration/CalDAVRemoveEmptyValueTest.php
@@ -1,15 +1,18 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Unit\DAV\Migration;
+namespace OCA\DAV\Tests\unit\DAV\Migration;
 
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\Migration\CalDAVRemoveEmptyValue;
 use OCP\IDBConnection;
 use OCP\Migration\IOutput;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Sabre\VObject\InvalidDataException;
 use Test\TestCase;
@@ -21,18 +24,10 @@ use Test\TestCase;
  * @group DB
  */
 class CalDAVRemoveEmptyValueTest extends TestCase {
-
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	private $logger;
-
-	/** @var CalDavBackend|\PHPUnit\Framework\MockObject\MockObject */
-	private $backend;
-
-	/** @var IOutput|\PHPUnit\Framework\MockObject\MockObject */
-	private $output;
-
-	/** @var string */
-	private $invalid = 'BEGIN:VCALENDAR
+	private LoggerInterface&MockObject $logger;
+	private CalDavBackend&MockObject $backend;
+	private IOutput&MockObject $output;
+	private string $invalid = 'BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Apple Inc.//Mac OS X 10.11.2//EN
 CALSCALE:GREGORIAN
@@ -52,8 +47,7 @@ CREATED;VALUE=:20151214T091032Z
 END:VEVENT
 END:VCALENDAR';
 
-	/** @var string */
-	private $valid = 'BEGIN:VCALENDAR
+	private string $valid = 'BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Apple Inc.//Mac OS X 10.11.2//EN
 CALSCALE:GREGORIAN
@@ -82,14 +76,14 @@ END:VCALENDAR';
 	}
 
 	public function testRunAllValid(): void {
-		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
+		/** @var CalDAVRemoveEmptyValue&MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
 				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])
-			->setMethods(['getInvalidObjects'])
+			->onlyMethods(['getInvalidObjects'])
 			->getMock();
 
 		$step->expects($this->once())
@@ -106,14 +100,14 @@ END:VCALENDAR';
 	}
 
 	public function testRunInvalid(): void {
-		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
+		/** @var CalDAVRemoveEmptyValue&MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
 				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])
-			->setMethods(['getInvalidObjects'])
+			->onlyMethods(['getInvalidObjects'])
 			->getMock();
 
 		$step->expects($this->once())
@@ -149,14 +143,14 @@ END:VCALENDAR';
 	}
 
 	public function testRunValid(): void {
-		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
+		/** @var CalDAVRemoveEmptyValue&MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
 				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])
-			->setMethods(['getInvalidObjects'])
+			->onlyMethods(['getInvalidObjects'])
 			->getMock();
 
 		$step->expects($this->once())
@@ -191,14 +185,14 @@ END:VCALENDAR';
 	}
 
 	public function testRunStillInvalid(): void {
-		/** @var CalDAVRemoveEmptyValue|\PHPUnit\Framework\MockObject\MockObject $step */
+		/** @var CalDAVRemoveEmptyValue&MockObject $step */
 		$step = $this->getMockBuilder(CalDAVRemoveEmptyValue::class)
 			->setConstructorArgs([
 				Server::get(IDBConnection::class),
 				$this->backend,
 				$this->logger
 			])
-			->setMethods(['getInvalidObjects'])
+			->onlyMethods(['getInvalidObjects'])
 			->getMock();
 
 		$step->expects($this->once())

--- a/apps/dav/tests/unit/Migration/CreateSystemAddressBookStepTest.php
+++ b/apps/dav/tests/unit/Migration/CreateSystemAddressBookStepTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Unit\Migration;
+namespace OCA\DAV\Tests\unit\Migration;
 
 use OCA\DAV\CardDAV\SyncService;
 use OCA\DAV\Migration\CreateSystemAddressBookStep;
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class CreateSystemAddressBookStepTest extends TestCase {
 
-	private SyncService|MockObject $syncService;
+	private SyncService&MockObject $syncService;
 	private CreateSystemAddressBookStep $step;
 
 	protected function setUp(): void {

--- a/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
+++ b/apps/dav/tests/unit/Migration/RegenerateBirthdayCalendarsTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -10,18 +12,13 @@ use OCA\DAV\Migration\RegenerateBirthdayCalendars;
 use OCP\BackgroundJob\IJobList;
 use OCP\IConfig;
 use OCP\Migration\IOutput;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class RegenerateBirthdayCalendarsTest extends TestCase {
-
-	/** @var IJobList | \PHPUnit\Framework\MockObject\MockObject */
-	private $jobList;
-
-	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-
-	/** @var RegenerateBirthdayCalendars */
-	private $migration;
+	private IJobList&MockObject $jobList;
+	private IConfig&MockObject $config;
+	private RegenerateBirthdayCalendars $migration;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
+++ b/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
@@ -22,23 +22,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class RemoveDeletedUsersCalendarSubscriptionsTest extends TestCase {
-	/**
-	 * @var IDBConnection|MockObject
-	 */
-	private $dbConnection;
-	/**
-	 * @var IUserManager|MockObject
-	 */
-	private $userManager;
-
-	/**
-	 * @var IOutput|MockObject
-	 */
-	private $output;
-	/**
-	 * @var RemoveDeletedUsersCalendarSubscriptions
-	 */
-	private $migration;
+	private IDBConnection&MockObject $dbConnection;
+	private IUserManager&MockObject $userManager;
+	private IOutput&MockObject $output;
+	private RemoveDeletedUsersCalendarSubscriptions $migration;
 
 
 	protected function setUp(): void {
@@ -60,10 +47,6 @@ class RemoveDeletedUsersCalendarSubscriptionsTest extends TestCase {
 
 	/**
 	 * @dataProvider dataTestRun
-	 * @param array $subscriptions
-	 * @param array $userExists
-	 * @param int $deletions
-	 * @throws \Exception
 	 */
 	public function testRun(array $subscriptions, array $userExists, int $deletions): void {
 		$qb = $this->createMock(IQueryBuilder::class);
@@ -132,21 +115,28 @@ class RemoveDeletedUsersCalendarSubscriptionsTest extends TestCase {
 		$this->migration->run($this->output);
 	}
 
-	public function dataTestRun(): array {
+	public static function dataTestRun(): array {
 		return [
 			[[], [], 0],
-			[[[
-				'id' => 1,
-				'principaluri' => 'users/principals/foo1',
-			],
+			[
 				[
-					'id' => 2,
-					'principaluri' => 'users/principals/bar1',
+					[
+						'id' => 1,
+						'principaluri' => 'users/principals/foo1',
+					],
+					[
+						'id' => 2,
+						'principaluri' => 'users/principals/bar1',
+					],
+					[
+						'id' => 3,
+						'principaluri' => 'users/principals/bar1',
+					],
+					[],
 				],
-				[
-					'id' => 3,
-					'principaluri' => 'users/principals/bar1',
-				]], ['foo1' => true, 'bar1' => false], 2]
+				['foo1' => true, 'bar1' => false],
+				2
+			],
 		];
 	}
 }

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningNodeTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -7,15 +9,13 @@ namespace OCA\DAV\Tests\unit\Provisioning\Apple;
 
 use OCA\DAV\Provisioning\Apple\AppleProvisioningNode;
 use OCP\AppFramework\Utility\ITimeFactory;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\DAV\PropPatch;
 use Test\TestCase;
 
 class AppleProvisioningNodeTest extends TestCase {
-	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
-	private $timeFactory;
-
-	/** @var AppleProvisioningNode */
-	private $node;
+	private ITimeFactory&MockObject $timeFactory;
+	private AppleProvisioningNode $node;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -27,7 +27,6 @@ class AppleProvisioningNodeTest extends TestCase {
 	public function testGetName(): void {
 		$this->assertEquals('apple-provisioning.mobileconfig', $this->node->getName());
 	}
-
 
 	public function testSetName(): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
@@ -139,8 +139,8 @@ class AppleProvisioningPluginTest extends TestCase {
 		$this->l10n->expects($this->exactly(2))
 			->method('t')
 			->willReturnMap([
-				['Configures a CalDAV account', 'LocalizedConfiguresCalDAV'],
-				['Configures a CardDAV account', 'LocalizedConfiguresCardDAV'],
+				['Configures a CalDAV account', [], 'LocalizedConfiguresCalDAV'],
+				['Configures a CardDAV account', [], 'LocalizedConfiguresCardDAV'],
 			]);
 
 		$this->sabreResponse->expects($this->once())

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -12,40 +14,27 @@ use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Server;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
 class AppleProvisioningPluginTest extends TestCase {
-	/** @var \Sabre\DAV\Server|\PHPUnit\Framework\MockObject\MockObject */
-	protected $server;
-
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	protected $userSession;
-
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	protected $urlGenerator;
-
-	/** @var ThemingDefaults|\PHPUnit\Framework\MockObject\MockObject */
-	protected $themingDefaults;
-
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	protected $request;
-
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	protected $l10n;
-
-	/** @var \Sabre\HTTP\RequestInterface|\PHPUnit\Framework\MockObject\MockObject */
-	protected $sabreRequest;
-
-	/** @var \Sabre\HTTP\ResponseInterface|\PHPUnit\Framework\MockObject\MockObject */
-	protected $sabreResponse;
-
-	/** @var AppleProvisioningPlugin */
-	protected $plugin;
+	protected Server&MockObject $server;
+	protected IUserSession&MockObject $userSession;
+	protected IURLGenerator&MockObject $urlGenerator;
+	protected ThemingDefaults&MockObject $themingDefaults;
+	protected IRequest&MockObject $request;
+	protected IL10N&MockObject $l10n;
+	protected RequestInterface&MockObject $sabreRequest;
+	protected ResponseInterface&MockObject $sabreResponse;
+	protected AppleProvisioningPlugin $plugin;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->server = $this->createMock(\Sabre\DAV\Server::class);
+		$this->server = $this->createMock(Server::class);
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->themingDefaults = $this->createMock(ThemingDefaults::class);
@@ -62,12 +51,12 @@ class AppleProvisioningPluginTest extends TestCase {
 			}
 		);
 
-		$this->sabreRequest = $this->createMock(\Sabre\HTTP\RequestInterface::class);
-		$this->sabreResponse = $this->createMock(\Sabre\HTTP\ResponseInterface::class);
+		$this->sabreRequest = $this->createMock(RequestInterface::class);
+		$this->sabreResponse = $this->createMock(ResponseInterface::class);
 	}
 
 	public function testInitialize(): void {
-		$server = $this->createMock(\Sabre\DAV\Server::class);
+		$server = $this->createMock(Server::class);
 
 		$plugin = new AppleProvisioningPlugin($this->userSession,
 			$this->urlGenerator, $this->themingDefaults, $this->request, $this->l10n,
@@ -149,24 +138,25 @@ class AppleProvisioningPluginTest extends TestCase {
 
 		$this->l10n->expects($this->exactly(2))
 			->method('t')
-			->withConsecutive(
-				['Configures a CalDAV account'],
-				['Configures a CardDAV account'],
-			)
-			->willReturnOnConsecutiveCalls(
-				'LocalizedConfiguresCalDAV',
-				'LocalizedConfiguresCardDAV',
-			);
+			->willReturnMap([
+				['Configures a CalDAV account', 'LocalizedConfiguresCalDAV'],
+				['Configures a CardDAV account', 'LocalizedConfiguresCardDAV'],
+			]);
 
 		$this->sabreResponse->expects($this->once())
 			->method('setStatus')
 			->with(200);
+
+		$calls = [
+			['Content-Disposition', 'attachment; filename="userName-apple-provisioning.mobileconfig"'],
+			['Content-Type', 'application/xml; charset=utf-8'],
+		];
 		$this->sabreResponse->expects($this->exactly(2))
 			->method('setHeader')
-			->withConsecutive(
-				['Content-Disposition', 'attachment; filename="userName-apple-provisioning.mobileconfig"'],
-				['Content-Type', 'application/xml; charset=utf-8'],
-			);
+			->willReturnCallback(function () use (&$calls) {
+				$expected = array_shift($calls);
+				$this->assertEquals($expected, func_get_args());
+			});
 		$this->sabreResponse->expects($this->once())
 			->method('setBody')
 			->with(<<<EOF

--- a/apps/dav/tests/unit/Search/ContactsSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/ContactsSearchProviderTest.php
@@ -17,27 +17,18 @@ use OCP\IUser;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\VObject\Reader;
 use Test\TestCase;
 
 class ContactsSearchProviderTest extends TestCase {
+	private IAppManager&MockObject $appManager;
+	private IL10N&MockObject $l10n;
+	private IURLGenerator&MockObject $urlGenerator;
+	private CardDavBackend&MockObject $backend;
+	private ContactsSearchProvider $provider;
 
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $appManager;
-
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10n;
-
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	private $urlGenerator;
-
-	/** @var CardDavBackend|\PHPUnit\Framework\MockObject\MockObject */
-	private $backend;
-
-	/** @var ContactsSearchProvider */
-	private $provider;
-
-	private $vcardTest0 = 'BEGIN:VCARD' . PHP_EOL .
+	private string $vcardTest0 = 'BEGIN:VCARD' . PHP_EOL .
 		'VERSION:3.0' . PHP_EOL .
 		'PRODID:-//Sabre//Sabre VObject 4.1.2//EN' . PHP_EOL .
 		'UID:Test' . PHP_EOL .
@@ -46,7 +37,7 @@ class ContactsSearchProviderTest extends TestCase {
 		'EMAIL:forrestgump@example.com' . PHP_EOL .
 		'END:VCARD';
 
-	private $vcardTest1 = 'BEGIN:VCARD' . PHP_EOL .
+	private string $vcardTest1 = 'BEGIN:VCARD' . PHP_EOL .
 		'VERSION:3.0' . PHP_EOL .
 		'PRODID:-//Sabre//Sabre VObject 4.1.2//EN' . PHP_EOL .
 		'PHOTO;ENCODING=b;TYPE=image/jpeg:' . PHP_EOL .
@@ -174,7 +165,7 @@ class ContactsSearchProviderTest extends TestCase {
 				$this->urlGenerator,
 				$this->backend,
 			])
-			->setMethods([
+			->onlyMethods([
 				'getDavUrlForContact',
 				'getDeepLinkToContactsApp',
 				'generateSubline',
@@ -191,11 +182,10 @@ class ContactsSearchProviderTest extends TestCase {
 			->willReturn('subline');
 		$provider->expects($this->exactly(2))
 			->method('getDeepLinkToContactsApp')
-			->withConsecutive(
-				['addressbook-uri-99', 'Test'],
-				['addressbook-uri-123', 'Test2']
-			)
-			->willReturn('deep-link-to-contacts');
+			->willReturnMap([
+				['addressbook-uri-99', 'Test', 'deep-link-to-contacts'],
+				['addressbook-uri-123', 'Test2', 'deep-link-to-contacts'],
+			]);
 
 		$actual = $provider->search($user, $query);
 		$data = $actual->jsonSerialize();

--- a/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
@@ -18,27 +18,19 @@ use OCP\Search\IFilter;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
+use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\VObject\Reader;
 use Test\TestCase;
 
 class EventsSearchProviderTest extends TestCase {
-	/** @var IAppManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $appManager;
-
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10n;
-
-	/** @var IURLGenerator|\PHPUnit\Framework\MockObject\MockObject */
-	private $urlGenerator;
-
-	/** @var CalDavBackend|\PHPUnit\Framework\MockObject\MockObject */
-	private $backend;
-
-	/** @var EventsSearchProvider */
-	private $provider;
+	private IAppManager&MockObject $appManager;
+	private IL10N&MockObject $l10n;
+	private IURLGenerator&MockObject $urlGenerator;
+	private CalDavBackend&MockObject $backend;
+	private EventsSearchProvider $provider;
 
 	// NO SUMMARY
-	private $vEvent0 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent0 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -54,7 +46,7 @@ class EventsSearchProviderTest extends TestCase {
 		'END:VCALENDAR';
 
 	// TIMED SAME DAY
-	private $vEvent1 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent1 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Tests//' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -88,7 +80,7 @@ class EventsSearchProviderTest extends TestCase {
 		'END:VCALENDAR';
 
 	// TIMED DIFFERENT DAY
-	private $vEvent2 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent2 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Tests//' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -122,7 +114,7 @@ class EventsSearchProviderTest extends TestCase {
 		'END:VCALENDAR';
 
 	// ALL-DAY ONE-DAY
-	private $vEvent3 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent3 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -138,7 +130,7 @@ class EventsSearchProviderTest extends TestCase {
 		'END:VCALENDAR';
 
 	// ALL-DAY MULTIPLE DAYS
-	private $vEvent4 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent4 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -154,7 +146,7 @@ class EventsSearchProviderTest extends TestCase {
 		'END:VCALENDAR';
 
 	// DURATION
-	private $vEvent5 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent5 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -170,7 +162,7 @@ class EventsSearchProviderTest extends TestCase {
 		'END:VCALENDAR';
 
 	// NO DTEND - DATE
-	private $vEvent6 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent6 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Apple Inc.//Mac OS X 10.11.6//EN' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -185,7 +177,7 @@ class EventsSearchProviderTest extends TestCase {
 		'END:VCALENDAR';
 
 	// NO DTEND - DATE-TIME
-	private $vEvent7 = 'BEGIN:VCALENDAR' . PHP_EOL .
+	private static string $vEvent7 = 'BEGIN:VCALENDAR' . PHP_EOL .
 		'VERSION:2.0' . PHP_EOL .
 		'PRODID:-//Tests//' . PHP_EOL .
 		'CALSCALE:GREGORIAN' . PHP_EOL .
@@ -327,19 +319,19 @@ class EventsSearchProviderTest extends TestCase {
 					'calendarid' => 99,
 					'calendartype' => CalDavBackend::CALENDAR_TYPE_CALENDAR,
 					'uri' => 'event0.ics',
-					'calendardata' => $this->vEvent0,
+					'calendardata' => self::$vEvent0,
 				],
 				[
 					'calendarid' => 123,
 					'calendartype' => CalDavBackend::CALENDAR_TYPE_CALENDAR,
 					'uri' => 'event1.ics',
-					'calendardata' => $this->vEvent1,
+					'calendardata' => self::$vEvent1,
 				],
 				[
 					'calendarid' => 1337,
 					'calendartype' => CalDavBackend::CALENDAR_TYPE_SUBSCRIPTION,
 					'uri' => 'event2.ics',
-					'calendardata' => $this->vEvent2,
+					'calendardata' => self::$vEvent2,
 				]
 			]);
 
@@ -350,7 +342,7 @@ class EventsSearchProviderTest extends TestCase {
 				$this->urlGenerator,
 				$this->backend,
 			])
-			->setMethods([
+			->onlyMethods([
 				'getDeepLinkToCalendarApp',
 				'generateSubline',
 			])
@@ -361,12 +353,11 @@ class EventsSearchProviderTest extends TestCase {
 			->willReturn('subline');
 		$provider->expects($this->exactly(3))
 			->method('getDeepLinkToCalendarApp')
-			->withConsecutive(
-				['principals/users/john.doe', 'calendar-uri-99', 'event0.ics'],
-				['principals/users/john.doe', 'calendar-uri-123', 'event1.ics'],
-				['principals/users/john.doe', 'subscription-uri-1337', 'event2.ics']
-			)
-			->willReturn('deep-link-to-calendar');
+			->willReturnMap([
+				['principals/users/john.doe', 'calendar-uri-99', 'event0.ics', 'deep-link-to-calendar'],
+				['principals/users/john.doe', 'calendar-uri-123', 'event1.ics', 'deep-link-to-calendar'],
+				['principals/users/john.doe', 'subscription-uri-1337', 'event2.ics', 'deep-link-to-calendar']
+			]);
 
 		$actual = $provider->search($user, $query);
 		$data = $actual->jsonSerialize();
@@ -428,9 +419,6 @@ class EventsSearchProviderTest extends TestCase {
 	}
 
 	/**
-	 * @param string $ics
-	 * @param string $expectedSubline
-	 *
 	 * @dataProvider generateSublineDataProvider
 	 */
 	public function testGenerateSubline(string $ics, string $expectedSubline): void {
@@ -450,15 +438,15 @@ class EventsSearchProviderTest extends TestCase {
 		$this->assertEquals($expectedSubline, $actual);
 	}
 
-	public function generateSublineDataProvider(): array {
+	public static function generateSublineDataProvider(): array {
 		return [
-			[$this->vEvent1, '08-16 09:00 - 10:00'],
-			[$this->vEvent2, '08-16 09:00 - 08-17 10:00'],
-			[$this->vEvent3, '10-05'],
-			[$this->vEvent4, '10-05 - 10-07'],
-			[$this->vEvent5, '10-05 - 10-09'],
-			[$this->vEvent6, '10-05'],
-			[$this->vEvent7, '08-16 09:00 - 09:00'],
+			[self::$vEvent1, '08-16 09:00 - 10:00'],
+			[self::$vEvent2, '08-16 09:00 - 08-17 10:00'],
+			[self::$vEvent3, '10-05'],
+			[self::$vEvent4, '10-05 - 10-07'],
+			[self::$vEvent5, '10-05 - 10-09'],
+			[self::$vEvent6, '10-05'],
+			[self::$vEvent7, '08-16 09:00 - 09:00'],
 		];
 	}
 }

--- a/apps/dav/tests/unit/Service/AbsenceServiceTest.php
+++ b/apps/dav/tests/unit/Service/AbsenceServiceTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\dav\tests\unit\Service;
+namespace OCA\DAV\Tests\unit\Service;
 
 use DateTimeImmutable;
 use DateTimeZone;
@@ -24,25 +24,16 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use OCP\User\Events\OutOfOfficeChangedEvent;
 use OCP\User\Events\OutOfOfficeScheduledEvent;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AbsenceServiceTest extends TestCase {
 	private AbsenceService $absenceService;
-
-	/** @var MockObject|AbsenceMapper */
-	private $absenceMapper;
-
-	/** @var MockObject|IEventDispatcher */
-	private $eventDispatcher;
-
-	/** @var MockObject|IJobList */
-	private $jobList;
-
-	/** @var MockObject|TimezoneService */
-	private $timezoneService;
-
-	/** @var MockObject|ITimeFactory */
-	private $timeFactory;
+	private AbsenceMapper&MockObject $absenceMapper;
+	private IEventDispatcher&MockObject $eventDispatcher;
+	private IJobList&MockObject $jobList;
+	private TimezoneService&MockObject $timezoneService;
+	private ITimeFactory&MockObject $timeFactory;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/dav/tests/unit/Service/DefaultContactServiceTest.php
+++ b/apps/dav/tests/unit/Service/DefaultContactServiceTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Unit\Service;
+namespace OCA\DAV\Tests\unit\Service;
 
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\Service\DefaultContactService;
@@ -24,12 +24,12 @@ use Symfony\Component\Uid\Uuid;
 use Test\TestCase;
 
 class DefaultContactServiceTest extends TestCase {
-	private DefaultContactService $service;
-	private MockObject|CardDavBackend $cardDav;
-	private MockObject|IAppManager $appManager;
-	private MockObject|IAppDataFactory $appDataFactory;
-	private MockObject|LoggerInterface $logger;
-	private MockObject|IAppConfig $config;
+	protected DefaultContactService $service;
+	protected CardDavBackend&MockObject $cardDav;
+	protected IAppManager&MockObject $appManager;
+	protected IAppDataFactory&MockObject $appDataFactory;
+	protected LoggerInterface&MockObject $logger;
+	protected IAppConfig&MockObject $config;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -84,7 +84,7 @@ class DefaultContactServiceTest extends TestCase {
 		$folder->method('getFile')->willReturn($file);
 		$appData->method('getFolder')->willReturn($folder);
 		$this->appDataFactory->method('get')->willReturn($appData);
-		
+
 		$capturedCardData = null;
 		$this->cardDav->expects($this->once())
 			->method('createCard')
@@ -97,9 +97,9 @@ class DefaultContactServiceTest extends TestCase {
 				}),
 				$this->anything()
 			)->willReturn(null);
-		
+
 		$this->service->createDefaultContact(123);
-		
+
 		$vcard = \Sabre\VObject\Reader::read($capturedCardData);
 		$this->assertNotEquals($originalUid, $vcard->UID->getValue());
 		$this->assertTrue(Uuid::isValid($vcard->UID->getValue()));

--- a/apps/dav/tests/unit/Service/UpcomingEventsServiceTest.php
+++ b/apps/dav/tests/unit/Service/UpcomingEventsServiceTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\DAV\Tests\Unit\DAV\Service;
+namespace OCA\DAV\Tests\unit\DAV\Service;
 
 use DateTimeImmutable;
 use OCA\DAV\CalDAV\UpcomingEventsService;
@@ -22,11 +22,11 @@ use PHPUnit\Framework\TestCase;
 
 class UpcomingEventsServiceTest extends TestCase {
 
-	private MockObject|IManager $calendarManager;
-	private ITimeFactory|MockObject $timeFactory;
-	private IUserManager|MockObject $userManager;
-	private IAppManager|MockObject $appManager;
-	private IURLGenerator|MockObject $urlGenerator;
+	private IManager&MockObject $calendarManager;
+	private ITimeFactory&MockObject $timeFactory;
+	private IUserManager&MockObject $userManager;
+	private IAppManager&MockObject $appManager;
+	private IURLGenerator&MockObject $urlGenerator;
 	private UpcomingEventsService $service;
 
 	protected function setUp(): void {

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
-namespace OCA\DAV\Tests\Unit\DAV\Settings;
+namespace OCA\DAV\Tests\unit\DAV\Settings;
 
 use OCA\DAV\Settings\CalDAVSettings;
 use OCP\App\IAppManager;


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
