### PR TITLE
test(encryption): prepare for PHPUnit 10

### DIFF
--- a/apps/encryption/tests/Command/FixEncryptedVersionTest.php
+++ b/apps/encryption/tests/Command/FixEncryptedVersionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2019 ownCloud GmbH
@@ -16,6 +18,7 @@ use OCP\IConfig;
 use OCP\ITempManager;
 use OCP\IUserManager;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
@@ -34,16 +37,13 @@ class FixEncryptedVersionTest extends TestCase {
 	use EncryptionTrait;
 	use UserTrait;
 
-	private $userId;
+	private string $userId;
 
-	/** @var FixEncryptedVersion */
-	private $fixEncryptedVersion;
+	private FixEncryptedVersion $fixEncryptedVersion;
 
-	/** @var CommandTester */
-	private $commandTester;
+	private CommandTester $commandTester;
 
-	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
-	protected $util;
+	protected Util&MockObject $util;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/apps/encryption/tests/Command/TestEnableMasterKey.php
+++ b/apps/encryption/tests/Command/TestEnableMasterKey.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.

--- a/apps/encryption/tests/Controller/RecoveryControllerTest.php
+++ b/apps/encryption/tests/Controller/RecoveryControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -13,26 +15,23 @@ use OCP\AppFramework\Http;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class RecoveryControllerTest extends TestCase {
-	/** @var RecoveryController */
-	private $controller;
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $requestMock;
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $configMock;
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10nMock;
-	/** @var Recovery|\PHPUnit\Framework\MockObject\MockObject */
-	private $recoveryMock;
+	protected RecoveryController $controller;
 
-	public function adminRecoveryProvider() {
+	protected IRequest&MockObject $requestMock;
+	protected IConfig&MockObject $configMock;
+	protected IL10N&MockObject $l10nMock;
+	protected Recovery&MockObject $recoveryMock;
+
+	public static function adminRecoveryProvider(): array {
 		return [
 			['test', 'test', '1', 'Recovery key successfully enabled', Http::STATUS_OK],
 			['', 'test', '1', 'Missing recovery key password', Http::STATUS_BAD_REQUEST],
 			['test', '', '1', 'Please repeat the recovery key password', Http::STATUS_BAD_REQUEST],
-			['test', 'soimething that doesn\'t match', '1', 'Repeated recovery key password does not match the provided recovery key password', Http::STATUS_BAD_REQUEST],
+			['test', 'something that doesn\'t match', '1', 'Repeated recovery key password does not match the provided recovery key password', Http::STATUS_BAD_REQUEST],
 			['test', 'test', '0', 'Recovery key successfully disabled', Http::STATUS_OK],
 		];
 	}
@@ -63,7 +62,7 @@ class RecoveryControllerTest extends TestCase {
 		$this->assertEquals($expectedStatus, $response->getStatus());
 	}
 
-	public function changeRecoveryPasswordProvider() {
+	public static function changeRecoveryPasswordProvider(): array {
 		return [
 			['test', 'test', 'oldtestFail', 'Could not change the password. Maybe the old password was not correct.', Http::STATUS_BAD_REQUEST],
 			['test', 'test', 'oldtest', 'Password successfully changed.', Http::STATUS_OK],
@@ -98,7 +97,7 @@ class RecoveryControllerTest extends TestCase {
 		$this->assertEquals($expectedStatus, $response->getStatus());
 	}
 
-	public function userSetRecoveryProvider() {
+	public static function userSetRecoveryProvider(): array {
 		return [
 			['1', 'Recovery Key enabled', Http::STATUS_OK],
 			['0', 'Could not enable the recovery key, please try again or contact your administrator', Http::STATUS_BAD_REQUEST]

--- a/apps/encryption/tests/Controller/SettingsControllerTest.php
+++ b/apps/encryption/tests/Controller/SettingsControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -24,37 +26,18 @@ use Test\TestCase;
 
 class SettingsControllerTest extends TestCase {
 
-	/** @var SettingsController */
-	private $controller;
+	protected SettingsController $controller;
 
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $requestMock;
-
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10nMock;
-
-	/** @var IUserManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $userManagerMock;
-
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	private $userSessionMock;
-
-	/** @var KeyManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $keyManagerMock;
-
-	/** @var Crypt|\PHPUnit\Framework\MockObject\MockObject */
-	private $cryptMock;
-
-	/** @var Session|\PHPUnit\Framework\MockObject\MockObject */
-	private $sessionMock;
-	/** @var MockObject|IUser */
-	private $user;
-
-	/** @var ISession|\PHPUnit\Framework\MockObject\MockObject */
-	private $ocSessionMock;
-
-	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
-	private $utilMock;
+	protected IRequest&MockObject $requestMock;
+	protected IL10N&MockObject $l10nMock;
+	protected IUserManager&MockObject $userManagerMock;
+	protected IUserSession&MockObject $userSessionMock;
+	protected KeyManager&MockObject $keyManagerMock;
+	protected Crypt&MockObject $cryptMock;
+	protected Session&MockObject $sessionMock;
+	protected IUser&MockObject $user;
+	protected ISession&MockObject $ocSessionMock;
+	protected Util&MockObject $utilMock;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -171,21 +154,17 @@ class SettingsControllerTest extends TestCase {
 		$newPassword = 'new';
 
 		$this->ocSessionMock->expects($this->once())
-			->method('get')->with('loginname')->willReturn('testUser');
+			->method('get')
+			->with('loginname')
+			->willReturn('testUser');
 
 		$this->userManagerMock
 			->expects($this->exactly(2))
 			->method('checkPassword')
-			->withConsecutive(
-				['testUserUid', 'new'],
-				['testUser', 'new'],
-			)
-			->willReturnOnConsecutiveCalls(
-				false,
-				true,
-			);
-
-
+			->willReturnMap([
+				['testUserUid', 'new', false],
+				['testUser', 'new', true],
+			]);
 
 		$this->cryptMock
 			->expects($this->once())

--- a/apps/encryption/tests/Controller/StatusControllerTest.php
+++ b/apps/encryption/tests/Controller/StatusControllerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -12,24 +14,17 @@ use OCA\Encryption\Session;
 use OCP\Encryption\IManager;
 use OCP\IL10N;
 use OCP\IRequest;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class StatusControllerTest extends TestCase {
 
-	/** @var IRequest|\PHPUnit\Framework\MockObject\MockObject */
-	private $requestMock;
+	protected IRequest&MockObject $requestMock;
+	protected IL10N&MockObject $l10nMock;
+	protected Session&MockObject $sessionMock;
+	protected IManager&MockObject $encryptionManagerMock;
 
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10nMock;
-
-	/** @var Session|\PHPUnit\Framework\MockObject\MockObject */
-	protected $sessionMock;
-
-	/** @var IManager | \PHPUnit\Framework\MockObject\MockObject */
-	protected $encryptionManagerMock;
-
-	/** @var StatusController */
-	protected $controller;
+	protected StatusController $controller;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -68,7 +63,7 @@ class StatusControllerTest extends TestCase {
 		$this->assertSame($expectedStatus, $data['status']);
 	}
 
-	public function dataTestGetStatus() {
+	public static function dataTestGetStatus(): array {
 		return [
 			[Session::INIT_EXECUTED, 'interactionNeeded'],
 			[Session::INIT_SUCCESSFUL, 'success'],

--- a/apps/encryption/tests/Crypto/DecryptAllTest.php
+++ b/apps/encryption/tests/Crypto/DecryptAllTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -12,28 +14,19 @@ use OCA\Encryption\Crypto\DecryptAll;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Session;
 use OCA\Encryption\Util;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Test\TestCase;
 
 class DecryptAllTest extends TestCase {
 
-	/** @var DecryptAll */
-	protected $instance;
+	protected DecryptAll $instance;
 
-	/** @var Util | \PHPUnit\Framework\MockObject\MockObject */
-	protected $util;
-
-	/** @var KeyManager | \PHPUnit\Framework\MockObject\MockObject */
-	protected $keyManager;
-
-	/** @var Crypt | \PHPUnit\Framework\MockObject\MockObject */
-	protected $crypt;
-
-	/** @var Session | \PHPUnit\Framework\MockObject\MockObject */
-	protected $session;
-
-	/** @var QuestionHelper | \PHPUnit\Framework\MockObject\MockObject */
-	protected $questionHelper;
+	protected Util&MockObject $util;
+	protected KeyManager&MockObject $keyManager;
+	protected Crypt&MockObject $crypt;
+	protected Session&MockObject $session;
+	protected QuestionHelper&MockObject $questionHelper;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -75,6 +68,7 @@ class DecryptAllTest extends TestCase {
 		$password = 'passwd';
 		$recoveryKey = 'recoveryKey';
 		$userKey = 'userKey';
+		$masterKey = 'userKey';
 		$unencryptedKey = 'unencryptedKey';
 
 		$this->keyManager->expects($this->any())->method('getRecoveryKeyId')
@@ -105,7 +99,7 @@ class DecryptAllTest extends TestCase {
 		);
 	}
 
-	public function dataTestGetPrivateKey() {
+	public static function dataTestGetPrivateKey() {
 		return [
 			['user1', 'recoveryKey', 'masterKeyId'],
 			['recoveryKeyId', 'recoveryKeyId', 'masterKeyId'],

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -26,34 +28,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class EncryptionTest extends TestCase {
-	/** @var Encryption */
-	private $instance;
 
-	/** @var KeyManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $keyManagerMock;
+	protected Encryption $instance;
 
-	/** @var EncryptAll|\PHPUnit\Framework\MockObject\MockObject */
-	private $encryptAllMock;
-
-	/** @var DecryptAll|\PHPUnit\Framework\MockObject\MockObject */
-	private $decryptAllMock;
-
-	/** @var Session|\PHPUnit\Framework\MockObject\MockObject */
-	private $sessionMock;
-
-	/** @var Crypt|\PHPUnit\Framework\MockObject\MockObject */
-	private $cryptMock;
-
-	/** @var Util|\PHPUnit\Framework\MockObject\MockObject */
-	private $utilMock;
-
-	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
-	private $loggerMock;
-
-	/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject */
-	private $l10nMock;
-
-	private IStorage&MockObject $storageMock;
+	protected KeyManager&MockObject $keyManagerMock;
+	protected EncryptAll&MockObject $encryptAllMock;
+	protected DecryptAll&MockObject $decryptAllMock;
+	protected Session&MockObject $sessionMock;
+	protected Crypt&MockObject $cryptMock;
+	protected Util&MockObject $utilMock;
+	protected LoggerInterface&MockObject $loggerMock;
+	protected IL10N&MockObject $l10nMock;
+	protected IStorage&MockObject $storageMock;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -175,7 +161,7 @@ class EncryptionTest extends TestCase {
 		);
 	}
 
-	public function dataProviderForTestGetPathToRealFile() {
+	public static function dataProviderForTestGetPathToRealFile(): array {
 		return [
 			['/user/files/foo/bar.txt', '/user/files/foo/bar.txt'],
 			['/user/files/foo.txt', '/user/files/foo.txt'],
@@ -228,7 +214,7 @@ class EncryptionTest extends TestCase {
 		}
 	}
 
-	public function dataTestBegin() {
+	public static function dataTestBegin(): array {
 		return [
 			['w', ['cipher' => 'myCipher'], 'legacyCipher', 'defaultCipher', 'fileKey', 'defaultCipher'],
 			['r', ['cipher' => 'myCipher'], 'legacyCipher', 'defaultCipher', 'fileKey', 'myCipher'],
@@ -305,7 +291,7 @@ class EncryptionTest extends TestCase {
 		);
 	}
 
-	public function dataTestUpdate() {
+	public static function dataTestUpdate(): array {
 		return [
 			['', false],
 			['fileKey', true]
@@ -387,7 +373,7 @@ class EncryptionTest extends TestCase {
 		);
 	}
 
-	public function dataTestShouldEncrypt() {
+	public static function dataTestShouldEncrypt(): array {
 		return [
 			['/user1/files/foo.txt', true, true, true],
 			['/user1/files_versions/foo.txt', true, true, true],

--- a/apps/encryption/tests/RecoveryTest.php
+++ b/apps/encryption/tests/RecoveryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.

--- a/apps/encryption/tests/SessionTest.php
+++ b/apps/encryption/tests/SessionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -10,17 +12,14 @@ namespace OCA\Encryption\Tests;
 use OCA\Encryption\Exceptions\PrivateKeyMissingException;
 use OCA\Encryption\Session;
 use OCP\ISession;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SessionTest extends TestCase {
 	private static $tempStorage = [];
-	/**
-	 * @var Session
-	 */
-	private $instance;
-	/** @var ISession|\PHPUnit\Framework\MockObject\MockObject */
-	private $sessionMock;
 
+	protected Session $instance;
+	protected ISession&MockObject $sessionMock;
 
 	public function testThatGetPrivateKeyThrowsExceptionWhenNotSet(): void {
 		$this->expectException(PrivateKeyMissingException::class);
@@ -122,10 +121,11 @@ class SessionTest extends TestCase {
 	 * @param bool $expected
 	 */
 	public function testIsReady($status, $expected): void {
-		/** @var Session | \PHPUnit\Framework\MockObject\MockObject $instance */
+		/** @var Session&MockObject $instance */
 		$instance = $this->getMockBuilder(Session::class)
 			->setConstructorArgs([$this->sessionMock])
-			->setMethods(['getStatus'])->getMock();
+			->onlyMethods(['getStatus'])
+			->getMock();
 
 		$instance->expects($this->once())->method('getStatus')
 			->willReturn($status);
@@ -133,7 +133,7 @@ class SessionTest extends TestCase {
 		$this->assertSame($expected, $instance->isReady());
 	}
 
-	public function dataTestIsReady() {
+	public static function dataTestIsReady(): array {
 		return [
 			[Session::INIT_SUCCESSFUL, true],
 			[Session::INIT_EXECUTED, false],

--- a/apps/encryption/tests/Settings/AdminTest.php
+++ b/apps/encryption/tests/Settings/AdminTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -12,24 +15,20 @@ use OCP\IL10N;
 use OCP\ISession;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class AdminTest extends TestCase {
-	/** @var Admin */
-	private $admin;
-	/** @var IL10N */
-	private $l;
-	/** @var LoggerInterface */
-	private $logger;
-	/** @var IUserSession */
-	private $userSession;
-	/** @var IConfig */
-	private $config;
-	/** @var IUserManager */
-	private $userManager;
-	/** @var ISession */
-	private $session;
+
+	protected Admin $admin;
+
+	protected IL10N&MockObject $l;
+	protected LoggerInterface&MockObject $logger;
+	protected IUserSession&MockObject $userSession;
+	protected IConfig&MockObject $config;
+	protected IUserManager&MockObject $userManager;
+	protected ISession&MockObject $session;
 
 	protected function setUp(): void {
 		parent::setUp();

--- a/apps/encryption/tests/Users/SetupTest.php
+++ b/apps/encryption/tests/Users/SetupTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -10,21 +12,15 @@ namespace OCA\Encryption\Tests\Users;
 use OCA\Encryption\Crypto\Crypt;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class SetupTest extends TestCase {
-	/**
-	 * @var KeyManager|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private $keyManagerMock;
-	/**
-	 * @var Crypt|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	private $cryptMock;
-	/**
-	 * @var Setup
-	 */
-	private $instance;
+
+	protected Setup $instance;
+
+	protected KeyManager&MockObject $keyManagerMock;
+	protected Crypt&MockObject $cryptMock;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -72,7 +68,7 @@ class SetupTest extends TestCase {
 		);
 	}
 
-	public function dataTestSetupUser() {
+	public static function dataTestSetupUser(): array {
 		return [
 			[true, true],
 			[false, true]

--- a/apps/encryption/tests/UtilTest.php
+++ b/apps/encryption/tests/UtilTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -20,22 +22,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class UtilTest extends TestCase {
-	private static $tempStorage = [];
 
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $configMock;
+	protected Util $instance;
+	protected static $tempStorage = [];
 
-	/** @var View|\PHPUnit\Framework\MockObject\MockObject */
-	private $filesMock;
-
-	/** @var IUserManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $userManagerMock;
-
-	/** @var IMountPoint|\PHPUnit\Framework\MockObject\MockObject */
-	private $mountMock;
-
-	/** @var Util */
-	private $instance;
+	protected IConfig&MockObject $configMock;
+	protected View&MockObject $filesMock;
+	protected IUserManager&MockObject $userManagerMock;
+	protected IMountPoint&MockObject $mountMock;
 
 	public function testSetRecoveryForUser(): void {
 		$this->instance->setRecoveryForUser('1');
@@ -134,7 +128,7 @@ class UtilTest extends TestCase {
 		);
 	}
 
-	public function dataTestIsMasterKeyEnabled() {
+	public static function dataTestIsMasterKeyEnabled(): array {
 		return [
 			['0', false],
 			['1', true]
@@ -155,7 +149,7 @@ class UtilTest extends TestCase {
 			$this->instance->shouldEncryptHomeStorage());
 	}
 
-	public function dataTestShouldEncryptHomeStorage() {
+	public static function dataTestShouldEncryptHomeStorage(): array {
 		return [
 			['1', true],
 			['0', false]
@@ -173,7 +167,7 @@ class UtilTest extends TestCase {
 		$this->instance->setEncryptHomeStorage($value);
 	}
 
-	public function dataTestSetEncryptHomeStorage() {
+	public static function dataTestSetEncryptHomeStorage(): array {
 		return [
 			[true, '1'],
 			[false, '0']

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -159,15 +159,15 @@ class AppManagerTest extends TestCase {
 		}
 	}
 
-	public function dataGetAppIcon(): array {
+	public static function dataGetAppIcon(): array {
 		$nothing = function ($appId) {
-			$this->assertEquals('test', $appId);
+			self::assertEquals('test', $appId);
 			throw new \RuntimeException();
 		};
 
 		$createCallback = function ($workingIcons) {
 			return function ($appId, $icon) use ($workingIcons) {
-				$this->assertEquals('test', $appId);
+				self::assertEquals('test', $appId);
 				if (in_array($icon, $workingIcons)) {
 					return '/path/' . $icon;
 				}

--- a/tests/lib/Files/FilenameValidatorTest.php
+++ b/tests/lib/Files/FilenameValidatorTest.php
@@ -409,7 +409,7 @@ class FilenameValidatorTest extends TestCase {
 		$this->assertEquals($expected, $validator->sanitizeFilename($filename));
 	}
 
-	public function dataSanitizeFilename(): array {
+	public static function dataSanitizeFilename(): array {
 		return [
 			'valid name' => [
 				'a * b.txt', ['.htaccess'], [], [], [], 'a * b.txt'


### PR DESCRIPTION
* for https://github.com/nextcloud/server/pull/48210

## Summary

Adjust encryption tests for PHPUnit 10 deprecations and removals.


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
