### PR TITLE
feat(file-versions): #53151 add VersionCreatedEvent event

### DIFF
--- a/apps/files_versions/composer/composer/autoload_classmap.php
+++ b/apps/files_versions/composer/composer/autoload_classmap.php
@@ -17,6 +17,7 @@ return array(
     'OCA\\Files_Versions\\Db\\VersionEntity' => $baseDir . '/../lib/Db/VersionEntity.php',
     'OCA\\Files_Versions\\Db\\VersionsMapper' => $baseDir . '/../lib/Db/VersionsMapper.php',
     'OCA\\Files_Versions\\Events\\CreateVersionEvent' => $baseDir . '/../lib/Events/CreateVersionEvent.php',
+    'OCA\\Files_Versions\\Events\\VersionCreatedEvent' => $baseDir . '/../lib/Events/VersionCreatedEvent.php',
     'OCA\\Files_Versions\\Events\\VersionRestoredEvent' => $baseDir . '/../lib/Events/VersionRestoredEvent.php',
     'OCA\\Files_Versions\\Expiration' => $baseDir . '/../lib/Expiration.php',
     'OCA\\Files_Versions\\Listener\\FileEventsListener' => $baseDir . '/../lib/Listener/FileEventsListener.php',

--- a/apps/files_versions/composer/composer/autoload_static.php
+++ b/apps/files_versions/composer/composer/autoload_static.php
@@ -32,6 +32,7 @@ class ComposerStaticInitFiles_Versions
         'OCA\\Files_Versions\\Db\\VersionEntity' => __DIR__ . '/..' . '/../lib/Db/VersionEntity.php',
         'OCA\\Files_Versions\\Db\\VersionsMapper' => __DIR__ . '/..' . '/../lib/Db/VersionsMapper.php',
         'OCA\\Files_Versions\\Events\\CreateVersionEvent' => __DIR__ . '/..' . '/../lib/Events/CreateVersionEvent.php',
+        'OCA\\Files_Versions\\Events\\VersionCreatedEvent' => __DIR__ . '/..' . '/../lib/Events/VersionCreatedEvent.php',
         'OCA\\Files_Versions\\Events\\VersionRestoredEvent' => __DIR__ . '/..' . '/../lib/Events/VersionRestoredEvent.php',
         'OCA\\Files_Versions\\Expiration' => __DIR__ . '/..' . '/../lib/Expiration.php',
         'OCA\\Files_Versions\\Listener\\FileEventsListener' => __DIR__ . '/..' . '/../lib/Listener/FileEventsListener.php',

--- a/apps/files_versions/lib/Events/VersionCreatedEvent.php
+++ b/apps/files_versions/lib/Events/VersionCreatedEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\Files_Versions\Events;
+
+use OCP\EventDispatcher\Event;
+use OCP\Files\Node;
+
+/**
+ * Event dispatched after a successful creation of a version
+ */
+class VersionCreatedEvent extends Event {
+	public function __construct(
+		private Node $node,
+		private int $revision,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * Node of the file that has been versioned
+	 */
+	public function getNode(): Node {
+		return $this->node;
+	}
+
+	/**
+	 * Revision of the file that has been versioned
+	 */
+	public function getRevision(): int {
+		return $this->revision;
+	}
+}

--- a/apps/files_versions/lib/Versions/INeedSyncVersionBackend.php
+++ b/apps/files_versions/lib/Versions/INeedSyncVersionBackend.php
@@ -14,7 +14,10 @@ use OCP\Files\File;
  * @since 28.0.0
  */
 interface INeedSyncVersionBackend {
-	public function createVersionEntity(File $file): void;
+	/**
+	 * @return void|null|int
+	 */
+	public function createVersionEntity(File $file);
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void;
 	public function deleteVersionsEntity(File $file): void;
 }

--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -225,7 +225,7 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 		$this->versionsMapper->delete($versionEntity);
 	}
 
-	public function createVersionEntity(File $file): void {
+	public function createVersionEntity(File $file): ?int {
 		$versionEntity = new VersionEntity();
 		$versionEntity->setFileId($file->getId());
 		$versionEntity->setTimestamp($file->getMTime());
@@ -238,7 +238,7 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 			try {
 				$this->versionsMapper->insert($versionEntity);
 				/* No errors, get out of the method */
-				return;
+				return $versionEntity->getTimestamp();
 			} catch (\OCP\DB\Exception $e) {
 				if (!in_array($e->getReason(), [
 					\OCP\DB\Exception::REASON_CONSTRAINT_VIOLATION,
@@ -253,6 +253,8 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 				$this->logger->warning('Constraint violation while inserting version, retrying with increased timestamp', ['exception' => $e]);
 			}
 		}
+
+		return null;
 	}
 
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void {

--- a/apps/files_versions/lib/Versions/VersionManager.php
+++ b/apps/files_versions/lib/Versions/VersionManager.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Versions\Versions;
 
+use OCA\Files_Versions\Events\VersionCreatedEvent;
 use OCA\Files_Versions\Events\VersionRestoredEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\File;
@@ -124,7 +125,11 @@ class VersionManager implements IVersionManager, IDeletableVersionBackend, INeed
 	public function createVersionEntity(File $file): void {
 		$backend = $this->getBackendForStorage($file->getStorage());
 		if ($backend instanceof INeedSyncVersionBackend) {
-			$backend->createVersionEntity($file);
+			$revision = $backend->createVersionEntity($file);
+
+			if (is_int($revision)) {
+				$this->dispatcher->dispatchTyped(new VersionCreatedEvent($file, $revision));
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #53151

## Summary

This event ensures the correct flow when creating custom metadata for a previously created version.

As I mentioned in that issue, that `+1` in the catch makes everything very fragile:

https://github.com/nextcloud/server/blob/c879bab3c932ec24c2cb9fd53fa741087e76cd58/apps/files_versions/lib/Versions/LegacyVersionsBackend.php#L251

We could even refactor [VersionAuthorListener](https://github.com/nextcloud/server/blob/c879bab3c932ec24c2cb9fd53fa741087e76cd58/apps/files_versions/lib/Listener/VersionAuthorListener.php) if you think it's a good idea, so that it uses this event and decouples it from file events, which means that not all cases are covered (https://github.com/nextcloud/server/issues/53152) and it is more fragile.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
