### PR TITLE
refactor(core): migrate core application to `IBootstrap`

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2873,12 +2873,6 @@
       <code><![CDATA[dispatch]]></code>
     </DeprecatedMethod>
   </file>
-  <file src="core/Application.php">
-    <DeprecatedMethod>
-      <code><![CDATA[getServer]]></code>
-      <code><![CDATA[registerService]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php">
     <DeprecatedClass>
       <code><![CDATA[Files::rmdirr($dir)]]></code>

--- a/core/AppInfo/Application.php
+++ b/core/AppInfo/Application.php
@@ -5,7 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
-namespace OC\Core;
+namespace OC\Core\AppInfo;
 
 use OC\Authentication\Events\RemoteWipeFinished;
 use OC\Authentication\Events\RemoteWipeStarted;

--- a/core/Application.php
+++ b/core/Application.php
@@ -17,16 +17,19 @@ use OC\Authentication\Listeners\UserDeletedStoreCleanupListener;
 use OC\Authentication\Listeners\UserDeletedTokenCleanupListener;
 use OC\Authentication\Listeners\UserDeletedWebAuthnCleanupListener;
 use OC\Authentication\Notifications\Notifier as AuthenticationNotifier;
+use OC\Core\Listener\AddMissingIndicesListener;
+use OC\Core\Listener\AddMissingPrimaryKeyListener;
 use OC\Core\Listener\BeforeTemplateRenderedListener;
 use OC\Core\Notification\CoreNotifier;
 use OC\TagManager;
 use OCP\AppFramework\App;
+use OCP\AppFramework\Bootstrap\IBootContext;
+use OCP\AppFramework\Bootstrap\IBootstrap;
+use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Http\Events\BeforeLoginTemplateRenderedEvent;
 use OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent;
 use OCP\DB\Events\AddMissingIndicesEvent;
 use OCP\DB\Events\AddMissingPrimaryKeyEvent;
-use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Notification\IManager as INotificationManager;
 use OCP\User\Events\BeforeUserDeletedEvent;
 use OCP\User\Events\UserDeletedEvent;
 use OCP\Util;
@@ -36,273 +39,49 @@ use OCP\Util;
  *
  * @package OC\Core
  */
-class Application extends App {
-	public function __construct() {
-		parent::__construct('core');
+class Application extends App implements IBootstrap {
 
-		$container = $this->getContainer();
+	public const APP_ID = 'core';
 
-		$container->registerService('defaultMailAddress', function () {
+	/**
+	 * Application constructor.
+	 */
+	public function __construct(array $urlParams = []) {
+		parent::__construct(self::APP_ID, $urlParams);
+	}
+
+	public function register(IRegistrationContext $context): void {
+		$context->registerService('defaultMailAddress', function () {
 			return Util::getDefaultEmailAddress('lostpassword-noreply');
 		});
 
-		$server = $container->getServer();
-		/** @var IEventDispatcher $eventDispatcher */
-		$eventDispatcher = $server->get(IEventDispatcher::class);
+		// register notifier
+		$context->registerNotifierService(CoreNotifier::class);
+		$context->registerNotifierService(AuthenticationNotifier::class);
 
-		$notificationManager = $server->get(INotificationManager::class);
-		$notificationManager->registerNotifierService(CoreNotifier::class);
-		$notificationManager->registerNotifierService(AuthenticationNotifier::class);
-
-		$eventDispatcher->addListener(AddMissingIndicesEvent::class, function (AddMissingIndicesEvent $event): void {
-			$event->addMissingIndex(
-				'share',
-				'share_with_index',
-				['share_with']
-			);
-			$event->addMissingIndex(
-				'share',
-				'parent_index',
-				['parent']
-			);
-			$event->addMissingIndex(
-				'share',
-				'owner_index',
-				['uid_owner']
-			);
-			$event->addMissingIndex(
-				'share',
-				'initiator_index',
-				['uid_initiator']
-			);
-
-			$event->addMissingIndex(
-				'filecache',
-				'fs_mtime',
-				['mtime']
-			);
-			$event->addMissingIndex(
-				'filecache',
-				'fs_size',
-				['size']
-			);
-			$event->addMissingIndex(
-				'filecache',
-				'fs_storage_path_prefix',
-				['storage', 'path'],
-				['lengths' => [null, 64]]
-			);
-			$event->addMissingIndex(
-				'filecache',
-				'fs_parent',
-				['parent']
-			);
-			$event->addMissingIndex(
-				'filecache',
-				'fs_name_hash',
-				['name']
-			);
-
-			$event->addMissingIndex(
-				'twofactor_providers',
-				'twofactor_providers_uid',
-				['uid']
-			);
-
-			$event->addMissingUniqueIndex(
-				'login_flow_v2',
-				'poll_token',
-				['poll_token'],
-				[],
-				true
-			);
-			$event->addMissingUniqueIndex(
-				'login_flow_v2',
-				'login_token',
-				['login_token'],
-				[],
-				true
-			);
-			$event->addMissingIndex(
-				'login_flow_v2',
-				'timestamp',
-				['timestamp'],
-				[],
-				true
-			);
-
-			$event->addMissingIndex(
-				'whats_new',
-				'version',
-				['version'],
-				[],
-				true
-			);
-
-			$event->addMissingIndex(
-				'cards',
-				'cards_abiduri',
-				['addressbookid', 'uri'],
-				[],
-				true
-			);
-
-			$event->replaceIndex(
-				'cards_properties',
-				['cards_prop_abid'],
-				'cards_prop_abid_name_value',
-				['addressbookid', 'name', 'value'],
-				false,
-			);
-
-			$event->addMissingIndex(
-				'calendarobjects_props',
-				'calendarobject_calid_index',
-				['calendarid', 'calendartype']
-			);
-
-			$event->addMissingIndex(
-				'schedulingobjects',
-				'schedulobj_principuri_index',
-				['principaluri']
-			);
-
-			$event->addMissingIndex(
-				'schedulingobjects',
-				'schedulobj_lastmodified_idx',
-				['lastmodified']
-			);
-
-			$event->addMissingIndex(
-				'properties',
-				'properties_path_index',
-				['userid', 'propertypath']
-			);
-			$event->addMissingIndex(
-				'properties',
-				'properties_pathonly_index',
-				['propertypath']
-			);
-			$event->addMissingIndex(
-				'properties',
-				'properties_name_path_user',
-				['propertyname', 'propertypath', 'userid']
-			);
-
-
-			$event->addMissingIndex(
-				'jobs',
-				'job_lastcheck_reserved',
-				['last_checked', 'reserved_at']
-			);
-
-			$event->addMissingIndex(
-				'direct_edit',
-				'direct_edit_timestamp',
-				['timestamp']
-			);
-
-			$event->addMissingIndex(
-				'preferences',
-				'prefs_uid_lazy_i',
-				['userid', 'lazy']
-			);
-			$event->addMissingIndex(
-				'preferences',
-				'prefs_app_key_ind_fl_i',
-				['appid', 'configkey', 'indexed', 'flags']
-			);
-
-			$event->addMissingIndex(
-				'mounts',
-				'mounts_class_index',
-				['mount_provider_class']
-			);
-			$event->addMissingIndex(
-				'mounts',
-				'mounts_user_root_path_index',
-				['user_id', 'root_id', 'mount_point'],
-				['lengths' => [null, null, 128]]
-			);
-
-			$event->addMissingIndex(
-				'systemtag_object_mapping',
-				'systag_by_tagid',
-				['systemtagid', 'objecttype']
-			);
-
-			$event->addMissingIndex(
-				'systemtag_object_mapping',
-				'systag_by_objectid',
-				['objectid']
-			);
-
-			$event->addMissingIndex(
-				'systemtag_object_mapping',
-				'systag_objecttype',
-				['objecttype']
-			);
-		});
-
-		$eventDispatcher->addListener(AddMissingPrimaryKeyEvent::class, function (AddMissingPrimaryKeyEvent $event): void {
-			$event->addMissingPrimaryKey(
-				'federated_reshares',
-				'federated_res_pk',
-				['share_id'],
-				'share_id_index'
-			);
-
-			$event->addMissingPrimaryKey(
-				'systemtag_object_mapping',
-				'som_pk',
-				['objecttype', 'objectid', 'systemtagid'],
-				'mapping'
-			);
-
-			$event->addMissingPrimaryKey(
-				'comments_read_markers',
-				'crm_pk',
-				['user_id', 'object_type', 'object_id'],
-				'comments_marker_index'
-			);
-
-			$event->addMissingPrimaryKey(
-				'collres_resources',
-				'crr_pk',
-				['collection_id', 'resource_type', 'resource_id'],
-				'collres_unique_res'
-			);
-
-			$event->addMissingPrimaryKey(
-				'collres_accesscache',
-				'cra_pk',
-				['user_id', 'collection_id', 'resource_type', 'resource_id'],
-				'collres_unique_user'
-			);
-
-			$event->addMissingPrimaryKey(
-				'filecache_extended',
-				'fce_pk',
-				['fileid'],
-				'fce_fileid_idx'
-			);
-		});
-
-		$eventDispatcher->addServiceListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
-		$eventDispatcher->addServiceListener(BeforeLoginTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
-		$eventDispatcher->addServiceListener(RemoteWipeStarted::class, RemoteWipeActivityListener::class);
-		$eventDispatcher->addServiceListener(RemoteWipeStarted::class, RemoteWipeNotificationsListener::class);
-		$eventDispatcher->addServiceListener(RemoteWipeStarted::class, RemoteWipeEmailListener::class);
-		$eventDispatcher->addServiceListener(RemoteWipeFinished::class, RemoteWipeActivityListener::class);
-		$eventDispatcher->addServiceListener(RemoteWipeFinished::class, RemoteWipeNotificationsListener::class);
-		$eventDispatcher->addServiceListener(RemoteWipeFinished::class, RemoteWipeEmailListener::class);
-		$eventDispatcher->addServiceListener(UserDeletedEvent::class, UserDeletedStoreCleanupListener::class);
-		$eventDispatcher->addServiceListener(UserDeletedEvent::class, UserDeletedTokenCleanupListener::class);
-		$eventDispatcher->addServiceListener(BeforeUserDeletedEvent::class, UserDeletedFilesCleanupListener::class);
-		$eventDispatcher->addServiceListener(UserDeletedEvent::class, UserDeletedFilesCleanupListener::class);
-		$eventDispatcher->addServiceListener(UserDeletedEvent::class, UserDeletedWebAuthnCleanupListener::class);
+		// register event listeners
+		$context->registerEventListener(AddMissingIndicesEvent::class, AddMissingIndicesListener::class);
+		$context->registerEventListener(AddMissingPrimaryKeyEvent::class, AddMissingPrimaryKeyListener::class);
+		$context->registerEventListener(BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
+		$context->registerEventListener(BeforeLoginTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
+		$context->registerEventListener(RemoteWipeStarted::class, RemoteWipeActivityListener::class);
+		$context->registerEventListener(RemoteWipeStarted::class, RemoteWipeNotificationsListener::class);
+		$context->registerEventListener(RemoteWipeStarted::class, RemoteWipeEmailListener::class);
+		$context->registerEventListener(RemoteWipeFinished::class, RemoteWipeActivityListener::class);
+		$context->registerEventListener(RemoteWipeFinished::class, RemoteWipeNotificationsListener::class);
+		$context->registerEventListener(RemoteWipeFinished::class, RemoteWipeEmailListener::class);
+		$context->registerEventListener(UserDeletedEvent::class, UserDeletedStoreCleanupListener::class);
+		$context->registerEventListener(UserDeletedEvent::class, UserDeletedTokenCleanupListener::class);
+		$context->registerEventListener(BeforeUserDeletedEvent::class, UserDeletedFilesCleanupListener::class);
+		$context->registerEventListener(UserDeletedEvent::class, UserDeletedFilesCleanupListener::class);
+		$context->registerEventListener(UserDeletedEvent::class, UserDeletedWebAuthnCleanupListener::class);
 
 		// Tags
-		$eventDispatcher->addServiceListener(UserDeletedEvent::class, TagManager::class);
+		$context->registerEventListener(UserDeletedEvent::class, TagManager::class);
 	}
+
+	public function boot(IBootContext $context): void {
+		// ...
+	}
+
 }

--- a/core/Listener/AddMissingIndicesListener.php
+++ b/core/Listener/AddMissingIndicesListener.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Listener;
+
+use OCP\DB\Events\AddMissingIndicesEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * @template-implements IEventListener<AddMissingIndicesEvent>
+ */
+class AddMissingIndicesListener implements IEventListener {
+
+	public function handle(Event $event): void {
+		if (!($event instanceof AddMissingIndicesEvent)) {
+			return;
+		}
+
+		$event->addMissingIndex(
+			'share',
+			'share_with_index',
+			['share_with']
+		);
+		$event->addMissingIndex(
+			'share',
+			'parent_index',
+			['parent']
+		);
+		$event->addMissingIndex(
+			'share',
+			'owner_index',
+			['uid_owner']
+		);
+		$event->addMissingIndex(
+			'share',
+			'initiator_index',
+			['uid_initiator']
+		);
+
+		$event->addMissingIndex(
+			'filecache',
+			'fs_mtime',
+			['mtime']
+		);
+		$event->addMissingIndex(
+			'filecache',
+			'fs_size',
+			['size']
+		);
+		$event->addMissingIndex(
+			'filecache',
+			'fs_storage_path_prefix',
+			['storage', 'path'],
+			['lengths' => [null, 64]]
+		);
+		$event->addMissingIndex(
+			'filecache',
+			'fs_parent',
+			['parent']
+		);
+		$event->addMissingIndex(
+			'filecache',
+			'fs_name_hash',
+			['name']
+		);
+
+		$event->addMissingIndex(
+			'twofactor_providers',
+			'twofactor_providers_uid',
+			['uid']
+		);
+
+		$event->addMissingUniqueIndex(
+			'login_flow_v2',
+			'poll_token',
+			['poll_token'],
+			[],
+			true
+		);
+		$event->addMissingUniqueIndex(
+			'login_flow_v2',
+			'login_token',
+			['login_token'],
+			[],
+			true
+		);
+		$event->addMissingIndex(
+			'login_flow_v2',
+			'timestamp',
+			['timestamp'],
+			[],
+			true
+		);
+
+		$event->addMissingIndex(
+			'whats_new',
+			'version',
+			['version'],
+			[],
+			true
+		);
+
+		$event->addMissingIndex(
+			'cards',
+			'cards_abiduri',
+			['addressbookid', 'uri'],
+			[],
+			true
+		);
+
+		$event->replaceIndex(
+			'cards_properties',
+			['cards_prop_abid'],
+			'cards_prop_abid_name_value',
+			['addressbookid', 'name', 'value'],
+			false,
+		);
+
+		$event->addMissingIndex(
+			'calendarobjects_props',
+			'calendarobject_calid_index',
+			['calendarid', 'calendartype']
+		);
+
+		$event->addMissingIndex(
+			'schedulingobjects',
+			'schedulobj_principuri_index',
+			['principaluri']
+		);
+
+		$event->addMissingIndex(
+			'schedulingobjects',
+			'schedulobj_lastmodified_idx',
+			['lastmodified']
+		);
+
+		$event->addMissingIndex(
+			'properties',
+			'properties_path_index',
+			['userid', 'propertypath']
+		);
+		$event->addMissingIndex(
+			'properties',
+			'properties_pathonly_index',
+			['propertypath']
+		);
+		$event->addMissingIndex(
+			'properties',
+			'properties_name_path_user',
+			['propertyname', 'propertypath', 'userid']
+		);
+
+
+		$event->addMissingIndex(
+			'jobs',
+			'job_lastcheck_reserved',
+			['last_checked', 'reserved_at']
+		);
+
+		$event->addMissingIndex(
+			'direct_edit',
+			'direct_edit_timestamp',
+			['timestamp']
+		);
+
+		$event->addMissingIndex(
+			'preferences',
+			'prefs_uid_lazy_i',
+			['userid', 'lazy']
+		);
+		$event->addMissingIndex(
+			'preferences',
+			'prefs_app_key_ind_fl_i',
+			['appid', 'configkey', 'indexed', 'flags']
+		);
+
+		$event->addMissingIndex(
+			'mounts',
+			'mounts_class_index',
+			['mount_provider_class']
+		);
+		$event->addMissingIndex(
+			'mounts',
+			'mounts_user_root_path_index',
+			['user_id', 'root_id', 'mount_point'],
+			['lengths' => [null, null, 128]]
+		);
+
+		$event->addMissingIndex(
+			'systemtag_object_mapping',
+			'systag_by_tagid',
+			['systemtagid', 'objecttype']
+		);
+
+		$event->addMissingIndex(
+			'systemtag_object_mapping',
+			'systag_by_objectid',
+			['objectid']
+		);
+
+		$event->addMissingIndex(
+			'systemtag_object_mapping',
+			'systag_objecttype',
+			['objecttype']
+		);
+	}
+}

--- a/core/Listener/AddMissingPrimaryKeyListener.php
+++ b/core/Listener/AddMissingPrimaryKeyListener.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Listener;
+
+use OCP\DB\Events\AddMissingPrimaryKeyEvent;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+
+/**
+ * @template-implements IEventListener<AddMissingPrimaryKeyEvent>
+ */
+class AddMissingPrimaryKeyListener implements IEventListener {
+
+	public function handle(Event $event): void {
+		if (!($event instanceof AddMissingPrimaryKeyEvent)) {
+			return;
+		}
+
+		$event->addMissingPrimaryKey(
+			'federated_reshares',
+			'federated_res_pk',
+			['share_id'],
+			'share_id_index'
+		);
+
+		$event->addMissingPrimaryKey(
+			'systemtag_object_mapping',
+			'som_pk',
+			['objecttype', 'objectid', 'systemtagid'],
+			'mapping'
+		);
+
+		$event->addMissingPrimaryKey(
+			'comments_read_markers',
+			'crm_pk',
+			['user_id', 'object_type', 'object_id'],
+			'comments_marker_index'
+		);
+
+		$event->addMissingPrimaryKey(
+			'collres_resources',
+			'crr_pk',
+			['collection_id', 'resource_type', 'resource_id'],
+			'collres_unique_res'
+		);
+
+		$event->addMissingPrimaryKey(
+			'collres_accesscache',
+			'cra_pk',
+			['user_id', 'collection_id', 'resource_type', 'resource_id'],
+			'collres_unique_user'
+		);
+
+		$event->addMissingPrimaryKey(
+			'filecache_extended',
+			'fce_pk',
+			['fileid'],
+			'fce_fileid_idx'
+		);
+	}
+}

--- a/lib/base.php
+++ b/lib/base.php
@@ -784,8 +784,8 @@ class OC {
 		// Make sure that the application class is not loaded before the database is setup
 		if ($systemConfig->getValue('installed', false)) {
 			$appManager->loadApp('settings');
-			/* Build core application to make sure that listeners are registered */
-			Server::get(\OC\Core\Application::class);
+			/* Run core application registration */
+			$bootstrapCoordinator->runLazyRegistration('core');
 		}
 
 		//make sure temporary files are cleaned up

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1202,7 +1202,7 @@ return array(
     'OC\\Contacts\\ContactsMenu\\Providers\\EMailProvider' => $baseDir . '/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php',
     'OC\\Contacts\\ContactsMenu\\Providers\\LocalTimeProvider' => $baseDir . '/lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php',
     'OC\\Contacts\\ContactsMenu\\Providers\\ProfileProvider' => $baseDir . '/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php',
-    'OC\\Core\\Application' => $baseDir . '/core/Application.php',
+    'OC\\Core\\AppInfo\\Application' => $baseDir . '/core/AppInfo/Application.php',
     'OC\\Core\\BackgroundJobs\\BackgroundCleanupUpdaterBackupsJob' => $baseDir . '/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php',
     'OC\\Core\\BackgroundJobs\\CheckForUserCertificates' => $baseDir . '/core/BackgroundJobs/CheckForUserCertificates.php',
     'OC\\Core\\BackgroundJobs\\CleanupLoginFlowV2' => $baseDir . '/core/BackgroundJobs/CleanupLoginFlowV2.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1385,6 +1385,8 @@ return array(
     'OC\\Core\\Exception\\LoginFlowV2ClientForbiddenException' => $baseDir . '/core/Exception/LoginFlowV2ClientForbiddenException.php',
     'OC\\Core\\Exception\\LoginFlowV2NotFoundException' => $baseDir . '/core/Exception/LoginFlowV2NotFoundException.php',
     'OC\\Core\\Exception\\ResetPasswordException' => $baseDir . '/core/Exception/ResetPasswordException.php',
+    'OC\\Core\\Listener\\AddMissingIndicesListener' => $baseDir . '/core/Listener/AddMissingIndicesListener.php',
+    'OC\\Core\\Listener\\AddMissingPrimaryKeyListener' => $baseDir . '/core/Listener/AddMissingPrimaryKeyListener.php',
     'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => $baseDir . '/core/Listener/BeforeMessageLoggedEventListener.php',
     'OC\\Core\\Listener\\BeforeTemplateRenderedListener' => $baseDir . '/core/Listener/BeforeTemplateRenderedListener.php',
     'OC\\Core\\Listener\\FeedBackHandler' => $baseDir . '/core/Listener/FeedBackHandler.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1243,7 +1243,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Contacts\\ContactsMenu\\Providers\\EMailProvider' => __DIR__ . '/../../..' . '/lib/private/Contacts/ContactsMenu/Providers/EMailProvider.php',
         'OC\\Contacts\\ContactsMenu\\Providers\\LocalTimeProvider' => __DIR__ . '/../../..' . '/lib/private/Contacts/ContactsMenu/Providers/LocalTimeProvider.php',
         'OC\\Contacts\\ContactsMenu\\Providers\\ProfileProvider' => __DIR__ . '/../../..' . '/lib/private/Contacts/ContactsMenu/Providers/ProfileProvider.php',
-        'OC\\Core\\Application' => __DIR__ . '/../../..' . '/core/Application.php',
+        'OC\\Core\\AppInfo\\Application' => __DIR__ . '/../../..' . '/core/AppInfo/Application.php',
         'OC\\Core\\BackgroundJobs\\BackgroundCleanupUpdaterBackupsJob' => __DIR__ . '/../../..' . '/core/BackgroundJobs/BackgroundCleanupUpdaterBackupsJob.php',
         'OC\\Core\\BackgroundJobs\\CheckForUserCertificates' => __DIR__ . '/../../..' . '/core/BackgroundJobs/CheckForUserCertificates.php',
         'OC\\Core\\BackgroundJobs\\CleanupLoginFlowV2' => __DIR__ . '/../../..' . '/core/BackgroundJobs/CleanupLoginFlowV2.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1426,6 +1426,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Exception\\LoginFlowV2ClientForbiddenException' => __DIR__ . '/../../..' . '/core/Exception/LoginFlowV2ClientForbiddenException.php',
         'OC\\Core\\Exception\\LoginFlowV2NotFoundException' => __DIR__ . '/../../..' . '/core/Exception/LoginFlowV2NotFoundException.php',
         'OC\\Core\\Exception\\ResetPasswordException' => __DIR__ . '/../../..' . '/core/Exception/ResetPasswordException.php',
+        'OC\\Core\\Listener\\AddMissingIndicesListener' => __DIR__ . '/../../..' . '/core/Listener/AddMissingIndicesListener.php',
+        'OC\\Core\\Listener\\AddMissingPrimaryKeyListener' => __DIR__ . '/../../..' . '/core/Listener/AddMissingPrimaryKeyListener.php',
         'OC\\Core\\Listener\\BeforeMessageLoggedEventListener' => __DIR__ . '/../../..' . '/core/Listener/BeforeMessageLoggedEventListener.php',
         'OC\\Core\\Listener\\BeforeTemplateRenderedListener' => __DIR__ . '/../../..' . '/core/Listener/BeforeTemplateRenderedListener.php',
         'OC\\Core\\Listener\\FeedBackHandler' => __DIR__ . '/../../..' . '/core/Listener/FeedBackHandler.php',

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -812,6 +812,10 @@ class AppManager implements IAppManager {
 	}
 
 	private function isAlwaysEnabled(string $appId): bool {
+		if ($appId === 'core') {
+			return true;
+		}
+
 		$alwaysEnabled = $this->getAlwaysEnabledApps();
 		return in_array($appId, $alwaysEnabled, true);
 	}

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -189,14 +189,14 @@ class URLGenerator implements IURLGenerator {
 		$basename = substr(basename($file), 0, -4);
 
 		try {
-			$appPath = $this->getAppManager()->getAppPath($appName);
-		} catch (AppPathNotFoundException $e) {
 			if ($appName === 'core' || $appName === '') {
 				$appName = 'core';
 				$appPath = false;
 			} else {
-				throw new RuntimeException('image not found: image: ' . $file . ' webroot: ' . \OC::$WEBROOT . ' serverroot: ' . \OC::$SERVERROOT);
+				$appPath = $this->getAppManager()->getAppPath($appName);
 			}
+		} catch (AppPathNotFoundException $e) {
+			throw new RuntimeException('image not found: image: ' . $file . ' webroot: ' . \OC::$WEBROOT . ' serverroot: ' . \OC::$SERVERROOT);
 		}
 
 		// Check if the app is in the app folder

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -316,6 +316,8 @@ class OC_App {
 		$appId = self::cleanAppId($appId);
 		if ($appId === '') {
 			return false;
+		} elseif ($appId === 'core') {
+			return __DIR__ . '/../../../core';
 		}
 
 		if (($dir = self::findAppInDirectories($appId, $refreshAppPath)) != false) {


### PR DESCRIPTION
## Summary

Resolve deprecation issues and makes code better maintainable by moving long event listener callbacks to dedicated listener class.

This allows us also to use bootstrap only features like the config lexicon (which needs a registration context).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
