### PR TITLE
fix(user_status): Avoid unique constraint violations from parallel he…

### DIFF
--- a/apps/user_status/lib/Service/StatusService.php
+++ b/apps/user_status/lib/Service/StatusService.php
@@ -167,7 +167,7 @@ class StatusService {
 		$userStatus->setIsBackup(false);
 
 		if ($userStatus->getId() === null) {
-			return $this->mapper->insert($userStatus);
+			return $this->insertWithoutThrowingUniqueConstrain($userStatus);
 		}
 
 		return $this->mapper->update($userStatus);
@@ -211,7 +211,7 @@ class StatusService {
 		$userStatus->setStatusMessageTimestamp($this->timeFactory->now()->getTimestamp());
 
 		if ($userStatus->getId() === null) {
-			return $this->mapper->insert($userStatus);
+			return $this->insertWithoutThrowingUniqueConstrain($userStatus);
 		}
 
 		return $this->mapper->update($userStatus);
@@ -313,7 +313,7 @@ class StatusService {
 		if ($userStatus->getId() !== null) {
 			return $this->mapper->update($userStatus);
 		}
-		return $this->mapper->insert($userStatus);
+		return $this->insertWithoutThrowingUniqueConstrain($userStatus);
 	}
 
 	/**
@@ -360,7 +360,7 @@ class StatusService {
 		$userStatus->setStatusMessageTimestamp($this->timeFactory->now()->getTimestamp());
 
 		if ($userStatus->getId() === null) {
-			return $this->mapper->insert($userStatus);
+			return $this->insertWithoutThrowingUniqueConstrain($userStatus);
 		}
 
 		return $this->mapper->update($userStatus);
@@ -583,5 +583,17 @@ class StatusService {
 
 		// For users that matched restore the previous status
 		$this->mapper->restoreBackupStatuses($restoreIds);
+	}
+
+	protected function insertWithoutThrowingUniqueConstrain(UserStatus $userStatus): UserStatus {
+		try {
+			return $this->mapper->insert($userStatus);
+		} catch (Exception $e) {
+			// Ignore if a parallel request already set the status
+			if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				throw $e;
+			}
+		}
+		return $userStatus;
 	}
 }


### PR DESCRIPTION
…artbeats and GET requests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
