### PR TITLE
fix(PreviewManager): use the forced mimetype in throwIfPreviewsDisabled

### DIFF
--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -154,7 +154,7 @@ class PreviewManager implements IPreview {
 		$mimeType = null,
 		bool $cacheResult = true,
 	): ISimpleFile {
-		$this->throwIfPreviewsDisabled($file);
+		$this->throwIfPreviewsDisabled($file, $mimeType);
 		$previewConcurrency = $this->getGenerator()->getNumConcurrentPreviews('preview_concurrency_all');
 		$sem = Generator::guardWithSemaphore(Generator::SEMAPHORE_ID_ALL, $previewConcurrency);
 		try {
@@ -178,7 +178,7 @@ class PreviewManager implements IPreview {
 	 * @since 19.0.0
 	 */
 	public function generatePreviews(File $file, array $specifications, $mimeType = null) {
-		$this->throwIfPreviewsDisabled($file);
+		$this->throwIfPreviewsDisabled($file, $mimeType);
 		return $this->getGenerator()->generatePreviews($file, $specifications, $mimeType);
 	}
 
@@ -213,13 +213,15 @@ class PreviewManager implements IPreview {
 	/**
 	 * Check if a preview can be generated for a file
 	 */
-	public function isAvailable(\OCP\Files\FileInfo $file): bool {
+	public function isAvailable(\OCP\Files\FileInfo $file, ?string $mimeType = null): bool {
 		if (!$this->enablePreviews) {
 			return false;
 		}
 
+		$fileMimeType = $mimeType ?? $file->getMimeType();
+
 		$this->registerCoreProviders();
-		if (!$this->isMimeSupported($file->getMimetype())) {
+		if (!$this->isMimeSupported($fileMimeType)) {
 			return false;
 		}
 
@@ -229,7 +231,7 @@ class PreviewManager implements IPreview {
 		}
 
 		foreach ($this->providers as $supportedMimeType => $providers) {
-			if (preg_match($supportedMimeType, $file->getMimetype())) {
+			if (preg_match($supportedMimeType, $fileMimeType)) {
 				foreach ($providers as $providerClosure) {
 					$provider = $this->helper->getProvider($providerClosure);
 					if (!($provider instanceof IProviderV2)) {
@@ -455,8 +457,8 @@ class PreviewManager implements IPreview {
 	/**
 	 * @throws NotFoundException if preview generation is disabled
 	 */
-	private function throwIfPreviewsDisabled(File $file): void {
-		if (!$this->isAvailable($file)) {
+	private function throwIfPreviewsDisabled(File $file, ?string $mimeType = null): void {
+		if (!$this->isAvailable($file, $mimeType)) {
 			throw new NotFoundException('Previews disabled');
 		}
 	}

--- a/lib/public/IPreview.php
+++ b/lib/public/IPreview.php
@@ -92,10 +92,12 @@ interface IPreview {
 	 * Check if a preview can be generated for a file
 	 *
 	 * @param \OCP\Files\FileInfo $file
+	 * @param string|null $mimeType To force a given mimetype for the file
 	 * @return bool
 	 * @since 8.0.0
+	 * @since 32.0.0 - isAvailable($mimeType) added the $mimeType argument to the signature
 	 */
-	public function isAvailable(\OCP\Files\FileInfo $file);
+	public function isAvailable(\OCP\Files\FileInfo $file, ?string $mimeType = null);
 
 	/**
 	 * Generates previews of a file


### PR DESCRIPTION
`PreviewManager::getPreview` can fail because it does not use the forced mimetype when checking if the preview is available.
This happens, for example, when `$file->getMimeType()` returns `application/octet-stream` because the file name has no extension.

This broke pretty recently, I saw it because the assistant is requesting previews for files which names have no extensions but we know their mimetype. It used to work fine by forcing the mimetype when calling `PreviewManager::getPreview`, now we get a `NotFoundException` because `isAvailable` returns false because it uses the mimetype from `$file->getMimeType()`.

I didn't see any other way than to add an optional param to `IPreview::isAvailable`. It does not break anything as it's a new optional param. Is that ok? I'm fine with implementing another approach.

This can be backported to stable31 and stable30.
stable29 and older are not affected IMO.