### PR TITLE
fix: expose via dav capabilities whether calendar app is enabled

### DIFF
--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -5,6 +5,7 @@
  */
 namespace OCA\DAV;
 
+use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
 use OCP\User\IAvailabilityCoordinator;
@@ -13,17 +14,19 @@ class Capabilities implements ICapability {
 	public function __construct(
 		private IConfig $config,
 		private IAvailabilityCoordinator $coordinator,
+		private IAppManager $appManager,
 	) {
 	}
 
 	/**
-	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
+	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, calendar_app_enabled: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
 	 */
 	public function getCapabilities() {
 		$capabilities = [
 			'dav' => [
 				'chunking' => '1.0',
 				'public_shares_chunking' => true,
+				'calendar_app_enabled' => $this->appManager->isEnabledForUser('calendar'),
 			]
 		];
 		if ($this->config->getSystemValueBool('bulkupload.enabled', true)) {

--- a/apps/dav/lib/Capabilities.php
+++ b/apps/dav/lib/Capabilities.php
@@ -5,7 +5,6 @@
  */
 namespace OCA\DAV;
 
-use OCP\App\IAppManager;
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
 use OCP\User\IAvailabilityCoordinator;
@@ -14,19 +13,17 @@ class Capabilities implements ICapability {
 	public function __construct(
 		private IConfig $config,
 		private IAvailabilityCoordinator $coordinator,
-		private IAppManager $appManager,
 	) {
 	}
 
 	/**
-	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, calendar_app_enabled: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
+	 * @return array{dav: array{chunking: string, public_shares_chunking: bool, bulkupload?: string, absence-supported?: bool, absence-replacement?: bool}}
 	 */
 	public function getCapabilities() {
 		$capabilities = [
 			'dav' => [
 				'chunking' => '1.0',
 				'public_shares_chunking' => true,
-				'calendar_app_enabled' => $this->appManager->isEnabledForUser('calendar'),
 			]
 		];
 		if ($this->config->getSystemValueBool('bulkupload.enabled', true)) {

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1006,7 +1006,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(CapabilitiesManager::class, function (ContainerInterface $c) {
 			$manager = new CapabilitiesManager($c->get(LoggerInterface::class));
 			$manager->registerCapability(function () use ($c) {
-				return new \OC\OCS\CoreCapabilities($c->get(\OCP\IConfig::class));
+				return new \OC\OCS\CoreCapabilities($c->get(\OCP\IConfig::class), $c->get(IAppManager::class), $c->get(IUserSession::class),);
 			});
 			$manager->registerCapability(function () use ($c) {
 				return $c->get(\OC\Security\Bruteforce\Capabilities::class);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Ref: https://github.com/nextcloud/spreed/issues/15249

## Summary
* Expose whether calendar app is enabled to be able to link to it
* Allows Talk Desktop client to pick it up

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
