### PR TITLE
fix: clear opcache after app extraction

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -341,6 +341,9 @@ class Installer {
 					// otherwise we just copy the outer directory
 					$this->copyRecursive($extractDir, $baseDir);
 					Files::rmdirr($extractDir);
+					if (function_exists('opcache_reset')) {
+						opcache_reset();
+					}
 					return;
 				}
 				// Signature does not match


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/52977

## Summary

> [!NOTE]
> Since I usually do not update apps from the app store on my development system, I have not tested this yet. If you believe this change makes sense, I will try to find some time to test it. Triggering such an error requires a bit of luck.
 
clear opcache post app update extraction to prevent outdated files issues.

opcache.validate_timestamps=0 disables automated file modification checks.


## TODO

- [ ] Try testing it :see_no_evil: 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
