### PR TITLE
feat(core): Add option to disable creating an admin user when installing

### DIFF
--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -44,6 +44,7 @@ class Install extends Command {
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'Login to connect to the database')
 			->addOption('database-pass', null, InputOption::VALUE_OPTIONAL, 'Password of the database user', null)
 			->addOption('database-table-space', null, InputOption::VALUE_OPTIONAL, 'Table space of the database (oci only)', null)
+			->addOption('disable-admin-user', null, InputOption::VALUE_NONE, 'Disable the creation of an admin user')
 			->addOption('admin-user', null, InputOption::VALUE_REQUIRED, 'Login of the admin account', 'admin')
 			->addOption('admin-pass', null, InputOption::VALUE_REQUIRED, 'Password of the admin account')
 			->addOption('admin-email', null, InputOption::VALUE_OPTIONAL, 'E-Mail of the admin account')
@@ -120,6 +121,7 @@ class Install extends Command {
 		if ($input->hasParameterOption('--database-pass')) {
 			$dbPass = (string)$input->getOption('database-pass');
 		}
+		$disableAdminUser = (bool)$input->getOption('disable-admin-user');
 		$adminLogin = $input->getOption('admin-user');
 		$adminPassword = $input->getOption('admin-pass');
 		$adminEmail = $input->getOption('admin-email');
@@ -142,7 +144,7 @@ class Install extends Command {
 			}
 		}
 
-		if (is_null($adminPassword)) {
+		if (!$disableAdminUser && $adminPassword === null) {
 			/** @var QuestionHelper $helper */
 			$helper = $this->getHelper('question');
 			$question = new Question('What is the password you like to use for the admin account <' . $adminLogin . '>?');
@@ -151,7 +153,7 @@ class Install extends Command {
 			$adminPassword = $helper->ask($input, $output, $question);
 		}
 
-		if ($adminEmail !== null && !filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
+		if (!$disableAdminUser && $adminEmail !== null && !filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
 			throw new InvalidArgumentException('Invalid e-mail-address <' . $adminEmail . '> for <' . $adminLogin . '>.');
 		}
 
@@ -161,6 +163,7 @@ class Install extends Command {
 			'dbpass' => $dbPass,
 			'dbname' => $dbName,
 			'dbhost' => $dbHost,
+			'admindisable' => $disableAdminUser,
 			'adminlogin' => $adminLogin,
 			'adminpass' => $adminPassword,
 			'adminemail' => $adminEmail,

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -304,11 +304,15 @@ class Setup {
 		$error = [];
 		$dbType = $options['dbtype'];
 
-		if (empty($options['adminlogin'])) {
-			$error[] = $l->t('Set an admin Login.');
-		}
-		if (empty($options['adminpass'])) {
-			$error[] = $l->t('Set an admin password.');
+		$disableAdminUser = (bool)($options['admindisable'] ?? false);
+
+		if (!$disableAdminUser) {
+			if (empty($options['adminlogin'])) {
+				$error[] = $l->t('Set an admin Login.');
+			}
+			if (empty($options['adminpass'])) {
+				$error[] = $l->t('Set an admin password.');
+			}
 		}
 		if (empty($options['directory'])) {
 			$options['directory'] = \OC::$SERVERROOT . '/data';
@@ -318,8 +322,6 @@ class Setup {
 			$dbType = 'sqlite';
 		}
 
-		$username = htmlspecialchars_decode($options['adminlogin']);
-		$password = htmlspecialchars_decode($options['adminpass']);
 		$dataDir = htmlspecialchars_decode($options['directory']);
 
 		$class = self::$dbSetupClasses[$dbType];
@@ -405,19 +407,22 @@ class Setup {
 			return $error;
 		}
 
-		$this->outputDebug($output, 'Create admin account');
-
-		// create the admin account and group
 		$user = null;
-		try {
-			$user = Server::get(IUserManager::class)->createUser($username, $password);
-			if (!$user) {
-				$error[] = "Account <$username> could not be created.";
+		if (!$disableAdminUser) {
+			$username = htmlspecialchars_decode($options['adminlogin']);
+			$password = htmlspecialchars_decode($options['adminpass']);
+			$this->outputDebug($output, 'Create admin account');
+
+			try {
+				$user = Server::get(IUserManager::class)->createUser($username, $password);
+				if (!$user) {
+					$error[] = "Account <$username> could not be created.";
+					return $error;
+				}
+			} catch (Exception $exception) {
+				$error[] = $exception->getMessage();
 				return $error;
 			}
-		} catch (Exception $exception) {
-			$error[] = $exception->getMessage();
-			return $error;
 		}
 
 		$config = Server::get(IConfig::class);
@@ -432,7 +437,7 @@ class Setup {
 		}
 
 		$group = Server::get(IGroupManager::class)->createGroup('admin');
-		if ($group instanceof IGroup) {
+		if ($user !== null && $group instanceof IGroup) {
 			$group->addUser($user);
 		}
 
@@ -464,26 +469,28 @@ class Setup {
 		$bootstrapCoordinator = Server::get(\OC\AppFramework\Bootstrap\Coordinator::class);
 		$bootstrapCoordinator->runInitialRegistration();
 
-		// Create a session token for the newly created user
-		// The token provider requires a working db, so it's not injected on setup
-		/** @var \OC\User\Session $userSession */
-		$userSession = Server::get(IUserSession::class);
-		$provider = Server::get(PublicKeyTokenProvider::class);
-		$userSession->setTokenProvider($provider);
-		$userSession->login($username, $password);
-		$user = $userSession->getUser();
-		if (!$user) {
-			$error[] = 'No account found in session.';
-			return $error;
-		}
-		$userSession->createSessionToken($request, $user->getUID(), $username, $password);
+		if (!$disableAdminUser) {
+			// Create a session token for the newly created user
+			// The token provider requires a working db, so it's not injected on setup
+			/** @var \OC\User\Session $userSession */
+			$userSession = Server::get(IUserSession::class);
+			$provider = Server::get(PublicKeyTokenProvider::class);
+			$userSession->setTokenProvider($provider);
+			$userSession->login($username, $password);
+			$user = $userSession->getUser();
+			if (!$user) {
+				$error[] = 'No account found in session.';
+				return $error;
+			}
+			$userSession->createSessionToken($request, $user->getUID(), $username, $password);
 
-		$session = $userSession->getSession();
-		$session->set('last-password-confirm', Server::get(ITimeFactory::class)->getTime());
+			$session = $userSession->getSession();
+			$session->set('last-password-confirm', Server::get(ITimeFactory::class)->getTime());
 
-		// Set email for admin
-		if (!empty($options['adminemail'])) {
-			$user->setSystemEMailAddress($options['adminemail']);
+			// Set email for admin
+			if (!empty($options['adminemail'])) {
+				$user->setSystemEMailAddress($options['adminemail']);
+			}
 		}
 
 		return $error;

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -375,7 +375,7 @@ class Setup {
 		$this->outputDebug($output, 'Configuring database');
 		$dbSetup->initialize($options);
 		try {
-			$dbSetup->setupDatabase($username);
+			$dbSetup->setupDatabase();
 		} catch (\OC\DatabaseSetupException $e) {
 			$error[] = [
 				'error' => $e->getMessage(),

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -127,10 +127,7 @@ abstract class AbstractDatabase {
 		return $connection;
 	}
 
-	/**
-	 * @param string $username
-	 */
-	abstract public function setupDatabase($username);
+	abstract public function setupDatabase();
 
 	public function runMigrations(?IOutput $output = null) {
 		if (!is_dir(\OC::$SERVERROOT . '/core/Migrations')) {

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -16,7 +16,7 @@ use OCP\Security\ISecureRandom;
 class MySQL extends AbstractDatabase {
 	public $dbprettyname = 'MySQL/MariaDB';
 
-	public function setupDatabase($username) {
+	public function setupDatabase() {
 		//check if the database user has admin right
 		$connection = $this->connect(['dbname' => null]);
 
@@ -28,7 +28,7 @@ class MySQL extends AbstractDatabase {
 		}
 
 		if ($this->tryCreateDbUser) {
-			$this->createSpecificUser($username, new ConnectionAdapter($connection));
+			$this->createSpecificUser('oc_admin', new ConnectionAdapter($connection));
 		}
 
 		$this->config->setValues([

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -40,7 +40,7 @@ class OCI extends AbstractDatabase {
 		return $errors;
 	}
 
-	public function setupDatabase($username) {
+	public function setupDatabase() {
 		try {
 			$this->connect();
 		} catch (\Exception $e) {

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -16,10 +16,9 @@ class PostgreSQL extends AbstractDatabase {
 	public $dbprettyname = 'PostgreSQL';
 
 	/**
-	 * @param string $username
 	 * @throws \OC\DatabaseSetupException
 	 */
-	public function setupDatabase($username) {
+	public function setupDatabase() {
 		try {
 			$connection = $this->connect([
 				'dbname' => 'postgres'
@@ -46,7 +45,7 @@ class PostgreSQL extends AbstractDatabase {
 					//use the admin login data for the new database user
 
 					//add prefix to the postgresql user name to prevent collisions
-					$this->dbUser = 'oc_' . strtolower($username);
+					$this->dbUser = 'oc_admin';
 					//create a new password so we don't need to store the admin config in the config file
 					$this->dbPassword = \OC::$server->get(ISecureRandom::class)->generate(30, ISecureRandom::CHAR_ALPHANUMERIC);
 

--- a/lib/private/Setup/Sqlite.php
+++ b/lib/private/Setup/Sqlite.php
@@ -45,7 +45,7 @@ class Sqlite extends AbstractDatabase {
 		}
 	}
 
-	public function setupDatabase($username) {
+	public function setupDatabase() {
 		$datadir = $this->config->getValue(
 			'datadirectory',
 			\OC::$SERVERROOT . '/data'


### PR DESCRIPTION
## Summary

When using non-database backends it can be annoying being forced to create an admin user during the installation process. Admin users can still be created through LDAP, OIDC and so on, so it's really not necessary to have a user with a database backend. Having to create this admin user is an additional burden since a password needs to be set and it should neither be simple nor random.

I did not add this option to the web installer because I believe for a lot of people using the web installer it's the only way they are able to install Nextcloud (due to technical restrictions not abilities). Enabling this option would result in a "bricked" instance for them since there is no way they could create a user after installation in order to login.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
