### PR TITLE
🚧 Fix `Start TLS failed, when connecting to LDAP host ldap://ldap.example.tld` on PHP 8.3.21, PHP 8.4.7

### DIFF
--- a/apps/user_ldap/lib/Connection.php
+++ b/apps/user_ldap/lib/Connection.php
@@ -692,6 +692,8 @@ class Connection extends LDAPUtility {
 			throw new ServerNotAvailableException('Connection failed');
 		}
 
+		$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_X_TLS_CACERTFILE, '/etc/ssl/certs/ca-certificates.crt');
+
 		if (!$this->ldap->setOption($this->ldapConnectionRes, LDAP_OPT_PROTOCOL_VERSION, 3)) {
 			throw new ServerNotAvailableException('Could not set required LDAP Protocol version.');
 		}


### PR DESCRIPTION
- Restores compatibility with PHP 8.3.21 due to the bug in https://github.com/php/php-src/issues/18529

The diff might help when after upgrading to PHP 8.3.21 you are faced with:
```
💥 ldap_start_tls(): Unable to start TLS: Connect error at …/apps/user_ldap/lib/LDAP.php#282
💥 Start TLS failed, when connecting to LDAP host ldap://ldap.example.tld.
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
