### PR TITLE
chore: adjust codeowners for stylesheets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /__mocks__                                    @nextcloud/server-frontend
 /__tests__                                    @nextcloud/server-frontend
 /cypress                                      @nextcloud/server-frontend
+**/css                                        @nextcloud/server-frontend
 **/js                                         @nextcloud/server-frontend
 **/src                                        @nextcloud/server-frontend
 *.js                                          @nextcloud/server-frontend
@@ -92,11 +93,11 @@ ResponseDefinitions.php             @provokateurin @nextcloud/server-backend
 /lib/public/UserStatus              @nickvergessen @nextcloud/talk-backend
 
 # Groupware
-/build/integration/dav_features/caldav.feature		@st3iny @SebastianKrupinski @tcitworld
-/build/integration/dav_features/carddav.feature		@hamza221 @SebastianKrupinski
-/lib/public/Calendar					@st3iny @SebastianKrupinski @tcitworld
-/lib/public/Contacts					@hamza221 @SebastianKrupinski
+/build/integration/dav_features/caldav.feature   @st3iny @SebastianKrupinski @tcitworld
+/build/integration/dav_features/carddav.feature  @hamza221 @SebastianKrupinski
+/lib/public/Calendar                             @st3iny @SebastianKrupinski @tcitworld
+/lib/public/Contacts                             @hamza221 @SebastianKrupinski
 
 # Personal interest
-*/Activity/*                        @nickvergessen @nextcloud/server-backend
-*/Notifications/*                   @nickvergessen @nextcloud/talk-backend
+*/Activity/*                                     @nickvergessen @nextcloud/server-backend
+*/Notifications/*                                @nickvergessen @nextcloud/talk-backend


### PR DESCRIPTION
## Summary

1. Fix code owners to assign frontend to CSS / SCSS changes instead of backend.
2. Fix mixed usage of tabs and spaces in the file.

Otherwise backenders were requested to review style changes....

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
