### PR TITLE
Codecov: disable telemetry

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -230,6 +230,7 @@ const config = {
 		codecovWebpackPlugin({
 			enableBundleAnalysis: !isDev && !isTesting,
 			bundleName: 'nextcloud',
+			telemetry: false,
 		}),
 	],
 	externals: {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->


## Summary

https://github.com/nextcloud/server/pull/52179 enabled Codecov's test and bundle analytics.

This pull request only disables the telemetry. I just want to raise awareness about it and raise the question: do we really need it?

When running npm run build, as we do for building the production assets, the webpack plugin is active and communicates externally.

> [codecov] Sending telemetry data on issues and performance to Codecov. To disable telemetry, set options.telemetry to false.

Telemetry is responsible for two requests to api.codecov.com. These requests do not contain sensitive data; they appear to be a check-in and check-out for the build process.

<details><summary>Request 1</summary>

```json
{
  "event_id": "063a21a232cf4a19a2e0d00ef47355d0",
  "sent_at": "2025-06-01T21:13:49.626Z",
  "trace": {
    "environment": "production",
    "release": "1.9.0",
    "public_key": "942e283ea612c29cc3371c6d27f57e58",
    "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
    "sample_rate": "1",
    "transaction": "Codecov Bundler Plugin Execution",
    "sampled": "true"
  }
}
{
  "type": "transaction"
}
{
  "contexts": {
    "trace": {
      "span_id": "88f72767334ca4ba",
      "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
      "data": {
        "sentry.origin": "manual",
        "sentry.op": "bundler-plugin-execution",
        "sentry.source": "custom",
        "sentry.sample_rate": 1
      },
      "op": "bundler-plugin-execution",
      "origin": "manual"
    },
    "runtime": {
      "name": "node",
      "version": "v22.15.1"
    }
  },
  "spans": [],
  "start_timestamp": 1748812429.623899,
  "timestamp": 1748812429.6243742,
  "transaction": "Codecov Bundler Plugin Execution",
  "type": "transaction",
  "transaction_info": {
    "source": "custom"
  },
  "platform": "node",
  "event_id": "063a21a232cf4a19a2e0d00ef47355d0",
  "environment": "production",
  "release": "1.9.0",
  "tags": {
    "node": "v22.15.1",
    "platform": "linux",
    "plugin.name": "@codecov/webpack-plugin",
    "plugin.version": "1.9.0",
    "auth_mode": "tokenless",
    "ci": false,
    "meta_framework": "none",
    "bundler": "webpack"
  }
}
```

</details>

<details><summary>Request 2</summary>

```json
{
  "event_id": "e96e4e58200b43508570c9126421ba80",
  "sent_at": "2025-06-01T21:14:38.347Z",
  "trace": {
    "environment": "production",
    "release": "1.9.0",
    "public_key": "942e283ea612c29cc3371c6d27f57e58",
    "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
    "sample_rate": "1",
    "transaction": "Codecov Bundler Plugin Execution",
    "sampled": "true"
  }
}
{
  "type": "transaction"
}
{
  "contexts": {
    "trace": {
      "parent_span_id": "88f72767334ca4ba",
      "span_id": "802b96226619e273",
      "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
      "data": {
        "sentry.origin": "manual",
        "sentry.op": "output.write",
        "sentry.source": "custom",
        "sentry.sample_rate": 1
      },
      "op": "output.write",
      "origin": "manual"
    },
    "runtime": {
      "name": "node",
      "version": "v22.15.1"
    }
  },
  "spans": [
    {
      "data": {
        "sentry.origin": "manual",
        "sentry.op": "output.write.detectProvider"
      },
      "description": "Detect Provider",
      "op": "output.write.detectProvider",
      "parent_span_id": "802b96226619e273",
      "span_id": "bd932a531d2cd00a",
      "start_timestamp": 1748812471.393833,
      "timestamp": 1748812471.483911,
      "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
      "origin": "manual"
    },
    {
      "data": {
        "sentry.origin": "manual",
        "sentry.op": "output.write.getPreSignedURL"
      },
      "description": "Get Pre-Signed URL",
      "op": "output.write.getPreSignedURL",
      "parent_span_id": "802b96226619e273",
      "span_id": "af5024bb099b671d",
      "start_timestamp": 1748812471.4842181,
      "timestamp": 1748812471.9964101,
      "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
      "origin": "manual"
    },
    {
      "data": {
        "sentry.origin": "manual",
        "sentry.op": "http.client",
        "http.request.method": "POST",
        "http.request.url": "https://api.codecov.io/upload/bundle_analysis/v1",
        "http.response.status_code": 202,
        "http.response_content_length": 440,
        "http.response.status_text": "Accepted"
      },
      "description": "Fetching Pre-Signed URL",
      "op": "http.client",
      "parent_span_id": "af5024bb099b671d",
      "span_id": "9a48679f9dbf1804",
      "start_timestamp": 1748812471.530388,
      "timestamp": 1748812471.994159,
      "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
      "origin": "manual"
    },
    {
      "data": {
        "sentry.origin": "manual",
        "sentry.op": "output.write.uploadStats"
      },
      "description": "Upload Stats",
      "op": "output.write.uploadStats",
      "parent_span_id": "802b96226619e273",
      "span_id": "b1b8d8a5d3e560de",
      "start_timestamp": 1748812471.9965694,
      "timestamp": 1748812478.343116,
      "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
      "origin": "manual"
    },
    {
      "data": {
        "sentry.origin": "manual",
        "sentry.op": "http.client",
        "http.request.method": "PUT",
        "http.response.status_code": 200,
        "http.response_content_length": 0,
        "http.response.status_text": "OK"
      },
      "description": "Uploading Stats",
      "op": "http.client",
      "parent_span_id": "b1b8d8a5d3e560de",
      "span_id": "82872b3486ddf1cc",
      "start_timestamp": 1748812472.0020504,
      "timestamp": 1748812478.3429804,
      "trace_id": "3d5c39eb83094814a9fb9d2780e07398",
      "origin": "manual"
    }
  ],
  "start_timestamp": 1748812471.3934011,
  "timestamp": 1748812478.3438063,
  "transaction": "Output Write",
  "type": "transaction",
  "transaction_info": {
    "source": "custom"
  },
  "platform": "node",
  "event_id": "e96e4e58200b43508570c9126421ba80",
  "environment": "production",
  "release": "1.9.0",
  "tags": {
    "node": "v22.15.1",
    "platform": "linux",
    "plugin.name": "@codecov/webpack-plugin",
    "plugin.version": "1.9.0",
    "auth_mode": "tokenless",
    "ci": false,
    "meta_framework": "none",
    "bundler": "webpack",
    "service": "local",
    "owner": "nextcloud",
    "repo": "server"
  }
}
```

</details> 


> [codecov] Detected CI provider: Local
[codecov] Attempting to fetch get-pre-signed-url, attempt: 1
[codecov] Successfully pre-signed URL fetched
[codecov] Attempting to fetch upload-stats, attempt: 1
[codecov] Successfully uploaded stats for bundle: nextcloud-array-push
assets by path *.js 12.5 MiB

Is sending two requests to the Google Storage service, uploading data about the bundle. Since we do not compile the assets on CI, I assume it is necessary to do it locally. However, I am not particularly in favor of every local build now uploading data to Codecov. Given the limited use of this feature, I would prefer to disable it again.

<details><summary>Request 3</summary>

```json
{
  "branch": "bug/53243/wrong-app-id-for-systemtags-settings",
  "build": null,
  "buildURL": null,
  "commit": "ffe5caa91b9f56e98f98a968d87eefa1991dfac2",
  "job": null,
  "pr": null,
  "service": "local",
  "slug": "nextcloud::::server",
  "git_service": "github"
}
```

</details> 

<details><summary>Request 4</summary>

Note: I emptied assets, chunks and modules. 

```json
{
  "version": "3",
  "builtAt": 1748812429646,
  "duration": 41714,
  "bundleName": "nextcloud-array-push",
  "outputPath": "/path/to/the/working/directory",
  "bundler": {
    "name": "webpack",
    "version": "5.99.9"
  },
  "plugin": {
    "name": "@codecov/webpack-plugin",
    "version": "1.9.0"
  },
  "assets": [],
  "chunks": [],
  "modules": []
}

```

</details> 


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
