### PR TITLE
test(files_sharing): split `testCanAccessShare` into separate tests and fix for PHPUnit 10

### DIFF
--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -1542,84 +1542,129 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertEquals($expected, $result->getData());
 	}
 
-	public function testCanAccessShare(): void {
-		$share = $this->getMockBuilder(IShare::class)->getMock();
+	public function testCanAccessShareAsOwner(): void {
+		$share = $this->createMock(IShare::class);
 		$share->method('getShareOwner')->willReturn($this->currentUser);
 		$this->assertTrue($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+	}
 
-		$share = $this->getMockBuilder(IShare::class)->getMock();
+	public function testCanAccessShareAsSharer(): void {
+		$share = $this->createMock(IShare::class);
 		$share->method('getSharedBy')->willReturn($this->currentUser);
 		$this->assertTrue($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+	}
 
-		$share = $this->getMockBuilder(IShare::class)->getMock();
+	public function testCanAccessShareAsSharee(): void {
+		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
 		$share->method('getSharedWith')->willReturn($this->currentUser);
 		$this->assertTrue($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+	}
 
-		$file = $this->getMockBuilder(File::class)->getMock();
+	public function testCannotAccessLinkShare(): void {
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareType')->willReturn(IShare::TYPE_LINK);
+		$share->method('getNodeId')->willReturn(42);
 
-		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
+		$userFolder = $this->createMock(Folder::class);
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturn($userFolder);
 
+		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+	}
+
+	/**
+	 * @dataProvider dataCanAccessShareWithPermissions
+	 */
+	public function testCanAccessShareWithPermissions(int $permissions, bool $expected): void {
+		$share = $this->createMock(IShare::class);
+		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
+		$share->method('getSharedWith')->willReturn($this->createMock(IUser::class));
+		$share->method('getNodeId')->willReturn(42);
+
+		$file = $this->createMock(File::class);
+
+		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$userFolder->method('getFirstNodeById')
 			->with($share->getNodeId())
 			->willReturn($file);
 		$userFolder->method('getById')
 			->with($share->getNodeId())
 			->willReturn([$file]);
+		$this->rootFolder->method('getUserFolder')
+			->with($this->currentUser)
+			->willReturn($userFolder);
 
 		$file->method('getPermissions')
-			->will($this->onConsecutiveCalls(Constants::PERMISSION_SHARE, Constants::PERMISSION_READ));
+			->willReturn($permissions);
 
-		// getPermissions -> share
-		$share = $this->getMockBuilder(IShare::class)->getMock();
-		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
-		$share->method('getSharedWith')->willReturn($this->getMockBuilder(IUser::class)->getMock());
-		$this->assertTrue($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+		if ($expected) {
+			$this->assertTrue($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+		} else {
+			$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+		}
+	}
 
-		// getPermissions -> read
-		$share = $this->getMockBuilder(IShare::class)->getMock();
-		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
-		$share->method('getSharedWith')->willReturn($this->getMockBuilder(IUser::class)->getMock());
-		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+	public static function dataCanAccessShareWithPermissions(): array {
+		return [
+			[Constants::PERMISSION_SHARE, true],
+			[Constants::PERMISSION_READ, false],
+			[Constants::PERMISSION_READ | Constants::PERMISSION_SHARE, true],
+		];
+	}
 
-		$share = $this->getMockBuilder(IShare::class)->getMock();
+	/**
+	 * @dataProvider dataCanAccessShareAsGroupMember
+	 */
+	public function testCanAccessShareAsGroupMember(string $group, bool $expected): void {
+		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_GROUP);
-		$share->method('getSharedWith')->willReturn('group');
+		$share->method('getSharedWith')->willReturn($group);
+		$share->method('getNodeId')->willReturn(42);
+
+		$file = $this->createMock(File::class);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getFirstNodeById')
+			->with($share->getNodeId())
+			->willReturn($file);
+		$userFolder->method('getById')
+			->with($share->getNodeId())
+			->willReturn([$file]);
+		$this->rootFolder->method('getUserFolder')
+			->with($this->currentUser)
+			->willReturn($userFolder);
 
 		$user = $this->createMock(IUser::class);
 		$this->userManager->method('get')
 			->with($this->currentUser)
 			->willReturn($user);
 
-		$group = $this->getMockBuilder(IGroup::class)->getMock();
+		$group = $this->createMock(IGroup::class);
 		$group->method('inGroup')->with($user)->willReturn(true);
-		$group2 = $this->getMockBuilder(IGroup::class)->getMock();
+		$group2 = $this->createMock(IGroup::class);
 		$group2->method('inGroup')->with($user)->willReturn(false);
 
 		$this->groupManager->method('get')->willReturnMap([
 			['group', $group],
 			['group2', $group2],
-			['groupnull', null],
+			['group-null', null],
 		]);
-		$this->assertTrue($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
 
-		$share = $this->createMock(IShare::class);
-		$share->method('getShareType')->willReturn(IShare::TYPE_GROUP);
-		$share->method('getSharedWith')->willReturn('group2');
-		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+		if ($expected) {
+			$this->assertTrue($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+		} else {
+			$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+		}
+	}
 
-		// null group
-		$share = $this->createMock(IShare::class);
-		$share->method('getShareType')->willReturn(IShare::TYPE_GROUP);
-		$share->method('getSharedWith')->willReturn('groupnull');
-		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
-
-		$share = $this->createMock(IShare::class);
-		$share->method('getShareType')->willReturn(IShare::TYPE_LINK);
-		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
+	public static function dataCanAccessShareAsGroupMember(): array {
+		return [
+			['group', true],
+			['group2', false],
+			['group-null', false],
+		];
 	}
 
 	public function dataCanAccessRoomShare() {


### PR DESCRIPTION
## Summary

- for https://github.com/nextcloud/server/pull/48210
  - split the test into individual test cases
  - fix invalid call to `onConsecutiveCalls` (it was called more than defined values and is deprecated in v10 anyways).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
