### PR TITLE
[stable30] fix(systemtags): fix translations for systemtags view

### DIFF
--- a/apps/systemtags/src/components/SystemTagsCreationControl.vue
+++ b/apps/systemtags/src/components/SystemTagsCreationControl.vue
@@ -1,0 +1,87 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div id="system-tags-creation-control">
+		<h4 class="inlineblock">
+			{{ t('systemtags', 'System tag management') }}
+		</h4>
+
+		<p class="settings-hint">
+			{{ t('systemtags', 'If enabled, only administrators can create and edit tags. Accounts can still assign and remove them from files.') }}
+		</p>
+
+		<NcCheckboxRadioSwitch type="switch"
+			:checked.sync="systemTagsCreationRestrictedToAdmin"
+			@update:checked="updateSystemTagsDefault">
+			{{ t('systemtags', 'Restrict tag creation and editing to administrators') }}
+		</NcCheckboxRadioSwitch>
+	</div>
+</template>
+
+<script lang="ts">
+import { loadState } from '@nextcloud/initial-state'
+import { showError, showSuccess } from '@nextcloud/dialogs'
+import { t } from '@nextcloud/l10n'
+
+import { updateSystemTagsAdminRestriction } from '../services/api.js'
+import logger from '../logger.ts'
+
+import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
+
+export default {
+	name: 'SystemTagsCreationControl',
+
+	components: {
+		NcCheckboxRadioSwitch,
+	},
+
+	setup() {
+		return {
+			t,
+		}
+	},
+
+	data() {
+		return {
+			// By default, system tags creation is not restricted to admins
+			systemTagsCreationRestrictedToAdmin: loadState('systemtags', 'restrictSystemTagsCreationToAdmin', false),
+		}
+	},
+	methods: {
+		async updateSystemTagsDefault(isRestricted: boolean) {
+			try {
+				const responseData = await updateSystemTagsAdminRestriction(isRestricted)
+				console.debug('updateSystemTagsDefault', responseData)
+				this.handleResponse({
+					isRestricted,
+					status: responseData.ocs?.meta?.status,
+				})
+			} catch (e) {
+				this.handleResponse({
+					errorMessage: t('systemtags', 'Unable to update setting'),
+					error: e,
+				})
+			}
+		},
+
+		handleResponse({ isRestricted, status, errorMessage, error }) {
+			if (status === 'ok') {
+				this.systemTagsCreationRestrictedToAdmin = isRestricted
+				showSuccess(isRestricted
+					? t('systemtags', 'System tag creation is now restricted to administrators')
+					: t('systemtags', 'System tag creation is now allowed for everybody'),
+				)
+				return
+			}
+
+			if (errorMessage) {
+				showError(errorMessage)
+				logger.error(errorMessage, error)
+			}
+		},
+	},
+}
+</script>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Manual backport of https://github.com/nextcloud/server/pull/53244

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
