### PR TITLE
ci(github): No longer fail-fast

### DIFF
--- a/.github/workflows/files-external-ftp.yml
+++ b/.github/workflows/files-external-ftp.yml
@@ -43,7 +43,6 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
-      # do not stop on another job's failure
       fail-fast: false
       matrix:
         php-versions: ['8.1', '8.4']

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -43,6 +43,7 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.2', '8.3', '8.4']
         include:

--- a/.github/workflows/files-external-sftp.yml
+++ b/.github/workflows/files-external-sftp.yml
@@ -43,7 +43,6 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
-      # do not stop on another job's failure
       fail-fast: false
       matrix:
         php-versions: ['8.1', '8.4']

--- a/.github/workflows/files-external-smb.yml
+++ b/.github/workflows/files-external-smb.yml
@@ -43,6 +43,7 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1']
         include:

--- a/.github/workflows/files-external-webdav.yml
+++ b/.github/workflows/files-external-webdav.yml
@@ -43,6 +43,7 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.2', '8.3', '8.4']
         include:

--- a/.github/workflows/files-external.yml
+++ b/.github/workflows/files-external.yml
@@ -42,6 +42,7 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.2', '8.3', '8.4']
         include:

--- a/.github/workflows/integration-dav.yml
+++ b/.github/workflows/integration-dav.yml
@@ -43,7 +43,6 @@ jobs:
     if: needs.changes.outputs.src != 'false' && github.repository_owner != 'nextcloud-gmbh'
 
     strategy:
-      # do not stop on another job's failure
       fail-fast: false
       matrix:
         php-versions: ['8.1']

--- a/.github/workflows/integration-litmus.yml
+++ b/.github/workflows/integration-litmus.yml
@@ -43,7 +43,6 @@ jobs:
     if: needs.changes.outputs.src != 'false' && github.repository_owner != 'nextcloud-gmbh'
 
     strategy:
-      # do not stop on another job's failure
       fail-fast: false
       matrix:
         php-versions: ['8.1']

--- a/.github/workflows/integration-s3-primary.yml
+++ b/.github/workflows/integration-s3-primary.yml
@@ -43,7 +43,6 @@ jobs:
     if: needs.changes.outputs.src != 'false' && github.repository_owner != 'nextcloud-gmbh'
 
     strategy:
-      # do not stop on another job's failure
       fail-fast: false
       matrix:
         php-versions: ['8.1']

--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -47,6 +47,7 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.2']
         include:

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -47,6 +47,7 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.2']
         include:

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -47,6 +47,7 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.2']
         include:

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -27,6 +27,7 @@ jobs:
     container: shivammathur/node:latest-i386
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1','8.3']
 

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -57,6 +57,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1']
         mariadb-versions: ['10.3', '10.6', '10.11', '11.4']

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -54,6 +54,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.3', '8.4']
         include:

--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -54,6 +54,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1']
         mysql-versions: ['8.4']

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -57,6 +57,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1']
         mysql-versions: ['8.0', '8.4']

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -57,6 +57,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1', '8.3', '8.4']
         include:

--- a/.github/workflows/phpunit-object-store-primary.yml
+++ b/.github/workflows/phpunit-object-store-primary.yml
@@ -47,7 +47,6 @@ jobs:
     if: ${{ github.repository_owner != 'nextcloud-gmbh' && needs.changes.outputs.src != 'false' }}
 
     strategy:
-      # do not stop on another job's failure
       fail-fast: false
       matrix:
         php-versions: ['8.1']

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -57,6 +57,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.1']
         # To keep the matrix smaller we ignore PostgreSQL versions in between as we already test the minimum and the maximum

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -57,6 +57,7 @@ jobs:
     if: needs.changes.outputs.src != 'false'
 
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['8.2', '8.3', '8.4']
         include:


### PR DESCRIPTION
On average this is costing us more CI time due to flaky tests, then we save by actually skipping them.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
