### PR TITLE
feat: add --unscanned option to files_external:scan

### DIFF
--- a/apps/files_external/lib/Command/Scan.php
+++ b/apps/files_external/lib/Command/Scan.php
@@ -54,6 +54,11 @@ class Scan extends StorageAuthBase {
 				InputOption::VALUE_OPTIONAL,
 				'The path in the storage to scan',
 				''
+			)->addOption(
+				'unscanned',
+				'',
+				InputOption::VALUE_NONE,
+				'only scan files which are marked as not fully scanned'
 			);
 		parent::configure();
 	}
@@ -84,7 +89,15 @@ class Scan extends StorageAuthBase {
 		});
 
 		try {
-			$scanner->scan($path);
+			if ($input->getOption('unscanned')) {
+				if ($path !== '') {
+					$output->writeln('<error>--unscanned is mutually exclusive with --path</error>');
+					return 1;
+				}
+				$scanner->backgroundScan();
+			} else {
+				$scanner->scan($path);
+			}
 		} catch (LockedException $e) {
 			if (is_string($e->getReadablePath()) && str_starts_with($e->getReadablePath(), 'scanner::')) {
 				if ($e->getReadablePath() === 'scanner::') {


### PR DESCRIPTION
Making it closer to feature parity with the regular scan command.

Should be especially useful in combination with `occ files_external:notify`