### PR TITLE
ci: Add storage name to run name for easier identification

### DIFF
--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -50,7 +50,7 @@ jobs:
           - php-versions: '8.2'
             coverage: ${{ github.event_name != 'pull_request' }}
 
-    name: php${{ matrix.php-versions }}-s3
+    name: php${{ matrix.php-versions }}-s3-minio
 
     services:
       minio:
@@ -132,9 +132,9 @@ jobs:
         php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
-            coverage: true
+            coverage: ${{ github.event_name != 'pull_request' }}
 
-    name: php${{ matrix.php-versions }}-s3
+    name: php${{ matrix.php-versions }}-s3-localstack
 
     services:
       localstack:


### PR DESCRIPTION
- Noticed in https://github.com/nextcloud/server/actions/runs/15394295923/job/43311057036?pr=48210 that it's annoying to find out quickly. You can look at the started container, but showing it directly is much better
- New run names in https://github.com/nextcloud/server/actions/runs/15398359761/job/43324696125?pr=53269

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
