### PR TITLE
fix(provisioning_api): Allow group details access for users with admin delegation

### DIFF
--- a/apps/provisioning_api/lib/Controller/GroupsController.php
+++ b/apps/provisioning_api/lib/Controller/GroupsController.php
@@ -98,6 +98,7 @@ class GroupsController extends AUserDataOCSController {
 	 */
 	#[NoAdminRequired]
 	#[AuthorizedAdminSetting(settings: Sharing::class)]
+	#[AuthorizedAdminSetting(settings: Users::class)]
 	public function getGroupsDetails(string $search = '', ?int $limit = null, int $offset = 0): DataResponse {
 		$groups = $this->groupManager->search($search, $limit, $offset);
 		$groups = array_values(array_map(function ($group) {


### PR DESCRIPTION
This fixes an issue where users with "Administration privileges → Users" could not access the groups details endpoint in the provisioning API, resulting in a 403 Forbidden error.

There is a problem with adding the  `AuthorizedAdminSetting` attribute (middleware) that only allows access to users with Sharing admin privileges.

Users with "`Users` admin" privileges should also be able to access group details.

Resolves: https://github.com/nextcloud/server/issues/52617

~Introduced in : https://github.com/nextcloud/server/pull/46815~