### PR TITLE
fix(files_versions): Log failure to compute node path

### DIFF
--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -402,6 +402,24 @@ class FileEventsListener implements IEventListener {
 			}
 		}
 
+		try {
+			$this->logger->debug('Failed to compute path for node', [
+				'node' => [
+					'path' => $node->getPath(),
+					'owner' => $owner,
+					'fileid' => $node->getId(),
+					'size' => $node->getSize(),
+					'mtime' => $node->getMTime(),
+				]
+			]);
+		} catch (NotFoundException) {
+			$this->logger->debug('Failed to compute path for node', [
+				'node' => [
+					'path' => $node->getPath(),
+					'owner' => $owner,
+				]
+			]);
+		}
 		return null;
 	}
 }

--- a/apps/files_versions/lib/Listener/FileEventsListener.php
+++ b/apps/files_versions/lib/Listener/FileEventsListener.php
@@ -12,6 +12,7 @@ use OC\DB\Exceptions\DbalException;
 use OC\Files\Filesystem;
 use OC\Files\Mount\MoveableMount;
 use OC\Files\Node\NonExistingFile;
+use OC\Files\Node\NonExistingFolder;
 use OC\Files\View;
 use OCA\Files_Versions\Storage;
 use OCA\Files_Versions\Versions\INeedSyncVersionBackend;
@@ -402,7 +403,7 @@ class FileEventsListener implements IEventListener {
 			}
 		}
 
-		try {
+		if (!($node instanceof NonExistingFile) && !($node instanceof NonExistingFolder)) {
 			$this->logger->debug('Failed to compute path for node', [
 				'node' => [
 					'path' => $node->getPath(),
@@ -412,7 +413,7 @@ class FileEventsListener implements IEventListener {
 					'mtime' => $node->getMTime(),
 				]
 			]);
-		} catch (NotFoundException) {
+		} else {
 			$this->logger->debug('Failed to compute path for node', [
 				'node' => [
 					'path' => $node->getPath(),


### PR DESCRIPTION
* Follow-up: https://github.com/nextcloud/server/pull/51609

## Summary

To avoid hidden bugs, add some debug logging when a node path cannot be
 computed from a received event, to have more information for debugging.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
