### PR TITLE
feat(RequestHeader): Add indirect parameter

### DIFF
--- a/lib/public/AppFramework/Http/Attribute/RequestHeader.php
+++ b/lib/public/AppFramework/Http/Attribute/RequestHeader.php
@@ -21,8 +21,8 @@ use Attribute;
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class RequestHeader {
 	/**
-	 * @param string $name The name of the request header
-	 * @param string $description The description of the request header
+	 * @param lowercase-string $name The name of the request header
+	 * @param non-empty-string $description The description of the request header
 	 */
 	public function __construct(
 		protected string $name,

--- a/lib/public/AppFramework/Http/Attribute/RequestHeader.php
+++ b/lib/public/AppFramework/Http/Attribute/RequestHeader.php
@@ -23,10 +23,12 @@ class RequestHeader {
 	/**
 	 * @param lowercase-string $name The name of the request header
 	 * @param non-empty-string $description The description of the request header
+	 * @param bool $indirect Allow indirect usage of the header for example in a middleware. Enabling this turns off the check which ensures that the header must be referenced in the controller method.
 	 */
 	public function __construct(
 		protected string $name,
 		protected string $description,
+		protected bool $indirect = false,
 	) {
 	}
 }

--- a/lib/public/AppFramework/Http/Attribute/RequestHeader.php
+++ b/lib/public/AppFramework/Http/Attribute/RequestHeader.php
@@ -29,22 +29,4 @@ class RequestHeader {
 		protected string $description,
 	) {
 	}
-
-	/**
-	 * @return string The name of the request header.
-	 *
-	 * @since 32.0.0
-	 */
-	public function getName(): string {
-		return $this->name;
-	}
-
-	/**
-	 * @return string The description of the request header.
-	 *
-	 * @since 32.0.0
-	 */
-	public function getDescription(): string {
-		return $this->description;
-	}
 }


### PR DESCRIPTION
## Summary

Stricter types based on https://github.com/nextcloud/openapi-extractor/pull/250 and added indirect parameter for https://github.com/nextcloud/openapi-extractor/issues/248.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
