### PR TITLE
 fix(files_sharing): Hide own reshares

### DIFF
--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -64,7 +64,7 @@ class TransferOwnership extends Command {
 				'transfer-incoming-shares',
 				null,
 				InputOption::VALUE_OPTIONAL,
-				'transfer incoming user file shares to destination user. Usage: --transfer-incoming-shares=1 (value required)',
+				'Incoming shares are always transferred now, so this option does not affect the ownership transfer anymore',
 				'2'
 			)->addOption(
 				'include-external-storage',
@@ -129,27 +129,6 @@ class TransferOwnership extends Command {
 		}
 
 		try {
-			$includeIncomingArgument = $input->getOption('transfer-incoming-shares');
-
-			switch ($includeIncomingArgument) {
-				case '0':
-					$includeIncoming = false;
-					break;
-				case '1':
-					$includeIncoming = true;
-					break;
-				case '2':
-					$includeIncoming = $this->config->getSystemValue('transferIncomingShares', false);
-					if (gettype($includeIncoming) !== 'boolean') {
-						$output->writeln("<error> config.php: 'transfer-incoming-shares': wrong usage. Transfer aborted.</error>");
-						return self::FAILURE;
-					}
-					break;
-				default:
-					$output->writeln('<error>Option --transfer-incoming-shares: wrong usage. Transfer aborted.</error>');
-					return self::FAILURE;
-			}
-
 			$this->transferService->transfer(
 				$sourceUserObject,
 				$destinationUserObject,
@@ -157,7 +136,6 @@ class TransferOwnership extends Command {
 				$output,
 				$input->getOption('move') === true,
 				false,
-				$includeIncoming,
 				$includeExternalStorage,
 			);
 		} catch (TransferOwnershipException $e) {

--- a/apps/files/lib/Service/OwnershipTransferService.php
+++ b/apps/files/lib/Service/OwnershipTransferService.php
@@ -72,7 +72,6 @@ class OwnershipTransferService {
 		?OutputInterface $output = null,
 		bool $move = false,
 		bool $firstLogin = false,
-		bool $transferIncomingShares = false,
 		bool $includeExternalStorage = false,
 	): void {
 		$output = $output ?? new NullOutput();
@@ -159,28 +158,26 @@ class OwnershipTransferService {
 		$sizeDifference = $sourceSize - $view->getFileInfo($finalTarget)->getSize();
 
 		// transfer the incoming shares
-		if ($transferIncomingShares === true) {
-			$sourceShares = $this->collectIncomingShares(
-				$sourceUid,
-				$output,
-				$sourcePath,
-			);
-			$destinationShares = $this->collectIncomingShares(
-				$destinationUid,
-				$output,
-				null,
-			);
-			$this->transferIncomingShares(
-				$sourceUid,
-				$destinationUid,
-				$sourceShares,
-				$destinationShares,
-				$output,
-				$path,
-				$finalTarget,
-				$move
-			);
-		}
+		$sourceShares = $this->collectIncomingShares(
+			$sourceUid,
+			$output,
+			$sourcePath,
+		);
+		$destinationShares = $this->collectIncomingShares(
+			$destinationUid,
+			$output,
+			null,
+		);
+		$this->transferIncomingShares(
+			$sourceUid,
+			$destinationUid,
+			$sourceShares,
+			$destinationShares,
+			$output,
+			$path,
+			$finalTarget,
+			$move
+		);
 
 		$destinationPath = $finalTarget . '/' . $path;
 		// restore the shares

--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -55,7 +55,7 @@ class MountProvider implements IMountProvider {
 
 		// filter out excluded shares and group shares that includes self
 		$shares = array_filter($shares, function (IShare $share) use ($user) {
-			return $share->getPermissions() > 0 && $share->getShareOwner() !== $user->getUID();
+			return $share->getPermissions() > 0 && $share->getShareOwner() !== $user->getUID() && $share->getSharedBy() !== $user->getUID();
 		});
 
 		$superShares = $this->buildSuperShares($shares, $user);

--- a/build/integration/features/bootstrap/CommandLineContext.php
+++ b/build/integration/features/bootstrap/CommandLineContext.php
@@ -109,19 +109,6 @@ class CommandLineContext implements \Behat\Behat\Context\Context {
 	}
 
 	/**
-	 * @When /^transferring ownership of path "([^"]+)" from "([^"]+)" to "([^"]+)" with received shares$/
-	 */
-	public function transferringOwnershipPathWithIncomingShares($path, $user1, $user2) {
-		$path = '--path=' . $path;
-		if ($this->runOcc(['files:transfer-ownership', $path, $user1, $user2, '--transfer-incoming-shares=1']) === 0) {
-			$this->lastTransferPath = $this->findLastTransferFolderForUser($user1, $user2);
-		} else {
-			// failure
-			$this->lastTransferPath = null;
-		}
-	}
-
-	/**
 	 * @When /^using received transfer folder of "([^"]+)" as dav path$/
 	 */
 	public function usingTransferFolderAsDavPath($user) {

--- a/build/integration/files_features/transfer-ownership.feature
+++ b/build/integration/files_features/transfer-ownership.feature
@@ -184,10 +184,10 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 		And using old dav path
-		And as "user0" the folder "/test" exists
+		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/test" does not exist
-		And As an "user0"
+		And as "user1" the folder "/test" exists
+		And As an "user1"
 		And Getting info of last share
 		And the OCS status code should be "100"
 		And Share fields of last share match with
@@ -210,13 +210,12 @@ Feature: transfer-ownership
 		And user "user1" accepts last share
 		When transferring ownership from "user0" to "user1"
 		And the command was successful
-		And As an "user1"
-		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 		And using old dav path
-		And as "user0" the folder "/test" exists
+		Then as "user0" the folder "/test" does not exist
+		When As an "user1"
 		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/test" does not exist
-		And As an "user1"
+		Then as "user1" the folder "/test" exists
+		And Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 		And Getting info of last share
 		And the OCS status code should be "100"
 		And Share fields of last share match with
@@ -242,10 +241,10 @@ Feature: transfer-ownership
 		And As an "user2"
 		Then Downloaded content when downloading file "/test/somefile.txt" with range "bytes=0-6" should be "This is"
 		And using old dav path
-		And as "user0" the folder "/test" exists
+		And as "user0" the folder "/test" does not exist
 		And using received transfer folder of "user1" as dav path
-		And as "user1" the folder "/test" does not exist
-		And As an "user0"
+		And as "user1" the folder "/test" exists
+		And As an "user1"
 		And Getting info of last share
 		And the OCS status code should be "100"
 		And Share fields of last share match with
@@ -253,7 +252,7 @@ Feature: transfer-ownership
 			| uid_file_owner | user3 |
 			| share_with | group1 |
 
-	Scenario: transferring ownership does not transfer received shares
+	Scenario: transferring ownership transfers received shares
 		Given user "user0" exists
 		And user "user1" exists
 		And user "user2" exists
@@ -264,16 +263,16 @@ Feature: transfer-ownership
 		And the command was successful
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path
-		Then as "user1" the folder "/test" does not exist
+		Then as "user1" the folder "/test" exists
 		And using old dav path
-		And as "user0" the folder "/test" exists
+		And as "user0" the folder "/test" does not exist
 		And As an "user2"
 		And Getting info of last share
 		And the OCS status code should be "100"
 		And Share fields of last share match with
 			| uid_owner | user2 |
 			| uid_file_owner | user2 |
-			| share_with | user0 |
+			| share_with | user1 |
 
 	@local_storage
 	Scenario: transferring ownership does not transfer external storage
@@ -516,26 +515,6 @@ Feature: transfer-ownership
 		Then the command failed with exit code 1
 		And the command error output contains the text "Moving a storage (user0/files/test) into another storage (user1) is not allowed"
 
-	Scenario: transferring ownership does not transfer received shares
-		Given user "user0" exists
-		And user "user1" exists
-		And user "user2" exists
-		And User "user2" created a folder "/test"
-		And User "user0" created a folder "/sub"
-		And folder "/test" of user "user2" is shared with user "user0" with permissions 31
-		And user "user0" accepts last share
-		And User "user0" moved folder "/test" to "/sub/test"
-		When transferring ownership of path "sub" from "user0" to "user1"
-		And the command was successful
-		And As an "user1"
-		And using received transfer folder of "user1" as dav path
-		Then as "user1" the folder "/sub" exists
-		And as "user1" the folder "/sub/test" does not exist
-		And using old dav path
-		And as "user0" the folder "/sub" does not exist
-		And Getting info of last share
-		And the OCS status code should be "404"
-
 	Scenario: transferring ownership transfers received shares into subdir when requested
 		Given user "user0" exists
 		And user "user1" exists
@@ -548,7 +527,7 @@ Feature: transfer-ownership
 		And User "user0" moved folder "/transfer-share" to "/sub/transfer-share"
 		And folder "/do-not-transfer" of user "user2" is shared with user "user0" with permissions 31
 		And user "user0" accepts last share
-		When transferring ownership of path "sub" from "user0" to "user1" with received shares
+		When transferring ownership of path "sub" from "user0" to "user1"
 		And the command was successful
 		And As an "user1"
 		And using received transfer folder of "user1" as dav path


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/51988

## Summary

Another attempt at https://github.com/nextcloud/server/issues/51988.
The fix is the same, but I've dug deeper into the issue and found that the integration tests don't transfer incoming shares when doing the ownership transfer. Just enabling incoming share transfer would have been enough, but this actually pointed to problem that we currently break reshares when doing ownership transfer without incoming shares.
The original user will still have the incoming share, while the outgoing (re-)share is transferred to the new user. My fix for hiding own reshares assumed, that one would always have access to the original share when you have a reshare for it.
With the partial ownership transfer this is not true and I believe this is wrong as we must always transfer all shares to guarantee that reshares are still working as expected.

This will require some changes in Talk integration tests because paths have changed:
```diff
diff --git a/tests/integration/features/sharing-4/transfer-ownership.feature b/tests/integration/features/sharing-4/transfer-ownership.feature
index cbf596344..12f547f0f 100644
--- a/tests/integration/features/sharing-4/transfer-ownership.feature
+++ b/tests/integration/features/sharing-4/transfer-ownership.feature
@@ -65,11 +65,11 @@ Feature: transfer-ownership
       | displayname_owner      | participant2-displayname |
       | uid_file_owner         | participant3 |
       | displayname_file_owner | participant3-displayname |
-      | path                   | /welcome (2).txt |
+      | path                   | /Talk/welcome (2).txt |
       | item_type              | file |
       | mimetype               | text/plain |
-      | storage_id             | shared::/welcome (2).txt |
-      | file_target            | /welcome (2).txt |
+      | storage_id             | shared::/Talk/welcome (2).txt |
+      | file_target            | /Talk/welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
     And user "participant2" gets last share
@@ -78,10 +78,10 @@ Feature: transfer-ownership
       | displayname_owner      | participant2-displayname |
       | uid_file_owner         | participant3 |
       | displayname_file_owner | participant3-displayname |
-      | path                   | /Talk/welcome (2).txt |
+      | path                   | REGEXP /^\/Transferred from participant1-displayname on [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}-[0-9]{2}-[0-9]{2}\/welcome \(2\)\.txt$/ |
       | item_type              | file |
       | mimetype               | text/plain |
-      | storage_id             | shared::/Talk/welcome (2).txt |
+      | storage_id             | REGEXP /^shared::\/Transferred from participant1-displayname on [0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}-[0-9]{2}-[0-9]{2}\/welcome \(2\)\.txt$/ |
       | file_target            | /Talk/welcome (2).txt |
       | share_with             | group room |
       | share_with_displayname | Group room |
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)