### PR TITLE
chore(integration): Hide webserver logs

### DIFF
--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -53,14 +53,8 @@ PHP_CLI_SERVER_WORKERS=2 php -S localhost:$PORT -t ../.. &> phpserver.log &
 PHPPID=$!
 echo $PHPPID
 
-# Output filtered php server logs
-tail -f phpserver.log | grep --line-buffered -v -E ":[0-9]+ Accepted$" | grep --line-buffered -v -E ":[0-9]+ Closing$" &
-LOGPID=$!
-echo $LOGPID
-
 function cleanup() {
     kill $PHPPID
-    kill $LOGPID
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary

The logs are very spammy and make it really hard to parse the output if something fails. I also never found them useful when debugging failing tests, so I just removed them entirely (they can still be found in the file if needed).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
