### PR TITLE
[stable29] ci: install correct version of user_saml for Nextcloud 29

### DIFF
--- a/.github/workflows/files-external-smb-kerberos.yml
+++ b/.github/workflows/files-external-smb-kerberos.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           repository: nextcloud/user_saml
           path: apps/user_saml
+          # Latest version for Nextcloud 29
+          ref: stable-6
 
       - name: Install user_saml
         run: |


### PR DESCRIPTION
## Summary

Fix CI when doing enterprise releases.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
