### PR TITLE
fix(notifications): Fix check for hasNotifiers when all apps use Regi…

### DIFF
--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -217,7 +217,9 @@ class Manager implements IManager {
 	 * @since 8.2.0
 	 */
 	public function hasNotifiers(): bool {
-		return !empty($this->notifiers) || !empty($this->notifierClasses);
+		return !empty($this->notifiers)
+			|| !empty($this->notifierClasses)
+			|| (!$this->parsedRegistrationContext && !empty($this->coordinator->getRegistrationContext()->getNotifierServices()));
 	}
 
 	/**


### PR DESCRIPTION
…strationContext

* Resolves: Red CI in https://github.com/nextcloud/notifications/actions/runs/15432761760/job/43433471031
* This is triggered by https://github.com/nextcloud/server/pull/53157 which removed the last non-RegistrationContext registered Notifier that was always there. After that pull request there was never a direct one and the RegistrationContext was not yet tested whether it really has any notifiers. This caused `hasNotifiers()` to return false even though it had notifiers later on when actually getting them. But the notifications app did an early exit with a better status code when non notifier exists.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
