### PR TITLE
fix: Set public link upload email notification to opt-in

### DIFF
--- a/apps/files_sharing/lib/Activity/Settings/PublicLinksUpload.php
+++ b/apps/files_sharing/lib/Activity/Settings/PublicLinksUpload.php
@@ -61,6 +61,6 @@ class PublicLinksUpload extends ShareActivitySettings {
 	 * @since 11.0.0
 	 */
 	public function isDefaultEnabledMail() {
-		return true;
+		return false;
 	}
 }


### PR DESCRIPTION
This now sets `isDefaultEnabled` to false. This makes email notifications for file uploads to public links disabled by default (opt-in) for users.

This addresses concerns about new notifications being enabled by default for existing users, leading to unexpected emails.

Related: https://github.com/nextcloud/server/pull/46945

