### PR TITLE
fix Unix socket syntax

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -120,7 +120,8 @@ $CONFIG = [
  * Your host server name, for example ``localhost``, ``hostname``,
  * ``hostname.example.com``, or the IP address.
  * To specify a port use ``hostname:####``, for IPv6 addresses use the URI notation ``[ip]:port``.
- * To specify a Unix socket use ``/path/to/directory/containing/socket``, e.g. ``/run/postgresql/``.
+ * To specify a Unix socket use ``localhost:/path/to/directory/containing/socket`` or
+ * ``:/path/to/directory/containing/socket``, e.g. ``localhost:/run/postgresql/``.
  */
 'dbhost' => '',
 


### PR DESCRIPTION
* Resolves: [Socket syntax unclear for dbhost variable](https://github.com/nextcloud/documentation/issues/11740)

## Summary

See https://github.com/nextcloud/documentation/pull/13173#discussion_r2120988439 for more explanations