### PR TITLE
fix: Pass over product name as capability

### DIFF
--- a/apps/theming/lib/Capabilities.php
+++ b/apps/theming/lib/Capabilities.php
@@ -41,6 +41,7 @@ class Capabilities implements IPublicCapability {
 	 * @return array{
 	 *     theming: array{
 	 *         name: string,
+	 *         productName: string,
 	 *         url: string,
 	 *         slogan: string,
 	 *         color: string,
@@ -94,6 +95,7 @@ class Capabilities implements IPublicCapability {
 		return [
 			'theming' => [
 				'name' => $this->theming->getName(),
+				'productName' => $this->theming->getProductName(),
 				'url' => $this->theming->getBaseUrl(),
 				'slogan' => $this->theming->getSlogan(),
 				'color' => $color,

--- a/apps/theming/openapi.json
+++ b/apps/theming/openapi.json
@@ -79,6 +79,7 @@
                         "type": "object",
                         "required": [
                             "name",
+                            "productName",
                             "url",
                             "slogan",
                             "color",
@@ -96,6 +97,9 @@
                         ],
                         "properties": {
                             "name": {
+                                "type": "string"
+                            },
+                            "productName": {
                                 "type": "string"
                             },
                             "url": {

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -54,6 +54,7 @@ class CapabilitiesTest extends TestCase {
 		return [
 			['name', 'url', 'slogan', '#FFFFFF', '#000000', 'logo', 'background', '#fff', '#000', 'http://absolute/', true, [
 				'name' => 'name',
+				'productName' => 'name',
 				'url' => 'url',
 				'slogan' => 'slogan',
 				'color' => '#FFFFFF',
@@ -71,6 +72,7 @@ class CapabilitiesTest extends TestCase {
 			]],
 			['name1', 'url2', 'slogan3', '#01e4a0', '#ffffff', 'logo5', 'background6', '#fff', '#000', 'http://localhost/', false, [
 				'name' => 'name1',
+				'productName' => 'name1',
 				'url' => 'url2',
 				'slogan' => 'slogan3',
 				'color' => '#01e4a0',
@@ -88,6 +90,7 @@ class CapabilitiesTest extends TestCase {
 			]],
 			['name1', 'url2', 'slogan3', '#000000', '#ffffff', 'logo5', 'backgroundColor', '#000000', '#ffffff', 'http://localhost/', true, [
 				'name' => 'name1',
+				'productName' => 'name1',
 				'url' => 'url2',
 				'slogan' => 'slogan3',
 				'color' => '#000000',
@@ -105,6 +108,7 @@ class CapabilitiesTest extends TestCase {
 			]],
 			['name1', 'url2', 'slogan3', '#000000', '#ffffff', 'logo5', 'backgroundColor', '#000000', '#ffffff', 'http://localhost/', false, [
 				'name' => 'name1',
+				'productName' => 'name1',
 				'url' => 'url2',
 				'slogan' => 'slogan3',
 				'color' => '#000000',
@@ -133,6 +137,9 @@ class CapabilitiesTest extends TestCase {
 			->willReturn($background);
 		$this->theming->expects($this->once())
 			->method('getName')
+			->willReturn($name);
+		$this->theming->expects($this->once())
+			->method('getProductName')
 			->willReturn($name);
 		$this->theming->expects($this->once())
 			->method('getBaseUrl')

--- a/openapi.json
+++ b/openapi.json
@@ -4047,6 +4047,7 @@
                         "type": "object",
                         "required": [
                             "name",
+                            "productName",
                             "url",
                             "slogan",
                             "color",
@@ -4064,6 +4065,9 @@
                         ],
                         "properties": {
                             "name": {
+                                "type": "string"
+                            },
+                            "productName": {
                                 "type": "string"
                             },
                             "url": {


### PR DESCRIPTION
This is being used to set the title and should be exposed to clients and the frontend

https://github.com/nextcloud/server/blob/9c5e4641114bdd255b5917bbf8fb6a39dcb5589d/apps/files/src/views/FilesList.vue#L489