### PR TITLE
fix: Do not enable applications which are not installed yet

### DIFF
--- a/apps/provisioning_api/lib/Controller/AppsController.php
+++ b/apps/provisioning_api/lib/Controller/AppsController.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\Provisioning_API\Controller;
 
+use OC\App\AppStore\AppNotFoundException;
 use OC\Installer;
 use OC_App;
 use OCP\App\AppPathNotFoundException;
@@ -124,7 +125,7 @@ class AppsController extends OCSController {
 			$this->appManager->enableApp($app);
 		} catch (\InvalidArgumentException $e) {
 			throw new OCSException($e->getMessage(), OCSController::RESPOND_UNAUTHORISED);
-		} catch (AppPathNotFoundException $e) {
+		} catch (AppPathNotFoundException|AppNotFoundException $e) {
 			throw new OCSException('The request app was not found', OCSController::RESPOND_NOT_FOUND);
 		}
 		return new DataResponse();

--- a/apps/provisioning_api/tests/Controller/AppsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppsControllerTest.php
@@ -7,14 +7,17 @@
  */
 namespace OCA\Provisioning_API\Tests\Controller;
 
+use OC\Installer;
 use OCA\Provisioning_API\Controller\AppsController;
 use OCA\Provisioning_API\Tests\TestCase;
 use OCP\App\IAppManager;
 use OCP\AppFramework\OCS\OCSException;
+use OCP\IAppConfig;
 use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserSession;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Class AppsTest
@@ -25,6 +28,8 @@ use OCP\Server;
  */
 class AppsControllerTest extends TestCase {
 	private IAppManager $appManager;
+	private IAppConfig&MockObject $appConfig;
+	private Installer&MockObject $installer;
 	private AppsController $api;
 	private IUserSession $userSession;
 
@@ -34,13 +39,17 @@ class AppsControllerTest extends TestCase {
 		$this->appManager = Server::get(IAppManager::class);
 		$this->groupManager = Server::get(IGroupManager::class);
 		$this->userSession = Server::get(IUserSession::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->installer = $this->createMock(Installer::class);
 
 		$request = $this->createMock(IRequest::class);
 
 		$this->api = new AppsController(
 			'provisioning_api',
 			$request,
-			$this->appManager
+			$this->appManager,
+			$this->installer,
+			$this->appConfig,
 		);
 	}
 

--- a/build/integration/run.sh
+++ b/build/integration/run.sh
@@ -18,6 +18,8 @@ HIDE_OC_LOGS=$2
 INSTALLED=$($OCC status | grep installed: | cut -d " " -f 5)
 
 if [ "$INSTALLED" == "true" ]; then
+    # Disable appstore to avoid spamming from CI
+    $OCC config:system:set appstoreenabled --value=false --type=boolean
     # Disable bruteforce protection because the integration tests do trigger them
     $OCC config:system:set auth.bruteforce.protection.enabled --value false --type bool
     # Disable rate limit protection because the integration tests do trigger them

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1049,6 +1049,7 @@ return array(
     'OC\\AppScriptDependency' => $baseDir . '/lib/private/AppScriptDependency.php',
     'OC\\AppScriptSort' => $baseDir . '/lib/private/AppScriptSort.php',
     'OC\\App\\AppManager' => $baseDir . '/lib/private/App/AppManager.php',
+    'OC\\App\\AppStore\\AppNotFoundException' => $baseDir . '/lib/private/App/AppStore/AppNotFoundException.php',
     'OC\\App\\AppStore\\Bundles\\Bundle' => $baseDir . '/lib/private/App/AppStore/Bundles/Bundle.php',
     'OC\\App\\AppStore\\Bundles\\BundleFetcher' => $baseDir . '/lib/private/App/AppStore/Bundles/BundleFetcher.php',
     'OC\\App\\AppStore\\Bundles\\EducationBundle' => $baseDir . '/lib/private/App/AppStore/Bundles/EducationBundle.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1090,6 +1090,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\AppScriptDependency' => __DIR__ . '/../../..' . '/lib/private/AppScriptDependency.php',
         'OC\\AppScriptSort' => __DIR__ . '/../../..' . '/lib/private/AppScriptSort.php',
         'OC\\App\\AppManager' => __DIR__ . '/../../..' . '/lib/private/App/AppManager.php',
+        'OC\\App\\AppStore\\AppNotFoundException' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/AppNotFoundException.php',
         'OC\\App\\AppStore\\Bundles\\Bundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/Bundle.php',
         'OC\\App\\AppStore\\Bundles\\BundleFetcher' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/BundleFetcher.php',
         'OC\\App\\AppStore\\Bundles\\EducationBundle' => __DIR__ . '/../../..' . '/lib/private/App/AppStore/Bundles/EducationBundle.php',

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -545,10 +545,15 @@ class AppManager implements IAppManager {
 	 * @param string $appId
 	 * @param bool $forceEnable
 	 * @throws AppPathNotFoundException
+	 * @throws \InvalidArgumentException if the application is not installed yet
 	 */
 	public function enableApp(string $appId, bool $forceEnable = false): void {
 		// Check if app exists
 		$this->getAppPath($appId);
+
+		if ($this->config->getAppValue($appId, 'installed_version', '') === '') {
+			throw new \InvalidArgumentException("$appId is not installed, cannot be enabled.");
+		}
 
 		if ($forceEnable) {
 			$this->overwriteNextcloudRequirement($appId);
@@ -594,6 +599,10 @@ class AppManager implements IAppManager {
 		$info = $this->getAppInfo($appId);
 		if (!empty($info['types']) && $this->hasProtectedAppType($info['types'])) {
 			throw new \InvalidArgumentException("$appId can't be enabled for groups.");
+		}
+
+		if ($this->config->getAppValue($appId, 'installed_version', '') === '') {
+			throw new \InvalidArgumentException("$appId is not installed, cannot be enabled.");
 		}
 
 		if ($forceEnable) {

--- a/lib/private/App/AppStore/AppNotFoundException.php
+++ b/lib/private/App/AppStore/AppNotFoundException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\App\AppStore;
+
+class AppNotFoundException extends \Exception {
+}

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OC;
 
 use Doctrine\DBAL\Exception\TableExistsException;
+use OC\App\AppStore\AppNotFoundException;
 use OC\App\AppStore\Bundles\Bundle;
 use OC\App\AppStore\Fetcher\AppFetcher;
 use OC\AppFramework\Bootstrap\Coordinator;
@@ -174,6 +175,7 @@ class Installer {
 	 * @param string $appId
 	 * @param bool [$allowUnstable]
 	 *
+	 * @throws AppNotFoundException If the app is not found on the appstore
 	 * @throws \Exception If the installation was not successful
 	 */
 	public function downloadApp(string $appId, bool $allowUnstable = false): void {
@@ -356,9 +358,9 @@ class Installer {
 			}
 		}
 
-		throw new \Exception(
+		throw new AppNotFoundException(
 			sprintf(
-				'Could not download app %s',
+				'Could not download app %s, it was not found on the appstore',
 				$appId
 			)
 		);


### PR DESCRIPTION
## Summary

It was previously possible for an application to be enabled but not installed, if this application is shipped and disabled by default, and enabled through the provisioning_api application.
This was the case of the testing application in integration tests, creating weird behaviors.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
