### PR TITLE
fix: hide guests group when searching for principals

### DIFF
--- a/apps/dav/lib/DAV/GroupPrincipalBackend.php
+++ b/apps/dav/lib/DAV/GroupPrincipalBackend.php
@@ -188,6 +188,10 @@ class GroupPrincipalBackend implements BackendInterface {
 					$groups = $this->groupManager->search($value, $searchLimit);
 
 					$results[] = array_reduce($groups, function (array $carry, IGroup $group) use ($restrictGroups) {
+						if ($group->hideFromCollaboration()) {
+							return $carry;
+						}
+
 						$gid = $group->getGID();
 						// is sharing restricted to groups only?
 						if ($restrictGroups !== false) {

--- a/apps/testing/composer/composer/autoload_classmap.php
+++ b/apps/testing/composer/composer/autoload_classmap.php
@@ -13,6 +13,7 @@ return array(
     'OCA\\Testing\\Controller\\LockingController' => $baseDir . '/../lib/Controller/LockingController.php',
     'OCA\\Testing\\Controller\\RateLimitTestController' => $baseDir . '/../lib/Controller/RateLimitTestController.php',
     'OCA\\Testing\\Conversion\\ConversionProvider' => $baseDir . '/../lib/Conversion/ConversionProvider.php',
+    'OCA\\Testing\\HiddenGroupBackend' => $baseDir . '/../lib/HiddenGroupBackend.php',
     'OCA\\Testing\\Listener\\GetDeclarativeSettingsValueListener' => $baseDir . '/../lib/Listener/GetDeclarativeSettingsValueListener.php',
     'OCA\\Testing\\Listener\\RegisterDeclarativeSettingsListener' => $baseDir . '/../lib/Listener/RegisterDeclarativeSettingsListener.php',
     'OCA\\Testing\\Listener\\SetDeclarativeSettingsValueListener' => $baseDir . '/../lib/Listener/SetDeclarativeSettingsValueListener.php',

--- a/apps/testing/composer/composer/autoload_static.php
+++ b/apps/testing/composer/composer/autoload_static.php
@@ -28,6 +28,7 @@ class ComposerStaticInitTesting
         'OCA\\Testing\\Controller\\LockingController' => __DIR__ . '/..' . '/../lib/Controller/LockingController.php',
         'OCA\\Testing\\Controller\\RateLimitTestController' => __DIR__ . '/..' . '/../lib/Controller/RateLimitTestController.php',
         'OCA\\Testing\\Conversion\\ConversionProvider' => __DIR__ . '/..' . '/../lib/Conversion/ConversionProvider.php',
+        'OCA\\Testing\\HiddenGroupBackend' => __DIR__ . '/..' . '/../lib/HiddenGroupBackend.php',
         'OCA\\Testing\\Listener\\GetDeclarativeSettingsValueListener' => __DIR__ . '/..' . '/../lib/Listener/GetDeclarativeSettingsValueListener.php',
         'OCA\\Testing\\Listener\\RegisterDeclarativeSettingsListener' => __DIR__ . '/..' . '/../lib/Listener/RegisterDeclarativeSettingsListener.php',
         'OCA\\Testing\\Listener\\SetDeclarativeSettingsValueListener' => __DIR__ . '/..' . '/../lib/Listener/SetDeclarativeSettingsValueListener.php',

--- a/apps/testing/lib/AppInfo/Application.php
+++ b/apps/testing/lib/AppInfo/Application.php
@@ -8,6 +8,7 @@ namespace OCA\Testing\AppInfo;
 
 use OCA\Testing\AlternativeHomeUserBackend;
 use OCA\Testing\Conversion\ConversionProvider;
+use OCA\Testing\HiddenGroupBackend;
 use OCA\Testing\Listener\GetDeclarativeSettingsValueListener;
 use OCA\Testing\Listener\RegisterDeclarativeSettingsListener;
 use OCA\Testing\Listener\SetDeclarativeSettingsValueListener;
@@ -26,6 +27,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\IGroupManager;
 use OCP\Settings\Events\DeclarativeSettingsGetValueEvent;
 use OCP\Settings\Events\DeclarativeSettingsRegisterFormEvent;
 use OCP\Settings\Events\DeclarativeSettingsSetValueEvent;
@@ -68,5 +70,8 @@ class Application extends App implements IBootstrap {
 			$userManager->clearBackends();
 			$userManager->registerBackend($context->getAppContainer()->get(AlternativeHomeUserBackend::class));
 		}
+
+		$groupManager = $server->get(IGroupManager::class);
+		$groupManager->addBackend($server->get(HiddenGroupBackend::class));
 	}
 }

--- a/apps/testing/lib/HiddenGroupBackend.php
+++ b/apps/testing/lib/HiddenGroupBackend.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Testing;
+
+use OCP\Group\Backend\ABackend;
+use OCP\Group\Backend\IHideFromCollaborationBackend;
+
+class HiddenGroupBackend extends ABackend implements IHideFromCollaborationBackend {
+	private string $groupName;
+
+	public function __construct(
+		string $groupName = 'hidden_group',
+	) {
+		$this->groupName = $groupName;
+	}
+
+	public function inGroup($uid, $gid): bool {
+		return false;
+	}
+
+	public function getUserGroups($uid): array {
+		return [];
+	}
+
+	public function getGroups($search = '', $limit = -1, $offset = 0): array {
+		return $offset === 0 ? [$this->groupName] : [];
+	}
+
+	public function groupExists($gid): bool {
+		return $gid === $this->groupName;
+	}
+
+	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0): array {
+		return [];
+	}
+
+	public function hideGroup(string $groupId): bool {
+		return true;
+	}
+}

--- a/build/integration/config/behat.yml
+++ b/build/integration/config/behat.yml
@@ -80,6 +80,8 @@ default:
         - CommandLineContext:
             baseUrl: http://localhost:8080
             ocPath: ../../
+        - PrincipalPropertySearchContext:
+            baseUrl: http://localhost:8080
     federation:
       paths:
         - "%paths.base%/../federation_features"

--- a/build/integration/dav_features/principal-property-search.feature
+++ b/build/integration/dav_features/principal-property-search.feature
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+Feature: principal-property-search
+	Background:
+		Given user "user0" exists
+		Given As an "admin"
+		Given invoking occ with "app:enable --force testing"
+
+	Scenario: Find a principal by a given displayname
+		When searching for a principal matching "user0"
+		Then The search HTTP status code should be "207"
+		And The search response should contain "<d:href>/remote.php/dav/principals/users/user0/</d:href>"

--- a/build/integration/features/bootstrap/PrincipalPropertySearchContext.php
+++ b/build/integration/features/bootstrap/PrincipalPropertySearchContext.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Behat\Behat\Context\Context;
+use GuzzleHttp\BodySummarizer;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Utils;
+use Psr\Http\Message\ResponseInterface;
+
+class PrincipalPropertySearchContext implements Context {
+	private string $baseUrl;
+	private Client $client;
+	private ResponseInterface $response;
+
+	public function __construct(string $baseUrl) {
+		$this->baseUrl = $baseUrl;
+
+		// in case of ci deployment we take the server url from the environment
+		$testServerUrl = getenv('TEST_SERVER_URL');
+		if ($testServerUrl !== false) {
+			$this->baseUrl = substr($testServerUrl, 0, -5);
+		}
+	}
+
+	/** @BeforeScenario */
+	public function setUpScenario(): void {
+		$this->client = $this->createGuzzleInstance();
+	}
+
+	/**
+	 * Create a Guzzle client with a higher truncateAt value to read full error responses.
+	 */
+	private function createGuzzleInstance(): Client {
+		$bodySummarizer = new BodySummarizer(2048);
+
+		$stack = new HandlerStack(Utils::chooseHandler());
+		$stack->push(Middleware::httpErrors($bodySummarizer), 'http_errors');
+		$stack->push(Middleware::redirect(), 'allow_redirects');
+		$stack->push(Middleware::cookies(), 'cookies');
+		$stack->push(Middleware::prepareBody(), 'prepare_body');
+
+		return new Client(['handler' => $stack]);
+	}
+
+	/**
+	 * @When searching for a principal matching :match
+	 * @param string $match
+	 * @throws \Exception
+	 */
+	public function principalPropertySearch(string $match) {
+		$davUrl = $this->baseUrl . '/remote.php/dav/';
+		$user = 'admin';
+		$password = 'admin';
+
+		$this->response = $this->client->request(
+			'REPORT',
+			$davUrl,
+			[
+				'body' => '<x0:principal-property-search xmlns:x0="DAV:" test="anyof">
+	<x0:property-search>
+		<x0:prop>
+			<x0:displayname/>
+			<x2:email-address xmlns:x2="http://sabredav.org/ns"/>
+		</x0:prop>
+		<x0:match>' . $match . '</x0:match>
+	</x0:property-search>
+	<x0:prop>
+		<x0:displayname/>
+		<x1:calendar-user-type xmlns:x1="urn:ietf:params:xml:ns:caldav"/>
+		<x1:calendar-user-address-set xmlns:x1="urn:ietf:params:xml:ns:caldav"/>
+		<x0:principal-URL/>
+		<x0:alternate-URI-set/>
+		<x2:email-address xmlns:x2="http://sabredav.org/ns"/>
+		<x3:language xmlns:x3="http://nextcloud.com/ns"/>
+		<x1:calendar-home-set xmlns:x1="urn:ietf:params:xml:ns:caldav"/>
+		<x1:schedule-inbox-URL xmlns:x1="urn:ietf:params:xml:ns:caldav"/>
+		<x1:schedule-outbox-URL xmlns:x1="urn:ietf:params:xml:ns:caldav"/>
+		<x1:schedule-default-calendar-URL xmlns:x1="urn:ietf:params:xml:ns:caldav"/>
+		<x3:resource-type xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-vehicle-type xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-vehicle-make xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-vehicle-model xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-vehicle-is-electric xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-vehicle-range xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-vehicle-seating-capacity xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-contact-person xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:resource-contact-person-vcard xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:room-type xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:room-seating-capacity xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:room-building-address xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:room-building-story xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:room-building-room-number xmlns:x3="http://nextcloud.com/ns"/>
+		<x3:room-features xmlns:x3="http://nextcloud.com/ns"/>
+	</x0:prop>
+	<x0:apply-to-principal-collection-set/>
+</x0:principal-property-search>
+',
+				'auth' => [
+					$user,
+					$password,
+				],
+				'headers' => [
+					'Content-Type' => 'application/xml; charset=UTF-8',
+					'Depth' => '0',
+				],
+			]
+		);
+	}
+
+	/**
+	 * @Then The search HTTP status code should be :code
+	 * @param string $code
+	 * @throws \Exception
+	 */
+	public function theHttpStatusCodeShouldBe(string $code): void {
+		if ((int)$code !== $this->response->getStatusCode()) {
+			throw new \Exception('Expected ' . (int)$code . ' got ' . $this->response->getStatusCode());
+		}
+	}
+
+	/**
+	 * @Then The search response should contain :needle
+	 * @param string $needle
+	 * @throws \Exception
+	 */
+	public function theResponseShouldContain(string $needle): void {
+		$body = $this->response->getBody()->getContents();
+
+		if (str_contains($body, $needle) === false) {
+			throw new \Exception('Response does not contain "' . $needle . '"');
+		}
+	}
+}

--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -452,6 +452,7 @@ Feature: provisioning
     Then groups returned are
       | España |
       | admin |
+      | hidden_group |
       | new-group |
 
   Scenario: create a subadmin


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

Resolves: #52958 

## Summary

Follow-up for https://github.com/nextcloud/server/pull/52914


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
