### PR TITLE
test: run all files_external tests for S3

### DIFF
--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -92,14 +92,15 @@ jobs:
 
       - name: Wait for S3
         run: |
-          sleep 10
           curl -f -m 1 --retry-connrefused --retry 10 --retry-delay 10 http://localhost:9000/minio/health/ready
 
       - name: PHPUnit
-        run: composer run test:files_external -- \
-          apps/files_external/tests/Storage/Amazons3Test.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
+        run: |
+          composer run test:files_external -- \
+            --group S3 \
+            --log-junit junit.xml \
+            apps/files_external/tests/Storage \
+            ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
 
       - name: Upload code coverage
         if: ${{ !cancelled() && matrix.coverage }}
@@ -113,6 +114,11 @@ jobs:
         uses: codecov/test-results-action@47f89e9acb64b76debcd5ea40642d25a4adced9f # v1.1.1
         with:
           flags: phpunit-files-external-s3
+
+      - name: Nextcloud logs
+        if: always()
+        run: |
+          cat data/nextcloud.log
 
       - name: S3 logs
         if: always()
@@ -170,11 +176,12 @@ jobs:
           echo "<?php return ['run' => true,'hostname' => 'localhost','key' => 'ignored','secret' => 'ignored', 'bucket' => 'bucket', 'port' => 4566, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/files_external/tests/config.amazons3.php
 
       - name: PHPUnit
-        run: composer run test:files_external -- \
-          apps/files_external/tests/Storage/Amazons3Test.php \
-          apps/files_external/tests/Storage/VersionedAmazonS3Test.php \
-          --log-junit junit.xml \
-          ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
+        run: |
+          composer run test:files_external -- \
+            --group S3 \
+            --log-junit junit.xml \
+            apps/files_external/tests/Storage \
+            ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}
 
       - name: Upload code coverage
         if: ${{ !cancelled() && matrix.coverage }}

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -146,7 +146,7 @@ jobs:
         env:
           SERVICES: s3
           DEBUG: 1
-        image: localstack/localstack@sha256:b52c16663c70b7234f217cb993a339b46686e30a1a5d9279cb5feeb2202f837c # v4.4.0
+        image: localstack/localstack@sha256:9d4253786e0effe974d77fe3c390358391a56090a4fff83b4600d8a64404d95d # v4.5.0
         ports:
           - "4566:4566"
 
@@ -173,7 +173,7 @@ jobs:
           composer install
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force files_external
-          echo "<?php return ['run' => true,'hostname' => 'localhost','key' => 'ignored','secret' => 'ignored', 'bucket' => 'bucket', 'port' => 4566, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/files_external/tests/config.amazons3.php
+          echo "<?php return ['run' => true, 'localstack' => true, 'hostname' => 'localhost','key' => 'ignored','secret' => 'ignored', 'bucket' => 'bucket', 'port' => 4566, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/files_external/tests/config.amazons3.php
 
       - name: PHPUnit
         run: |

--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -45,9 +45,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.4']
         include:
-          - php-versions: '8.2'
+          - php-versions: '8.3'
             coverage: ${{ github.event_name != 'pull_request' }}
 
     name: php${{ matrix.php-versions }}-s3-minio
@@ -88,7 +88,7 @@ jobs:
           composer install
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
           ./occ app:enable --force files_external
-          echo "<?php return ['run' => true, 'secret' => 'actually-not-secret', 'passwordsalt' => 'actually-not-secret', 'hostname' => 'localhost','key' => '$OBJECT_STORE_KEY','secret' => '$OBJECT_STORE_SECRET', 'bucket' => 'bucket', 'port' => 9000, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/files_external/tests/config.amazons3.php
+          echo "<?php return ['run' => true, 'minio' => true, 'secret' => 'actually-not-secret', 'passwordsalt' => 'actually-not-secret', 'hostname' => 'localhost','key' => '$OBJECT_STORE_KEY','secret' => '$OBJECT_STORE_SECRET', 'bucket' => 'bucket', 'port' => 9000, 'use_ssl' => false, 'autocreate' => true, 'use_path_style' => true];" > apps/files_external/tests/config.amazons3.php
 
       - name: Wait for S3
         run: |
@@ -134,7 +134,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.4']
         include:
           - php-versions: '8.3'
             coverage: ${{ github.event_name != 'pull_request' }}

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -48,6 +48,10 @@ class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
 	}
 
 	public function testHashInFileName(): void {
-		$this->markTestSkipped('Localstack has a bug with hashes in filename');
+		if (isset($this->config['localstack'])) {
+			$this->markTestSkipped('Localstack has a bug with hashes in filename');
+		}
+
+		parent::testHashInFileName();
 	}
 }

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -13,6 +13,7 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  * Class Amazons3Test
  *
  * @group DB
+ * @group S3
  *
  * @package OCA\Files_External\Tests\Storage
  */
@@ -25,7 +26,7 @@ class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$this->config = include('files_external/tests/config.amazons3.php');
-		if (! is_array($this->config) or ! $this->config['run']) {
+		if (!is_array($this->config) || !$this->config['run']) {
 			$this->markTestSkipped('AmazonS3 backend not configured');
 		}
 		$this->instance = new AmazonS3($this->config + [

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -46,12 +46,4 @@ class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
 	public function testStat(): void {
 		$this->markTestSkipped('S3 doesn\'t update the parents folder mtime');
 	}
-
-	public function testHashInFileName(): void {
-		if (isset($this->config['localstack'])) {
-			$this->markTestSkipped('Localstack has a bug with hashes in filename');
-		}
-
-		parent::testHashInFileName();
-	}
 }

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -14,6 +14,7 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  * Class Amazons3Test
  *
  * @group DB
+ * @group S3
  *
  * @package OCA\Files_External\Tests\Storage
  */

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -19,7 +19,7 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  * @package OCA\Files_External\Tests\Storage
  */
 class Amazons3Test extends \Test\Files\Storage\Storage {
-	private $config;
+	protected $config;
 	/** @var AmazonS3 */
 	protected $instance;
 
@@ -27,7 +27,7 @@ class Amazons3Test extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$this->config = include('files_external/tests/config.amazons3.php');
-		if (! is_array($this->config) or ! $this->config['run']) {
+		if (!is_array($this->config) || !$this->config['run']) {
 			$this->markTestSkipped('AmazonS3 backend not configured');
 		}
 		$this->instance = new AmazonS3($this->config);
@@ -43,12 +43,5 @@ class Amazons3Test extends \Test\Files\Storage\Storage {
 
 	public function testStat(): void {
 		$this->markTestSkipped('S3 doesn\'t update the parents folder mtime');
-	}
-
-	public function testHashInFileName(): void {
-		if (isset($this->config['localstack'])) {
-			$this->markTestSkipped('Localstack has a bug with hashes in filename');
-		}
-		parent::testHashInFileName();
 	}
 }

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -46,6 +46,9 @@ class Amazons3Test extends \Test\Files\Storage\Storage {
 	}
 
 	public function testHashInFileName(): void {
-		$this->markTestSkipped('Localstack has a bug with hashes in filename');
+		if (isset($this->config['localstack'])) {
+			$this->markTestSkipped('Localstack has a bug with hashes in filename');
+		}
+		parent::testHashInFileName();
 	}
 }

--- a/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
+++ b/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
@@ -26,4 +26,12 @@ class VersionedAmazonS3Test extends Amazons3Test {
 			$this->markTestSkipped("s3 backend doesn't seem to support versioning");
 		}
 	}
+
+	public function testCopyOverWriteDirectory(): void {
+		if (isset($this->config['minio'])) {
+			$this->markTestSkipped('MinIO has a bug with batch deletion on versioned storages, see https://github.com/minio/minio/issues/21366');
+		}
+
+		parent::testCopyOverWriteDirectory();
+	}
 }

--- a/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
+++ b/apps/files_external/tests/Storage/VersionedAmazonS3Test.php
@@ -10,6 +10,7 @@ namespace OCA\Files_External\Tests\Storage;
 
 /**
  * @group DB
+ * @group S3
  */
 class VersionedAmazonS3Test extends Amazons3Test {
 	protected function setUp(): void {


### PR DESCRIPTION
## Summary

PHPUnit 9 could only run 1 test file or 1 directory specified by command line, so the versioned S3 and the multipart tests were never run. Also for PHPUnit 10 we in the beginning disabled them.

This enables running all, additionally:
- Reenable localstack tests - mentioned bugs were fixed so it is possible to test again
- Disable one MinIO test due to a bug: https://github.com/minio/minio/issues/21366


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
