### PR TITLE
Fix/49584 background worker interval fixes

### DIFF
--- a/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
+++ b/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
@@ -40,9 +40,7 @@ class UserStatusAutomation extends TimedJob {
 	) {
 		parent::__construct($timeFactory);
 
-		// Interval 0 might look weird, but the last_checked is always moved
-		// to the next time we need this and then it's 0 seconds ago.
-		$this->setInterval(0);
+		$this->setInterval(1);
 	}
 
 	/**

--- a/apps/files_reminders/lib/BackgroundJob/ScheduledNotifications.php
+++ b/apps/files_reminders/lib/BackgroundJob/ScheduledNotifications.php
@@ -13,10 +13,10 @@ use OCA\FilesReminders\Db\ReminderMapper;
 use OCA\FilesReminders\Service\ReminderService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\Job;
+use OCP\BackgroundJob\TimedJob;
 use Psr\Log\LoggerInterface;
 
-class ScheduledNotifications extends Job {
+class ScheduledNotifications extends TimedJob {
 	public function __construct(
 		ITimeFactory $time,
 		protected ReminderMapper $reminderMapper,
@@ -24,6 +24,8 @@ class ScheduledNotifications extends Job {
 		protected LoggerInterface $logger,
 	) {
 		parent::__construct($time);
+
+		$this->setInterval(1);
 	}
 
 	/**

--- a/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
+++ b/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
@@ -32,8 +32,7 @@ class ClearOldStatusesBackgroundJob extends TimedJob {
 	) {
 		parent::__construct($time);
 
-		// Run every time the cron is run
-		$this->setInterval(0);
+		$this->setInterval(1);
 	}
 
 	/**

--- a/core/Command/Background/JobWorker.php
+++ b/core/Command/Background/JobWorker.php
@@ -46,13 +46,6 @@ class JobWorker extends JobBase {
 				'Only execute the worker once (as a regular cron execution would do it)'
 			)
 			->addOption(
-				'interval',
-				'i',
-				InputOption::VALUE_OPTIONAL,
-				'Interval in seconds in which the worker should repeat already processed jobs (set to 0 for no repeat)',
-				5
-			)
-			->addOption(
 				'stop_after',
 				't',
 				InputOption::VALUE_OPTIONAL,

--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -7,6 +7,8 @@
  */
 namespace OC\Log;
 
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\IConfig;
 use OCP\Log\RotationTrait;
 use Psr\Log\LoggerInterface;
@@ -17,8 +19,14 @@ use Psr\Log\LoggerInterface;
  * For more professional log management set the 'logfile' config to a different
  * location and manage that with your own tools.
  */
-class Rotate extends \OCP\BackgroundJob\Job {
+class Rotate extends TimedJob {
 	use RotationTrait;
+
+	public function __construct(ITimeFactory $time) {
+		parent::__construct($time);
+
+		$this->setInterval(5);
+	}
 
 	public function run($argument): void {
 		$config = \OCP\Server::get(IConfig::class);

--- a/lib/public/BackgroundJob/TimedJob.php
+++ b/lib/public/BackgroundJob/TimedJob.php
@@ -90,7 +90,7 @@ abstract class TimedJob extends Job {
 	 * @since 25.0.0
 	 */
 	final public function start(IJobList $jobList): void {
-		if (($this->time->getTime() - $this->lastRun) > $this->interval) {
+		if (($this->time->getTime() - $this->lastRun) >= $this->interval) {
 			if ($this->interval >= 12 * 60 * 60 && $this->isTimeSensitive()) {
 				Server::get(LoggerInterface::class)->debug('TimedJob ' . get_class($this) . ' has a configured interval of ' . $this->interval . ' seconds, but is also marked as time sensitive. Please consider marking it as time insensitive to allow more sensitive jobs to run when needed.');
 			}


### PR DESCRIPTION
## Summary

### Context

This PR comes from an investigation done for issue https://github.com/nextcloud/server/issues/49584

The user reported that running `occ background-job:worker --interval 5` does not run jobs every 5 seconds as advertised.
Upon investigation, I found out that the implementation for the `--interval` option was never merged and the option seems to be a leftover from the [PR where background workers were introduced](https://github.com/nextcloud/server/pull/30359).

While investigating the issue above, I also found out that when running `occ background-job:worker` the same job can be seen running several times even when the job is a TimedJob with an interval > 0. It turned out that the problem comes from an inconsistency in the comparison of timestamps between the logic that picks up jobs to execute and the logic inside TimedJob itself.

Moreover, jobs that apparently ran when executing `cron.php` in the same second, were actually not run but silently skipped.

### Content of the PR

For the reasons above, this PR:

- Changes `TimedJob` to run timed jobs when they are picked up at the exact same second they are due.
- Makes `Rotate` and `ScheduledNotifications` extend `TimedJob` and assigns respectively 5s and 1s interval.
- Drops the unused `--interval` option in `occ background-job:worker`
- To keep the current behaviour, changed `ClearOldStatusesBackgroundJob` and `UserStatusAutomation` to run in intervals of 1s.

## TODO

- [ ] Confirm that the Rotate and ScheduledNotifications can be converted to TimedJobs
- [ ] Confirm that the above Jobs' newly set interval, respectively 5s and 1s, is OK
- [ ] Confirm that it's ok to keep running the `ClearOldStatusesBackgroundJob` and `UserStatusAutomation` every second

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
