### PR TITLE
fix(403): Make design consistent with 404 + add default hint

### DIFF
--- a/core/templates/403.php
+++ b/core/templates/403.php
@@ -14,9 +14,17 @@ if (!isset($_)) {//standalone  page is not supported anymore - redirect to /
 }
 // @codeCoverageIgnoreEnd
 ?>
-<div class="guest-box">
+<div class="body-login-container update">
+	<div class="icon-big icon-password"></div>
 	<h2><?php p($l->t('Access forbidden')); ?></h2>
-		<p class='hint'><?php if (isset($_['message'])) {
-			p($_['message']);
-		}?></p>
-</ul>
+	<p class="hint">
+		<?php if (isset($_['message'])): ?>
+			<?php p($_['message']); ?>
+		<?php else: ?>
+			<?php p($l->t('You are not allowed to access this page.')); ?>
+		<?php endif; ?>
+	</p>
+	<p><a class="button primary" href="<?php p(\OCP\Server::get(\OCP\IURLGenerator::class)->linkTo('', 'index.php')) ?>">
+		<?php p($l->t('Back to %s', [$theme->getName()])); ?>
+	</a></p>
+</div>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #39584 <!-- related github issue -->

## Summary

* Adds a default hint message (consistent with 404)
* Adds an icon (consistent with 404 handler)
* Adds box around main content (consistent with 404 handler)
* Fixes an HTML syntax bug that was causing the footer to appear immediately after the error

### After:
![image](https://github.com/user-attachments/assets/c5df4120-4073-4486-877a-5088ccf7c68b)

### And, for comparison, the 404 page already looks like this:

![image](https://github.com/user-attachments/assets/f5311838-66ce-4f6e-8b64-3e5b7b96f7f1)

### Before:

![image](https://github.com/user-attachments/assets/e60a765b-c761-4275-a5f7-3a03234f603d)

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
