### PR TITLE
Fix interval option in `occ background-job:worker`

### DIFF
--- a/core/Command/Background/JobWorker.php
+++ b/core/Command/Background/JobWorker.php
@@ -50,7 +50,7 @@ class JobWorker extends JobBase {
 				'i',
 				InputOption::VALUE_OPTIONAL,
 				'Interval in seconds in which the worker should repeat already processed jobs (set to 0 for no repeat)',
-				5
+				1
 			)
 			->addOption(
 				'stop_after',
@@ -114,8 +114,11 @@ class JobWorker extends JobBase {
 				}
 
 				$output->writeln('Waiting for new jobs to be queued', OutputInterface::VERBOSITY_VERBOSE);
+				if ((int)$input->getOption('interval') === 0) {
+					break;
+				}
 				// Re-check interval for new jobs
-				sleep(1);
+				sleep((int)$input->getOption('interval'));
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

### Context

This PR comes from an investigation done for issue https://github.com/nextcloud/server/issues/49584

The user reported that running `occ background-job:worker --interval 5` does not run jobs every 5 seconds as advertised.
Upon investigation, I found out that the implementation for the `--interval` option was never merged and the option seems to be a leftover from the [PR where background workers were introduced](https://github.com/nextcloud/server/pull/30359).

This PR makes uses the passed interval and follows the behaviour described in the parameter's description. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
