### PR TITLE
fix(tests): Fix 32bits PHPUnit tests

### DIFF
--- a/.github/workflows/object-storage-azure.yml
+++ b/.github/workflows/object-storage-azure.yml
@@ -99,7 +99,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit
         env:

--- a/.github/workflows/object-storage-s3.yml
+++ b/.github/workflows/object-storage-s3.yml
@@ -100,7 +100,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: Wait for S3
         run: |

--- a/.github/workflows/object-storage-swift.yml
+++ b/.github/workflows/object-storage-swift.yml
@@ -96,7 +96,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit
         env:

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           mkdir data
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit
         run: composer run test -- --exclude-group PRIMARY-azure,PRIMARY-s3,PRIMARY-swift,Memcached,Redis,RoutingWeirdness

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -62,7 +62,7 @@ jobs:
           composer install
           mkdir data
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f index.php
+          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
 
       - name: PHPUnit
         run: composer run test -- --exclude-group PRIMARY-azure,PRIMARY-s3,PRIMARY-swift,Memcached,Redis,RoutingWeirdness

--- a/.github/workflows/phpunit-32bits.yml
+++ b/.github/workflows/phpunit-32bits.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'version.php'
       - '.github/workflows/phpunit-32bits.yml'
+      - 'tests/phpunit-autotest.xml'
   workflow_dispatch:
   schedule:
     - cron: "15 1 * * 1-6"
@@ -47,7 +48,7 @@ jobs:
         uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a #v2.33.0
         with:
           php-version: ${{ matrix.php-versions }}
-          extensions: ctype, curl, dom, fileinfo, gd, imagick, intl, json, mbstring, openssl, pdo_sqlite, posix, sqlite, xml, zip, apcu
+          extensions: bz2, ctype, curl, dom, fileinfo, gd, iconv, imagick, intl, json, libxml, mbstring, openssl, pcntl, posix, redis, session, simplexml, xmlreader, xmlwriter, zip, zlib, sqlite, pdo_sqlite, apcu, ldap
           coverage: none
           ini-file: development
           ini-values:
@@ -55,11 +56,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up dependencies
+        run: composer i
+
       - name: Set up Nextcloud
         env:
           DB_PORT: 4444
         run: |
-          composer install
           mkdir data
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=autotest --database-pass=rootpassword --admin-user admin --admin-pass admin
           php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0

--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -122,7 +122,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit
         run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}

--- a/.github/workflows/phpunit-memcached.yml
+++ b/.github/workflows/phpunit-memcached.yml
@@ -96,7 +96,7 @@ jobs:
           mkdir data
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit memcached tests
         run: composer run test -- --group Memcache,Memcached --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.xml' || '' }}

--- a/.github/workflows/phpunit-mysql-sharding.yml
+++ b/.github/workflows/phpunit-mysql-sharding.yml
@@ -154,7 +154,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit
         run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}

--- a/.github/workflows/phpunit-mysql.yml
+++ b/.github/workflows/phpunit-mysql.yml
@@ -122,7 +122,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=mysql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit
         run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}

--- a/.github/workflows/phpunit-nodb.yml
+++ b/.github/workflows/phpunit-nodb.yml
@@ -102,7 +102,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit nodb testsuite
         run: composer run test -- --exclude-group DB,SLOWDB --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.nodb.xml' || '' }}

--- a/.github/workflows/phpunit-object-store-primary.yml
+++ b/.github/workflows/phpunit-object-store-primary.yml
@@ -95,7 +95,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-host=127.0.0.1 --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass password
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: Wait for S3
         run: |

--- a/.github/workflows/phpunit-oci.yml
+++ b/.github/workflows/phpunit-oci.yml
@@ -126,7 +126,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=oci --database-name=${{ matrix.oracle-versions < 23 && 'XE' || 'FREE'  }} --database-host=127.0.0.1 --database-port=1521 --database-user=system --database-pass=oracle --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit
         run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}

--- a/.github/workflows/phpunit-pgsql.yml
+++ b/.github/workflows/phpunit-pgsql.yml
@@ -117,7 +117,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=pgsql --database-name=nextcloud --database-host=127.0.0.1 --database-port=$DB_PORT --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: PHPUnit database tests
         run: composer run test:db -- --log-junit junit.xml ${{ matrix.coverage && '--coverage-clover ./clover.db.xml' || '' }}

--- a/.github/workflows/phpunit-sqlite.yml
+++ b/.github/workflows/phpunit-sqlite.yml
@@ -100,7 +100,7 @@ jobs:
           cp tests/redis.config.php config/
           cp tests/preseed-config.php config/config.php
           ./occ maintenance:install --verbose --database=sqlite --database-name=nextcloud --database-user=root --database-pass=rootpassword --admin-user admin --admin-pass admin
-          php -f tests/enable_all.php | grep -i -C9999 error && echo "Error during app setup" && exit 1 || exit 0
+          php -f tests/enable_all.php
 
       - name: Nextcloud debug information
         run: ./occ app:list && echo "======= System config =======" && ./occ config:list system

--- a/apps/files_sharing/tests/Listener/LoadAdditionalListenerTest.php
+++ b/apps/files_sharing/tests/Listener/LoadAdditionalListenerTest.php
@@ -16,6 +16,7 @@ use OCP\EventDispatcher\Event;
 use OCP\IConfig;
 use OCP\L10N\IFactory;
 use OCP\Share\IManager;
+use OCP\Util;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -37,6 +38,21 @@ class LoadAdditionalListenerTest extends TestCase {
 		$this->factory = $this->createMock(IFactory::class);
 		$this->initialStateService = $this->createMock(InitialStateService::class);
 		$this->config = $this->createMock(IConfig::class);
+
+		/* Empty static array to avoid inter-test conflicts */
+		\OC_Util::$styles = [];
+		self::invokePrivate(Util::class, 'scripts', [[]]);
+		self::invokePrivate(Util::class, 'scriptDeps', [[]]);
+		self::invokePrivate(Util::class, 'scriptsInit', [[]]);
+	}
+
+	protected function tearDown(): void {
+		parent::tearDown();
+
+		\OC_Util::$styles = [];
+		self::invokePrivate(Util::class, 'scripts', [[]]);
+		self::invokePrivate(Util::class, 'scriptDeps', [[]]);
+		self::invokePrivate(Util::class, 'scriptsInit', [[]]);
 	}
 
 	public function testHandleIgnoresNonMatchingEvent(): void {
@@ -61,7 +77,7 @@ class LoadAdditionalListenerTest extends TestCase {
 		$this->overwriteService(InitialStateService::class, $this->initialStateService);
 		$this->overwriteService(IConfig::class, $this->config);
 
-		$scriptsBefore = \OCP\Util::getScripts();
+		$scriptsBefore = Util::getScripts();
 		$this->assertNotContains('files_sharing/l10n/language_mock', $scriptsBefore);
 		$this->assertNotContains('files_sharing/js/additionalScripts', $scriptsBefore);
 		$this->assertNotContains('files_sharing/js/init', $scriptsBefore);
@@ -71,14 +87,12 @@ class LoadAdditionalListenerTest extends TestCase {
 		$listener->handle($this->event);
 
 		// assert array $scripts contains the expected scripts
-		$scriptsAfter = \OCP\Util::getScripts();
+		$scriptsAfter = Util::getScripts();
 		$this->assertContains('files_sharing/l10n/language_mock', $scriptsAfter);
 		$this->assertContains('files_sharing/js/additionalScripts', $scriptsAfter);
 		$this->assertNotContains('files_sharing/js/init', $scriptsAfter);
 
 		$this->assertContains('files_sharing/css/icons', \OC_Util::$styles);
-
-		$this->assertTrue(true);
 	}
 
 	public function testHandleWithLoadAdditionalScriptsEventWithShareApiEnabled(): void {
@@ -92,17 +106,15 @@ class LoadAdditionalListenerTest extends TestCase {
 		$this->overwriteService(IConfig::class, $this->config);
 		$this->overwriteService(IFactory::class, $this->factory);
 
-		$scriptsBefore = \OCP\Util::getScripts();
+		$scriptsBefore = Util::getScripts();
 		$this->assertNotContains('files_sharing/js/init', $scriptsBefore);
 
 		// Util static methods can't be easily mocked, so just ensure no exceptions
 		$listener->handle($this->event);
 
-		$scriptsAfter = \OCP\Util::getScripts();
+		$scriptsAfter = Util::getScripts();
 
 		// assert array $scripts contains the expected scripts
 		$this->assertContains('files_sharing/js/init', $scriptsAfter);
-
-		$this->assertTrue(true);
 	}
 }

--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -8,12 +8,8 @@
 require_once __DIR__ . '/../lib/base.php';
 
 function enableApp($app) {
-	try {
-		(new \OC_App())->enable($app);
-		echo "Enabled application {$app}\n";
-	} catch (Exception $e) {
-		echo $e;
-	}
+	(new \OC_App())->enable($app);
+	echo "Enabled application {$app}\n";
 }
 
 foreach (new \DirectoryIterator(__DIR__ . '/../apps/') as $file) {

--- a/tests/enable_all.php
+++ b/tests/enable_all.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SPDX-FileCopyrightText: 2016-2018 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016-2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2012-2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -10,6 +10,7 @@ require_once __DIR__ . '/../lib/base.php';
 function enableApp($app) {
 	try {
 		(new \OC_App())->enable($app);
+		echo "Enabled application {$app}\n";
 	} catch (Exception $e) {
 		echo $e;
 	}


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Follow-up of https://github.com/nextcloud/server/pull/48210 which broke 32bit testing in CI

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
