### PR TITLE
Fix TimedJob execution time to allow job execution exactly when scheduled

### DIFF
--- a/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
+++ b/apps/dav/lib/BackgroundJob/UserStatusAutomation.php
@@ -40,8 +40,9 @@ class UserStatusAutomation extends TimedJob {
 	) {
 		parent::__construct($timeFactory);
 
-		// Interval 0 might look weird, but the last_checked is always moved
-		// to the next time we need this and then it's 0 seconds ago.
+		// interval = 0 might look odd, but it's intentional. last_run is set to
+		// the user's next available time, so the job runs immediately when
+		// that time comes.
 		$this->setInterval(0);
 	}
 

--- a/apps/dav/lib/Listener/UserEventsListener.php
+++ b/apps/dav/lib/Listener/UserEventsListener.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 
 namespace OCA\DAV\Listener;
 
+use OCA\DAV\BackgroundJob\UserStatusAutomation;
 use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CardDAV\CardDavBackend;
 use OCA\DAV\CardDAV\SyncService;
 use OCA\DAV\Service\ExampleContactService;
 use OCA\DAV\Service\ExampleEventService;
 use OCP\Accounts\UserUpdatedEvent;
+use OCP\BackgroundJob\IJobList;
 use OCP\Defaults;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
@@ -49,6 +51,7 @@ class UserEventsListener implements IEventListener {
 		private ExampleContactService $exampleContactService,
 		private ExampleEventService $exampleEventService,
 		private LoggerInterface $logger,
+		private IJobList $jobList,
 	) {
 	}
 
@@ -123,6 +126,8 @@ class UserEventsListener implements IEventListener {
 		foreach ($this->addressBooksToDelete[$uid] as $addressBook) {
 			$this->cardDav->deleteAddressBook($addressBook['id']);
 		}
+
+		$this->jobList->remove(UserStatusAutomation::class, ['userId' => $uid]);
 
 		unset($this->calendarsToDelete[$uid]);
 		unset($this->subscriptionsToDelete[$uid]);

--- a/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
+++ b/apps/user_status/lib/BackgroundJob/ClearOldStatusesBackgroundJob.php
@@ -32,8 +32,7 @@ class ClearOldStatusesBackgroundJob extends TimedJob {
 	) {
 		parent::__construct($time);
 
-		// Run every time the cron is run
-		$this->setInterval(0);
+		$this->setInterval(60);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR is a follow-up to address issues discovered while investigating issue https://github.com/nextcloud/server/issues/49584

While investigating the issue above, I noticed that when running `occ background-job:worker` the same job can be seen running several times, with each run in rapid succession after the other. The problem comes from an inconsistency in the comparison of timestamps between the logic that picks up jobs to execute and the logic inside `TimedJob::start`.

The jobs appearing in rapid succession would appear as ran, but because of the logic they would not really run until the next second. For the same reason, jobs that apparently ran when executing `cron.php` in the same second they were scheduled, were actually not run but silently skipped until the next run.

For the reasons above, this PR:

- Changes `TimedJob` to run timed jobs when they are picked up at the exact same second they are due.
- To keep the current behaviour, changed `ClearOldStatusesBackgroundJob` and `UserStatusAutomation` to run in intervals of 1s.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
