### PR TITLE
fix: make Rotate a TimedJob and run every hour

### DIFF
--- a/lib/private/Log/Rotate.php
+++ b/lib/private/Log/Rotate.php
@@ -7,6 +7,8 @@
  */
 namespace OC\Log;
 
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
 use OCP\IConfig;
 use OCP\Log\RotationTrait;
 use Psr\Log\LoggerInterface;
@@ -17,8 +19,14 @@ use Psr\Log\LoggerInterface;
  * For more professional log management set the 'logfile' config to a different
  * location and manage that with your own tools.
  */
-class Rotate extends \OCP\BackgroundJob\Job {
+class Rotate extends TimedJob {
 	use RotationTrait;
+
+	public function __construct(ITimeFactory $time) {
+		parent::__construct($time);
+
+		$this->setInterval(3600);
+	}
 
 	public function run($argument): void {
 		$config = \OCP\Server::get(IConfig::class);


### PR DESCRIPTION
## Summary

This PR is a follow-up to address issues discovered while investigating issue https://github.com/nextcloud/server/issues/49584

When running `occ background-job:worker`, some jobs can be seen running constantly and `Rotate` is one of them. It should be safe to run the rotation job every 5 seconds.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
