### PR TITLE
fix: make ScheduledNotifications a TimedJob and run every minute

### DIFF
--- a/apps/files_reminders/lib/BackgroundJob/ScheduledNotifications.php
+++ b/apps/files_reminders/lib/BackgroundJob/ScheduledNotifications.php
@@ -13,10 +13,10 @@ use OCA\FilesReminders\Db\ReminderMapper;
 use OCA\FilesReminders\Service\ReminderService;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
-use OCP\BackgroundJob\Job;
+use OCP\BackgroundJob\TimedJob;
 use Psr\Log\LoggerInterface;
 
-class ScheduledNotifications extends Job {
+class ScheduledNotifications extends TimedJob {
 	public function __construct(
 		ITimeFactory $time,
 		protected ReminderMapper $reminderMapper,
@@ -24,6 +24,8 @@ class ScheduledNotifications extends Job {
 		protected LoggerInterface $logger,
 	) {
 		parent::__construct($time);
+
+		$this->setInterval(60);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
This PR is a follow-up to address issues discovered while investigating issue https://github.com/nextcloud/server/issues/49584

When running `occ background-job:worker`, some jobs can be seen running constantly and `ScheduledNotifications` is one of them. It should be safe to run the rotation job every second.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
