### PR TITLE
feat: Implement custom Updater for object store storage

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1649,6 +1649,7 @@ return array(
     'OC\\Files\\ObjectStore\\Mapper' => $baseDir . '/lib/private/Files/ObjectStore/Mapper.php',
     'OC\\Files\\ObjectStore\\ObjectStoreScanner' => $baseDir . '/lib/private/Files/ObjectStore/ObjectStoreScanner.php',
     'OC\\Files\\ObjectStore\\ObjectStoreStorage' => $baseDir . '/lib/private/Files/ObjectStore/ObjectStoreStorage.php',
+    'OC\\Files\\ObjectStore\\ObjectStoreUpdater' => $baseDir . '/lib/private/Files/ObjectStore/ObjectStoreUpdater.php',
     'OC\\Files\\ObjectStore\\PrimaryObjectStoreConfig' => $baseDir . '/lib/private/Files/ObjectStore/PrimaryObjectStoreConfig.php',
     'OC\\Files\\ObjectStore\\S3' => $baseDir . '/lib/private/Files/ObjectStore/S3.php',
     'OC\\Files\\ObjectStore\\S3ConfigTrait' => $baseDir . '/lib/private/Files/ObjectStore/S3ConfigTrait.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1690,6 +1690,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Files\\ObjectStore\\Mapper' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/Mapper.php',
         'OC\\Files\\ObjectStore\\ObjectStoreScanner' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/ObjectStoreScanner.php',
         'OC\\Files\\ObjectStore\\ObjectStoreStorage' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/ObjectStoreStorage.php',
+        'OC\\Files\\ObjectStore\\ObjectStoreUpdater' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/ObjectStoreUpdater.php',
         'OC\\Files\\ObjectStore\\PrimaryObjectStoreConfig' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/PrimaryObjectStoreConfig.php',
         'OC\\Files\\ObjectStore\\S3' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3.php',
         'OC\\Files\\ObjectStore\\S3ConfigTrait' => __DIR__ . '/../../..' . '/lib/private/Files/ObjectStore/S3ConfigTrait.php',

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -272,7 +272,7 @@ class Updater implements IUpdater {
 	 *
 	 * @param string $internalPath
 	 */
-	private function correctParentStorageMtime($internalPath) {
+	public function correctParentStorageMtime($internalPath) {
 		$parentId = $this->cache->getParentId($internalPath);
 		$parent = dirname($internalPath);
 		if ($parentId != -1) {

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -14,11 +14,11 @@ use Icewind\Streams\CountWrapper;
 use Icewind\Streams\IteratorDirectory;
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\CacheEntry;
+use OC\Files\Cache\Updater;
 use OC\Files\Storage\PolyFill\CopyDirectory;
 use OCP\Files\Cache\ICache;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\Cache\IScanner;
-use OCP\Files\Cache\IUpdater;
 use OCP\Files\FileInfo;
 use OCP\Files\GenericFileException;
 use OCP\Files\NotFoundException;
@@ -820,7 +820,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common implements IChunkedFil
 		$this->preserveCacheItemsOnDelete = $preserve;
 	}
 
-	public function getUpdater(?IStorage $storage = null): IUpdater {
+	public function getUpdater(?IStorage $storage = null): Updater {
 		if (!$storage) {
 			$storage = $this;
 		}

--- a/lib/private/Files/ObjectStore/ObjectStoreUpdater.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreUpdater.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Files\ObjectStore;
+
+use OC\Files\Cache\Updater;
+
+/**
+ * Custom Updater class for `ObjectStoreStorage`.
+ * This wrapper will do nothing when the `update` method is called.
+ * This is to skip heavy cache operations, as they are already done in `ObjectStoreStorage`.
+ */
+class ObjectStoreUpdater extends Updater {
+	public function update($path, $time = null, ?int $sizeDifference = null) {
+		// Noop
+	}
+}

--- a/lib/private/Files/ObjectStore/ObjectStoreUpdater.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreUpdater.php
@@ -18,4 +18,8 @@ class ObjectStoreUpdater extends Updater {
 	public function update($path, $time = null, ?int $sizeDifference = null) {
 		// Noop
 	}
+
+	public function remove($path) {
+		// Noop
+	}
 }

--- a/lib/public/Files/Cache/IUpdater.php
+++ b/lib/public/Files/Cache/IUpdater.php
@@ -28,6 +28,7 @@ interface IUpdater {
 	 *
 	 * @param string $path the path of the file to propagate the changes for
 	 * @param int|null $time the timestamp to set as mtime for the parent folders, if left out the current time is used
+	 * @return void
 	 * @since 9.0.0
 	 */
 	public function propagate($path, $time = null);
@@ -37,6 +38,7 @@ interface IUpdater {
 	 *
 	 * @param string $path
 	 * @param int $time
+	 * @return void
 	 * @since 9.0.0
 	 */
 	public function update($path, $time = null, ?int $sizeDifference = null);
@@ -45,6 +47,7 @@ interface IUpdater {
 	 * Remove $path from the cache and update the size, etag and mtime of the parent folders
 	 *
 	 * @param string $path
+	 * @return void
 	 * @since 9.0.0
 	 */
 	public function remove($path);
@@ -55,6 +58,7 @@ interface IUpdater {
 	 * @param IStorage $sourceStorage
 	 * @param string $source
 	 * @param string $target
+	 * @return void
 	 * @since 9.0.0
 	 */
 	public function renameFromStorage(IStorage $sourceStorage, $source, $target);


### PR DESCRIPTION
Add Custom Updater class for `ObjectStoreStorage`.
This wrapper will do nothing when the `update` method is called.
This is to skip heavy cache operations, as they are already done in `ObjectStoreStorage`.

Replaces https://github.com/nextcloud/server/pull/52998