### PR TITLE
fix(storage): unlink dir symlinks without deleting targets

### DIFF
--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -99,41 +99,51 @@ class Local extends Common {
 		if (!$this->isDeletable($path)) {
 			return false;
 		}
+
+		$sourcePath = $this->getSourcePath($path);
+		clearstatcache(true, $sourcePath);
+
+		if (is_link($sourcePath)) {
+			return unlink($sourcePath);
+		}
+
 		try {
-			if (is_link($this->getSourcePath($path))) {
-				clearstatcache(true, $this->getSourcePath($path));
-				return unlink($this->getSourcePath($path));
-			} else {
-				$it = new \RecursiveIteratorIterator(
-					new \RecursiveDirectoryIterator($this->getSourcePath($path)),
-					\RecursiveIteratorIterator::CHILD_FIRST
-				);
-				/**
-				 * RecursiveDirectoryIterator on an NFS path isn't iterable with foreach
-				 * This bug is fixed in PHP 5.5.9 or before
-				 * See #8376
-				 */
-				$it->rewind();
-				while ($it->valid()) {
-					/**
-					 * @var \SplFileInfo $file
-					 */
-					$file = $it->current();
-					clearstatcache(true, $file->getRealPath());
-					if (in_array($file->getBasename(), ['.', '..'])) {
-						$it->next();
-						continue;
-					} elseif ($file->isFile() || $file->isLink()) {
-						unlink($file->getPathname());
-					} elseif ($file->isDir()) {
-						rmdir($file->getPathname());
-					}
+			$it = new \RecursiveIteratorIterator(
+				new \RecursiveDirectoryIterator($sourcePath),
+				\RecursiveIteratorIterator::CHILD_FIRST
+			);
+
+			/**
+			 * RecursiveDirectoryIterator on an NFS path isn't iterable with foreach.
+			 * This bug is fixed in PHP 5.5.9 or before.
+			 * See #8376.
+			 */
+			$it->rewind();
+			while ($it->valid()) {
+				/** @var \SplFileInfo $file */
+				$file = $it->current();
+				clearstatcache(true, $file->getRealPath());
+
+				if (in_array($file->getBasename(), ['.', '..'], true)) {
 					$it->next();
+					continue;
 				}
-				unset($it);  // Release iterator and thereby its potential directory lock (e.g. in case of VirtualBox shared folders)
-				clearstatcache(true, $this->getSourcePath($path));
-				return rmdir($this->getSourcePath($path));
+
+				if ($file->isFile() || $file->isLink()) {
+					unlink($file->getPathname());
+				} elseif ($file->isDir()) {
+					rmdir($file->getPathname());
+				}
+
+				$it->next();
 			}
+
+			// Release the iterator and its potential directory lock,
+			// for example on VirtualBox shared folders.
+			unset($it);
+
+			clearstatcache(true, $sourcePath);
+			return rmdir($sourcePath);
 		} catch (\UnexpectedValueException $e) {
 			return false;
 		}

--- a/lib/private/Files/Storage/Local.php
+++ b/lib/private/Files/Storage/Local.php
@@ -100,35 +100,40 @@ class Local extends Common {
 			return false;
 		}
 		try {
-			$it = new \RecursiveIteratorIterator(
-				new \RecursiveDirectoryIterator($this->getSourcePath($path)),
-				\RecursiveIteratorIterator::CHILD_FIRST
-			);
-			/**
-			 * RecursiveDirectoryIterator on an NFS path isn't iterable with foreach
-			 * This bug is fixed in PHP 5.5.9 or before
-			 * See #8376
-			 */
-			$it->rewind();
-			while ($it->valid()) {
+			if (is_link($this->getSourcePath($path))) {
+				clearstatcache(true, $this->getSourcePath($path));
+				return unlink($this->getSourcePath($path));
+			} else {
+				$it = new \RecursiveIteratorIterator(
+					new \RecursiveDirectoryIterator($this->getSourcePath($path)),
+					\RecursiveIteratorIterator::CHILD_FIRST
+				);
 				/**
-				 * @var \SplFileInfo $file
+				 * RecursiveDirectoryIterator on an NFS path isn't iterable with foreach
+				 * This bug is fixed in PHP 5.5.9 or before
+				 * See #8376
 				 */
-				$file = $it->current();
-				clearstatcache(true, $file->getRealPath());
-				if (in_array($file->getBasename(), ['.', '..'])) {
+				$it->rewind();
+				while ($it->valid()) {
+					/**
+					 * @var \SplFileInfo $file
+					 */
+					$file = $it->current();
+					clearstatcache(true, $file->getRealPath());
+					if (in_array($file->getBasename(), ['.', '..'])) {
+						$it->next();
+						continue;
+					} elseif ($file->isFile() || $file->isLink()) {
+						unlink($file->getPathname());
+					} elseif ($file->isDir()) {
+						rmdir($file->getPathname());
+					}
 					$it->next();
-					continue;
-				} elseif ($file->isFile() || $file->isLink()) {
-					unlink($file->getPathname());
-				} elseif ($file->isDir()) {
-					rmdir($file->getPathname());
 				}
-				$it->next();
+				unset($it);  // Release iterator and thereby its potential directory lock (e.g. in case of VirtualBox shared folders)
+				clearstatcache(true, $this->getSourcePath($path));
+				return rmdir($this->getSourcePath($path));
 			}
-			unset($it);  // Release iterator and thereby its potential directory lock (e.g. in case of VirtualBox shared folders)
-			clearstatcache(true, $this->getSourcePath($path));
-			return rmdir($this->getSourcePath($path));
 		} catch (\UnexpectedValueException $e) {
 			return false;
 		}

--- a/tests/lib/Files/Storage/LocalTest.php
+++ b/tests/lib/Files/Storage/LocalTest.php
@@ -102,6 +102,50 @@ class LocalTest extends Storage {
 		$this->addToAssertionCount(1);
 	}
 
+	public static function directorySymlinkRemovalProvider(): array {
+		return [
+			'rmdir' => ['rmdir'],
+			'unlink' => ['unlink'],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('directorySymlinkRemovalProvider')]
+	public function testRemovingDirectorySymlinkPreservesTarget(string $operation): void {
+		$targetPath = $this->tmpDir . 'target';
+		$linkPath = $this->tmpDir . 'link';
+
+		$this->assertTrue($this->instance->mkdir('target'));
+		$this->assertSame(
+			strlen('target contents'),
+			$this->instance->file_put_contents('target/file.txt', 'target contents'),
+		);
+
+		if (!@symlink($targetPath, $linkPath)) {
+			$this->markTestSkipped('Failed to create directory symlink');
+		}
+
+		$this->assertTrue(is_link($linkPath));
+		$this->assertTrue($this->instance->$operation('link'));
+
+		$this->assertFalse(
+			is_link($linkPath),
+			'The symbolic link should be removed',
+		);
+		$this->assertDirectoryExists(
+			$targetPath,
+			'The target directory should be preserved',
+		);
+		$this->assertFileExists(
+			$targetPath . '/file.txt',
+			'Files inside the target directory should be preserved',
+		);
+		$this->assertSame(
+			'target contents',
+			file_get_contents($targetPath . '/file.txt'),
+			'The target file contents should remain unchanged',
+		);
+	}
+
 	public function testWriteUmaskFilePutContents(): void {
 		$oldMask = umask(0333);
 		$this->instance->file_put_contents('test.txt', 'sad');


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.


* Resolves: #
-->

## Summary

Nextcloud supports following symbolic links when `localstorage.allowsymlinks` is enabled. However, deleting a symbolic link to a directory recursively deleted the contents of the target directory before failing to remove the link itself.

This change detects when the path passed to local storage directory removal is a symbolic link and unlinks it directly, preserving the target directory and its contents.

### Before

Given:

```text
.
├── afolder
│   └── test.txt
├── alink -> afolder
└── welcome.txt
```

Created with:

```bash
mkdir afolder
touch afolder/test.txt
ln -s afolder alink
```

Deleting `alink` recursively removed `afolder/test.txt` and then reported an error:

```json
{
  "method": "DELETE",
  "url": "/remote.php/dav/files/admin/alink",
  "message": "rmdir(/data/dev/nextcloud/data/admin/files/alink): Not a directory"
}
```

The resulting structure was:

```text
.
├── afolder
└── welcome.txt
```

![Screenshot from 2025-06-12 08-29-22](https://github.com/user-attachments/assets/d08fdc6e-055b-4575-91d5-e6f3f3cbc1be)



### After

Deleting `alink` now removes only the symbolic link. The link target and its contents are preserved:

```text
.
├── afolder
│   └── test.txt
└── welcome.txt
```

![Screenshot from 2025-06-12 08-32-20](https://github.com/user-attachments/assets/88dddd6c-5c20-4eff-8233-254266e5473f)

### Implementation

- Resolve the local source path once.
- Clear cached filesystem metadata before checking the path type.
- Detect a top-level symbolic link before constructing the recursive directory iterator.
- Unlink symbolic links directly instead of traversing their targets.
- Preserve the existing recursive removal behavior for real directories.
- Simplify the control flow in `Local::rmdir()`.

Added parameterized regression coverage in `LocalTest.php` for deletion through both storage entry points:

- `Local::rmdir()`
- `Local::unlink()`

The tests verify that:

- The symbolic link is removed.
- The target directory remains.
- Files inside the target remain.
- The target file contents are unchanged.
- Environments that cannot create symbolic links skip the test.

## Todo

Quite new to the Nextcloud codebase, any pointer to a test related to symlink is welcomed.

## Checklist

- [x] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
