### PR TITLE
fix(router): In debug mode, cache routes only for 3 seconds

### DIFF
--- a/lib/private/Route/CachingRouter.php
+++ b/lib/private/Route/CachingRouter.php
@@ -80,7 +80,7 @@ class CachingRouter extends Router {
 		if (!$cachedRoutes) {
 			parent::loadRoutes();
 			$cachedRoutes = $this->serializeRouteCollection($this->root);
-			$this->cache->set($key, $cachedRoutes, 3600);
+			$this->cache->set($key, $cachedRoutes, ($this->config->getSystemValueBool('debug') ? 3 : 3600));
 		}
 		$matcher = new CompiledUrlMatcher($cachedRoutes, $this->context);
 		$this->eventLogger->start('cacheroute:url:match', 'Symfony URL match call');

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -53,7 +53,7 @@ class Router implements IRouter {
 	public function __construct(
 		protected LoggerInterface $logger,
 		IRequest $request,
-		private IConfig $config,
+		protected IConfig $config,
 		protected IEventLogger $eventLogger,
 		private ContainerInterface $container,
 		protected IAppManager $appManager,


### PR DESCRIPTION
## Summary

This allows testing a newly added or changed route in your application without having to wait 1 hour or bump the application version.
I thought about disabling the `CachingRouter` in debug mode instead, but that would mean none of us devs would run its code on our test instance and would increase the risk of missing issues in there.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
