### PR TITLE
fix(OCM-invites): Use the correct way of getting the email

### DIFF
--- a/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
+++ b/apps/cloud_federation_api/lib/Controller/RequestHandlerController.php
@@ -271,7 +271,7 @@ class RequestHandlerController extends Controller {
 			$response->throttle();
 			return $response;
 		}
-		
+
 		if ($invitation->isAccepted() === true) {
 			$response = ['message' => 'Invite already accepted', 'error' => true];
 			$status = Http::STATUS_CONFLICT;
@@ -291,8 +291,8 @@ class RequestHandlerController extends Controller {
 			$response->throttle();
 			return $response;
 		}
-		
-		$sharedFromEmail = $localUser->getPrimaryEMailAddress();
+
+		$sharedFromEmail = $localUser->getEMailAddress();
 		if ($sharedFromEmail === null) {
 			$response = ['message' => 'Invalid or non existing token', 'error' => true];
 			$status = Http::STATUS_BAD_REQUEST;


### PR DESCRIPTION
It seems primary email can sometimes be empty, even if the user has an email set.

This patch should fix that so that we always have an email if it exists.