### PR TITLE
fix(profiler): set default values for fputcsv arguments to avoid depreciation warning

### DIFF
--- a/lib/private/Profiler/FileProfilerStorage.php
+++ b/lib/private/Profiler/FileProfilerStorage.php
@@ -161,7 +161,7 @@ class FileProfilerStorage {
 				$profile->getTime(),
 				$profile->getParentToken(),
 				$profile->getStatusCode(),
-			]);
+			], escape: '');
 			fclose($file);
 		}
 


### PR DESCRIPTION
Avoids flooding logs with

```
[Thu Jun 12 18:22:25 2025] {"app":"PHP","message":"fputcsv(): the $escape parameter must be provided as its default value will change at server\/lib\/private\/Profiler\/FileProfilerStorage.php#157"}
```