### PR TITLE
fix: don't create an empty file before writing the contents in OC_Util::copyr

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -187,14 +187,13 @@ class OC_Util {
 					$child = $target->newFolder($file);
 					self::copyr($source . '/' . $file, $child);
 				} else {
-					$child = $target->newFile($file);
 					$sourceStream = fopen($source . '/' . $file, 'r');
 					if ($sourceStream === false) {
 						$logger->error(sprintf('Could not fopen "%s"', $source . '/' . $file), ['app' => 'core']);
 						closedir($dir);
 						return;
 					}
-					$child->putContent($sourceStream);
+					$target->newFile($file, $sourceStream);
 				}
 			}
 		}


### PR DESCRIPTION
no need to write to the storage twice