### PR TITLE
fix: pass parent id to correctParentStorageMtime when known

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -89,7 +89,7 @@ class Updater implements IUpdater {
 		if ($this->cache instanceof Cache && $sizeDifference === null) {
 			$this->cache->correctFolderSize($path, $data);
 		}
-		$this->correctParentStorageMtime($path);
+		$this->correctParentStorageMtime($path, $data['parent'] ?? null);
 		$this->propagator->propagateChange($path, $time, $sizeDifference ?? 0);
 	}
 
@@ -108,10 +108,11 @@ class Updater implements IUpdater {
 
 		$this->cache->remove($path);
 
-		$this->correctParentStorageMtime($path);
 		if ($entry instanceof ICacheEntry) {
+			$this->correctParentStorageMtime($path, $entry->getParentId());
 			$this->propagator->propagateChange($path, time(), -$entry->getSize());
 		} else {
+			$this->correctParentStorageMtime($path);
 			$this->propagator->propagateChange($path, time());
 			if ($this->cache instanceof Cache) {
 				$this->cache->correctFolderSize($parent);
@@ -197,7 +198,7 @@ class Updater implements IUpdater {
 			$this->cache->correctFolderSize($target);
 		}
 		if ($sourceUpdater instanceof Updater) {
-			$sourceUpdater->correctParentStorageMtime($source);
+			$sourceUpdater->correctParentStorageMtime($source, $sourceInfo ? $sourceInfo->getParentId() : null);
 		}
 		$this->correctParentStorageMtime($target);
 		$this->updateStorageMTimeOnly($target);
@@ -223,8 +224,10 @@ class Updater implements IUpdater {
 	/**
 	 * Update the storage_mtime of the direct parent in the cache to the mtime from the storage
 	 */
-	private function correctParentStorageMtime(string $internalPath): void {
-		$parentId = $this->cache->getParentId($internalPath);
+	private function correctParentStorageMtime(string $internalPath, ?int $parentId = null) {
+		if ($parentId === null) {
+			$parentId = $this->cache->getParentId($internalPath);
+		}
 		$parent = dirname($internalPath);
 		if ($parentId !== -1) {
 			$mtime = $this->storage->filemtime($parent);


### PR DESCRIPTION
We already know it most of the time, so no need to query it.