### PR TITLE
Set Strict-Transport-Security header in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -60,6 +60,9 @@
   <FilesMatch "\.(otf|woff2?)$">
     Header set Cache-Control "max-age=604800"
   </FilesMatch>
+
+  # Enforce HTTPS by setting the Strict-Transport-Security header for all responses
+  Header always set Strict-Transport-Security "max-age=15552000; includeSubDomains"
 </IfModule>
 
 <IfModule mod_php.c>


### PR DESCRIPTION
Enforce HTTPS by configuring Strict-Transport-Security header

This change addresses the recommendation in the Nextcloud Documentation and admin panel to enable HTTP Strict Transport Security.

For more information, refer to the official Nextcloud documentation: https://docs.nextcloud.com/server/latest/admin_manual/installation/harden_server.html#enable-http-strict-transport-security