### PR TITLE
fix(ObjectStore): Make S3 "connect_timeout" option configurable

### DIFF
--- a/lib/private/Files/ObjectStore/S3ConfigTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConfigTrait.php
@@ -18,6 +18,10 @@ trait S3ConfigTrait {
 	/** Maximum number of concurrent multipart uploads */
 	protected int $concurrency;
 
+	/** Timeout, in seconds, for the connection to S3 server, not for the
+	 *  request. */
+	protected float $connectTimeout;
+
 	protected int $timeout;
 
 	protected string|false $proxy;

--- a/lib/private/Files/ObjectStore/S3ConnectionTrait.php
+++ b/lib/private/Files/ObjectStore/S3ConnectionTrait.php
@@ -39,6 +39,7 @@ trait S3ConnectionTrait {
 		// Default to 5 like the S3 SDK does
 		$this->concurrency = $params['concurrency'] ?? 5;
 		$this->proxy = $params['proxy'] ?? false;
+		$this->connectTimeout = $params['connect_timeout'] ?? 5;
 		$this->timeout = $params['timeout'] ?? 15;
 		$this->storageClass = !empty($params['storageClass']) ? $params['storageClass'] : 'STANDARD';
 		$this->uploadPartSize = $params['uploadPartSize'] ?? 524288000;
@@ -102,8 +103,7 @@ trait S3ConnectionTrait {
 			'use_arn_region' => false,
 			'http' => [
 				'verify' => $this->getCertificateBundlePath(),
-				// Timeout for the connection to S3 server, not for the request.
-				'connect_timeout' => 5
+				'connect_timeout' => $this->connectTimeout,
 			],
 			'use_aws_shared_config_files' => false,
 			'retries' => [


### PR DESCRIPTION
Follow up to #46317

The hardcoded connection timeout of 5 seconds may not be enough in some cases, so now it is got from the ObjectStore arguments in Nextcloud configuration, falling back to 5 if not set.

The connection timeout is set in seconds, but decimal precision can be used for subsecond accuracy (for example, 4.2 for 4200 milliseconds).

Note that the option is actually [`http->connect_timeout` when passed to the SDK](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_configuration.html#config-http), but it was kept as a flat `connect_timeout` rather than a nested `http->connect_timeout` in the ObjectStore arguments for simplicity.

Documentation: https://github.com/nextcloud/documentation/pull/13226