### PR TITLE
feat(internal-link): event on request

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\Services\IInitialState;
 use OCP\Authentication\TwoFactorAuth\IRegistry;
 use OCP\Collaboration\Resources\LoadAdditionalScriptsEvent as ResourcesLoadAdditionalScriptsEvent;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Events\InternalLinkRequestEvent;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
@@ -91,7 +92,10 @@ class ViewController extends Controller {
 
 		// This is the entry point from the `/f/{fileid}` URL which is hardcoded in the server.
 		try {
-			return $this->redirectToFile((int)$fileid, $opendetails, $openfile);
+			$event = new InternalLinkRequestEvent($fileid);
+			$this->eventDispatcher->dispatchTyped($event);
+
+			return $event->getResponse() ?? $this->redirectToFile((int)$fileid, $opendetails, $openfile);
 		} catch (NotFoundException $e) {
 			// Keep the fileid even if not found, it will be used
 			// to detect the file could not be found and warn the user

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -434,6 +434,7 @@ return array(
     'OCP\\Files\\Events\\FileCacheUpdated' => $baseDir . '/lib/public/Files/Events/FileCacheUpdated.php',
     'OCP\\Files\\Events\\FileScannedEvent' => $baseDir . '/lib/public/Files/Events/FileScannedEvent.php',
     'OCP\\Files\\Events\\FolderScannedEvent' => $baseDir . '/lib/public/Files/Events/FolderScannedEvent.php',
+    'OCP\\Files\\Events\\InternalLinkRequestEvent' => $baseDir . '/lib/public/Files/Events/InternalLinkRequestEvent.php',
     'OCP\\Files\\Events\\InvalidateMountCacheEvent' => $baseDir . '/lib/public/Files/Events/InvalidateMountCacheEvent.php',
     'OCP\\Files\\Events\\NodeAddedToCache' => $baseDir . '/lib/public/Files/Events/NodeAddedToCache.php',
     'OCP\\Files\\Events\\NodeAddedToFavorite' => $baseDir . '/lib/public/Files/Events/NodeAddedToFavorite.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -475,6 +475,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\Events\\FileCacheUpdated' => __DIR__ . '/../../..' . '/lib/public/Files/Events/FileCacheUpdated.php',
         'OCP\\Files\\Events\\FileScannedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/FileScannedEvent.php',
         'OCP\\Files\\Events\\FolderScannedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/FolderScannedEvent.php',
+        'OCP\\Files\\Events\\InternalLinkRequestEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/InternalLinkRequestEvent.php',
         'OCP\\Files\\Events\\InvalidateMountCacheEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Events/InvalidateMountCacheEvent.php',
         'OCP\\Files\\Events\\NodeAddedToCache' => __DIR__ . '/../../..' . '/lib/public/Files/Events/NodeAddedToCache.php',
         'OCP\\Files\\Events\\NodeAddedToFavorite' => __DIR__ . '/../../..' . '/lib/public/Files/Events/NodeAddedToFavorite.php',

--- a/lib/public/Files/Events/InternalLinkRequestEvent.php
+++ b/lib/public/Files/Events/InternalLinkRequestEvent.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Files\Events;
+
+use OCA\Files\Controller\ViewController;
+use OCP\AppFramework\Http\RedirectResponse;
+use OCP\EventDispatcher\Event;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Allow a modification of the behavior on internal-link request ('/index.php/f/12345')
+ *
+ * A listener can generate its own RedirectResponse() to be sent back to the client.
+ *
+ * @see ViewController::showFile
+ * @since 33.0.0
+ */
+class InternalLinkRequestEvent extends Event {
+	private ?RedirectResponse $response = null;
+
+	/**
+	 * @since 33.0.0
+	 */
+	public function __construct(
+		private readonly string $fileId,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * returns the requested file id
+	 *
+	 * @since 33.0.0
+	 */
+	public function getFileId(): string {
+		return $this->fileId;
+	}
+
+	/**
+	 * set a new RedirectResponse
+	 *
+	 * @since 33.0.0
+	 */
+	public function setResponse(RedirectResponse $response): void {
+		if ($this->response === null) {
+			$this->response = $response;
+		} else {
+			Server::get(LoggerInterface::class)->notice('a RedirectResponse was already set', ['exception' => new \Exception('')]);
+		}
+	}
+
+	/**
+	 * return the new response
+	 *
+	 * @since 33.0.0
+	 */
+	public function getResponse(): ?RedirectResponse {
+		return $this->response;
+	}
+}


### PR DESCRIPTION
Allow a modification of the behavior on internal-link request (`'/index.php/f/12345'`)

Any listener can change the value of the FileId or even force a new `Response()` to be sent back to the client.