### PR TITLE
fix: Fix theming for disabled accounts

### DIFF
--- a/.github/workflows/integration-sqlite.yml
+++ b/.github/workflows/integration-sqlite.yml
@@ -70,6 +70,7 @@ jobs:
           - 'setup_features'
           - 'sharees_features'
           - 'sharing_features'
+          - 'theming_features'
           - 'videoverification_features'
 
         php-versions: ['8.1']

--- a/build/integration/config/behat.yml
+++ b/build/integration/config/behat.yml
@@ -266,3 +266,13 @@ default:
               - admin
               - admin
             regular_user_password: 123456
+    theming:
+      paths:
+        - "%paths.base%/../theming_features"
+      contexts:
+        - FeatureContext:
+            baseUrl: http://localhost:8080
+            admin:
+              - admin
+              - admin
+            regular_user_password: 123456

--- a/build/integration/features/bootstrap/BasicStructure.php
+++ b/build/integration/features/bootstrap/BasicStructure.php
@@ -20,6 +20,7 @@ trait BasicStructure {
 	use Avatar;
 	use Download;
 	use Mail;
+	use Theming;
 
 	/** @var string */
 	private $currentUser = '';

--- a/build/integration/features/bootstrap/Theming.php
+++ b/build/integration/features/bootstrap/Theming.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+require __DIR__ . '/../../vendor/autoload.php';
+
+trait Theming {
+
+	private bool $undoAllThemingChangesAfterScenario = false;
+
+	/**
+	 * @AfterScenario
+	 */
+	public function undoAllThemingChanges() {
+		if (!$this->undoAllThemingChangesAfterScenario) {
+			return;
+		}
+
+		$this->loggingInUsingWebAs('admin');
+		$this->sendingAToWithRequesttoken('POST', '/index.php/apps/theming/ajax/undoAllChanges');
+
+		$this->undoAllThemingChangesAfterScenario = false;
+	}
+
+	/**
+	 * @When logged in admin uploads theming image for :key from file :source
+	 *
+	 * @param string $key
+	 * @param string $source
+	 */
+	public function loggedInAdminUploadsThemingImageForFromFile(string $key, string $source) {
+		$this->undoAllThemingChangesAfterScenario = true;
+
+		$file = \GuzzleHttp\Psr7\Utils::streamFor(fopen($source, 'r'));
+
+		$this->sendingAToWithRequesttoken('POST', '/index.php/apps/theming/ajax/uploadImage?key=' . $key,
+			[
+				'multipart' => [
+					[
+						'name' => 'image',
+						'contents' => $file
+					]
+				]
+			]);
+		$this->theHTTPStatusCodeShouldBe('200');
+	}
+}

--- a/build/integration/theming_features/theming.feature
+++ b/build/integration/theming_features/theming.feature
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+Feature: theming
+
+	Background:
+		Given user "user0" exists
+
+	Scenario: themed stylesheets are available for users
+		Given As an "user0"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/default.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/light.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/dark.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/light-highcontrast.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/dark-highcontrast.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/opendyslexic.css"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed stylesheets are available for guests
+		Given As an "anonymous"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/default.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/light.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/dark.css"
+		Then the HTTP status code should be "200"
+		# Themes that can not be explicitly set by a guest could have been
+		# globally set too through "enforce_theme".
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/light-highcontrast.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/dark-highcontrast.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/opendyslexic.css"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed stylesheets are available for disabled users
+		Given As an "admin"
+		And assure user "user0" is disabled
+		And As an "user0"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/default.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/light.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/dark.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/light-highcontrast.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/dark-highcontrast.css"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/theme/opendyslexic.css"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed images are available for users
+		Given Logging in using web as "admin"
+		And logged in admin uploads theming image for "background" from file "data/clouds.jpg"
+		And logged in admin uploads theming image for "logo" from file "data/coloured-pattern-non-square.png"
+		And logged in admin uploads theming image for "logoheader" from file "data/coloured-pattern-non-square.png"
+		And As an "user0"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/background"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/logo"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/logoheader"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed images are available for guests
+		Given Logging in using web as "admin"
+		And logged in admin uploads theming image for "background" from file "data/clouds.jpg"
+		And logged in admin uploads theming image for "logo" from file "data/coloured-pattern-non-square.png"
+		And logged in admin uploads theming image for "logoheader" from file "data/coloured-pattern-non-square.png"
+		And As an "anonymous"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/background"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/logo"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/logoheader"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed images are available for disabled users
+		Given Logging in using web as "admin"
+		And logged in admin uploads theming image for "background" from file "data/clouds.jpg"
+		And logged in admin uploads theming image for "logo" from file "data/coloured-pattern-non-square.png"
+		And logged in admin uploads theming image for "logoheader" from file "data/coloured-pattern-non-square.png"
+		And As an "admin"
+		And assure user "user0" is disabled
+		And As an "user0"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/background"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/logo"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/image/logoheader"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed icons are available for users
+		Given As an "user0"
+		When sending "GET" with exact url to "/index.php/apps/theming/favicon"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/icon"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/favicon/dashboard"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/icon/dashboard"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed icons are available for guests
+		Given As an "anonymous"
+		When sending "GET" with exact url to "/index.php/apps/theming/favicon"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/icon"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/favicon/dashboard"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/icon/dashboard"
+		Then the HTTP status code should be "200"
+
+	Scenario: themed icons are available for disabled users
+		Given As an "admin"
+		And assure user "user0" is disabled
+		And As an "user0"
+		When sending "GET" with exact url to "/index.php/apps/theming/favicon"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/icon"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/favicon/dashboard"
+		Then the HTTP status code should be "200"
+		When sending "GET" with exact url to "/index.php/apps/theming/icon/dashboard"
+		Then the HTTP status code should be "200"

--- a/lib/base.php
+++ b/lib/base.php
@@ -12,6 +12,7 @@ use OC\Share20\GroupDeletedListener;
 use OC\Share20\Hooks;
 use OC\Share20\UserDeletedListener;
 use OC\Share20\UserRemovedListener;
+use OC\User\DisabledUserException;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\BeforeFileSystemSetupEvent;
 use OCP\Group\Events\GroupDeletedEvent;
@@ -1026,7 +1027,27 @@ class OC {
 				// OAuth needs to support basic auth too, so the login is not valid
 				// inside Nextcloud and the Login exception would ruin it.
 				if ($request->getRawPathInfo() !== '/apps/oauth2/api/v1/token') {
-					self::handleLogin($request);
+					try {
+						self::handleLogin($request);
+					} catch (DisabledUserException $e) {
+						// Disabled users would not be seen as logged in and
+						// trying to log them in would fail, so the login
+						// exception is ignored for the themed stylesheets and
+						// images.
+						if ($request->getRawPathInfo() !== '/apps/theming/theme/default.css'
+							&& $request->getRawPathInfo() !== '/apps/theming/theme/light.css'
+							&& $request->getRawPathInfo() !== '/apps/theming/theme/dark.css'
+							&& $request->getRawPathInfo() !== '/apps/theming/theme/light-highcontrast.css'
+							&& $request->getRawPathInfo() !== '/apps/theming/theme/dark-highcontrast.css'
+							&& $request->getRawPathInfo() !== '/apps/theming/theme/opendyslexic.css'
+							&& $request->getRawPathInfo() !== '/apps/theming/image/background'
+							&& $request->getRawPathInfo() !== '/apps/theming/image/logo'
+							&& $request->getRawPathInfo() !== '/apps/theming/image/logoheader'
+							&& !str_starts_with($request->getRawPathInfo(), '/apps/theming/favicon')
+							&& !str_starts_with($request->getRawPathInfo(), '/apps/theming/icon')) {
+							throw $e;
+						}
+					}
 				}
 			}
 		}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -2124,6 +2124,7 @@ return array(
     'OC\\User\\Backend' => $baseDir . '/lib/private/User/Backend.php',
     'OC\\User\\BackgroundJobs\\CleanupDeletedUsers' => $baseDir . '/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php',
     'OC\\User\\Database' => $baseDir . '/lib/private/User/Database.php',
+    'OC\\User\\DisabledUserException' => $baseDir . '/lib/private/User/DisabledUserException.php',
     'OC\\User\\DisplayNameCache' => $baseDir . '/lib/private/User/DisplayNameCache.php',
     'OC\\User\\LazyUser' => $baseDir . '/lib/private/User/LazyUser.php',
     'OC\\User\\Listeners\\BeforeUserDeletedListener' => $baseDir . '/lib/private/User/Listeners/BeforeUserDeletedListener.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -2165,6 +2165,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\User\\Backend' => __DIR__ . '/../../..' . '/lib/private/User/Backend.php',
         'OC\\User\\BackgroundJobs\\CleanupDeletedUsers' => __DIR__ . '/../../..' . '/lib/private/User/BackgroundJobs/CleanupDeletedUsers.php',
         'OC\\User\\Database' => __DIR__ . '/../../..' . '/lib/private/User/Database.php',
+        'OC\\User\\DisabledUserException' => __DIR__ . '/../../..' . '/lib/private/User/DisabledUserException.php',
         'OC\\User\\DisplayNameCache' => __DIR__ . '/../../..' . '/lib/private/User/DisplayNameCache.php',
         'OC\\User\\LazyUser' => __DIR__ . '/../../..' . '/lib/private/User/LazyUser.php',
         'OC\\User\\Listeners\\BeforeUserDeletedListener' => __DIR__ . '/../../..' . '/lib/private/User/Listeners/BeforeUserDeletedListener.php',

--- a/lib/private/User/DisabledUserException.php
+++ b/lib/private/User/DisabledUserException.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OC\User;
+
+class DisabledUserException extends LoginException {
+}

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -320,7 +320,7 @@ class Session implements IUserSession, Emitter {
 			// disabled users can not log in
 			// injecting l10n does not work - there is a circular dependency between session and \OCP\L10N\IFactory
 			$message = \OCP\Util::getL10N('lib')->t('Account disabled');
-			throw new LoginException($message);
+			throw new DisabledUserException($message);
 		}
 
 		if ($regenerateSessionId) {

--- a/lib/private/legacy/OC_User.php
+++ b/lib/private/legacy/OC_User.php
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 use OC\Authentication\Token\IProvider;
-use OC\User\LoginException;
+use OC\User\DisabledUserException;
 use OCP\Authentication\Exceptions\InvalidTokenException;
 use OCP\Authentication\Exceptions\WipeTokenException;
 use OCP\Authentication\Token\IToken;
@@ -151,7 +151,7 @@ class OC_User {
 
 				if ($userSession->getUser() && !$userSession->getUser()->isEnabled()) {
 					$message = \OC::$server->getL10N('lib')->t('Account disabled');
-					throw new LoginException($message);
+					throw new DisabledUserException($message);
 				}
 				$userSession->setLoginName($uid);
 				$request = OC::$server->getRequest();


### PR DESCRIPTION
The Theming app [injects the stylesheets for the different themes](https://github.com/nextcloud/server/blob/381077028adf388a7081cf42026570c6be47b198/apps/theming/lib/Service/ThemeInjectionService.php#L34) in the `<header>` element of the page, and those stylesheets are then loaded by the browser [from a `Controller`](https://github.com/nextcloud/server/blob/f1448fcf0777db7d4254cb0a3ef94d63be9f7a24/apps/theming/lib/Controller/ThemingController.php#L384) (a plain `Controller`, not an `OCSController`). The stylesheets, in turn, may also get some images (like the background) also [from the `Controller`](https://github.com/nextcloud/server/blob/f1448fcf0777db7d4254cb0a3ef94d63be9f7a24/apps/theming/lib/Controller/ThemingController.php#L345).

When handling a request to _index.php_ it is checked whether the user is logged in and, if not, a login is tried. [A disabled user is explicitly seen as not logged in](https://github.com/nextcloud/server/blob/5003467f98ac89d6b05477d2be2d24961d8348b0/lib/private/User/Session.php#L226), so a login is always tried in that case, but [disabled users are also explicitly prevented to log in](https://github.com/nextcloud/server/blob/5003467f98ac89d6b05477d2be2d24961d8348b0/lib/private/User/Session.php#L318-L323), so the login also fails. Due to that trying to get any of the themed stylesheets or images with a disabled account (to be able to show the "Account disabled" error page) fails with an HTTP status 401. Note that all this happens even before [the route is matched](https://github.com/nextcloud/server/blob/78ff8e233fcfaf596a85ddc3bbacda7aca537fa1/lib/base.php#L1033) and the Middleware does its magic, so the requests fail even if the controller endpoint is marked as a public page.

To solve the issue, and to avoid touching this basic logic as much as possible, the login exception is now ignored (if the user is disabled) for some specific requests to the Theming app. There are probably better, cleaner and/or more elegant fixes, and I am not even sure if this one could be somehow problematic... so improvements are welcome :-)

Note that disabled accounts keep their own custom theme. However, [`getBackground` is not a public page](https://github.com/nextcloud/server/blob/085d4c93647bef0136ce8c639c7567ed659217f2/apps/theming/lib/Controller/UserThemeController.php#L132) so even if the login exception is ignored for it requests by disabled accounts would still fail, so the custom background image can not be got. Independently of that, it could be argued that the global theme, be it custom or not, should be used instead for disabled accounts. It would be necessary to adjust the calls to `getUserValue` throught the Theming app (for example, [when getting the background](https://github.com/nextcloud/server/blob/1580c8612b01bfa780d1a7372080a27d182fb7dd/apps/theming/lib/Service/BackgroundService.php#L297)) to use the global value instead if the account is disabled, as [the default `IConfig` implementation always returns the user value, no matter if the account is disabled or not](https://github.com/nextcloud/server/blob/394febb5d9f1ada1c6dfd0316a6a994b87c7148a/lib/private/AllConfig.php#L259-L286). However, as keeping the account theme might be fine too nothing was changed in that regard (neither to allow getting the custom background nor to use the global theme).

## How to test (scenario 1)

- Log in as an admin
- Open the Theming section in the Administration settings
- Upload a custom background
- In a private window, log in with another account
- In the original window, open the Accounts settings
- Disable the other account
- In the private window, reload the page

### Result with this pull request

The custom background and matching colour scheme is used

### Result without this pull request

The default background and matching colour scheme is used


## How to test (scenario 2)

- Log in as an admin
- Open the Theming section in the Administration settings
- Upload a custom background
- In a private window, log in with another account
- Open the Theming section in the Personal setting
- Upload another custom background
- In the original window, open the Accounts settings
- Disable the other account
- In the private window, reload the page

### Result with this pull request

The custom (account specific, not global) colour scheme is used, although there is no background image

### Result without this pull request

The default background and matching colour scheme theme is used
