### PR TITLE
fix(sharing): fix json decoding the list of groups excluded from sharing

### DIFF
--- a/lib/private/Share20/ShareDisableChecker.php
+++ b/lib/private/Share20/ShareDisableChecker.php
@@ -38,7 +38,7 @@ class ShareDisableChecker {
 
 		if ($excludeGroups && $excludeGroups !== 'no') {
 			$groupsList = $this->config->getAppValue('core', 'shareapi_exclude_groups_list', '');
-			$excludedGroups = json_decode($groupsList);
+			$excludedGroups = json_decode($groupsList, true);
 			if (is_null($excludedGroups)) {
 				$excludedGroups = explode(',', $groupsList);
 				$newValue = json_encode($excludedGroups);


### PR DESCRIPTION
`json_decode()` returns stdclass by default instead of an associative object, which can't be used for `array_diff` or `array_intersect` later

This can prevent login as it's used when mounting user storages.

## Summary

<details>
<pre>
{
  "Exception": "Exception",
  "Message": "array_intersect(): Argument #2 must be of type array, stdClass given in file '/var/www/nc/nextcloud-30.0.10/lib/private/Share20/ShareDisableChecker.php' line 69",
  "Code": 0,
  "Trace": [
    {
      "file": "/var/www/nc/nextcloud-30.0.10/lib/private/AppFramework/App.php",
      "line": 161,
      "function": "dispatch",
      "class": "OC\\\\AppFramework\\\\Http\\\\Dispatcher",
      "type": "->"
    },
    {
      "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Route/Router.php",
      "line": 303,
      "function": "main",
      "class": "OC\\\\AppFramework\\\\App",
      "type": "::"
    },
    {
      "file": "/var/www/nc/nextcloud-30.0.10/lib/base.php",
      "line": 1010,
      "function": "match",
      "class": "OC\\\\Route\\\\Router",
      "type": "->"
    },
    {
      "file": "/var/www/nc/nextcloud-30.0.10/index.php",
      "line": 24,
      "function": "handleRequest",
      "class": "OC",
      "type": "::"
    }
  ],
  "File": "/var/www/nc/nextcloud-30.0.10/lib/private/AppFramework/Http/Dispatcher.php",
  "Line": 146,
  "Previous": {
    "Exception": "TypeError",
    "Message": "array_intersect(): Argument #2 must be of type array, stdClass given",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Share20/ShareDisableChecker.php",
        "line": 69,
        "function": "array_intersect"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Files/SetupManager.php",
        "line": 119,
        "function": "sharingDisabledForUser",
        "class": "OC\\\\Share20\\\\ShareDisableChecker",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Files/SetupManager.php",
        "line": 327,
        "function": "setupBuiltinWrappers",
        "class": "OC\\\\Files\\\\SetupManager",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Files/SetupManager.php",
        "line": 222,
        "function": "setupRoot",
        "class": "OC\\\\Files\\\\SetupManager",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Files/SetupManager.php",
        "line": 303,
        "function": "oneTimeUserSetup",
        "class": "OC\\\\Files\\\\SetupManager",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Files/SetupManager.php",
        "line": 202,
        "function": "setupForUserWith",
        "class": "OC\\\\Files\\\\SetupManager",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Files/Filesystem.php",
        "line": 332,
        "function": "setupForUser",
        "class": "OC\\\\Files\\\\SetupManager",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Cache/File.php",
        "line": 34,
        "function": "initMountPoints",
        "class": "OC\\\\Files\\\\Filesystem",
        "type": "::"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Cache/File.php",
        "line": 155,
        "function": "getStorage",
        "class": "OC\\\\Cache\\\\File",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/base.php",
        "line": 845,
        "function": "gc",
        "class": "OC\\\\Cache\\\\File",
        "type": "->"
      },
      {
        "function": "{closure}",
        "class": "OC",
        "type": "::",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Hooks/EmitterTrait.php",
        "line": 88,
        "function": "call_user_func_array"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Hooks/PublicEmitter.php",
        "line": 22,
        "function": "emit",
        "class": "OC\\\\Hooks\\\\BasicEmitter",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/User/Session.php",
        "line": 349,
        "function": "emit",
        "class": "OC\\\\Hooks\\\\PublicEmitter",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/CompleteLoginCommand.php",
        "line": 22,
        "function": "completeLogin",
        "class": "OC\\\\User\\\\Session",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/ALoginCommand.php",
        "line": 22,
        "function": "process",
        "class": "OC\\\\Authentication\\\\Login\\\\CompleteLoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/LoggedInCheckCommand.php",
        "line": 41,
        "function": "processNextOrFinishSuccessfully",
        "class": "OC\\\\Authentication\\\\Login\\\\ALoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/ALoginCommand.php",
        "line": 22,
        "function": "process",
        "class": "OC\\\\Authentication\\\\Login\\\\LoggedInCheckCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/EmailLoginCommand.php",
        "line": 51,
        "function": "processNextOrFinishSuccessfully",
        "class": "OC\\\\Authentication\\\\Login\\\\ALoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/ALoginCommand.php",
        "line": 22,
        "function": "process",
        "class": "OC\\\\Authentication\\\\Login\\\\EmailLoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/UidLoginCommand.php",
        "line": 36,
        "function": "processNextOrFinishSuccessfully",
        "class": "OC\\\\Authentication\\\\Login\\\\ALoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/ALoginCommand.php",
        "line": 22,
        "function": "process",
        "class": "OC\\\\Authentication\\\\Login\\\\UidLoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/UserDisabledCheckCommand.php",
        "line": 39,
        "function": "processNextOrFinishSuccessfully",
        "class": "OC\\\\Authentication\\\\Login\\\\ALoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/ALoginCommand.php",
        "line": 22,
        "function": "process",
        "class": "OC\\\\Authentication\\\\Login\\\\UserDisabledCheckCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/PreLoginHookCommand.php",
        "line": 34,
        "function": "processNextOrFinishSuccessfully",
        "class": "OC\\\\Authentication\\\\Login\\\\ALoginCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Authentication/Login/Chain.php",
        "line": 45,
        "function": "process",
        "class": "OC\\\\Authentication\\\\Login\\\\PreLoginHookCommand",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/core/Controller/LoginController.php",
        "line": 326,
        "function": "process",
        "class": "OC\\\\Authentication\\\\Login\\\\Chain",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 208,
        "function": "tryLogin",
        "class": "OC\\\\Core\\\\Controller\\\\LoginController",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 114,
        "function": "executeController",
        "class": "OC\\\\AppFramework\\\\Http\\\\Dispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\\\AppFramework\\\\Http\\\\Dispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/private/Route/Router.php",
        "line": 303,
        "function": "main",
        "class": "OC\\\\AppFramework\\\\App",
        "type": "::"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/lib/base.php",
        "line": 1010,
        "function": "match",
        "class": "OC\\\\Route\\\\Router",
        "type": "->"
      },
      {
        "file": "/var/www/nc/nextcloud-30.0.10/index.php",
        "line": 24,
        "function": "handleRequest",
        "class": "OC",
        "type": "::"
      }
    ],
    "File": "/var/www/nc/nextcloud-30.0.10/lib/private/Share20/ShareDisableChecker.php",
    "Line": 69
  },
  "message": "array_intersect(): Argument #2 must be of type array, stdClass given in file '/var/www/nc/nextcloud-30.0.10/lib/private/Share20/ShareDisableChecker.php' line 69",
  "exception": {},
  "CustomMessage": "array_intersect(): Argument #2 must be of type array, stdClass g"
}
</pre>
</details>

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
