### PR TITLE
fix(session): log session_regenerate_id for debugging

### DIFF
--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -123,7 +123,14 @@ class Internal extends Session {
 		}
 
 		try {
+			$oldId = $this->getId();
 			@session_regenerate_id($deleteOldSession);
+			$newId = $this->getId();
+			$this->logger->debug('Regenerated session ID', [
+				'oldId' => $oldId,
+				'newId' => $newId,
+				'deleteOldSession' => $deleteOldSession,
+			]);
 		} catch (\Error $e) {
 			$this->trapError($e->getCode(), $e->getMessage());
 		}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* For debugging of #42157 

## Summary

From https://www.php.net/manual/en/function.session-regenerate-id.php

> You should not destroy old session data immediately, but should use destroy time-stamp and control access to old session ID. Otherwise, concurrent access to page may result in inconsistent state, or you may have lost session, or it may cause client (browser) side race condition and may create many session ID needlessly. Immediate session data deletion disables session hijack attack detection and prevention also. 

A session decryption error like HMAC mismatch triggers the session ID to regenerate, which in turn could lead to a lost session.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
