### PR TITLE
feat(log): add opt-in session ID logging

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1142,6 +1142,16 @@ $CONFIG = [
 'log.backtrace' => false,
 
 /**
+ * Enables logging the PHP session ID with each log line
+ *
+ * This can be used for session-related debugging, e.g. to see when a session
+ * is ended or restarted.
+ *
+ * Defaults to ``false``.
+ */
+'log.sessionId' => false,
+
+/**
  * This uses PHP.date formatting; see https://www.php.net/manual/en/function.date.php
  *
  * Defaults to ISO 8601 ``2005-08-15T15:52:01+00:00`` - see \DateTime::ATOM

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -15,11 +15,13 @@ use OC\Log\ExceptionSerializer;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ILogger;
 use OCP\IRequest;
+use OCP\ISession;
 use OCP\IUserSession;
 use OCP\Log\BeforeMessageLoggedEvent;
 use OCP\Log\IDataLogger;
 use OCP\Log\IFileBased;
 use OCP\Log\IWriter;
+use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\Support\CrashReport\IRegistry;
 use Throwable;
 use function array_merge;
@@ -169,6 +171,13 @@ class Log implements ILogger, IDataLogger {
 		$logBacktrace = $this->config->getValue('log.backtrace', false);
 		if (!$hasBacktrace && $logBacktrace) {
 			$entry['backtrace'] = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+		}
+		if ($this->config->getValue('log.sessionId', false)) {
+			try {
+				$entry['sessionId'] = \OCP\Server::get(ISession::class)->getId();
+			} catch (SessionNotAvailableException) {
+				$entry['sessionId'] = false;
+			}
 		}
 
 		try {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* For cases like https://github.com/nextcloud/server/issues/42157

## Summary

Optionally allow admins to enable logging of session IDs. This allows to see when a new session is started for a user. That information is not trackable right now.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
