### PR TITLE
fix: Correctly ignore lazy ghost initialization in debug warning about direct constructor call

### DIFF
--- a/lib/public/AppFramework/App.php
+++ b/lib/public/AppFramework/App.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  */
 namespace OCP\AppFramework;
 
+use OC\AppFramework\Utility\SimpleContainer;
 use OC\ServerContainer;
 use OCP\IConfig;
 use OCP\Server;
@@ -70,9 +71,10 @@ class App {
 					$setUpViaQuery = true;
 					break;
 				} elseif (isset($step['class'], $step['function'], $step['args'][0]) &&
-					$step['class'] === \ReflectionClass::class &&
-					$step['function'] === 'initializeLazyObject' &&
+					$step['class'] === SimpleContainer::class &&
+					preg_match('/{closure:OC\\\\AppFramework\\\\Utility\\\\SimpleContainer::buildClass\\(\\):\\d+}/', $step['function']) &&
 					$step['args'][0] === $this) {
+					/* We are setup through a lazy ghost, fine */
 					$setUpViaQuery = true;
 					break;
 				}


### PR DESCRIPTION
* Resolves: #53463

## Summary

It appears that ReflectionClass does not appear in the trace in the end, so we need to match the closure to be sure we’re fine.
I use preg_match so that it does not break when the line number of the closure changes.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
