### PR TITLE
fix(encryption): Do not register user key related event listeners

### DIFF
--- a/apps/encryption/lib/AppInfo/Application.php
+++ b/apps/encryption/lib/AppInfo/Application.php
@@ -72,7 +72,12 @@ class Application extends App implements IBootstrap {
 		}
 	}
 
-	public function registerEventListeners(IConfig $config, IEventDispatcher $eventDispatcher, IManager $encryptionManager): void {
+	public function registerEventListeners(
+		IConfig $config,
+		IEventDispatcher $eventDispatcher,
+		IManager $encryptionManager,
+		Util $util,
+	): void {
 		if (!$encryptionManager->isEnabled()) {
 			return;
 		}
@@ -84,18 +89,23 @@ class Application extends App implements IBootstrap {
 		}
 
 		// No maintenance so register all events
-		$eventDispatcher->addServiceListener(UserCreatedEvent::class, UserEventsListener::class);
-		$eventDispatcher->addServiceListener(UserDeletedEvent::class, UserEventsListener::class);
-		$eventDispatcher->addServiceListener(BeforePasswordUpdatedEvent::class, UserEventsListener::class);
-		$eventDispatcher->addServiceListener(PasswordUpdatedEvent::class, UserEventsListener::class);
-		$eventDispatcher->addServiceListener(BeforePasswordResetEvent::class, UserEventsListener::class);
-		$eventDispatcher->addServiceListener(PasswordResetEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(UserLoggedInEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(UserLoggedInWithCookieEvent::class, UserEventsListener::class);
 		$eventDispatcher->addServiceListener(UserLoggedOutEvent::class, UserEventsListener::class);
+		if (!$util->isMasterKeyEnabled()) {
+			// Only make sense if no master key is used
+			$eventDispatcher->addServiceListener(UserCreatedEvent::class, UserEventsListener::class);
+			$eventDispatcher->addServiceListener(UserDeletedEvent::class, UserEventsListener::class);
+			$eventDispatcher->addServiceListener(BeforePasswordUpdatedEvent::class, UserEventsListener::class);
+			$eventDispatcher->addServiceListener(PasswordUpdatedEvent::class, UserEventsListener::class);
+			$eventDispatcher->addServiceListener(BeforePasswordResetEvent::class, UserEventsListener::class);
+			$eventDispatcher->addServiceListener(PasswordResetEvent::class, UserEventsListener::class);
+		}
 	}
 
-	public function registerEncryptionModule(IManager $encryptionManager) {
+	public function registerEncryptionModule(
+		IManager $encryptionManager,
+	) {
 		$container = $this->getContainer();
 
 		$encryptionManager->registerEncryptionModule(

--- a/apps/encryption/lib/Services/PassphraseService.php
+++ b/apps/encryption/lib/Services/PassphraseService.php
@@ -55,6 +55,11 @@ class PassphraseService {
 			return true;
 		}
 
+		if ($this->util->isMasterKeyEnabled()) {
+			$this->logger->error('setPassphraseForUser should never be called when master key is enabled');
+			return true;
+		}
+
 		// Check user exists on backend
 		$user = $this->userManager->get($userId);
 		if ($user === null) {


### PR DESCRIPTION
* Resolves: #52259

## Summary

Do not register user key related event listeners when master key is enabled.
Also added a safeguard in PassphraseService.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
