### PR TITLE
chore: Cleanup DIContainer class

### DIFF
--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -23,12 +23,12 @@ use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IRequest;
-use OCP\IServerContainer;
 use OCP\IUserManager;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as ShareManager;
 use OCP\Share\IShare;
+use Psr\Container\ContainerInterface;
 
 /**
  * @psalm-import-type Files_SharingDeletedShare from ResponseDefinitions
@@ -44,7 +44,7 @@ class DeletedShareAPIController extends OCSController {
 		private IGroupManager $groupManager,
 		private IRootFolder $rootFolder,
 		private IAppManager $appManager,
-		private IServerContainer $serverContainer,
+		private ContainerInterface $serverContainer,
 	) {
 		parent::__construct($appName, $request);
 	}

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -24,11 +24,11 @@ use OCP\Files\NotFoundException;
 use OCP\IGroupManager;
 use OCP\IRequest;
 use OCP\IUserManager;
+use OCP\Server;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager as ShareManager;
 use OCP\Share\IShare;
-use Psr\Container\ContainerInterface;
 
 /**
  * @psalm-import-type Files_SharingDeletedShare from ResponseDefinitions
@@ -44,7 +44,6 @@ class DeletedShareAPIController extends OCSController {
 		private IGroupManager $groupManager,
 		private IRootFolder $rootFolder,
 		private IAppManager $appManager,
-		private ContainerInterface $serverContainer,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -202,7 +201,7 @@ class DeletedShareAPIController extends OCSController {
 			throw new QueryException();
 		}
 
-		return $this->serverContainer->get('\OCA\Talk\Share\Helper\DeletedShareAPIController');
+		return Server::get('\OCA\Talk\Share\Helper\DeletedShareAPIController');
 	}
 
 	/**
@@ -219,7 +218,7 @@ class DeletedShareAPIController extends OCSController {
 			throw new QueryException();
 		}
 
-		return $this->serverContainer->get('\OCA\Deck\Sharing\ShareAPIHelper');
+		return Server::get('\OCA\Deck\Sharing\ShareAPIHelper');
 	}
 
 	/**
@@ -236,6 +235,6 @@ class DeletedShareAPIController extends OCSController {
 			throw new QueryException();
 		}
 
-		return $this->serverContainer->get('\OCA\ScienceMesh\Sharing\ShareAPIHelper');
+		return Server::get('\OCA\ScienceMesh\Sharing\ShareAPIHelper');
 	}
 }

--- a/apps/settings/tests/AppInfo/ApplicationTest.php
+++ b/apps/settings/tests/AppInfo/ApplicationTest.php
@@ -39,7 +39,7 @@ class ApplicationTest extends TestCase {
 
 	public function testContainerAppName(): void {
 		$this->app = new Application();
-		$this->assertEquals('settings', $this->container->getAppName());
+		$this->assertEquals('settings', $this->container->get('appName'));
 	}
 
 	public static function dataContainerQuery(): array {

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1581,9 +1581,6 @@
       <code><![CDATA[new QueryException()]]></code>
       <code><![CDATA[new QueryException()]]></code>
     </DeprecatedClass>
-    <DeprecatedInterface>
-      <code><![CDATA[private]]></code>
-    </DeprecatedInterface>
   </file>
   <file src="apps/files_sharing/lib/Controller/ShareAPIController.php">
     <DeprecatedClass>
@@ -3364,18 +3361,12 @@
     </UndefinedMethod>
   </file>
   <file src="lib/private/AppFramework/DependencyInjection/DIContainer.php">
-    <ImplementedReturnTypeMismatch>
-      <code><![CDATA[boolean|null]]></code>
-    </ImplementedReturnTypeMismatch>
     <InvalidReturnStatement>
       <code><![CDATA[$this->server]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[\OCP\IServerContainer]]></code>
     </InvalidReturnType>
-    <UndefinedInterfaceMethod>
-      <code><![CDATA[getAppDataDir]]></code>
-    </UndefinedInterfaceMethod>
   </file>
   <file src="lib/private/AppFramework/Http/Dispatcher.php">
     <NullArgument>

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -101,7 +101,7 @@ class App {
 		$profiler->setEnabled($profiler->isEnabled() && !is_null($urlParams) && isset($urlParams['_route']) && !str_starts_with($urlParams['_route'], 'profiler.'));
 		if ($profiler->isEnabled()) {
 			\OC::$server->get(IEventLogger::class)->activate();
-			$profiler->add(new RoutingDataCollector($container['AppName'], $controllerName, $methodName));
+			$profiler->add(new RoutingDataCollector($container['appName'], $controllerName, $methodName));
 		}
 
 		$eventLogger->start('app:controller:params', 'Gather controller parameters');
@@ -115,7 +115,7 @@ class App {
 			$request = $container->get(IRequest::class);
 			$request->setUrlParameters($container['urlParams']);
 		}
-		$appName = $container['AppName'];
+		$appName = $container['appName'];
 
 		$eventLogger->end('app:controller:params');
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -116,6 +116,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 
 		$this->registerAlias(\OCP\WorkflowEngine\IManager::class, Manager::class);
 
+		$this->registerService(ContainerInterface::class, fn (ContainerInterface $c) => $c);
 		$this->registerDeprecatedAlias(IAppContainer::class, ContainerInterface::class);
 
 		// commonly used attributes

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -44,6 +44,7 @@ use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IRequest;
 use OCP\IServerContainer;
+use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Security\Ip\IRemoteAddress;
@@ -110,8 +111,8 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerDeprecatedAlias(IAppContainer::class, ContainerInterface::class);
 
 		// commonly used attributes
-		$this->registerService('userId', function (ContainerInterface $c): string {
-			return $c->get(IUserSession::class)->getSession()->get('user_id');
+		$this->registerService('userId', function (ContainerInterface $c): ?string {
+			return $c->get(ISession::class)->get('user_id');
 		});
 
 		$this->registerService('webRoot', function (ContainerInterface $c): string {
@@ -358,6 +359,9 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		} elseif ($this->appName === 'core' && str_starts_with($name, 'OC\\Core\\')) {
 			return parent::query($name);
 		} elseif (str_starts_with($name, \OC\AppFramework\App::buildAppNamespace($this->appName) . '\\')) {
+			return parent::query($name);
+		} elseif (str_starts_with($name, 'OC\\AppFramework\\Services\\')) {
+			/* AppFramework services are scoped to the application */
 			return parent::query($name);
 		}
 

--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -64,7 +64,8 @@ class Dispatcher {
 	 * @param LoggerInterface $logger
 	 * @param IEventLogger $eventLogger
 	 */
-	public function __construct(Http $protocol,
+	public function __construct(
+		Http $protocol,
 		MiddlewareDispatcher $middlewareDispatcher,
 		ControllerMethodReflector $reflector,
 		IRequest $request,
@@ -72,7 +73,8 @@ class Dispatcher {
 		ConnectionAdapter $connection,
 		LoggerInterface $logger,
 		IEventLogger $eventLogger,
-		ContainerInterface $appContainer) {
+		ContainerInterface $appContainer,
+	) {
 		$this->protocol = $protocol;
 		$this->middlewareDispatcher = $middlewareDispatcher;
 		$this->reflector = $reflector;

--- a/lib/private/AppFramework/Http/Output.php
+++ b/lib/private/AppFramework/Http/Output.php
@@ -13,14 +13,9 @@ use OCP\AppFramework\Http\IOutput;
  * Very thin wrapper class to make output testable
  */
 class Output implements IOutput {
-	/** @var string */
-	private $webRoot;
-
-	/**
-	 * @param $webRoot
-	 */
-	public function __construct($webRoot) {
-		$this->webRoot = $webRoot;
+	public function __construct(
+		private string $webRoot,
+	) {
 	}
 
 	/**

--- a/lib/private/AppFramework/Middleware/Security/SameSiteCookieMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/SameSiteCookieMiddleware.php
@@ -14,16 +14,10 @@ use OCP\AppFramework\Http\Response;
 use OCP\AppFramework\Middleware;
 
 class SameSiteCookieMiddleware extends Middleware {
-	/** @var Request */
-	private $request;
-
-	/** @var ControllerMethodReflector */
-	private $reflector;
-
-	public function __construct(Request $request,
-		ControllerMethodReflector $reflector) {
-		$this->request = $request;
-		$this->reflector = $reflector;
+	public function __construct(
+		private Request $request,
+		private ControllerMethodReflector $reflector,
+	) {
 	}
 
 	public function beforeController($controller, $methodName) {
@@ -59,7 +53,7 @@ class SameSiteCookieMiddleware extends Middleware {
 		throw $exception;
 	}
 
-	protected function setSameSiteCookie() {
+	protected function setSameSiteCookie(): void {
 		$cookieParams = $this->request->getCookieParams();
 		$secureCookie = ($cookieParams['secure'] === true) ? 'secure; ' : '';
 		$policies = [

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -14,6 +14,7 @@ use OCP\IContainer;
 use Pimple\Container;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
@@ -185,8 +186,21 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 	 * @param string $alias the alias that should be registered
 	 * @param string $target the target that should be resolved instead
 	 */
-	public function registerAlias($alias, $target) {
-		$this->registerService($alias, function (ContainerInterface $container) use ($target) {
+	public function registerAlias($alias, $target): void {
+		$this->registerService($alias, function (ContainerInterface $container) use ($target): mixed {
+			return $container->get($target);
+		}, false);
+	}
+
+	protected function registerDeprecatedAlias(string $alias, string $target): void {
+		$this->registerService($alias, function (ContainerInterface $container) use ($target, $alias): mixed {
+			try {
+				$logger = $container->get(LoggerInterface::class);
+				$logger->debug('The requested alias "' . $alias . '" is deprecated. Please request "' . $target . '" directly. This alias will be removed in a future Nextcloud version.', ['app' => 'serverDI']);
+			} catch (ContainerExceptionInterface $e) {
+				// Could not get logger. Continue
+			}
+
 			return $container->get($target);
 		}, false);
 	}

--- a/lib/private/EventDispatcher/EventDispatcher.php
+++ b/lib/private/EventDispatcher/EventDispatcher.php
@@ -14,7 +14,7 @@ use OCP\Broadcast\Events\IBroadcastEvent;
 use OCP\EventDispatcher\ABroadcastedEvent;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\IServerContainer;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher as SymfonyDispatcher;
 use function get_class;
@@ -22,7 +22,7 @@ use function get_class;
 class EventDispatcher implements IEventDispatcher {
 	public function __construct(
 		private SymfonyDispatcher $dispatcher,
-		private IServerContainer $container,
+		private ContainerInterface $container,
 		private LoggerInterface $logger,
 	) {
 		// inject the event dispatcher into the logger

--- a/lib/private/EventDispatcher/ServiceEventListener.php
+++ b/lib/private/EventDispatcher/ServiceEventListener.php
@@ -12,7 +12,7 @@ namespace OC\EventDispatcher;
 use OCP\AppFramework\QueryException;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IServerContainer;
+use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use function sprintf;
 
@@ -23,24 +23,13 @@ use function sprintf;
  * created by the service container
  */
 final class ServiceEventListener {
-	/** @var IServerContainer */
-	private $container;
+	private ?IEventListener $service = null;
 
-	/** @var string */
-	private $class;
-
-	/** @var LoggerInterface */
-	private $logger;
-
-	/** @var null|IEventListener */
-	private $service;
-
-	public function __construct(IServerContainer $container,
-		string $class,
-		LoggerInterface $logger) {
-		$this->container = $container;
-		$this->class = $class;
-		$this->logger = $logger;
+	public function __construct(
+		private ContainerInterface $container,
+		private string $class,
+		private LoggerInterface $logger,
+	) {
 	}
 
 	public function __invoke(Event $event) {
@@ -49,7 +38,7 @@ final class ServiceEventListener {
 				// TODO: fetch from the app containers, otherwise any custom services,
 				//       parameters and aliases won't be resolved.
 				//       See https://github.com/nextcloud/server/issues/27793 for details.
-				$this->service = $this->container->query($this->class);
+				$this->service = $this->container->get($this->class);
 			} catch (QueryException $e) {
 				$this->logger->error(
 					sprintf(

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -871,7 +871,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$c->get(IMimeTypeDetector::class)
 			);
 		});
-		$this->registerService(\OCP\IRequest::class, function (ContainerInterface $c) {
+		$this->registerService(Request::class, function (ContainerInterface $c) {
 			if (isset($this['urlParams'])) {
 				$urlParams = $this['urlParams'];
 			} else {
@@ -905,6 +905,7 @@ class Server extends ServerContainer implements IServerContainer {
 				$stream
 			);
 		});
+		$this->registerAlias(\OCP\IRequest::class, Request::class);
 
 		$this->registerService(IRequestId::class, function (ContainerInterface $c): IRequestId {
 			return new RequestId(

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -238,7 +238,6 @@ use OCP\User\Events\UserLoggedInEvent;
 use OCP\User\Events\UserLoggedInWithCookieEvent;
 use OCP\User\Events\UserLoggedOutEvent;
 use OCP\User\IAvailabilityCoordinator;
-use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
@@ -268,9 +267,7 @@ class Server extends ServerContainer implements IServerContainer {
 		$this->registerService(ContainerInterface::class, function (ContainerInterface $c) {
 			return $c;
 		});
-		$this->registerService(\OCP\IServerContainer::class, function (ContainerInterface $c) {
-			return $c;
-		});
+		$this->registerDeprecatedAlias(\OCP\IServerContainer::class, ContainerInterface::class);
 
 		$this->registerAlias(\OCP\Calendar\IManager::class, \OC\Calendar\Manager::class);
 
@@ -1682,7 +1679,6 @@ class Server extends ServerContainer implements IServerContainer {
 	 * @deprecated 20.0.0 Use get(\OCP\Files\AppData\IAppDataFactory::class)->get($app) instead
 	 */
 	public function getAppDataDir($app) {
-		/** @var \OC\Files\AppData\Factory $factory */
 		$factory = $this->get(\OC\Files\AppData\Factory::class);
 		return $factory->get($app);
 	}
@@ -1693,19 +1689,5 @@ class Server extends ServerContainer implements IServerContainer {
 	 */
 	public function getCloudIdManager() {
 		return $this->get(ICloudIdManager::class);
-	}
-
-	private function registerDeprecatedAlias(string $alias, string $target) {
-		$this->registerService($alias, function (ContainerInterface $container) use ($target, $alias) {
-			try {
-				/** @var LoggerInterface $logger */
-				$logger = $container->get(LoggerInterface::class);
-				$logger->debug('The requested alias "' . $alias . '" is deprecated. Please request "' . $target . '" directly. This alias will be removed in a future Nextcloud version.', ['app' => 'serverDI']);
-			} catch (ContainerExceptionInterface $e) {
-				// Could not get logger. Continue
-			}
-
-			return $container->get($target);
-		}, false);
 	}
 }

--- a/tests/lib/AppFramework/AppTest.php
+++ b/tests/lib/AppFramework/AppTest.php
@@ -29,7 +29,7 @@ function rrmdir($directory) {
 
 
 class AppTest extends \Test\TestCase {
-	private $container;
+	private DIContainer $container;
 	private $io;
 	private $api;
 	private $controller;
@@ -55,8 +55,8 @@ class AppTest extends \Test\TestCase {
 		$this->controllerMethod = 'method';
 
 		$this->container[$this->controllerName] = $this->controller;
-		$this->container['Dispatcher'] = $this->dispatcher;
-		$this->container['OCP\\AppFramework\\Http\\IOutput'] = $this->io;
+		$this->container[Dispatcher::class] = $this->dispatcher;
+		$this->container[IOutput::class] = $this->io;
 		$this->container['urlParams'] = ['_route' => 'not-profiler'];
 
 		$this->appPath = __DIR__ . '/../../../apps/namespacetestapp';
@@ -165,7 +165,7 @@ class AppTest extends \Test\TestCase {
 	}
 
 	public function testCoreApp(): void {
-		$this->container['AppName'] = 'core';
+		$this->container['appName'] = 'core';
 		$this->container['OC\Core\Controller\Foo'] = $this->controller;
 		$this->container['urlParams'] = ['_route' => 'not-profiler'];
 
@@ -183,7 +183,7 @@ class AppTest extends \Test\TestCase {
 	}
 
 	public function testSettingsApp(): void {
-		$this->container['AppName'] = 'settings';
+		$this->container['appName'] = 'settings';
 		$this->container['OCA\Settings\Controller\Foo'] = $this->controller;
 		$this->container['urlParams'] = ['_route' => 'not-profiler'];
 
@@ -201,7 +201,7 @@ class AppTest extends \Test\TestCase {
 	}
 
 	public function testApp(): void {
-		$this->container['AppName'] = 'bar';
+		$this->container['appName'] = 'bar';
 		$this->container['OCA\Bar\Controller\Foo'] = $this->controller;
 		$this->container['urlParams'] = ['_route' => 'not-profiler'];
 

--- a/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIContainerTest.php
@@ -18,13 +18,13 @@ use OCP\AppFramework\Middleware;
 use OCP\AppFramework\QueryException;
 use OCP\IConfig;
 use OCP\IRequestId;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @group DB
  */
 class DIContainerTest extends \Test\TestCase {
-	/** @var DIContainer|\PHPUnit\Framework\MockObject\MockObject */
-	private $container;
+	private DIContainer&MockObject $container;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -45,11 +45,13 @@ class DIContainerTest extends \Test\TestCase {
 
 	public function testProvidesAppName(): void {
 		$this->assertTrue(isset($this->container['AppName']));
+		$this->assertTrue(isset($this->container['appName']));
 	}
 
 
 	public function testAppNameIsSetCorrectly(): void {
 		$this->assertEquals('name', $this->container['AppName']);
+		$this->assertEquals('name', $this->container['appName']);
 	}
 
 	public function testMiddlewareDispatcherIncludesSecurityMiddleware(): void {


### PR DESCRIPTION
## Summary

Cleanup DIContainer class.
Also removed the `@deprecated` tag from the class as this class will not be removed, only the interface IAppContainer and associated methods should be removed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
