### PR TITLE
fix(maintenance): refresh page when turned off (sometimes)

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -242,6 +242,7 @@ class OC {
 			// render error page
 			$template = Server::get(ITemplateManager::class)->getTemplate('', 'update.user', 'guest');
 			\OCP\Util::addScript('core', 'maintenance');
+			\OCP\Util::addScript('core', 'common');
 			\OCP\Util::addStyle('core', 'guest');
 			$template->printPage();
 			die();


### PR DESCRIPTION
We [claim on the user-facing maintenance page](https://github.com/nextcloud/server/blob/64208b6d2273269cd51bb6e4a7aa939a144bc93c/core/templates/update.user.php#L11) that it'll automatically refresh when service is restored. However [the JS-based watcher](https://github.com/nextcloud/server/blob/64208b6d2273269cd51bb6e4a7aa939a144bc93c/core/src/maintenance.js#L6-L7) wasn't loading because depends on `common`[^1].

Not sure how long this was broken for, but probably going back at least several majors (maybe more).

Still only a partial solution to the broader problem, but addresses the scenario that occurs when toggling maintenance mode during operations that do *not* use the built-in Updater[^2].

Follow-up ideas:

- [ ] Adjust and clean up template design and language (what I was doing when I noticed this)
- [ ] Remove dependencies on other JS assets
- [ ] Remove dependencies on styling pulled from running system / or ?

[^1]: Since the maintenance page is "special" (and relatively simple) we should/could probably eliminate it's dependence on `common`. Of course the maintenance page is still stuck with styling dependencies... See next item.

[^2]: During normal operations, toggling maintenance mode on/off will work (and refresh automatically with this PR), but when using the standard Updater presumably it'll break due to both a loss of styling *and* Javascript asset access. This is because [in the Updater we replace the entry points](https://github.com/nextcloud/updater/blob/bc4d8f66da3d2d5e3000d60ca6cc97dfbb9021aa/lib/Updater.php#L818-L835) as an intermediate step. Directly related to #5789. Also, somewhat related to, #35787.
