### PR TITLE
[stable30] ci: Fix running files external s3 tests

### DIFF
--- a/.github/workflows/files-external-s3.yml
+++ b/.github/workflows/files-external-s3.yml
@@ -122,7 +122,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.4']
+        php-versions: ['8.1', '8.2', '8.3']
         include:
           - php-versions: '8.3'
             coverage: true


### PR DESCRIPTION
Follow up to #53424 

[PHP >= 8.4 is not supported in Nextcloud 30](https://github.com/nextcloud/server/blob/dae7c159f728a90ffa53247d6e033abdae5d2bd6/lib/versioncheck.php#L16-L17).
