### PR TITLE
docs: fix config sample to work with RST documentation

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2644,9 +2644,7 @@ $CONFIG = [
  * from ``OC\Accounts\AccountManager``.
  *
  * Example: Set phone property to private scope:
- * [
- *   \OCP\Accounts\IAccountManager::PROPERTY_PHONE => \OCP\Accounts\IAccountManager::SCOPE_PRIVATE
- * ]
+ * ``[\OCP\Accounts\IAccountManager::PROPERTY_PHONE => \OCP\Accounts\IAccountManager::SCOPE_PRIVATE]``
  */
 'account_manager.default_property_scope' => [],
 


### PR DESCRIPTION
The docs are extracted to the admin docs so it must be valid RST syntax.
