### PR TITLE
fix: generate csrf tokens if two factor challenge is ongoing

### DIFF
--- a/core/Controller/CSRFTokenController.php
+++ b/core/Controller/CSRFTokenController.php
@@ -34,6 +34,8 @@ class CSRFTokenController extends Controller {
 	 *
 	 * 200: CSRF token returned
 	 * 403: Strict cookie check failed
+	 *
+	 * @NoTwoFactorRequired
 	 */
 	#[PublicPage]
 	#[NoCSRFRequired]


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: CSRF token not being refreshed while a two-factor challenge is ongoing

## Summary

The frontend heartbeat should be able to refresh the CSRF token while there is an ongoing two-factor challenge. Otherwise, there will be CSRF token errors if the user takes too long to complete the challenge.

### How to reproduce?

1. Set the heartbeat interval to 10 seconds: `core/src/session-heartbeat.ts` -> `getInterval()`
2. Set up multiple two-factor challenges.
3. Log out and in again.
4. Don't choose a two-factor challenge.
5. Observe the network log and see that the heartbeat fails to refresh the token (redirect instead of token JSON response for `/csrftoken`).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
