### PR TITLE
fix(metadata): Skip generating metadata if there are some pending UpdateSingleMetadata job already

### DIFF
--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -417,13 +417,17 @@ class JobList implements IJobList {
 		}
 	}
 
-	public function countByClass(): array {
+	public function countByClass(?string $class = null): array {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('class')
 			->selectAlias($query->func()->count('id'), 'count')
 			->from('jobs')
 			->orderBy('count')
 			->groupBy('class');
+
+		if ($class !== null) {
+			$query->where($query->expr()->eq('class', $query->createNamedParameter($class)));
+		}
 
 		$result = $query->executeQuery();
 

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -164,8 +164,9 @@ interface IJobList {
 	/**
 	 * Returns a count of jobs per Job class
 	 *
+	 * @param class-string<IJob>|null $class
 	 * @return list<array{class:class-string, count:int}>
 	 * @since 30.0.0
 	 */
-	public function countByClass(): array;
+	public function countByClass(?string $class = null): array;
 }


### PR DESCRIPTION
This prevents the `GenerateMetadataJob` job from quickly piling up `UpdateSingleMetadata` jobs. This is an issue in big instances where that number can quickly reach millions of job.

Also switch to an iterator to go through the user list instead of fetching the whole user list.
This will reset the progress to 0 on instances that haven't finished it yet, but files won't be reprocessed.