### PR TITLE
fix(HttpClient): let local curl set encoding based what it is built with

### DIFF
--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -85,7 +85,8 @@ class Client implements IClient {
 		}
 
 		if (!isset($options[RequestOptions::HEADERS]['Accept-Encoding'])) {
-			$options[RequestOptions::HEADERS]['Accept-Encoding'] = 'gzip';
+			// let curl populate with whatever encodings it has been built with
+			$options['curl'][CURLOPT_ACCEPT_ENCODING] = '';
 		}
 
 		// Fallback for save_to


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This is a mixture of a fix and an enhancement.

In the HTTP client, previously we forced `Accept-Encoding` to gzip but it's possible for a local curl:

- not to have been built with gzip
- to support additional encoding types

In most cases this won't change behavior (i.e. gzip will still be used). In others, the specific server/client combo will simply choose something "better".

Notes:

- GuzzleHttp online docs are out of date:
  - https://github.com/guzzle/guzzle/pull/3215
  - https://github.com/guzzle/guzzle/blob/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77/docs/request-options.rst#decode_content
- https://php.watch/articles/curl-php-accept-encoding-compression
- `CURLOPT_ACCEPT_ENCODING` is the non-deprecated equivalent of `CURLOPT_ENCODING`
  - https://www.php.net/manual/en/curl.constants.php#constant.curlopt-accept-encoding
  - https://curl.se/libcurl/c/CURLOPT_ACCEPT_ENCODING.html

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
