### PR TITLE
fix: revive always storing lowercased email addresses

### DIFF
--- a/build/integration/features/provisioning-v1.feature
+++ b/build/integration/features/provisioning-v1.feature
@@ -187,6 +187,18 @@ Feature: provisioning
       | timezoneOffset | 0 |
       | pronouns | NULL |
 
+  Scenario: Edit a user with mixed case emails
+    Given As an "admin"
+    And user "brand-new-user" exists
+    And sending "PUT" to "/cloud/users/brand-new-user" with
+      | key | email |
+      | value | mixed-CASE@Nextcloud.com |
+    And the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    Then user "brand-new-user" has
+      | id | brand-new-user |
+      | email | mixed-case@nextcloud.com |
+
   Scenario: Edit a user account properties scopes
     Given user "brand-new-user" exists
     And As an "brand-new-user"

--- a/core/Migrations/Version32000Date20250620081925.php
+++ b/core/Migrations/Version32000Date20250620081925.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Migrations;
+
+/**
+ * Run the old migration Version24000Date20211210141942 again.
+ */
+class Version32000Date20250620081925 extends Version24000Date20211210141942 {
+}

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1472,6 +1472,7 @@ return array(
     'OC\\Core\\Migrations\\Version31000Date20240101084401' => $baseDir . '/core/Migrations/Version31000Date20240101084401.php',
     'OC\\Core\\Migrations\\Version31000Date20240814184402' => $baseDir . '/core/Migrations/Version31000Date20240814184402.php',
     'OC\\Core\\Migrations\\Version31000Date20250213102442' => $baseDir . '/core/Migrations/Version31000Date20250213102442.php',
+    'OC\\Core\\Migrations\\Version32000Date20250620081925' => $baseDir . '/core/Migrations/Version32000Date20250620081925.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\ResponseDefinitions' => $baseDir . '/core/ResponseDefinitions.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1513,6 +1513,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version31000Date20240101084401' => __DIR__ . '/../../..' . '/core/Migrations/Version31000Date20240101084401.php',
         'OC\\Core\\Migrations\\Version31000Date20240814184402' => __DIR__ . '/../../..' . '/core/Migrations/Version31000Date20240814184402.php',
         'OC\\Core\\Migrations\\Version31000Date20250213102442' => __DIR__ . '/../../..' . '/core/Migrations/Version31000Date20250213102442.php',
+        'OC\\Core\\Migrations\\Version32000Date20250620081925' => __DIR__ . '/../../..' . '/core/Migrations/Version32000Date20250620081925.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\ResponseDefinitions' => __DIR__ . '/../../..' . '/core/ResponseDefinitions.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -1045,6 +1045,11 @@ class UserConfig implements IUserConfig {
 		int $flags,
 		ValueType $type,
 	): bool {
+		// Primary email addresses are always(!) expected to be lowercase
+		if ($app === 'settings' && $key === 'email') {
+			$value = strtolower($value);
+		}
+
 		$this->assertParams($userId, $app, $key);
 		if (!$this->matchAndApplyLexiconDefinition($userId, $app, $key, $lazy, $type, $flags)) {
 			// returns false as database is not updated

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -93,6 +93,27 @@ class AllConfigTest extends \Test\TestCase {
 		$config->deleteUserValue('userSet', 'appSet', 'keySet');
 	}
 
+	/**
+	 * This test needs to stay! Emails are expected to be lowercase due to performance reasons.
+	 * This way we can skip the expensive casing change on the database.
+	 */
+	public function testSetUserValueSettingsEmail(): void {
+		$selectAllSQL = 'SELECT `userid`, `appid`, `configkey`, `configvalue` FROM `*PREFIX*preferences` WHERE `userid` = ?';
+		$config = $this->getConfig();
+
+		$config->setUserValue('userSet', 'settings', 'email', 'mixed.CASE@domain.COM');
+
+		$result = $this->connection->executeQuery($selectAllSQL, ['userSet'])->fetchAll();
+
+		$this->assertEquals(1, count($result));
+		$this->assertEquals([
+			'userid' => 'userSet',
+			'appid' => 'settings',
+			'configkey' => 'email',
+			'configvalue' => 'mixed.case@domain.com'
+		], $result[0]);
+	}
+
 	public function testSetUserValueWithPreCondition(): void {
 		$config = $this->getConfig();
 

--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -1241,6 +1241,19 @@ class UserConfigTest extends TestCase {
 		}
 	}
 
+	/**
+	 * This test needs to stay! Emails are expected to be lowercase due to performance reasons.
+	 * This way we can skip the expensive casing change on the database.
+	 */
+	public function testSetValueMixedWithSettingsEmail(): void {
+		$userConfig = $this->generateUserConfig();
+
+		$edited = $userConfig->setValueMixed('user1', 'settings', 'email', 'mixed.CASE@Nextcloud.com');
+		$this->assertTrue($edited);
+
+		$actual = $userConfig->getValueMixed('user1', 'settings', 'email');
+		$this->assertEquals('mixed.case@nextcloud.com', $actual);
+	}
 
 	public static function providerSetValueString(): array {
 		return [

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [32, 0, 0, 0];
+$OC_Version = [32, 0, 0, 1];
 
 // The human-readable string
 $OC_VersionString = '32.0.0 dev';


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Ref: https://github.com/nextcloud/server/issues/50239#issuecomment-2988300363

## Summary

This fix was first implemented in https://github.com/nextcloud/server/pull/30197 but got lost.

**Before:** Mixed case emails (from LDAP) are saved as is in `oc_preferences`.
**After:** Mixed case emails are saved in lowercase in `oc_preferences`.

## TODO

- [x] Needs a migration of existing broken values

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
