### PR TITLE
feat(lexicon): events onSet() and initialize()

### DIFF
--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -19,6 +19,7 @@ return array(
     'OCA\\Settings\\Command\\AdminDelegation\\Add' => $baseDir . '/../lib/Command/AdminDelegation/Add.php',
     'OCA\\Settings\\Command\\AdminDelegation\\Remove' => $baseDir . '/../lib/Command/AdminDelegation/Remove.php',
     'OCA\\Settings\\Command\\AdminDelegation\\Show' => $baseDir . '/../lib/Command/AdminDelegation/Show.php',
+    'OCA\\Settings\\ConfigLexicon' => $baseDir . '/../lib/ConfigLexicon.php',
     'OCA\\Settings\\Controller\\AISettingsController' => $baseDir . '/../lib/Controller/AISettingsController.php',
     'OCA\\Settings\\Controller\\AdminSettingsController' => $baseDir . '/../lib/Controller/AdminSettingsController.php',
     'OCA\\Settings\\Controller\\AppSettingsController' => $baseDir . '/../lib/Controller/AppSettingsController.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -34,6 +34,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\Command\\AdminDelegation\\Add' => __DIR__ . '/..' . '/../lib/Command/AdminDelegation/Add.php',
         'OCA\\Settings\\Command\\AdminDelegation\\Remove' => __DIR__ . '/..' . '/../lib/Command/AdminDelegation/Remove.php',
         'OCA\\Settings\\Command\\AdminDelegation\\Show' => __DIR__ . '/..' . '/../lib/Command/AdminDelegation/Show.php',
+        'OCA\\Settings\\ConfigLexicon' => __DIR__ . '/..' . '/../lib/ConfigLexicon.php',
         'OCA\\Settings\\Controller\\AISettingsController' => __DIR__ . '/..' . '/../lib/Controller/AISettingsController.php',
         'OCA\\Settings\\Controller\\AdminSettingsController' => __DIR__ . '/..' . '/../lib/Controller/AdminSettingsController.php',
         'OCA\\Settings\\Controller\\AppSettingsController' => __DIR__ . '/..' . '/../lib/Controller/AppSettingsController.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -12,6 +12,7 @@ use OC\AppFramework\Utility\TimeFactory;
 use OC\Authentication\Events\AppPasswordCreatedEvent;
 use OC\Authentication\Token\IProvider;
 use OC\Server;
+use OCA\Settings\ConfigLexicon;
 use OCA\Settings\Hooks;
 use OCA\Settings\Listener\AppPasswordCreatedActivityListener;
 use OCA\Settings\Listener\GroupRemovedListener;
@@ -128,6 +129,9 @@ class Application extends App implements IBootstrap {
 
 		// Register Settings Form(s)
 		$context->registerDeclarativeSettings(MailProvider::class);
+
+		// Register Config Lexicon
+		$context->registerConfigLexicon(ConfigLexicon::class);
 
 		/**
 		 * Core class wrappers

--- a/apps/settings/lib/ConfigLexicon.php
+++ b/apps/settings/lib/ConfigLexicon.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings;
+
+use NCU\Config\Lexicon\ConfigLexiconEntry;
+use NCU\Config\Lexicon\ConfigLexiconStrictness;
+use NCU\Config\Lexicon\IConfigLexicon;
+use NCU\Config\ValueType;
+
+/**
+ * ConfigLexicon for 'settings' app/user configs
+ */
+class ConfigLexicon implements IConfigLexicon {
+	public function getStrictness(): ConfigLexiconStrictness {
+		return ConfigLexiconStrictness::IGNORE;
+	}
+
+	/**
+	 * @inheritDoc
+	 * @return ConfigLexiconEntry[]
+	 */
+	public function getAppConfigs(): array {
+		return [
+		];
+	}
+
+	/**
+	 * @inheritDoc
+	 * @return ConfigLexiconEntry[]
+	 */
+	public function getUserConfigs(): array {
+		return [
+			(new ConfigLexiconEntry('email', ValueType::STRING, '', 'email'))->onSet(function (string &$value): void { $value = strtolower($value); }),
+		];
+	}
+}

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -470,13 +470,6 @@ class AppConfig implements IAppConfig {
 		} elseif (isset($this->fastCache[$app][$key])) {
 			$value = $this->fastCache[$app][$key];
 		} else {
-			// unknown value, might want to execute something instead of just returning default.
-			// default value will be stored in database, unless false is returned
-			if (($lexiconEntry?->executeOnInit() !== null)
-				&& $lexiconEntry->executeOnInit()($default) !== false) {
-				$this->setTypedValue($app, $key, $default, $lazy, $type);
-			}
-
 			return $default;
 		}
 

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -754,13 +754,6 @@ class UserConfig implements IUserConfig {
 		} elseif (isset($this->fastCache[$userId][$app][$key])) {
 			$value = $this->fastCache[$userId][$app][$key];
 		} else {
-			// unknown value, might want to execute something instead of just returning default.
-			// default value will be stored in database, unless false is returned
-			if (($lexiconEntry?->executeOnInit() !== null)
-				&& $lexiconEntry->executeOnInit()($default) !== false) {
-				$this->setTypedValue($userId, $app, $key, $default, $lazy, 0, $type);
-			}
-
 			return $default;
 		}
 

--- a/lib/unstable/Config/Lexicon/ConfigLexiconEntry.php
+++ b/lib/unstable/Config/Lexicon/ConfigLexiconEntry.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace NCU\Config\Lexicon;
 
+use Closure;
 use NCU\Config\ValueType;
 
 /**
@@ -22,6 +23,8 @@ class ConfigLexiconEntry {
 
 	private string $definition = '';
 	private ?string $default = null;
+	private ?Closure $initialize = null;
+	private ?Closure $onSet = null;
 
 	/**
 	 * @param string $key config key
@@ -134,6 +137,48 @@ class ConfigLexiconEntry {
 		}
 
 		return $this->default;
+	}
+
+	/**
+	 * set a closure to be executed when reading a non-set config value
+	 * first param of the closure is the default value of the config key.
+	 *
+	 * @experimental 32.0.0
+	 */
+	public function initialize(Closure $closure): self {
+		$this->initialize = $closure;
+		return $this;
+	}
+
+	/**
+	 * returns if something needs to be executed when reading a non-set config value
+	 *
+	 * @return Closure|null NULL if nothing is supposed to happens
+	 * @experimental 32.0.0
+	 */
+	public function executeOnInit(): ?Closure {
+		return $this->initialize;
+	}
+
+	/**
+	 * set a closure to be executed when setting a value to this config key
+	 * first param of the closure is future value.
+	 *
+	 * @experimental 32.0.0
+	 */
+	public function onSet(Closure $closure): self {
+		$this->onSet = $closure;
+		return $this;
+	}
+
+	/**
+	 * returns if something needs to be executed when writing a new value
+	 *
+	 * @return Closure|null NULL if nothing is supposed to happens
+	 * @experimental 32.0.0
+	 */
+	public function executeOnSet(): ?Closure {
+		return $this->onSet;
 	}
 
 	/**

--- a/lib/unstable/Config/Lexicon/ConfigLexiconEntry.php
+++ b/lib/unstable/Config/Lexicon/ConfigLexiconEntry.php
@@ -23,7 +23,6 @@ class ConfigLexiconEntry {
 
 	private string $definition = '';
 	private ?string $default = null;
-	private ?Closure $initialize = null;
 	private ?Closure $onSet = null;
 
 	/**
@@ -137,27 +136,6 @@ class ConfigLexiconEntry {
 		}
 
 		return $this->default;
-	}
-
-	/**
-	 * set a closure to be executed when reading a non-set config value
-	 * first param of the closure is the default value of the config key.
-	 *
-	 * @experimental 32.0.0
-	 */
-	public function initialize(Closure $closure): self {
-		$this->initialize = $closure;
-		return $this;
-	}
-
-	/**
-	 * returns if something needs to be executed when reading a non-set config value
-	 *
-	 * @return Closure|null NULL if nothing is supposed to happens
-	 * @experimental 32.0.0
-	 */
-	public function executeOnInit(): ?Closure {
-		return $this->initialize;
 	}
 
 	/**

--- a/tests/lib/Config/LexiconTest.php
+++ b/tests/lib/Config/LexiconTest.php
@@ -203,4 +203,33 @@ class LexiconTest extends TestCase {
 		$this->configManager->migrateConfigLexiconKeys(TestConfigLexicon_I::APPID);
 		$this->assertSame(false, $this->appConfig->getValueBool(TestConfigLexicon_I::APPID, 'key4'));
 	}
+
+	public function testAppConfigOnSetEdit() {
+		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'key5', 42);
+		$this->assertSame(52, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'key5'));
+	}
+
+	public function testAppConfigOnSetIgnore() {
+		$this->appConfig->setValueInt(TestConfigLexicon_I::APPID, 'key5', 142);
+		$this->assertSame(12, $this->appConfig->getValueInt(TestConfigLexicon_I::APPID, 'key5'));
+	}
+
+	public function testUserConfigOnSetEdit() {
+		$this->userConfig->setValueInt('user1', TestConfigLexicon_I::APPID, 'key5', 42);
+		$this->assertSame(32, $this->userConfig->getValueInt('user1', TestConfigLexicon_I::APPID, 'key5'));
+	}
+
+	public function testUserConfigOnSetIgnore() {
+		$this->userConfig->setValueInt('user1', TestConfigLexicon_I::APPID, 'key5', 142);
+		$this->assertSame(12, $this->userConfig->getValueInt('user1', TestConfigLexicon_I::APPID, 'key5'));
+	}
+
+	public function testAppConfigInitialize() {
+		$this->assertSame('random_string', $this->appConfig->getValueString(TestConfigLexicon_I::APPID, 'key6'));
+	}
+
+	public function testUserConfigInitialize() {
+		$this->assertSame('random_string', $this->userConfig->getValueString('user1', TestConfigLexicon_I::APPID, 'key6'));
+	}
+
 }

--- a/tests/lib/Config/LexiconTest.php
+++ b/tests/lib/Config/LexiconTest.php
@@ -223,13 +223,4 @@ class LexiconTest extends TestCase {
 		$this->userConfig->setValueInt('user1', TestConfigLexicon_I::APPID, 'key5', 142);
 		$this->assertSame(12, $this->userConfig->getValueInt('user1', TestConfigLexicon_I::APPID, 'key5'));
 	}
-
-	public function testAppConfigInitialize() {
-		$this->assertSame('random_string', $this->appConfig->getValueString(TestConfigLexicon_I::APPID, 'key6'));
-	}
-
-	public function testUserConfigInitialize() {
-		$this->assertSame('random_string', $this->userConfig->getValueString('user1', TestConfigLexicon_I::APPID, 'key6'));
-	}
-
 }

--- a/tests/lib/Config/TestConfigLexicon_I.php
+++ b/tests/lib/Config/TestConfigLexicon_I.php
@@ -42,16 +42,6 @@ class TestConfigLexicon_I implements IConfigLexicon {
 					return true;
 				}
 			),
-			(new ConfigLexiconEntry('key6', ValueType::STRING, '', 'test key'))->initialize(
-				function (string &$d): void {
-					$d = 'random_string';
-				}
-			),
-			(new ConfigLexiconEntry('key6', ValueType::STRING, '', 'test key'))->initialize(
-				function (string &$d): void {
-					$d = 'random_string';
-				}
-			),
 			(new ConfigLexiconEntry('email', ValueType::STRING, '', 'email'))->onSet(
 				function (string &$value): void {
 					$value = strtolower($value);
@@ -73,11 +63,6 @@ class TestConfigLexicon_I implements IConfigLexicon {
 					$v = (string)($i - 10);
 
 					return true;
-				}
-			),
-			(new ConfigLexiconEntry('key6', ValueType::STRING, '', 'test key'))->initialize(
-				function (string &$d): void {
-					$d = 'random_string';
 				}
 			),
 		];

--- a/tests/lib/Config/TestConfigLexicon_I.php
+++ b/tests/lib/Config/TestConfigLexicon_I.php
@@ -27,14 +27,59 @@ class TestConfigLexicon_I implements IConfigLexicon {
 			new ConfigLexiconEntry('key1', ValueType::STRING, 'abcde', 'test key', true, IAppConfig::FLAG_SENSITIVE),
 			new ConfigLexiconEntry('key2', ValueType::INT, 12345, 'test key', false),
 			new ConfigLexiconEntry('key3', ValueType::INT, 12345, 'test key', true, rename: 'old_key3'),
-			new ConfigLexiconEntry('key4', ValueType::BOOL, 12345, 'test key', true, rename: 'old_key4', options: ConfigLexiconEntry::RENAME_INVERT_BOOLEAN),
+			new ConfigLexiconEntry(
+				'key4', ValueType::BOOL, 12345, 'test key', true, rename: 'old_key4',
+				options: ConfigLexiconEntry::RENAME_INVERT_BOOLEAN
+			),
+			(new ConfigLexiconEntry('key5', ValueType::INT, 12, 'test key', true))->onSet(
+				function (string &$v): bool {
+					$i = (int)$v;
+					if ($i > 100) {
+						return false;
+					}
+					$v = (string)($i + 10);
+
+					return true;
+				}
+			),
+			(new ConfigLexiconEntry('key6', ValueType::STRING, '', 'test key'))->initialize(
+				function (string &$d): void {
+					$d = 'random_string';
+				}
+			),
+			(new ConfigLexiconEntry('key6', ValueType::STRING, '', 'test key'))->initialize(
+				function (string &$d): void {
+					$d = 'random_string';
+				}
+			),
+			(new ConfigLexiconEntry('email', ValueType::STRING, '', 'email'))->onSet(
+				function (string &$value): void {
+					$value = strtolower($value);
+				}
+			),
 		];
 	}
 
 	public function getUserConfigs(): array {
 		return [
 			new ConfigLexiconEntry('key1', ValueType::STRING, 'abcde', 'test key', true, IUserConfig::FLAG_SENSITIVE),
-			new ConfigLexiconEntry('key2', ValueType::INT, 12345, 'test key', false)
+			new ConfigLexiconEntry('key2', ValueType::INT, 12345, 'test key', false),
+			(new ConfigLexiconEntry('key5', ValueType::INT, 12, 'test key', true))->onSet(
+				function (string &$v): bool {
+					$i = (int)$v;
+					if ($i > 100) {
+						return false;
+					}
+					$v = (string)($i - 10);
+
+					return true;
+				}
+			),
+			(new ConfigLexiconEntry('key6', ValueType::STRING, '', 'test key'))->initialize(
+				function (string &$d): void {
+					$d = 'random_string';
+				}
+			),
 		];
 	}
 


### PR DESCRIPTION
adding events when working on config keys

- add `onSet()` which is executed when a new value is set for this config key. Can be used to modify the new value before being stored into database, or to cancel the process if the new value is considered invalid (by returning _false_):
 
```
(new ConfigLexiconEntry('email', ValueType::STRING, '', 'email'))->onSet(
				function (string &$value): void {
					$value = strtolower($value);
				}
			),
```

```
(new ConfigLexiconEntry('email', ValueType::STRING, '', 'email'))->onSet(
				function (string &$value): bool {
					return ((int)$value > 100);
				}
			),
```

- ~~add `initialize()` which is executed when reading a config key that has no known value. Can be used to fill the value at first read, unless the closure returns _false_~~

<details>
  <summary>not in this PR anymore</summary>
```
(new ConfigLexiconEntry('email', ValueType::STRING, '', 'email'))->initialize(
				function (string &$value): void {
					$value = $this->secureRandom->generate(5, 'abcdefghijklmnopqrstuvwxyz0123456789');
				}
			),	
```
</details>

`initialize()` has been removed, will be prep in a separated PR and forgotten until it needs to be added in the future!

