### PR TITLE
fix(caldav): Use parameter for query to neutralize it in query diffs

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -2986,7 +2986,7 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 					'calendarid' => $query->createNamedParameter($calendarId),
 					'operation' => $query->createNamedParameter($operation),
 					'calendartype' => $query->createNamedParameter($calendarType),
-					'created_at' => time(),
+					'created_at' => $query->createNamedParameter(time()),
 				]);
 			foreach ($objectUris as $uri) {
 				$query->setParameter('uri', $uri);


### PR DESCRIPTION
Comparing the triggered queries from 2 exactly same requests:
## Before
```diff
- primary  2 INSERT INTO "oc_calendarchanges" ("uri", "synctoken", "calendarid", "operation", "calendartype", "created_at") VALUES(:uri, :dcValue1, :dcValue2, :dcValue3, :dcValue4, 1750427906)
+ primary  2 INSERT INTO "oc_calendarchanges" ("uri", "synctoken", "calendarid", "operation", "calendartype", "created_at") VALUES(:uri, :dcValue1, :dcValue2, :dcValue3, :dcValue4, 1750428016)
```
## After
```diff
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
