### PR TITLE
Feature/53428 auto create collection on upload

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -395,6 +395,7 @@ return array(
     'OCA\\DAV\\Upload\\FutureFile' => $baseDir . '/../lib/Upload/FutureFile.php',
     'OCA\\DAV\\Upload\\PartFile' => $baseDir . '/../lib/Upload/PartFile.php',
     'OCA\\DAV\\Upload\\RootCollection' => $baseDir . '/../lib/Upload/RootCollection.php',
+    'OCA\\DAV\\Upload\\UploadAutoMkcolPlugin' => $baseDir . '/../lib/Upload/UploadAutoMkcolPlugin.php',
     'OCA\\DAV\\Upload\\UploadFile' => $baseDir . '/../lib/Upload/UploadFile.php',
     'OCA\\DAV\\Upload\\UploadFolder' => $baseDir . '/../lib/Upload/UploadFolder.php',
     'OCA\\DAV\\Upload\\UploadHome' => $baseDir . '/../lib/Upload/UploadHome.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -410,6 +410,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Upload\\FutureFile' => __DIR__ . '/..' . '/../lib/Upload/FutureFile.php',
         'OCA\\DAV\\Upload\\PartFile' => __DIR__ . '/..' . '/../lib/Upload/PartFile.php',
         'OCA\\DAV\\Upload\\RootCollection' => __DIR__ . '/..' . '/../lib/Upload/RootCollection.php',
+        'OCA\\DAV\\Upload\\UploadAutoMkcolPlugin' => __DIR__ . '/..' . '/../lib/Upload/UploadAutoMkcolPlugin.php',
         'OCA\\DAV\\Upload\\UploadFile' => __DIR__ . '/..' . '/../lib/Upload/UploadFile.php',
         'OCA\\DAV\\Upload\\UploadFolder' => __DIR__ . '/..' . '/../lib/Upload/UploadFolder.php',
         'OCA\\DAV\\Upload\\UploadHome' => __DIR__ . '/..' . '/../lib/Upload/UploadHome.php',

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -63,6 +63,7 @@ use OCA\DAV\Provisioning\Apple\AppleProvisioningPlugin;
 use OCA\DAV\SystemTag\SystemTagPlugin;
 use OCA\DAV\Upload\ChunkingPlugin;
 use OCA\DAV\Upload\ChunkingV2Plugin;
+use OCA\DAV\Upload\UploadAutoMkcolPlugin;
 use OCA\Theming\ThemingDefaults;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
@@ -232,6 +233,7 @@ class Server {
 
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 		$this->server->addPlugin(new RequestIdHeaderPlugin(\OCP\Server::get(IRequest::class)));
+		$this->server->addPlugin(new UploadAutoMkcolPlugin());
 		$this->server->addPlugin(new ChunkingV2Plugin(\OCP\Server::get(ICacheFactory::class)));
 		$this->server->addPlugin(new ChunkingPlugin());
 		$this->server->addPlugin(new ZipFolderPlugin(

--- a/apps/dav/lib/Upload/UploadAutoMkcolPlugin.php
+++ b/apps/dav/lib/Upload/UploadAutoMkcolPlugin.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Upload;
+
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use function Sabre\Uri\split as uriSplit;
+
+/**
+ * Class that allows automatically creating non-existing collections on file
+ * upload.
+ *
+ * Since this functionality is not WebDAV compliant, it needs a special
+ * header to be activated.
+ */
+class UploadAutoMkcolPlugin extends ServerPlugin {
+
+	private Server $server;
+
+	public function initialize(Server $server): void {
+		$server->on('beforeMethod:PUT', [$this, 'beforeMethod']);
+		$this->server = $server;
+	}
+
+	/**
+	 * @throws NotFound a node  expected to exist cannot be found
+	 */
+	public function beforeMethod(RequestInterface $request, ResponseInterface $response): bool {
+		if ($request->getHeader('X-NC-WebDAV-Auto-Mkcol') !== '1') {
+			return true;
+		}
+
+		[$path,] = uriSplit($request->getPath());
+
+		if ($this->server->tree->nodeExists($path)) {
+			return true;
+		}
+
+		$parts = explode('/', trim($path, '/'));
+		$rootPath = array_shift($parts);
+		$node = $this->server->tree->getNodeForPath('/' . $rootPath);
+
+		if (!($node instanceof ICollection)) {
+			// the root node is not a collection, let SabreDAV handle it
+			return true;
+		}
+
+		foreach ($parts as $part) {
+			if (!$node->childExists($part)) {
+				$node->createDirectory($part);
+			}
+
+			$node = $node->getChild($part);
+		}
+
+		return true;
+	}
+}

--- a/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
+++ b/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Tests\unit\Upload;
+
+use Generator;
+use OCA\DAV\Upload\UploadAutoMkcolPlugin;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\ICollection;
+use Sabre\DAV\INode;
+use Sabre\DAV\Server;
+use Sabre\DAV\Tree;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Test\TestCase;
+
+class UploadAutoMkcolPluginTest extends TestCase {
+
+	private Tree&MockObject $tree;
+	private RequestInterface&MockObject $request;
+	private ResponseInterface&MockObject $response;
+
+	public static function dataMissingHeaderShouldReturnTrue(): Generator {
+		yield 'missing X-NC-WebDAV-Auto-Mkcol header' => [null];
+		yield 'empty X-NC-WebDAV-Auto-Mkcol header' => [''];
+		yield 'invalid X-NC-WebDAV-Auto-Mkcol header' => ['enable'];
+	}
+
+	public function testBeforeMethodWithRootNodeNotAnICollectionShouldReturnTrue(): void {
+		$this->request->method('getHeader')->willReturn('1');
+		$this->request->expects(self::once())
+			->method('getPath')
+			->willReturn('/non-relevant/path.txt');
+		$this->tree->expects(self::once())
+			->method('nodeExists')
+			->with('/non-relevant')
+			->willReturn(false);
+
+		$mockNode = $this->getMockBuilder(INode::class);
+		$this->tree->expects(self::once())
+			->method('getNodeForPath')
+			->willReturn($mockNode);
+
+		$return = $this->plugin->beforeMethod($this->request, $this->response);
+		$this->assertTrue($return);
+	}
+
+	/**
+	 * @dataProvider dataMissingHeaderShouldReturnTrue
+	 */
+	public function testBeforeMethodWithMissingHeaderShouldReturnTrue(?string $header): void {
+		$this->request->expects(self::once())
+			->method('getHeader')
+			->with('X-NC-WebDAV-Auto-Mkcol')
+			->willReturn($header);
+
+		$this->request->expects(self::never())
+			->method('getPath');
+
+		$return = $this->plugin->beforeMethod($this->request, $this->response);
+		self::assertTrue($return);
+	}
+
+	public function testBeforeMethodWithExistingPathShouldReturnTrue(): void {
+		$this->request->method('getHeader')->willReturn('1');
+		$this->request->expects(self::once())
+			->method('getPath')
+			->willReturn('/files/user/deep/image.jpg');
+		$this->tree->expects(self::once())
+			->method('nodeExists')
+			->with('/files/user/deep')
+			->willReturn(true);
+
+		$this->tree->expects(self::never())
+			->method('getNodeForPath');
+
+		$return = $this->plugin->beforeMethod($this->request, $this->response);
+		self::assertTrue($return);
+	}
+
+	public function testBeforeMethodShouldSucceed(): void {
+		$this->request->method('getHeader')->willReturn('1');
+		$this->request->expects(self::once())
+			->method('getPath')
+			->willReturn('/files/user/my/deep/path/image.jpg');
+		$this->tree->expects(self::once())
+			->method('nodeExists')
+			->with('/files/user/my/deep/path')
+			->willReturn(false);
+
+		$mockNode = $this->createMock(ICollection::class);
+		$this->tree->expects(self::once())
+			->method('getNodeForPath')
+			->with('/files')
+			->willReturn($mockNode);
+		$mockNode->expects(self::exactly(4))
+			->method('childExists')
+			->willReturnMap([
+				['user', true],
+				['my', true],
+				['deep', false],
+				['path', false],
+			]);
+		$mockNode->expects(self::exactly(2))
+			->method('createDirectory');
+		$mockNode->expects(self::exactly(4))
+			->method('getChild')
+			->willReturn($mockNode);
+
+		$return = $this->plugin->beforeMethod($this->request, $this->response);
+		self::assertTrue($return);
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$server = $this->createMock(Server::class);
+		$this->tree = $this->createMock(Tree::class);
+
+		$server->tree = $this->tree;
+		$this->plugin = new UploadAutoMkcolPlugin();
+
+		$this->request = $this->createMock(RequestInterface::class);
+		$this->response = $this->createMock(ResponseInterface::class);
+		$server->httpRequest = $this->request;
+		$server->httpResponse = $this->response;
+
+		$this->plugin->initialize($server);
+	}
+}


### PR DESCRIPTION
* Resolves: #53428

## Summary

This PR adds the ability for clients to ask the WebDAV server to create nested directories while uploading files if they don't exist.

**NOTE:** this functionality is not WebDAV compliant. For this reason, to enable this behaviour the header `X-Create-Tree: enable` must be sent within the PUT request that uploads the file.

## TODO

- [x] Add documentation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
  - [x] https://github.com/nextcloud/documentation/pull/13303
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
