### PR TITLE
[stable30] fix: adjust translation placeholders to fix translation sq…

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -2939,18 +2939,16 @@
 								// TODO: 409 means current folder does not exist, redirect ?
 								if (status === 404) {
 									// source not found, so remove it from the list
-									OC.Notification.show(t('files', 'Could not rename "{fileName}", it does not exist any more',
-										{fileName: oldName}), {timeout: 7, type: 'error'}
-									);
+									OC.Notification.show(t('files', 'Could not rename "{oldName}", it does not exist any more', { oldName }), {timeout: 7, type: 'error'});
 
 									self.remove(newName, {updateSummary: true});
 									return;
 								} else if (status === 412) {
 									// target exists
 									OC.Notification.show(
-										t('files', 'The name "{targetName}" is already used in the folder "{dir}". Please choose a different name.',
+										t('files', 'The name "{newName}" is already used in the folder "{dir}". Please choose a different name.',
 										{
-											targetName: newName,
+											newName,
 											dir: self.getCurrentDirectory(),
 										}),
 										{
@@ -2959,9 +2957,7 @@
 									);
 								} else {
 									// restore the item to its previous state
-									OC.Notification.show(t('files', 'Could not rename "{fileName}"',
-										{fileName: oldName}), {type: 'error'}
-									);
+									OC.Notification.show(t('files', 'Could not rename "{oldName}"', { oldName }), { type: 'error' });
 								}
 								updateInList(oldFileInfo);
 							});


### PR DESCRIPTION
* Resolves: Client Ticket

## Summary
- Adjusted translation place holders to match, as the same string with two different place holders will not be handled properly by transifex

![image](https://github.com/user-attachments/assets/381bac7e-fbe4-4ca8-ab83-e347010fb2d5)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
