### PR TITLE
feat(previews): allow ffmpeg to connect direct for AWS S3 buckets

### DIFF
--- a/apps/files_external/lib/Lib/Backend/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Backend/AmazonS3.php
@@ -28,6 +28,8 @@ class AmazonS3 extends Backend {
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('port', $l->t('Port')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
+				(new DefinitionParameter('proxy', $l->t('Proxy')))
+					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('region', $l->t('Region')))
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),
 				(new DefinitionParameter('storageClass', $l->t('Storage Class')))
@@ -42,6 +44,9 @@ class AmazonS3 extends Backend {
 				(new DefinitionParameter('useMultipartCopy', $l->t('Enable multipart copy')))
 					->setType(DefinitionParameter::VALUE_BOOLEAN)
 					->setDefaultValue(true),
+				(new DefinitionParameter('use_presigned_url', $l->t('Use presigned S3 url')))
+					->setType(DefinitionParameter::VALUE_BOOLEAN)
+					->setDefaultValue(false),
 				(new DefinitionParameter('sse_c_key', $l->t('SSE-C encryption key')))
 					->setType(DefinitionParameter::VALUE_PASSWORD)
 					->setFlag(DefinitionParameter::FLAG_OPTIONAL),

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -23,6 +23,7 @@ use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\ITempManager;
 use OCP\Server;
+use Override;
 use Psr\Log\LoggerInterface;
 
 class AmazonS3 extends Common {
@@ -761,34 +762,43 @@ class AmazonS3 extends Common {
 		return $size;
 	}
 
-	/**
-	 * Generates and returns a presigned URL that expires after set duration
-	 *
-	 */
+	#[Override]
 	public function getDirectDownload(string $path): array|false {
+		if (!$this->isUsePresignedUrl()) {
+			return false;
+		}
+
 		$command = $this->getConnection()->getCommand('GetObject', [
 			'Bucket' => $this->bucket,
 			'Key' => $path,
 		]);
-		$duration = '+10 minutes';
-		$expiration = new \DateTime();
-		$expiration->modify($duration);
+		$expiration = new \DateTimeImmutable('+60 minutes');
 
-		// generate a presigned URL that expires after $duration time
-		$request = $this->getConnection()->createPresignedRequest($command, $duration, []);
 		try {
-			$presignedUrl = (string)$request->getUri();
+			// generate a presigned URL that expires after $expiration time
+			$presignedUrl = (string)$this->getConnection()->createPresignedRequest($command, $expiration, [
+				'signPayload' => true,
+			])->getUri();
 		} catch (S3Exception $exception) {
 			$this->logger->error($exception->getMessage(), [
 				'app' => 'files_external',
 				'exception' => $exception,
 			]);
+			return false;
 		}
-		$result = [
+		return [
 			'url' => $presignedUrl,
-			'presigned' => true,
-			'expiration' => $expiration,
+			'expiration' => $expiration->getTimestamp(),
 		];
-		return $result;
+	}
+
+	#[Override]
+	public function getDirectDownloadById(string $fileId): array|false {
+		if (!$this->isUsePresignedUrl()) {
+			return false;
+		}
+
+		$entry = $this->getCache()->get((int)$fileId);
+		return $this->getDirectDownload($entry->getPath());
 	}
 }

--- a/apps/files_external/lib/Lib/Storage/AmazonS3.php
+++ b/apps/files_external/lib/Lib/Storage/AmazonS3.php
@@ -760,4 +760,35 @@ class AmazonS3 extends Common {
 
 		return $size;
 	}
+
+	/**
+	 * Generates and returns a presigned URL that expires after set duration
+	 *
+	 */
+	public function getDirectDownload(string $path): array|false {
+		$command = $this->getConnection()->getCommand('GetObject', [
+			'Bucket' => $this->bucket,
+			'Key' => $path,
+		]);
+		$duration = '+10 minutes';
+		$expiration = new \DateTime();
+		$expiration->modify($duration);
+
+		// generate a presigned URL that expires after $duration time
+		$request = $this->getConnection()->createPresignedRequest($command, $duration, []);
+		try {
+			$presignedUrl = (string)$request->getUri();
+		} catch (S3Exception $exception) {
+			$this->logger->error($exception->getMessage(), [
+				'app' => 'files_external',
+				'exception' => $exception,
+			]);
+		}
+		$result = [
+			'url' => $presignedUrl,
+			'presigned' => true,
+			'expiration' => $expiration,
+		];
+		return $result;
+	}
 }

--- a/lib/private/Files/ObjectStore/S3ObjectTrait.php
+++ b/lib/private/Files/ObjectStore/S3ObjectTrait.php
@@ -298,14 +298,14 @@ trait S3ObjectTrait {
 	}
 
 	public function preSignedUrl(string $urn, \DateTimeInterface $expiration): ?string {
+		if (!$this->isUsePresignedUrl()) {
+			return null;
+		}
+
 		$command = $this->getConnection()->getCommand('GetObject', [
 			'Bucket' => $this->getBucket(),
 			'Key' => $urn,
 		]);
-
-		if (!$this->isUsePresignedUrl()) {
-			return null;
-		}
 
 		try {
 			return (string)$this->getConnection()->createPresignedRequest($command, $expiration, [

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -43,21 +43,18 @@ class Movie extends ProviderV2 {
 	}
 
 	private function connectDirect(File $file): string|false {
-		if (stream_get_meta_data($file->fopen('r'))['seekable'] !== true) {
+		if ($file->isEncrypted()) {
 			return false;
 		}
 
 		// Checks for availability to access the video file directly via HTTP/HTTPS.
 		// Returns a string containing URL if available. Only implemented and tested
-		// with Amazon S3 currently.  In all other cases, return false. ffmpeg
+		// with Amazon S3 currently. In all other cases, return false. ffmpeg
 		// supports other protocols so this function may expand in the future.
-		$gddValues = $file->getStorage()->getDirectDownload($file->getName());
+		$gddValues = $file->getStorage()->getDirectDownloadById((string)$file->getId());
 
-		if (is_array($gddValues)) {
-			if (array_key_exists('url', $gddValues) && array_key_exists('presigned', $gddValues)) {
-				$directUrl = (str_starts_with($gddValues['url'], 'http') && ($gddValues['presigned'] === true)) ? $gddValues['url'] : false;
-				return $directUrl;
-			}
+		if (is_array($gddValues) && array_key_exists('url', $gddValues)) {
+			return str_starts_with($gddValues['url'], 'http') ? $gddValues['url'] : false;
 		}
 		return false;
 	}
@@ -81,7 +78,7 @@ class Movie extends ProviderV2 {
 
 		// If HTTP/HTTPS direct connect is not available or if the file is encrypted,
 		// process normally
-		if (($connectDirect === false) || $file->isEncrypted()) {
+		if ($connectDirect === false) {
 			// By default, download $sizeAttempts from the file along with
 			// the 'moov' atom.
 			// Example bitrates in the higher range:

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -42,6 +42,26 @@ class Movie extends ProviderV2 {
 		return is_string($this->binary);
 	}
 
+	private function connectDirect(File $file): string|false {
+		if (stream_get_meta_data($file->fopen('r'))['seekable'] !== true) {
+			return false;
+		}
+
+		// Checks for availability to access the video file directly via HTTP/HTTPS.
+		// Returns a string containing URL if available. Only implemented and tested
+		// with Amazon S3 currently.  In all other cases, return false. ffmpeg
+		// supports other protocols so this function may expand in the future.
+		$gddValues = $file->getStorage()->getDirectDownload($file->getName());
+
+		if (is_array($gddValues)) {
+			if (array_key_exists('url', $gddValues) && array_key_exists('presigned', $gddValues)) {
+				$directUrl = (str_starts_with($gddValues['url'], 'http') && ($gddValues['presigned'] === true)) ? $gddValues['url'] : false;
+				return $directUrl;
+			}
+		}
+		return false;
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -54,74 +74,87 @@ class Movie extends ProviderV2 {
 
 		$result = null;
 
+		$connectDirect = $this->connectDirect($file);
+
 		// Timestamps to make attempts to generate a still
 		$timeAttempts = [5, 1, 0];
 
-		// By default, download $sizeAttempts from the file along with
-		// the 'moov' atom.
-		// Example bitrates in the higher range:
-		// 4K HDR H265 60 FPS = 75 Mbps = 9 MB per second needed for a still
-		// 1080p H265 30 FPS = 10 Mbps = 1.25 MB per second needed for a still
-		// 1080p H264 30 FPS = 16 Mbps = 2 MB per second needed for a still
-		$sizeAttempts = [1024 * 1024 * 10];
+		// If HTTP/HTTPS direct connect is not available or if the file is encrypted,
+		// process normally
+		if (($connectDirect === false) || $file->isEncrypted()) {
+			// By default, download $sizeAttempts from the file along with
+			// the 'moov' atom.
+			// Example bitrates in the higher range:
+			// 4K HDR H265 60 FPS = 75 Mbps = 9 MB per second needed for a still
+			// 1080p H265 30 FPS = 10 Mbps = 1.25 MB per second needed for a still
+			// 1080p H264 30 FPS = 16 Mbps = 2 MB per second needed for a still
+			$sizeAttempts = [1024 * 1024 * 10];
 
-		if ($this->useTempFile($file)) {
-			if ($file->getStorage()->isLocal()) {
-				// Temp file required but file is local, so retrieve $sizeAttempt bytes first,
-				// and if it doesn't work, retrieve the entire file.
-				$sizeAttempts[] = null;
+			if ($this->useTempFile($file)) {
+				if ($file->getStorage()->isLocal()) {
+					// Temp file required but file is local, so retrieve $sizeAttempt bytes first,
+					// and if it doesn't work, retrieve the entire file.
+					$sizeAttempts[] = null;
+				}
+			} else {
+				// Temp file is not required and file is local so retrieve entire file.
+				$sizeAttempts = [null];
+			}
+
+			foreach ($sizeAttempts as $size) {
+				$absPath = false;
+				// File is remote, generate a sparse file
+				if (!$file->getStorage()->isLocal()) {
+					$absPath = $this->getSparseFile($file, $size);
+				}
+				// Defaults to existing routine if generating sparse file fails
+				if ($absPath === false) {
+					$absPath = $this->getLocalFile($file, $size);
+				}
+				if ($absPath === false) {
+					Server::get(LoggerInterface::class)->error(
+						'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
+						['app' => 'core']
+					);
+					return null;
+				}
+
+				// Attempt still image grabs from selected timestamps
+				foreach ($timeAttempts as $timeStamp) {
+					$result = $this->generateThumbNail($maxX, $maxY, $absPath, $timeStamp);
+					if ($result !== null) {
+						break;
+					}
+					Server::get(LoggerInterface::class)->debug(
+						'Movie preview generation attempt failed'
+							. ', file=' . $file->getPath()
+							. ', time=' . $timeStamp
+							. ', size=' . ($size ?? 'entire file'),
+						['app' => 'core']
+					);
+				}
+
+				$this->cleanTmpFiles();
+
+				if ($result !== null) {
+					Server::get(LoggerInterface::class)->debug(
+						'Movie preview generation attempt success'
+							. ', file=' . $file->getPath()
+							. ', time=' . $timeStamp
+							. ', size=' . ($size ?? 'entire file'),
+						['app' => 'core']
+					);
+					break;
+				}
 			}
 		} else {
-			// Temp file is not required and file is local so retrieve entire file.
-			$sizeAttempts = [null];
-		}
-
-		foreach ($sizeAttempts as $size) {
-			$absPath = false;
-			// File is remote, generate a sparse file
-			if (!$file->getStorage()->isLocal()) {
-				$absPath = $this->getSparseFile($file, $size);
-			}
-			// Defaults to existing routine if generating sparse file fails
-			if ($absPath === false) {
-				$absPath = $this->getLocalFile($file, $size);
-			}
-			if ($absPath === false) {
-				Server::get(LoggerInterface::class)->error(
-					'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
-					['app' => 'core']
-				);
-				return null;
-			}
-
-			// Attempt still image grabs from selected timestamps
+			// HTTP/HTTPS direct connect is available so pass the URL directly to ffmpeg
 			foreach ($timeAttempts as $timeStamp) {
-				$result = $this->generateThumbNail($maxX, $maxY, $absPath, $timeStamp);
+				$result = $this->generateThumbNail($maxX, $maxY, $connectDirect, $timeStamp);
 				if ($result !== null) {
 					break;
 				}
-				Server::get(LoggerInterface::class)->debug(
-					'Movie preview generation attempt failed'
-						. ', file=' . $file->getPath()
-						. ', time=' . $timeStamp
-						. ', size=' . ($size ?? 'entire file'),
-					['app' => 'core']
-				);
 			}
-
-			$this->cleanTmpFiles();
-
-			if ($result !== null) {
-				Server::get(LoggerInterface::class)->debug(
-					'Movie preview generation attempt success'
-						. ', file=' . $file->getPath()
-						. ', time=' . $timeStamp
-						. ', size=' . ($size ?? 'entire file'),
-					['app' => 'core']
-				);
-				break;
-			}
-
 		}
 		if ($result === null) {
 			Server::get(LoggerInterface::class)->error(
@@ -329,7 +362,6 @@ class Movie extends ProviderV2 {
 				return $image;
 			}
 		}
-
 
 		unlink($tmpPath);
 		return null;


### PR DESCRIPTION
* Resolves: #52079 

## Summary
Allow preview generation on AWS S3 buckets by creating a presigned URL for the file and then passing it directly to ffmpeg which is able to handle http/https already. It can locate the moov atom even if it's at the end of the video file and it does not need to retrieve the whole file to do it.

The presigned URL expires after 10 minute which should be more than enough for this purpose.

## TODO

- [ ] Need more testing.
- [ ] Open to suggestions, critiques, criticisms.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
