### PR TITLE
fix: throw a better error if we don't get an authorization header for security confirmation

### DIFF
--- a/lib/private/AppFramework/Middleware/Security/Exceptions/NotConfirmedException.php
+++ b/lib/private/AppFramework/Middleware/Security/Exceptions/NotConfirmedException.php
@@ -14,7 +14,7 @@ use OCP\AppFramework\Http;
  * @package OC\AppFramework\Middleware\Security\Exceptions
  */
 class NotConfirmedException extends SecurityException {
-	public function __construct() {
-		parent::__construct('Password confirmation is required', Http::STATUS_FORBIDDEN);
+	public function __construct(string $message = 'Password confirmation is required') {
+		parent::__construct($message, Http::STATUS_FORBIDDEN);
 	}
 }

--- a/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/Security/PasswordConfirmationMiddleware.php
@@ -79,6 +79,9 @@ class PasswordConfirmationMiddleware extends Middleware {
 
 		if ($this->isPasswordConfirmationStrict($reflectionMethod)) {
 			$authHeader = $this->request->getHeader('Authorization');
+			if (!str_starts_with(strtolower($authHeader), 'basic ')) {
+				throw new NotConfirmedException('Required authorization header missing');
+			}
 			[, $password] = explode(':', base64_decode(substr($authHeader, 6)), 2);
 			$loginName = $this->session->get('loginname');
 			$loginResult = $this->userManager->checkPassword($loginName, $password);


### PR DESCRIPTION
Improves the error message logged for cases like https://github.com/nextcloud/server/issues/53472