### PR TITLE
test: create new file with content when creating test files for versioning tests

### DIFF
--- a/apps/files_versions/tests/StorageTest.php
+++ b/apps/files_versions/tests/StorageTest.php
@@ -49,10 +49,10 @@ class StorageTest extends TestCase {
 	protected function createPastFile(string $path, int $mtime): void {
 		try {
 			$file = $this->userFolder->get($path);
+			$file->putContent((string)$mtime);
 		} catch (NotFoundException $e) {
-			$file = $this->userFolder->newFile($path);
+			$file = $this->userFolder->newFile($path, (string)$mtime);
 		}
-		$file->putContent((string)$mtime);
 		$file->touch($mtime);
 	}
 


### PR DESCRIPTION
https://github.com/nextcloud/server/pull/53462 caused creating an empty¹ file on s3 to create a version, messing with the versioning tests.

This removes the empty¹ file step in the tests.

1: s3 doesn't actually support empty files, so we create a 1 byte file instead