### PR TITLE
fix(files): Remove redundant setting

### DIFF
--- a/apps/files/src/views/Settings.vue
+++ b/apps/files/src/views/Settings.vue
@@ -34,12 +34,6 @@
 				@update:checked="setConfig('crop_image_previews', $event)">
 				{{ t('files', 'Crop image previews') }}
 			</NcCheckboxRadioSwitch>
-			<NcCheckboxRadioSwitch v-if="enableGridView"
-				data-cy-files-settings-setting="grid_view"
-				:checked="userConfig.grid_view"
-				@update:checked="setConfig('grid_view', $event)">
-				{{ t('files', 'Enable the grid view') }}
-			</NcCheckboxRadioSwitch>
 			<NcCheckboxRadioSwitch data-cy-files-settings-setting="folder_tree"
 				:checked="userConfig.folder_tree"
 				@update:checked="setConfig('folder_tree', $event)">


### PR DESCRIPTION
## Summary

This setting is already present in the main view, where it is much more visible, it is also the only one that is documented. Having it in both places is redundant and unnecessary clutter.

Please do tell me if there is a reason for this that I am not aware of.

## TODO

- [ ] Manual l10n changes may be needed?
- [ ] In general, more may be necessary, but I'm not sure, this is my first time trying to touch Nextcloud code, please be gentle.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
