### PR TITLE
[stable31] fix(admin_audit): Avoid crash when rename event fileid changes

### DIFF
--- a/apps/admin_audit/lib/Actions/Files.php
+++ b/apps/admin_audit/lib/Actions/Files.php
@@ -73,7 +73,7 @@ class Files extends Action {
 	public function afterRename(NodeRenamedEvent $event): void {
 		try {
 			$target = $event->getTarget();
-			$originalSource = $this->renamedNodes[$target->getId()];
+			$originalSource = $this->renamedNodes[$target->getId()] ?? $event->getSource();
 			$params = [
 				'newid' => $target->getId(),
 				'oldpath' => $originalSource->getPath(),


### PR DESCRIPTION
## Summary

This was fixed on master another way, but for stable31 we should still avoid the crash.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
