### PR TITLE
fix(encryption): Catch exceptions in encrypt-all command and continue

### DIFF
--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -249,7 +249,14 @@ class EncryptAll {
 		$target = $path . '.encrypted.' . time();
 
 		try {
-			$this->rootView->copy($source, $target);
+			$copySuccess = $this->rootView->copy($source, $target);
+			if ($copySuccess === false) {
+				/* Copy failed, abort */
+				if ($this->rootView->file_exists($target)) {
+					$this->rootView->unlink($target);
+				}
+				throw new \Exception('Copy failed for ' . $source);
+			}
 			$this->rootView->rename($target, $source);
 		} catch (DecryptionFailedException $e) {
 			if ($this->rootView->file_exists($target)) {

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -23,6 +23,7 @@ use OCP\Mail\IMailer;
 use OCP\Security\ISecureRandom;
 use OCP\UserInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Helper\QuestionHelper;
@@ -46,6 +47,7 @@ class EncryptAllTest extends TestCase {
 	protected \Symfony\Component\Console\Output\OutputInterface&MockObject $outputInterface;
 	protected UserInterface&MockObject $userInterface;
 	protected ISecureRandom&MockObject $secureRandom;
+	protected LoggerInterface&MockObject $logger;
 
 	protected EncryptAll $encryptAll;
 
@@ -76,6 +78,7 @@ class EncryptAllTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->userInterface = $this->getMockBuilder(UserInterface::class)
 			->disableOriginalConstructor()->getMock();
+		$this->logger = $this->createMock(LoggerInterface::class);
 
 		/**
 		 * We need format method to return a string
@@ -106,12 +109,13 @@ class EncryptAllTest extends TestCase {
 			$this->l,
 			$this->l10nFactory,
 			$this->questionHelper,
-			$this->secureRandom
+			$this->secureRandom,
+			$this->logger,
 		);
 	}
 
 	public function testEncryptAll(): void {
-		/** @var EncryptAll | \PHPUnit\Framework\MockObject\MockObject  $encryptAll */
+		/** @var EncryptAll&MockObject $encryptAll */
 		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
@@ -125,7 +129,8 @@ class EncryptAllTest extends TestCase {
 					$this->l,
 					$this->l10nFactory,
 					$this->questionHelper,
-					$this->secureRandom
+					$this->secureRandom,
+					$this->logger,
 				]
 			)
 			->onlyMethods(['createKeyPairs', 'encryptAllUsersFiles', 'outputPasswords'])
@@ -140,7 +145,7 @@ class EncryptAllTest extends TestCase {
 	}
 
 	public function testEncryptAllWithMasterKey(): void {
-		/** @var EncryptAll | \PHPUnit\Framework\MockObject\MockObject  $encryptAll */
+		/** @var EncryptAll&MockObject $encryptAll */
 		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
@@ -154,7 +159,8 @@ class EncryptAllTest extends TestCase {
 					$this->l,
 					$this->l10nFactory,
 					$this->questionHelper,
-					$this->secureRandom
+					$this->secureRandom,
+					$this->logger,
 				]
 			)
 			->onlyMethods(['createKeyPairs', 'encryptAllUsersFiles', 'outputPasswords'])
@@ -170,7 +176,7 @@ class EncryptAllTest extends TestCase {
 	}
 
 	public function testCreateKeyPairs(): void {
-		/** @var EncryptAll | \PHPUnit\Framework\MockObject\MockObject  $encryptAll */
+		/** @var EncryptAll&MockObject $encryptAll */
 		$encryptAll = $this->getMockBuilder(EncryptAll::class)
 			->setConstructorArgs(
 				[
@@ -184,7 +190,8 @@ class EncryptAllTest extends TestCase {
 					$this->l,
 					$this->l10nFactory,
 					$this->questionHelper,
-					$this->secureRandom
+					$this->secureRandom,
+					$this->logger,
 				]
 			)
 			->onlyMethods(['setupUserFS', 'generateOneTimePassword'])
@@ -234,7 +241,8 @@ class EncryptAllTest extends TestCase {
 					$this->l,
 					$this->l10nFactory,
 					$this->questionHelper,
-					$this->secureRandom
+					$this->secureRandom,
+					$this->logger,
 				]
 			)
 			->onlyMethods(['encryptUsersFiles'])
@@ -275,7 +283,8 @@ class EncryptAllTest extends TestCase {
 					$this->l,
 					$this->l10nFactory,
 					$this->questionHelper,
-					$this->secureRandom
+					$this->secureRandom,
+					$this->logger,
 				]
 			)
 			->onlyMethods(['encryptFile', 'setupUserFS'])


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

`encryption:encrypt-all` sometimes run into exception, for instance if a file is locked.
Log the exception and continue instead of crashing.
Also add better handling for fopen failures in the Encryption wrapper.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
