### PR TITLE
feat(occ): Add commands to list all routes and match a single one

### DIFF
--- a/core/Command/Router/ListRoutes.php
+++ b/core/Command/Router/ListRoutes.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Command\Router;
+
+use OC\Core\Command\Base;
+use OC\Route\Router;
+use OCP\App\AppPathNotFoundException;
+use OCP\App\IAppManager;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListRoutes extends Base {
+
+	public function __construct(
+		protected IAppManager $appManager,
+		protected Router $router,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setName('router:list')
+			->setDescription('Find the target of a route or all routes of an app')
+			->addArgument(
+				'app',
+				InputArgument::OPTIONAL | InputArgument::IS_ARRAY,
+				'Only list routes of these apps',
+			)
+			->addOption(
+				'ocs',
+				null,
+				InputOption::VALUE_NONE,
+				'Only list OCS routes',
+			)
+			->addOption(
+				'index',
+				null,
+				InputOption::VALUE_NONE,
+				'Only list index.php routes',
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$apps = $input->getArgument('app');
+		if (empty($apps)) {
+			$this->router->loadRoutes();
+		} else {
+			foreach ($apps as $app) {
+				if ($app === 'core') {
+					$this->router->loadRoutes($app, false);
+					continue;
+				}
+
+				try {
+					$this->appManager->getAppPath($app);
+				} catch (AppPathNotFoundException $e) {
+					$output->writeln('<comment>App ' . $app . ' not found</comment>');
+					return self::FAILURE;
+				}
+
+				if (!$this->appManager->isEnabledForAnyone($app)) {
+					$output->writeln('<comment>App ' . $app . ' is not enabled</comment>');
+					return self::FAILURE;
+				}
+
+				$this->router->loadRoutes($app, true);
+			}
+		}
+
+		$ocsOnly = $input->getOption('ocs');
+		$indexOnly = $input->getOption('index');
+
+		$rows = [];
+		$collection = $this->router->getRouteCollection();
+		foreach ($collection->all() as $routeName => $route) {
+			if (str_starts_with($routeName, 'ocs.')) {
+				if ($indexOnly) {
+					continue;
+				}
+				$routeName = substr($routeName, 4);
+			} elseif ($ocsOnly) {
+				continue;
+			}
+
+			$path = $route->getPath();
+			if (str_starts_with($path, '/ocsapp/')) {
+				$path = '/ocs/v2.php/' . substr($path, strlen('/ocsapp/'));
+			}
+			$row = [
+				'route' => $routeName,
+				'request' => implode(', ', $route->getMethods()),
+				'path' => $path,
+			];
+
+			if ($output->isVerbose()) {
+				$row['requirements'] = json_encode($route->getRequirements());
+			}
+
+			$rows[] = $row;
+		}
+
+		usort($rows, static function (array $a, array $b): int {
+			$aRoute = $a['route'];
+			if (str_starts_with($aRoute, 'ocs.')) {
+				$aRoute = substr($aRoute, 4);
+			}
+			$bRoute = $b['route'];
+			if (str_starts_with($bRoute, 'ocs.')) {
+				$bRoute = substr($bRoute, 4);
+			}
+			return $aRoute <=> $bRoute;
+		});
+
+		$this->writeTableInOutputFormat($input, $output, $rows);
+		return self::SUCCESS;
+	}
+}

--- a/core/Command/Router/MatchRoute.php
+++ b/core/Command/Router/MatchRoute.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Command\Router;
+
+use OC\Core\Command\Base;
+use OC\Route\Router;
+use OCP\App\IAppManager;
+use OCP\Server;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RequestContext;
+
+class MatchRoute extends Base {
+
+	public function __construct(
+		private Router $router,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure(): void {
+		parent::configure();
+		$this
+			->setName('router:match')
+			->setDescription('Match a URL to the target route')
+			->addArgument(
+				'path',
+				InputArgument::REQUIRED,
+				'Path of the request',
+			)
+			->addOption(
+				'method',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'HTTP method',
+				'GET',
+			)
+		;
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$context = new RequestContext(method: strtoupper($input->getOption('method')));
+		$this->router->setContext($context);
+
+		$path = $input->getArgument('path');
+		if (str_starts_with($path, '/index.php/')) {
+			$path = substr($path, 10);
+		}
+		if (str_starts_with($path, '/ocs/v1.php/') || str_starts_with($path, '/ocs/v2.php/')) {
+			$path = '/ocsapp' . substr($path, strlen('/ocs/v2.php'));
+		}
+
+		try {
+			$route = $this->router->findMatchingRoute($path);
+		} catch (MethodNotAllowedException) {
+			$output->writeln('<error>Method not allowed on this path</error>');
+			return self::FAILURE;
+		} catch (ResourceNotFoundException) {
+			$output->writeln('<error>Path not matched</error>');
+			if (preg_match('/\/apps\/([^\/]+)\//', $path, $matches)) {
+				$appManager = Server::get(IAppManager::class);
+				if (!$appManager->isEnabledForAnyone($matches[1])) {
+					$output->writeln('');
+					$output->writeln('<comment>App ' . $matches[1] . ' is not enabled</comment>');
+				}
+			}
+			return self::FAILURE;
+		}
+
+		$row = [
+			'route' => $route['_route'],
+			'appid' => $route['caller'][0] ?? null,
+			'controller' => $route['caller'][1] ?? null,
+			'method' => $route['caller'][2] ?? null,
+		];
+
+		if ($output->isVerbose()) {
+			$route = $this->router->getRouteCollection()->get($row['route']);
+			$row['path'] = $route->getPath();
+			if (str_starts_with($row['path'], '/ocsapp/')) {
+				$row['path'] = '/ocs/v2.php/' . substr($row['path'], strlen('/ocsapp/'));
+			}
+			$row['requirements'] = json_encode($route->getRequirements());
+		}
+
+		$this->writeTableInOutputFormat($input, $output, [$row]);
+		return self::SUCCESS;
+	}
+}

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -71,6 +71,8 @@ use OC\Core\Command\Maintenance\UpdateTheme;
 use OC\Core\Command\Memcache\RedisCommand;
 use OC\Core\Command\Preview\Generate;
 use OC\Core\Command\Preview\ResetRenderedTexts;
+use OC\Core\Command\Router\ListRoutes;
+use OC\Core\Command\Router\MatchRoute;
 use OC\Core\Command\Security\BruteforceAttempts;
 use OC\Core\Command\Security\BruteforceResetAttempts;
 use OC\Core\Command\Security\ExportCertificates;
@@ -110,6 +112,8 @@ $application->add(Server::get(SignApp::class));
 $application->add(Server::get(SignCore::class));
 $application->add(Server::get(CheckApp::class));
 $application->add(Server::get(CheckCore::class));
+$application->add(Server::get(ListRoutes::class));
+$application->add(Server::get(MatchRoute::class));
 
 $config = Server::get(IConfig::class);
 

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1297,6 +1297,8 @@ return array(
     'OC\\Core\\Command\\Preview\\Generate' => $baseDir . '/core/Command/Preview/Generate.php',
     'OC\\Core\\Command\\Preview\\Repair' => $baseDir . '/core/Command/Preview/Repair.php',
     'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => $baseDir . '/core/Command/Preview/ResetRenderedTexts.php',
+    'OC\\Core\\Command\\Router\\ListRoutes' => $baseDir . '/core/Command/Router/ListRoutes.php',
+    'OC\\Core\\Command\\Router\\MatchRoute' => $baseDir . '/core/Command/Router/MatchRoute.php',
     'OC\\Core\\Command\\Security\\BruteforceAttempts' => $baseDir . '/core/Command/Security/BruteforceAttempts.php',
     'OC\\Core\\Command\\Security\\BruteforceResetAttempts' => $baseDir . '/core/Command/Security/BruteforceResetAttempts.php',
     'OC\\Core\\Command\\Security\\ExportCertificates' => $baseDir . '/core/Command/Security/ExportCertificates.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1338,6 +1338,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\Preview\\Generate' => __DIR__ . '/../../..' . '/core/Command/Preview/Generate.php',
         'OC\\Core\\Command\\Preview\\Repair' => __DIR__ . '/../../..' . '/core/Command/Preview/Repair.php',
         'OC\\Core\\Command\\Preview\\ResetRenderedTexts' => __DIR__ . '/../../..' . '/core/Command/Preview/ResetRenderedTexts.php',
+        'OC\\Core\\Command\\Router\\ListRoutes' => __DIR__ . '/../../..' . '/core/Command/Router/ListRoutes.php',
+        'OC\\Core\\Command\\Router\\MatchRoute' => __DIR__ . '/../../..' . '/core/Command/Router/MatchRoute.php',
         'OC\\Core\\Command\\Security\\BruteforceAttempts' => __DIR__ . '/../../..' . '/core/Command/Security/BruteforceAttempts.php',
         'OC\\Core\\Command\\Security\\BruteforceResetAttempts' => __DIR__ . '/../../..' . '/core/Command/Security/BruteforceResetAttempts.php',
         'OC\\Core\\Command\\Security\\ExportCertificates' => __DIR__ . '/../../..' . '/core/Command/Security/ExportCertificates.php',

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -74,6 +74,14 @@ class Router implements IRouter {
 		$this->root = $this->getCollection('root');
 	}
 
+	public function setContext(RequestContext $context): void {
+		$this->context = $context;
+	}
+
+	public function getRouteCollection() {
+		return $this->root;
+	}
+
 	/**
 	 * Get the files to load the routes from
 	 *
@@ -102,7 +110,7 @@ class Router implements IRouter {
 	 *
 	 * @param null|string $app
 	 */
-	public function loadRoutes($app = null) {
+	public function loadRoutes(?string $app = null, bool $skipLoadingCore = false): void {
 		if (is_string($app)) {
 			$app = $this->appManager->cleanAppId($app);
 		}
@@ -165,7 +173,7 @@ class Router implements IRouter {
 		}
 		$this->eventLogger->end('route:load:files');
 
-		if (!isset($this->loadedApps['core'])) {
+		if (!$skipLoadingCore && !isset($this->loadedApps['core'])) {
 			$this->loadedApps['core'] = true;
 			$this->useCollection('root');
 			$this->setupRoutes($this->getAttributeRoutes('core'), 'core');


### PR DESCRIPTION
## Match a route
- `-v` for path and requirements of parameters
- `--method` to specify HTTP method
```
$ occ router:match '/ocs/v2.php/apps/activity/api/v2/activity/{filter}' 
+------------------------------+----------+-----------------+-----------+
| route                        | appid    | controller      | method    |
+------------------------------+----------+-----------------+-----------+
| ocs.activity.apiv2.getfilter | activity | APIv2Controller | getFilter |
+------------------------------+----------+-----------------+-----------+

$ occ router:match '/ocs/v2.php/apps/activity/api/v2/remote/1234567890' -v --method POST
+---------------------------------------------+----------+--------------------------+-----------------+-------------------------------------------------+--------------+
| route                                       | appid    | controller               | method          | path                                            | requirements |
+---------------------------------------------+----------+--------------------------+-----------------+-------------------------------------------------+--------------+
| ocs.activity.remoteactivity.receiveactivity | activity | RemoteActivityController | receiveActivity | /ocs/v2.php/apps/activity/api/v2/remote/{token} | []           |
+---------------------------------------------+----------+--------------------------+-----------------+-------------------------------------------------+--------------+
```


## List all routes (of apps)
- `-v` for requirements of parameters
- `--ocs` to only list OCS routes
- `--index` to only list index.php routes
- Optional argument list of apps

```
$ occ router:list notifications -v
+-----------------------------------------------+---------+-------------------------------------------------------------------------------+--------------------------------------+
| route                                         | request | path                                                                          | requirements                         |
+-----------------------------------------------+---------+-------------------------------------------------------------------------------+--------------------------------------+
| notifications.api.generatenotification        | POST    | /ocs/v2.php/apps/notifications/api/{apiVersion}/admin_notifications/{userId}  | {"apiVersion":"(v1|v2)"}             |
| notifications.api.generatenotificationv3      | POST    | /ocs/v2.php/apps/notifications/api/{apiVersion3}/admin_notifications/{userId} | {"apiVersion3":"(v3)"}               |
| notifications.api.selftestpush                | POST    | /ocs/v2.php/apps/notifications/api/{apiVersion3}/test/self                    | {"apiVersion3":"(v3)"}               |
| notifications.endpoint.confirmidsforuser      | POST    | /ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/exists          | {"apiVersion":"(v1|v2)"}             |
| notifications.endpoint.deleteallnotifications | DELETE  | /ocs/v2.php/apps/notifications/api/{apiVersion}/notifications                 | {"apiVersion":"(v1|v2)"}             |
| notifications.endpoint.deletenotification     | DELETE  | /ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}            | {"apiVersion":"(v1|v2)","id":"\\d+"} |
| notifications.endpoint.getnotification        | GET     | /ocs/v2.php/apps/notifications/api/{apiVersion}/notifications/{id}            | {"apiVersion":"(v1|v2)","id":"\\d+"} |
| notifications.endpoint.listnotifications      | GET     | /ocs/v2.php/apps/notifications/api/{apiVersion}/notifications                 | {"apiVersion":"(v1|v2)"}             |
| notifications.push.registerdevice             | POST    | /ocs/v2.php/apps/notifications/api/{apiVersion}/push                          | {"apiVersion":"(v2)"}                |
| notifications.push.removedevice               | DELETE  | /ocs/v2.php/apps/notifications/api/{apiVersion}/push                          | {"apiVersion":"(v2)"}                |
| notifications.settings.admin                  | POST    | /ocs/v2.php/apps/notifications/api/{apiVersion}/settings/admin                | {"apiVersion":"(v2)"}                |
| notifications.settings.personal               | POST    | /ocs/v2.php/apps/notifications/api/{apiVersion}/settings                      | {"apiVersion":"(v2)"}                |
+-----------------------------------------------+---------+-------------------------------------------------------------------------------+--------------------------------------+


$ occ router:list activity
+-----------------------------------------+---------+----------------------------------------------------+
| route                                   | request | path                                               |
+-----------------------------------------+---------+----------------------------------------------------+
| activity.activities.index               | GET     | /apps/activity/                                    |
| activity.activities.showlist            | GET     | /apps/activity/{filter}                            |
| activity.apiv1.get                      | GET     | /ocs/v2.php/cloud/activity                         |
| activity.apiv2.getdefault               | GET     | /ocs/v2.php/apps/activity/api/v2/activity          |
| activity.apiv2.getfilter                | GET     | /ocs/v2.php/apps/activity/api/v2/activity/{filter} |
| activity.apiv2.listfilters              | GET     | /ocs/v2.php/apps/activity/api/v2/activity/filters  |
| activity.feed.show                      | GET     | /apps/activity/rss.php                             |
| activity.remoteactivity.receiveactivity | POST    | /ocs/v2.php/apps/activity/api/v2/remote/{token}    |
| activity.settings.admin                 | POST    | /apps/activity/settings/admin                      |
| activity.settings.feed                  | POST    | /apps/activity/settings/feed                       |
| activity.settings.personal              | POST    | /apps/activity/settings                            |
+-----------------------------------------+---------+----------------------------------------------------+

$ occ router:list activity --ocs
+-----------------------------------------+---------+----------------------------------------------------+
| route                                   | request | path                                               |
+-----------------------------------------+---------+----------------------------------------------------+
| activity.apiv1.get                      | GET     | /ocs/v2.php/cloud/activity                         |
| activity.apiv2.getdefault               | GET     | /ocs/v2.php/apps/activity/api/v2/activity          |
| activity.apiv2.getfilter                | GET     | /ocs/v2.php/apps/activity/api/v2/activity/{filter} |
| activity.apiv2.listfilters              | GET     | /ocs/v2.php/apps/activity/api/v2/activity/filters  |
| activity.remoteactivity.receiveactivity | POST    | /ocs/v2.php/apps/activity/api/v2/remote/{token}    |
+-----------------------------------------+---------+----------------------------------------------------+

$ occ router:list activity --index
+------------------------------+---------+-------------------------------+
| route                        | request | path                          |
+------------------------------+---------+-------------------------------+
| activity.activities.index    | GET     | /apps/activity/               |
| activity.activities.showlist | GET     | /apps/activity/{filter}       |
| activity.feed.show           | GET     | /apps/activity/rss.php        |
| activity.settings.admin      | POST    | /apps/activity/settings/admin |
| activity.settings.feed       | POST    | /apps/activity/settings/feed  |
| activity.settings.personal   | POST    | /apps/activity/settings       |
+------------------------------+---------+-------------------------------+

```


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
