### PR TITLE
Align app id for federation in error messages

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -115,9 +115,9 @@ class GetSharedSecret extends Job {
 		} catch (ClientException $e) {
 			$status = $e->getCode();
 			if ($status === Http::STATUS_FORBIDDEN) {
-				$this->logger->info($target . ' refused to exchange a shared secret with you.', ['app' => 'federation']);
+				$this->logger->info($target . ' refused to exchange a shared secret with you.');
 			} else {
-				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage(), ['app' => 'federation']);
+				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage());
 			}
 		} catch (RequestException $e) {
 			$status = -1; // There is no status code if we could not connect
@@ -149,8 +149,7 @@ class GetSharedSecret extends Job {
 				);
 			} else {
 				$this->logger->error(
-					'remote server "' . $target . '"" does not return a valid shared secret. Received data: ' . $body,
-					['app' => 'federation']
+					'remote server "' . $target . '"" does not return a valid shared secret. Received data: ' . $body
 				);
 				$this->trustedServers->setServerStatus($target, TrustedServers::STATUS_FAILURE);
 			}

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -126,16 +126,16 @@ class RequestSharedSecret extends Job {
 		} catch (ClientException $e) {
 			$status = $e->getCode();
 			if ($status === Http::STATUS_FORBIDDEN) {
-				$this->logger->info($target . ' refused to ask for a shared secret.', ['app' => 'federation']);
+				$this->logger->info($target . ' refused to ask for a shared secret.');
 			} else {
-				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage(), ['app' => 'federation']);
+				$this->logger->info($target . ' responded with a ' . $status . ' containing: ' . $e->getMessage());
 			}
 		} catch (RequestException $e) {
 			$status = -1; // There is no status code if we could not connect
-			$this->logger->info('Could not connect to ' . $target, ['app' => 'federation']);
+			$this->logger->info('Could not connect to ' . $target);
 		} catch (\Throwable $e) {
 			$status = Http::STATUS_INTERNAL_SERVER_ERROR;
-			$this->logger->error($e->getMessage(), ['app' => 'federation', 'exception' => $e]);
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
 		}
 
 		// if we received a unexpected response we try again later

--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -98,7 +98,7 @@ class OCSAuthAPIController extends OCSController {
 	public function requestSharedSecret(string $url, string $token): DataResponse {
 		if ($this->trustedServers->isTrustedServer($url) === false) {
 			$this->throttler->registerAttempt('federationSharedSecret', $this->request->getRemoteAddress());
-			$this->logger->error('remote server not trusted (' . $url . ') while requesting shared secret', ['app' => 'federation']);
+			$this->logger->error('remote server not trusted (' . $url . ') while requesting shared secret');
 			throw new OCSForbiddenException();
 		}
 
@@ -107,8 +107,7 @@ class OCSAuthAPIController extends OCSController {
 		$localToken = $this->dbHandler->getToken($url);
 		if (strcmp($localToken, $token) > 0) {
 			$this->logger->info(
-				'remote server (' . $url . ') presented lower token. We will initiate the exchange of the shared secret.',
-				['app' => 'federation']
+				'remote server (' . $url . ') presented lower token. We will initiate the exchange of the shared secret.'
 			);
 			throw new OCSForbiddenException();
 		}
@@ -141,7 +140,7 @@ class OCSAuthAPIController extends OCSController {
 	public function getSharedSecret(string $url, string $token): DataResponse {
 		if ($this->trustedServers->isTrustedServer($url) === false) {
 			$this->throttler->registerAttempt('federationSharedSecret', $this->request->getRemoteAddress());
-			$this->logger->error('remote server not trusted (' . $url . ') while getting shared secret', ['app' => 'federation']);
+			$this->logger->error('remote server not trusted (' . $url . ') while getting shared secret');
 			throw new OCSForbiddenException();
 		}
 
@@ -149,8 +148,7 @@ class OCSAuthAPIController extends OCSController {
 			$this->throttler->registerAttempt('federationSharedSecret', $this->request->getRemoteAddress());
 			$expectedToken = $this->dbHandler->getToken($url);
 			$this->logger->error(
-				'remote server (' . $url . ') didn\'t send a valid token (got "' . $token . '" but expected "' . $expectedToken . '") while getting shared secret',
-				['app' => 'federation']
+				'remote server (' . $url . ') didn\'t send a valid token (got "' . $token . '" but expected "' . $expectedToken . '") while getting shared secret'
 			);
 			throw new OCSForbiddenException();
 		}

--- a/apps/federation/lib/SyncJob.php
+++ b/apps/federation/lib/SyncJob.php
@@ -27,7 +27,6 @@ class SyncJob extends TimedJob {
 		$this->syncService->syncThemAll(function ($url, $ex): void {
 			if ($ex instanceof \Exception) {
 				$this->logger->error("Error while syncing $url.", [
-					'app' => 'fed-sync',
 					'exception' => $ex,
 				]);
 			}

--- a/apps/federation/lib/TrustedServers.php
+++ b/apps/federation/lib/TrustedServers.php
@@ -169,7 +169,6 @@ class TrustedServers {
 			}
 		} catch (\Exception $e) {
 			$this->logger->error('No Nextcloud server.', [
-				'app' => 'federation',
 				'exception' => $e,
 			]);
 			return false;


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The background job for the address book sync uses a different app id "fed-sync", making it harder to grep the logs for. 

Dropping all "app" definitions in the federation app, as the scoped psr logger will set it anyway.




## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
