### PR TITLE
fix(nullcache): make get compliant with the interface

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4112,31 +4112,12 @@
     </InvalidOperand>
   </file>
   <file src="lib/private/Lockdown/Filesystem/NullCache.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[get]]></code>
-    </InvalidNullableReturnType>
     <InvalidReturnStatement>
       <code><![CDATA[[]]]></code>
     </InvalidReturnStatement>
     <InvalidReturnType>
       <code><![CDATA[getIncomplete]]></code>
     </InvalidReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$file !== '' ? null :
-			new CacheEntry([
-				'fileid' => -1,
-				'parent' => -1,
-				'name' => '',
-				'path' => '',
-				'size' => '0',
-				'mtime' => time(),
-				'storage_mtime' => time(),
-				'etag' => '',
-				'mimetype' => FileInfo::MIMETYPE_FOLDER,
-				'mimepart' => 'httpd',
-				'permissions' => Constants::PERMISSION_READ
-			])]]></code>
-    </NullableReturnStatement>
   </file>
   <file src="lib/private/Lockdown/Filesystem/NullStorage.php">
     <TooManyArguments>

--- a/lib/private/Lockdown/Filesystem/NullCache.php
+++ b/lib/private/Lockdown/Filesystem/NullCache.php
@@ -21,20 +21,23 @@ class NullCache implements ICache {
 	}
 
 	public function get($file) {
-		return $file !== '' ? null :
-			new CacheEntry([
-				'fileid' => -1,
-				'parent' => -1,
-				'name' => '',
-				'path' => '',
-				'size' => '0',
-				'mtime' => time(),
-				'storage_mtime' => time(),
-				'etag' => '',
-				'mimetype' => FileInfo::MIMETYPE_FOLDER,
-				'mimepart' => 'httpd',
-				'permissions' => Constants::PERMISSION_READ
-			]);
+		if ($file !== '') {
+			return false;
+		}
+
+		return 	new CacheEntry([
+			'fileid' => -1,
+			'parent' => -1,
+			'name' => '',
+			'path' => '',
+			'size' => '0',
+			'mtime' => time(),
+			'storage_mtime' => time(),
+			'etag' => '',
+			'mimetype' => FileInfo::MIMETYPE_FOLDER,
+			'mimepart' => 'httpd',
+			'permissions' => Constants::PERMISSION_READ
+		]);
 	}
 
 	public function getFolderContents($folder) {

--- a/tests/lib/Lockdown/Filesystem/NullCacheTest.php
+++ b/tests/lib/Lockdown/Filesystem/NullCacheTest.php
@@ -27,7 +27,7 @@ class NulLCacheTest extends \Test\TestCase {
 	}
 
 	public function testGetEmpty(): void {
-		$this->assertNull($this->cache->get('foo'));
+		$this->assertFalse($this->cache->get('foo'));
 	}
 
 	public function testGet(): void {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The code style update in pull request https://github.com/nextcloud/server/pull/53625 appears to trigger a Psalm warning about NullCache returning null, which makes it non-compliant with the interface. This seems like a valid finding; however, I am not familiar with this part, and a thorough review should be done.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
