### PR TITLE
docs(http): update return type for getBody

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3943,12 +3943,6 @@
       <code><![CDATA[ArrayCache]]></code>
       <code><![CDATA[ArrayCache]]></code>
     </InvalidClass>
-    <InvalidReturnStatement>
-      <code><![CDATA[$response->getBody()]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[fopen]]></code>
-    </InvalidReturnType>
   </file>
   <file src="lib/private/Files/Storage/Local.php">
     <TypeDoesNotContainNull>
@@ -4197,12 +4191,6 @@
     </ImplementedReturnTypeMismatch>
   </file>
   <file src="lib/private/Remote/Instance.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[$request->getBody()]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[bool|string]]></code>
-    </InvalidReturnType>
     <InvalidScalarArgument>
       <code><![CDATA[$response]]></code>
     </InvalidScalarArgument>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4059,16 +4059,6 @@
       <code><![CDATA[isAdmin]]></code>
     </UndefinedInterfaceMethod>
   </file>
-  <file src="lib/private/Http/Client/Response.php">
-    <InvalidNullableReturnType>
-      <code><![CDATA[string|resource]]></code>
-    </InvalidNullableReturnType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->stream ?
-			$this->response->getBody()->detach():
-			$this->response->getBody()->getContents()]]></code>
-    </NullableReturnStatement>
-  </file>
   <file src="lib/private/Installer.php">
     <InvalidArgument>
       <code><![CDATA[false]]></code>

--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -350,7 +350,13 @@ class DAV extends Common {
 					}
 				}
 
-				return $response->getBody();
+				$content = $response->getBody();
+
+				if ($content === null || is_string($content)) {
+					return false;
+				}
+
+				return $content;
 			case 'w':
 			case 'wb':
 			case 'a':
@@ -390,6 +396,8 @@ class DAV extends Common {
 					$this->writeBack($tmpFile, $path);
 				});
 		}
+
+		return false;
 	}
 
 	public function writeBack(string $tmpFile, string $path): void {

--- a/lib/private/Http/Client/Response.php
+++ b/lib/private/Http/Client/Response.php
@@ -11,49 +11,25 @@ namespace OC\Http\Client;
 use OCP\Http\Client\IResponse;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * Class Response
- *
- * @package OC\Http
- */
 class Response implements IResponse {
-	/** @var ResponseInterface */
-	private $response;
+	private ResponseInterface $response;
+	private bool $stream;
 
-	/**
-	 * @var bool
-	 */
-	private $stream;
-
-	/**
-	 * @param ResponseInterface $response
-	 * @param bool $stream
-	 */
-	public function __construct(ResponseInterface $response, $stream = false) {
+	public function __construct(ResponseInterface $response, bool $stream = false) {
 		$this->response = $response;
 		$this->stream = $stream;
 	}
 
-	/**
-	 * @return string|resource
-	 */
 	public function getBody() {
 		return $this->stream ?
 			$this->response->getBody()->detach():
 			$this->response->getBody()->getContents();
 	}
 
-	/**
-	 * @return int
-	 */
 	public function getStatusCode(): int {
 		return $this->response->getStatusCode();
 	}
 
-	/**
-	 * @param string $key
-	 * @return string
-	 */
 	public function getHeader(string $key): string {
 		$headers = $this->response->getHeader($key);
 
@@ -64,9 +40,6 @@ class Response implements IResponse {
 		return $headers[0];
 	}
 
-	/**
-	 * @return array
-	 */
 	public function getHeaders(): array {
 		return $this->response->getHeaders();
 	}

--- a/lib/private/Remote/Instance.php
+++ b/lib/private/Remote/Instance.php
@@ -123,7 +123,13 @@ class Instance implements IInstance {
 	private function downloadStatus($url) {
 		try {
 			$request = $this->clientService->newClient()->get($url);
-			return $request->getBody();
+			$content = $request->getBody();
+
+			// IResponse.getBody responds with null|resource if returning a stream response was requested.
+			// As that's not the case here, we can just ignore the psalm warning by adding an assertion.
+			assert(is_string($content));
+
+			return $content;
 		} catch (\Exception $e) {
 			return false;
 		}

--- a/lib/private/Updater/VersionCheck.php
+++ b/lib/private/Updater/VersionCheck.php
@@ -105,17 +105,20 @@ class VersionCheck {
 	}
 
 	/**
-	 * @codeCoverageIgnore
-	 * @param string $url
-	 * @return resource|string
 	 * @throws \Exception
 	 */
-	protected function getUrlContent($url) {
-		$client = $this->clientService->newClient();
-		$response = $client->get($url, [
+	protected function getUrlContent(string $url): string {
+		$response = $this->clientService->newClient()->get($url, [
 			'timeout' => 5,
 		]);
-		return $response->getBody();
+
+		$content = $response->getBody();
+
+		// IResponse.getBody responds with null|resource if returning a stream response was requested.
+		// As that's not the case here, we can just ignore the psalm warning by adding an assertion.
+		assert(is_string($content));
+
+		return $content;
 	}
 
 	private function computeCategory(): int {

--- a/lib/public/Http/Client/IResponse.php
+++ b/lib/public/Http/Client/IResponse.php
@@ -15,8 +15,9 @@ namespace OCP\Http\Client;
  */
 interface IResponse {
 	/**
-	 * @return string|resource
+	 * @return null|resource|string
 	 * @since 8.1.0
+	 * @sicne 8.2.0 with stream enabled, the function returns null or a resource
 	 */
 	public function getBody();
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The code style update in pull request https://github.com/nextcloud/server/pull/53625 appears to trigger a Psalm warning about Response returning null, which makes it non-compliant with the interface. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
