### PR TITLE
chore(Log): remove unused getEntries method

### DIFF
--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -8,7 +8,6 @@
 namespace OC\Log;
 
 use OC\SystemConfig;
-use OCP\ILogger;
 use OCP\Log\IFileBased;
 use OCP\Log\IWriter;
 

--- a/lib/private/Log/File.php
+++ b/lib/private/Log/File.php
@@ -69,52 +69,7 @@ class File extends LogDetails implements IWriter, IFileBased {
 		}
 	}
 
-	/**
-	 * get entries from the log in reverse chronological order
-	 */
-	public function getEntries(int $limit = 50, int $offset = 0): array {
-		$minLevel = $this->config->getValue('loglevel', ILogger::WARN);
-		$entries = [];
-		$handle = @fopen($this->logFile, 'rb');
-		if ($handle) {
-			fseek($handle, 0, SEEK_END);
-			$pos = ftell($handle);
-			$line = '';
-			$entriesCount = 0;
-			$lines = 0;
-			// Loop through each character of the file looking for new lines
-			while ($pos >= 0 && ($limit === null || $entriesCount < $limit)) {
-				fseek($handle, $pos);
-				$ch = fgetc($handle);
-				if ($ch == "\n" || $pos == 0) {
-					if ($line != '') {
-						// Add the first character if at the start of the file,
-						// because it doesn't hit the else in the loop
-						if ($pos == 0) {
-							$line = $ch . $line;
-						}
-						$entry = json_decode($line);
-						// Add the line as an entry if it is passed the offset and is equal or above the log level
-						if ($entry->level >= $minLevel) {
-							$lines++;
-							if ($lines > $offset) {
-								$entries[] = $entry;
-								$entriesCount++;
-							}
-						}
-						$line = '';
-					}
-				} else {
-					$line = $ch . $line;
-				}
-				$pos--;
-			}
-			fclose($handle);
-		}
-		return $entries;
-	}
-
-	public function getLogFilePath():string {
+	public function getLogFilePath(): string {
 		return $this->logFile;
 	}
 }

--- a/lib/public/Log/IFileBased.php
+++ b/lib/public/Log/IFileBased.php
@@ -16,9 +16,4 @@ interface IFileBased {
 	 * @since 14.0.0
 	 */
 	public function getLogFilePath():string;
-
-	/**
-	 * @since 14.0.0
-	 */
-	public function getEntries(int $limit = 50, int $offset = 0): array;
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

This method hasn't been used since ~#2214. All this functionality was moved to the LogReader app. It was de facto deprecated nearly 10 years ago. There are zero references to it across all of GitHub. Technically a public API, but...

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
