### PR TITLE
perf: cache server checks in local cache, not session

### DIFF
--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -304,6 +304,7 @@ class OC_Util {
 	 */
 	public static function checkServer(\OC\SystemConfig $config) {
 		$l = \OC::$server->getL10N('lib');
+		$localCache = \OCP\Server::get(\OCP\ICacheFactory::class)->createLocal('system');
 		$errors = [];
 		$CONFIG_DATADIRECTORY = $config->getValue('datadirectory', OC::$SERVERROOT . '/data');
 
@@ -312,8 +313,8 @@ class OC_Util {
 			$errors = self::checkDataDirectoryValidity($CONFIG_DATADIRECTORY);
 		}
 
-		// Assume that if checkServer() succeeded before in this session, then all is fine.
-		if (\OC::$server->getSession()->exists('checkServer_succeeded') && \OC::$server->getSession()->get('checkServer_succeeded')) {
+		// Skip re-evaluation if everything is fine
+		if ($localCache->get('checkServer_succeeded') === true) {
 			return $errors;
 		}
 
@@ -511,8 +512,8 @@ class OC_Util {
 			}
 		}
 
-		// Cache the result of this function
-		\OC::$server->getSession()->set('checkServer_succeeded', count($errors) == 0);
+		// Cache the result of this function for an hour
+		$localCache->set('checkServer_succeeded', $errors === [], 3600);
 
 		return $errors;
 	}

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -21,7 +21,6 @@ use OCP\HintException;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\IRequest;
-use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
@@ -260,8 +259,9 @@ class OC_Util {
 	 *
 	 * @return array arrays with error messages and hints
 	 */
-	public static function checkServer(SystemConfig $config) {
-		$l = \OCP\Server::get(IFactory::class)->get('lib');
+	public static function checkServer(SystemConfig $config): array {
+		$l = Server::get(IFactory::class)->get('lib');
+		$localCache = Server::get(\OCP\ICacheFactory::class)->createLocal('system');
 		$errors = [];
 		$CONFIG_DATADIRECTORY = $config->getValue('datadirectory', OC::$SERVERROOT . '/data');
 
@@ -270,8 +270,8 @@ class OC_Util {
 			$errors = self::checkDataDirectoryValidity($CONFIG_DATADIRECTORY);
 		}
 
-		// Assume that if checkServer() succeeded before in this session, then all is fine.
-		if (Server::get(ISession::class)->exists('checkServer_succeeded') && Server::get(ISession::class)->get('checkServer_succeeded')) {
+		// Skip re-evaluation if everything is fine
+		if ($localCache->get('checkServer_succeeded') === true) {
 			return $errors;
 		}
 
@@ -447,8 +447,8 @@ class OC_Util {
 			}
 		}
 
-		// Cache the result of this function
-		Server::get(ISession::class)->set('checkServer_succeeded', count($errors) == 0);
+		// Cache the result of this function for an hour
+		$localCache->set('checkServer_succeeded', $errors === [], 3600);
 
 		return $errors;
 	}

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -7,6 +7,7 @@
 
 namespace Test;
 
+use OCP\ICacheFactory;
 use OCP\ISession;
 use OCP\ITempManager;
 use OCP\Server;
@@ -45,7 +46,7 @@ class UtilCheckServerTest extends \Test\TestCase {
 		$this->datadir = Server::get(ITempManager::class)->getTemporaryFolder();
 
 		file_put_contents($this->datadir . '/.ncdata', '# Nextcloud data directory');
-		Server::get(ISession::class)->set('checkServer_succeeded', false);
+		Server::get(ICacheFactory::class)->createLocal('system')->set('checkServer_succeeded', false, 10);
 	}
 
 	protected function tearDown(): void {

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use OC\SystemConfig;
+use OCP\ICacheFactory;
 use OCP\ISession;
 use OCP\ITempManager;
 use OCP\Server;
@@ -47,7 +48,7 @@ class UtilCheckServerTest extends \Test\TestCase {
 		$this->datadir = Server::get(ITempManager::class)->getTemporaryFolder();
 
 		file_put_contents($this->datadir . '/.ncdata', '# Nextcloud data directory');
-		Server::get(ISession::class)->set('checkServer_succeeded', false);
+		Server::get(ICacheFactory::class)->createLocal('system')->set('checkServer_succeeded', false, 10);
 	}
 
 	#[\Override]


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Caching was added in https://github.com/owncloud/core/pull/4441. It makes sense to cache the steps, but not on a user session level. The checks are global to the instance. Cache it for everyone, and make the cached value accessible to requests that do not use sessions.
Every time we read or write session the PHP session has to be opened. For a simple system that means disk IO, for a scaled setup that means network IO to contact Redis. Local cache (APCu) has low latency.

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
