### PR TITLE
fix: no migrations ran when apps loaded for phpunit

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,6 +22,7 @@ foreach (new \DirectoryIterator(__DIR__ . '/../apps/') as $file) {
 		continue;
 	}
 	\OC_App::loadApp($file->getFilename());
+	\OC_App::updateApp($file->getFilename());
 }
 
 OC_Hook::clear();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

When running phpunit tests all the core apps are enabled, but their migrations are never ran at least for files_external. Not sure if this is the right way to make sure the migrations also run, but that does fix it at least for my case. Noticed this while finding root cause for why phpunit tests failed in integration_openai.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
