### PR TITLE
fix(settings): use correct scope for translations

### DIFF
--- a/apps/settings/lib/SetupChecks/MimeTypeMigrationAvailable.php
+++ b/apps/settings/lib/SetupChecks/MimeTypeMigrationAvailable.php
@@ -10,18 +10,15 @@ namespace OCA\Settings\SetupChecks;
 
 use OC\Repair\RepairMimeTypes;
 use OCP\IL10N;
-use OCP\L10N\IFactory;
 use OCP\SetupCheck\ISetupCheck;
 use OCP\SetupCheck\SetupResult;
 
 class MimeTypeMigrationAvailable implements ISetupCheck {
-	private IL10N $l10n;
 
 	public function __construct(
-		IFactory $l10nFactory,
 		private RepairMimeTypes $repairMimeTypes,
+		private IL10N $l10n,
 	) {
-		$this->l10n = $l10nFactory->get('core');
 	}
 
 	public function getCategory(): string {


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/53691

## Summary

The translations are in settings not in core so the scope was set wrong.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
