### PR TITLE
fix(encryption): Catch NotFoundException in ShareDeletedEvent listener

### DIFF
--- a/lib/private/Encryption/EncryptionEventListener.php
+++ b/lib/private/Encryption/EncryptionEventListener.php
@@ -19,6 +19,7 @@ use OCP\EventDispatcher\IEventListener;
 use OCP\Files\Events\Node\NodeRenamedEvent;
 use OCP\Files\NotFoundException;
 use OCP\IUser;
+use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\Events\ShareCreatedEvent;
 use OCP\Share\Events\ShareDeletedEvent;
@@ -32,6 +33,7 @@ class EncryptionEventListener implements IEventListener {
 		private IUserSession $userSession,
 		private SetupManager $setupManager,
 		private Manager $encryptionManager,
+		private IUserManager $userManager,
 	) {
 	}
 
@@ -54,7 +56,7 @@ class EncryptionEventListener implements IEventListener {
 			try {
 				// In case the unsharing happens in a background job, we don't have
 				// a session and we load instead the user from the UserManager
-				$owner = $event->getShare()->getShareOwner();
+				$owner = $this->userManager->get($event->getShare()->getShareOwner());
 				$this->getUpdate($owner)->postUnshared($event->getShare()->getNode());
 			} catch (NotFoundException $e) {
 				/* The node was deleted already, nothing to update */
@@ -83,7 +85,7 @@ class EncryptionEventListener implements IEventListener {
 			$this->updater = new Update(
 				new Util(
 					new View(),
-					\OC::$server->getUserManager(),
+					$this->userManager,
 					\OC::$server->getGroupManager(),
 					\OC::$server->getConfig()),
 				\OC::$server->getEncryptionManager(),


### PR DESCRIPTION
* Resolves: #53651

## Summary

Avoids issues when a share is deleted after the node itself is already deleted.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
