### PR TITLE
fix: permissions when copying from readonly storage

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -193,8 +193,18 @@ class Updater implements IUpdater {
 			if (!$parentInCache) {
 				$parentData = $this->scanner->scan($parent, Scanner::SCAN_SHALLOW, -1, false);
 				$parentInCache = $parentData !== null;
+			} else {
+				$parentData = $this->cache->get($parent);
 			}
 			if ($parentInCache) {
+				if ($sourceInfo instanceof CacheEntry) {
+					$permissionsToSet = $parentData->getPermissions();
+					if ($sourceInfo->getMimeType() !== ICacheEntry::DIRECTORY_MIMETYPE) {
+						$permissionsToSet &= ~\OCP\Constants::PERMISSION_CREATE;
+					}
+					$sourceInfo['copy_from_storage_permissions'] = $permissionsToSet;
+					unset($sourceInfo['scan_permissions']);
+				}
 				$this->cache->copyFromCache($sourceCache, $sourceInfo, $target);
 			}
 		});


### PR DESCRIPTION
* Resolves: #51846

## Summary

https://github.com/nextcloud/server/issues/51846#issuecomment-3018706766

## TODO

- [ ] Cleanup. Perhaps a bit hacky.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
