### PR TITLE
chore/rector: make phpunit dataproviders phpunit 12 compatible

### DIFF
--- a/apps/comments/tests/Unit/Collaboration/CommentersSorterTest.php
+++ b/apps/comments/tests/Unit/Collaboration/CommentersSorterTest.php
@@ -25,9 +25,9 @@ class CommentersSorterTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider sortDataProvider
 	 * @param $data
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sortDataProvider')]
 	public function testSort($data): void {
 		$commentMocks = [];
 		foreach ($data['actors'] as $actorType => $actors) {

--- a/apps/comments/tests/Unit/Controller/NotificationsTest.php
+++ b/apps/comments/tests/Unit/Controller/NotificationsTest.php
@@ -138,7 +138,7 @@ class NotificationsTest extends TestCase {
 		$this->commentsManager->expects($this->any())
 			->method('get')
 			->with('42')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 
 		$this->rootFolder->expects($this->never())
 			->method('getUserFolder');

--- a/apps/comments/tests/Unit/EventHandlerTest.php
+++ b/apps/comments/tests/Unit/EventHandlerTest.php
@@ -57,9 +57,7 @@ class EventHandlerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider handledProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('handledProvider')]
 	public function testHandled(string $eventType): void {
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);

--- a/apps/comments/tests/Unit/Notification/ListenerTest.php
+++ b/apps/comments/tests/Unit/Notification/ListenerTest.php
@@ -45,10 +45,10 @@ class ListenerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider eventProvider
 	 * @param string $eventType
 	 * @param string $notificationMethod
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('eventProvider')]
 	public function testEvaluate($eventType, $notificationMethod): void {
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);
@@ -110,9 +110,7 @@ class ListenerTest extends TestCase {
 		$this->listener->evaluate($event);
 	}
 
-	/**
-	 * @dataProvider eventProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('eventProvider')]
 	public function testEvaluateNoMentions(string $eventType): void {
 		/** @var IComment|MockObject $comment */
 		$comment = $this->createMock(IComment::class);

--- a/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/CalendarMigratorTest.php
@@ -44,7 +44,7 @@ class CalendarMigratorTest extends TestCase {
 		$this->output = $this->createMock(OutputInterface::class);
 	}
 
-	public function dataAssets(): array {
+	public static function dataAssets(): array {
 		return array_map(
 			function (string $filename) {
 				/** @var VCalendar $vCalendar */
@@ -89,9 +89,7 @@ class CalendarMigratorTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataAssets
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAssets')]
 	public function testImportExportAsset(string $userId, string $filename, string $initialCalendarUri, VCalendar $importCalendar): void {
 		$user = $this->userManager->createUser($userId, 'topsecretpassword');
 

--- a/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
+++ b/apps/dav/tests/integration/UserMigration/ContactsMigratorTest.php
@@ -44,7 +44,7 @@ class ContactsMigratorTest extends TestCase {
 		$this->output = $this->createMock(OutputInterface::class);
 	}
 
-	public function dataAssets(): array {
+	public static function dataAssets(): array {
 		return array_map(
 			function (string $filename) {
 				$vCardSplitter = new VCardSplitter(
@@ -91,11 +91,11 @@ class ContactsMigratorTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataAssets
 	 *
 	 * @param array{displayName: string, description?: string} $importMetadata
 	 * @param VCard[] $importCards
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAssets')]
 	public function testImportExportAsset(string $userId, string $filename, string $initialAddressBookUri, array $importMetadata, array $importCards): void {
 		$user = $this->userManager->createUser($userId, 'topsecretpassword');
 

--- a/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
+++ b/apps/dav/tests/unit/Avatars/AvatarHomeTest.php
@@ -27,9 +27,7 @@ class AvatarHomeTest extends TestCase {
 		$this->home = new AvatarHome(['uri' => 'principals/users/admin'], $this->avatarManager);
 	}
 
-	/**
-	 * @dataProvider providesForbiddenMethods
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesForbiddenMethods')]
 	public function testForbiddenMethods($method): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -60,9 +58,7 @@ class AvatarHomeTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesTestGetChild
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesTestGetChild')]
 	public function testGetChild(?string $expectedException, bool $hasAvatar, string $path): void {
 		if ($expectedException !== null) {
 			$this->expectException($expectedException);
@@ -87,9 +83,7 @@ class AvatarHomeTest extends TestCase {
 		self::assertEquals(1, count($avatarNodes));
 	}
 
-	/**
-	 * @dataProvider providesTestGetChild
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesTestGetChild')]
 	public function testChildExists(?string $expectedException, bool $hasAvatar, string $path): void {
 		$avatar = $this->createMock(IAvatar::class);
 		$avatar->method('exists')->willReturn($hasAvatar);

--- a/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/EventReminderJobTest.php
@@ -45,12 +45,12 @@ class EventReminderJobTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider data
 	 *
 	 * @param bool $sendEventReminders
 	 * @param bool $sendEventRemindersMode
 	 * @param bool $expectCall
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('data')]
 	public function testRun(bool $sendEventReminders, bool $sendEventRemindersMode, bool $expectCall): void {
 		$this->config->expects($this->exactly($sendEventReminders ? 2 : 1))
 			->method('getAppValue')

--- a/apps/dav/tests/unit/BackgroundJob/PruneOutdatedSyncTokensJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/PruneOutdatedSyncTokensJobTest.php
@@ -39,9 +39,7 @@ class PruneOutdatedSyncTokensJobTest extends TestCase {
 		$this->backgroundJob = new PruneOutdatedSyncTokensJob($this->timeFactory, $this->calDavBackend, $this->cardDavBackend, $this->config, $this->logger);
 	}
 
-	/**
-	 * @dataProvider dataForTestRun
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestRun')]
 	public function testRun(string $configToKeep, string $configRetentionDays, int $actualLimit, int $retentionDays, int $deletedCalendarSyncTokens, int $deletedAddressBookSyncTokens): void {
 		$this->config->expects($this->exactly(2))
 			->method('getAppValue')

--- a/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/RefreshWebcalJobTest.php
@@ -41,9 +41,8 @@ class RefreshWebcalJobTest extends TestCase {
 	 * @param int $lastRun
 	 * @param int $time
 	 * @param bool $process
-	 *
-	 * @dataProvider runDataProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
 	public function testRun(int $lastRun, int $time, bool $process): void {
 		$backgroundJob = new RefreshWebcalJob($this->refreshWebcalService, $this->config, $this->logger, $this->timeFactory);
 		$backgroundJob->setId(42);

--- a/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
+++ b/apps/dav/tests/unit/BackgroundJob/UserStatusAutomationTest.php
@@ -88,9 +88,7 @@ class UserStatusAutomationTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataRun
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRun')]
 	public function testRunNoOOO(string $ruleDay, string $currentTime, bool $isAvailable): void {
 		$user = $this->createConfiguredMock(IUser::class, [
 			'getUID' => 'user'

--- a/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/BackendTest.php
@@ -71,9 +71,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCallTriggerCalendarActivity
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCallTriggerCalendarActivity')]
 	public function testCallTriggerCalendarActivity(string $method, array $payload, string $expectedSubject, array $expectedPayload): void {
 		$backend = $this->getBackend(['triggerCalendarActivity']);
 		$backend->expects($this->once())
@@ -168,9 +166,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTriggerCalendarActivity
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTriggerCalendarActivity')]
 	public function testTriggerCalendarActivity(string $action, array $data, array $shares, array $changedProperties, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
@@ -299,9 +295,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetUsersForShares
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsersForShares')]
 	public function testGetUsersForShares(array $shares, array $groups, array $expected): void {
 		$backend = $this->getBackend();
 

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/CalendarTest.php
@@ -57,10 +57,10 @@ class CalendarTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFilterTypes
 	 * @param string[] $types
 	 * @param string[] $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilterTypes')]
 	public function testFilterTypes(array $types, array $expected): void {
 		$this->assertEquals($expected, $this->filter->filterTypes($types));
 	}

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/GenericTest.php
@@ -24,35 +24,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testImplementsInterface(string $filterClass): void {
 		$filter = Server::get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetIdentifier(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetName(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetPriority(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -62,9 +54,7 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetIcon(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -72,18 +62,14 @@ class GenericTest extends TestCase {
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testFilterTypes(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testAllowedApps(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);

--- a/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Filter/TodoTest.php
@@ -57,10 +57,10 @@ class TodoTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFilterTypes
 	 * @param string[] $types
 	 * @param string[] $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilterTypes')]
 	public function testFilterTypes(array $types, array $expected): void {
 		$this->assertEquals($expected, $this->filter->filterTypes($types));
 	}

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/BaseTest.php
@@ -44,9 +44,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSetSubjects
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetSubjects')]
 	public function testSetSubjects(string $subject, array $parameters): void {
 		$event = $this->createMock(IEvent::class);
 		$event->expects($this->once())
@@ -68,9 +66,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGenerateCalendarParameter
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateCalendarParameter')]
 	public function testGenerateCalendarParameter(array $data, string $name): void {
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())
@@ -93,9 +89,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGenerateLegacyCalendarParameter
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateLegacyCalendarParameter')]
 	public function testGenerateLegacyCalendarParameter(int $id, string $name): void {
 		$this->assertEquals([
 			'type' => 'calendar',
@@ -111,9 +105,7 @@ class BaseTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGenerateGroupParameter
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateGroupParameter')]
 	public function testGenerateGroupParameter(string $gid): void {
 		$this->assertEquals([
 			'type' => 'user-group',

--- a/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Provider/EventTest.php
@@ -67,9 +67,7 @@ class EventTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGenerateObjectParameter
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateObjectParameter')]
 	public function testGenerateObjectParameter(int $id, string $name, ?array $link, bool $calendarAppEnabled = true): void {
 		$affectedUser = 'otheruser';
 		if ($link) {
@@ -150,9 +148,7 @@ class EventTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider generateObjectParameterLinkEncodingDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('generateObjectParameterLinkEncodingDataProvider')]
 	public function testGenerateObjectParameterLinkEncoding(array $link, string $objectId): void {
 		$generatedLink = [
 			'objectId' => $objectId,
@@ -185,9 +181,7 @@ class EventTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGenerateObjectParameterThrows
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenerateObjectParameterThrows')]
 	public function testGenerateObjectParameterThrows(string|array $eventData, string $exception = InvalidArgumentException::class): void {
 		$this->expectException($exception);
 

--- a/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
+++ b/apps/dav/tests/unit/CalDAV/Activity/Setting/GenericTest.php
@@ -23,35 +23,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testImplementsInterface(string $settingClass): void {
 		$setting = Server::get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testGetIdentifier(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testGetName(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testGetPriority(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
@@ -61,36 +53,28 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testCanChangeStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testIsDefaultEnabledStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testCanChangeMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testIsDefaultEnabledMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);

--- a/apps/dav/tests/unit/CalDAV/AppCalendar/AppCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/AppCalendar/AppCalendarTest.php
@@ -61,7 +61,7 @@ class AppCalendarTest extends TestCase {
 		];
 		$this->writeableCalendar->expects($this->exactly(3))
 			->method('createFromString')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalDavBackendTest.php
@@ -112,9 +112,7 @@ class CalDavBackendTest extends AbstractCalDavBackend {
 		];
 	}
 
-	/**
-	 * @dataProvider providesSharingData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesSharingData')]
 	public function testCalendarSharing($userCanRead, $userCanWrite, $groupCanRead, $groupCanWrite, $add, $principals): void {
 		$logger = $this->createMock(\Psr\Log\LoggerInterface::class);
 		$config = $this->createMock(IConfig::class);
@@ -403,9 +401,7 @@ EOD;
 		$this->assertCount(0, $calendarObjects);
 	}
 
-	/**
-	 * @dataProvider providesCalendarQueryParameters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesCalendarQueryParameters')]
 	public function testCalendarQuery($expectedEventsInResult, $propFilters, $compFilter): void {
 		$calendarId = $this->createTestCalendar();
 		$events = [];
@@ -692,9 +688,9 @@ EOS;
 	}
 
 	/**
-	 * @dataProvider providesSchedulingData
 	 * @param $objectData
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesSchedulingData')]
 	public function testScheduling($objectData): void {
 		$this->backend->createSchedulingObject(self::UNIT_TEST_USER, 'Sample Schedule', $objectData);
 
@@ -710,9 +706,7 @@ EOS;
 		$this->assertCount(0, $sos);
 	}
 
-	/**
-	 * @dataProvider providesCalDataForGetDenormalizedData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesCalDataForGetDenormalizedData')]
 	public function testGetDenormalizedData($expected, $key, $calData): void {
 		try {
 			$actual = $this->backend->getDenormalizedData($calData);
@@ -878,9 +872,7 @@ EOD;
 		$this->assertEquals(count($search5), 0);
 	}
 
-	/**
-	 * @dataProvider searchDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchDataProvider')]
 	public function testSearch(bool $isShared, array $searchOptions, int $count): void {
 		$calendarId = $this->createTestCalendar();
 

--- a/apps/dav/tests/unit/CalDAV/CalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarTest.php
@@ -144,9 +144,7 @@ class CalendarTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataPropPatch
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPropPatch')]
 	public function testPropPatch(string $ownerPrincipal, string $principalUri, array $mutations, bool $shared): void {
 		/** @var CalDavBackend&MockObject $backend */
 		$backend = $this->createMock(CalDavBackend::class);
@@ -168,9 +166,7 @@ class CalendarTest extends TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @dataProvider providesReadOnlyInfo
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesReadOnlyInfo')]
 	public function testAcl($expectsWrite, $readOnlyValue, $hasOwnerSet, $uri = 'default'): void {
 		/** @var CalDavBackend&MockObject $backend */
 		$backend = $this->createMock(CalDavBackend::class);
@@ -270,9 +266,7 @@ class CalendarTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesConfidentialClassificationData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
 	public function testPrivateClassification(int $expectedChildren, bool $isShared): void {
 		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
@@ -310,9 +304,7 @@ class CalendarTest extends TestCase {
 		$this->assertEquals(!$isShared, $c->childExists('event-2'));
 	}
 
-	/**
-	 * @dataProvider providesConfidentialClassificationData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
 	public function testConfidentialClassification(int $expectedChildren, bool $isShared): void {
 		$start = '20160609';
 		$end = '20160610';

--- a/apps/dav/tests/unit/CalDAV/Integration/ExternalCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/Integration/ExternalCalendarTest.php
@@ -66,9 +66,7 @@ class ExternalCalendarTest extends TestCase {
 		$this->assertTrue(ExternalCalendar::isAppGeneratedCalendar('app-generated--example--foo--2'));
 	}
 
-	/**
-	 * @dataProvider splitAppGeneratedCalendarUriDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('splitAppGeneratedCalendarUriDataProvider')]
 	public function testSplitAppGeneratedCalendarUriInvalid(string $name):void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Provided calendar uri was not app-generated');

--- a/apps/dav/tests/unit/CalDAV/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/PluginTest.php
@@ -36,9 +36,7 @@ class PluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider linkProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('linkProvider')]
 	public function testGetCalendarHomeForPrincipal(string $input, string $expected): void {
 		$this->assertSame($expected, $this->plugin->getCalendarHomeForPrincipal($input));
 	}

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarTest.php
@@ -16,9 +16,7 @@ use Sabre\VObject\Reader;
 
 class PublicCalendarTest extends CalendarTest {
 
-	/**
-	 * @dataProvider providesConfidentialClassificationData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
 	public function testPrivateClassification(int $expectedChildren, bool $isShared): void {
 		$calObject0 = ['uri' => 'event-0', 'classification' => CalDavBackend::CLASSIFICATION_PUBLIC];
 		$calObject1 = ['uri' => 'event-1', 'classification' => CalDavBackend::CLASSIFICATION_CONFIDENTIAL];
@@ -57,9 +55,7 @@ class PublicCalendarTest extends CalendarTest {
 		$this->assertFalse($c->childExists('event-2'));
 	}
 
-	/**
-	 * @dataProvider providesConfidentialClassificationData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesConfidentialClassificationData')]
 	public function testConfidentialClassification(int $expectedChildren, bool $isShared): void {
 		$start = '20160609';
 		$end = '20160610';

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotificationProvider/PushProviderTest.php
@@ -107,7 +107,7 @@ class PushProviderTest extends AbstractNotificationProviderTestCase {
 		];
 		$this->manager->expects($this->exactly(3))
 			->method('notify')
-			->willReturnCallback(function ($notification) use (&$calls) {
+			->willReturnCallback(function ($notification) use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, $notification);
 			});

--- a/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/NotifierTest.php
@@ -170,9 +170,7 @@ class NotifierTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataPrepare
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPrepare')]
 	public function testPrepare(string $subjectType, array $subjectParams, string $subject, array $messageParams, string $message): void {
 		/** @var INotification&MockObject $notification */
 		$notification = $this->createMock(INotification::class);

--- a/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/Reminder/ReminderServiceTest.php
@@ -747,7 +747,7 @@ EOD;
 		];
 		$this->backend->expects($this->exactly(5))
 			->method('removeReminder')
-			->willReturnCallback(function () use (&$removeReminderCalls) {
+			->willReturnCallback(function () use (&$removeReminderCalls): void {
 				$expected = array_shift($removeReminderCalls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
+++ b/apps/dav/tests/unit/CalDAV/ResourceBooking/AbstractPrincipalBackendTestCase.php
@@ -246,9 +246,7 @@ abstract class AbstractPrincipalBackendTestCase extends TestCase {
 		$this->assertEquals(0, $actual);
 	}
 
-	/**
-	 * @dataProvider dataSearchPrincipals
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchPrincipals')]
 	public function testSearchPrincipals($expected, $test): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->once())

--- a/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
+++ b/apps/dav/tests/unit/CalDAV/Schedule/PluginTest.php
@@ -74,7 +74,7 @@ class PluginTest extends TestCase {
 		];
 		$this->server->expects($this->exactly(count($calls)))
 			->method('on')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});
@@ -251,9 +251,7 @@ class PluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider propFindDefaultCalendarUrlProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('propFindDefaultCalendarUrlProvider')]
 	public function testPropFindDefaultCalendarUrl(string $principalUri, ?string $calendarHome, bool $isResource, string $calendarUri, string $displayName, bool $exists, bool $deleted = false, bool $hasExistingCalendars = false, bool $propertiesForPath = true): void {
 		$propFind = new PropFind(
 			$principalUri,

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/ConnectionTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/ConnectionTest.php
@@ -32,9 +32,7 @@ class ConnectionTest extends TestCase {
 		$this->connection = new Connection($this->clientService, $this->config, $this->logger);
 	}
 
-	/**
-	 * @dataProvider runLocalURLDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('runLocalURLDataProvider')]
 	public function testLocalUrl($source): void {
 		$subscription = [
 			'id' => 42,
@@ -94,8 +92,8 @@ class ConnectionTest extends TestCase {
 	/**
 	 * @param string $result
 	 * @param string $contentType
-	 * @dataProvider urlDataProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('urlDataProvider')]
 	public function testConnection(string $url, string $result, string $contentType): void {
 		$client = $this->createMock(IClient::class);
 		$response = $this->createMock(IResponse::class);

--- a/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
+++ b/apps/dav/tests/unit/CalDAV/WebcalCaching/RefreshWebcalServiceTest.php
@@ -34,9 +34,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		$this->time = $this->createMock(ITimeFactory::class);
 	}
 
-	/**
-	 * @dataProvider runDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
 	public function testRun(string $body, string $contentType, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
 			->onlyMethods(['getRandomCalendarObjectUri'])
@@ -83,9 +81,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
-	/**
-	 * @dataProvider identicalDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('identicalDataProvider')]
 	public function testRunIdentical(string $uid, array $calendarObject, string $body, string $contentType, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
 			->onlyMethods(['getRandomCalendarObjectUri'])
@@ -200,9 +196,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
-	/**
-	 * @dataProvider runDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
 	public function testRunCreateCalendarNoException(string $body, string $contentType, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
 			->onlyMethods(['getRandomCalendarObjectUri', 'getSubscription',])
@@ -246,9 +240,7 @@ class RefreshWebcalServiceTest extends TestCase {
 		$refreshWebcalService->refreshSubscription('principals/users/testuser', 'sub123');
 	}
 
-	/**
-	 * @dataProvider runDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
 	public function testRunCreateCalendarBadRequest(string $body, string $contentType, string $result): void {
 		$refreshWebcalService = $this->getMockBuilder(RefreshWebcalService::class)
 			->onlyMethods(['getRandomCalendarObjectUri', 'getSubscription'])

--- a/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/Activity/BackendTest.php
@@ -71,9 +71,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCallTriggerAddressBookActivity
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCallTriggerAddressBookActivity')]
 	public function testCallTriggerAddressBookActivity(string $method, array $payload, string $expectedSubject, array $expectedPayload): void {
 		$backend = $this->getBackend(['triggerAddressbookActivity']);
 		$backend->expects($this->once())
@@ -151,10 +149,10 @@ class BackendTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTriggerAddressBookActivity
 	 * @param string[]|null $shareUsers
 	 * @param string[] $users
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTriggerAddressBookActivity')]
 	public function testTriggerAddressBookActivity(string $action, array $data, array $shares, array $changedProperties, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
@@ -315,10 +313,10 @@ class BackendTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTriggerCardActivity
 	 * @param string[]|null $shareUsers
 	 * @param string[] $users
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTriggerCardActivity')]
 	public function testTriggerCardActivity(string $action, array $addressBookData, array $shares, array $cardData, string $currentUser, string $author, ?array $shareUsers, array $users): void {
 		$backend = $this->getBackend(['getUsersForShares']);
 
@@ -432,9 +430,7 @@ class BackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetUsersForShares
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsersForShares')]
 	public function testGetUsersForShares(array $shares, array $groups, array $expected): void {
 		$backend = $this->getBackend();
 

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -103,9 +103,7 @@ class AddressBookImplTest extends TestCase {
 		$this->assertSame(2, count($result));
 	}
 
-	/**
-	 * @dataProvider dataTestCreate
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCreate')]
 	public function testCreate(array $properties): void {
 		$uid = 'uid';
 
@@ -230,9 +228,7 @@ class AddressBookImplTest extends TestCase {
 		$addressBookImpl->createOrUpdate($properties);
 	}
 
-	/**
-	 * @dataProvider dataTestGetPermissions
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetPermissions')]
 	public function testGetPermissions(array $permissions, int $expected): void {
 		$this->addressBook->expects($this->once())->method('getACL')
 			->willReturn($permissions);

--- a/apps/dav/tests/unit/CardDAV/AddressBookTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookTest.php
@@ -117,9 +117,7 @@ class AddressBookTest extends TestCase {
 		$addressBook->propPatch(new PropPatch(['{DAV:}displayname' => 'Test address book']));
 	}
 
-	/**
-	 * @dataProvider providesReadOnlyInfo
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesReadOnlyInfo')]
 	public function testAcl(bool $expectsWrite, ?bool $readOnlyValue, bool $hasOwnerSet): void {
 		/** @var MockObject | CardDavBackend $backend */
 		$backend = $this->createMock(CardDavBackend::class);

--- a/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/BirthdayServiceTest.php
@@ -50,9 +50,7 @@ class BirthdayServiceTest extends TestCase {
 			$this->dbConnection, $this->l10n);
 	}
 
-	/**
-	 * @dataProvider providesVCards
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesVCards')]
 	public function testBuildBirthdayFromContact(?string $expectedSummary, ?string $expectedDTStart, ?string $expectedRrule, ?string $expectedFieldType, ?string $expectedUnknownYear, ?string $expectedOriginalYear, ?string $expectedReminder, ?string $data, string $fieldType, string $prefix, bool $supports4Bytes, ?string $configuredReminder): void {
 		$this->dbConnection->method('supports4ByteText')->willReturn($supports4Bytes);
 		$cal = $this->service->buildDateFromContact($data, $fieldType, $prefix, $configuredReminder);
@@ -146,7 +144,7 @@ class BirthdayServiceTest extends TestCase {
 		];
 		$this->calDav->expects($this->exactly(count($calls)))
 			->method('deleteCalendarObject')
-			->willReturnCallback(function ($calendarId, $objectUri) use (&$calls) {
+			->willReturnCallback(function ($calendarId, $objectUri) use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, [$calendarId, $objectUri]);
 			});
@@ -200,9 +198,7 @@ class BirthdayServiceTest extends TestCase {
 		$service->onCardChanged(666, 'gump.vcf', '');
 	}
 
-	/**
-	 * @dataProvider providesCardChanges
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesCardChanges')]
 	public function testOnCardChanged(string $expectedOp): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
@@ -246,7 +242,7 @@ class BirthdayServiceTest extends TestCase {
 			];
 			$this->calDav->expects($this->exactly(count($calls)))
 				->method('deleteCalendarObject')
-				->willReturnCallback(function ($calendarId, $objectUri) use (&$calls) {
+				->willReturnCallback(function ($calendarId, $objectUri) use (&$calls): void {
 					$expected = array_shift($calls);
 					$this->assertEquals($expected, [$calendarId, $objectUri]);
 				});
@@ -264,7 +260,7 @@ class BirthdayServiceTest extends TestCase {
 			];
 			$this->calDav->expects($this->exactly(count($createCalendarObjectCalls)))
 				->method('createCalendarObject')
-				->willReturnCallback(function ($calendarId, $objectUri, $calendarData) use (&$createCalendarObjectCalls) {
+				->willReturnCallback(function ($calendarId, $objectUri, $calendarData) use (&$createCalendarObjectCalls): void {
 					$expected = array_shift($createCalendarObjectCalls);
 					$this->assertEquals($expected, [$calendarId, $objectUri, $calendarData]);
 				});
@@ -284,7 +280,7 @@ class BirthdayServiceTest extends TestCase {
 			];
 			$this->calDav->expects($this->exactly(count($updateCalendarObjectCalls)))
 				->method('updateCalendarObject')
-				->willReturnCallback(function ($calendarId, $objectUri, $calendarData) use (&$updateCalendarObjectCalls) {
+				->willReturnCallback(function ($calendarId, $objectUri, $calendarData) use (&$updateCalendarObjectCalls): void {
 					$expected = array_shift($updateCalendarObjectCalls);
 					$this->assertEquals($expected, [$calendarId, $objectUri, $calendarData]);
 				});
@@ -293,9 +289,7 @@ class BirthdayServiceTest extends TestCase {
 		$service->onCardChanged(666, 'gump.vcf', '');
 	}
 
-	/**
-	 * @dataProvider providesBirthday
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesBirthday')]
 	public function testBirthdayEvenChanged(bool $expected, string $old, string $new): void {
 		$new = Reader::read($new);
 		$this->assertEquals($expected, $this->service->birthdayEvenChanged($old, $new));
@@ -369,7 +363,7 @@ class BirthdayServiceTest extends TestCase {
 		];
 		$this->calDav->expects($this->exactly(count($calls)))
 			->method('deleteCalendarObject')
-			->willReturnCallback(function ($calendarId, $objectUri, $calendarType) use (&$calls) {
+			->willReturnCallback(function ($calendarId, $objectUri, $calendarType) use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, [$calendarId, $objectUri, $calendarType]);
 			});

--- a/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
+++ b/apps/dav/tests/unit/CardDAV/CardDavBackendTest.php
@@ -249,7 +249,7 @@ class CardDavBackendTest extends TestCase {
 		];
 		$backend->expects($this->exactly(count($calls)))
 			->method('updateProperties')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});
@@ -437,7 +437,7 @@ class CardDavBackendTest extends TestCase {
 		];
 		$this->backend->expects($this->exactly(count($calls)))
 			->method('addChange')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});
@@ -645,9 +645,7 @@ class CardDavBackendTest extends TestCase {
 		$this->invokePrivate($this->backend, 'getCardId', [1, 'uri']);
 	}
 
-	/**
-	 * @dataProvider dataTestSearch
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSearch')]
 	public function testSearch(string $pattern, array $properties, array $options, array $expected): void {
 		/** @var VCard $vCards */
 		$vCards = [];

--- a/apps/dav/tests/unit/CardDAV/ConverterTest.php
+++ b/apps/dav/tests/unit/CardDAV/ConverterTest.php
@@ -79,9 +79,7 @@ class ConverterTest extends TestCase {
 		return $accountManager;
 	}
 
-	/**
-	 * @dataProvider providesNewUsers
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesNewUsers')]
 	public function testCreation($expectedVCard, $displayName = null, $eMailAddress = null, $cloudId = null): void {
 		$user = $this->getUserMock((string)$displayName, $eMailAddress, $cloudId);
 		$accountManager = $this->getAccountManager($user);
@@ -189,9 +187,7 @@ class ConverterTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesNames
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesNames')]
 	public function testNameSplitter(string $expected, string $fullName): void {
 		$converter = new Converter($this->accountManager, $this->userManager, $this->urlGenerator, $this->logger);
 		$r = $converter->splitFullName($fullName);

--- a/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
+++ b/apps/dav/tests/unit/CardDAV/ImageExportPluginTest.php
@@ -45,9 +45,7 @@ class ImageExportPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	/**
-	 * @dataProvider providesQueryParams
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesQueryParams')]
 	public function testQueryParams(array $param): void {
 		$this->request->expects($this->once())->method('getQueryParameters')->willReturn($param);
 		$result = $this->plugin->httpGet($this->request, $this->response);
@@ -88,9 +86,7 @@ class ImageExportPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestCard
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCard')]
 	public function testCard(?int $size, bool $photo): void {
 		$query = ['photo' => null];
 		if ($size !== null) {
@@ -142,7 +138,7 @@ class ImageExportPluginTest extends TestCase {
 			];
 			$this->response->expects($this->exactly(count($setHeaderCalls)))
 				->method('setHeader')
-				->willReturnCallback(function () use (&$setHeaderCalls) {
+				->willReturnCallback(function () use (&$setHeaderCalls): void {
 					$expected = array_shift($setHeaderCalls);
 					$this->assertEquals($expected, func_get_args());
 				});
@@ -160,7 +156,7 @@ class ImageExportPluginTest extends TestCase {
 			];
 			$this->response->expects($this->exactly(count($setHeaderCalls)))
 				->method('setHeader')
-				->willReturnCallback(function () use (&$setHeaderCalls) {
+				->willReturnCallback(function () use (&$setHeaderCalls): void {
 					$expected = array_shift($setHeaderCalls);
 					$this->assertEquals($expected, func_get_args());
 				});

--- a/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
+++ b/apps/dav/tests/unit/CardDAV/SyncServiceTest.php
@@ -325,9 +325,7 @@ END:VCARD';
 		];
 	}
 
-	/**
-	 * @dataProvider dataActivatedUsers
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataActivatedUsers')]
 	public function testUpdateAndDeleteUser(bool $activated, int $createCalls, int $updateCalls, int $deleteCalls): void {
 		/** @var CardDavBackend | MockObject $backend */
 		$backend = $this->getMockBuilder(CardDavBackend::class)->disableOriginalConstructor()->getMock();
@@ -427,9 +425,7 @@ END:VCARD';
 		);
 	}
 
-	/**
-	 * @dataProvider providerUseAbsoluteUriReport
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerUseAbsoluteUriReport')]
 	public function testUseAbsoluteUriReport(string $host, string $expected): void {
 		$body = '<?xml version="1.0"?>
 <d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:card="urn:ietf:params:xml:ns:carddav" xmlns:oc="http://owncloud.org/ns">

--- a/apps/dav/tests/unit/Command/ListAddressbooksTest.php
+++ b/apps/dav/tests/unit/Command/ListAddressbooksTest.php
@@ -78,9 +78,7 @@ class ListAddressbooksTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecute
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecute')]
 	public function testWithCorrectUser(bool $readOnly, string $output): void {
 		$this->userManager->expects($this->once())
 			->method('userExists')

--- a/apps/dav/tests/unit/Command/ListCalendarsTest.php
+++ b/apps/dav/tests/unit/Command/ListCalendarsTest.php
@@ -79,9 +79,7 @@ class ListCalendarsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecute
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecute')]
 	public function testWithCorrectUser(bool $readOnly, string $output): void {
 		$this->userManager->expects($this->once())
 			->method('userExists')

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -64,9 +64,7 @@ class MoveCalendarTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecute
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecute')]
 	public function testWithBadUserOrigin(bool $userOriginExists, bool $userDestinationExists): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -178,9 +176,7 @@ class MoveCalendarTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestMoveWithDestinationNotPartOfGroup
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestMoveWithDestinationNotPartOfGroup')]
 	public function testMoveWithDestinationNotPartOfGroup(bool $shareWithGroupMembersOnly): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')
@@ -311,9 +307,7 @@ class MoveCalendarTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestMoveWithCalendarAlreadySharedToDestination
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestMoveWithCalendarAlreadySharedToDestination')]
 	public function testMoveWithCalendarAlreadySharedToDestination(bool $force): void {
 		$this->userManager->expects($this->exactly(2))
 			->method('userExists')

--- a/apps/dav/tests/unit/Comments/CommentsNodeTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsNodeTest.php
@@ -174,7 +174,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		$this->comment->expects($this->once())
 			->method('setMessage')
 			->with($msg)
-			->will($this->throwException(new \Exception('buh!')));
+			->willThrowException(new \Exception('buh!'));
 
 		$this->comment->expects($this->any())
 			->method('getActorType')
@@ -209,7 +209,7 @@ class CommentsNodeTest extends \Test\TestCase {
 
 		$this->comment->expects($this->once())
 			->method('setMessage')
-			->will($this->throwException(new MessageTooLongException()));
+			->willThrowException(new MessageTooLongException());
 
 		$this->comment->expects($this->any())
 			->method('getActorType')
@@ -469,9 +469,7 @@ class CommentsNodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider readCommentProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('readCommentProvider')]
 	public function testGetPropertiesUnreadProperty(\DateTime $creationDT, ?\DateTime $readDT, string $expected): void {
 		$this->comment->expects($this->any())
 			->method('getCreationDateTime')

--- a/apps/dav/tests/unit/Comments/CommentsPluginTest.php
+++ b/apps/dav/tests/unit/Comments/CommentsPluginTest.php
@@ -184,7 +184,7 @@ class CommentsPluginTest extends \Test\TestCase {
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
 			->with('/' . $path)
-			->will($this->throwException(new \Sabre\DAV\Exception\NotFound()));
+			->willThrowException(new \Sabre\DAV\Exception\NotFound());
 
 		$request = $this->getMockBuilder(RequestInterface::class)
 			->disableOriginalConstructor()

--- a/apps/dav/tests/unit/Comments/EntityCollectionTest.php
+++ b/apps/dav/tests/unit/Comments/EntityCollectionTest.php
@@ -68,7 +68,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('55')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 
 		$this->collection->getChild('55');
 	}
@@ -114,7 +114,7 @@ class EntityCollectionTest extends \Test\TestCase {
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('44')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 
 		$this->assertFalse($this->collection->childExists('44'));
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/AuthTest.php
@@ -196,7 +196,7 @@ class AuthTest extends TestCase {
 			->expects($this->once())
 			->method('logClientIn')
 			->with('MyTestUser', 'MyTestPassword')
-			->will($this->throwException(new PasswordLoginForbiddenException()));
+			->willThrowException(new PasswordLoginForbiddenException());
 		$this->session
 			->expects($this->once())
 			->method('close');

--- a/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/BlockLegacyClientPluginTest.php
@@ -55,9 +55,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider oldDesktopClientProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('oldDesktopClientProvider')]
 	public function testBeforeHandlerException(string $userAgent, ERROR_TYPE $errorType): void {
 		$this->themingDefaults
 			->expects($this->atMost(1))
@@ -95,8 +93,8 @@ class BlockLegacyClientPluginTest extends TestCase {
 
 	/**
 	 * Ensure that there is no room for XSS attack through configured URL / version
-	 * @dataProvider oldDesktopClientProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('oldDesktopClientProvider')]
 	public function testBeforeHandlerExceptionPreventXSSAttack(string $userAgent, ERROR_TYPE $errorType): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -142,9 +140,7 @@ class BlockLegacyClientPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider newAndAlternateDesktopClientProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('newAndAlternateDesktopClientProvider')]
 	public function testBeforeHandlerSuccess(string $userAgent): void {
 		/** @var RequestInterface|MockObject $request */
 		$request = $this->createMock(RequestInterface::class);

--- a/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
@@ -43,9 +43,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider nodeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('nodeProvider')]
 	public function testHandleGetProperties(string $class, bool $expectedSuccessful): void {
 		$propFind = $this->createMock(PropFind::class);
 
@@ -69,9 +67,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider baseUriProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('baseUriProvider')]
 	public function testGetCommentsLink(string $baseUri, string $fid, ?string $expectedHref): void {
 		$node = $this->createMock(File::class);
 		$node->expects($this->any())
@@ -93,9 +89,7 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider userProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('userProvider')]
 	public function testGetUnreadCount(?string $user): void {
 		$node = $this->createMock(File::class);
 		$node->expects($this->any())

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -373,26 +373,20 @@ class DirectoryTest extends \Test\TestCase {
 		$this->assertEquals([200, 800], $dir->getQuotaInfo()); //200 used, 800 free
 	}
 
-	/**
-	 * @dataProvider moveFailedProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('moveFailedProvider')]
 	public function testMoveFailed(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
 		$this->moveTest($source, $destination, $updatables, $deletables);
 	}
 
-	/**
-	 * @dataProvider moveSuccessProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('moveSuccessProvider')]
 	public function testMoveSuccess(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->moveTest($source, $destination, $updatables, $deletables);
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @dataProvider moveFailedInvalidCharsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('moveFailedInvalidCharsProvider')]
 	public function testMoveFailedInvalidChars(string $source, string $destination, array $updatables, array $deletables): void {
 		$this->expectException(InvalidPath::class);
 

--- a/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ExceptionLoggerPluginTest.php
@@ -42,9 +42,7 @@ class ExceptionLoggerPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	/**
-	 * @dataProvider providesExceptions
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesExceptions')]
 	public function testLogging(string $expectedLogLevel, \Throwable $e): void {
 		$this->init();
 

--- a/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FakeLockerPluginTest.php
@@ -41,7 +41,7 @@ class FakeLockerPluginTest extends TestCase {
 		];
 		$server->expects($this->exactly(count($calls)))
 			->method('on')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});
@@ -74,7 +74,7 @@ class FakeLockerPluginTest extends TestCase {
 		];
 		$propFind->expects($this->exactly(count($calls)))
 			->method('handle')
-			->willReturnCallback(function ($propertyName) use (&$calls) {
+			->willReturnCallback(function ($propertyName) use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, $propertyName);
 			});
@@ -119,9 +119,7 @@ class FakeLockerPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider tokenDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tokenDataProvider')]
 	public function testValidateTokens(array $input, array $expected): void {
 		$request = $this->createMock(RequestInterface::class);
 		$this->fakeLockerPlugin->validateTokens($request, $input);

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -150,9 +150,7 @@ class FileTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider fopenFailuresProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('fopenFailuresProvider')]
 	public function testSimplePutFails(?\Throwable $thrownException, string $expectedException, bool $checkPreviousClass = true): void {
 		// setup
 		$storage = $this->getMockBuilder(Local::class)
@@ -175,7 +173,7 @@ class FileTest extends TestCase {
 		if ($thrownException !== null) {
 			$storage->expects($this->once())
 				->method('writeStream')
-				->will($this->throwException($thrownException));
+				->willThrowException($thrownException);
 		} else {
 			$storage->expects($this->once())
 				->method('writeStream')
@@ -316,8 +314,8 @@ class FileTest extends TestCase {
 
 	/**
 	 * Test putting a file with string Mtime
-	 * @dataProvider legalMtimeProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('legalMtimeProvider')]
 	public function testPutSingleFileLegalMtime(mixed $requestMtime, ?int $resultMtime): void {
 		$request = new Request([
 			'server' => [

--- a/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesPluginTest.php
@@ -294,7 +294,7 @@ class FilesPluginTest extends TestCase {
 
 		$node->expects($this->once())
 			->method('getDirectDownload')
-			->will($this->throwException(new StorageNotAvailableException()));
+			->willThrowException(new StorageNotAvailableException());
 
 		$this->plugin->handleGetProperties(
 			$propFind,
@@ -652,9 +652,7 @@ class FilesPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider downloadHeadersProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('downloadHeadersProvider')]
 	public function testDownloadHeaders(bool $isClumsyAgent, string $contentDispositionHeader): void {
 		$request = $this->createMock(RequestInterface::class);
 		$response = $this->createMock(ResponseInterface::class);
@@ -688,7 +686,7 @@ class FilesPluginTest extends TestCase {
 		$response
 			->expects($this->exactly(count($calls)))
 			->method('addHeader')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertSame($expected, func_get_args());
 			});

--- a/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesReportPluginTest.php
@@ -846,9 +846,7 @@ class FilesReportPluginTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider filesBaseUriProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('filesBaseUriProvider')]
 	public function testFilesBaseUri(string $uri, string $reportPath, string $expectedUri): void {
 		$this->assertEquals($expectedUri, self::invokePrivate($this->plugin, 'getFilesBaseUri', [$uri, $reportPath]));
 	}

--- a/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/NodeTest.php
@@ -51,9 +51,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider davPermissionsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('davPermissionsProvider')]
 	public function testDavPermissions(int $permissions, string $type, bool $shared, int $shareRootPermissions, bool $mounted, string $internalPath, string $expected): void {
 		$info = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()
@@ -141,9 +139,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider sharePermissionsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sharePermissionsProvider')]
 	public function testSharePermissions(string $type, ?string $user, int $permissions, int $expected): void {
 		$storage = $this->createMock(IStorage::class);
 		$storage->method('getPermissions')->willReturn($permissions);
@@ -242,9 +238,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider sanitizeMtimeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sanitizeMtimeProvider')]
 	public function testSanitizeMtime(string|int $mtime, int $expected): void {
 		$view = $this->getMockBuilder(View::class)
 			->disableOriginalConstructor()
@@ -264,9 +258,7 @@ class NodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider invalidSanitizeMtimeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidSanitizeMtimeProvider')]
 	public function testInvalidSanitizeMtime(int|string $mtime): void {
 		$this->expectException(\InvalidArgumentException::class);
 

--- a/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ObjectTreeTest.php
@@ -39,9 +39,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider copyDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyDataProvider')]
 	public function testCopy(string $sourcePath, string $targetPath, string $targetParent): void {
 		$view = $this->createMock(View::class);
 		$view->expects($this->once())
@@ -83,9 +81,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$objectTree->copy($sourcePath, $targetPath);
 	}
 
-	/**
-	 * @dataProvider copyDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyDataProvider')]
 	public function testCopyFailNotCreatable($sourcePath, $targetPath, $targetParent): void {
 		$this->expectException(\Sabre\DAV\Exception\Forbidden::class);
 
@@ -124,9 +120,7 @@ class ObjectTreeTest extends \Test\TestCase {
 		$objectTree->copy($sourcePath, $targetPath);
 	}
 
-	/**
-	 * @dataProvider nodeForPathProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('nodeForPathProvider')]
 	public function testGetNodeForPath(
 		string $inputFileName,
 		string $fileInfoQueryPath,

--- a/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PrincipalTest.php
@@ -463,9 +463,7 @@ class PrincipalTest extends TestCase {
 			['{http://sabredav.org/ns}email-address' => 'foo']));
 	}
 
-	/**
-	 * @dataProvider searchPrincipalsDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchPrincipalsDataProvider')]
 	public function testSearchPrincipals(bool $sharingEnabled, bool $groupsOnly, string $test, array $result): void {
 		$this->shareManager->expects($this->once())
 			->method('shareAPIEnabled')
@@ -826,9 +824,7 @@ class PrincipalTest extends TestCase {
 		$this->assertEquals(null, $this->connector->findByUri('mailto:user@foo.com', 'principals/users'));
 	}
 
-	/**
-	 * @dataProvider findByUriWithGroupRestrictionDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('findByUriWithGroupRestrictionDataProvider')]
 	public function testFindByUriWithGroupRestriction(string $uri, string $email, ?string $expects): void {
 		$this->shareManager->expects($this->once())
 			->method('shareApiEnabled')
@@ -879,9 +875,7 @@ class PrincipalTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider findByUriWithoutGroupRestrictionDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('findByUriWithoutGroupRestrictionDataProvider')]
 	public function testFindByUriWithoutGroupRestriction(string $uri, string $email, string $expects): void {
 		$this->shareManager->expects($this->once())
 			->method('shareApiEnabled')

--- a/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PublicAuthTest.php
@@ -114,7 +114,7 @@ class PublicAuthTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('getShareByToken')
 			->with('GX9HSGQrGE')
-			->will($this->throwException(new ShareNotFound()));
+			->willThrowException(new ShareNotFound());
 
 		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
 		self::invokePrivate($this->auth, 'checkToken');

--- a/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/QuotaPluginTest.php
@@ -25,9 +25,7 @@ class QuotaPluginTest extends TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	/**
-	 * @dataProvider lengthProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('lengthProvider')]
 	public function testLength(?int $expected, array $headers): void {
 		$this->init(0);
 
@@ -36,9 +34,7 @@ class QuotaPluginTest extends TestCase {
 		$this->assertEquals($expected, $length);
 	}
 
-	/**
-	 * @dataProvider quotaOkayProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('quotaOkayProvider')]
 	public function testCheckQuota(int $quota, array $headers): void {
 		$this->init($quota);
 
@@ -47,9 +43,7 @@ class QuotaPluginTest extends TestCase {
 		$this->assertTrue($result);
 	}
 
-	/**
-	 * @dataProvider quotaExceededProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('quotaExceededProvider')]
 	public function testCheckExceededQuota(int $quota, array $headers): void {
 		$this->expectException(\Sabre\DAV\Exception\InsufficientStorage::class);
 
@@ -59,9 +53,7 @@ class QuotaPluginTest extends TestCase {
 		$this->plugin->checkQuota('');
 	}
 
-	/**
-	 * @dataProvider quotaOkayProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('quotaOkayProvider')]
 	public function testCheckQuotaOnPath(int $quota, array $headers): void {
 		$this->init($quota, 'sub/test.txt');
 

--- a/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/RequestTest/DeleteTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\Connector\Sabre\RequestTest;
 
 use OCP\AppFramework\Http;
+use OCP\Files\FileInfo;
 
 /**
  * Class DeleteTest
@@ -30,7 +31,7 @@ class DeleteTest extends RequestTestCase {
 		$mount->getStorage()->unlink($mount->getInternalPath($internalPath));
 
 		// cache entry still exists
-		$this->assertInstanceOf(\OCP\Files\FileInfo::class, $view->getFileInfo('foo.txt'));
+		$this->assertInstanceOf(FileInfo::class, $view->getFileInfo('foo.txt'));
 
 		$response = $this->request($view, $user, 'pass', 'DELETE', '/foo.txt');
 

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -54,9 +54,7 @@ class SharesPluginTest extends \Test\TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	/**
-	 * @dataProvider sharesGetPropertiesDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sharesGetPropertiesDataProvider')]
 	public function testGetProperties(array $shareTypes): void {
 		$sabreNode = $this->createMock(Node::class);
 		$sabreNode->expects($this->any())
@@ -119,9 +117,7 @@ class SharesPluginTest extends \Test\TestCase {
 		$this->assertEquals($shareTypes, $result[200][self::SHARETYPES_PROPERTYNAME]->getShareTypes());
 	}
 
-	/**
-	 * @dataProvider sharesGetPropertiesDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sharesGetPropertiesDataProvider')]
 	public function testPreloadThenGetProperties(array $shareTypes): void {
 		$sabreNode1 = $this->createMock(File::class);
 		$sabreNode1->method('getId')

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -58,9 +58,7 @@ class TagsPluginTest extends \Test\TestCase {
 		$this->plugin->initialize($this->server);
 	}
 
-	/**
-	 * @dataProvider tagsGetPropertiesDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tagsGetPropertiesDataProvider')]
 	public function testGetProperties(array $tags, array $requestedProperties, array $expectedProperties): void {
 		$node = $this->createMock(Node::class);
 		$node->expects($this->any())
@@ -95,9 +93,7 @@ class TagsPluginTest extends \Test\TestCase {
 		$this->assertEquals($expectedProperties, $result);
 	}
 
-	/**
-	 * @dataProvider tagsGetPropertiesDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tagsGetPropertiesDataProvider')]
 	public function testPreloadThenGetProperties(array $tags, array $requestedProperties, array $expectedProperties): void {
 		$node1 = $this->createMock(File::class);
 		$node1->expects($this->any())
@@ -269,7 +265,7 @@ class TagsPluginTest extends \Test\TestCase {
 		];
 		$this->tagger->expects($this->exactly(count($calls)))
 			->method('tagAs')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});
@@ -322,7 +318,7 @@ class TagsPluginTest extends \Test\TestCase {
 		];
 		$this->tagger->expects($this->exactly(count($calls)))
 			->method('tagAs')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
+++ b/apps/dav/tests/unit/Controller/InvitationResponseControllerTest.php
@@ -53,9 +53,7 @@ class InvitationResponseControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider attendeeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
 	public function testAccept(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -117,9 +115,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	/**
-	 * @dataProvider attendeeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
 	public function testAcceptSequence(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -181,9 +177,7 @@ EOF;
 		$this->assertTrue($called);
 	}
 
-	/**
-	 * @dataProvider attendeeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
 	public function testAcceptRecurrenceId(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -273,9 +267,7 @@ EOF;
 		$this->assertEquals([], $response->getParams());
 	}
 
-	/**
-	 * @dataProvider attendeeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
 	public function testDecline(bool $isExternalAttendee): void {
 		$this->buildQueryExpects('TOKEN123', [
 			'id' => 0,
@@ -344,9 +336,7 @@ EOF;
 		$this->assertEquals(['token' => 'TOKEN123'], $response->getParams());
 	}
 
-	/**
-	 * @dataProvider attendeeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('attendeeProvider')]
 	public function testProcessMoreOptionsResult(bool $isExternalAttendee): void {
 		$this->request->expects($this->once())
 			->method('getParam')

--- a/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
+++ b/apps/dav/tests/unit/DAV/BrowserErrorPagePluginTest.php
@@ -15,9 +15,7 @@ use Sabre\HTTP\Response;
 
 class BrowserErrorPagePluginTest extends \Test\TestCase {
 
-	/**
-	 * @dataProvider providesExceptions
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesExceptions')]
 	public function test(int $expectedCode, \Throwable $exception): void {
 		/** @var BrowserErrorPagePlugin&MockObject $plugin */
 		$plugin = $this->getMockBuilder(BrowserErrorPagePlugin::class)->onlyMethods(['sendResponse', 'generateBody'])->getMock();

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -271,9 +271,7 @@ class CustomPropertiesBackendTest extends TestCase {
 
 	}
 
-	/**
-	 * @dataProvider propFindPrincipalScheduleDefaultCalendarProviderUrlProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('propFindPrincipalScheduleDefaultCalendarProviderUrlProvider')]
 	public function testPropFindPrincipalScheduleDefaultCalendarUrl(
 		string $user,
 		array $nodes,
@@ -335,9 +333,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals($returnedProps, $setProps);
 	}
 
-	/**
-	 * @dataProvider propPatchProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('propPatchProvider')]
 	public function testPropPatch(string $path, array $existing, array $props, array $result): void {
 		$this->server->method('calculateUri')
 			->willReturnCallback(function ($uri) {
@@ -418,9 +414,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		$this->assertEquals([], $storedProps);
 	}
 
-	/**
-	 * @dataProvider deleteProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('deleteProvider')]
 	public function testDelete(string $path): void {
 		$this->insertProps('dummy_user_42', $path, ['foo' => 'bar']);
 		$this->backend->delete($path);
@@ -434,9 +428,7 @@ class CustomPropertiesBackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider moveProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('moveProvider')]
 	public function testMove(string $source, string $target): void {
 		$this->insertProps('dummy_user_42', $source, ['foo' => 'bar']);
 		$this->backend->move($source, $target);

--- a/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
+++ b/apps/dav/tests/unit/DAV/GroupPrincipalTest.php
@@ -192,9 +192,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 			['{DAV:}displayname' => 'Foo']));
 	}
 
-	/**
-	 * @dataProvider searchPrincipalsDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchPrincipalsDataProvider')]
 	public function testSearchPrincipals(bool $sharingEnabled, bool $groupSharingEnabled, bool $groupsOnly, string $test, array $result): void {
 		$this->shareManager->expects($this->once())
 			->method('shareAPIEnabled')
@@ -265,9 +263,7 @@ class GroupPrincipalTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider findByUriDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('findByUriDataProvider')]
 	public function testFindByUri(bool $sharingEnabled, bool $groupSharingEnabled, bool $groupsOnly, string $findUri, ?string $result): void {
 		$this->shareManager->expects($this->once())
 			->method('shareAPIEnabled')

--- a/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
+++ b/apps/dav/tests/unit/DAV/SystemPrincipalBackendTest.php
@@ -14,9 +14,7 @@ use Test\TestCase;
 
 class SystemPrincipalBackendTest extends TestCase {
 
-	/**
-	 * @dataProvider providesPrefix
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesPrefix')]
 	public function testGetPrincipalsByPrefix(array $expected, string $prefix): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalsByPrefix($prefix);
@@ -38,9 +36,7 @@ class SystemPrincipalBackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesPath
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesPath')]
 	public function testGetPrincipalByPath(?array $expected, string $path): void {
 		$backend = new SystemPrincipalBackend();
 		$result = $backend->getPrincipalByPath($path);
@@ -59,9 +55,7 @@ class SystemPrincipalBackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesPrincipalForGetGroupMemberSet
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesPrincipalForGetGroupMemberSet')]
 	public function testGetGroupMemberSetExceptional(?string $principal): void {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Principal not found');
@@ -83,9 +77,7 @@ class SystemPrincipalBackendTest extends TestCase {
 		$this->assertEquals(['principals/system/system'], $result);
 	}
 
-	/**
-	 * @dataProvider providesPrincipalForGetGroupMembership
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesPrincipalForGetGroupMembership')]
 	public function testGetGroupMembershipExceptional(string $principal): void {
 		$this->expectException(Exception::class);
 		$this->expectExceptionMessage('Principal not found');

--- a/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
+++ b/apps/dav/tests/unit/DAV/ViewOnlyPluginTest.php
@@ -94,9 +94,7 @@ class ViewOnlyPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesDataForCanGet
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesDataForCanGet')]
 	public function testCanGet(bool $isVersion, ?bool $attrEnabled, bool $expectCanDownloadFile, bool $allowViewWithoutDownload): void {
 		$nodeInfo = $this->createMock(File::class);
 		if ($isVersion) {

--- a/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
+++ b/apps/dav/tests/unit/Listener/ActivityUpdaterListenerTest.php
@@ -36,9 +36,7 @@ class ActivityUpdaterListenerTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataForTestHandleCalendarObjectDeletedEvent
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestHandleCalendarObjectDeletedEvent')]
 	public function testHandleCalendarObjectDeletedEvent(int $calendarId, array $calendarData, array $shares, array $objectData, bool $createsActivity): void {
 		$event = new CalendarObjectDeletedEvent($calendarId, $calendarData, $shares, $objectData);
 		$this->logger->expects($this->once())->method('debug')->with(
@@ -60,9 +58,7 @@ class ActivityUpdaterListenerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataForTestHandleCalendarDeletedEvent
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestHandleCalendarDeletedEvent')]
 	public function testHandleCalendarDeletedEvent(int $calendarId, array $calendarData, array $shares, bool $createsActivity): void {
 		$event = new CalendarDeletedEvent($calendarId, $calendarData, $shares);
 		$this->logger->expects($this->once())->method('debug')->with(

--- a/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
+++ b/apps/dav/tests/unit/Migration/RefreshWebcalJobRegistrarTest.php
@@ -105,7 +105,7 @@ class RefreshWebcalJobRegistrarTest extends TestCase {
 		];
 		$this->jobList->expects($this->exactly(2))
 			->method('add')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
+++ b/apps/dav/tests/unit/Migration/RemoveDeletedUsersCalendarSubscriptionsTest.php
@@ -45,9 +45,7 @@ class RemoveDeletedUsersCalendarSubscriptionsTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestRun
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRun')]
 	public function testRun(array $subscriptions, array $userExists, int $deletions): void {
 		$qb = $this->createMock(IQueryBuilder::class);
 

--- a/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
+++ b/apps/dav/tests/unit/Provisioning/Apple/AppleProvisioningPluginTest.php
@@ -153,7 +153,7 @@ class AppleProvisioningPluginTest extends TestCase {
 		];
 		$this->sabreResponse->expects($this->exactly(2))
 			->method('setHeader')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
@@ -418,9 +418,7 @@ class EventsSearchProviderTest extends TestCase {
 		$this->assertEquals('absolute-url-to-route', $actual);
 	}
 
-	/**
-	 * @dataProvider generateSublineDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('generateSublineDataProvider')]
 	public function testGenerateSubline(string $ics, string $expectedSubline): void {
 		$vCalendar = Reader::read($ics, Reader::OPTION_FORGIVING);
 		$eventComponent = $vCalendar->VEVENT;

--- a/apps/dav/tests/unit/Search/TasksSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/TasksSearchProviderTest.php
@@ -289,9 +289,7 @@ class TasksSearchProviderTest extends TestCase {
 		$this->assertEquals('absolute-url-link-to-route-tasks.indexcalendars/uri-john.doe/tasks/task-uri.ics', $actual);
 	}
 
-	/**
-	 * @dataProvider generateSublineDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('generateSublineDataProvider')]
 	public function testGenerateSubline(string $ics, string $expectedSubline): void {
 		$vCalendar = Reader::read($ics, Reader::OPTION_FORGIVING);
 		$taskComponent = $vCalendar->VTODO;

--- a/apps/dav/tests/unit/ServerTest.php
+++ b/apps/dav/tests/unit/ServerTest.php
@@ -20,9 +20,7 @@ use OCP\IRequest;
  */
 class ServerTest extends \Test\TestCase {
 
-	/**
-	 * @dataProvider providesUris
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesUris')]
 	public function test(string $uri, array $plugins): void {
 		/** @var IRequest | \PHPUnit\Framework\MockObject\MockObject $r */
 		$r = $this->createMock(IRequest::class);

--- a/apps/dav/tests/unit/Service/ExampleContactServiceTest.php
+++ b/apps/dav/tests/unit/Service/ExampleContactServiceTest.php
@@ -173,7 +173,7 @@ class ExampleContactServiceTest extends TestCase {
 		return [[true], [false]];
 	}
 
-	/** @dataProvider provideDefaultContactEnableData */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideDefaultContactEnableData')]
 	public function testIsDefaultContactEnabled(bool $enabled): void {
 		$this->appConfig->expects(self::once())
 			->method('getAppValueBool')
@@ -183,7 +183,7 @@ class ExampleContactServiceTest extends TestCase {
 		$this->assertEquals($enabled, $this->service->isDefaultContactEnabled());
 	}
 
-	/** @dataProvider provideDefaultContactEnableData */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideDefaultContactEnableData')]
 	public function testSetDefaultContactEnabled(bool $enabled): void {
 		$this->appConfig->expects(self::once())
 			->method('setAppValueBool')

--- a/apps/dav/tests/unit/Service/ExampleEventServiceTest.php
+++ b/apps/dav/tests/unit/Service/ExampleEventServiceTest.php
@@ -62,7 +62,7 @@ class ExampleEventServiceTest extends TestCase {
 		];
 	}
 
-	/** @dataProvider provideCustomEventData */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideCustomEventData')]
 	public function testCreateExampleEventWithCustomEvent($customEventIcs): void {
 		$this->appConfig->expects(self::once())
 			->method('getValueBool')
@@ -142,7 +142,7 @@ class ExampleEventServiceTest extends TestCase {
 		$this->service->createExampleEvent(1000);
 	}
 
-	/** @dataProvider provideCustomEventData */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideCustomEventData')]
 	public function testGetExampleEventWithCustomEvent($customEventIcs): void {
 		$exampleEventFolder = $this->createMock(ISimpleFolder::class);
 		$this->appData->expects(self::once())

--- a/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
+++ b/apps/dav/tests/unit/Settings/CalDAVSettingsTest.php
@@ -57,7 +57,7 @@ class CalDAVSettingsTest extends TestCase {
 			['sendEventRemindersPush', true],
 		];
 		$this->initialState->method('provideInitialState')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagMappingNodeTest.php
@@ -107,9 +107,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider tagNodeDeleteProviderPermissionException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeDeleteProviderPermissionException')]
 	public function testDeleteTagExpectedException(ISystemTag $tag, $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')
@@ -152,7 +150,7 @@ class SystemTagMappingNodeTest extends \Test\TestCase {
 		$this->tagMapper->expects($this->once())
 			->method('unassignTags')
 			->with(123, 'files', 1)
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 
 		$this->getMappingNode($tag, [123])->delete();
 	}

--- a/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagNodeTest.php
@@ -49,9 +49,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		return [[true], [false]];
 	}
 
-	/**
-	 * @dataProvider adminFlagProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('adminFlagProvider')]
 	public function testGetters(bool $isAdmin): void {
 		$tag = new SystemTag('1', 'Test', true, true);
 		$node = $this->getTagNode($isAdmin, $tag);
@@ -89,9 +87,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider tagNodeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeProvider')]
 	public function testUpdateTag(bool $isAdmin, ISystemTag $originalTag, array $changedArgs): void {
 		$this->tagManager->expects($this->once())
 			->method('canUserSeeTag')
@@ -149,9 +145,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider tagNodeProviderPermissionException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeProviderPermissionException')]
 	public function testUpdateTagPermissionException(ISystemTag $originalTag, array $changedArgs, string $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')
@@ -192,7 +186,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('updateTag')
 			->with(1, 'Renamed', true, true)
-			->will($this->throwException(new TagAlreadyExistsException()));
+			->willThrowException(new TagAlreadyExistsException());
 		$this->getTagNode(false, $tag)->update('Renamed', true, true, null);
 	}
 
@@ -212,13 +206,11 @@ class SystemTagNodeTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('updateTag')
 			->with(1, 'Renamed', true, true)
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 		$this->getTagNode(false, $tag)->update('Renamed', true, true, null);
 	}
 
-	/**
-	 * @dataProvider adminFlagProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('adminFlagProvider')]
 	public function testDeleteTag(bool $isAdmin): void {
 		$tag = new SystemTag('1', 'tag1', true, true);
 		$this->tagManager->expects($isAdmin ? $this->once() : $this->never())
@@ -249,9 +241,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider tagNodeDeleteProviderPermissionException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tagNodeDeleteProviderPermissionException')]
 	public function testDeleteTagPermissionException(ISystemTag $tag, string $expectedException): void {
 		$this->tagManager->expects($this->any())
 			->method('canUserSeeTag')
@@ -276,7 +266,7 @@ class SystemTagNodeTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('deleteTags')
 			->with('1')
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 		$this->getTagNode(true, $tag)->delete();
 	}
 }

--- a/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagPluginTest.php
@@ -142,9 +142,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider getPropertiesDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getPropertiesDataProvider')]
 	public function testGetProperties(ISystemTag $systemTag, array $groups, array $requestedProperties, array $expectedProperties): void {
 		$this->user->expects($this->any())
 			->method('getUID')
@@ -341,9 +339,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 			[true, true, 'group1|group2'],
 		];
 	}
-	/**
-	 * @dataProvider createTagInsufficientPermissionsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('createTagInsufficientPermissionsProvider')]
 	public function testCreateNotAssignableTagAsRegularUser(bool $userVisible, bool $userAssignable, string $groups): void {
 		$this->expectException(\Sabre\DAV\Exception\BadRequest::class);
 		$this->expectExceptionMessage('Not sufficient permissions');
@@ -452,9 +448,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider createTagProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('createTagProvider')]
 	public function testCreateTagInByIdCollection(bool $userVisible, bool $userAssignable, string $groups): void {
 		$this->user->expects($this->once())
 			->method('getUID')
@@ -601,7 +595,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')
-			->will($this->throwException(new \Sabre\DAV\Exception\NotFound()));
+			->willThrowException(new \Sabre\DAV\Exception\NotFound());
 
 		$this->tagManager->expects($this->never())
 			->method('createTag');
@@ -619,9 +613,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$this->plugin->httpPost($request, $response);
 	}
 
-	/**
-	 * @dataProvider nodeClassProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('nodeClassProvider')]
 	public function testCreateTagConflict(string $nodeClass): void {
 		$this->expectException(\Sabre\DAV\Exception\Conflict::class);
 
@@ -644,7 +636,7 @@ class SystemTagPluginTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('createTag')
 			->with('Test', true, false)
-			->will($this->throwException(new TagAlreadyExistsException('Tag already exists')));
+			->willThrowException(new TagAlreadyExistsException('Tag already exists'));
 
 		$this->tree->expects($this->any())
 			->method('getNodeForPath')

--- a/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsByIdCollectionTest.php
@@ -101,7 +101,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
 			->with(['invalid'])
-			->will($this->throwException(new \InvalidArgumentException()));
+			->willThrowException(new \InvalidArgumentException());
 
 		$this->getNode()->getChild('invalid');
 	}
@@ -113,7 +113,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
 			->with(['444'])
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 
 		$this->getNode()->getChild('444');
 	}
@@ -185,9 +185,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider childExistsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('childExistsProvider')]
 	public function testChildExists(bool $userVisible, bool $expectedResult): void {
 		$tag = new SystemTag('123', 'One', $userVisible, false);
 		$this->tagManager->expects($this->once())
@@ -207,7 +205,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
 			->with(['123'])
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 
 		$this->assertFalse($this->getNode()->childExists('123'));
 	}
@@ -219,7 +217,7 @@ class SystemTagsByIdCollectionTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
 			->with(['invalid'])
-			->will($this->throwException(new \InvalidArgumentException()));
+			->willThrowException(new \InvalidArgumentException());
 
 		$this->getNode()->childExists('invalid');
 	}

--- a/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
+++ b/apps/dav/tests/unit/SystemTag/SystemTagsObjectMappingCollectionTest.php
@@ -93,9 +93,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider permissionsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('permissionsProvider')]
 	public function testAssignTagNoPermission(bool $userVisible, bool $userAssignable, string $expectedException): void {
 		$tag = new SystemTag('1', 'Test', $userVisible, $userAssignable);
 		$this->tagManager->expects($this->once())
@@ -131,7 +129,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->tagManager->expects($this->once())
 			->method('getTagsByIds')
 			->with(['555'])
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 
 		$this->getNode()->createFile('555');
 	}
@@ -208,7 +206,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')
 			->with([111], 'files', 'badid')
-			->will($this->throwException(new \InvalidArgumentException()));
+			->willThrowException(new \InvalidArgumentException());
 
 		$this->getNode()->getChild('badid');
 	}
@@ -220,7 +218,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')
 			->with([111], 'files', '777')
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 
 		$this->getNode()->getChild('777');
 	}
@@ -312,7 +310,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')
 			->with([111], 'files', '555')
-			->will($this->throwException(new TagNotFoundException()));
+			->willThrowException(new TagNotFoundException());
 
 		$this->assertFalse($this->getNode()->childExists('555'));
 	}
@@ -324,7 +322,7 @@ class SystemTagsObjectMappingCollectionTest extends \Test\TestCase {
 		$this->tagMapper->expects($this->once())
 			->method('haveTag')
 			->with([111], 'files', '555')
-			->will($this->throwException(new \InvalidArgumentException()));
+			->willThrowException(new \InvalidArgumentException());
 
 		$this->getNode()->childExists('555');
 	}

--- a/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
+++ b/apps/dav/tests/unit/Upload/AssemblyStreamTest.php
@@ -12,9 +12,7 @@ use Sabre\DAV\File;
 
 class AssemblyStreamTest extends \Test\TestCase {
 
-	/**
-	 * @dataProvider providesNodes()
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesNodes')]
 	public function testGetContents(string $expected, array $nodeData): void {
 		$nodes = [];
 		foreach ($nodeData as $data) {
@@ -26,9 +24,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 		$this->assertEquals($expected, $content);
 	}
 
-	/**
-	 * @dataProvider providesNodes()
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesNodes')]
 	public function testGetContentsFread(string $expected, array $nodeData, int $chunkLength = 3): void {
 		$nodes = [];
 		foreach ($nodeData as $data) {
@@ -48,9 +44,7 @@ class AssemblyStreamTest extends \Test\TestCase {
 		$this->assertEquals($expected, $content);
 	}
 
-	/**
-	 * @dataProvider providesNodes()
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesNodes')]
 	public function testSeek(string $expected, array $nodeData): void {
 		$nodes = [];
 		foreach ($nodeData as $data) {

--- a/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
+++ b/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
@@ -50,9 +50,7 @@ class UploadAutoMkcolPluginTest extends TestCase {
 		$this->assertTrue($return);
 	}
 
-	/**
-	 * @dataProvider dataMissingHeaderShouldReturnTrue
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataMissingHeaderShouldReturnTrue')]
 	public function testBeforeMethodWithMissingHeaderShouldReturnTrue(?string $header): void {
 		$this->request->expects(self::once())
 			->method('getHeader')

--- a/apps/encryption/tests/Command/TestEnableMasterKey.php
+++ b/apps/encryption/tests/Command/TestEnableMasterKey.php
@@ -55,11 +55,11 @@ class TestEnableMasterKey extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestExecute
 	 *
 	 * @param bool $isAlreadyEnabled
 	 * @param string $answer
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestExecute')]
 	public function testExecute($isAlreadyEnabled, $answer): void {
 		$this->util->expects($this->once())->method('isMasterKeyEnabled')
 			->willReturn($isAlreadyEnabled);
@@ -81,7 +81,7 @@ class TestEnableMasterKey extends TestCase {
 		$this->invokePrivate($this->enableMasterKey, 'execute', [$this->input, $this->output]);
 	}
 
-	public function dataTestExecute() {
+	public static function dataTestExecute() {
 		return [
 			[true, ''],
 			[false, 'y'],

--- a/apps/encryption/tests/Controller/RecoveryControllerTest.php
+++ b/apps/encryption/tests/Controller/RecoveryControllerTest.php
@@ -37,13 +37,13 @@ class RecoveryControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider adminRecoveryProvider
 	 * @param $recoveryPassword
 	 * @param $passConfirm
 	 * @param $enableRecovery
 	 * @param $expectedMessage
 	 * @param $expectedStatus
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('adminRecoveryProvider')]
 	public function testAdminRecovery($recoveryPassword, $passConfirm, $enableRecovery, $expectedMessage, $expectedStatus): void {
 		$this->recoveryMock->expects($this->any())
 			->method('enableAdminRecovery')
@@ -73,13 +73,13 @@ class RecoveryControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider changeRecoveryPasswordProvider
 	 * @param $password
 	 * @param $confirmPassword
 	 * @param $oldPassword
 	 * @param $expectedMessage
 	 * @param $expectedStatus
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('changeRecoveryPasswordProvider')]
 	public function testChangeRecoveryPassword($password, $confirmPassword, $oldPassword, $expectedMessage, $expectedStatus): void {
 		$this->recoveryMock->expects($this->any())
 			->method('changeRecoveryKeyPassword')
@@ -105,11 +105,11 @@ class RecoveryControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider userSetRecoveryProvider
 	 * @param $enableRecovery
 	 * @param $expectedMessage
 	 * @param $expectedStatus
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('userSetRecoveryProvider')]
 	public function testUserSetRecovery($enableRecovery, $expectedMessage, $expectedStatus): void {
 		$this->recoveryMock->expects($this->any())
 			->method('setRecoveryForUser')

--- a/apps/encryption/tests/Controller/StatusControllerTest.php
+++ b/apps/encryption/tests/Controller/StatusControllerTest.php
@@ -50,11 +50,11 @@ class StatusControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetStatus
 	 *
 	 * @param string $status
 	 * @param string $expectedStatus
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetStatus')]
 	public function testGetStatus($status, $expectedStatus): void {
 		$this->sessionMock->expects($this->once())
 			->method('getStatus')->willReturn($status);

--- a/apps/encryption/tests/Crypto/CryptTest.php
+++ b/apps/encryption/tests/Crypto/CryptTest.php
@@ -80,9 +80,8 @@ class CryptTest extends TestCase {
 
 	/**
 	 * test generateHeader with valid key formats
-	 *
-	 * @dataProvider dataTestGenerateHeader
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGenerateHeader')]
 	public function testGenerateHeader($keyFormat, $expected): void {
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
@@ -130,10 +129,10 @@ class CryptTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProviderGetCipher
 	 * @param string $configValue
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderGetCipher')]
 	public function testGetCipher($configValue, $expected): void {
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
@@ -173,9 +172,7 @@ class CryptTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestSplitMetaData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitMetaData')]
 	public function testSplitMetaData($data, $expected): void {
 		$this->config->method('getSystemValueBool')
 			->with('encryption_skip_signature_check', false)
@@ -200,9 +197,7 @@ class CryptTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestHasSignature
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestHasSignature')]
 	public function testHasSignature($data, $expected): void {
 		$this->config->method('getSystemValueBool')
 			->with('encryption_skip_signature_check', false)
@@ -219,9 +214,7 @@ class CryptTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestHasSignatureFail
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestHasSignatureFail')]
 	public function testHasSignatureFail($cipher): void {
 		$this->expectException(GenericEncryptionException::class);
 
@@ -249,10 +242,10 @@ class CryptTest extends TestCase {
 	/**
 	 * test removePadding()
 	 *
-	 * @dataProvider dataProviderRemovePadding
 	 * @param $data
 	 * @param $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderRemovePadding')]
 	public function testRemovePadding($data, $expected): void {
 		$result = self::invokePrivate($this->crypt, 'removePadding', [$data]);
 		$this->assertSame($expected, $result);
@@ -327,9 +320,8 @@ class CryptTest extends TestCase {
 
 	/**
 	 * test return values of valid ciphers
-	 *
-	 * @dataProvider dataTestGetKeySize
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetKeySize')]
 	public function testGetKeySize($cipher, $expected): void {
 		$result = $this->invokePrivate($this->crypt, 'getKeySize', [$cipher]);
 		$this->assertSame($expected, $result);
@@ -354,9 +346,7 @@ class CryptTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestDecryptPrivateKey
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDecryptPrivateKey')]
 	public function testDecryptPrivateKey($header, $privateKey, $expectedCipher, $isValidKey, $expected): void {
 		$this->config->method('getSystemValueBool')
 			->willReturnMap([

--- a/apps/encryption/tests/Crypto/DecryptAllTest.php
+++ b/apps/encryption/tests/Crypto/DecryptAllTest.php
@@ -59,11 +59,11 @@ class DecryptAllTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetPrivateKey
 	 *
 	 * @param string $user
 	 * @param string $recoveryKeyId
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetPrivateKey')]
 	public function testGetPrivateKey($user, $recoveryKeyId, $masterKeyId): void {
 		$password = 'passwd';
 		$recoveryKey = 'recoveryKey';

--- a/apps/encryption/tests/Crypto/EncryptAllTest.php
+++ b/apps/encryption/tests/Crypto/EncryptAllTest.php
@@ -249,7 +249,7 @@ class EncryptAllTest extends TestCase {
 		$encryptAllCalls = [];
 		$encryptAll->expects($this->exactly(2))
 			->method('encryptUsersFiles')
-			->willReturnCallback(function ($uid) use (&$encryptAllCalls) {
+			->willReturnCallback(function ($uid) use (&$encryptAllCalls): void {
 				$encryptAllCalls[] = $uid;
 			});
 
@@ -317,7 +317,7 @@ class EncryptAllTest extends TestCase {
 		$encryptAllCalls = [];
 		$encryptAll->expects($this->exactly(2))
 			->method('encryptFile')
-			->willReturnCallback(function (string $path) use (&$encryptAllCalls) {
+			->willReturnCallback(function (string $path) use (&$encryptAllCalls): void {
 				$encryptAllCalls[] = $path;
 			});
 
@@ -346,9 +346,9 @@ class EncryptAllTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestEncryptFile
 	 * @param $isEncrypted
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestEncryptFile')]
 	public function testEncryptFile($isEncrypted): void {
 		$fileInfo = $this->createMock(FileInfo::class);
 		$fileInfo->expects($this->any())->method('isEncrypted')

--- a/apps/encryption/tests/Crypto/EncryptionTest.php
+++ b/apps/encryption/tests/Crypto/EncryptionTest.php
@@ -152,9 +152,7 @@ class EncryptionTest extends TestCase {
 		return $publicKeys;
 	}
 
-	/**
-	 * @dataProvider dataProviderForTestGetPathToRealFile
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderForTestGetPathToRealFile')]
 	public function testGetPathToRealFile($path, $expected): void {
 		$this->assertSame($expected,
 			self::invokePrivate($this->instance, 'getPathToRealFile', [$path])
@@ -170,9 +168,7 @@ class EncryptionTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestBegin
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestBegin')]
 	public function testBegin($mode, $header, $legacyCipher, $defaultCipher, $fileKey, $expected): void {
 		$this->sessionMock->expects($this->once())
 			->method('decryptAllModeActivated')
@@ -265,11 +261,11 @@ class EncryptionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestUpdate
 	 *
 	 * @param string $fileKey
 	 * @param boolean $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUpdate')]
 	public function testUpdate($fileKey, $expected): void {
 		$this->keyManagerMock->expects($this->once())
 			->method('getFileKey')->willReturn($fileKey);
@@ -354,9 +350,8 @@ class EncryptionTest extends TestCase {
 	/**
 	 * by default the encryption module should encrypt regular files, files in
 	 * files_versions and files in files_trashbin
-	 *
-	 * @dataProvider dataTestShouldEncrypt
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShouldEncrypt')]
 	public function testShouldEncrypt($path, $shouldEncryptHomeStorage, $isHomeStorage, $expected): void {
 		$this->utilMock->expects($this->once())->method('shouldEncryptHomeStorage')
 			->willReturn($shouldEncryptHomeStorage);

--- a/apps/encryption/tests/KeyManagerTest.php
+++ b/apps/encryption/tests/KeyManagerTest.php
@@ -166,9 +166,7 @@ class KeyManagerTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestUserHasKeys
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUserHasKeys')]
 	public function testUserHasKeys($key, $expected): void {
 		$this->keyStorageMock->expects($this->exactly(2))
 			->method('getUserKey')
@@ -221,10 +219,9 @@ class KeyManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestInit
-	 *
 	 * @param bool $useMasterKey
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestInit')]
 	public function testInit($useMasterKey): void {
 		/** @var KeyManager&MockObject $instance */
 		$instance = $this->getMockBuilder(KeyManager::class)
@@ -248,7 +245,7 @@ class KeyManagerTest extends TestCase {
 		$sessionSetStatusCalls = [];
 		$this->sessionMock->expects($this->exactly(2))
 			->method('setStatus')
-			->willReturnCallback(function (string $status) use (&$sessionSetStatusCalls) {
+			->willReturnCallback(function (string $status) use (&$sessionSetStatusCalls): void {
 				$sessionSetStatusCalls[] = $status;
 			});
 
@@ -356,13 +353,13 @@ class KeyManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetFileKey
 	 *
 	 * @param $uid
 	 * @param $isMasterKeyEnabled
 	 * @param $privateKey
 	 * @param $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetFileKey')]
 	public function testGetFileKey($uid, $isMasterKeyEnabled, $privateKey, $encryptedFileKey, $expected): void {
 		$path = '/foo.txt';
 
@@ -452,13 +449,13 @@ class KeyManagerTest extends TestCase {
 	/**
 	 * test add public share key and or recovery key to the list of public keys
 	 *
-	 * @dataProvider dataTestAddSystemKeys
 	 *
 	 * @param array $accessList
 	 * @param array $publicKeys
 	 * @param string $uid
 	 * @param array $expectedKeys
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestAddSystemKeys')]
 	public function testAddSystemKeys($accessList, $publicKeys, $uid, $expectedKeys): void {
 		$publicShareKeyId = 'publicShareKey';
 		$recoveryKeyId = 'recoveryKey';
@@ -539,10 +536,9 @@ class KeyManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestValidateMasterKey
-	 *
 	 * @param $masterKey
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestValidateMasterKey')]
 	public function testValidateMasterKey($masterKey): void {
 		/** @var KeyManager&MockObject $instance */
 		$instance = $this->getMockBuilder(KeyManager::class)

--- a/apps/encryption/tests/SessionTest.php
+++ b/apps/encryption/tests/SessionTest.php
@@ -115,11 +115,11 @@ class SessionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestIsReady
 	 *
 	 * @param int $status
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsReady')]
 	public function testIsReady($status, $expected): void {
 		/** @var Session&MockObject $instance */
 		$instance = $this->getMockBuilder(Session::class)

--- a/apps/encryption/tests/Settings/AdminTest.php
+++ b/apps/encryption/tests/Settings/AdminTest.php
@@ -53,7 +53,7 @@ class AdminTest extends TestCase {
 	public function testGetForm(): void {
 		$this->config
 			->method('getAppValue')
-			->will($this->returnCallback(function ($app, $key, $default) {
+			->willReturnCallback(function ($app, $key, $default) {
 				if ($app === 'encryption' && $key === 'recoveryAdminEnabled' && $default === '0') {
 					return '1';
 				}
@@ -61,7 +61,7 @@ class AdminTest extends TestCase {
 					return '1';
 				}
 				return $default;
-			}));
+			});
 		$params = [
 			'recoveryEnabled' => '1',
 			'initStatus' => '0',

--- a/apps/encryption/tests/Users/SetupTest.php
+++ b/apps/encryption/tests/Users/SetupTest.php
@@ -46,11 +46,11 @@ class SetupTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestSetupUser
 	 *
 	 * @param bool $hasKeys
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetupUser')]
 	public function testSetupUser($hasKeys, $expected): void {
 		$this->keyManagerMock->expects($this->once())->method('userHasKeys')
 			->with('uid')->willReturn($hasKeys);

--- a/apps/encryption/tests/UtilTest.php
+++ b/apps/encryption/tests/UtilTest.php
@@ -115,11 +115,11 @@ class UtilTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestIsMasterKeyEnabled
 	 *
 	 * @param string $value
 	 * @param bool $expect
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsMasterKeyEnabled')]
 	public function testIsMasterKeyEnabled($value, $expect): void {
 		$this->configMock->expects($this->once())->method('getAppValue')
 			->with('encryption', 'useMasterKey', '1')->willReturn($value);
@@ -136,10 +136,10 @@ class UtilTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestShouldEncryptHomeStorage
 	 * @param string $returnValue return value from getAppValue()
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShouldEncryptHomeStorage')]
 	public function testShouldEncryptHomeStorage($returnValue, $expected): void {
 		$this->configMock->expects($this->once())->method('getAppValue')
 			->with('encryption', 'encryptHomeStorage', '1')
@@ -157,10 +157,10 @@ class UtilTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestSetEncryptHomeStorage
 	 * @param $value
 	 * @param $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetEncryptHomeStorage')]
 	public function testSetEncryptHomeStorage($value, $expected): void {
 		$this->configMock->expects($this->once())->method('setAppValue')
 			->with('encryption', 'encryptHomeStorage', $expected);

--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -80,9 +80,7 @@ class AddressHandlerTest extends \Test\TestCase {
 		return $testCases;
 	}
 
-	/**
-	 * @dataProvider dataTestSplitUserRemote
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitUserRemote')]
 	public function testSplitUserRemote(string $remote, string $expectedUser, string $expectedUrl): void {
 		$this->contactsManager->expects($this->any())
 			->method('search')
@@ -111,18 +109,14 @@ class AddressHandlerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestSplitUserRemoteError
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitUserRemoteError')]
 	public function testSplitUserRemoteError(string $id): void {
 		$this->expectException(HintException::class);
 
 		$this->addressHandler->splitUserRemote($id);
 	}
 
-	/**
-	 * @dataProvider dataTestCompareAddresses
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCompareAddresses')]
 	public function testCompareAddresses(string $user1, string $server1, string $user2, string $server2, bool $expected): void {
 		$this->assertSame($expected,
 			$this->addressHandler->compareAddresses($user1, $server1, $user2, $server2)
@@ -149,9 +143,7 @@ class AddressHandlerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestRemoveProtocolFromUrl
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRemoveProtocolFromUrl')]
 	public function testRemoveProtocolFromUrl(string $url, string $expectedResult): void {
 		$result = $this->addressHandler->removeProtocolFromUrl($url);
 		$this->assertSame($expectedResult, $result);
@@ -165,9 +157,7 @@ class AddressHandlerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestUrlContainProtocol
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUrlContainProtocol')]
 	public function testUrlContainProtocol(string $url, bool $expectedResult): void {
 		$result = $this->addressHandler->urlContainProtocol($url);
 		$this->assertSame($expectedResult, $result);

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -85,9 +85,7 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestCreateFederatedShare
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCreateFederatedShare')]
 	public function testCreateFederatedShare(
 		string $shareWith,
 		bool $outgoingSharesAllowed,

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -117,9 +117,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestCreate
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCreate')]
 	public function testCreate(?\DateTime $expirationDate, ?string $expectedDataDate): void {
 		$share = $this->shareManager->newShare();
 
@@ -419,9 +417,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider dataTestUpdate
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUpdate')]
 	public function testUpdate(string $owner, string $sharedBy, ?\DateTime $expirationDate): void {
 		$this->provider = $this->getMockBuilder(FederatedShareProvider::class)
 			->setConstructorArgs(
@@ -705,7 +701,6 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDeleteUser
 	 *
 	 * @param string $owner The owner of the share (uid)
 	 * @param string $initiator The initiator of the share (uid)
@@ -713,6 +708,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	 * @param string $deletedUser The user that is deleted
 	 * @param bool $rowDeleted Is the row deleted in this setup
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteUser')]
 	public function testDeleteUser(string $owner, string $initiator, string $recipient, string $deletedUser, bool $rowDeleted): void {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')
@@ -742,9 +738,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->assertCount($rowDeleted ? 0 : 1, $data);
 	}
 
-	/**
-	 * @dataProvider dataTestIsOutgoingServer2serverShareEnabled
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsOutgoingServer2serverShareEnabled')]
 	public function testIsOutgoingServer2serverShareEnabled(bool $internalOnly, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('onlyInternalFederation')
 			->willReturn($internalOnly);
@@ -766,9 +760,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestIsIncomingServer2serverShareEnabled
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsIncomingServer2serverShareEnabled')]
 	public function testIsIncomingServer2serverShareEnabled(bool $onlyInternal, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('onlyInternalFederation')
 			->willReturn($onlyInternal);
@@ -790,9 +782,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestIsLookupServerQueriesEnabled
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsLookupServerQueriesEnabled')]
 	public function testIsLookupServerQueriesEnabled(bool $gsEnabled, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('isGlobalScaleEnabled')
 			->willReturn($gsEnabled);
@@ -818,9 +808,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestIsLookupServerUploadEnabled
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsLookupServerUploadEnabled')]
 	public function testIsLookupServerUploadEnabled(bool $gsEnabled, string $isEnabled, bool $expected): void {
 		$this->gsConfig->expects($this->once())->method('isGlobalScaleEnabled')
 			->willReturn($gsEnabled);

--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -78,9 +78,7 @@ class NotificationsTest extends \Test\TestCase {
 	}
 
 
-	/**
-	 * @dataProvider dataTestSendUpdateToRemote
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSendUpdateToRemote')]
 	public function testSendUpdateToRemote(int $try, array $httpRequestResult, bool $expected): void {
 		$remote = 'http://remote';
 		$id = 42;

--- a/apps/federatedfilesharing/tests/Settings/AdminTest.php
+++ b/apps/federatedfilesharing/tests/Settings/AdminTest.php
@@ -53,9 +53,7 @@ class AdminTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider sharingStateProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sharingStateProvider')]
 	public function testGetForm(bool $state): void {
 		$this->federatedShareProvider
 			->expects($this->once())
@@ -110,7 +108,7 @@ class AdminTest extends TestCase {
 		];
 		$this->initialState->expects($this->exactly(10))
 			->method('provideInitialState')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertSame($expected, func_get_args());
 			});

--- a/apps/federatedfilesharing/tests/TestCase.php
+++ b/apps/federatedfilesharing/tests/TestCase.php
@@ -93,7 +93,7 @@ abstract class TestCase extends \Test\TestCase {
 		Server::get(IUserSession::class)->setUser(null);
 		Filesystem::tearDown();
 		Server::get(IUserSession::class)->login($user, $password);
-		\OCP\Server::get(IRootFolder::class)->getUserFolder($user);
+		Server::get(IRootFolder::class)->getUserFolder($user);
 
 		\OC_Util::setupFS($user);
 	}

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -76,9 +76,7 @@ class GetSharedSecretTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestExecute
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestExecute')]
 	public function testExecute(bool $isTrustedServer, bool $retainBackgroundJob): void {
 		/** @var GetSharedSecret&MockObject $getSharedSecret */
 		$getSharedSecret = $this->getMockBuilder(GetSharedSecret::class)
@@ -136,9 +134,7 @@ class GetSharedSecretTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestRun
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRun')]
 	public function testRun(int $statusCode): void {
 		$target = 'targetURL';
 		$source = 'sourceURL';

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -66,9 +66,7 @@ class RequestSharedSecretTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestStart
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestStart')]
 	public function testStart(bool $isTrustedServer, bool $retainBackgroundJob): void {
 		/** @var RequestSharedSecret&MockObject $requestSharedSecret */
 		$requestSharedSecret = $this->getMockBuilder(RequestSharedSecret::class)
@@ -127,9 +125,7 @@ class RequestSharedSecretTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestRun
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRun')]
 	public function testRun(int $statusCode, int $attempt = 0): void {
 		$target = 'targetURL';
 		$source = 'sourceURL';

--- a/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
+++ b/apps/federation/tests/Controller/OCSAuthAPIControllerTest.php
@@ -64,9 +64,7 @@ class OCSAuthAPIControllerTest extends TestCase {
 			->willReturn($this->currentTime);
 	}
 
-	/**
-	 * @dataProvider dataTestRequestSharedSecret
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRequestSharedSecret')]
 	public function testRequestSharedSecret(string $token, string $localToken, bool $isTrustedServer, bool $ok): void {
 		$url = 'url';
 
@@ -106,9 +104,7 @@ class OCSAuthAPIControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestGetSharedSecret
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetSharedSecret')]
 	public function testGetSharedSecret(bool $isTrustedServer, bool $isValidToken, bool $ok): void {
 		$url = 'url';
 		$token = 'token';

--- a/apps/federation/tests/Controller/SettingsControllerTest.php
+++ b/apps/federation/tests/Controller/SettingsControllerTest.php
@@ -65,9 +65,7 @@ class SettingsControllerTest extends TestCase {
 		$this->assertArrayHasKey('id', $data);
 	}
 
-	/**
-	 * @dataProvider checkServerFails
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('checkServerFails')]
 	public function testAddServerFail(bool $isTrustedServer, bool $isNextcloud): void {
 		$this->trustedServers
 			->expects($this->any())
@@ -115,9 +113,7 @@ class SettingsControllerTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider checkServerFails
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('checkServerFails')]
 	public function testCheckServerFail(bool $isTrustedServer, bool $isNextcloud): void {
 		$this->trustedServers
 			->expects($this->any())

--- a/apps/federation/tests/DAV/FedAuthTest.php
+++ b/apps/federation/tests/DAV/FedAuthTest.php
@@ -15,9 +15,7 @@ use Test\TestCase;
 
 class FedAuthTest extends TestCase {
 
-	/**
-	 * @dataProvider providesUser
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesUser')]
 	public function testFedAuth(bool $expected, string $user, string $password): void {
 		/** @var DbHandler&MockObject $db */
 		$db = $this->createMock(DbHandler::class);

--- a/apps/federation/tests/DbHandlerTest.php
+++ b/apps/federation/tests/DbHandlerTest.php
@@ -52,12 +52,12 @@ class DbHandlerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestAddServer
 	 *
 	 * @param string $url passed to the method
 	 * @param string $expectedUrl the url we expect to be written to the db
 	 * @param string $expectedHash the hash value we expect to be written to the db
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestAddServer')]
 	public function testAddServer(string $url, string $expectedUrl, string $expectedHash): void {
 		$id = $this->dbHandler->addServer($url);
 
@@ -128,9 +128,7 @@ class DbHandlerTest extends TestCase {
 		$this->assertSame($id2, (int)$result[1]['id']);
 	}
 
-	/**
-	 * @dataProvider dataTestServerExists
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestServerExists')]
 	public function testServerExists(string $serverInTable, string $checkForServer, bool $expected): void {
 		$this->dbHandler->addServer($serverInTable);
 		$this->assertSame($expected,
@@ -234,9 +232,8 @@ class DbHandlerTest extends TestCase {
 
 	/**
 	 * hash should always be computed with the normalized URL
-	 *
-	 * @dataProvider dataTestHash
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestHash')]
 	public function testHash(string $url, string $expected): void {
 		$this->assertSame($expected,
 			$this->invokePrivate($this->dbHandler, 'hash', [$url])
@@ -252,9 +249,7 @@ class DbHandlerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestNormalizeUrl
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestNormalizeUrl')]
 	public function testNormalizeUrl(string $url, string $expected): void {
 		$this->assertSame($expected,
 			$this->invokePrivate($this->dbHandler, 'normalizeUrl', [$url])
@@ -271,9 +266,7 @@ class DbHandlerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesAuth
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesAuth')]
 	public function testAuth(bool $expectedResult, string $user, string $password): void {
 		if ($expectedResult) {
 			$this->dbHandler->addServer('url1');

--- a/apps/federation/tests/Settings/AdminTest.php
+++ b/apps/federation/tests/Settings/AdminTest.php
@@ -20,7 +20,7 @@ class AdminTest extends TestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
-		$this->trustedServers = $this->createMock(\OCA\Federation\TrustedServers::class);
+		$this->trustedServers = $this->createMock(TrustedServers::class);
 		$this->admin = new Admin(
 			$this->trustedServers,
 			$this->createMock(IL10N::class)

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -170,9 +170,7 @@ class TrustedServersTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestIsNextcloudServer
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsNextcloudServer')]
 	public function testIsNextcloudServer(int $statusCode, bool $isValidNextcloudVersion, bool $expected): void {
 		$server = 'server1';
 
@@ -239,9 +237,7 @@ class TrustedServersTest extends TestCase {
 		$this->assertFalse($this->trustedServers->isNextcloudServer($server));
 	}
 
-	/**
-	 * @dataProvider dataTestCheckNextcloudVersion
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCheckNextcloudVersion')]
 	public function testCheckNextcloudVersion(string $status): void {
 		$this->assertTrue(self::invokePrivate($this->trustedServers, 'checkNextcloudVersion', [$status]));
 	}
@@ -253,9 +249,7 @@ class TrustedServersTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestCheckNextcloudVersionTooLow
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCheckNextcloudVersionTooLow')]
 	public function testCheckNextcloudVersionTooLow(string $status): void {
 		$this->expectException(HintException::class);
 		$this->expectExceptionMessage('Remote server version is too low. 9.0 is required.');
@@ -269,9 +263,7 @@ class TrustedServersTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestUpdateProtocol
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUpdateProtocol')]
 	public function testUpdateProtocol(string $url, string $expected): void {
 		$this->assertSame($expected,
 			self::invokePrivate($this->trustedServers, 'updateProtocol', [$url])

--- a/apps/files/tests/Activity/Filter/GenericTest.php
+++ b/apps/files/tests/Activity/Filter/GenericTest.php
@@ -27,35 +27,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testImplementsInterface(string $filterClass): void {
 		$filter = Server::get($filterClass);
 		$this->assertInstanceOf(IFilter::class, $filter);
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetIdentifier(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getIdentifier());
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetName(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsString($filter->getName());
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetPriority(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -65,9 +57,7 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testGetIcon(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
@@ -75,18 +65,14 @@ class GenericTest extends TestCase {
 		$this->assertStringStartsWith('http', $filter->getIcon());
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testFilterTypes(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);
 		$this->assertIsArray($filter->filterTypes([]));
 	}
 
-	/**
-	 * @dataProvider dataFilters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilters')]
 	public function testAllowedApps(string $filterClass): void {
 		/** @var IFilter $filter */
 		$filter = Server::get($filterClass);

--- a/apps/files/tests/Activity/ProviderTest.php
+++ b/apps/files/tests/Activity/ProviderTest.php
@@ -90,9 +90,7 @@ class ProviderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetFile
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetFile')]
 	public function testGetFile(array|string $parameter, ?int $eventId, string $id, string $name, string $path): void {
 		$provider = $this->getProvider();
 
@@ -136,9 +134,7 @@ class ProviderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetUser
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUser')]
 	public function testGetUser(string $uid, ?string $userDisplayName, ?array $cloudIdData, array $expected): void {
 		$provider = $this->getProvider();
 

--- a/apps/files/tests/Activity/Setting/GenericTest.php
+++ b/apps/files/tests/Activity/Setting/GenericTest.php
@@ -22,35 +22,27 @@ class GenericTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testImplementsInterface(string $settingClass): void {
 		$setting = Server::get($settingClass);
 		$this->assertInstanceOf(ISetting::class, $setting);
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testGetIdentifier(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getIdentifier());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testGetName(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsString($setting->getName());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testGetPriority(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
@@ -60,36 +52,28 @@ class GenericTest extends TestCase {
 		$this->assertLessThanOrEqual(100, $priority);
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testCanChangeStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeStream());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testIsDefaultEnabledStream(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->isDefaultEnabledStream());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testCanChangeMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);
 		$this->assertIsBool($setting->canChangeMail());
 	}
 
-	/**
-	 * @dataProvider dataSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSettings')]
 	public function testIsDefaultEnabledMail(string $settingClass): void {
 		/** @var ISetting $setting */
 		$setting = Server::get($settingClass);

--- a/apps/files/tests/AdvancedCapabilitiesTest.php
+++ b/apps/files/tests/AdvancedCapabilitiesTest.php
@@ -23,9 +23,7 @@ class AdvancedCapabilitiesTest extends TestCase {
 		$this->capabilities = new AdvancedCapabilities($this->service);
 	}
 
-	/**
-	 * @dataProvider dataGetCapabilities
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetCapabilities')]
 	public function testGetCapabilities(bool $wcf): void {
 		$this->service
 			->expects(self::once())

--- a/apps/files/tests/Command/DeleteOrphanedFilesTest.php
+++ b/apps/files/tests/Command/DeleteOrphanedFilesTest.php
@@ -117,7 +117,7 @@ class DeleteOrphanedFilesTest extends TestCase {
 		$output
 			->expects($this->exactly(3))
 			->method('writeln')
-			->willReturnCallback(function (string $message) use (&$calls) {
+			->willReturnCallback(function (string $message) use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertSame($expected, $message);
 			});

--- a/apps/files/tests/Controller/ApiControllerTest.php
+++ b/apps/files/tests/Controller/ApiControllerTest.php
@@ -119,7 +119,7 @@ class ApiControllerTest extends TestCase {
 		$this->tagService->expects($this->once())
 			->method('updateFileTags')
 			->with('/path.txt', ['Tag1', 'Tag2'])
-			->will($this->throwException(new NotFoundException('My error message')));
+			->willThrowException(new NotFoundException('My error message'));
 
 		$expected = new DataResponse(['message' => 'My error message'], Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expected, $this->apiController->updateFileTags('/path.txt', ['Tag1', 'Tag2']));
@@ -129,7 +129,7 @@ class ApiControllerTest extends TestCase {
 		$this->tagService->expects($this->once())
 			->method('updateFileTags')
 			->with('/path.txt', ['Tag1', 'Tag2'])
-			->will($this->throwException(new StorageNotAvailableException('My error message')));
+			->willThrowException(new StorageNotAvailableException('My error message'));
 
 		$expected = new DataResponse(['message' => 'My error message'], Http::STATUS_SERVICE_UNAVAILABLE);
 		$this->assertEquals($expected, $this->apiController->updateFileTags('/path.txt', ['Tag1', 'Tag2']));
@@ -139,7 +139,7 @@ class ApiControllerTest extends TestCase {
 		$this->tagService->expects($this->once())
 			->method('updateFileTags')
 			->with('/path.txt', ['Tag1', 'Tag2'])
-			->will($this->throwException(new \Exception('My error message')));
+			->willThrowException(new \Exception('My error message'));
 
 		$expected = new DataResponse(['message' => 'My error message'], Http::STATUS_NOT_FOUND);
 		$this->assertEquals($expected, $this->apiController->updateFileTags('/path.txt', ['Tag1', 'Tag2']));

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -210,9 +210,7 @@ class ViewControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestShortRedirect
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShortRedirect')]
 	public function testShortRedirect(?string $openfile, ?string $opendetails, string $result): void {
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')

--- a/apps/files/tests/HelperTest.php
+++ b/apps/files/tests/HelperTest.php
@@ -76,9 +76,7 @@ class HelperTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider sortDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sortDataProvider')]
 	public function testSortByName(string $sort, bool $sortDescending, array $expectedOrder): void {
 		if (($sort === 'mtime') && (PHP_INT_SIZE < 8)) {
 			$this->markTestSkipped('Skip mtime sorting on 32bit');

--- a/apps/files/tests/Service/TagServiceTest.php
+++ b/apps/files/tests/Service/TagServiceTest.php
@@ -53,7 +53,7 @@ class TagServiceTest extends \Test\TestCase {
 			->withAnyParameters()
 			->willReturn($user);
 
-		$this->root = \OCP\Server::get(IRootFolder::class)->getUserFolder($this->user);
+		$this->root = Server::get(IRootFolder::class)->getUserFolder($this->user);
 
 		$this->tagger = Server::get(ITagManager::class)->load('files');
 		$this->tagService = $this->getTagService();

--- a/apps/files_external/tests/Auth/AuthMechanismTest.php
+++ b/apps/files_external/tests/Auth/AuthMechanismTest.php
@@ -37,9 +37,7 @@ class AuthMechanismTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider validateStorageProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
 	public function testValidateStorage(bool $expectedSuccess, string $scheme, bool $definitionSuccess): void {
 		$mechanism = $this->getMockBuilder(AuthMechanism::class)
 			->onlyMethods(['validateStorageDefinition'])

--- a/apps/files_external/tests/Auth/Password/GlobalAuthTest.php
+++ b/apps/files_external/tests/Auth/Password/GlobalAuthTest.php
@@ -29,7 +29,7 @@ class GlobalAuthTest extends TestCase {
 	}
 
 	private function getStorageConfig($type, $config = []) {
-		/** @var \OCA\Files_External\Lib\StorageConfig&MockObject $storageConfig */
+		/** @var StorageConfig&MockObject $storageConfig */
 		$storageConfig = $this->createMock(StorageConfig::class);
 		$storageConfig->expects($this->any())
 			->method('getType')

--- a/apps/files_external/tests/Backend/BackendTest.php
+++ b/apps/files_external/tests/Backend/BackendTest.php
@@ -41,9 +41,7 @@ class BackendTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider validateStorageProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
 	public function testValidateStorage(bool $expectedSuccess, bool $definitionSuccess): void {
 		$backend = $this->getMockBuilder(Backend::class)
 			->onlyMethods(['validateStorageDefinition'])

--- a/apps/files_external/tests/Config/UserPlaceholderHandlerTest.php
+++ b/apps/files_external/tests/Config/UserPlaceholderHandlerTest.php
@@ -53,17 +53,13 @@ class UserPlaceholderHandlerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider optionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('optionProvider')]
 	public function testHandle(string|array $option, string|array $expected): void {
 		$this->setUser();
 		$this->assertSame($expected, $this->handler->handle($option));
 	}
 
-	/**
-	 * @dataProvider optionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('optionProvider')]
 	public function testHandleNoUser(string|array $option): void {
 		$this->shareManager->expects($this->once())
 			->method('getShareByToken')

--- a/apps/files_external/tests/Controller/StoragesControllerTestCase.php
+++ b/apps/files_external/tests/Controller/StoragesControllerTestCase.php
@@ -186,9 +186,7 @@ abstract class StoragesControllerTestCase extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider mountPointNamesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('mountPointNamesProvider')]
 	public function testAddOrUpdateStorageInvalidMountPoint($mountPoint): void {
 		$storageConfig = new StorageConfig(1);
 		$storageConfig->setMountPoint($mountPoint);
@@ -235,7 +233,7 @@ abstract class StoragesControllerTestCase extends \Test\TestCase {
 	public function testAddOrUpdateStorageInvalidBackend(): void {
 		$this->service->expects($this->exactly(2))
 			->method('createStorage')
-			->will($this->throwException(new \InvalidArgumentException()));
+			->willThrowException(new \InvalidArgumentException());
 		$this->service->expects($this->never())
 			->method('addStorage');
 		$this->service->expects($this->never())
@@ -292,7 +290,7 @@ abstract class StoragesControllerTestCase extends \Test\TestCase {
 			->willReturn($storageConfig);
 		$this->service->expects($this->once())
 			->method('updateStorage')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 
 		$response = $this->controller->update(
 			255,
@@ -320,7 +318,7 @@ abstract class StoragesControllerTestCase extends \Test\TestCase {
 	public function testDeleteStorageNonExisting(): void {
 		$this->service->expects($this->once())
 			->method('removeStorage')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 
 		$response = $this->controller->destroy(255);
 		$this->assertEquals(Http::STATUS_NOT_FOUND, $response->getStatus());
@@ -357,9 +355,7 @@ abstract class StoragesControllerTestCase extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider validateStorageProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
 	public function testValidateStorage(bool $backendValidate, bool $authMechValidate, bool $expectSuccess): void {
 		$backend = $this->getBackendMock();
 		$backend->method('validateStorage')

--- a/apps/files_external/tests/DefinitionParameterTest.php
+++ b/apps/files_external/tests/DefinitionParameterTest.php
@@ -68,9 +68,7 @@ class DefinitionParameterTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider validateValueProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateValueProvider')]
 	public function testValidateValue($type, $flags, $value, $success, $expectedValue = null): void {
 		$param = new Param('foo', 'bar');
 		$param->setType($type);

--- a/apps/files_external/tests/FrontendDefinitionTraitTest.php
+++ b/apps/files_external/tests/FrontendDefinitionTraitTest.php
@@ -8,6 +8,7 @@
 namespace OCA\Files_External\Tests;
 
 use OCA\Files_External\Lib\DefinitionParameter;
+use OCA\Files_External\Lib\FrontendDefinitionTrait;
 use OCA\Files_External\Lib\StorageConfig;
 
 class FrontendDefinitionTraitTest extends \Test\TestCase {
@@ -17,7 +18,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->getMock();
 		$param->method('getName')->willReturn('foo');
 
-		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\FrontendDefinitionTrait::class);
+		$trait = $this->getMockForTrait(FrontendDefinitionTrait::class);
 		$trait->setText('test');
 		$trait->addParameters([$param]);
 		$trait->addCustomJs('foo/bar.js');
@@ -40,9 +41,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider validateStorageProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateStorageProvider')]
 	public function testValidateStorage(bool $expectedSuccess, array $params): void {
 		$backendParams = [];
 		foreach ($params as $name => $valid) {
@@ -68,7 +67,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 		$storageConfig->expects($this->any())
 			->method('setBackendOption');
 
-		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\FrontendDefinitionTrait::class);
+		$trait = $this->getMockForTrait(FrontendDefinitionTrait::class);
 		$trait->setText('test');
 		$trait->addParameters($backendParams);
 
@@ -99,7 +98,7 @@ class FrontendDefinitionTraitTest extends \Test\TestCase {
 			->method('setBackendOption')
 			->with('param', 'foobar');
 
-		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\FrontendDefinitionTrait::class);
+		$trait = $this->getMockForTrait(FrontendDefinitionTrait::class);
 		$trait->setText('test');
 		$trait->addParameter($param);
 

--- a/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
+++ b/apps/files_external/tests/LegacyDependencyCheckPolyfillTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\Files_External\Tests;
 
+use OCA\Files_External\Lib\LegacyDependencyCheckPolyfill;
 use OCA\Files_External\Lib\MissingDependency;
 
 class LegacyDependencyCheckPolyfillTest extends \Test\TestCase {
@@ -23,7 +24,7 @@ class LegacyDependencyCheckPolyfillTest extends \Test\TestCase {
 	}
 
 	public function testCheckDependencies(): void {
-		$trait = $this->getMockForTrait(\OCA\Files_External\Lib\LegacyDependencyCheckPolyfill::class);
+		$trait = $this->getMockForTrait(LegacyDependencyCheckPolyfill::class);
 		$trait->expects($this->once())
 			->method('getStorageClass')
 			->willReturn(self::class);

--- a/apps/files_external/tests/OwnCloudFunctionsTest.php
+++ b/apps/files_external/tests/OwnCloudFunctionsTest.php
@@ -87,9 +87,7 @@ class OwnCloudFunctionsTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider configUrlProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('configUrlProvider')]
 	public function testConfig(array $config, string $expectedUri): void {
 		$config['user'] = 'someuser';
 		$config['password'] = 'somepassword';

--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -208,9 +208,7 @@ class BackendServiceTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider invalidConfigPlaceholderProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidConfigPlaceholderProvider')]
 	public function testRegisterConfigHandlerInvalid(array $placeholders): void {
 		$this->expectException(\RuntimeException::class);
 

--- a/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/GlobalStoragesServiceTest.php
@@ -115,9 +115,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider storageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('storageDataProvider')]
 	public function testAddStorage($storageParams): void {
 		$storage = $this->makeStorageConfig($storageParams);
 		$newStorage = $this->service->addStorage($storage);
@@ -139,9 +137,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		$this->assertEquals($baseId + 1, $nextStorage->getId());
 	}
 
-	/**
-	 * @dataProvider storageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('storageDataProvider')]
 	public function testUpdateStorage($updatedStorageParams): void {
 		$updatedStorage = $this->makeStorageConfig($updatedStorageParams);
 		$storage = $this->makeStorageConfig([
@@ -281,9 +277,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider hooksAddStorageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hooksAddStorageDataProvider')]
 	public function testHooksAddStorage($applicableUsers, $applicableGroups, $expectedCalls): void {
 		$storage = $this->makeTestStorageData();
 		$storage->setApplicableUsers($applicableUsers);
@@ -419,9 +413,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider hooksUpdateStorageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hooksUpdateStorageDataProvider')]
 	public function testHooksUpdateStorage(
 		array $sourceApplicableUsers,
 		array $sourceApplicableGroups,
@@ -579,9 +571,7 @@ class GlobalStoragesServiceTest extends StoragesServiceTestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider hooksDeleteStorageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hooksDeleteStorageDataProvider')]
 	public function testHooksDeleteStorage(
 		array $sourceApplicableUsers,
 		array $sourceApplicableGroups,

--- a/apps/files_external/tests/Service/StoragesServiceTestCase.php
+++ b/apps/files_external/tests/Service/StoragesServiceTestCase.php
@@ -250,9 +250,7 @@ abstract class StoragesServiceTestCase extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider deleteStorageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('deleteStorageDataProvider')]
 	public function testDeleteStorage(array $backendOptions, string $rustyStorageId): void {
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\DAV');
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');

--- a/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserGlobalStoragesServiceTest.php
@@ -98,9 +98,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		];
 	}
 
-	/**
-	 * @dataProvider applicableStorageProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('applicableStorageProvider')]
 	public function testGetStorageWithApplicable($applicableUsers, $applicableGroups, $isVisible): void {
 		$backend = $this->backendService->getBackend('identifier:\OCA\Files_External\Lib\Backend\SMB');
 		$authMechanism = $this->backendService->getAuthMechanism('identifier:\Auth\Mechanism');
@@ -174,9 +172,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		$this->ActualNonExistingStorageTest();
 	}
 
-	/**
-	 * @dataProvider deleteStorageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('deleteStorageDataProvider')]
 	public function testDeleteStorage($backendOptions, $rustyStorageId): void {
 		$this->expectException(\DomainException::class);
 
@@ -230,9 +226,7 @@ class UserGlobalStoragesServiceTest extends GlobalStoragesServiceTest {
 		];
 	}
 
-	/**
-	 * @dataProvider getUniqueStoragesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getUniqueStoragesProvider')]
 	public function testGetUniqueStorages(
 		$priority1, $applicableUsers1, $applicableGroups1,
 		$priority2, $applicableUsers2, $applicableGroups2,

--- a/apps/files_external/tests/Service/UserStoragesServiceTest.php
+++ b/apps/files_external/tests/Service/UserStoragesServiceTest.php
@@ -8,6 +8,7 @@
 namespace OCA\Files_External\Tests\Service;
 
 use OC\Files\Filesystem;
+use OC\User\User;
 use OCA\Files_External\Lib\StorageConfig;
 use OCA\Files_External\MountConfig;
 use OCA\Files_External\NotFoundException;
@@ -27,7 +28,7 @@ use Test\Traits\UserTrait;
 class UserStoragesServiceTest extends StoragesServiceTestCase {
 	use UserTrait;
 
-	protected \OC\User\User $user;
+	protected User $user;
 
 	protected string $userId;
 	protected StoragesService $globalStoragesService;
@@ -127,9 +128,7 @@ class UserStoragesServiceTest extends StoragesServiceTestCase {
 		$this->assertEmpty(self::$hookCalls);
 	}
 
-	/**
-	 * @dataProvider deleteStorageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('deleteStorageDataProvider')]
 	public function testDeleteStorage($backendOptions, $rustyStorageId): void {
 		parent::testDeleteStorage($backendOptions, $rustyStorageId);
 

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -46,9 +46,7 @@ class SftpTest extends \Test\Files\Storage\Storage {
 		parent::tearDown();
 	}
 
-	/**
-	 * @dataProvider configProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('configProvider')]
 	public function testStorageId($config, $expectedStorageId): void {
 		$instance = new SFTP($config);
 		$this->assertEquals($expectedStorageId, $instance->getId());

--- a/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/DeletedShareAPIController.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Sharing\Controller;
 
+use OCA\Deck\Sharing\ShareAPIHelper;
 use OCA\Files_Sharing\ResponseDefinitions;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
@@ -210,7 +211,7 @@ class DeletedShareAPIController extends OCSController {
 	 * If the Deck application is not enabled or the helper is not available
 	 * a QueryException is thrown instead.
 	 *
-	 * @return \OCA\Deck\Sharing\ShareAPIHelper
+	 * @return ShareAPIHelper
 	 * @throws QueryException
 	 */
 	private function getDeckShareHelper() {
@@ -227,7 +228,7 @@ class DeletedShareAPIController extends OCSController {
 	 * If the sciencemesh application is not enabled or the helper is not available
 	 * a QueryException is thrown instead.
 	 *
-	 * @return \OCA\Deck\Sharing\ShareAPIHelper
+	 * @return ShareAPIHelper
 	 * @throws QueryException
 	 */
 	private function getSciencemeshShareHelper() {

--- a/apps/files_sharing/lib/Controller/ShareAPIController.php
+++ b/apps/files_sharing/lib/Controller/ShareAPIController.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 namespace OCA\Files_Sharing\Controller;
 
 use Exception;
+use OC\Files\FileInfo;
 use OC\Files\Storage\Wrapper\Wrapper;
 use OCA\Circles\Api\v1\Circles;
+use OCA\Deck\Sharing\ShareAPIHelper;
 use OCA\Files\Helper;
 use OCA\Files_Sharing\Exceptions\SharingRightsException;
 use OCA\Files_Sharing\External\Storage;
@@ -596,7 +598,7 @@ class ShareAPIController extends OCSController {
 		// combine all permissions to determine if the user can share this file
 		$nodes = $userFolder->getById($node->getId());
 		foreach ($nodes as $nodeById) {
-			/** @var \OC\Files\FileInfo $fileInfo */
+			/** @var FileInfo $fileInfo */
 			$fileInfo = $node->getFileInfo();
 			$fileInfo['permissions'] |= $nodeById->getPermissions();
 		}
@@ -1820,7 +1822,7 @@ class ShareAPIController extends OCSController {
 	 * If the Deck application is not enabled or the helper is not available
 	 * a ContainerExceptionInterface is thrown instead.
 	 *
-	 * @return \OCA\Deck\Sharing\ShareAPIHelper
+	 * @return ShareAPIHelper
 	 * @throws ContainerExceptionInterface
 	 */
 	private function getDeckShareHelper() {
@@ -1837,7 +1839,7 @@ class ShareAPIController extends OCSController {
 	 * If the sciencemesh application is not enabled or the helper is not available
 	 * a ContainerExceptionInterface is thrown instead.
 	 *
-	 * @return \OCA\Deck\Sharing\ShareAPIHelper
+	 * @return ShareAPIHelper
 	 * @throws ContainerExceptionInterface
 	 */
 	private function getSciencemeshShareHelper() {

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -41,12 +41,9 @@ class Manager {
 	/** @var string|null */
 	private $uid;
 
-	/** @var \OC\Files\Mount\Manager */
-	private $mountManager;
-
 	public function __construct(
 		private IDBConnection $connection,
-		\OC\Files\Mount\Manager $mountManager,
+		private \OC\Files\Mount\Manager $mountManager,
 		private IStorageFactory $storageLoader,
 		private IClientService $clientService,
 		private IManager $notificationManager,
@@ -60,7 +57,6 @@ class Manager {
 		private LoggerInterface $logger,
 	) {
 		$user = $userSession->getUser();
-		$this->mountManager = $mountManager;
 		$this->uid = $user ? $user->getUID() : null;
 	}
 

--- a/apps/files_sharing/tests/ApiTest.php
+++ b/apps/files_sharing/tests/ApiTest.php
@@ -1281,7 +1281,7 @@ class ApiTest extends TestCase {
 		\OC_Hook::clear('\OCA\Files_Sharing\Tests\ApiTest', 'initTestMountPointsHook');
 	}
 
-	public function datesProvider() {
+	public static function datesProvider() {
 		$date = new \DateTime();
 		$date->setTime(0, 0);
 		$date->add(new \DateInterval('P5D'));
@@ -1297,9 +1297,9 @@ class ApiTest extends TestCase {
 	/**
 	 * Make sure only ISO 8601 dates are accepted
 	 *
-	 * @dataProvider datesProvider
 	 * @group RoutingWeirdness
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('datesProvider')]
 	public function testPublicLinkExpireDate($date, $valid): void {
 		$ocs = $this->createOCS(self::TEST_FILES_SHARING_API_USER1);
 

--- a/apps/files_sharing/tests/ApplicationTest.php
+++ b/apps/files_sharing/tests/ApplicationTest.php
@@ -87,9 +87,7 @@ class ApplicationTest extends TestCase {
 		return $result;
 	}
 
-	/**
-	 * @dataProvider providesDataForCanGet
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesDataForCanGet')]
 	public function testCheckDirectCanBeDownloaded(string $path, Folder $userFolder, bool $run): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('test');
@@ -168,9 +166,7 @@ class ApplicationTest extends TestCase {
 		return $return;
 	}
 
-	/**
-	 * @dataProvider providesDataForCanZip
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesDataForCanZip')]
 	public function testCheckZipCanBeDownloaded(string $dir, array $files, Folder $userFolder, bool $run): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('test');

--- a/apps/files_sharing/tests/Collaboration/ShareRecipientSorterTest.php
+++ b/apps/files_sharing/tests/Collaboration/ShareRecipientSorterTest.php
@@ -36,9 +36,9 @@ class ShareRecipientSorterTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider sortDataProvider
 	 * @param $data
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sortDataProvider')]
 	public function testSort($data): void {
 		$node = $this->createMock(Node::class);
 
@@ -115,7 +115,7 @@ class ShareRecipientSorterTest extends TestCase {
 		$this->assertEquals($originalArray, $workArray);
 	}
 
-	public function sortDataProvider() {
+	public static function sortDataProvider() {
 		return [[
 			[
 				#0 – sort properly and otherwise keep existing order

--- a/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
+++ b/apps/files_sharing/tests/Command/CleanupRemoteStoragesTest.php
@@ -169,14 +169,14 @@ class CleanupRemoteStoragesTest extends TestCase {
 		$output
 			->expects($this->any())
 			->method('writeln')
-			->willReturnCallback(function (string $text) use (&$outputCalls) {
+			->willReturnCallback(function (string $text) use (&$outputCalls): void {
 				$outputCalls[] = $text;
 			});
 
 		$this->cloudIdManager
 			->expects($this->any())
 			->method('getCloudId')
-			->will($this->returnCallback(function (string $user, string $remote) {
+			->willReturnCallback(function (string $user, string $remote) {
 				$cloudIdMock = $this->createMock(ICloudId::class);
 
 				// The remotes are already sanitized in the original data, so
@@ -187,7 +187,7 @@ class CleanupRemoteStoragesTest extends TestCase {
 					->willReturn($remote);
 
 				return $cloudIdMock;
-			}));
+			});
 
 		$this->command->execute($input, $output);
 

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -272,7 +272,7 @@ class ShareAPIControllerTest extends TestCase {
 		$node->expects($this->once())
 			->method('lock')
 			->with(ILockingProvider::LOCK_SHARED)
-			->will($this->throwException(new LockedException('mypath')));
+			->willThrowException(new LockedException('mypath'));
 
 		$this->assertFalse($this->invokePrivate($this->ocs, 'canDeleteFromSelf', [$share]));
 		$this->assertFalse($this->invokePrivate($this->ocs, 'canDeleteShare', [$share]));
@@ -824,9 +824,7 @@ class ShareAPIControllerTest extends TestCase {
 		return $data;
 	}
 
-	/**
-	 * @dataProvider dataGetShare
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetShare')]
 	public function testGetShare(IShare $share, array $result): void {
 		/** @var ShareAPIController&MockObject $ocs */
 		$ocs = $this->getMockBuilder(ShareAPIController::class)
@@ -1457,9 +1455,7 @@ class ShareAPIControllerTest extends TestCase {
 		return $data;
 	}
 
-	/**
-	 * @dataProvider dataGetShares
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetShares')]
 	public function testGetShares(array $getSharesParameters, array $shares, array $extraShareTypes, array $expected): void {
 		/** @var ShareAPIController&MockObject $ocs */
 		$ocs = $this->getMockBuilder(ShareAPIController::class)
@@ -1575,9 +1571,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
 	}
 
-	/**
-	 * @dataProvider dataCanAccessShareWithPermissions
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCanAccessShareWithPermissions')]
 	public function testCanAccessShareWithPermissions(int $permissions, bool $expected): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
@@ -1615,9 +1609,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCanAccessShareAsGroupMember
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCanAccessShareAsGroupMember')]
 	public function testCanAccessShareAsGroupMember(string $group, bool $expected): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_GROUP);
@@ -1695,13 +1687,13 @@ class ShareAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataCanAccessRoomShare
 	 *
 	 * @param bool $expects
 	 * @param IShare $share
 	 * @param bool helperAvailable
 	 * @param bool canAccessShareByHelper
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCanAccessRoomShare')]
 	public function testCanAccessRoomShare(bool $expected, IShare $share, bool $helperAvailable, bool $canAccessShareByHelper): void {
 		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->method('getUserFolder')
@@ -1761,7 +1753,7 @@ class ShareAPIControllerTest extends TestCase {
 		$userFolder->expects($this->once())
 			->method('get')
 			->with('invalid-path')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 
 		$this->ocs->createShare('invalid-path');
 	}
@@ -2935,9 +2927,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
-	/**
-	 * @dataProvider publicUploadParamsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('publicUploadParamsProvider')]
 	public function testUpdateLinkShareEnablePublicUpload($permissions, $publicUpload, $expireDate, $password): void {
 		$ocs = $this->mockFormatShare();
 
@@ -2986,7 +2976,7 @@ class ShareAPIControllerTest extends TestCase {
 	}
 
 
-	public function publicLinkValidPermissionsProvider() {
+	public static function publicLinkValidPermissionsProvider() {
 		return [
 			[Constants::PERMISSION_CREATE],
 			[Constants::PERMISSION_READ],
@@ -2996,9 +2986,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider publicLinkValidPermissionsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('publicLinkValidPermissionsProvider')]
 	public function testUpdateLinkShareSetCRUDPermissions($permissions): void {
 		$ocs = $this->mockFormatShare();
 
@@ -3043,7 +3031,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
-	public function publicLinkInvalidPermissionsProvider1() {
+	public static function publicLinkInvalidPermissionsProvider1() {
 		return [
 			[Constants::PERMISSION_DELETE],
 			[Constants::PERMISSION_UPDATE],
@@ -3051,9 +3039,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider publicLinkInvalidPermissionsProvider1
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('publicLinkInvalidPermissionsProvider1')]
 	public function testUpdateLinkShareSetInvalidCRUDPermissions1($permissions): void {
 		$this->expectException(OCSBadRequestException::class);
 		$this->expectExceptionMessage('Share must at least have READ or CREATE permissions');
@@ -3061,16 +3047,14 @@ class ShareAPIControllerTest extends TestCase {
 		$this->testUpdateLinkShareSetCRUDPermissions($permissions, null);
 	}
 
-	public function publicLinkInvalidPermissionsProvider2() {
+	public static function publicLinkInvalidPermissionsProvider2() {
 		return [
 			[Constants::PERMISSION_CREATE | Constants::PERMISSION_DELETE],
 			[Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE],
 		];
 	}
 
-	/**
-	 * @dataProvider publicLinkInvalidPermissionsProvider2
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('publicLinkInvalidPermissionsProvider2')]
 	public function testUpdateLinkShareSetInvalidCRUDPermissions2($permissions): void {
 		$this->expectException(OCSBadRequestException::class);
 		$this->expectExceptionMessage('Share must have READ permission if UPDATE or DELETE permission is set');
@@ -3106,7 +3090,7 @@ class ShareAPIControllerTest extends TestCase {
 		$ocs->updateShare(42, null, 'password', null, 'true', '2000-01-a');
 	}
 
-	public function publicUploadParamsProvider() {
+	public static function publicUploadParamsProvider() {
 		return [
 			[null, 'true', null, 'password'],
 			// legacy had no delete
@@ -3122,9 +3106,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider publicUploadParamsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('publicUploadParamsProvider')]
 	public function testUpdateLinkSharePublicUploadNotAllowed($permissions, $publicUpload, $expireDate, $password): void {
 		$this->expectException(OCSForbiddenException::class);
 		$this->expectExceptionMessage('Public upload disabled by the administrator');
@@ -4900,13 +4882,13 @@ class ShareAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFormatShare
 	 *
 	 * @param array $expects
 	 * @param IShare $share
 	 * @param array $users
 	 * @param $exception
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFormatShare')]
 	public function testFormatShare(array $expects, IShare $share, array $users, $exception): void {
 		$this->userManager->method('get')->willReturnMap($users);
 
@@ -5119,13 +5101,13 @@ class ShareAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFormatRoomShare
 	 *
 	 * @param array $expects
 	 * @param IShare $share
 	 * @param bool $helperAvailable
 	 * @param array $formatShareByHelper
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFormatRoomShare')]
 	public function testFormatRoomShare(array $expects, IShare $share, bool $helperAvailable, array $formatShareByHelper): void {
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)

--- a/apps/files_sharing/tests/Controller/ShareControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareControllerTest.php
@@ -176,7 +176,7 @@ class ShareControllerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('getShareByToken')
 			->with('invalidtoken')
-			->will($this->throwException(new ShareNotFound()));
+			->willThrowException(new ShareNotFound());
 
 		$this->expectException(NotFoundException::class);
 
@@ -613,9 +613,9 @@ class ShareControllerTest extends \Test\TestCase {
 
 		$this->l10n->expects($this->any())
 			->method('t')
-			->will($this->returnCallback(function ($text, $parameters) {
+			->willReturnCallback(function ($text, $parameters) {
 				return vsprintf($text, $parameters);
-			}));
+			});
 
 		$this->defaults->expects(self::any())
 			->method('getProductName')

--- a/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareesAPIControllerTest.php
@@ -70,7 +70,7 @@ class ShareesAPIControllerTest extends TestCase {
 		);
 	}
 
-	public function dataSearch(): array {
+	public static function dataSearch(): array {
 		$noRemote = [IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_EMAIL];
 		$allTypes = [IShare::TYPE_USER, IShare::TYPE_GROUP, IShare::TYPE_REMOTE, IShare::TYPE_REMOTE_GROUP, IShare::TYPE_EMAIL];
 
@@ -198,7 +198,6 @@ class ShareesAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSearch
 	 *
 	 * @param array $getData
 	 * @param string $apiSetting
@@ -212,6 +211,7 @@ class ShareesAPIControllerTest extends TestCase {
 	 * @param bool $allowGroupSharing
 	 * @throws OCSBadRequestException
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearch')]
 	public function testSearch(
 		array $getData,
 		string $apiSetting,
@@ -302,7 +302,7 @@ class ShareesAPIControllerTest extends TestCase {
 		$this->assertInstanceOf(DataResponse::class, $sharees->search($search, $itemType, $page, $perPage, $shareType));
 	}
 
-	public function dataSearchInvalid(): array {
+	public static function dataSearchInvalid(): array {
 		return [
 			// Test invalid pagination
 			[[
@@ -329,11 +329,11 @@ class ShareesAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSearchInvalid
 	 *
 	 * @param array $getData
 	 * @param string $message
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchInvalid')]
 	public function testSearchInvalid($getData, $message): void {
 		$page = $getData['page'] ?? 1;
 		$perPage = $getData['perPage'] ?? 200;
@@ -377,7 +377,7 @@ class ShareesAPIControllerTest extends TestCase {
 		}
 	}
 
-	public function dataIsRemoteSharingAllowed() {
+	public static function dataIsRemoteSharingAllowed() {
 		return [
 			['file', true],
 			['folder', true],
@@ -387,11 +387,11 @@ class ShareesAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsRemoteSharingAllowed
 	 *
 	 * @param string $itemType
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsRemoteSharingAllowed')]
 	public function testIsRemoteSharingAllowed($itemType, $expected): void {
 		$this->assertSame($expected, $this->invokePrivate($this->sharees, 'isRemoteSharingAllowed', [$itemType]));
 	}
@@ -420,7 +420,7 @@ class ShareesAPIControllerTest extends TestCase {
 		$this->sharees->search('', null, 1, 10, [], false);
 	}
 
-	public function dataGetPaginationLink() {
+	public static function dataGetPaginationLink() {
 		return [
 			[1, '/ocs/v1.php', ['perPage' => 2], '<?perPage=2&page=2>; rel="next"'],
 			[10, '/ocs/v2.php', ['perPage' => 2], '<?perPage=2&page=11>; rel="next"'],
@@ -428,13 +428,13 @@ class ShareesAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetPaginationLink
 	 *
 	 * @param int $page
 	 * @param string $scriptName
 	 * @param array $params
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetPaginationLink')]
 	public function testGetPaginationLink($page, $scriptName, $params, $expected): void {
 		$this->request->expects($this->once())
 			->method('getScriptName')
@@ -443,7 +443,7 @@ class ShareesAPIControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->invokePrivate($this->sharees, 'getPaginationLink', [$page, $params]));
 	}
 
-	public function dataIsV2() {
+	public static function dataIsV2() {
 		return [
 			['/ocs/v1.php', false],
 			['/ocs/v2.php', true],
@@ -451,11 +451,11 @@ class ShareesAPIControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsV2
 	 *
 	 * @param string $scriptName
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsV2')]
 	public function testIsV2($scriptName, $expected): void {
 		$this->request->expects($this->once())
 			->method('getScriptName')

--- a/apps/files_sharing/tests/ExpireSharesJobTest.php
+++ b/apps/files_sharing/tests/ExpireSharesJobTest.php
@@ -90,7 +90,7 @@ class ExpireSharesJobTest extends \Test\TestCase {
 		return $shares;
 	}
 
-	public function dataExpireLinkShare() {
+	public static function dataExpireLinkShare() {
 		return [
 			[false,   '', false, false],
 			[false,   '',  true, false],
@@ -106,13 +106,13 @@ class ExpireSharesJobTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataExpireLinkShare
 	 *
 	 * @param bool addExpiration Should we add an expire date
 	 * @param string $interval The dateInterval
 	 * @param bool $addInterval If true add to the current time if false subtract
 	 * @param bool $shouldExpire Should this share be expired
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExpireLinkShare')]
 	public function testExpireLinkShare($addExpiration, $interval, $addInterval, $shouldExpire): void {
 		$this->loginAsUser($this->user1);
 

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -108,10 +108,10 @@ class ManagerTest extends TestCase {
 		$this->userManager->expects($this->any())->method('get')->willReturn($this->user);
 		$this->groupManager->expects($this->any())->method(('getUserGroups'))->willReturn([$group1, $group2]);
 		$this->groupManager->expects($this->any())->method(('get'))
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['group1', $group1],
 				['group2', $group2],
-			]));
+			]);
 	}
 
 	protected function tearDown(): void {

--- a/apps/files_sharing/tests/ExternalStorageTest.php
+++ b/apps/files_sharing/tests/ExternalStorageTest.php
@@ -20,7 +20,7 @@ use OCP\Http\Client\IResponse;
  * @group DB
  */
 class ExternalStorageTest extends \Test\TestCase {
-	public function optionsProvider() {
+	public static function optionsProvider() {
 		return [
 			[
 				'http://remoteserver:8080/owncloud',
@@ -88,9 +88,7 @@ class ExternalStorageTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider optionsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('optionsProvider')]
 	public function testStorageMountOptions($inputUri, $baseUri): void {
 		$storage = $this->getTestStorage($inputUri);
 		$this->assertEquals($baseUri, $storage->getBaseUri());

--- a/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
@@ -73,12 +73,12 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataBeforeController
 	 *
 	 * @param Controller $controller
 	 * @param bool $enabled
 	 * @param bool $exception
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataBeforeController')]
 	public function testBeforeController(Controller $controller, $enabled, $exception): void {
 		$this->shareManager->method('shareApiEnabled')->willReturn($enabled);
 
@@ -105,11 +105,11 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataAfterController
 	 *
 	 * @param Controller $controller
 	 * @param bool $called
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterController')]
 	public function testAfterController(Controller $controller): void {
 		if ($controller instanceof ShareAPIController) {
 			$controller->expects($this->once())->method('cleanup');

--- a/apps/files_sharing/tests/Middleware/SharingCheckMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/SharingCheckMiddlewareTest.php
@@ -80,7 +80,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 		$this->assertFalse(self::invokePrivate($this->sharingCheckMiddleware, 'isSharingEnabled'));
 	}
 
-	public function externalSharesChecksDataProvider() {
+	public static function externalSharesChecksDataProvider() {
 		$data = [];
 
 		foreach ([false, true] as $annIn) {
@@ -115,9 +115,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 		return $data;
 	}
 
-	/**
-	 * @dataProvider externalSharesChecksDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('externalSharesChecksDataProvider')]
 	public function testExternalSharesChecks($annotations, $config, $expectedResult): void {
 		$this->reflector
 			->expects($this->atLeastOnce())
@@ -131,9 +129,7 @@ class SharingCheckMiddlewareTest extends \Test\TestCase {
 		$this->assertEquals($expectedResult, self::invokePrivate($this->sharingCheckMiddleware, 'externalSharesChecks'));
 	}
 
-	/**
-	 * @dataProvider externalSharesChecksDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('externalSharesChecksDataProvider')]
 	public function testBeforeControllerWithExternalShareControllerWithSharingEnabled($annotations, $config, $noException): void {
 		$this->appManager
 			->expects($this->once())

--- a/apps/files_sharing/tests/ShareTest.php
+++ b/apps/files_sharing/tests/ShareTest.php
@@ -189,8 +189,8 @@ class ShareTest extends TestCase {
 
 	/**
 	 * shared files should never have delete permissions
-	 * @dataProvider dataProviderTestFileSharePermissions
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderTestFileSharePermissions')]
 	public function testFileSharePermissions($permission, $expectedvalid): void {
 		$pass = true;
 		try {
@@ -208,7 +208,7 @@ class ShareTest extends TestCase {
 		$this->assertEquals($expectedvalid, $pass);
 	}
 
-	public function dataProviderTestFileSharePermissions() {
+	public static function dataProviderTestFileSharePermissions() {
 		$permission1 = Constants::PERMISSION_ALL;
 		$permission3 = Constants::PERMISSION_READ;
 		$permission4 = Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE;

--- a/apps/files_sharing/tests/SharedMountTest.php
+++ b/apps/files_sharing/tests/SharedMountTest.php
@@ -225,11 +225,11 @@ class SharedMountTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProviderTestStripUserFilesPath
 	 * @param string $path
 	 * @param string $expectedResult
 	 * @param bool $exception if a exception is expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderTestStripUserFilesPath')]
 	public function testStripUserFilesPath($path, $expectedResult, $exception): void {
 		$testClass = new DummyTestClassSharedMount(null, null);
 		try {
@@ -244,7 +244,7 @@ class SharedMountTest extends TestCase {
 		}
 	}
 
-	public function dataProviderTestStripUserFilesPath() {
+	public static function dataProviderTestStripUserFilesPath() {
 		return [
 			['/user/files/foo.txt', '/foo.txt', false],
 			['/user/files/folder/foo.txt', '/folder/foo.txt', false],

--- a/apps/files_sharing/tests/SharedStorageTest.php
+++ b/apps/files_sharing/tests/SharedStorageTest.php
@@ -571,7 +571,7 @@ class SharedStorageTest extends TestCase {
 		$share->method('getShareOwner')->willReturn(self::TEST_FILES_SHARING_API_USER1);
 		$share->method('getNodeId')->willReturn(1);
 		$ownerView = $this->createMock(View::class);
-		$ownerView->method('getPath')->will($this->throwException(new NotFoundException()));
+		$ownerView->method('getPath')->willThrowException(new NotFoundException());
 		$storage = new SharedStorage([
 			'ownerView' => $ownerView,
 			'superShare' => $share,

--- a/apps/files_sharing/tests/SharesReminderJobTest.php
+++ b/apps/files_sharing/tests/SharesReminderJobTest.php
@@ -95,7 +95,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 		parent::tearDown();
 	}
 
-	public function dataSharesReminder() {
+	public static function dataSharesReminder() {
 		$someMail = 'test@test.com';
 		$noExpirationDate = null;
 		$today = new \DateTime();
@@ -144,7 +144,6 @@ class SharesReminderJobTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSharesReminder
 	 *
 	 * @param \DateTime|null $expirationDate Share expiration date
 	 * @param string $email Share with this email. If empty, the share is of type TYPE_USER and the sharee is user2
@@ -152,6 +151,7 @@ class SharesReminderJobTest extends \Test\TestCase {
 	 * @param int $permissions
 	 * @param bool $shouldBeReminded
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSharesReminder')]
 	public function testSharesReminder(
 		?\DateTime $expirationDate, string $email, bool $isEmpty, int $permissions, bool $shouldBeReminded,
 	): void {

--- a/apps/files_sharing/tests/UpdaterTest.php
+++ b/apps/files_sharing/tests/UpdaterTest.php
@@ -124,7 +124,7 @@ class UpdaterTest extends TestCase {
 		Filesystem::getLoader()->removeStorageWrapper('oc_trashbin');
 	}
 
-	public function shareFolderProvider() {
+	public static function shareFolderProvider() {
 		return [
 			['/'],
 			['/my_shares'],
@@ -134,10 +134,10 @@ class UpdaterTest extends TestCase {
 	/**
 	 * if a file gets shared the etag for the recipients root should change
 	 *
-	 * @dataProvider shareFolderProvider
 	 *
 	 * @param string $shareFolder share folder to use
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('shareFolderProvider')]
 	public function testShareFile($shareFolder): void {
 		$config = Server::get(IConfig::class);
 		$oldShareFolder = $config->getSystemValue('share_folder');

--- a/apps/files_trashbin/tests/Command/CleanUpTest.php
+++ b/apps/files_trashbin/tests/Command/CleanUpTest.php
@@ -69,9 +69,7 @@ class CleanUpTest extends TestCase {
 		$this->assertCount(10, $result);
 	}
 
-	/**
-	 * @dataProvider dataTestRemoveDeletedFiles
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRemoveDeletedFiles')]
 	public function testRemoveDeletedFiles(bool $nodeExists): void {
 		$this->initTable();
 		$this->rootFolder
@@ -129,7 +127,7 @@ class CleanUpTest extends TestCase {
 	 */
 	public function testExecuteDeleteListOfUsers(): void {
 		$userIds = ['user1', 'user2', 'user3'];
-		$instance = $this->getMockBuilder(\OCA\Files_Trashbin\Command\CleanUp::class)
+		$instance = $this->getMockBuilder(CleanUp::class)
 			->onlyMethods(['removeDeletedFiles'])
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->dbConnection])
 			->getMock();
@@ -159,7 +157,7 @@ class CleanUpTest extends TestCase {
 	public function testExecuteAllUsers(): void {
 		$userIds = [];
 		$backendUsers = ['user1', 'user2'];
-		$instance = $this->getMockBuilder(\OCA\Files_Trashbin\Command\CleanUp::class)
+		$instance = $this->getMockBuilder(CleanUp::class)
 			->onlyMethods(['removeDeletedFiles'])
 			->setConstructorArgs([$this->rootFolder, $this->userManager, $this->dbConnection])
 			->getMock();

--- a/apps/files_trashbin/tests/ExpirationTest.php
+++ b/apps/files_trashbin/tests/ExpirationTest.php
@@ -82,9 +82,7 @@ class ExpirationTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider expirationData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('expirationData')]
 	public function testExpiration(string $retentionObligation, int $timeNow, int $timestamp, bool $quotaExceeded, bool $expectedResult): void {
 		$mockedConfig = $this->getMockedConfig($retentionObligation);
 		$mockedTimeFactory = $this->getMockedTimeFactory($timeNow);
@@ -110,9 +108,7 @@ class ExpirationTest extends \Test\TestCase {
 	}
 
 
-	/**
-	 * @dataProvider timestampTestData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('timestampTestData')]
 	public function testGetMaxAgeAsTimestamp(string $configValue, bool|int $expectedMaxAgeTimestamp): void {
 		$mockedConfig = $this->getMockedConfig($configValue);
 		$mockedTimeFactory = $this->getMockedTimeFactory(

--- a/apps/files_trashbin/tests/Sabre/TrashbinPluginTest.php
+++ b/apps/files_trashbin/tests/Sabre/TrashbinPluginTest.php
@@ -29,9 +29,7 @@ class TrashbinPluginTest extends TestCase {
 		$this->server = new Server($tree);
 	}
 
-	/**
-	 * @dataProvider quotaProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('quotaProvider')]
 	public function testQuota(int $quota, int $fileSize, bool $expectedResult): void {
 		$fileInfo = $this->createMock(ITrashItem::class);
 		$fileInfo->method('getSize')

--- a/apps/files_trashbin/tests/StorageTest.php
+++ b/apps/files_trashbin/tests/StorageTest.php
@@ -311,7 +311,7 @@ class StorageTest extends \Test\TestCase {
 		$recipientUser = $this->getUniqueId('recipient_');
 		Server::get(IUserManager::class)->createUser($recipientUser, $recipientUser);
 
-		$node = \OCP\Server::get(IRootFolder::class)->getUserFolder($this->user)->get('share');
+		$node = Server::get(IRootFolder::class)->getUserFolder($this->user)->get('share');
 		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setNode($node)
 			->setShareType(IShare::TYPE_USER)
@@ -362,7 +362,7 @@ class StorageTest extends \Test\TestCase {
 
 		$recipientUser = $this->getUniqueId('recipient_');
 		Server::get(IUserManager::class)->createUser($recipientUser, $recipientUser);
-		$node = \OCP\Server::get(IRootFolder::class)->getUserFolder($this->user)->get('share');
+		$node = Server::get(IRootFolder::class)->getUserFolder($this->user)->get('share');
 		$share = Server::get(\OCP\Share\IManager::class)->newShare();
 		$share->setNode($node)
 			->setShareType(IShare::TYPE_USER)
@@ -496,7 +496,7 @@ class StorageTest extends \Test\TestCase {
 		/**
 		 * @var Temporary&MockObject $storage
 		 */
-		$storage = $this->getMockBuilder(\OC\Files\Storage\Temporary::class)
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setConstructorArgs([[]])
 			->onlyMethods(['rename', 'unlink', 'moveFromStorage'])
 			->getMock();
@@ -533,7 +533,7 @@ class StorageTest extends \Test\TestCase {
 		/**
 		 * @var Temporary&MockObject $storage
 		 */
-		$storage = $this->getMockBuilder(\OC\Files\Storage\Temporary::class)
+		$storage = $this->getMockBuilder(Temporary::class)
 			->setConstructorArgs([[]])
 			->onlyMethods(['rename', 'unlink', 'rmdir'])
 			->getMock();
@@ -560,14 +560,12 @@ class StorageTest extends \Test\TestCase {
 		$this->assertCount(0, $results);
 	}
 
-	/**
-	 * @dataProvider dataTestShouldMoveToTrash
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShouldMoveToTrash')]
 	public function testShouldMoveToTrash(string $mountPoint, string $path, bool $userExists, bool $appDisablesTrash, bool $expected): void {
 		$fileID = 1;
 		$cache = $this->createMock(ICache::class);
 		$cache->expects($this->any())->method('getId')->willReturn($fileID);
-		$tmpStorage = $this->createMock(\OC\Files\Storage\Temporary::class);
+		$tmpStorage = $this->createMock(Temporary::class);
 		$tmpStorage->expects($this->any())->method('getCache')->willReturn($cache);
 		$userManager = $this->getMockBuilder(IUserManager::class)
 			->disableOriginalConstructor()->getMock();

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -354,7 +354,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * Test restoring a file
 	 */
 	public function testRestoreFileInRoot(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$file = $userFolder->newFile('file1.txt');
 		$file->putContent('foo');
 
@@ -386,7 +386,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * Test restoring a file in subfolder
 	 */
 	public function testRestoreFileInSubfolder(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$folder = $userFolder->newFolder('folder');
 		$file = $folder->newFile('file1.txt');
 		$file->putContent('foo');
@@ -419,7 +419,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * Test restoring a folder
 	 */
 	public function testRestoreFolder(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$folder = $userFolder->newFolder('folder');
 		$file = $folder->newFile('file1.txt');
 		$file->putContent('foo');
@@ -452,7 +452,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * Test restoring a file from inside a trashed folder
 	 */
 	public function testRestoreFileFromTrashedSubfolder(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$folder = $userFolder->newFolder('folder');
 		$file = $folder->newFile('file1.txt');
 		$file->putContent('foo');
@@ -486,7 +486,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * The file should then land in the root.
 	 */
 	public function testRestoreFileWithMissingSourceFolder(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$folder = $userFolder->newFolder('folder');
 		$file = $folder->newFile('file1.txt');
 		$file->putContent('foo');
@@ -523,7 +523,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * with the same name in the root folder
 	 */
 	public function testRestoreFileDoesNotOverwriteExistingInRoot(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$file = $userFolder->newFile('file1.txt');
 		$file->putContent('foo');
 
@@ -563,7 +563,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * with the same name in the source folder
 	 */
 	public function testRestoreFileDoesNotOverwriteExistingInSubfolder(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$folder = $userFolder->newFolder('folder');
 		$file = $folder->newFile('file1.txt');
 		$file->putContent('foo');
@@ -617,7 +617,7 @@ class TrashbinTest extends \Test\TestCase {
 	 * the file to root instead
 	 */
 	public function testRestoreFileIntoReadOnlySourceFolder(): void {
-		$userFolder = \OCP\Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
 		$folder = $userFolder->newFolder('folder');
 		$file = $folder->newFile('file1.txt');
 		$file->putContent('foo');
@@ -673,7 +673,7 @@ class TrashbinTest extends \Test\TestCase {
 		Filesystem::tearDown();
 		\OC_User::setUserId($user);
 		\OC_Util::setupFS($user);
-		\OCP\Server::get(IRootFolder::class)->getUserFolder($user);
+		Server::get(IRootFolder::class)->getUserFolder($user);
 	}
 }
 

--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -9,6 +9,7 @@
 namespace OCA\Files_Versions;
 
 use OC\Files\Filesystem;
+use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\Search\SearchBinaryOperator;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
@@ -419,8 +420,8 @@ class Storage {
 
 		try {
 			// TODO add a proper way of overwriting a file while maintaining file ids
-			if ($storage1->instanceOfStorage(\OC\Files\ObjectStore\ObjectStoreStorage::class)
-				|| $storage2->instanceOfStorage(\OC\Files\ObjectStore\ObjectStoreStorage::class)
+			if ($storage1->instanceOfStorage(ObjectStoreStorage::class)
+				|| $storage2->instanceOfStorage(ObjectStoreStorage::class)
 			) {
 				$source = $storage1->fopen($internalPath1, 'r');
 				$result = $source !== false;

--- a/apps/files_versions/tests/Command/CleanupTest.php
+++ b/apps/files_versions/tests/Command/CleanupTest.php
@@ -43,9 +43,9 @@ class CleanupTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestDeleteVersions
 	 * @param boolean $nodeExists
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDeleteVersions')]
 	public function testDeleteVersions(bool $nodeExists): void {
 		$this->rootFolder->expects($this->once())
 			->method('nodeExists')

--- a/apps/files_versions/tests/ExpirationTest.php
+++ b/apps/files_versions/tests/ExpirationTest.php
@@ -81,9 +81,7 @@ class ExpirationTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider expirationData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('expirationData')]
 	public function testExpiration(string $retentionObligation, int $timeNow, int $timestamp, bool $quotaExceeded, bool $expectedResult): void {
 		$mockedConfig = $this->getMockedConfig($retentionObligation);
 		$mockedTimeFactory = $this->getMockedTimeFactory($timeNow);

--- a/apps/files_versions/tests/VersioningTest.php
+++ b/apps/files_versions/tests/VersioningTest.php
@@ -140,8 +140,8 @@ class VersioningTest extends \Test\TestCase {
 	/**
 	 * @medium
 	 * test expire logic
-	 * @dataProvider versionsProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('versionsProvider')]
 	public function testGetExpireList($versions, $sizeOfAllDeletedFiles): void {
 
 		// last interval end at 2592000

--- a/apps/oauth2/tests/Controller/OauthApiControllerTest.php
+++ b/apps/oauth2/tests/Controller/OauthApiControllerTest.php
@@ -223,7 +223,7 @@ class OauthApiControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->oauthApiController->getToken('refresh_token', null, 'validrefresh', null, null));
 	}
 
-	public function invalidClientProvider() {
+	public static function invalidClientProvider() {
 		return [
 			['invalidClientId', 'invalidClientSecret'],
 			['clientId', 'invalidClientSecret'],
@@ -232,11 +232,11 @@ class OauthApiControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider invalidClientProvider
 	 *
 	 * @param string $clientId
 	 * @param string $clientSecret
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidClientProvider')]
 	public function testRefreshTokenInvalidClient($clientId, $clientSecret): void {
 		$expected = new JSONResponse([
 			'error' => 'invalid_client',

--- a/apps/provisioning_api/tests/CapabilitiesTest.php
+++ b/apps/provisioning_api/tests/CapabilitiesTest.php
@@ -48,16 +48,14 @@ class CapabilitiesTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider getCapabilitiesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getCapabilitiesProvider')]
 	public function testGetCapabilities(bool $federationAppEnabled, bool $federatedFileSharingAppEnabled, bool $lookupServerEnabled, bool $expectedFederatedScopeEnabled, bool $expectedPublishedScopeEnabled): void {
 		$this->appManager->expects($this->any())
 			->method('isEnabledForUser')
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['federation', null, $federationAppEnabled],
 				['federatedfilesharing', null, $federatedFileSharingAppEnabled],
-			]));
+			]);
 
 		$federatedShareProvider = $this->createMock(FederatedShareProvider::class);
 		$this->overwriteService(FederatedShareProvider::class, $federatedShareProvider);

--- a/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
@@ -103,9 +103,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetKeys
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetKeys')]
 	public function testGetKeys(string $app, ?array $keys, ?\Throwable $throws, int $status): void {
 		$api = $this->getInstance(['verifyAppId']);
 		if ($throws instanceof \Exception) {
@@ -144,9 +142,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetValue
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetValue')]
 	public function testGetValue(string $app, string $key, string $default, ?string $return, ?\Throwable $throws, int $status): void {
 		$api = $this->getInstance(['verifyAppId']);
 		if ($throws instanceof \Exception) {
@@ -190,9 +186,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSetValue
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetValue')]
 	public function testSetValue(string $app, string $key, string $value, ?\Throwable $appThrows, ?\Throwable $keyThrows, int $status, int|\Throwable $type = IAppConfig::VALUE_MIXED): void {
 		$adminUser = $this->createMock(IUser::class);
 		$adminUser->expects($this->once())
@@ -290,9 +284,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataDeleteValue
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteValue')]
 	public function testDeleteValue(string $app, string $key, ?\Throwable $appThrows, ?\Throwable $keyThrows, int $status): void {
 		$api = $this->getInstance(['verifyAppId', 'verifyConfigKey']);
 		if ($appThrows instanceof \Exception) {
@@ -356,9 +348,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataVerifyAppIdThrows
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataVerifyAppIdThrows')]
 	public function testVerifyAppIdThrows(string $app): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -375,9 +365,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataVerifyConfigKey
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataVerifyConfigKey')]
 	public function testVerifyConfigKey(string $app, string $key, string $value): void {
 		$api = $this->getInstance();
 		$this->invokePrivate($api, 'verifyConfigKey', [$app, $key, $value]);
@@ -398,9 +386,7 @@ class AppConfigControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataVerifyConfigKeyThrows
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataVerifyConfigKeyThrows')]
 	public function testVerifyConfigKeyThrows(string $app, string $key, string $value): void {
 		$this->expectException(\InvalidArgumentException::class);
 

--- a/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/GroupsControllerTest.php
@@ -77,7 +77,7 @@ class GroupsControllerTest extends \Test\TestCase {
 	}
 
 	private function createGroup(string $gid): IGroup&MockObject {
-		$group = $this->createMock(\OCP\IGroup::class);
+		$group = $this->createMock(IGroup::class);
 		$group
 			->method('getGID')
 			->willReturn($gid);
@@ -161,9 +161,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetGroups
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetGroups')]
 	public function testGetGroups(?string $search, int $limit, int $offset): void {
 		$groups = [$this->createGroup('group1'), $this->createGroup('group2')];
 
@@ -180,12 +178,12 @@ class GroupsControllerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetGroups
 	 *
 	 * @param string|null $search
 	 * @param int|null $limit
 	 * @param int|null $offset
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetGroups')]
 	public function testGetGroupsDetails($search, $limit, $offset): void {
 		$groups = [$this->createGroup('group1'), $this->createGroup('group2')];
 

--- a/apps/provisioning_api/tests/Controller/UsersControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/UsersControllerTest.php
@@ -199,8 +199,7 @@ class UsersControllerTest extends TestCase {
 			->willReturn($subAdminManager);
 		$this->groupManager
 			->expects($this->any())
-			->method('displayNamesInGroup')
-			->will($this->onConsecutiveCalls(['AnotherUserInTheFirstGroup' => []], ['UserInTheSecondGroup' => []]));
+			->method('displayNamesInGroup')->willReturnOnConsecutiveCalls(['AnotherUserInTheFirstGroup' => []], ['UserInTheSecondGroup' => []]);
 
 		$expected = [
 			'users' => [
@@ -790,7 +789,7 @@ class UsersControllerTest extends TestCase {
 		$this->logger
 			->expects($this->exactly(2))
 			->method('info')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});
@@ -814,7 +813,7 @@ class UsersControllerTest extends TestCase {
 			->expects($this->once())
 			->method('createUser')
 			->with('NewUser', 'PasswordOfTheNewUser')
-			->will($this->throwException($exception));
+			->willThrowException($exception);
 		$this->logger
 			->expects($this->once())
 			->method('error')
@@ -994,7 +993,7 @@ class UsersControllerTest extends TestCase {
 		$this->logger
 			->expects($this->exactly(3))
 			->method('info')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});
@@ -1534,9 +1533,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSearchByPhoneNumbers
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchByPhoneNumbers')]
 	public function testSearchByPhoneNumbers(string $location, array $search, int $status, ?array $searchUsers, ?array $userMatches, array $expected): void {
 		$knownTo = 'knownTo';
 		$user = $this->createMock(IUser::class);
@@ -1862,9 +1859,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider selfEditChangePropertyProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('selfEditChangePropertyProvider')]
 	public function testEditUserRegularUserSelfEditChangeProperty($propertyName, $oldValue, $newValue): void {
 		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
@@ -1940,9 +1935,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider selfEditChangePropertyProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('selfEditChangePropertyProvider')]
 	public function testEditUserRegularUserSelfEditChangePropertyScope($propertyName, $oldScope, $newScope): void {
 		$loggedInUser = $this->getMockBuilder(IUser::class)
 			->disableOriginalConstructor()
@@ -2277,9 +2270,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataEditUserSelfEditChangeLanguageButForced
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataEditUserSelfEditChangeLanguageButForced')]
 	public function testEditUserSelfEditChangeLanguageButForced($forced): void {
 		$this->expectException(OCSException::class);
 
@@ -2373,9 +2364,7 @@ class UsersControllerTest extends TestCase {
 		$this->assertEquals([], $this->api->editUser('UserToEdit', 'language', 'de')->getData());
 	}
 
-	/**
-	 * @dataProvider dataEditUserSelfEditChangeLanguageButForced
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataEditUserSelfEditChangeLanguageButForced')]
 	public function testEditUserAdminEditChangeLanguageInvalidLanguage(): void {
 		$this->expectException(OCSException::class);
 
@@ -4363,9 +4352,7 @@ class UsersControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetEditableFields
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetEditableFields')]
 	public function testGetEditableFields(bool $allowedToChangeDisplayName, bool $allowedToChangeEmail, string $userBackend, array $expected): void {
 		$this->config->method('getSystemValue')->willReturnCallback(fn (string $key, mixed $default) => match ($key) {
 			'allow_user_to_change_display_name' => $allowedToChangeDisplayName,
@@ -4400,7 +4387,7 @@ class UsersControllerTest extends TestCase {
 
 		$account = $this->createMock(IAccount::class);
 		$account->method('getProperty')
-			->will($this->returnValueMap($mockedProperties));
+			->willReturnMap($mockedProperties);
 
 		$this->accountManager->expects($this->any())->method('getAccount')
 			->with($targetUser)

--- a/apps/provisioning_api/tests/Middleware/ProvisioningApiMiddlewareTest.php
+++ b/apps/provisioning_api/tests/Middleware/ProvisioningApiMiddlewareTest.php
@@ -44,9 +44,7 @@ class ProvisioningApiMiddlewareTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataAnnotation
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAnnotation')]
 	public function testBeforeController(bool $subadminRequired, bool $isAdmin, bool $isSubAdmin, bool $hasSettingAuthorizationAnnotation, bool $shouldThrowException): void {
 		$middleware = new ProvisioningApiMiddleware(
 			$this->reflector,
@@ -83,9 +81,7 @@ class ProvisioningApiMiddlewareTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataAfterException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterException')]
 	public function testAfterException(\Exception $exception, bool $forwared): void {
 		$middleware = new ProvisioningApiMiddleware(
 			$this->reflector,

--- a/apps/settings/tests/Activity/SecurityProviderTest.php
+++ b/apps/settings/tests/Activity/SecurityProviderTest.php
@@ -50,9 +50,7 @@ class SecurityProviderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider subjectData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('subjectData')]
 	public function testParse(string $subject): void {
 		$lang = 'ru';
 		$event = $this->createMock(IEvent::class);

--- a/apps/settings/tests/AppInfo/ApplicationTest.php
+++ b/apps/settings/tests/AppInfo/ApplicationTest.php
@@ -56,9 +56,7 @@ class ApplicationTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataContainerQuery
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataContainerQuery')]
 	public function testContainerQuery(string $service, string $expected): void {
 		$this->assertTrue($this->container->query($service) instanceof $expected);
 	}

--- a/apps/settings/tests/Controller/AuthSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/AuthSettingsControllerTest.php
@@ -120,7 +120,7 @@ class AuthSettingsControllerTest extends TestCase {
 
 		$this->session->expects($this->once())
 			->method('getId')
-			->will($this->throwException(new SessionNotAvailableException()));
+			->willThrowException(new SessionNotAvailableException());
 
 		$expected = new JSONResponse();
 		$expected->setStatus(Http::STATUS_SERVICE_UNAVAILABLE);
@@ -137,7 +137,7 @@ class AuthSettingsControllerTest extends TestCase {
 		$this->tokenProvider->expects($this->once())
 			->method('getToken')
 			->with('sessionid')
-			->will($this->throwException(new InvalidTokenException()));
+			->willThrowException(new InvalidTokenException());
 
 		$expected = new JSONResponse();
 		$expected->setStatus(Http::STATUS_SERVICE_UNAVAILABLE);
@@ -213,9 +213,7 @@ class AuthSettingsControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataRenameToken
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenameToken')]
 	public function testUpdateRename(string $name, string $newName): void {
 		$tokenId = 42;
 		$token = $this->createMock(PublicKeyToken::class);
@@ -253,9 +251,7 @@ class AuthSettingsControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUpdateFilesystemScope
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateFilesystemScope')]
 	public function testUpdateFilesystemScope(bool $filesystem, bool $newFilesystem): void {
 		$tokenId = 42;
 		$token = $this->createMock(PublicKeyToken::class);

--- a/apps/settings/tests/Controller/MailSettingsControllerTest.php
+++ b/apps/settings/tests/Controller/MailSettingsControllerTest.php
@@ -79,7 +79,7 @@ class MailSettingsControllerTest extends \Test\TestCase {
 		];
 		$this->config->expects($this->exactly(2))
 			->method('setSystemValues')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/settings/tests/Controller/UsersControllerTest.php
+++ b/apps/settings/tests/Controller/UsersControllerTest.php
@@ -235,9 +235,7 @@ class UsersControllerTest extends \Test\TestCase {
 		return $account;
 	}
 
-	/**
-	 * @dataProvider dataTestSetUserSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetUserSettings')]
 	public function testSetUserSettings(string $email, bool $validEmail, int $expectedStatus): void {
 		$controller = $this->getController(false, ['saveUserSettings']);
 		$user = $this->createMock(IUser::class);
@@ -497,9 +495,7 @@ class UsersControllerTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestSetUserSettingsSubset
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetUserSettingsSubset')]
 	public function testSetUserSettingsSubset(string $property, string $propertyValue): void {
 		$controller = $this->getController(false, ['saveUserSettings']);
 		$user = $this->createMock(IUser::class);
@@ -641,9 +637,7 @@ class UsersControllerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestSaveUserSettings
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSaveUserSettings')]
 	public function testSaveUserSettings(array $data, ?string $oldEmailAddress, ?string $oldDisplayName): void {
 		$controller = $this->getController();
 		$user = $this->createMock(IUser::class);
@@ -758,9 +752,7 @@ class UsersControllerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestSaveUserSettingsException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSaveUserSettingsException')]
 	public function testSaveUserSettingsException(
 		array $data,
 		string $oldEmailAddress,
@@ -843,9 +835,7 @@ class UsersControllerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestGetVerificationCode
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetVerificationCode')]
 	public function testGetVerificationCode(string $account, string $type, array $dataBefore, array $expectedData, bool $onlyVerificationCode): void {
 		$message = 'Use my Federated Cloud ID to share with me: user@nextcloud.com';
 		$signature = 'theSignature';
@@ -940,9 +930,7 @@ class UsersControllerTest extends \Test\TestCase {
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $result->getStatus());
 	}
 
-	/**
-	 * @dataProvider dataTestCanAdminChangeUserPasswords
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCanAdminChangeUserPasswords')]
 	public function testCanAdminChangeUserPasswords(
 		bool $encryptionEnabled,
 		bool $encryptionModuleLoaded,

--- a/apps/settings/tests/Settings/Admin/MailTest.php
+++ b/apps/settings/tests/Settings/Admin/MailTest.php
@@ -38,7 +38,7 @@ class MailTest extends TestCase {
 		];
 	}
 
-	/** @dataProvider dataGetForm */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetForm')]
 	public function testGetForm(bool $sendmail) {
 		$finder = $this->createMock(IBinaryFinder::class);
 		$finder->expects(self::once())

--- a/apps/settings/tests/Settings/Admin/SecurityTest.php
+++ b/apps/settings/tests/Settings/Admin/SecurityTest.php
@@ -46,9 +46,7 @@ class SecurityTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider encryptionSettingsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('encryptionSettingsProvider')]
 	public function testGetFormWithOnlyOneBackend(bool $enabled): void {
 		$this->manager
 			->expects($this->once())
@@ -76,9 +74,9 @@ class SecurityTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider encryptionSettingsProvider
 	 * @param bool $enabled
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('encryptionSettingsProvider')]
 	public function testGetFormWithMultipleBackends($enabled): void {
 		$this->manager
 			->expects($this->once())

--- a/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
+++ b/apps/settings/tests/Settings/Personal/Security/AuthtokensTest.php
@@ -97,7 +97,7 @@ class AuthtokensTest extends TestCase {
 		];
 		$this->initialState->expects($this->exactly(2))
 			->method('provideInitialState')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
+++ b/apps/settings/tests/SetupChecks/DataDirectoryProtectedTest.php
@@ -54,9 +54,7 @@ class DataDirectoryProtectedTest extends TestCase {
 			->getMock();
 	}
 
-	/**
-	 * @dataProvider dataTestStatusCode
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestStatusCode')]
 	public function testStatusCode(array $status, string $expected, bool $hasBody): void {
 		$responses = array_map(function ($state) use ($hasBody) {
 			$response = $this->createMock(IResponse::class);

--- a/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/ForwardedForHeadersTest.php
@@ -43,9 +43,7 @@ class ForwardedForHeadersTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataForwardedForHeadersWorking
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataForwardedForHeadersWorking')]
 	public function testForwardedForHeadersWorking(array $trustedProxies, string $remoteAddrNotForwarded, string $remoteAddr, string $result): void {
 		$this->config->expects($this->once())
 			->method('getSystemValue')

--- a/apps/settings/tests/SetupChecks/LoggingLevelTest.php
+++ b/apps/settings/tests/SetupChecks/LoggingLevelTest.php
@@ -59,7 +59,7 @@ class LoggingLevelTest extends TestCase {
 		];
 	}
 
-	/** @dataProvider dataRun */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRun')]
 	public function testRun(string|int $value, string $expected): void {
 		$this->urlGenerator->method('linkToDocs')->willReturn('admin-logging');
 

--- a/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
+++ b/apps/settings/tests/SetupChecks/SecurityHeadersTest.php
@@ -106,9 +106,7 @@ class SecurityHeadersTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSuccess
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSuccess')]
 	public function testSuccess(array $headers): void {
 		$headers = array_merge(
 			[
@@ -147,9 +145,7 @@ class SecurityHeadersTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataFailure
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFailure')]
 	public function testFailure(array $headers, string $msg): void {
 		$headers = array_merge(
 			[

--- a/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
+++ b/apps/settings/tests/SetupChecks/WellKnownUrlsTest.php
@@ -96,8 +96,8 @@ class WellKnownUrlsTest extends TestCase {
 
 	/**
 	 * Test responses
-	 * @dataProvider dataTestResponses
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestResponses')]
 	public function testResponses($responses, string $expectedSeverity): void {
 		$this->config
 			->expects($this->once())

--- a/apps/settings/tests/UserMigration/AccountMigratorTest.php
+++ b/apps/settings/tests/UserMigration/AccountMigratorTest.php
@@ -85,9 +85,7 @@ class AccountMigratorTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataImportExportAccount
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataImportExportAccount')]
 	public function testImportExportAccount(string $userId, array $importData, string $avatarPath, array $importConfig): void {
 		$user = $this->userManager->createUser($userId, 'topsecretpassword');
 		$avatarExt = pathinfo($avatarPath, PATHINFO_EXTENSION);

--- a/apps/sharebymail/tests/ShareByMailProviderTest.php
+++ b/apps/sharebymail/tests/ShareByMailProviderTest.php
@@ -844,9 +844,7 @@ class ShareByMailProviderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUpdateSendPassword
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateSendPassword')]
 	public function testUpdateSendPassword(?string $plainTextPassword, string $originalPassword, string $newPassword, bool $originalSendPasswordByTalk, bool $newSendPasswordByTalk, bool $sendMail): void {
 		$node = $this->createMock(File::class);
 		$node->expects($this->any())->method('getName')->willReturn('filename');

--- a/apps/testing/lib/HiddenGroupBackend.php
+++ b/apps/testing/lib/HiddenGroupBackend.php
@@ -13,12 +13,9 @@ use OCP\Group\Backend\ABackend;
 use OCP\Group\Backend\IHideFromCollaborationBackend;
 
 class HiddenGroupBackend extends ABackend implements IHideFromCollaborationBackend {
-	private string $groupName;
-
 	public function __construct(
-		string $groupName = 'hidden_group',
+		private string $groupName = 'hidden_group',
 	) {
-		$this->groupName = $groupName;
 	}
 
 	public function inGroup($uid, $gid): bool {

--- a/apps/theming/tests/CapabilitiesTest.php
+++ b/apps/theming/tests/CapabilitiesTest.php
@@ -128,9 +128,9 @@ class CapabilitiesTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetCapabilities
 	 * @param non-empty-array<string, string> $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetCapabilities')]
 	public function testGetCapabilities(string $name, string $url, string $slogan, string $color, string $textColor, string $logo, string $background, string $backgroundColor, string $backgroundTextColor, string $baseUrl, bool $backgroundThemed, array $expected): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')

--- a/apps/theming/tests/Controller/IconControllerTest.php
+++ b/apps/theming/tests/Controller/IconControllerTest.php
@@ -95,13 +95,13 @@ class IconControllerTest extends TestCase {
 		$this->imageManager->expects($this->once())
 			->method('getImage', false)
 			->with('favicon')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(true);
 		$this->imageManager->expects($this->once())
 			->method('getCachedImage')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 		$this->iconBuilder->expects($this->once())
 			->method('getFavicon')
 			->with('core')
@@ -119,7 +119,7 @@ class IconControllerTest extends TestCase {
 		$this->imageManager->expects($this->once())
 			->method('getImage')
 			->with('favicon', false)
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(false);
@@ -144,7 +144,7 @@ class IconControllerTest extends TestCase {
 
 		$this->imageManager->expects($this->once())
 			->method('getImage')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(true);
@@ -155,7 +155,7 @@ class IconControllerTest extends TestCase {
 		$file = $this->iconFileMock('filename', 'filecontent');
 		$this->imageManager->expects($this->once())
 			->method('getCachedImage')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 		$this->imageManager->expects($this->once())
 			->method('setCachedImage')
 			->willReturn($file);
@@ -169,7 +169,7 @@ class IconControllerTest extends TestCase {
 		$this->imageManager->expects($this->once())
 			->method('getImage')
 			->with('favicon')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 		$this->imageManager->expects($this->any())
 			->method('shouldReplaceIcons')
 			->willReturn(false);

--- a/apps/theming/tests/Controller/ThemingControllerTest.php
+++ b/apps/theming/tests/Controller/ThemingControllerTest.php
@@ -97,9 +97,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUpdateStylesheetSuccess
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateStylesheetSuccess')]
 	public function testUpdateStylesheetSuccess(string $setting, string $value, string $message): void {
 		$this->themingDefaults
 			->expects($this->once())
@@ -155,9 +153,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUpdateStylesheetError
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateStylesheetError')]
 	public function testUpdateStylesheetError(string $setting, string $value, string $message): void {
 		$this->themingDefaults
 			->expects($this->never())
@@ -346,9 +342,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUpdateImages
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateImages')]
 	public function testUpdateLogoNormalLogoUpload(string $mimeType, bool $folderExists = true): void {
 		$tmpLogo = Server::get(ITempManager::class)->getTemporaryFolder() . '/logo.svg';
 		$destination = Server::get(ITempManager::class)->getTemporaryFolder();
@@ -504,9 +498,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataPhpUploadErrors
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPhpUploadErrors')]
 	public function testUpdateLogoLoginScreenUploadWithInvalidImageUpload(int $error, string $expectedErrorMessage): void {
 		$this->request
 			->expects($this->once())
@@ -543,9 +535,7 @@ class ThemingControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->themingController->uploadImage());
 	}
 
-	/**
-	 * @dataProvider dataPhpUploadErrors
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPhpUploadErrors')]
 	public function testUpdateLogoUploadWithInvalidImageUpload($error, $expectedErrorMessage): void {
 		$this->request
 			->expects($this->once())
@@ -614,9 +604,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUndoDelete
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUndoDelete')]
 	public function testUndoDelete(string $value, string $filename): void {
 		$this->l10n
 			->expects($this->once())
@@ -716,9 +704,7 @@ class ThemingControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetManifest
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetManifest')]
 	public function testGetManifest(bool $standalone): void {
 		$this->config
 			->expects($this->once())

--- a/apps/theming/tests/Controller/UserThemeControllerTest.php
+++ b/apps/theming/tests/Controller/UserThemeControllerTest.php
@@ -92,9 +92,7 @@ class UserThemeControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestThemes
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestThemes')]
 	public function testEnableTheme(string $themeId, ?string $exception = null): void {
 		$this->themesService
 			->expects($this->any())
@@ -109,9 +107,7 @@ class UserThemeControllerTest extends TestCase {
 		$this->assertEquals($expected, $this->userThemeController->enableTheme($themeId));
 	}
 
-	/**
-	 * @dataProvider dataTestThemes
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestThemes')]
 	public function testDisableTheme(string $themeId, ?string $exception = null): void {
 		$this->themesService
 			->expects($this->any())

--- a/apps/theming/tests/IconBuilderTest.php
+++ b/apps/theming/tests/IconBuilderTest.php
@@ -63,9 +63,7 @@ class IconBuilderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataRenderAppIcon
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenderAppIcon')]
 	public function testRenderAppIcon(string $app, string $color, string $file): void {
 		$this->checkImagick();
 		$this->themingDefaults->expects($this->once())
@@ -89,9 +87,7 @@ class IconBuilderTest extends TestCase {
 		// cloud be something like $expectedIcon->compareImages($icon, Imagick::METRIC_MEANABSOLUTEERROR)[1])
 	}
 
-	/**
-	 * @dataProvider dataRenderAppIcon
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenderAppIcon')]
 	public function testGetTouchIcon(string $app, string $color, string $file): void {
 		$this->checkImagick();
 		$this->themingDefaults->expects($this->once())
@@ -116,9 +112,7 @@ class IconBuilderTest extends TestCase {
 		// cloud be something like $expectedIcon->compareImages($icon, Imagick::METRIC_MEANABSOLUTEERROR)[1])
 	}
 
-	/**
-	 * @dataProvider dataRenderAppIcon
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRenderAppIcon')]
 	public function testGetFavicon(string $app, string $color, string $file): void {
 		$this->checkImagick();
 		$this->imageManager->expects($this->once())

--- a/apps/theming/tests/ImageManagerTest.php
+++ b/apps/theming/tests/ImageManagerTest.php
@@ -221,7 +221,7 @@ class ImageManagerTest extends TestCase {
 		$folder->expects($this->once())
 			->method('getFile')
 			->with('filename')
-			->will($this->throwException(new NotFoundException()));
+			->willThrowException(new NotFoundException());
 		$image = $this->imageManager->getCachedImage('filename');
 	}
 
@@ -313,9 +313,7 @@ class ImageManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUpdateImage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateImage')]
 	public function testUpdateImage(string $key, string $tmpFile, bool $folderExists, bool $shouldConvert): void {
 		$file = $this->createMock(ISimpleFile::class);
 		$folder = $this->createMock(ISimpleFolder::class);

--- a/apps/theming/tests/Service/ThemesServiceTest.php
+++ b/apps/theming/tests/Service/ThemesServiceTest.php
@@ -126,11 +126,11 @@ class ThemesServiceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestEnableTheme
 	 *
 	 * @param string[] $enabledThemes
 	 * @param string[] $expectedEnabled
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestEnableTheme')]
 	public function testEnableTheme(string $toEnable, array $enabledThemes, array $expectedEnabled): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -159,11 +159,11 @@ class ThemesServiceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestDisableTheme
 	 *
 	 * @param string[] $enabledThemes
 	 * @param string[] $expectedEnabled
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDisableTheme')]
 	public function testDisableTheme(string $toDisable, array $enabledThemes, array $expectedEnabled): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -193,10 +193,9 @@ class ThemesServiceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestIsEnabled
-	 *
 	 * @param string[] $enabledThemes
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsEnabled')]
 	public function testIsEnabled(string $themeId, array $enabledThemes, bool $expected): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -270,11 +269,11 @@ class ThemesServiceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestSetEnabledThemes
 	 *
 	 * @param string[] $enabledThemes
 	 * @param string[] $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSetEnabledThemes')]
 	public function testSetEnabledThemes(array $enabledThemes, array $expected): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())

--- a/apps/theming/tests/ServicesTest.php
+++ b/apps/theming/tests/ServicesTest.php
@@ -60,9 +60,7 @@ class ServicesTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider queryData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('queryData')]
 	public function testContainerQuery(string $service, ?string $expected = null): void {
 		if ($expected === null) {
 			$expected = $service;

--- a/apps/theming/tests/Settings/PersonalTest.php
+++ b/apps/theming/tests/Settings/PersonalTest.php
@@ -87,10 +87,9 @@ class PersonalTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetForm
-	 *
 	 * @param string[] $enabledThemes
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetForm')]
 	public function testGetForm(string $enforcedTheme, array $themesState): void {
 		$this->config->expects($this->once())
 			->method('getSystemValueString')

--- a/apps/theming/tests/Themes/AccessibleThemeTestCase.php
+++ b/apps/theming/tests/Themes/AccessibleThemeTestCase.php
@@ -147,9 +147,7 @@ class AccessibleThemeTestCase extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataAccessibilityPairs
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAccessibilityPairs')]
 	public function testAccessibilityOfVariables(array $mainColors, array $backgroundColors, float $minContrast): void {
 		if (!isset($this->theme)) {
 			$this->markTestSkipped('You need to setup $this->theme in your setUp function');

--- a/apps/theming/tests/Themes/DyslexiaFontTest.php
+++ b/apps/theming/tests/Themes/DyslexiaFontTest.php
@@ -146,11 +146,10 @@ class DyslexiaFontTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetCustomCss
-	 *
 	 * Ensure the fonts are always loaded from the web root
 	 * despite having url rewriting enabled or not
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetCustomCss')]
 	public function testGetCustomCss(string $webRoot, bool $prettyUrlsEnabled): void {
 		\OC::$WEBROOT = $webRoot;
 		$this->config->expects($this->any())

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -183,9 +183,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider legalUrlProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('legalUrlProvider')]
 	public function testGetImprintURL(string $imprintUrl): void {
 		$this->config
 			->expects($this->once())
@@ -196,9 +194,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->assertEquals($imprintUrl, $this->template->getImprintUrl());
 	}
 
-	/**
-	 * @dataProvider legalUrlProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('legalUrlProvider')]
 	public function testGetPrivacyURL(string $privacyUrl): void {
 		$this->config
 			->expects($this->once())
@@ -346,9 +342,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider invalidLegalUrlProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidLegalUrlProvider')]
 	public function testGetShortFooterInvalidImprint(string $invalidImprintUrl): void {
 		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
@@ -365,9 +359,7 @@ class ThemingDefaultsTest extends TestCase {
 		$this->assertEquals('<a href="url" target="_blank" rel="noreferrer noopener" class="entity-name">Name</a> – Slogan', $this->template->getShortFooter());
 	}
 
-	/**
-	 * @dataProvider invalidLegalUrlProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidLegalUrlProvider')]
 	public function testGetShortFooterInvalidPrivacy(string $invalidPrivacyUrl): void {
 		$this->navigationManager->expects($this->once())->method('getAll')->with(INavigationManager::TYPE_GUEST)->willReturn([]);
 		$this->config
@@ -455,9 +447,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetColorPrimary
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetColorPrimary')]
 	public function testGetColorPrimary(bool $disableTheming, string $primaryColor, string $userPrimaryColor, string $expected): void {
 		$user = $this->createMock(IUser::class);
 		$this->userSession->expects($this->any())
@@ -798,9 +788,7 @@ class ThemingDefaultsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataReplaceImagePath
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataReplaceImagePath')]
 	public function testReplaceImagePath(string $app, string $image, string|bool $result = 'themingRoute?v=1234abcd'): void {
 		$this->cache->expects($this->any())
 			->method('get')

--- a/apps/theming/tests/UtilTest.php
+++ b/apps/theming/tests/UtilTest.php
@@ -48,9 +48,7 @@ class UtilTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataColorContrast
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataColorContrast')]
 	public function testColorContrast(string $color1, string $color2, int|float $contrast): void {
 		$this->assertEqualsWithDelta($contrast, $this->util->colorContrast($color1, $color2), .001);
 	}
@@ -63,9 +61,7 @@ class UtilTest extends TestCase {
 			['#ffff00', true],
 		];
 	}
-	/**
-	 * @dataProvider dataInvertTextColor
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataInvertTextColor')]
 	public function testInvertTextColor(string $color, bool $expected): void {
 		$invert = $this->util->invertTextColor($color);
 		$this->assertEquals($expected, $invert);
@@ -143,9 +139,7 @@ class UtilTest extends TestCase {
 		$this->assertEquals($expected, $button);
 	}
 
-	/**
-	 * @dataProvider dataGetAppIcon
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppIcon')]
 	public function testGetAppIcon(string $app, string $expected): void {
 		$this->appData->expects($this->any())
 			->method('getFolder')
@@ -178,9 +172,7 @@ class UtilTest extends TestCase {
 		$this->assertEquals($file, $icon);
 	}
 
-	/**
-	 * @dataProvider dataGetAppImage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppImage')]
 	public function testGetAppImage(string $app, string $image, string|bool $expected): void {
 		$this->assertEquals($expected, $this->util->getAppImage($app, $image));
 	}
@@ -226,9 +218,7 @@ class UtilTest extends TestCase {
 			['backgroundColor', false],
 		];
 	}
-	/**
-	 * @dataProvider dataIsBackgroundThemed
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsBackgroundThemed')]
 	public function testIsBackgroundThemed(string $backgroundMime, bool $expected): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')

--- a/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
+++ b/apps/twofactor_backupcodes/tests/Unit/Activity/ProviderTest.php
@@ -51,9 +51,7 @@ class ProviderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider subjectData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('subjectData')]
 	public function testParse(string $subject): void {
 		$lang = 'ru';
 		$event = $this->createMock(IEvent::class);

--- a/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
+++ b/apps/updatenotification/tests/BackgroundJob/UpdateAvailableNotificationsTest.php
@@ -152,9 +152,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCheckCoreUpdate
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckCoreUpdate')]
 	public function testCheckCoreUpdate(string $channel, mixed $versionCheck, mixed $version, ?string $readableVersion, ?int $errorDays): void {
 		$job = $this->getJob([
 			'createNotifications',
@@ -231,9 +229,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCheckAppUpdates
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckAppUpdates')]
 	public function testCheckAppUpdates(array $apps, array $isUpdateAvailable, array $notifications): void {
 		$job = $this->getJob([
 			'isUpdateAvailable',
@@ -268,9 +264,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCreateNotifications
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateNotifications')]
 	public function testCreateNotifications(string $app, string $version, string|false $lastNotification, string|false $callDelete, bool $createNotification, ?array $users, ?array $userNotifications): void {
 		$job = $this->getJob([
 			'deleteOutdatedNotifications',
@@ -351,9 +345,7 @@ class UpdateAvailableNotificationsTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetUsersToNotify
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsersToNotify')]
 	public function testGetUsersToNotify(array $groups, array $groupUsers, array $expected): void {
 		$job = $this->getJob();
 
@@ -394,10 +386,10 @@ class UpdateAvailableNotificationsTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDeleteOutdatedNotifications
 	 * @param string $app
 	 * @param string $version
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteOutdatedNotifications')]
 	public function testDeleteOutdatedNotifications(string $app, string $version): void {
 		$notification = $this->createMock(INotification::class);
 		$notification->expects($this->once())

--- a/apps/updatenotification/tests/Controller/APIControllerTest.php
+++ b/apps/updatenotification/tests/Controller/APIControllerTest.php
@@ -55,9 +55,7 @@ class APIControllerTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataGetAppChangelog
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppChangelog')]
 	public function testGetAppChangelogEntry(
 		array $params,
 		bool $hasChanges,

--- a/apps/updatenotification/tests/Notification/NotifierTest.php
+++ b/apps/updatenotification/tests/Notification/NotifierTest.php
@@ -89,9 +89,7 @@ class NotifierTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataUpdateAlreadyInstalledCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdateAlreadyInstalledCheck')]
 	public function testUpdateAlreadyInstalledCheck(string $versionNotification, string $versionInstalled, bool $exception): void {
 		$notifier = $this->getNotifier();
 

--- a/apps/updatenotification/tests/Settings/AdminTest.php
+++ b/apps/updatenotification/tests/Settings/AdminTest.php
@@ -448,9 +448,7 @@ class AdminTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider changesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('changesProvider')]
 	public function testFilterChanges($changes, $userLang, $expectation): void {
 		$iterator = $this->createMock(ILanguageIterator::class);
 		$iterator->expects($this->any())

--- a/apps/user_ldap/tests/AccessTest.php
+++ b/apps/user_ldap/tests/AccessTest.php
@@ -132,10 +132,10 @@ class AccessTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider convertSID2StrSuccessData
 	 * @param array $sidArray
 	 * @param $sidExpected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('convertSID2StrSuccessData')]
 	public function testConvertSID2StrSuccess(array $sidArray, $sidExpected): void {
 		$sidBinary = implode('', $sidArray);
 		$this->assertSame($sidExpected, $this->access->convertSID2Str($sidBinary));
@@ -219,9 +219,7 @@ class AccessTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dnInputDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dnInputDataProvider')]
 	public function testStringResemblesDN(string $input, array|bool $interResult, bool $expectedResult): void {
 		[$lw, $con, $um, $helper] = $this->getConnectorAndLdapMock();
 		/** @var IConfig&MockObject $config */
@@ -240,9 +238,7 @@ class AccessTest extends TestCase {
 		$this->assertSame($expectedResult, $access->stringResemblesDN($input));
 	}
 
-	/**
-	 * @dataProvider dnInputDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dnInputDataProvider')]
 	public function testStringResemblesDNLDAPmod(string $input, array|bool $interResult, bool $expectedResult): void {
 		[, $con, $um, $helper] = $this->getConnectorAndLdapMock();
 		/** @var IConfig&MockObject $config */
@@ -414,9 +410,7 @@ class AccessTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dNAttributeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dNAttributeProvider')]
 	public function testSanitizeDN(string $attribute): void {
 		[$lw, $con, $um, $helper] = $this->getConnectorAndLdapMock();
 		/** @var IConfig&MockObject $config */
@@ -698,9 +692,7 @@ class AccessTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider intUsernameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('intUsernameProvider')]
 	public function testSanitizeUsername(string $name, ?string $expected): void {
 		if ($expected === null) {
 			$this->expectException(\InvalidArgumentException::class);
@@ -709,9 +701,7 @@ class AccessTest extends TestCase {
 		$this->assertSame($expected, $sanitizedName);
 	}
 
-	/**
-	 * @dataProvider groupIDCandidateProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('groupIDCandidateProvider')]
 	public function testSanitizeGroupIDCandidate(string $name, string $expected): void {
 		$sanitizedName = $this->access->sanitizeGroupIDCandidate($name);
 		$this->assertSame($expected, $sanitizedName);

--- a/apps/user_ldap/tests/ConfigurationTest.php
+++ b/apps/user_ldap/tests/ConfigurationTest.php
@@ -86,9 +86,7 @@ class ConfigurationTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider configurationDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('configurationDataProvider')]
 	public function testSetValue(string $key, string|array $input, string|array $expected): void {
 		$this->configuration->setConfiguration([$key => $input]);
 		$this->assertSame($this->configuration->$key, $expected);
@@ -105,17 +103,13 @@ class ConfigurationTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider avatarRuleValueProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('avatarRuleValueProvider')]
 	public function testGetAvatarAttributes(string $setting, array $expected): void {
 		$this->configuration->setConfiguration(['ldapUserAvatarRule' => $setting]);
 		$this->assertSame($expected, $this->configuration->getAvatarAttributes());
 	}
 
-	/**
-	 * @dataProvider avatarRuleValueProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('avatarRuleValueProvider')]
 	public function testResolveRule(string $setting, array $expected): void {
 		$this->configuration->setConfiguration(['ldapUserAvatarRule' => $setting]);
 		// so far the only thing that can get resolved :)

--- a/apps/user_ldap/tests/ConnectionTest.php
+++ b/apps/user_ldap/tests/ConnectionTest.php
@@ -101,8 +101,7 @@ class ConnectionTest extends \Test\TestCase {
 		// Not called often enough? Then, the fallback to the backup server is broken.
 		$this->connection->expects($this->exactly(2))
 			->method('getFromCache')
-			->with('overrideMainServer')
-			->will($this->onConsecutiveCalls(false, false, true, true));
+			->with('overrideMainServer')->willReturnOnConsecutiveCalls(false, false, true, true);
 
 		$this->connection->expects($this->once())
 			->method('writeToCache')

--- a/apps/user_ldap/tests/Group_LDAPTest.php
+++ b/apps/user_ldap/tests/Group_LDAPTest.php
@@ -475,9 +475,7 @@ class Group_LDAPTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider groupWithMembersProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('groupWithMembersProvider')]
 	public function testInGroupMember(string $gid, string $groupDn, array $memberDNs): void {
 		$uid = 'someUser';
 		$userDn = $memberDNs[0];
@@ -516,9 +514,7 @@ class Group_LDAPTest extends TestCase {
 		$this->assertTrue($this->groupBackend->inGroup($uid, $gid));
 	}
 
-	/**
-	 * @dataProvider groupWithMembersProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('groupWithMembersProvider')]
 	public function testInGroupMemberNot(string $gid, string $groupDn, array $memberDNs): void {
 		$uid = 'unelatedUser';
 		$userDn = 'uid=unrelatedUser,ou=unrelatedTeam,ou=unrelatedDepartment,dc=someDomain,dc=someTld';
@@ -557,9 +553,7 @@ class Group_LDAPTest extends TestCase {
 		$this->assertFalse($this->groupBackend->inGroup($uid, $gid));
 	}
 
-	/**
-	 * @dataProvider groupWithMembersProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('groupWithMembersProvider')]
 	public function testInGroupMemberUid(string $gid, string $groupDn, array $memberDNs): void {
 		$memberUids = [];
 		$userRecords = [];
@@ -767,8 +761,7 @@ class Group_LDAPTest extends TestCase {
 			->method('username2dn')
 			->willReturn($dn);
 		$this->access->expects($this->exactly(5))
-			->method('readAttribute')
-			->will($this->onConsecutiveCalls($expectedGroups, [], [], [], []));
+			->method('readAttribute')->willReturnOnConsecutiveCalls($expectedGroups, [], [], [], []);
 		$this->access->expects($this->any())
 			->method('dn2groupname')
 			->willReturnArgument(0);
@@ -947,9 +940,7 @@ class Group_LDAPTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider nestedGroupsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('nestedGroupsProvider')]
 	public function testGetGroupsByMember(bool $nestedGroups): void {
 		$groupFilter = '(&(objectclass=nextcloudGroup)(nextcloudEnabled=TRUE))';
 		$this->access->connection->expects($this->any())
@@ -1321,9 +1312,7 @@ class Group_LDAPTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider groupMemberProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('groupMemberProvider')]
 	public function testGroupMembers(array $expectedResult, array $groupsInfo): void {
 		$this->access->expects($this->any())
 			->method('readAttribute')
@@ -1362,9 +1351,7 @@ class Group_LDAPTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider displayNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('displayNameProvider')]
 	public function testGetDisplayName(string $expected, bool|array $ldapResult): void {
 		$gid = 'graphic_novelists';
 

--- a/apps/user_ldap/tests/Jobs/CleanUpTest.php
+++ b/apps/user_ldap/tests/Jobs/CleanUpTest.php
@@ -61,7 +61,7 @@ class CleanUpTest extends TestCase {
 	public function test_runNotAllowedByBrokenHelper(): void {
 		$this->mocks['helper']->expects($this->once())
 			->method('haveDisabledConfigurations')
-			->will($this->throwException(new Exception()));
+			->willThrowException(new Exception());
 
 		$this->mocks['ocConfig']->expects($this->never())
 			->method('getSystemValue');

--- a/apps/user_ldap/tests/Jobs/SyncTest.php
+++ b/apps/user_ldap/tests/Jobs/SyncTest.php
@@ -102,9 +102,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider intervalDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('intervalDataProvider')]
 	public function testUpdateInterval(int $userCount, int $pagingSize1, int $pagingSize2): void {
 		$this->config->expects($this->once())
 			->method('setAppValue')
@@ -145,9 +143,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider moreResultsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('moreResultsProvider')]
 	public function testMoreResults($pagingSize, $results, $expected): void {
 		$connection = $this->getMockBuilder(Connection::class)
 			->setConstructorArgs([
@@ -204,9 +200,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider cycleDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('cycleDataProvider')]
 	public function testDetermineNextCycle(?array $cycleData, array $prefixes, ?array $expectedCycle): void {
 		$this->helper->expects($this->any())
 			->method('getServerConfigurationPrefixes')
@@ -220,7 +214,7 @@ class SyncTest extends TestCase {
 			];
 			$this->config->expects($this->exactly(2))
 				->method('setAppValue')
-				->willReturnCallback(function () use (&$calls) {
+				->willReturnCallback(function () use (&$calls): void {
 					$expected = array_shift($calls);
 					$this->assertEquals($expected, func_get_args());
 				});
@@ -284,9 +278,7 @@ class SyncTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider runDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('runDataProvider')]
 	public function testRun(array $runData): void {
 		$this->config->expects($this->any())
 			->method('getAppValue')
@@ -322,7 +314,7 @@ class SyncTest extends TestCase {
 		];
 		$this->config->expects($this->exactly(3))
 			->method('setAppValue')
-			->willReturnCallback(function () use (&$calls) {
+			->willReturnCallback(function () use (&$calls): void {
 				$expected = array_shift($calls);
 				$this->assertEquals($expected, func_get_args());
 			});

--- a/apps/user_ldap/tests/LDAPTest.php
+++ b/apps/user_ldap/tests/LDAPTest.php
@@ -33,9 +33,7 @@ class LDAPTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider errorProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('errorProvider')]
 	public function testSearchWithErrorHandler(string $errorMessage, bool $passThrough): void {
 		$wasErrorHandlerCalled = false;
 		$errorHandler = function ($number, $message, $file, $line) use (&$wasErrorHandlerCalled): void {

--- a/apps/user_ldap/tests/Migration/UUIDFixInsertTest.php
+++ b/apps/user_ldap/tests/Migration/UUIDFixInsertTest.php
@@ -86,9 +86,7 @@ class UUIDFixInsertTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider recordProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('recordProvider')]
 	public function testRun(array $userBatches, array $groupBatches): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
@@ -116,9 +114,7 @@ class UUIDFixInsertTest extends TestCase {
 		$this->job->run($out);
 	}
 
-	/**
-	 * @dataProvider recordProviderTooLongAndNone
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('recordProviderTooLongAndNone')]
 	public function testRunWithManyAndNone(array $userBatches, array $groupBatches): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')

--- a/apps/user_ldap/tests/Service/BirthdateParserServiceTest.php
+++ b/apps/user_ldap/tests/Service/BirthdateParserServiceTest.php
@@ -35,9 +35,7 @@ class BirthdateParserServiceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider parseBirthdateDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('parseBirthdateDataProvider')]
 	public function testParseBirthdate(
 		string $value,
 		?DateTimeImmutable $expected,

--- a/apps/user_ldap/tests/User/ManagerTest.php
+++ b/apps/user_ldap/tests/User/ManagerTest.php
@@ -85,9 +85,7 @@ class ManagerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dnProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dnProvider')]
 	public function testGetByDNExisting(string $inputDN): void {
 		$uid = '563418fc-423b-1033-8d1c-ad5f418ee02e';
 
@@ -184,9 +182,7 @@ class ManagerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider attributeRequestProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('attributeRequestProvider')]
 	public function testGetAttributes($minimal): void {
 		$this->connection->setConfiguration([
 			'ldapEmailAttribute' => 'MAIL',

--- a/apps/user_ldap/tests/User/OfflineUserTest.php
+++ b/apps/user_ldap/tests/User/OfflineUserTest.php
@@ -47,9 +47,7 @@ class OfflineUserTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider shareOwnerProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('shareOwnerProvider')]
 	public function testHasActiveShares(array $existingShareTypes, bool $expected): void {
 		$shareMock = $this->createMock(IShare::class);
 

--- a/apps/user_ldap/tests/User/UserTest.php
+++ b/apps/user_ldap/tests/User/UserTest.php
@@ -780,9 +780,7 @@ class UserTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider extStorageHomeDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('extStorageHomeDataProvider')]
 	public function testUpdateExtStorageHome(string $expected, ?string $valueFromLDAP = null, bool $isSet = true): void {
 		if ($valueFromLDAP === null) {
 			$this->connection->expects($this->once())
@@ -936,9 +934,7 @@ class UserTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider emptyHomeFolderAttributeValueProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('emptyHomeFolderAttributeValueProvider')]
 	public function testGetHomePathNotConfigured(string $attributeValue): void {
 		$this->connection->expects($this->any())
 			->method('__get')
@@ -1012,9 +1008,7 @@ class UserTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider displayNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('displayNameProvider')]
 	public function testComposeAndStoreDisplayName(string $part1, string $part2, string $expected, bool $expectTriggerChange): void {
 		$this->config->expects($this->once())
 			->method('setUserValue');

--- a/apps/user_ldap/tests/User_LDAPTest.php
+++ b/apps/user_ldap/tests/User_LDAPTest.php
@@ -1325,9 +1325,7 @@ class User_LDAPTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider avatarDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('avatarDataProvider')]
 	public function testCanChangeAvatar(string|bool $imageData, bool $expected): void {
 		$isValidImage = str_starts_with((string)$imageData, 'valid');
 
@@ -1452,9 +1450,7 @@ class User_LDAPTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider actionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('actionProvider')]
 	public function testImplementsAction(string $configurable, string|int $value, int $actionCode, bool $expected): void {
 		$this->pluginManager->expects($this->once())
 			->method('getImplementedActions')

--- a/apps/user_status/tests/Unit/CapabilitiesTest.php
+++ b/apps/user_status/tests/Unit/CapabilitiesTest.php
@@ -24,9 +24,7 @@ class CapabilitiesTest extends TestCase {
 		$this->capabilities = new Capabilities($this->emojiHelper);
 	}
 
-	/**
-	 * @dataProvider getCapabilitiesDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getCapabilitiesDataProvider')]
 	public function testGetCapabilities(bool $supportsEmojis): void {
 		$this->emojiHelper->expects($this->once())
 			->method('doesPlatformSupportEmoji')

--- a/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
+++ b/apps/user_status/tests/Unit/Controller/UserStatusControllerTest.php
@@ -87,9 +87,7 @@ class UserStatusControllerTest extends TestCase {
 		$this->controller->getStatus();
 	}
 
-	/**
-	 * @dataProvider setStatusDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('setStatusDataProvider')]
 	public function testSetStatus(
 		string $statusType,
 		?string $statusIcon,
@@ -149,9 +147,7 @@ class UserStatusControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider setPredefinedMessageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('setPredefinedMessageDataProvider')]
 	public function testSetPredefinedMessage(
 		string $messageId,
 		?int $clearAt,
@@ -211,9 +207,7 @@ class UserStatusControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider setCustomMessageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('setCustomMessageDataProvider')]
 	public function testSetCustomMessage(
 		?string $statusIcon,
 		string $message,

--- a/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
+++ b/apps/user_status/tests/Unit/Db/UserStatusMapperTest.php
@@ -134,9 +134,7 @@ class UserStatusMapperTest extends TestCase {
 		$this->mapper->insert($userStatus2);
 	}
 
-	/**
-	 * @dataProvider clearStatusesOlderThanDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('clearStatusesOlderThanDataProvider')]
 	public function testClearStatusesOlderThan(string $status, bool $isUserDefined, int $timestamp, bool $expectsClean): void {
 		$oldStatus = UserStatus::fromParams([
 			'userId' => 'john.doe',
@@ -233,9 +231,7 @@ class UserStatusMapperTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCreateBackupStatus
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateBackupStatus')]
 	public function testCreateBackupStatus(bool $hasStatus, bool $hasBackup, bool $backupCreated): void {
 		if ($hasStatus) {
 			$userStatus1 = new UserStatus();

--- a/apps/user_status/tests/Unit/Listener/UserLiveStatusListenerTest.php
+++ b/apps/user_status/tests/Unit/Listener/UserLiveStatusListenerTest.php
@@ -49,9 +49,7 @@ class UserLiveStatusListenerTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider handleEventWithCorrectEventDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('handleEventWithCorrectEventDataProvider')]
 	public function testHandleWithCorrectEvent(
 		string $userId,
 		string $previousStatus,

--- a/apps/user_status/tests/Unit/Service/PredefinedStatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/PredefinedStatusServiceTest.php
@@ -93,9 +93,7 @@ class PredefinedStatusServiceTest extends TestCase {
 		], $actual);
 	}
 
-	/**
-	 * @dataProvider getIconForIdDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getIconForIdDataProvider')]
 	public function testGetIconForId(string $id, ?string $expectedIcon): void {
 		$actual = $this->service->getIconForId($id);
 		$this->assertEquals($expectedIcon, $actual);
@@ -113,9 +111,7 @@ class PredefinedStatusServiceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider getTranslatedStatusForIdDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getTranslatedStatusForIdDataProvider')]
 	public function testGetTranslatedStatusForId(string $id, ?string $expected): void {
 		$this->l10n->method('t')
 			->willReturnArgument(0);
@@ -136,9 +132,7 @@ class PredefinedStatusServiceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider isValidIdDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('isValidIdDataProvider')]
 	public function testIsValidId(string $id, bool $expected): void {
 		$actual = $this->service->isValidId($id);
 		$this->assertEquals($expected, $actual);

--- a/apps/user_status/tests/Unit/Service/StatusServiceTest.php
+++ b/apps/user_status/tests/Unit/Service/StatusServiceTest.php
@@ -221,9 +221,7 @@ class StatusServiceTest extends TestCase {
 		$this->assertNull($status->getMessageId());
 	}
 
-	/**
-	 * @dataProvider setStatusDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('setStatusDataProvider')]
 	public function testSetStatus(
 		string $userId,
 		string $status,
@@ -344,9 +342,7 @@ class StatusServiceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider setPredefinedMessageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('setPredefinedMessageDataProvider')]
 	public function testSetPredefinedMessage(
 		string $userId,
 		string $messageId,
@@ -433,9 +429,7 @@ class StatusServiceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider setCustomMessageDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('setCustomMessageDataProvider')]
 	public function testSetCustomMessage(
 		string $userId,
 		?string $statusIcon,
@@ -799,9 +793,7 @@ class StatusServiceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSetUserStatus
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetUserStatus')]
 	public function testSetUserStatus(string $messageId, string $oldMessageId, bool $expectedUpdateShortcut): void {
 		$previous = new UserStatus();
 		$previous->setId(1);

--- a/apps/webhook_listeners/tests/Service/PHPMongoQueryTest.php
+++ b/apps/webhook_listeners/tests/Service/PHPMongoQueryTest.php
@@ -38,9 +38,7 @@ class PHPMongoQueryTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecuteQuery
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteQuery')]
 	public function testExecuteQuery(array $query, array $document, bool $matches): void {
 		$this->assertEquals($matches, PHPMongoQuery::executeQuery($query, $document));
 	}

--- a/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
+++ b/apps/workflowengine/tests/Check/AbstractStringCheckTest.php
@@ -50,9 +50,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecuteStringCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteStringCheck')]
 	public function testExecuteStringCheck(string $operation, string $checkValue, string $actualValue, bool $expected): void {
 		$check = $this->getCheckMock();
 
@@ -69,9 +67,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataValidateCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheck')]
 	public function testValidateCheck(string $operator, string $value): void {
 		$check = $this->getCheckMock();
 
@@ -90,9 +86,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataValidateCheckInvalid
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheckInvalid')]
 	public function testValidateCheckInvalid(string $operator, string $value, int $exceptionCode, string $exceptionMessage): void {
 		$check = $this->getCheckMock();
 
@@ -112,9 +106,7 @@ class AbstractStringCheckTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataMatch
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataMatch')]
 	public function testMatch(string $pattern, string $subject, array $matches, bool $expected): void {
 		$check = $this->getCheckMock();
 

--- a/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
+++ b/apps/workflowengine/tests/Check/RequestRemoteAddressTest.php
@@ -44,9 +44,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecuteCheckIPv4
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv4')]
 	public function testExecuteCheckMatchesIPv4(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
@@ -57,9 +55,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		$this->assertEquals($expected, $check->executeCheck('matchesIPv4', $value));
 	}
 
-	/**
-	 * @dataProvider dataExecuteCheckIPv4
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv4')]
 	public function testExecuteCheckNotMatchesIPv4(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
@@ -82,9 +78,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecuteCheckIPv6
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv6')]
 	public function testExecuteCheckMatchesIPv6(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 
@@ -95,9 +89,7 @@ class RequestRemoteAddressTest extends \Test\TestCase {
 		$this->assertEquals($expected, $check->executeCheck('matchesIPv6', $value));
 	}
 
-	/**
-	 * @dataProvider dataExecuteCheckIPv6
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheckIPv6')]
 	public function testExecuteCheckNotMatchesIPv6(string $value, string $ip, bool $expected): void {
 		$check = new RequestRemoteAddress($this->getL10NMock(), $this->request);
 

--- a/apps/workflowengine/tests/Check/RequestTimeTest.php
+++ b/apps/workflowengine/tests/Check/RequestTimeTest.php
@@ -63,9 +63,7 @@ class RequestTimeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecuteCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheck')]
 	public function testExecuteCheckIn(string $value, int $timestamp, bool $expected): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 
@@ -76,9 +74,7 @@ class RequestTimeTest extends \Test\TestCase {
 		$this->assertEquals($expected, $check->executeCheck('in', $value));
 	}
 
-	/**
-	 * @dataProvider dataExecuteCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheck')]
 	public function testExecuteCheckNotIn(string $value, int $timestamp, bool $expected): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 
@@ -97,9 +93,7 @@ class RequestTimeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataValidateCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheck')]
 	public function testValidateCheck(string $operator, string $value): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 		$check->validateCheck($operator, $value);
@@ -118,9 +112,7 @@ class RequestTimeTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataValidateCheckInvalid
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateCheckInvalid')]
 	public function testValidateCheckInvalid(string $operator, string $value, int $exceptionCode, string $exceptionMessage): void {
 		$check = new RequestTime($this->getL10NMock(), $this->timeFactory);
 

--- a/apps/workflowengine/tests/Check/RequestUserAgentTest.php
+++ b/apps/workflowengine/tests/Check/RequestUserAgentTest.php
@@ -82,9 +82,7 @@ class RequestUserAgentTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecuteCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteCheck')]
 	public function testExecuteCheck(string $operation, string $checkValue, string $actualValue, bool $expected): void {
 		$this->request->expects($this->once())
 			->method('getHeader')

--- a/build/rector.php
+++ b/build/rector.php
@@ -12,6 +12,7 @@ use PhpParser\Node;
 use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterface;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\PHPUnit\AnnotationsToAttributes\Rector\ClassMethod\DataProviderAnnotationToAttributeRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector;
 use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
@@ -84,6 +85,7 @@ $config = RectorConfig::configure()
 	->withRules([
 		UseSpecificWillMethodRector::class,
 		StaticDataProviderClassMethodRector::class,
+		DataProviderAnnotationToAttributeRector::class,
 	])
 	->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
 		'inline_public' => true,

--- a/build/rector.php
+++ b/build/rector.php
@@ -13,6 +13,7 @@ use Rector\CodingStyle\Contract\ClassNameImport\ClassNameImportSkipVoterInterfac
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\PHPUnit\CodeQuality\Rector\MethodCall\UseSpecificWillMethodRector;
+use Rector\PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
 use Rector\ValueObject\Application\File;
 
@@ -81,7 +82,8 @@ $config = RectorConfig::configure()
 	->withImportNames(importShortClasses:false)
 	->withTypeCoverageLevel(0)
 	->withRules([
-		UseSpecificWillMethodRector::class
+		UseSpecificWillMethodRector::class,
+		StaticDataProviderClassMethodRector::class,
 	])
 	->withConfiguredRule(ClassPropertyAssignToConstructorPromotionRector::class, [
 		'inline_public' => true,

--- a/core/ajax/update.php
+++ b/core/ajax/update.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+use OC\Core\Listener\FeedBackHandler;
 use OC\DB\MigratorExecuteSqlEvent;
 use OC\Installer;
 use OC\IntegrityCheck\Checker;
@@ -76,7 +77,7 @@ if (Util::needUpgrade()) {
 			$eventSource->send('success', $l->t('[%d / %d]: %s', [$event->getCurrentStep(), $event->getMaxStep(), $event->getSql()]));
 		}
 	);
-	$feedBack = new \OC\Core\Listener\FeedBackHandler($eventSource, $l);
+	$feedBack = new FeedBackHandler($eventSource, $l);
 	$dispatcher->addListener(RepairStartEvent::class, [$feedBack, 'handleRepairFeedback']);
 	$dispatcher->addListener(RepairAdvanceEvent::class, [$feedBack, 'handleRepairFeedback']);
 	$dispatcher->addListener(RepairFinishEvent::class, [$feedBack, 'handleRepairFeedback']);

--- a/tests/Core/Command/Apps/AppsDisableTest.php
+++ b/tests/Core/Command/Apps/AppsDisableTest.php
@@ -37,12 +37,12 @@ class AppsDisableTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataCommandInput
 	 * @param $appId
 	 * @param $groups
 	 * @param $statusCode
 	 * @param $pattern
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCommandInput')]
 	public function testCommandInput($appId, $statusCode, $pattern): void {
 		$input = ['app-id' => $appId];
 

--- a/tests/Core/Command/Apps/AppsEnableTest.php
+++ b/tests/Core/Command/Apps/AppsEnableTest.php
@@ -41,12 +41,12 @@ class AppsEnableTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataCommandInput
 	 * @param $appId
 	 * @param $groups
 	 * @param $statusCode
 	 * @param $pattern
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCommandInput')]
 	public function testCommandInput($appId, $groups, $statusCode, $pattern): void {
 		$input = ['app-id' => $appId];
 

--- a/tests/Core/Command/Config/App/DeleteConfigTest.php
+++ b/tests/Core/Command/Config/App/DeleteConfigTest.php
@@ -70,9 +70,7 @@ class DeleteConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataDelete
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDelete')]
 	public function testDelete(string $configName, bool $configExists, bool $checkIfExists, int $expectedReturn, string $expectedMessage): void {
 		$this->appConfig->expects(($checkIfExists) ? $this->once() : $this->never())
 			->method('getKeys')

--- a/tests/Core/Command/Config/App/GetConfigTest.php
+++ b/tests/Core/Command/Config/App/GetConfigTest.php
@@ -80,9 +80,7 @@ class GetConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGet
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGet')]
 	public function testGet(string $configName, mixed $value, bool $configExists, mixed $defaultValue, bool $hasDefault, string $outputFormat, int $expectedReturn, ?string $expectedMessage): void {
 		if (!$expectedReturn) {
 			if ($configExists) {

--- a/tests/Core/Command/Config/App/SetConfigTest.php
+++ b/tests/Core/Command/Config/App/SetConfigTest.php
@@ -60,9 +60,7 @@ class SetConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSet
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSet')]
 	public function testSet(string $configName, mixed $newValue, bool $configExists, bool $updateOnly, bool $updated, string $expectedMessage): void {
 		$this->appConfig->method('hasKey')
 			->with('app-name', $configName)

--- a/tests/Core/Command/Config/ImportTest.php
+++ b/tests/Core/Command/Config/ImportTest.php
@@ -35,7 +35,7 @@ class ImportTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OCP\IConfig $config */
+		/** @var IConfig $config */
 		$this->command = new Import($config);
 	}
 
@@ -50,10 +50,9 @@ class ImportTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validateAppsArrayData
-	 *
 	 * @param mixed $configValue
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateAppsArrayData')]
 	public function testValidateAppsArray($configValue): void {
 		$this->invokePrivate($this->command, 'validateAppsArray', [['app' => ['name' => $configValue]]]);
 		$this->assertTrue(true, 'Asserting that no exception is thrown');
@@ -69,10 +68,9 @@ class ImportTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validateAppsArrayThrowsData
-	 *
 	 * @param mixed $configValue
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateAppsArrayThrowsData')]
 	public function testValidateAppsArrayThrows($configValue): void {
 		try {
 			$this->invokePrivate($this->command, 'validateAppsArray', [['app' => ['name' => $configValue]]]);
@@ -99,10 +97,9 @@ class ImportTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider checkTypeRecursivelyData
-	 *
 	 * @param mixed $configValue
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('checkTypeRecursivelyData')]
 	public function testCheckTypeRecursively($configValue): void {
 		$this->invokePrivate($this->command, 'checkTypeRecursively', [$configValue, 'name']);
 		$this->assertTrue(true, 'Asserting that no exception is thrown');
@@ -118,10 +115,9 @@ class ImportTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider checkTypeRecursivelyThrowsData
-	 *
 	 * @param mixed $configValue
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('checkTypeRecursivelyThrowsData')]
 	public function testCheckTypeRecursivelyThrows($configValue): void {
 		try {
 			$this->invokePrivate($this->command, 'checkTypeRecursively', [$configValue, 'name']);
@@ -140,10 +136,9 @@ class ImportTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validateArrayData
-	 *
 	 * @param array $configArray
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateArrayData')]
 	public function testValidateArray($configArray): void {
 		$this->invokePrivate($this->command, 'validateArray', [$configArray]);
 		$this->assertTrue(true, 'Asserting that no exception is thrown');
@@ -158,11 +153,11 @@ class ImportTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validateArrayThrowsData
 	 *
 	 * @param mixed $configArray
 	 * @param string $expectedException
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateArrayThrowsData')]
 	public function testValidateArrayThrows($configArray, $expectedException): void {
 		try {
 			$this->invokePrivate($this->command, 'validateArray', [$configArray]);

--- a/tests/Core/Command/Config/ListConfigsTest.php
+++ b/tests/Core/Command/Config/ListConfigsTest.php
@@ -262,7 +262,6 @@ class ListConfigsTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider listData
 	 *
 	 * @param string $app
 	 * @param array $systemConfigs
@@ -271,6 +270,7 @@ class ListConfigsTest extends TestCase {
 	 * @param bool $private
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('listData')]
 	public function testList($app, $systemConfigs, $systemConfigMap, $appConfig, $private, $expected): void {
 		$this->systemConfig->expects($this->any())
 			->method('getKeys')

--- a/tests/Core/Command/Config/System/CastHelperTest.php
+++ b/tests/Core/Command/Config/System/CastHelperTest.php
@@ -37,9 +37,7 @@ class CastHelperTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider castValueProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('castValueProvider')]
 	public function testCastValue($value, $type, $expectedValue): void {
 		$this->assertSame(
 			$expectedValue,
@@ -59,9 +57,7 @@ class CastHelperTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider castValueInvalidProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('castValueInvalidProvider')]
 	public function testCastValueInvalid($value, $type): void {
 		$this->expectException(\InvalidArgumentException::class);
 

--- a/tests/Core/Command/Config/System/DeleteConfigTest.php
+++ b/tests/Core/Command/Config/System/DeleteConfigTest.php
@@ -35,7 +35,7 @@ class DeleteConfigTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OC\SystemConfig $systemConfig */
+		/** @var SystemConfig $systemConfig */
 		$this->command = new DeleteConfig($systemConfig);
 	}
 
@@ -73,7 +73,6 @@ class DeleteConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider deleteData
 	 *
 	 * @param string $configName
 	 * @param bool $configExists
@@ -81,6 +80,7 @@ class DeleteConfigTest extends TestCase {
 	 * @param int $expectedReturn
 	 * @param string $expectedMessage
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('deleteData')]
 	public function testDelete($configName, $configExists, $checkIfExists, $expectedReturn, $expectedMessage): void {
 		$this->systemConfig->expects(($checkIfExists) ? $this->once() : $this->never())
 			->method('getKeys')
@@ -166,7 +166,6 @@ class DeleteConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider deleteArrayData
 	 *
 	 * @param string[] $configNames
 	 * @param bool $configKeyExists
@@ -176,6 +175,7 @@ class DeleteConfigTest extends TestCase {
 	 * @param int $expectedReturn
 	 * @param string $expectedMessage
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('deleteArrayData')]
 	public function testArrayDelete(array $configNames, $configKeyExists, $checkIfKeyExists, $configValue, $updateValue, $expectedReturn, $expectedMessage): void {
 		$this->systemConfig->expects(($checkIfKeyExists) ? $this->once() : $this->never())
 			->method('getKeys')

--- a/tests/Core/Command/Config/System/GetConfigTest.php
+++ b/tests/Core/Command/Config/System/GetConfigTest.php
@@ -35,7 +35,7 @@ class GetConfigTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OC\SystemConfig $systemConfig */
+		/** @var SystemConfig $systemConfig */
 		$this->command = new GetConfig($systemConfig);
 	}
 
@@ -89,7 +89,6 @@ class GetConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider getData
 	 *
 	 * @param string[] $configNames
 	 * @param mixed $value
@@ -100,6 +99,7 @@ class GetConfigTest extends TestCase {
 	 * @param int $expectedReturn
 	 * @param string $expectedMessage
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getData')]
 	public function testGet($configNames, $value, $configExists, $defaultValue, $hasDefault, $outputFormat, $expectedReturn, $expectedMessage): void {
 		if (is_array($configNames)) {
 			$configName = $configNames[0];

--- a/tests/Core/Command/Config/System/SetConfigTest.php
+++ b/tests/Core/Command/Config/System/SetConfigTest.php
@@ -36,7 +36,7 @@ class SetConfigTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OC\SystemConfig $systemConfig */
+		/** @var SystemConfig $systemConfig */
 		$this->command = new SetConfig($systemConfig, new CastHelper());
 	}
 
@@ -50,13 +50,13 @@ class SetConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTest
 	 *
 	 * @param array $configNames
 	 * @param string $newValue
 	 * @param mixed $existingData
 	 * @param mixed $expectedValue
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTest')]
 	public function testSet($configNames, $newValue, $existingData, $expectedValue): void {
 		$this->systemConfig->expects($this->once())
 			->method('setValue')
@@ -87,9 +87,7 @@ class SetConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider setUpdateOnlyProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('setUpdateOnlyProvider')]
 	public function testSetUpdateOnly($configNames, $existingData): void {
 		$this->expectException(\UnexpectedValueException::class);
 

--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -46,7 +46,7 @@ class ChangeKeyStorageRootTest extends TestCase {
 	/** @var OutputInterface | \PHPUnit\Framework\MockObject\MockObject */
 	protected $outputInterface;
 
-	/** @var \OCP\UserInterface |  \PHPUnit\Framework\MockObject\MockObject */
+	/** @var UserInterface|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userInterface;
 
 	protected function setUp(): void {
@@ -78,9 +78,7 @@ class ChangeKeyStorageRootTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestExecute
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestExecute')]
 	public function testExecute($newRoot, $answer, $successMoveKey): void {
 		$changeKeyStorageRoot = $this->getMockBuilder('OC\Core\Command\Encryption\ChangeKeyStorageRoot')
 			->setConstructorArgs(
@@ -135,7 +133,7 @@ class ChangeKeyStorageRootTest extends TestCase {
 	}
 
 	public function testMoveAllKeys(): void {
-		/** @var \OC\Core\Command\Encryption\ChangeKeyStorageRoot $changeKeyStorageRoot */
+		/** @var ChangeKeyStorageRoot $changeKeyStorageRoot */
 		$changeKeyStorageRoot = $this->getMockBuilder('OC\Core\Command\Encryption\ChangeKeyStorageRoot')
 			->setConstructorArgs(
 				[
@@ -166,11 +164,11 @@ class ChangeKeyStorageRootTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestPrepareNewRootException
 	 *
 	 * @param bool $dirExists
 	 * @param bool $couldCreateFile
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestPrepareNewRootException')]
 	public function testPrepareNewRootException($dirExists, $couldCreateFile): void {
 		$this->expectException(\Exception::class);
 
@@ -190,12 +188,12 @@ class ChangeKeyStorageRootTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestMoveSystemKeys
 	 *
 	 * @param bool $dirExists
 	 * @param bool $targetExists
 	 * @param bool $executeRename
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestMoveSystemKeys')]
 	public function testMoveSystemKeys($dirExists, $targetExists, $executeRename): void {
 		$changeKeyStorageRoot = $this->getMockBuilder('OC\Core\Command\Encryption\ChangeKeyStorageRoot')
 			->setConstructorArgs(
@@ -256,13 +254,13 @@ class ChangeKeyStorageRootTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestMoveUserEncryptionFolder
 	 *
 	 * @param bool $userExists
 	 * @param bool $isDir
 	 * @param bool $targetExists
 	 * @param bool $shouldRename
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestMoveUserEncryptionFolder')]
 	public function testMoveUserEncryptionFolder($userExists, $isDir, $targetExists, $shouldRename): void {
 		$changeKeyStorageRoot = $this->getMockBuilder('OC\Core\Command\Encryption\ChangeKeyStorageRoot')
 			->setConstructorArgs(
@@ -308,9 +306,7 @@ class ChangeKeyStorageRootTest extends TestCase {
 	}
 
 
-	/**
-	 * @dataProvider dataTestPrepareParentFolder
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestPrepareParentFolder')]
 	public function testPrepareParentFolder($path, $pathExists): void {
 		$this->view->expects($this->any())->method('file_exists')
 			->willReturnCallback(

--- a/tests/Core/Command/Encryption/DecryptAllTest.php
+++ b/tests/Core/Command/Encryption/DecryptAllTest.php
@@ -18,13 +18,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class DecryptAllTest extends TestCase {
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IConfig */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IConfig */
 	protected $config;
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Encryption\IManager */
 	protected $encryptionManager;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\App\IAppManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IAppManager */
 	protected $appManager;
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Input\InputInterface */
@@ -110,9 +110,7 @@ class DecryptAllTest extends TestCase {
 		$this->invokePrivate($instance, 'resetMaintenanceAndTrashbin');
 	}
 
-	/**
-	 * @dataProvider dataTestExecute
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestExecute')]
 	public function testExecute($encryptionEnabled, $continue): void {
 		$instance = new DecryptAll(
 			$this->encryptionManager,

--- a/tests/Core/Command/Encryption/DisableTest.php
+++ b/tests/Core/Command/Encryption/DisableTest.php
@@ -34,7 +34,7 @@ class DisableTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OCP\IConfig $config */
+		/** @var IConfig $config */
 		$this->command = new Disable($config);
 	}
 
@@ -47,12 +47,12 @@ class DisableTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDisable
 	 *
 	 * @param string $oldStatus
 	 * @param bool $isUpdating
 	 * @param string $expectedString
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDisable')]
 	public function testDisable($oldStatus, $isUpdating, $expectedString): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')

--- a/tests/Core/Command/Encryption/EnableTest.php
+++ b/tests/Core/Command/Encryption/EnableTest.php
@@ -56,9 +56,7 @@ class EnableTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataEnable
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataEnable')]
 	public function testEnable(string $oldStatus, ?string $defaultModule, array $availableModules, bool $isUpdating, string $expectedString, string $expectedDefaultModuleString): void {
 		if ($isUpdating) {
 			$this->config->expects($this->once())

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -19,13 +19,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class EncryptAllTest extends TestCase {
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\IConfig */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IConfig */
 	protected $config;
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Encryption\IManager */
 	protected $encryptionManager;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\App\IAppManager */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IAppManager */
 	protected $appManager;
 
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Input\InputInterface */
@@ -37,7 +37,7 @@ class EncryptAllTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Helper\QuestionHelper */
 	protected $questionHelper;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Encryption\IEncryptionModule */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|IEncryptionModule */
 	protected $encryptionModule;
 
 	/** @var EncryptAll */
@@ -78,9 +78,7 @@ class EncryptAllTest extends TestCase {
 		$this->invokePrivate($instance, 'resetMaintenanceAndTrashbin');
 	}
 
-	/**
-	 * @dataProvider dataTestExecute
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestExecute')]
 	public function testExecute($answer, $askResult): void {
 		$command = new EncryptAll($this->encryptionManager, $this->appManager, $this->config, $this->questionHelper);
 

--- a/tests/Core/Command/Encryption/SetDefaultModuleTest.php
+++ b/tests/Core/Command/Encryption/SetDefaultModuleTest.php
@@ -53,7 +53,6 @@ class SetDefaultModuleTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetDefaultModule
 	 *
 	 * @param string $oldModule
 	 * @param string $newModule
@@ -61,6 +60,7 @@ class SetDefaultModuleTest extends TestCase {
 	 * @param bool $updateSuccess
 	 * @param string $expectedString
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetDefaultModule')]
 	public function testSetDefaultModule($oldModule, $newModule, $updateModule, $updateSuccess, $expectedString): void {
 		$this->consoleInput->expects($this->once())
 			->method('getArgument')
@@ -91,7 +91,6 @@ class SetDefaultModuleTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetDefaultModule
 	 *
 	 * @param string $oldModule
 	 * @param string $newModule
@@ -99,6 +98,7 @@ class SetDefaultModuleTest extends TestCase {
 	 * @param bool $updateSuccess
 	 * @param string $expectedString
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetDefaultModule')]
 	public function testMaintenanceMode($oldModule, $newModule, $updateModule, $updateSuccess, $expectedString): void {
 		$this->consoleInput->expects($this->never())
 			->method('getArgument')

--- a/tests/Core/Command/Log/FileTest.php
+++ b/tests/Core/Command/Log/FileTest.php
@@ -72,9 +72,7 @@ class FileTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider changeRotateSizeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('changeRotateSizeProvider')]
 	public function testChangeRotateSize($optionValue, $configValue): void {
 		$this->config->method('getSystemValue')->willReturnArgument(1);
 		$this->consoleInput->method('getOption')

--- a/tests/Core/Command/Log/ManageTest.php
+++ b/tests/Core/Command/Log/ManageTest.php
@@ -100,9 +100,7 @@ class ManageTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataConvertLevelString
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataConvertLevelString')]
 	public function testConvertLevelString(string $levelString, int $expectedInt): void {
 		$this->assertEquals($expectedInt,
 			self::invokePrivate($this->command, 'convertLevelString', [$levelString])
@@ -126,9 +124,7 @@ class ManageTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataConvertLevelNumber
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataConvertLevelNumber')]
 	public function testConvertLevelNumber(int $levelNum, string $expectedString): void {
 		$this->assertEquals($expectedString,
 			self::invokePrivate($this->command, 'convertLevelNumber', [$levelNum])

--- a/tests/Core/Command/Maintenance/DataFingerprintTest.php
+++ b/tests/Core/Command/Maintenance/DataFingerprintTest.php
@@ -36,7 +36,7 @@ class DataFingerprintTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OCP\IConfig $config */
+		/** @var IConfig $config */
 		$this->command = new DataFingerprint($this->config, $this->timeFactory);
 	}
 

--- a/tests/Core/Command/Maintenance/ModeTest.php
+++ b/tests/Core/Command/Maintenance/ModeTest.php
@@ -112,7 +112,6 @@ class ModeTest extends TestCase {
 	/**
 	 * Asserts that execute works as expected.
 	 *
-	 * @dataProvider getExecuteTestData
 	 * @param string $option The command option.
 	 * @param bool $currentMaintenanceState The current maintenance state.
 	 * @param null|bool $expectedMaintenanceState
@@ -120,6 +119,7 @@ class ModeTest extends TestCase {
 	 * @param string $expectedOutput The expected command output.
 	 * @throws \Exception
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getExecuteTestData')]
 	public function testExecute(
 		string $option,
 		bool $currentMaintenanceState,

--- a/tests/Core/Command/Preview/CleanupTest.php
+++ b/tests/Core/Command/Preview/CleanupTest.php
@@ -100,9 +100,7 @@ class CleanupTest extends TestCase {
 		$this->assertEquals(1, $this->repair->run($this->input, $this->output));
 	}
 
-	/**
-	 * @dataProvider dataForTestCleanupWithDeleteException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataForTestCleanupWithDeleteException')]
 	public function testCleanupWithDeleteException(string $exceptionClass, string $errorMessage): void {
 		$previewFolder = $this->createMock(Folder::class);
 		$previewFolder->expects($this->once())

--- a/tests/Core/Command/Preview/RepairTest.php
+++ b/tests/Core/Command/Preview/RepairTest.php
@@ -111,9 +111,7 @@ class RepairTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataEmptyTest
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataEmptyTest')]
 	public function testEmptyExecute($directoryNames, $expectedOutput): void {
 		$previewFolder = $this->getMockBuilder(Folder::class)
 			->getMock();

--- a/tests/Core/Command/User/AddTest.php
+++ b/tests/Core/Command/User/AddTest.php
@@ -84,9 +84,7 @@ class AddTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider addEmailDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('addEmailDataProvider')]
 	public function testAddEmail(
 		?string $email,
 		bool $isEmailValid,

--- a/tests/Core/Command/User/DeleteTest.php
+++ b/tests/Core/Command/User/DeleteTest.php
@@ -35,7 +35,7 @@ class DeleteTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OCP\IUserManager $userManager */
+		/** @var IUserManager $userManager */
 		$this->command = new Delete($userManager);
 	}
 
@@ -48,11 +48,11 @@ class DeleteTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validUserLastSeen
 	 *
 	 * @param bool $deleteSuccess
 	 * @param string $expectedString
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validUserLastSeen')]
 	public function testValidUser($deleteSuccess, $expectedString): void {
 		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->once())

--- a/tests/Core/Command/User/LastSeenTest.php
+++ b/tests/Core/Command/User/LastSeenTest.php
@@ -35,7 +35,7 @@ class LastSeenTest extends TestCase {
 		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
 		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
 
-		/** @var \OCP\IUserManager $userManager */
+		/** @var IUserManager $userManager */
 		$this->command = new LastSeen($userManager);
 	}
 
@@ -47,11 +47,11 @@ class LastSeenTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider validUserLastSeen
 	 *
 	 * @param int $lastSeen
 	 * @param string $expectedString
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validUserLastSeen')]
 	public function testValidUser($lastSeen, $expectedString): void {
 		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->once())

--- a/tests/Core/Command/User/ProfileTest.php
+++ b/tests/Core/Command/User/ProfileTest.php
@@ -166,9 +166,7 @@ class ProfileTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCheckInput
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckInput')]
 	public function testCheckInput(array $arguments, array $options, array $parameterOptions, bool $existingUser, ?string $expectedException): void {
 		$this->consoleInput->expects($this->any())
 			->method('getArgument')
@@ -233,9 +231,8 @@ class ProfileTest extends TestCase {
 
 	/**
 	 * Tests the deletion mechanism on profile settings.
-	 *
-	 * @dataProvider dataExecuteDeleteProfileProperty
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteDeleteProfileProperty')]
 	public function testExecuteDeleteProfileProperty(string $configKey, string $value, bool $errorIfNotExists, ?string $expectedLine, int $expectedReturn): void {
 		$uid = 'username';
 		$appName = 'profile';
@@ -327,9 +324,7 @@ class ProfileTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataExecuteGet
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteGet')]
 	public function testExecuteGet(string $key, string $value, ?string $defaultValue, string $expectedLine, int $expectedReturn): void {
 		$command = $this->getCommand([
 			'writeArrayInOutputFormat',

--- a/tests/Core/Command/User/SettingTest.php
+++ b/tests/Core/Command/User/SettingTest.php
@@ -164,7 +164,6 @@ class SettingTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataCheckInput
 	 *
 	 * @param array $arguments
 	 * @param array $options
@@ -172,6 +171,7 @@ class SettingTest extends TestCase {
 	 * @param mixed $user
 	 * @param string $expectedException
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckInput')]
 	public function testCheckInput($arguments, $options, $parameterOptions, $user, $expectedException): void {
 		$this->consoleInput->expects($this->any())
 			->method('getArgument')
@@ -233,13 +233,13 @@ class SettingTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataExecuteDelete
 	 *
 	 * @param string|null $value
 	 * @param bool $errorIfNotExists
 	 * @param string $expectedLine
 	 * @param int $expectedReturn
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteDelete')]
 	public function testExecuteDelete($value, $errorIfNotExists, $expectedLine, $expectedReturn): void {
 		$command = $this->getCommand([
 			'writeArrayInOutputFormat',
@@ -297,13 +297,13 @@ class SettingTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataExecuteSet
 	 *
 	 * @param string|null $value
 	 * @param bool $updateOnly
 	 * @param string $expectedLine
 	 * @param int $expectedReturn
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteSet')]
 	public function testExecuteSet($value, $updateOnly, $expectedLine, $expectedReturn): void {
 		$command = $this->getCommand([
 			'writeArrayInOutputFormat',
@@ -364,13 +364,13 @@ class SettingTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataExecuteGet
 	 *
 	 * @param string|null $value
 	 * @param string|null $defaultValue
 	 * @param string $expectedLine
 	 * @param int $expectedReturn
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExecuteGet')]
 	public function testExecuteGet($value, $defaultValue, $expectedLine, $expectedReturn): void {
 		$command = $this->getCommand([
 			'writeArrayInOutputFormat',

--- a/tests/Core/Controller/AutoCompleteControllerTest.php
+++ b/tests/Core/Controller/AutoCompleteControllerTest.php
@@ -154,9 +154,7 @@ class AutoCompleteControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider searchDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchDataProvider')]
 	public function testGet(array $searchResults, array $expected, string $searchTerm, ?string $itemType, ?string $itemId, ?string $sorter): void {
 		$this->collaboratorSearch->expects($this->once())
 			->method('search')

--- a/tests/Core/Controller/ClientFlowLoginControllerTest.php
+++ b/tests/Core/Controller/ClientFlowLoginControllerTest.php
@@ -603,11 +603,11 @@ class ClientFlowLoginControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGeneratePasswordWithHttpsProxy
 	 * @param array $headers
 	 * @param string $protocol
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGeneratePasswordWithHttpsProxy')]
 	public function testGeneratePasswordWithHttpsProxy(array $headers, $protocol, $expected): void {
 		$this->session
 			->expects($this->once())

--- a/tests/Core/Controller/GuestAvatarControllerTest.php
+++ b/tests/Core/Controller/GuestAvatarControllerTest.php
@@ -8,6 +8,7 @@ namespace Core\Controller;
 
 use OC\Core\Controller\GuestAvatarController;
 use OCP\AppFramework\Http\FileDisplayResponse;
+use OCP\Files\File;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IAvatar;
 use OCP\IAvatarManager;
@@ -39,7 +40,7 @@ class GuestAvatarControllerTest extends \Test\TestCase {
 	private $avatar;
 
 	/**
-	 * @var \OCP\Files\File|\PHPUnit\Framework\MockObject\MockObject
+	 * @var File|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private $file;
 

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -351,9 +351,7 @@ class LoginControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider passwordResetDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('passwordResetDataProvider')]
 	public function testShowLoginFormWithPasswordResetOption($canChangePassword,
 		$expectedResult): void {
 		$this->userSession

--- a/tests/Core/Controller/LostControllerTest.php
+++ b/tests/Core/Controller/LostControllerTest.php
@@ -687,10 +687,10 @@ class LostControllerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTwoUsersWithSameEmailOneDisabled
 	 * @param bool $userEnabled1
 	 * @param bool $userEnabled2
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTwoUsersWithSameEmailOneDisabled')]
 	public function testTwoUsersWithSameEmailOneDisabled(bool $userEnabled1, bool $userEnabled2): void {
 		$user1 = $this->createMock(IUser::class);
 		$user1->method('getEMailAddress')

--- a/tests/Core/Controller/NavigationControllerTest.php
+++ b/tests/Core/Controller/NavigationControllerTest.php
@@ -48,7 +48,7 @@ class NavigationControllerTest extends TestCase {
 			[true],
 		];
 	}
-	/** @dataProvider dataGetNavigation */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetNavigation')]
 	public function testGetAppNavigation(bool $absolute): void {
 		$this->navigationManager->expects($this->once())
 			->method('getAll')
@@ -76,7 +76,7 @@ class NavigationControllerTest extends TestCase {
 		}
 	}
 
-	/** @dataProvider dataGetNavigation */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetNavigation')]
 	public function testGetSettingsNavigation(bool $absolute): void {
 		$this->navigationManager->expects($this->once())
 			->method('getAll')

--- a/tests/Core/Controller/WipeControllerTest.php
+++ b/tests/Core/Controller/WipeControllerTest.php
@@ -47,9 +47,8 @@ class WipeControllerTest extends TestCase {
 	 * @param bool $valid
 	 * @param bool $couldPerform
 	 * @param bool $result
-	 *
-	 * @dataProvider dataTest
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTest')]
 	public function testCheckWipe(bool $valid, bool $couldPerform, bool $result): void {
 		if (!$valid) {
 			$this->remoteWipe->method('start')
@@ -76,9 +75,8 @@ class WipeControllerTest extends TestCase {
 	 * @param bool $valid
 	 * @param bool $couldPerform
 	 * @param bool $result
-	 *
-	 * @dataProvider dataTest
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTest')]
 	public function testWipeDone(bool $valid, bool $couldPerform, bool $result): void {
 		if (!$valid) {
 			$this->remoteWipe->method('finish')

--- a/tests/Core/Data/LoginFlowV2CredentialsTest.php
+++ b/tests/Core/Data/LoginFlowV2CredentialsTest.php
@@ -12,7 +12,7 @@ use OC\Core\Data\LoginFlowV2Credentials;
 use Test\TestCase;
 
 class LoginFlowV2CredentialsTest extends TestCase {
-	/** @var \OC\Core\Data\LoginFlowV2Credentials */
+	/** @var LoginFlowV2Credentials */
 	private $fixture;
 
 	public function setUp(): void {

--- a/tests/Core/Middleware/TwoFactorMiddlewareTest.php
+++ b/tests/Core/Middleware/TwoFactorMiddlewareTest.php
@@ -243,9 +243,7 @@ class TwoFactorMiddlewareTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataRequires2FASetupDone
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRequires2FASetupDone')]
 	public function testRequires2FASetupDone(bool $hasProvider, bool $missingProviders, bool $expectEception): void {
 		if ($hasProvider) {
 			$provider = $this->createMock(IProvider::class);

--- a/tests/Core/Service/LoginFlowV2ServiceUnitTest.php
+++ b/tests/Core/Service/LoginFlowV2ServiceUnitTest.php
@@ -31,25 +31,25 @@ use Test\TestCase;
  * Unit tests for \OC\Core\Service\LoginFlowV2Service
  */
 class LoginFlowV2ServiceUnitTest extends TestCase {
-	/** @var \OCP\IConfig */
+	/** @var IConfig */
 	private $config;
 
-	/** @var \OCP\Security\ICrypto */
+	/** @var ICrypto */
 	private $crypto;
 
 	/** @var LoggerInterface|MockObject */
 	private $logger;
 
-	/** @var \OC\Core\Db\LoginFlowV2Mapper */
+	/** @var LoginFlowV2Mapper */
 	private $mapper;
 
-	/** @var \OCP\Security\ISecureRandom */
+	/** @var ISecureRandom */
 	private $secureRandom;
 
-	/** @var \OC\Core\Service\LoginFlowV2Service */
+	/** @var LoginFlowV2Service */
 	private $subjectUnderTest;
 
-	/** @var \OCP\AppFramework\Utility\ITimeFactory */
+	/** @var ITimeFactory */
 	private $timeFactory;
 
 	/** @var \OC\Authentication\Token\IProvider */

--- a/tests/lib/Accounts/AccountManagerTest.php
+++ b/tests/lib/Accounts/AccountManagerTest.php
@@ -462,10 +462,7 @@ class AccountManagerTest extends TestCase {
 			->getMock();
 	}
 
-	/**
-	 * @dataProvider dataTrueFalse
-	 *
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTrueFalse')]
 	public function testUpdateUser(array $newData, array $oldData, bool $insertNew, bool $updateExisting): void {
 		$accountManager = $this->getInstance(['getUser', 'insertNewUser', 'updateExistingUser']);
 		/** @var IUser $user */
@@ -684,9 +681,7 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataParsePhoneNumber
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataParsePhoneNumber')]
 	public function testSanitizePhoneNumberOnUpdateAccount(string $phoneInput, string $defaultRegion, ?string $phoneNumber): void {
 		$this->config->method('getSystemValueString')
 			->willReturn($defaultRegion);
@@ -738,9 +733,7 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSanitizeOnUpdate
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSanitizeOnUpdate')]
 	public function testSanitizingOnUpdateAccount(string $property, string $input, ?string $output): void {
 
 		if ($property === IAccountManager::PROPERTY_FEDIVERSE) {
@@ -823,9 +816,7 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSanitizeFediverseServer
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSanitizeFediverseServer')]
 	public function testSanitizingFediverseServer(string $input, ?string $output, bool $hasInternet, ?string $serverResponse): void {
 		$this->config->expects(self::once())
 			->method('getSystemValueBool')
@@ -882,9 +873,7 @@ class AccountManagerTest extends TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider searchDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchDataProvider')]
 	public function testSearchUsers(string $property, array $values, array $expected): void {
 		$this->populateOrUpdate();
 
@@ -960,9 +949,7 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCheckEmailVerification
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCheckEmailVerification')]
 	public function testCheckEmailVerification(array $userData, ?string $newEmail): void {
 		$user = $this->makeUser(...$userData);
 		// Once because of getAccount, once because of getUser
@@ -1027,9 +1014,7 @@ class AccountManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSetDefaultPropertyScopes
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetDefaultPropertyScopes')]
 	public function testSetDefaultPropertyScopes(array $propertyScopes, array $expectedResultScopes): void {
 		$user = $this->makeUser('steve', 'Steve Smith', 'steve@steve.steve');
 		$this->config->expects($this->once())->method('getSystemValue')->with('account_manager.default_property_scope', [])->willReturn($propertyScopes);

--- a/tests/lib/Accounts/AccountPropertyTest.php
+++ b/tests/lib/Accounts/AccountPropertyTest.php
@@ -70,9 +70,7 @@ class AccountPropertyTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider scopesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('scopesProvider')]
 	public function testSetScopeMapping(string $storedScope, ?string $returnedScope): void {
 		if ($returnedScope === null) {
 			$this->expectException(\InvalidArgumentException::class);

--- a/tests/lib/Accounts/HooksTest.php
+++ b/tests/lib/Accounts/HooksTest.php
@@ -44,7 +44,6 @@ class HooksTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestChangeUserHook
 	 *
 	 * @param $params
 	 * @param $data
@@ -52,6 +51,7 @@ class HooksTest extends TestCase {
 	 * @param $setDisplayName
 	 * @param $error
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestChangeUserHook')]
 	public function testChangeUserHook($params, $data, $setEmail, $setDisplayName, $error): void {
 		if ($error) {
 			$this->accountManager->expects($this->never())->method('updateAccount');

--- a/tests/lib/Activity/ManagerTest.php
+++ b/tests/lib/Activity/ManagerTest.php
@@ -88,11 +88,11 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider getUserFromTokenThrowInvalidTokenData
 	 *
 	 * @param string $token
 	 * @param array $users
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getUserFromTokenThrowInvalidTokenData')]
 	public function testGetUserFromTokenThrowInvalidToken($token, $users): void {
 		$this->expectException(\UnexpectedValueException::class);
 
@@ -109,12 +109,12 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider getUserFromTokenData
 	 *
 	 * @param string $userLoggedIn
 	 * @param string $token
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getUserFromTokenData')]
 	public function testGetUserFromToken($userLoggedIn, $token, $expected): void {
 		if ($userLoggedIn !== null) {
 			$this->mockUserSession($userLoggedIn);
@@ -200,10 +200,10 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPublish
 	 * @param string|null $author
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPublish')]
 	public function testPublish($author, $expected): void {
 		if ($author !== null) {
 			$authorObject = $this->getMockBuilder(IUser::class)

--- a/tests/lib/AllConfigTest.php
+++ b/tests/lib/AllConfigTest.php
@@ -22,7 +22,7 @@ use OCP\PreConditionNotMetException;
 use OCP\Server;
 
 class AllConfigTest extends \Test\TestCase {
-	/** @var \OCP\IDBConnection */
+	/** @var IDBConnection */
 	protected $connection;
 
 	protected function getConfig($systemConfig = null, $connection = null) {
@@ -159,9 +159,9 @@ class AllConfigTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetUserValueUnexpectedValue
 	 * @param mixed $value
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetUserValueUnexpectedValue')]
 	public function testSetUserValueUnexpectedValue($value): void {
 		$this->expectException(\UnexpectedValueException::class);
 

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -139,9 +139,7 @@ class AppManagerTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataGetAppIcon
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppIcon')]
 	public function testGetAppIcon($callback, ?bool $dark, ?string $expected): void {
 		$this->urlGenerator->expects($this->atLeastOnce())
 			->method('imagePath')
@@ -310,10 +308,9 @@ class AppManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataEnableAppForGroupsAllowedTypes
-	 *
 	 * @param array $appInfo
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataEnableAppForGroupsAllowedTypes')]
 	public function testEnableAppForGroupsAllowedTypes(array $appInfo): void {
 		$group1 = $this->createMock(IGroup::class);
 		$group1->method('getGID')
@@ -369,11 +366,11 @@ class AppManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataEnableAppForGroupsForbiddenTypes
 	 *
 	 * @param string $type
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataEnableAppForGroupsForbiddenTypes')]
 	public function testEnableAppForGroupsForbiddenTypes($type): void {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('test can\'t be enabled for groups.');
@@ -776,9 +773,7 @@ class AppManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider isBackendRequiredDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('isBackendRequiredDataProvider')]
 	public function testIsBackendRequired(
 		string $backend,
 		array $appBackends,

--- a/tests/lib/App/AppStore/Fetcher/AppDiscoverFetcherTest.php
+++ b/tests/lib/App/AppStore/Fetcher/AppDiscoverFetcherTest.php
@@ -72,9 +72,7 @@ class AppDiscoverFetcherTest extends FetcherBase {
 		$this->assertEquals([], $this->fetcher->get());
 	}
 
-	/**
-	 * @dataProvider dataGetETag
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetETag')]
 	public function testGetEtag(?string $expected, bool $throws, string $content = ''): void {
 		$folder = $this->createMock(ISimpleFolder::class);
 		if (!$throws) {

--- a/tests/lib/App/AppStore/Version/VersionParserTest.php
+++ b/tests/lib/App/AppStore/Version/VersionParserTest.php
@@ -57,11 +57,11 @@ class VersionParserTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider versionProvider
 	 *
 	 * @param string $input
 	 * @param Version $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('versionProvider')]
 	public function testGetVersion($input,
 		Version $expected): void {
 		$this->assertEquals($expected, $this->versionParser->getVersion($input));

--- a/tests/lib/App/CompareVersionTest.php
+++ b/tests/lib/App/CompareVersionTest.php
@@ -54,9 +54,7 @@ class CompareVersionTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider comparisonData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('comparisonData')]
 	public function testComparison(string $actualVersion, string $requiredVersion,
 		string $comparator, bool $expected): void {
 		$isCompatible = $this->compare->isCompatible($actualVersion, $requiredVersion,

--- a/tests/lib/App/DependencyAnalyzerTest.php
+++ b/tests/lib/App/DependencyAnalyzerTest.php
@@ -68,13 +68,13 @@ class DependencyAnalyzerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providesPhpVersion
 	 *
 	 * @param string $expectedMissing
 	 * @param string $minVersion
 	 * @param string $maxVersion
 	 * @param string $intSize
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesPhpVersion')]
 	public function testPhpVersion($expectedMissing, $minVersion, $maxVersion, $intSize): void {
 		$app = [
 			'dependencies' => [
@@ -97,10 +97,10 @@ class DependencyAnalyzerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providesDatabases
 	 * @param $expectedMissing
 	 * @param $databases
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesDatabases')]
 	public function testDatabases($expectedMissing, $databases): void {
 		$app = [
 			'dependencies' => [
@@ -116,11 +116,11 @@ class DependencyAnalyzerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providesCommands
 	 *
 	 * @param string $expectedMissing
 	 * @param string|null $commands
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesCommands')]
 	public function testCommand($expectedMissing, $commands): void {
 		$app = [
 			'dependencies' => [
@@ -136,10 +136,10 @@ class DependencyAnalyzerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providesLibs
 	 * @param $expectedMissing
 	 * @param $libs
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesLibs')]
 	public function testLibs($expectedMissing, $libs): void {
 		$app = [
 			'dependencies' => [
@@ -156,10 +156,10 @@ class DependencyAnalyzerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providesOS
 	 * @param $expectedMissing
 	 * @param $oss
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesOS')]
 	public function testOS($expectedMissing, $oss): void {
 		$app = [
 			'dependencies' => []
@@ -175,10 +175,10 @@ class DependencyAnalyzerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providesOC
 	 * @param $expectedMissing
 	 * @param $oc
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesOC')]
 	public function testOC($expectedMissing, $oc): void {
 		$app = [
 			'dependencies' => []

--- a/tests/lib/App/InfoParserTest.php
+++ b/tests/lib/App/InfoParserTest.php
@@ -13,7 +13,7 @@ use OCP\Cache\CappedMemoryCache;
 use Test\TestCase;
 
 class InfoParserTest extends TestCase {
-	/** @var OCP\Cache\CappedMemoryCache */
+	/** @var CappedMemoryCache */
 	private static $cache;
 
 	public static function setUpBeforeClass(): void {
@@ -32,16 +32,12 @@ class InfoParserTest extends TestCase {
 		$this->assertEquals($expectedData, $data);
 	}
 
-	/**
-	 * @dataProvider providesInfoXml
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesInfoXml')]
 	public function testParsingValidXmlWithoutCache($expectedJson, $xmlFile): void {
 		$this->parserTest($expectedJson, $xmlFile);
 	}
 
-	/**
-	 * @dataProvider providesInfoXml
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesInfoXml')]
 	public function testParsingValidXmlWithCache($expectedJson, $xmlFile): void {
 		$this->parserTest($expectedJson, $xmlFile, self::$cache);
 	}

--- a/tests/lib/App/PlatformRepositoryTest.php
+++ b/tests/lib/App/PlatformRepositoryTest.php
@@ -11,10 +11,10 @@ use OC\App\PlatformRepository;
 
 class PlatformRepositoryTest extends \Test\TestCase {
 	/**
-	 * @dataProvider providesVersions
 	 * @param $expected
 	 * @param $input
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesVersions')]
 	public function testVersion($input, $expected): void {
 		$pr = new PlatformRepository();
 		$normalizedVersion = $pr->normalizeVersion($input);

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -268,11 +268,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppKeys
 	 *
 	 * @param string $appId
 	 * @param array $expectedKeys
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppKeys')]
 	public function testGetKeys(string $appId, array $expectedKeys): void {
 		$config = $this->generateAppConfig();
 		$this->assertEqualsCanonicalizing($expectedKeys, $config->getKeys($appId));
@@ -284,13 +284,13 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetKeys
 	 *
 	 * @param string $appId
 	 * @param string $configKey
 	 * @param string $value
 	 * @param bool $lazy
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetKeys')]
 	public function testHasKey(string $appId, string $configKey, string $value, int $type, bool $lazy): void {
 		$config = $this->generateAppConfig();
 		$this->assertEquals(true, $config->hasKey($appId, $configKey, $lazy));
@@ -321,9 +321,7 @@ class AppConfigTest extends TestCase {
 		$this->assertSame(true, $config->hasKey('non-sensitive-app', 'lazy-key', null));
 	}
 
-	/**
-	 * @dataProvider providerGetKeys
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetKeys')]
 	public function testIsSensitive(
 		string $appId, string $configKey, string $configValue, int $type, bool $lazy, bool $sensitive,
 	): void {
@@ -365,9 +363,7 @@ class AppConfigTest extends TestCase {
 		$config->isSensitive('non-sensitive-app', 'lazy-key', false);
 	}
 
-	/**
-	 * @dataProvider providerGetKeys
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetKeys')]
 	public function testIsLazy(string $appId, string $configKey, string $configValue, int $type, bool $lazy,
 	): void {
 		$config = $this->generateAppConfig();
@@ -408,11 +404,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppKeys
 	 *
 	 * @param string $appId
 	 * @param array $keys
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppKeys')]
 	public function testGetAllValuesWithEmptyKey(string $appId, array $keys): void {
 		$config = $this->generateAppConfig();
 		$this->assertEqualsCanonicalizing($keys, array_keys($config->getAllValues($appId, '')));
@@ -558,23 +554,23 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetValueMixed
 	 *
 	 * @param string $key
 	 * @param string $value
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueMixed')]
 	public function testGetValueMixed(string $key, string $value): void {
 		$config = $this->generateAppConfig();
 		$this->assertSame($value, $config->getValueMixed('typed', $key));
 	}
 
 	/**
-	 * @dataProvider providerGetValueMixed
 	 *
 	 * @param string $key
 	 * @param string $value
 	 * @param int $type
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueMixed')]
 	public function testGetValueType(string $key, string $value, int $type): void {
 		$config = $this->generateAppConfig();
 		$this->assertSame($type, $config->getValueType('typed', $key));

--- a/tests/lib/AppFramework/AppTest.php
+++ b/tests/lib/AppFramework/AppTest.php
@@ -132,9 +132,7 @@ class AppTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataNoOutput
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoOutput')]
 	public function testNoOutput(string $statusCode): void {
 		$return = [$statusCode, [], [], $this->output, new Response()];
 		$this->dispatcher->expects($this->once())

--- a/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
+++ b/tests/lib/AppFramework/Bootstrap/RegistrationContextTest.php
@@ -68,9 +68,7 @@ class RegistrationContextTest extends TestCase {
 		$this->context->delegateEventListenerRegistrations($dispatcher);
 	}
 
-	/**
-	 * @dataProvider dataProvider_TrueFalse
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProvider_TrueFalse')]
 	public function testRegisterService(bool $shared): void {
 		$app = $this->createMock(App::class);
 		$service = 'abc';

--- a/tests/lib/AppFramework/Controller/PublicShareControllerTest.php
+++ b/tests/lib/AppFramework/Controller/PublicShareControllerTest.php
@@ -68,9 +68,7 @@ class PublicShareControllerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataIsAuthenticated
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsAuthenticated')]
 	public function testIsAuthenticatedNotPasswordProtected(bool $protected, string $token1, string $token2, string $hash1, string $hash2, bool $expected): void {
 		$controller = new TestController('app', $this->request, $this->session, $hash2, $protected);
 

--- a/tests/lib/AppFramework/Db/EntityTest.php
+++ b/tests/lib/AppFramework/Db/EntityTest.php
@@ -225,9 +225,7 @@ class EntityTest extends \Test\TestCase {
 	}
 
 
-	/**
-	 * @dataProvider dataSetterCasts
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetterCasts')]
 	public function testSetterCasts(string $field, mixed $in, mixed $out): void {
 		$entity = new TestEntity();
 		$entity->{'set' . $field}($in);

--- a/tests/lib/AppFramework/Db/QBMapperDBTest.php
+++ b/tests/lib/AppFramework/Db/QBMapperDBTest.php
@@ -64,7 +64,7 @@ class QBDBTestMapper extends QBMapper {
  * @group DB
  */
 class QBMapperDBTest extends TestCase {
-	/** @var \Doctrine\DBAL\Connection|\OCP\IDBConnection */
+	/** @var \Doctrine\DBAL\Connection|IDBConnection */
 	protected $connection;
 	protected $schemaSetup = false;
 

--- a/tests/lib/AppFramework/Db/TransactionalTest.php
+++ b/tests/lib/AppFramework/Db/TransactionalTest.php
@@ -28,10 +28,9 @@ class TransactionalTest extends TestCase {
 		$test = new class($this->db) {
 			use TTransactional;
 
-			private IDBConnection $db;
-
-			public function __construct(IDBConnection $db) {
-				$this->db = $db;
+			public function __construct(
+				private IDBConnection $db,
+			) {
 			}
 
 			public function fail(): void {
@@ -55,10 +54,9 @@ class TransactionalTest extends TestCase {
 		$test = new class($this->db) {
 			use TTransactional;
 
-			private IDBConnection $db;
-
-			public function __construct(IDBConnection $db) {
-				$this->db = $db;
+			public function __construct(
+				private IDBConnection $db,
+			) {
 			}
 
 			public function succeed(): int {

--- a/tests/lib/AppFramework/Http/DispatcherTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherTest.php
@@ -32,7 +32,7 @@ use Psr\Log\LoggerInterface;
 class TestController extends Controller {
 	/**
 	 * @param string $appName
-	 * @param \OCP\IRequest $request
+	 * @param IRequest $request
 	 */
 	public function __construct($appName, $request) {
 		parent::__construct($appName, $request);
@@ -547,9 +547,7 @@ class DispatcherTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider rangeDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('rangeDataProvider')]
 	public function testEnsureParameterValueSatisfiesRange(int $min, int $max, int $input, bool $throw): void {
 		$this->reflector = $this->createMock(ControllerMethodReflector::class);
 		$this->reflector->expects($this->any())

--- a/tests/lib/AppFramework/Http/DownloadResponseTest.php
+++ b/tests/lib/AppFramework/Http/DownloadResponseTest.php
@@ -27,9 +27,7 @@ class DownloadResponseTest extends \Test\TestCase {
 		$this->assertEquals('content', $headers['Content-Type']);
 	}
 
-	/**
-	 * @dataProvider filenameEncodingProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('filenameEncodingProvider')]
 	public function testFilenameEncoding(string $input, string $expected): void {
 		$response = new ChildDownloadResponse($input, 'content');
 		$headers = $response->getHeaders();

--- a/tests/lib/AppFramework/Http/JSONResponseTest.php
+++ b/tests/lib/AppFramework/Http/JSONResponseTest.php
@@ -58,10 +58,10 @@ class JSONResponseTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider renderDataProvider
 	 * @param array $input
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('renderDataProvider')]
 	public function testRender(array $input, $expected): void {
 		$this->json->setData($input);
 		$this->assertEquals($expected, $this->json->render());

--- a/tests/lib/AppFramework/Http/RequestTest.php
+++ b/tests/lib/AppFramework/Http/RequestTest.php
@@ -260,9 +260,7 @@ class RequestTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataNotJsonData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNotJsonData')]
 	public function testNotJsonPost(string $testData): void {
 		global $data;
 		$data = $testData;
@@ -709,9 +707,7 @@ class RequestTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetRemoteAddress
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetRemoteAddress')]
 	public function testGetRemoteAddress(array $headers, array $trustedProxies, array $forwardedForHeaders, string $expected): void {
 		$this->config
 			->method('getSystemValue')
@@ -760,11 +756,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataHttpProtocol
 	 *
 	 * @param mixed $input
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataHttpProtocol')]
 	public function testGetHttpProtocol($input, $expected): void {
 		$request = new Request(
 			[
@@ -950,11 +946,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataUserAgent
 	 * @param string $testAgent
 	 * @param array $userAgent
 	 * @param bool $matches
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUserAgent')]
 	public function testUserAgent($testAgent, $userAgent, $matches): void {
 		$request = new Request(
 			[
@@ -972,11 +968,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataUserAgent
 	 * @param string $testAgent
 	 * @param array $userAgent
 	 * @param bool $matches
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUserAgent')]
 	public function testUndefinedUserAgent($testAgent, $userAgent, $matches): void {
 		$request = new Request(
 			[],
@@ -1154,11 +1150,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataMatchClientVersion
 	 * @param string $testAgent
 	 * @param string $userAgent
 	 * @param string $version
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataMatchClientVersion')]
 	public function testMatchClientVersion(string $testAgent, string $userAgent, string $version): void {
 		preg_match($userAgent, $testAgent, $matches);
 
@@ -1373,9 +1369,7 @@ class RequestTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetServerHostTrustedDomain
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetServerHostTrustedDomain')]
 	public function testGetServerHostTrustedDomain(string $expected, $trustedDomain): void {
 		$this->config
 			->method('getSystemValue')
@@ -1485,11 +1479,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGenericPathInfo
 	 * @param string $requestUri
 	 * @param string $scriptName
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenericPathInfo')]
 	public function testGetPathInfoWithoutSetEnvGeneric($requestUri, $scriptName, $expected): void {
 		$request = new Request(
 			[
@@ -1508,11 +1502,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGenericPathInfo
 	 * @param string $requestUri
 	 * @param string $scriptName
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGenericPathInfo')]
 	public function testGetRawPathInfoWithoutSetEnvGeneric($requestUri, $scriptName, $expected): void {
 		$request = new Request(
 			[
@@ -1531,11 +1525,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataRawPathInfo
 	 * @param string $requestUri
 	 * @param string $scriptName
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRawPathInfo')]
 	public function testGetRawPathInfoWithoutSetEnv($requestUri, $scriptName, $expected): void {
 		$request = new Request(
 			[
@@ -1554,11 +1548,11 @@ class RequestTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPathInfo
 	 * @param string $requestUri
 	 * @param string $scriptName
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPathInfo')]
 	public function testGetPathInfoWithoutSetEnv($requestUri, $scriptName, $expected): void {
 		$request = new Request(
 			[
@@ -1629,9 +1623,7 @@ class RequestTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetRequestUriWithOverwrite
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetRequestUriWithOverwrite')]
 	public function testGetRequestUriWithOverwrite($expectedUri, $overwriteWebRoot, $overwriteCondAddr, $remoteAddr = ''): void {
 		$this->config
 			->expects($this->exactly(2))
@@ -2184,9 +2176,7 @@ class RequestTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataInvalidToken
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataInvalidToken')]
 	public function testPassesCSRFCheckWithInvalidToken(string $invalidToken): void {
 		/** @var Request $request */
 		$request = $this->getMockBuilder(Request::class)

--- a/tests/lib/AppFramework/Http/ResponseTest.php
+++ b/tests/lib/AppFramework/Http/ResponseTest.php
@@ -16,7 +16,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 
 class ResponseTest extends \Test\TestCase {
 	/**
-	 * @var \OCP\AppFramework\Http\Response
+	 * @var Response
 	 */
 	private $childResponse;
 

--- a/tests/lib/AppFramework/Http/TemplateResponseTest.php
+++ b/tests/lib/AppFramework/Http/TemplateResponseTest.php
@@ -13,7 +13,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 
 class TemplateResponseTest extends \Test\TestCase {
 	/**
-	 * @var \OCP\AppFramework\Http\TemplateResponse
+	 * @var TemplateResponse
 	 */
 	private $tpl;
 

--- a/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/NotModifiedMiddlewareTest.php
@@ -54,9 +54,7 @@ class NotModifiedMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataModified
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataModified')]
 	public function testMiddleware(?string $etag, string $etagHeader, ?\DateTime $lastModified, string $lastModifiedHeader, bool $notModifiedSet): void {
 		$this->request->method('getHeader')
 			->willReturnCallback(function (string $name) use ($etagHeader, $lastModifiedHeader) {

--- a/tests/lib/AppFramework/Middleware/OCSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/OCSMiddlewareTest.php
@@ -61,9 +61,7 @@ class OCSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataAfterException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterException')]
 	public function testAfterExceptionOCSv1(string $controller, \Exception $exception, bool $forward, string $message = '', int $code = 0): void {
 		$controller = $this->createMock($controller);
 		$this->request
@@ -92,9 +90,7 @@ class OCSMiddlewareTest extends \Test\TestCase {
 		$this->assertSame(Http::STATUS_OK, $result->getStatus());
 	}
 
-	/**
-	 * @dataProvider dataAfterException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterException')]
 	public function testAfterExceptionOCSv2(string $controller, \Exception $exception, bool $forward, string $message = '', int $code = 0): void {
 		$controller = $this->createMock($controller);
 		$this->request
@@ -121,9 +117,7 @@ class OCSMiddlewareTest extends \Test\TestCase {
 		$this->assertSame($code, $result->getStatus());
 	}
 
-	/**
-	 * @dataProvider dataAfterException
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterException')]
 	public function testAfterExceptionOCSv2SubFolder(string $controller, \Exception $exception, bool $forward, string $message = '', int $code = 0): void {
 		$controller = $this->createMock($controller);
 		$this->request
@@ -167,9 +161,7 @@ class OCSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataAfterController
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterController')]
 	public function testAfterController(string $controller, Response $response, bool $converted, int $convertedOCSStatus = 0): void {
 		$controller = $this->createMock($controller);
 		$OCSMiddleware = new OCSMiddleware($this->request);

--- a/tests/lib/AppFramework/Middleware/PublicShare/PublicShareMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/PublicShare/PublicShareMiddlewareTest.php
@@ -67,9 +67,7 @@ class PublicShareMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataShareApi
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataShareApi')]
 	public function testBeforeControllerShareApiDisabled(string $shareApi, string $shareLinks): void {
 		$controller = $this->createMock(PublicShareController::class);
 

--- a/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/CORSMiddlewareTest.php
@@ -53,9 +53,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSetCORSAPIHeader
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetCORSAPIHeader')]
 	public function testSetCORSAPIHeader(string $method): void {
 		$request = new Request(
 			[
@@ -98,9 +96,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataNoOriginHeaderNoCORSHEADER
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoOriginHeaderNoCORSHEADER')]
 	public function testNoOriginHeaderNoCORSHEADER(string $method): void {
 		$request = new Request(
 			[],
@@ -122,9 +118,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCorsIgnoredIfWithCredentialsHeaderPresent
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCorsIgnoredIfWithCredentialsHeaderPresent')]
 	public function testCorsIgnoredIfWithCredentialsHeaderPresent(string $method): void {
 		$this->expectException(SecurityException::class);
 
@@ -154,9 +148,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataNoCORSOnAnonymousPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCORSOnAnonymousPublicPage')]
 	public function testNoCORSOnAnonymousPublicPage(string $method): void {
 		$request = new Request(
 			[],
@@ -188,9 +180,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCORSShouldNeverAllowCookieAuth
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCORSShouldNeverAllowCookieAuth')]
 	public function testCORSShouldNeverAllowCookieAuth(string $method): void {
 		$request = new Request(
 			[],
@@ -220,9 +210,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCORSShouldRelogin
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCORSShouldRelogin')]
 	public function testCORSShouldRelogin(string $method): void {
 		$request = new Request(
 			['server' => [
@@ -251,9 +239,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCORSShouldFailIfPasswordLoginIsForbidden
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCORSShouldFailIfPasswordLoginIsForbidden')]
 	public function testCORSShouldFailIfPasswordLoginIsForbidden(string $method): void {
 		$this->expectException(SecurityException::class);
 
@@ -284,9 +270,7 @@ class CORSMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCORSShouldNotAllowCookieAuth
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCORSShouldNotAllowCookieAuth')]
 	public function testCORSShouldNotAllowCookieAuth(string $method): void {
 		$this->expectException(SecurityException::class);
 

--- a/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/PasswordConfirmationMiddlewareTest.php
@@ -91,9 +91,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 		$this->middleware->beforeController($this->controller, __FUNCTION__);
 	}
 
-	/**
-	 * @dataProvider dataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
 	public function testAnnotation($backend, $lastConfirm, $currentTime, $exception): void {
 		$this->reflector->reflect($this->controller, __FUNCTION__);
 
@@ -126,9 +124,7 @@ class PasswordConfirmationMiddlewareTest extends TestCase {
 		$this->assertSame($exception, $thrown);
 	}
 
-	/**
-	 * @dataProvider dataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
 	public function testAttribute($backend, $lastConfirm, $currentTime, $exception): void {
 		$this->reflector->reflect($this->controller, __FUNCTION__);
 

--- a/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
+++ b/tests/lib/AppFramework/Middleware/Security/SecurityMiddlewareTest.php
@@ -195,9 +195,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredPublicPage')]
 	public function testSetNavigationEntry(string $method): void {
 		$this->navigationManager->expects($this->once())
 			->method('setActiveEntry')
@@ -245,9 +243,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequired')]
 	public function testAjaxNotAdminCheck(string $method): void {
 		$this->ajaxExceptionStatus(
 			$method,
@@ -256,9 +252,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPublicPage')]
 	public function testAjaxStatusCSRFCheck(string $method): void {
 		$this->ajaxExceptionStatus(
 			$method,
@@ -267,9 +261,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredPublicPage')]
 	public function testAjaxStatusAllGood(string $method): void {
 		$this->ajaxExceptionStatus(
 			$method,
@@ -288,9 +280,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredPublicPage')]
 	public function testNoChecks(string $method): void {
 		$this->request->expects($this->never())
 			->method('passesCSRFCheck')
@@ -329,9 +319,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	}
 
 
-	/**
-	 * @dataProvider dataPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPublicPage')]
 	public function testCsrfCheck(string $method): void {
 		$this->expectException(CrossSiteRequestForgeryException::class);
 
@@ -345,9 +333,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->middleware->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredPublicPage')]
 	public function testNoCsrfCheck(string $method): void {
 		$this->request->expects($this->never())
 			->method('passesCSRFCheck')
@@ -357,9 +343,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->middleware->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPublicPage')]
 	public function testPassesCsrfCheck(string $method): void {
 		$this->request->expects($this->once())
 			->method('passesCSRFCheck')
@@ -372,9 +356,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->middleware->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPublicPage')]
 	public function testFailCsrfCheck(string $method): void {
 		$this->expectException(CrossSiteRequestForgeryException::class);
 
@@ -389,9 +371,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->middleware->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataPublicPageStrictCookieRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPublicPageStrictCookieRequired')]
 	public function testStrictCookieRequiredCheck(string $method): void {
 		$this->expectException(\OC\AppFramework\Middleware\Security\Exceptions\StrictCookieMissingException::class);
 
@@ -405,9 +385,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->middleware->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredPublicPage')]
 	public function testNoStrictCookieRequiredCheck(string $method): void {
 		$this->request->expects($this->never())
 			->method('passesStrictCookieCheck')
@@ -417,9 +395,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->middleware->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredPublicPageStrictCookieRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredPublicPageStrictCookieRequired')]
 	public function testPassesStrictCookieRequiredCheck(string $method): void {
 		$this->request
 			->expects($this->once())
@@ -445,12 +421,12 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataCsrfOcsController
 	 * @param string $controllerClass
 	 * @param bool $hasOcsApiHeader
 	 * @param bool $hasBearerAuth
 	 * @param bool $exception
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCsrfOcsController')]
 	public function testCsrfOcsController(string $controllerClass, bool $hasOcsApiHeader, bool $hasBearerAuth, bool $exception): void {
 		$this->request
 			->method('getHeader')
@@ -477,30 +453,22 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider dataNoAdminRequiredNoCSRFRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoAdminRequiredNoCSRFRequired')]
 	public function testLoggedInCheck(string $method): void {
 		$this->securityCheck($method, 'isLoggedIn');
 	}
 
-	/**
-	 * @dataProvider dataNoAdminRequiredNoCSRFRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoAdminRequiredNoCSRFRequired')]
 	public function testFailLoggedInCheck(string $method): void {
 		$this->securityCheck($method, 'isLoggedIn', true);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequired')]
 	public function testIsAdminCheck(string $method): void {
 		$this->securityCheck($method, 'isAdminUser');
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredSubAdminRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredSubAdminRequired')]
 	public function testIsNotSubAdminCheck(string $method): void {
 		$this->reader->reflect($this->controller, $method);
 		$sec = $this->getMiddleware(true, false, false);
@@ -509,9 +477,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$sec->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredSubAdminRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredSubAdminRequired')]
 	public function testIsSubAdminCheck(string $method): void {
 		$this->reader->reflect($this->controller, $method);
 		$sec = $this->getMiddleware(true, false, true);
@@ -520,9 +486,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequiredSubAdminRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequiredSubAdminRequired')]
 	public function testIsSubAdminAndAdminCheck(string $method): void {
 		$this->reader->reflect($this->controller, $method);
 		$sec = $this->getMiddleware(true, true, true);
@@ -531,16 +495,12 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @dataProvider dataNoCSRFRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoCSRFRequired')]
 	public function testFailIsAdminCheck(string $method): void {
 		$this->securityCheck($method, 'isAdminUser', true);
 	}
 
-	/**
-	 * @dataProvider dataNoAdminRequiredNoCSRFRequiredPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoAdminRequiredNoCSRFRequiredPublicPage')]
 	public function testRestrictedAppLoggedInPublicPage(string $method): void {
 		$middleware = $this->getMiddleware(true, false, false);
 		$this->reader->reflect($this->controller, $method);
@@ -557,9 +517,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @dataProvider dataNoAdminRequiredNoCSRFRequiredPublicPage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoAdminRequiredNoCSRFRequiredPublicPage')]
 	public function testRestrictedAppNotLoggedInPublicPage(string $method): void {
 		$middleware = $this->getMiddleware(false, false, false);
 		$this->reader->reflect($this->controller, $method);
@@ -576,9 +534,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @dataProvider dataNoAdminRequiredNoCSRFRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNoAdminRequiredNoCSRFRequired')]
 	public function testRestrictedAppLoggedIn(string $method): void {
 		$middleware = $this->getMiddleware(true, false, false, false);
 		$this->reader->reflect($this->controller, $method);
@@ -675,9 +631,9 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider exceptionProvider
 	 * @param SecurityException $exception
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('exceptionProvider')]
 	public function testAfterExceptionReturnsTemplateResponse(SecurityException $exception): void {
 		$this->request = new Request(
 			[
@@ -711,9 +667,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$this->assertTrue($response instanceof JSONResponse);
 	}
 
-	/**
-	 * @dataProvider dataExAppRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExAppRequired')]
 	public function testExAppRequired(string $method): void {
 		$middleware = $this->getMiddleware(true, false, false);
 		$this->reader->reflect($this->controller, $method);
@@ -732,9 +686,7 @@ class SecurityMiddlewareTest extends \Test\TestCase {
 		$middleware->beforeController($this->controller, $method);
 	}
 
-	/**
-	 * @dataProvider dataExAppRequired
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataExAppRequired')]
 	public function testExAppRequiredError(string $method): void {
 		$middleware = $this->getMiddleware(true, false, false, false);
 		$this->reader->reflect($this->controller, $method);

--- a/tests/lib/AppFramework/OCS/V2ResponseTest.php
+++ b/tests/lib/AppFramework/OCS/V2ResponseTest.php
@@ -15,9 +15,7 @@ use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\OCSController;
 
 class V2ResponseTest extends \Test\TestCase {
-	/**
-	 * @dataProvider providesStatusCodes
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesStatusCodes')]
 	public function testStatusCodeMapper(int $expected, int $sc): void {
 		$response = new V2Response(new DataResponse([], $sc));
 		$this->assertEquals($expected, $response->getStatus());

--- a/tests/lib/AppFramework/Services/AppConfigTest.php
+++ b/tests/lib/AppFramework/Services/AppConfigTest.php
@@ -57,11 +57,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerHasAppKey
 	 *
 	 * @param bool $lazy
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerHasAppKey')]
 	public function testHasAppKey(bool $lazy, bool $expected): void {
 		$key = 'key';
 		$this->appConfigCore->expects($this->once())
@@ -87,11 +87,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerIsSensitive
 	 *
 	 * @param bool $lazy
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerIsSensitive')]
 	public function testIsSensitive(bool $lazy, bool $expected): void {
 		$key = 'key';
 		$this->appConfigCore->expects($this->once())
@@ -103,11 +103,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerIsSensitive
 	 *
 	 * @param bool $lazy
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerIsSensitive')]
 	public function testIsSensitiveException(bool $lazy, bool $expected): void {
 		$key = 'unknown-key';
 		$this->appConfigCore->expects($this->once())
@@ -132,10 +132,9 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerIsLazy
-	 *
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerIsLazy')]
 	public function testIsLazy(bool $expected): void {
 		$key = 'key';
 		$this->appConfigCore->expects($this->once())
@@ -172,11 +171,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAllAppValues
 	 *
 	 * @param string $key
 	 * @param bool $filtered
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAllAppValues')]
 	public function testGetAllAppValues(string $key, bool $filtered): void {
 		$expected = [
 			'key1' => 'value1',
@@ -229,12 +228,12 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueString(bool $lazy, bool $sensitive, bool $expected): void {
 		$key = 'key';
 		$value = 'valueString';
@@ -247,11 +246,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueStringException(bool $lazy, bool $sensitive): void {
 		$key = 'key';
 		$value = 'valueString';
@@ -265,12 +264,12 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueInt(bool $lazy, bool $sensitive, bool $expected): void {
 		$key = 'key';
 		$value = 42;
@@ -283,11 +282,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueIntException(bool $lazy, bool $sensitive): void {
 		$key = 'key';
 		$value = 42;
@@ -301,12 +300,12 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueFloat(bool $lazy, bool $sensitive, bool $expected): void {
 		$key = 'key';
 		$value = 3.14;
@@ -319,11 +318,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueFloatException(bool $lazy, bool $sensitive): void {
 		$key = 'key';
 		$value = 3.14;
@@ -351,11 +350,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValueBool
 	 *
 	 * @param bool $lazy
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValueBool')]
 	public function testSetAppValueBool(bool $lazy, bool $expected): void {
 		$key = 'key';
 		$value = true;
@@ -368,10 +367,9 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValueBool
-	 *
 	 * @param bool $lazy
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValueBool')]
 	public function testSetAppValueBoolException(bool $lazy): void {
 		$key = 'key';
 		$value = true;
@@ -385,12 +383,12 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueArray(bool $lazy, bool $sensitive, bool $expected): void {
 		$key = 'key';
 		$value = ['item' => true];
@@ -403,11 +401,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerSetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $sensitive
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetAppValue')]
 	public function testSetAppValueArrayException(bool $lazy, bool $sensitive): void {
 		$key = 'key';
 		$value = ['item' => true];
@@ -467,11 +465,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $exist
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueString(bool $lazy, bool $exist): void {
 		$key = 'key';
 		$value = 'valueString';
@@ -487,10 +485,9 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
-	 *
 	 * @param bool $lazy
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueStringException(bool $lazy): void {
 		$key = 'key';
 		$default = 'default';
@@ -505,11 +502,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $exist
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueInt(bool $lazy, bool $exist): void {
 		$key = 'key';
 		$value = 42;
@@ -525,10 +522,9 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
-	 *
 	 * @param bool $lazy
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueIntException(bool $lazy): void {
 		$key = 'key';
 		$default = 17;
@@ -543,11 +539,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $exist
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueFloat(bool $lazy, bool $exist): void {
 		$key = 'key';
 		$value = 3.14;
@@ -563,10 +559,9 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
-	 *
 	 * @param bool $lazy
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueFloatException(bool $lazy): void {
 		$key = 'key';
 		$default = 17.04;
@@ -581,11 +576,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $exist
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueBool(bool $lazy, bool $exist): void {
 		$key = 'key';
 		$value = true;
@@ -601,10 +596,9 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
-	 *
 	 * @param bool $lazy
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueBoolException(bool $lazy): void {
 		$key = 'key';
 		$default = false;
@@ -619,11 +613,11 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
 	 *
 	 * @param bool $lazy
 	 * @param bool $exist
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueArray(bool $lazy, bool $exist): void {
 		$key = 'key';
 		$value = ['item' => true];
@@ -639,10 +633,9 @@ class AppConfigTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider providerGetAppValue
-	 *
 	 * @param bool $lazy
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAppValue')]
 	public function testGetAppValueArrayException(bool $lazy): void {
 		$key = 'key';
 		$default = [];

--- a/tests/lib/AppFramework/Utility/SimpleContainerTest.php
+++ b/tests/lib/AppFramework/Utility/SimpleContainerTest.php
@@ -201,9 +201,7 @@ class SimpleContainerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider sanitizeNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sanitizeNameProvider')]
 	public function testSanitizeName($register, $query): void {
 		$this->container->registerService($register, function () {
 			return 'abc';

--- a/tests/lib/AppTest.php
+++ b/tests/lib/AppTest.php
@@ -314,9 +314,7 @@ class AppTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider appVersionsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('appVersionsProvider')]
 	public function testIsAppCompatible($ocVersion, $appInfo, $expectedResult): void {
 		$this->assertEquals($expectedResult, \OC_App::isAppCompatible($ocVersion, $appInfo));
 	}
@@ -468,9 +466,8 @@ class AppTest extends \Test\TestCase {
 
 	/**
 	 * Test enabled apps
-	 *
-	 * @dataProvider appConfigValuesProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('appConfigValuesProvider')]
 	public function testEnabledApps($user, $expectedApps, $forceAll): void {
 		$userManager = Server::get(IUserManager::class);
 		$groupManager = Server::get(IGroupManager::class);
@@ -575,7 +572,7 @@ class AppTest extends \Test\TestCase {
 			Server::get(IEventDispatcher::class),
 			Server::get(LoggerInterface::class),
 			Server::get(ServerVersion::class),
-			\OCP\Server::get(ConfigManager::class),
+			Server::get(ConfigManager::class),
 		));
 	}
 
@@ -624,10 +621,10 @@ class AppTest extends \Test\TestCase {
 	/**
 	 * Test app info parser
 	 *
-	 * @dataProvider appDataProvider
 	 * @param array $data
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('appDataProvider')]
 	public function testParseAppInfo(array $data, array $expected): void {
 		$this->assertSame($expected, \OC_App::parseAppInfo($data));
 	}

--- a/tests/lib/Authentication/Token/ManagerTest.php
+++ b/tests/lib/Authentication/Token/ManagerTest.php
@@ -157,9 +157,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider tokenData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tokenData')]
 	public function testUpdateToken(IToken|string $token): void {
 		if (is_string($token)) {
 			$token = $this->createMock($token);
@@ -172,9 +170,7 @@ class ManagerTest extends TestCase {
 		$this->manager->updateToken($token);
 	}
 
-	/**
-	 * @dataProvider tokenData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tokenData')]
 	public function testUpdateTokenActivity(IToken|string $token): void {
 		if (is_string($token)) {
 			$token = $this->createMock($token);
@@ -187,9 +183,7 @@ class ManagerTest extends TestCase {
 		$this->manager->updateTokenActivity($token);
 	}
 
-	/**
-	 * @dataProvider tokenData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tokenData')]
 	public function testGetPassword(IToken|string $token): void {
 		if (is_string($token)) {
 			$token = $this->createMock($token);
@@ -204,9 +198,7 @@ class ManagerTest extends TestCase {
 		$this->assertSame('password', $result);
 	}
 
-	/**
-	 * @dataProvider tokenData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tokenData')]
 	public function testSetPassword(IToken|string $token): void {
 		if (is_string($token)) {
 			$token = $this->createMock($token);

--- a/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/ManagerTest.php
@@ -218,9 +218,8 @@ class ManagerTest extends TestCase {
 	 * enabled providers.
 	 *
 	 * If any of these providers is active, 2FA is enabled
-	 *
-	 * @dataProvider providerStatesFixData
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerStatesFixData')]
 	public function testIsTwoFactorAuthenticatedFixesProviderStates(bool $providerEnabled, bool $expected): void {
 		$this->providerRegistry->expects($this->once())
 			->method('getProviderStates')

--- a/tests/lib/Avatar/AvatarManagerTest.php
+++ b/tests/lib/Avatar/AvatarManagerTest.php
@@ -204,9 +204,7 @@ class AvatarManagerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetAvatarScopes
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAvatarScopes')]
 	public function testGetAvatarScopes($avatarScope, $isPublicCall, $isKnownUser, $expectedPlaceholder): void {
 		if ($isPublicCall) {
 			$requestingUser = null;

--- a/tests/lib/Avatar/UserAvatarTest.php
+++ b/tests/lib/Avatar/UserAvatarTest.php
@@ -27,10 +27,10 @@ class UserAvatarTest extends \Test\TestCase {
 	/** @var \OC\Avatar\UserAvatar */
 	private $avatar;
 
-	/** @var \OC\User\User | \PHPUnit\Framework\MockObject\MockObject $user */
+	/** @var User|\PHPUnit\Framework\MockObject\MockObject $user */
 	private $user;
 
-	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	private $config;
 
 	protected function setUp(): void {
@@ -247,9 +247,7 @@ class UserAvatarTest extends \Test\TestCase {
 	}
 
 
-	/**
-	 * @dataProvider avatarTextData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('avatarTextData')]
 	public function testGetAvatarText($displayName, $expectedAvatarText): void {
 		$user = $this->getUserWithDisplayName($displayName);
 		$avatar = $this->getUserAvatar($user);
@@ -287,7 +285,7 @@ class UserAvatarTest extends \Test\TestCase {
 	}
 
 	private function getUserAvatar($user) {
-		/** @var \OCP\IL10N | \PHPUnit\Framework\MockObject\MockObject $l */
+		/** @var IL10N|\PHPUnit\Framework\MockObject\MockObject $l */
 		$l = $this->createMock(IL10N::class);
 		$l->method('t')->willReturnArgument(0);
 

--- a/tests/lib/BackgroundJob/DummyJobList.php
+++ b/tests/lib/BackgroundJob/DummyJobList.php
@@ -10,6 +10,7 @@ namespace Test\BackgroundJob;
 
 use OC\BackgroundJob\JobList;
 use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\Job;
 use OCP\Server;
 
 /**
@@ -132,7 +133,7 @@ class DummyJobList extends JobList {
 	/**
 	 * set the job that was last ran
 	 *
-	 * @param \OCP\BackgroundJob\Job $job
+	 * @param Job $job
 	 */
 	public function setLastJob(IJob $job): void {
 		$i = array_search($job, $this->jobs);

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -30,13 +30,13 @@ class JobListTest extends TestCase {
 	/** @var \OC\BackgroundJob\JobList */
 	protected $instance;
 
-	/** @var \OCP\IDBConnection */
+	/** @var IDBConnection */
 	protected $connection;
 
-	/** @var \OCP\IConfig|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
 	protected $config;
 
-	/** @var \OCP\AppFramework\Utility\ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var ITimeFactory|\PHPUnit\Framework\MockObject\MockObject */
 	protected $timeFactory;
 	private bool $ran = false;
 
@@ -90,9 +90,9 @@ class JobListTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider argumentProvider
 	 * @param $argument
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('argumentProvider')]
 	public function testAddRemove($argument): void {
 		$existingJobs = $this->getAllSorted();
 		$job = new TestJob();
@@ -112,9 +112,9 @@ class JobListTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider argumentProvider
 	 * @param $argument
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('argumentProvider')]
 	public function testRemoveDifferentArgument($argument): void {
 		$existingJobs = $this->getAllSorted();
 		$job = new TestJob();
@@ -133,9 +133,9 @@ class JobListTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider argumentProvider
 	 * @param $argument
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('argumentProvider')]
 	public function testHas($argument): void {
 		$job = new TestJob();
 		$this->assertFalse($this->instance->has($job, $argument));
@@ -149,9 +149,9 @@ class JobListTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider argumentProvider
 	 * @param $argument
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('argumentProvider')]
 	public function testHasDifferentArgument($argument): void {
 		$job = new TestJob();
 		$this->instance->add($job, $argument);
@@ -241,9 +241,9 @@ class JobListTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider argumentProvider
 	 * @param $argument
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('argumentProvider')]
 	public function testGetById($argument): void {
 		$job = new TestJob();
 		$this->instance->add($job, $argument);

--- a/tests/lib/Cache/FileCacheTest.php
+++ b/tests/lib/Cache/FileCacheTest.php
@@ -11,6 +11,7 @@ namespace Test\Cache;
 use OC\Cache\File;
 use OC\Files\Filesystem;
 use OC\Files\Storage\Local;
+use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OCP\Files\LockNotAcquiredException;
@@ -39,11 +40,11 @@ class FileCacheTest extends TestCache {
 	 * */
 	private $datadir;
 	/**
-	 * @var \OC\Files\Storage\Storage
+	 * @var Storage
 	 * */
 	private $storage;
 	/**
-	 * @var \OC\Files\View
+	 * @var View
 	 * */
 	private $rootView;
 
@@ -141,9 +142,7 @@ class FileCacheTest extends TestCache {
 		];
 	}
 
-	/**
-	 * @dataProvider lockExceptionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('lockExceptionProvider')]
 	public function testGarbageCollectIgnoreLockedKeys($testException): void {
 		$mockStorage = $this->setupMockStorage();
 

--- a/tests/lib/Cache/TestCache.php
+++ b/tests/lib/Cache/TestCache.php
@@ -8,9 +8,11 @@
 
 namespace Test\Cache;
 
+use OCP\ICache;
+
 abstract class TestCache extends \Test\TestCase {
 	/**
-	 * @var \OCP\ICache cache;
+	 * @var ICache cache;
 	 */
 	protected $instance;
 

--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -144,9 +144,7 @@ class ManagerTest extends TestCase {
 
 	}
 
-	/**
-	 * @dataProvider searchProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchProvider')]
 	public function testSearch($search1, $search2, $expected): void {
 		/** @var ICalendar | MockObject $calendar1 */
 		$calendar1 = $this->createMock(ICalendar::class);
@@ -171,9 +169,7 @@ class ManagerTest extends TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
-	/**
-	 * @dataProvider searchProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchProvider')]
 	public function testSearchOptions($search1, $search2, $expected): void {
 		/** @var ICalendar | MockObject $calendar1 */
 		$calendar1 = $this->createMock(ICalendar::class);

--- a/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
@@ -418,7 +418,6 @@ class GroupPluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetGroups
 	 *
 	 * @param string $searchTerm
 	 * @param bool $shareWithGroupOnly
@@ -431,6 +430,7 @@ class GroupPluginTest extends TestCase {
 	 * @param bool $reachedEnd
 	 * @param bool|IGroup $singleGroup
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetGroups')]
 	public function testSearch(
 		string $searchTerm,
 		bool $shareWithGroupOnly,

--- a/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/LookupPluginTest.php
@@ -118,9 +118,9 @@ class LookupPluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider searchDataProvider
 	 * @param array $searchParams
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchDataProvider')]
 	public function testSearch(array $searchParams): void {
 		$type = new SearchResultType('lookup');
 
@@ -176,11 +176,11 @@ class LookupPluginTest extends TestCase {
 
 
 	/**
-	 * @dataProvider dataSearchEnableDisableLookupServer
 	 * @param array $searchParams
 	 * @param bool $GSEnabled
 	 * @param bool $LookupEnabled
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchEnableDisableLookupServer')]
 	public function testSearchEnableDisableLookupServer(array $searchParams, $GSEnabled, $LookupEnabled): void {
 		$type = new SearchResultType('lookup');
 

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -87,7 +87,6 @@ class MailPluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetEmail
 	 *
 	 * @param string $searchTerm
 	 * @param array $contacts
@@ -95,6 +94,7 @@ class MailPluginTest extends TestCase {
 	 * @param array $expected
 	 * @param bool $reachedEnd
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetEmail')]
 	public function testSearch($searchTerm, $contacts, $shareeEnumeration, $expected, $exactIdMatch, $reachedEnd, $validEmail): void {
 		$this->config->expects($this->any())
 			->method('getAppValue')
@@ -569,7 +569,6 @@ class MailPluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetEmailGroupsOnly
 	 *
 	 * @param string $searchTerm
 	 * @param array $contacts
@@ -578,6 +577,7 @@ class MailPluginTest extends TestCase {
 	 * @param bool $reachedEnd
 	 * @param array groups
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetEmailGroupsOnly')]
 	public function testSearchGroupsOnly($searchTerm, $contacts, $expected, $exactIdMatch, $reachedEnd, $userToGroupMapping, $validEmail): void {
 		$this->config->expects($this->any())
 			->method('getAppValue')
@@ -594,7 +594,7 @@ class MailPluginTest extends TestCase {
 
 		$this->instantiatePlugin();
 
-		/** @var \OCP\IUser | \PHPUnit\Framework\MockObject\MockObject */
+		/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
 		$currentUser = $this->createMock('\OCP\IUser');
 
 		$currentUser->expects($this->any())

--- a/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
@@ -71,7 +71,6 @@ class RemotePluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetRemote
 	 *
 	 * @param string $searchTerm
 	 * @param array $contacts
@@ -80,6 +79,7 @@ class RemotePluginTest extends TestCase {
 	 * @param bool $exactIdMatch
 	 * @param bool $reachedEnd
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetRemote')]
 	public function testSearch($searchTerm, array $contacts, $shareeEnumeration, array $expected, $exactIdMatch, $reachedEnd): void {
 		$this->config->expects($this->any())
 			->method('getAppValue')
@@ -112,12 +112,12 @@ class RemotePluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestSplitUserRemote
 	 *
 	 * @param string $remote
 	 * @param string $expectedUser
 	 * @param string $expectedUrl
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitUserRemote')]
 	public function testSplitUserRemote($remote, $expectedUser, $expectedUrl): void {
 		$this->instantiatePlugin();
 
@@ -131,10 +131,9 @@ class RemotePluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestSplitUserRemoteError
-	 *
 	 * @param string $id
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestSplitUserRemoteError')]
 	public function testSplitUserRemoteError($id): void {
 		$this->expectException(\Exception::class);
 

--- a/tests/lib/Collaboration/Collaborators/SearchResultTest.php
+++ b/tests/lib/Collaboration/Collaborators/SearchResultTest.php
@@ -38,10 +38,10 @@ class SearchResultTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataAddResultSet
 	 * @param array $toAdd
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAddResultSet')]
 	public function testAddResultSet(array $toAdd, array $expected): void {
 		$result = new SearchResult();
 
@@ -67,12 +67,12 @@ class SearchResultTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataHasResult
 	 * @param array $toAdd
 	 * @param string $type
 	 * @param string $id
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataHasResult')]
 	public function testHasResult(array $toAdd, $type, $id, $expected): void {
 		$result = new SearchResult();
 

--- a/tests/lib/Collaboration/Collaborators/SearchTest.php
+++ b/tests/lib/Collaboration/Collaborators/SearchTest.php
@@ -30,9 +30,7 @@ class SearchTest extends TestCase {
 		$this->search = new Search($this->container);
 	}
 
-	/**
-	 * @dataProvider dataSearchSharees
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchSharees')]
 	public function testSearch(
 		string $searchTerm,
 		array $shareTypes,

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -418,7 +418,6 @@ class UserPluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetUsers
 	 *
 	 * @param string $searchTerm
 	 * @param bool $shareWithGroupOnly
@@ -431,6 +430,7 @@ class UserPluginTest extends TestCase {
 	 * @param bool|IUser $singleUser
 	 * @param array $users
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsers')]
 	public function testSearch(
 		$searchTerm,
 		$shareWithGroupOnly,
@@ -535,11 +535,11 @@ class UserPluginTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider takeOutCurrentUserProvider
 	 * @param array $users
 	 * @param array $expectedUIDs
 	 * @param $currentUserId
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('takeOutCurrentUserProvider')]
 	public function testTakeOutCurrentUser(array $users, array $expectedUIDs, $currentUserId): void {
 		$this->instantiatePlugin();
 
@@ -717,9 +717,7 @@ class UserPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSearchEnumeration
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchEnumeration')]
 	public function testSearchEnumerationLimit($search, $userGroups, $matchingUsers, $result, $mockedSettings): void {
 		$this->mockConfig($mockedSettings);
 

--- a/tests/lib/Command/AsyncBusTestCase.php
+++ b/tests/lib/Command/AsyncBusTestCase.php
@@ -64,7 +64,7 @@ abstract class AsyncBusTestCase extends TestCase {
 	public static $lastCommand;
 
 	/**
-	 * @var \OCP\Command\IBus
+	 * @var IBus
 	 */
 	private $bus;
 

--- a/tests/lib/Command/BackgroundModeTest.php
+++ b/tests/lib/Command/BackgroundModeTest.php
@@ -35,9 +35,7 @@ class BackgroundModeTest extends TestCase {
 		$this->command->setDefinition($inputDefinition);
 	}
 
-	/**
-	 * @dataProvider dataModeCommand
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataModeCommand')]
 	public function testModeCommand(string $mode): void {
 		$this->appConfig->expects($this->once())
 			->method('setValueString')

--- a/tests/lib/Command/CronBusTest.php
+++ b/tests/lib/Command/CronBusTest.php
@@ -8,6 +8,7 @@
 namespace Test\Command;
 
 use OC\Command\CronBus;
+use OCP\BackgroundJob\IJobList;
 use Test\BackgroundJob\DummyJobList;
 
 /**
@@ -15,7 +16,7 @@ use Test\BackgroundJob\DummyJobList;
  */
 class CronBusTest extends AsyncBusTestCase {
 	/**
-	 * @var \OCP\BackgroundJob\IJobList
+	 * @var IJobList
 	 */
 	private $jobList;
 

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -15,7 +15,7 @@ use Test\TestCase;
 
 class CommentTest extends TestCase {
 	/**
-	 * @throws \OCP\Comments\IllegalIDChangeException
+	 * @throws IllegalIDChangeException
 	 */
 	public function testSettersValidInput(): void {
 		$comment = new Comment();
@@ -74,7 +74,7 @@ class CommentTest extends TestCase {
 	}
 
 	/**
-	 * @throws \OCP\Comments\IllegalIDChangeException
+	 * @throws IllegalIDChangeException
 	 */
 	public function testResetId(): void {
 		$comment = new Comment();
@@ -96,9 +96,7 @@ class CommentTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider simpleSetterProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('simpleSetterProvider')]
 	public function testSimpleSetterInvalidInput($field, $input): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -121,9 +119,7 @@ class CommentTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider roleSetterProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('roleSetterProvider')]
 	public function testSetRoleInvalidInput($role, $type, $id): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -209,12 +205,12 @@ class CommentTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider mentionsProvider
 	 *
 	 * @param string $message
 	 * @param array $expectedMentions
 	 * @param ?string $author
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('mentionsProvider')]
 	public function testMentions(string $message, array $expectedMentions, ?string $author = null): void {
 		$comment = new Comment();
 		$comment->setMessage($message);

--- a/tests/lib/Comments/ManagerTest.php
+++ b/tests/lib/Comments/ManagerTest.php
@@ -376,9 +376,7 @@ class ManagerTest extends TestCase {
 		], $amount);
 	}
 
-	/**
-	 * @dataProvider dataGetForObjectSince
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetForObjectSince')]
 	public function testGetForObjectSince(?int $lastKnown, string $order, int $limit, int $resultFrom, int $resultTo): void {
 		$ids = [];
 		$ids[] = $this->addDatabaseEntry(0, 0);
@@ -424,9 +422,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider invalidCreateArgsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidCreateArgsProvider')]
 	public function testCreateCommentInvalidArguments(string|int $aType, string|int $aId, string|int $oType, string|int $oId): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -471,9 +467,7 @@ class ManagerTest extends TestCase {
 		$manager->get($id);
 	}
 
-	/**
-	 * @dataProvider providerTestSave
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestSave')]
 	public function testSave(string $message, string $actorId, string $verb, ?string $parentId, ?string $id = ''): IComment {
 		$manager = $this->getManager();
 		$comment = new Comment();
@@ -613,9 +607,7 @@ class ManagerTest extends TestCase {
 			];
 	}
 
-	/**
-	 * @dataProvider invalidActorArgsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidActorArgsProvider')]
 	public function testDeleteReferencesOfActorInvalidInput(string|int $type, string|int $id): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -680,9 +672,7 @@ class ManagerTest extends TestCase {
 			];
 	}
 
-	/**
-	 * @dataProvider invalidObjectArgsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidObjectArgsProvider')]
 	public function testDeleteCommentsAtObjectInvalidInput(string|int $type, string|int $id): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -1006,9 +996,7 @@ class ManagerTest extends TestCase {
 		}
 	}
 
-	/**
-	 * @dataProvider providerTestReactionAddAndDelete
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestReactionAddAndDelete')]
 	public function testReactionAddAndDelete(array $comments, array $reactionsExpected): void {
 		$this->skipIfNotSupport4ByteUTF();
 		$manager = $this->getManager();
@@ -1093,9 +1081,7 @@ class ManagerTest extends TestCase {
 		return $comments;
 	}
 
-	/**
-	 * @dataProvider providerTestRetrieveAllReactions
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestRetrieveAllReactions')]
 	public function testRetrieveAllReactions(array $comments, array $expected): void {
 		$this->skipIfNotSupport4ByteUTF();
 		$manager = $this->getManager();
@@ -2357,9 +2343,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerTestRetrieveAllReactionsWithSpecificReaction
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestRetrieveAllReactionsWithSpecificReaction')]
 	public function testRetrieveAllReactionsWithSpecificReaction(array $comments, string $reaction, array $expected): void {
 		$this->skipIfNotSupport4ByteUTF();
 		$manager = $this->getManager();
@@ -2412,9 +2396,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerTestGetReactionComment
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestGetReactionComment')]
 	public function testGetReactionComment(array $comments, array $expected, bool $notFound): void {
 		$this->skipIfNotSupport4ByteUTF();
 		$manager = $this->getManager();
@@ -2481,9 +2463,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerTestReactionMessageSize
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestReactionMessageSize')]
 	public function testReactionMessageSize(string $reactionString, bool $valid): void {
 		$this->skipIfNotSupport4ByteUTF();
 		if (!$valid) {
@@ -2512,9 +2492,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerTestReactionsSummarizeOrdered
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestReactionsSummarizeOrdered')]
 	public function testReactionsSummarizeOrdered(array $comments, array $expected, bool $isFullMatch): void {
 		$this->skipIfNotSupport4ByteUTF();
 		$manager = $this->getManager();

--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -348,9 +348,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerHasKey
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerHasKey')]
 	public function testHasKey(string $userId, string $appId, string $key, ?bool $lazy, bool $result): void {
 		$userConfig = $this->generateUserConfig();
 		$this->assertEquals($result, $userConfig->hasKey($userId, $appId, $key, $lazy));
@@ -375,9 +373,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerIsSensitive
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerIsSensitive')]
 	public function testIsSensitive(
 		string $userId,
 		string $appId,
@@ -406,9 +402,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerIsLazy
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerIsLazy')]
 	public function testIsLazy(
 		string $userId,
 		string $appId,
@@ -541,9 +535,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetValues
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValues')]
 	public function testGetValues(
 		string $userId,
 		string $appId,
@@ -642,9 +634,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetAllValues
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetAllValues')]
 	public function testGetAllValues(
 		string $userId,
 		bool $filtered,
@@ -686,9 +676,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSearchValuesByApps
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSearchValuesByApps')]
 	public function testSearchValuesByApps(
 		string $userId,
 		string $key,
@@ -736,9 +724,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSearchValuesByUsers
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSearchValuesByUsers')]
 	public function testSearchValuesByUsers(
 		string $app,
 		string $key,
@@ -760,9 +746,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSearchValuesByValueString
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSearchValuesByValueString')]
 	public function testSearchUsersByValueString(
 		string $app,
 		string $key,
@@ -782,9 +766,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSearchValuesByValueInt
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSearchValuesByValueInt')]
 	public function testSearchUsersByValueInt(
 		string $app,
 		string $key,
@@ -802,9 +784,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSearchValuesByValues
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSearchValuesByValues')]
 	public function testSearchUsersByValues(
 		string $app,
 		string $key,
@@ -822,9 +802,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSearchValuesByValueBool
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSearchValuesByValueBool')]
 	public function testSearchUsersByValueBool(
 		string $app,
 		string $key,
@@ -903,9 +881,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetValueMixed
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueMixed')]
 	public function testGetValueMixed(
 		?array $preload,
 		string $userId,
@@ -919,9 +895,7 @@ class UserConfigTest extends TestCase {
 		$this->assertEquals($result, $userConfig->getValueMixed($userId, $app, $key, $default, $lazy));
 	}
 
-	/**
-	 * @dataProvider providerGetValueMixed
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueMixed')]
 	public function testGetValueString(
 		?array $preload,
 		string $userId,
@@ -961,9 +935,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetValueInt
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueInt')]
 	public function testGetValueInt(
 		?array $preload,
 		string $userId,
@@ -1002,9 +974,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetValueFloat
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueFloat')]
 	public function testGetValueFloat(
 		?array $preload,
 		string $userId,
@@ -1063,9 +1033,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetValueBool
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueBool')]
 	public function testGetValueBool(
 		?array $preload,
 		string $userId,
@@ -1100,9 +1068,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetValueArray
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueArray')]
 	public function testGetValueArray(
 		?array $preload,
 		string $userId,
@@ -1156,9 +1122,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetValueType
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetValueType')]
 	public function testGetValueType(
 		?array $preload,
 		string $userId,
@@ -1215,9 +1179,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSetValueMixed
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetValueMixed')]
 	public function testSetValueMixed(
 		?array $preload,
 		string $userId,
@@ -1298,9 +1260,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSetValueString
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetValueString')]
 	public function testSetValueString(
 		?array $preload,
 		string $userId,
@@ -1361,9 +1321,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSetValueInt
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetValueInt')]
 	public function testSetValueInt(
 		?array $preload,
 		string $userId,
@@ -1424,9 +1382,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSetValueFloat
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetValueFloat')]
 	public function testSetValueFloat(
 		?array $preload,
 		string $userId,
@@ -1488,9 +1444,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerSetValueArray
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerSetValueArray')]
 	public function testSetValueArray(
 		?array $preload,
 		string $userId,
@@ -1534,9 +1488,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerUpdateSensitive
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerUpdateSensitive')]
 	public function testUpdateSensitive(
 		?array $preload,
 		string $userId,
@@ -1575,9 +1527,7 @@ class UserConfigTest extends TestCase {
 		return [[true], [false]];
 	}
 
-	/**
-	 * @dataProvider providerUpdateGlobalSensitive
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerUpdateGlobalSensitive')]
 	public function testUpdateGlobalSensitive(bool $sensitive): void {
 		$userConfig = $this->generateUserConfig($preload ?? []);
 		$app = 'app2';
@@ -1624,9 +1574,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerUpdateLazy
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerUpdateLazy')]
 	public function testUpdateLazy(
 		?array $preload,
 		string $userId,
@@ -1658,9 +1606,7 @@ class UserConfigTest extends TestCase {
 		return [[true], [false]];
 	}
 
-	/**
-	 * @dataProvider providerUpdateGlobalLazy
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerUpdateGlobalLazy')]
 	public function testUpdateGlobalLazy(bool $lazy): void {
 		$userConfig = $this->generateUserConfig($preload ?? []);
 		$app = 'app2';
@@ -1728,9 +1674,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerGetDetails
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerGetDetails')]
 	public function testGetDetails(string $userId, string $app, string $key, array $result): void {
 		$userConfig = $this->generateUserConfig($preload ?? []);
 		$this->assertEqualsCanonicalizing($result, $userConfig->getDetails($userId, $app, $key));
@@ -1748,9 +1692,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerDeletePreference
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerDeletePreference')]
 	public function testDeletePreference(
 		?array $preload,
 		string $userId,
@@ -1779,9 +1721,7 @@ class UserConfigTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providerDeleteKey
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerDeleteKey')]
 	public function testDeleteKey(
 		?array $preload,
 		string $app,

--- a/tests/lib/Contacts/ContactsMenu/Providers/LocalTimeProviderTest.php
+++ b/tests/lib/Contacts/ContactsMenu/Providers/LocalTimeProviderTest.php
@@ -110,9 +110,7 @@ class LocalTimeProviderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestProcess
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestProcess')]
 	public function testProcess(bool $hasCurrentUser, ?string $currentUserTZ, ?string $targetUserTZ, string $expected): void {
 		$entry = $this->createMock(IEntry::class);
 		$entry->expects($this->once())

--- a/tests/lib/ContactsManagerTest.php
+++ b/tests/lib/ContactsManagerTest.php
@@ -65,9 +65,7 @@ class ContactsManagerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider searchProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchProvider')]
 	public function testSearch($search1, $search2, $expectedResult): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBook $addressbook */
 		$addressbook1 = $this->getMockBuilder('\OCP\IAddressBookEnabled')
@@ -109,9 +107,7 @@ class ContactsManagerTest extends \Test\TestCase {
 		$this->assertEquals($expectedResult, $result);
 	}
 
-	/**
-	 * @dataProvider searchProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('searchProvider')]
 	public function testSearchDisabledAb($search1): void {
 		/** @var \PHPUnit\Framework\MockObject\MockObject|IAddressBookEnabled $addressbook */
 		$addressbook1 = $this->getMockBuilder('\OCP\IAddressBookEnabled')

--- a/tests/lib/DB/ConnectionFactoryTest.php
+++ b/tests/lib/DB/ConnectionFactoryTest.php
@@ -28,10 +28,10 @@ class ConnectionFactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider splitHostFromPortAndSocketData
 	 * @param string $host
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('splitHostFromPortAndSocketData')]
 	public function testSplitHostFromPortAndSocket($host, array $expected): void {
 		/** @var SystemConfig $config */
 		$config = $this->createMock(SystemConfig::class);

--- a/tests/lib/DB/Exception/DbalExceptionTest.php
+++ b/tests/lib/DB/Exception/DbalExceptionTest.php
@@ -35,10 +35,10 @@ class DbalExceptionTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDriverException
 	 * @param string $class
 	 * @param int $reason
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDriverException')]
 	public function testDriverException(string $class, int $reason): void {
 		$result = DbalException::wrap(new $class($this->driverException, null));
 		$this->assertSame($reason, $result->getReason());

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -185,10 +185,10 @@ class MigrationsTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetMigration
 	 * @param string $alias
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetMigration')]
 	public function testGetMigration($alias, $expected): void {
 		$this->migrationService = $this->getMockBuilder(MigrationService::class)
 			->onlyMethods(['getMigratedVersions', 'findMigrations'])

--- a/tests/lib/DB/MigratorTest.php
+++ b/tests/lib/DB/MigratorTest.php
@@ -279,13 +279,13 @@ class MigratorTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataNotNullEmptyValuesFailOracle
 	 *
 	 * @param int $parameterType
 	 * @param bool|int|string $value
 	 * @param string $columnType
 	 * @param bool $oracleThrows
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNotNullEmptyValuesFailOracle')]
 	public function testNotNullEmptyValuesFailOracle(int $parameterType, $value, string $columnType, bool $oracleThrows): void {
 		$startSchema = new Schema([], [], $this->getSchemaConfig());
 		$table = $startSchema->createTable($this->tableName);

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -20,7 +20,7 @@ use Test\TestCase;
  * @group DB
  */
 class ExpressionBuilderDBTest extends TestCase {
-	/** @var \Doctrine\DBAL\Connection|\OCP\IDBConnection */
+	/** @var \Doctrine\DBAL\Connection|IDBConnection */
 	protected $connection;
 	protected $schemaSetup = false;
 
@@ -48,12 +48,12 @@ class ExpressionBuilderDBTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider likeProvider
 	 *
 	 * @param string $param1
 	 * @param string $param2
 	 * @param boolean $match
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('likeProvider')]
 	public function testLike($param1, $param2, $match): void {
 		$query = $this->connection->getQueryBuilder();
 
@@ -85,12 +85,12 @@ class ExpressionBuilderDBTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider ilikeProvider
 	 *
 	 * @param string $param1
 	 * @param string $param2
 	 * @param boolean $match
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('ilikeProvider')]
 	public function testILike($param1, $param2, $match): void {
 		$query = $this->connection->getQueryBuilder();
 

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -30,7 +30,7 @@ class ExpressionBuilderTest extends TestCase {
 	/** @var DoctrineExpressionBuilder */
 	protected $doctrineExpressionBuilder;
 
-	/** @var \OCP\IDBConnection */
+	/** @var IDBConnection */
 	protected $connection;
 
 	/** @var \Doctrine\DBAL\Connection */
@@ -67,7 +67,6 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataComparison
 	 *
 	 * @param string $comparison
 	 * @param mixed $input1
@@ -75,6 +74,7 @@ class ExpressionBuilderTest extends TestCase {
 	 * @param mixed $input2
 	 * @param bool $isInput2Literal
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataComparison')]
 	public function testComparison($comparison, $input1, $isInput1Literal, $input2, $isInput2Literal): void {
 		[$doctrineInput1, $ocInput1] = $this->helpWithLiteral($input1, $isInput1Literal);
 		[$doctrineInput2, $ocInput2] = $this->helpWithLiteral($input2, $isInput2Literal);
@@ -95,13 +95,13 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataComparisons
 	 *
 	 * @param mixed $input1
 	 * @param bool $isInput1Literal
 	 * @param mixed $input2
 	 * @param bool $isInput2Literal
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataComparisons')]
 	public function testEquals($input1, $isInput1Literal, $input2, $isInput2Literal): void {
 		[$doctrineInput1, $ocInput1] = $this->helpWithLiteral($input1, $isInput1Literal);
 		[$doctrineInput2, $ocInput2] = $this->helpWithLiteral($input2, $isInput2Literal);
@@ -113,13 +113,13 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataComparisons
 	 *
 	 * @param mixed $input1
 	 * @param bool $isInput1Literal
 	 * @param mixed $input2
 	 * @param bool $isInput2Literal
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataComparisons')]
 	public function testNotEquals($input1, $isInput1Literal, $input2, $isInput2Literal): void {
 		[$doctrineInput1, $ocInput1] = $this->helpWithLiteral($input1, $isInput1Literal);
 		[$doctrineInput2, $ocInput2] = $this->helpWithLiteral($input2, $isInput2Literal);
@@ -131,13 +131,13 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataComparisons
 	 *
 	 * @param mixed $input1
 	 * @param bool $isInput1Literal
 	 * @param mixed $input2
 	 * @param bool $isInput2Literal
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataComparisons')]
 	public function testLowerThan($input1, $isInput1Literal, $input2, $isInput2Literal): void {
 		[$doctrineInput1, $ocInput1] = $this->helpWithLiteral($input1, $isInput1Literal);
 		[$doctrineInput2, $ocInput2] = $this->helpWithLiteral($input2, $isInput2Literal);
@@ -149,13 +149,13 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataComparisons
 	 *
 	 * @param mixed $input1
 	 * @param bool $isInput1Literal
 	 * @param mixed $input2
 	 * @param bool $isInput2Literal
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataComparisons')]
 	public function testLowerThanEquals($input1, $isInput1Literal, $input2, $isInput2Literal): void {
 		[$doctrineInput1, $ocInput1] = $this->helpWithLiteral($input1, $isInput1Literal);
 		[$doctrineInput2, $ocInput2] = $this->helpWithLiteral($input2, $isInput2Literal);
@@ -167,13 +167,13 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataComparisons
 	 *
 	 * @param mixed $input1
 	 * @param bool $isInput1Literal
 	 * @param mixed $input2
 	 * @param bool $isInput2Literal
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataComparisons')]
 	public function testGreaterThan($input1, $isInput1Literal, $input2, $isInput2Literal): void {
 		[$doctrineInput1, $ocInput1] = $this->helpWithLiteral($input1, $isInput1Literal);
 		[$doctrineInput2, $ocInput2] = $this->helpWithLiteral($input2, $isInput2Literal);
@@ -185,13 +185,13 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataComparisons
 	 *
 	 * @param mixed $input1
 	 * @param bool $isInput1Literal
 	 * @param mixed $input2
 	 * @param bool $isInput2Literal
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataComparisons')]
 	public function testGreaterThanEquals($input1, $isInput1Literal, $input2, $isInput2Literal): void {
 		[$doctrineInput1, $ocInput1] = $this->helpWithLiteral($input1, $isInput1Literal);
 		[$doctrineInput2, $ocInput2] = $this->helpWithLiteral($input2, $isInput2Literal);
@@ -224,11 +224,11 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataLike
 	 *
 	 * @param mixed $input
 	 * @param bool $isLiteral
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLike')]
 	public function testLike($input, $isLiteral): void {
 		[$doctrineInput, $ocInput] = $this->helpWithLiteral($input, $isLiteral);
 
@@ -239,11 +239,11 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataLike
 	 *
 	 * @param mixed $input
 	 * @param bool $isLiteral
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLike')]
 	public function testNotLike($input, $isLiteral): void {
 		[$doctrineInput, $ocInput] = $this->helpWithLiteral($input, $isLiteral);
 
@@ -263,11 +263,11 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIn
 	 *
 	 * @param mixed $input
 	 * @param bool $isLiteral
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIn')]
 	public function testIn($input, $isLiteral): void {
 		[$doctrineInput, $ocInput] = $this->helpWithLiteral($input, $isLiteral);
 
@@ -278,11 +278,11 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIn
 	 *
 	 * @param mixed $input
 	 * @param bool $isLiteral
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIn')]
 	public function testNotIn($input, $isLiteral): void {
 		[$doctrineInput, $ocInput] = $this->helpWithLiteral($input, $isLiteral);
 
@@ -332,11 +332,11 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataLiteral
 	 *
 	 * @param mixed $input
 	 * @param string|null $type
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLiteral')]
 	public function testLiteral($input, $type): void {
 		/** @var \OC\DB\QueryBuilder\Literal $actual */
 		$actual = $this->expressionBuilder->literal($input, $type);
@@ -376,13 +376,13 @@ class ExpressionBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataClobComparisons
 	 * @param string $function
 	 * @param mixed $value
 	 * @param mixed $type
 	 * @param bool $compareKeyToValue
 	 * @param int $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataClobComparisons')]
 	public function testClobComparisons($function, $value, $type, $compareKeyToValue, $expected): void {
 		$appId = $this->getUniqueID('testing');
 		$this->createConfig($appId, 1, 4);

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -21,7 +21,7 @@ use Test\TestCase;
  * @package Test\DB\QueryBuilder
  */
 class FunctionBuilderTest extends TestCase {
-	/** @var \Doctrine\DBAL\Connection|\OCP\IDBConnection */
+	/** @var \Doctrine\DBAL\Connection|IDBConnection */
 	protected $connection;
 
 	protected function setUp(): void {
@@ -30,9 +30,7 @@ class FunctionBuilderTest extends TestCase {
 		$this->connection = Server::get(IDBConnection::class);
 	}
 
-	/**
-	 * @dataProvider providerTestConcatString
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providerTestConcatString')]
 	public function testConcatString($closure): void {
 		$query = $this->connection->getQueryBuilder();
 		[$real, $arguments, $return] = $closure($query);
@@ -335,9 +333,7 @@ class FunctionBuilderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider octetLengthProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('octetLengthProvider')]
 	public function testOctetLength(string $str, int $bytes): void {
 		$query = $this->connection->getQueryBuilder();
 
@@ -360,9 +356,7 @@ class FunctionBuilderTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider charLengthProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('charLengthProvider')]
 	public function testCharLength(string $str, int $bytes): void {
 		$query = $this->connection->getQueryBuilder();
 

--- a/tests/lib/DB/QueryBuilder/Partitioned/JoinConditionTest.php
+++ b/tests/lib/DB/QueryBuilder/Partitioned/JoinConditionTest.php
@@ -41,9 +41,7 @@ class JoinConditionTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider platformProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('platformProvider')]
 	public function testParseCondition(string $platform): void {
 		$query = $this->getBuilder($platform);
 		$param1 = $query->createNamedParameter('files');
@@ -63,9 +61,7 @@ class JoinConditionTest extends TestCase {
 		], $parsed->toConditions);
 	}
 
-	/**
-	 * @dataProvider platformProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('platformProvider')]
 	public function testParseCastCondition(string $platform): void {
 		$query = $this->getBuilder($platform);
 

--- a/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/QueryBuilderTest.php
@@ -100,11 +100,11 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFirstResult
 	 *
 	 * @param int|null $firstResult
 	 * @param array $expectedSet
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFirstResult')]
 	public function testFirstResult($firstResult, $expectedSet): void {
 		$this->deleteTestingRows();
 		$this->createTestingRows();
@@ -137,11 +137,11 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataMaxResults
 	 *
 	 * @param int $maxResult
 	 * @param array $expectedSet
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataMaxResults')]
 	public function testMaxResults($maxResult, $expectedSet): void {
 		$this->deleteTestingRows();
 		$this->createTestingRows();
@@ -189,12 +189,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSelect
 	 *
 	 * @param array $selectArguments
 	 * @param array $expected
 	 * @param string $expectedLiteral
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSelect')]
 	public function testSelect($selectArguments, $expected, $expectedLiteral = ''): void {
 		$this->deleteTestingRows();
 		$this->createTestingRows();
@@ -242,12 +242,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSelectAlias
 	 *
 	 * @param mixed $select
 	 * @param array $alias
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSelectAlias')]
 	public function testSelectAlias($select, $alias, $expected): void {
 		$this->deleteTestingRows();
 		$this->createTestingRows();
@@ -366,12 +366,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataAddSelect
 	 *
 	 * @param array $selectArguments
 	 * @param array $expected
 	 * @param string $expectedLiteral
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAddSelect')]
 	public function testAddSelect($selectArguments, $expected, $expectedLiteral = ''): void {
 		$this->deleteTestingRows();
 		$this->createTestingRows();
@@ -418,13 +418,13 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDelete
 	 *
 	 * @param string $tableName
 	 * @param string $tableAlias
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDelete')]
 	public function testDelete($tableName, $tableAlias, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->delete($tableName, $tableAlias);
 
@@ -447,13 +447,13 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataUpdate
 	 *
 	 * @param string $tableName
 	 * @param string $tableAlias
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUpdate')]
 	public function testUpdate($tableName, $tableAlias, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->update($tableName, $tableAlias);
 
@@ -475,12 +475,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataInsert
 	 *
 	 * @param string $tableName
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataInsert')]
 	public function testInsert($tableName, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->insert($tableName);
 
@@ -517,7 +517,6 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFrom
 	 *
 	 * @param string|IQueryFunction $table1Name
 	 * @param string $table1Alias
@@ -526,6 +525,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFrom')]
 	public function testFrom($table1Name, $table1Alias, $table2Name, $table2Alias, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->from($table1Name, $table1Alias);
 		if ($table2Name !== null) {
@@ -565,7 +565,6 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataJoin
 	 *
 	 * @param string $fromAlias
 	 * @param string $tableName
@@ -574,6 +573,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataJoin')]
 	public function testJoin($fromAlias, $tableName, $tableAlias, $condition, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->from('data1', 'd1');
 		$this->queryBuilder->join(
@@ -595,7 +595,6 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataJoin
 	 *
 	 * @param string $fromAlias
 	 * @param string $tableName
@@ -604,6 +603,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataJoin')]
 	public function testInnerJoin($fromAlias, $tableName, $tableAlias, $condition, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->from('data1', 'd1');
 		$this->queryBuilder->innerJoin(
@@ -645,7 +645,6 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataLeftJoin
 	 *
 	 * @param string $fromAlias
 	 * @param string $tableName
@@ -654,6 +653,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLeftJoin')]
 	public function testLeftJoin($fromAlias, $tableName, $tableAlias, $condition, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->from('data1', 'd1');
 		$this->queryBuilder->leftJoin(
@@ -695,7 +695,6 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataRightJoin
 	 *
 	 * @param string $fromAlias
 	 * @param string $tableName
@@ -704,6 +703,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataRightJoin')]
 	public function testRightJoin($fromAlias, $tableName, $tableAlias, $condition, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->from('data1', 'd1');
 		$this->queryBuilder->rightJoin(
@@ -734,7 +734,6 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSet
 	 *
 	 * @param string $partOne1
 	 * @param string $partOne2
@@ -743,6 +742,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSet')]
 	public function testSet($partOne1, $partOne2, $partTwo1, $partTwo2, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->update('data');
 		$this->queryBuilder->set($partOne1, $partOne2);
@@ -769,12 +769,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataWhere
 	 *
 	 * @param array $whereArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataWhere')]
 	public function testWhere($whereArguments, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->select('column');
 		call_user_func_array(
@@ -794,12 +794,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataWhere
 	 *
 	 * @param array $whereArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataWhere')]
 	public function testAndWhere($whereArguments, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->select('column');
 		call_user_func_array(
@@ -826,12 +826,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataOrWhere
 	 *
 	 * @param array $whereArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataOrWhere')]
 	public function testOrWhere($whereArguments, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->select('column');
 		call_user_func_array(
@@ -858,12 +858,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGroupBy
 	 *
 	 * @param array $groupByArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGroupBy')]
 	public function testGroupBy($groupByArguments, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->select('column');
 		call_user_func_array(
@@ -890,12 +890,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataAddGroupBy
 	 *
 	 * @param array $groupByArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAddGroupBy')]
 	public function testAddGroupBy($groupByArguments, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->select('column');
 		$this->queryBuilder->groupBy('column1');
@@ -922,13 +922,13 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetValue
 	 *
 	 * @param string $column
 	 * @param string $value
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetValue')]
 	public function testSetValue($column, $value, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->insert('data');
 		$this->queryBuilder->setValue($column, $value);
@@ -945,13 +945,13 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetValue
 	 *
 	 * @param string $column
 	 * @param string $value
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetValue')]
 	public function testValues($column, $value, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->insert('data');
 		$this->queryBuilder->values([
@@ -987,12 +987,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataHaving
 	 *
 	 * @param array $havingArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataHaving')]
 	public function testHaving($havingArguments, $expectedQueryPart, $expectedQuery): void {
 		call_user_func_array(
 			[$this->queryBuilder, 'having'],
@@ -1028,12 +1028,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataAndHaving
 	 *
 	 * @param array $havingArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAndHaving')]
 	public function testAndHaving($havingArguments, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->having('condition1');
 		call_user_func_array(
@@ -1070,12 +1070,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataOrHaving
 	 *
 	 * @param array $havingArguments
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataOrHaving')]
 	public function testOrHaving($havingArguments, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->having('condition1');
 		call_user_func_array(
@@ -1103,13 +1103,13 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataOrderBy
 	 *
 	 * @param string $sort
 	 * @param string $order
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataOrderBy')]
 	public function testOrderBy($sort, $order, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->orderBy($sort, $order);
 
@@ -1139,7 +1139,6 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataAddOrderBy
 	 *
 	 * @param string $sort2
 	 * @param string $order2
@@ -1147,6 +1146,7 @@ class QueryBuilderTest extends \Test\TestCase {
 	 * @param array $expectedQueryPart
 	 * @param string $expectedQuery
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataAddOrderBy')]
 	public function testAddOrderBy($sort2, $order2, $order1, $expectedQueryPart, $expectedQuery): void {
 		$this->queryBuilder->orderBy('column1', $order1);
 		$this->queryBuilder->addOrderBy($sort2, $order2);
@@ -1219,12 +1219,12 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetTableName
 	 *
 	 * @param string|IQueryFunction $tableName
 	 * @param bool $automatic
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetTableName')]
 	public function testGetTableName($tableName, $automatic, $expected): void {
 		if ($automatic !== null) {
 			$this->queryBuilder->automaticTablePrefix($automatic);
@@ -1244,11 +1244,11 @@ class QueryBuilderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetColumnName
 	 * @param string $column
 	 * @param string $prefix
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetColumnName')]
 	public function testGetColumnName($column, $prefix, $expected): void {
 		$this->assertSame(
 			$expected,

--- a/tests/lib/DB/QueryBuilder/QuoteHelperTest.php
+++ b/tests/lib/DB/QueryBuilder/QuoteHelperTest.php
@@ -38,10 +38,10 @@ class QuoteHelperTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataQuoteColumnName
 	 * @param mixed $input
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataQuoteColumnName')]
 	public function testQuoteColumnName($input, $expected): void {
 		$this->assertSame(
 			$expected,
@@ -73,10 +73,10 @@ class QuoteHelperTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataQuoteColumnNames
 	 * @param mixed $input
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataQuoteColumnNames')]
 	public function testQuoteColumnNames($input, $expected): void {
 		$this->assertSame(
 			$expected,

--- a/tests/lib/DateTimeFormatterTest.php
+++ b/tests/lib/DateTimeFormatterTest.php
@@ -78,9 +78,7 @@ class DateTimeFormatterTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider formatTimeSpanData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('formatTimeSpanData')]
 	public function testFormatTimeSpan($expected, $timestamp, $compare, $locale = null): void {
 		$this->assertEquals((string)$expected, (string)$this->formatter->formatTimeSpan($timestamp, $compare, $locale));
 	}
@@ -144,9 +142,7 @@ class DateTimeFormatterTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider formatDateSpanData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('formatDateSpanData')]
 	public function testFormatDateSpan($expected, $timestamp, $compare = null, $locale = null): void {
 		$this->assertEquals((string)$expected, (string)$this->formatter->formatDateSpan($timestamp, $compare, $locale));
 	}
@@ -157,9 +153,7 @@ class DateTimeFormatterTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider formatDateData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('formatDateData')]
 	public function testFormatDate($timestamp, $expected): void {
 		$this->assertEquals($expected, (string)$this->formatter->formatDate($timestamp));
 	}
@@ -171,9 +165,7 @@ class DateTimeFormatterTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider formatDateTimeData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('formatDateTimeData')]
 	public function testFormatDateTime($timestamp, $timeZone, $expected): void {
 		$this->assertEquals($expected, (string)$this->formatter->formatDateTime($timestamp, 'long', 'long', $timeZone));
 	}

--- a/tests/lib/EmojiHelperTest.php
+++ b/tests/lib/EmojiHelperTest.php
@@ -27,9 +27,8 @@ class EmojiHelperTest extends TestCase {
 	/**
 	 * @param bool $supports4ByteText
 	 * @param bool $expected
-	 *
-	 * @dataProvider doesPlatformSupportEmojiDataProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('doesPlatformSupportEmojiDataProvider')]
 	public function testDoesPlatformSupportEmoji(bool $supports4ByteText, bool $expected): void {
 		$this->db->expects($this->once())
 			->method('supports4ByteText')
@@ -48,9 +47,8 @@ class EmojiHelperTest extends TestCase {
 	/**
 	 * @param string $emoji
 	 * @param bool $expected
-	 *
-	 * @dataProvider isValidSingleEmojiDataProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('isValidSingleEmojiDataProvider')]
 	public function testIsValidSingleEmoji(string $emoji, bool $expected): void {
 		$actual = $this->helper->isValidSingleEmoji($emoji);
 

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -45,7 +45,7 @@ class DecryptAllTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Output\OutputInterface */
 	protected $outputInterface;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\UserInterface */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|UserInterface */
 	protected $userInterface;
 
 	/** @var DecryptAll */
@@ -94,11 +94,11 @@ class DecryptAllTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDecryptAll
 	 * @param bool $prepareResult
 	 * @param string $user
 	 * @param bool $userExistsChecked
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDecryptAll')]
 	public function testDecryptAll($prepareResult, $user, $userExistsChecked): void {
 		if ($userExistsChecked) {
 			$this->userManager->expects($this->once())->method('userExists')->willReturn(true);
@@ -154,9 +154,9 @@ class DecryptAllTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTrueFalse
 	 * @param bool $success
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTrueFalse')]
 	public function testPrepareEncryptionModules($success): void {
 		$user = 'user1';
 
@@ -186,9 +186,7 @@ class DecryptAllTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataTestDecryptAllUsersFiles
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDecryptAllUsersFiles')]
 	public function testDecryptAllUsersFiles($user): void {
 		/** @var DecryptAll | \PHPUnit\Framework\MockObject\MockObject |  $instance */
 		$instance = $this->getMockBuilder('OC\Encryption\DecryptAll')
@@ -318,9 +316,7 @@ class DecryptAllTest extends TestCase {
 		$this->invokePrivate($instance, 'decryptUsersFiles', ['user1', $progressBar, '']);
 	}
 
-	/**
-	 * @dataProvider dataTrueFalse
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTrueFalse')]
 	public function testDecryptFile($isEncrypted): void {
 		$path = 'test.txt';
 

--- a/tests/lib/Encryption/EncryptionWrapperTest.php
+++ b/tests/lib/Encryption/EncryptionWrapperTest.php
@@ -29,7 +29,7 @@ class EncryptionWrapperTest extends TestCase {
 	/** @var \PHPUnit\Framework\MockObject\MockObject | \OC\Encryption\Manager */
 	private $manager;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OC\Memcache\ArrayCache */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|ArrayCache */
 	private $arrayCache;
 
 	protected function setUp(): void {
@@ -43,9 +43,7 @@ class EncryptionWrapperTest extends TestCase {
 	}
 
 
-	/**
-	 * @dataProvider provideWrapStorage
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideWrapStorage')]
 	public function testWrapStorage($expectedWrapped, $wrappedStorages): void {
 		$storage = $this->getMockBuilder(IStorage::class)
 			->disableOriginalConstructor()

--- a/tests/lib/Encryption/Keys/StorageTest.php
+++ b/tests/lib/Encryption/Keys/StorageTest.php
@@ -124,13 +124,13 @@ class StorageTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetFileKey
 	 *
 	 * @param string $path
 	 * @param string $strippedPartialName
 	 * @param bool $originalKeyExists
 	 * @param string $expectedKeyContent
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetFileKey')]
 	public function testGetFileKey($path, $strippedPartialName, $originalKeyExists, $expectedKeyContent): void {
 		$this->config->method('getSystemValueString')
 			->with('version')
@@ -408,9 +408,7 @@ class StorageTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataProviderCopyRename
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderCopyRename')]
 	public function testRenameKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget): void {
 		$this->view->expects($this->any())
 			->method('file_exists')
@@ -439,9 +437,7 @@ class StorageTest extends TestCase {
 		$this->storage->renameKeys($source, $target);
 	}
 
-	/**
-	 * @dataProvider dataProviderCopyRename
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderCopyRename')]
 	public function testCopyKeys($source, $target, $systemWideMountSource, $systemWideMountTarget, $expectedSource, $expectedTarget): void {
 		$this->view->expects($this->any())
 			->method('file_exists')
@@ -510,13 +506,13 @@ class StorageTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetPathToKeys
 	 *
 	 * @param string $path
 	 * @param boolean $systemWideMountPoint
 	 * @param string $storageRoot
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetPathToKeys')]
 	public function testGetPathToKeys($path, $systemWideMountPoint, $storageRoot, $expected): void {
 		$this->invokePrivate($this->storage, 'root_dir', [$storageRoot]);
 
@@ -569,9 +565,9 @@ class StorageTest extends TestCase {
 
 
 	/**
-	 * @dataProvider dataTestBackupUserKeys
 	 * @param bool $createBackupDir
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestBackupUserKeys')]
 	public function testBackupUserKeys($createBackupDir): void {
 		$storage = $this->getMockBuilder('OC\Encryption\Keys\Storage')
 			->setConstructorArgs([$this->view, $this->util, $this->crypto, $this->config])

--- a/tests/lib/Encryption/ManagerTest.php
+++ b/tests/lib/Encryption/ManagerTest.php
@@ -266,7 +266,7 @@ class ManagerTest extends TestCase {
 		$encryptionModule->expects($this->any())
 			->method('getDisplayName')
 			->willReturn('TestDummyModule' . $id);
-		/** @var \OCP\Encryption\IEncryptionModule $encryptionModule */
+		/** @var IEncryptionModule $encryptionModule */
 		$manager->registerEncryptionModule('ID' . $id, 'TestDummyModule' . $id, function () use ($encryptionModule) {
 			return $encryptionModule;
 		});

--- a/tests/lib/Encryption/UpdateTest.php
+++ b/tests/lib/Encryption/UpdateTest.php
@@ -77,13 +77,13 @@ class UpdateTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestUpdate
 	 *
 	 * @param string $path
 	 * @param boolean $isDir
 	 * @param array $allFiles
 	 * @param integer $numberOfFiles
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestUpdate')]
 	public function testUpdate($path, $isDir, $allFiles, $numberOfFiles): void {
 		$updateMock = $this->getUpdateMock(['getOwnerPath']);
 		$updateMock->expects($this->once())->method('getOwnerPath')
@@ -121,11 +121,11 @@ class UpdateTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestPostRename
 	 *
 	 * @param string $source
 	 * @param string $target
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestPostRename')]
 	public function testPostRename($source, $target): void {
 		$updateMock = $this->getUpdateMock(['update','getOwnerPath']);
 

--- a/tests/lib/Encryption/UtilTest.php
+++ b/tests/lib/Encryption/UtilTest.php
@@ -55,9 +55,7 @@ class UtilTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider providesHeadersForEncryptionModule
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesHeadersForEncryptionModule')]
 	public function testGetEncryptionModuleId($expected, $header): void {
 		$id = $this->util->getEncryptionModuleId($header);
 		$this->assertEquals($expected, $id);
@@ -71,9 +69,7 @@ class UtilTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesHeaders
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesHeaders')]
 	public function testCreateHeader($expected, $header, $moduleId): void {
 		$em = $this->createMock(IEncryptionModule::class);
 		$em->expects($this->any())->method('getId')->willReturn($moduleId);
@@ -104,9 +100,7 @@ class UtilTest extends TestCase {
 		$this->util->createHeader($header, $em);
 	}
 
-	/**
-	 * @dataProvider providePathsForTestIsExcluded
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providePathsForTestIsExcluded')]
 	public function testIsExcluded($path, $keyStorageRoot, $expected): void {
 		$this->config->expects($this->once())
 			->method('getAppValue')
@@ -145,9 +139,7 @@ class UtilTest extends TestCase {
 		return false;
 	}
 
-	/**
-	 * @dataProvider dataTestIsFile
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsFile')]
 	public function testIsFile($path, $expected): void {
 		$this->assertSame($expected,
 			$this->util->isFile($path)
@@ -167,11 +159,11 @@ class UtilTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestStripPartialFileExtension
 	 *
 	 * @param string $path
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestStripPartialFileExtension')]
 	public function testStripPartialFileExtension($path, $expected): void {
 		$this->assertSame($expected,
 			$this->util->stripPartialFileExtension($path));
@@ -186,9 +178,7 @@ class UtilTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestParseRawHeader
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestParseRawHeader')]
 	public function testParseRawHeader($rawHeader, $expected): void {
 		$result = $this->util->parseRawHeader($rawHeader);
 		$this->assertSameSize($expected, $result);
@@ -214,12 +204,12 @@ class UtilTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetFileKeyDir
 	 *
 	 * @param bool $isSystemWideMountPoint
 	 * @param string $storageRoot
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetFileKeyDir')]
 	public function testGetFileKeyDir($isSystemWideMountPoint, $storageRoot, $expected): void {
 		$path = '/user1/files/foo/bar.txt';
 		$owner = 'user1';

--- a/tests/lib/ErrorHandlerTest.php
+++ b/tests/lib/ErrorHandlerTest.php
@@ -55,10 +55,10 @@ class ErrorHandlerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider passwordProvider
 	 * @param string $username
 	 * @param string $password
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('passwordProvider')]
 	public function testRemovePasswordFromError($username, $password): void {
 		$url = 'http://' . $username . ':' . $password . '@owncloud.org';
 		$expectedResult = 'http://xxx:xxx@owncloud.org';

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -65,9 +65,7 @@ class CloudIdManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetDisplayNameFromContact
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetDisplayNameFromContact')]
 	public function testGetDisplayNameFromContact(string $cloudId, ?string $displayName, ?string $expected): void {
 		$returnedContact = [
 			'CLOUD' => [$cloudId],
@@ -98,9 +96,7 @@ class CloudIdManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider cloudIdProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('cloudIdProvider')]
 	public function testResolveCloudId(string $cloudId, string $user, string $noProtocolRemote, string $cleanId): void {
 		$displayName = 'Ample Ex';
 
@@ -130,9 +126,7 @@ class CloudIdManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider invalidCloudIdProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidCloudIdProvider')]
 	public function testInvalidCloudId(string $cloudId): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -154,9 +148,7 @@ class CloudIdManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider getCloudIdProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getCloudIdProvider')]
 	public function testGetCloudId(string $user, ?string $remote, string $id, ?string $searchCloudId = null, ?string $localHost = 'https://example.com', ?string $expectedRemoteId = null): void {
 		if ($remote !== null) {
 			$this->contactsManager->expects($this->any())

--- a/tests/lib/Federation/CloudIdTest.php
+++ b/tests/lib/Federation/CloudIdTest.php
@@ -37,9 +37,7 @@ class CloudIdTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetDisplayCloudId
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetDisplayCloudId')]
 	public function testGetDisplayCloudId(string $id, string $user, string $remote, string $display, ?string $addressbookName = null): void {
 		$this->cloudIdManager->expects($this->once())
 			->method('getDisplayNameFromContact')

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -38,20 +38,20 @@ class LongId extends Temporary {
  */
 class CacheTest extends \Test\TestCase {
 	/**
-	 * @var \OC\Files\Storage\Temporary $storage ;
+	 * @var Temporary $storage ;
 	 */
 	protected $storage;
 	/**
-	 * @var \OC\Files\Storage\Temporary $storage2 ;
+	 * @var Temporary $storage2 ;
 	 */
 	protected $storage2;
 
 	/**
-	 * @var \OC\Files\Cache\Cache $cache
+	 * @var Cache $cache
 	 */
 	protected $cache;
 	/**
-	 * @var \OC\Files\Cache\Cache $cache2
+	 * @var Cache $cache2
 	 */
 	protected $cache2;
 
@@ -162,9 +162,7 @@ class CacheTest extends \Test\TestCase {
 		$this->assertEquals(new CacheEntry(['size' => 12, 'mtime' => 15]), $this->cache->get($file1));
 	}
 
-	/**
-	 * @dataProvider folderDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('folderDataProvider')]
 	public function testFolder($folder): void {
 		if (strpos($folder, 'F09F9890')) {
 			// 4 byte UTF doesn't work on mysql
@@ -335,9 +333,9 @@ class CacheTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider putWithAllKindOfQuotesData
 	 * @param $fileName
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('putWithAllKindOfQuotesData')]
 	public function testPutWithAllKindOfQuotes($fileName): void {
 		$this->assertEquals(Cache::NOT_FOUND, $this->cache->get($fileName));
 		$this->cache->put($fileName, ['size' => 20, 'mtime' => 25, 'mimetype' => 'foo/file', 'etag' => $fileName]);
@@ -470,9 +468,7 @@ class CacheTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider movePathProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('movePathProvider')]
 	public function testMove($sourceFolder, $targetFolder, $children): void {
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/bar'];
 		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
@@ -597,7 +593,7 @@ class CacheTest extends \Test\TestCase {
 		$folderWith0308 = "\x53\x63\x68\x6f\xcc\x88\x6e";
 
 		/**
-		 * @var \OC\Files\Cache\Cache | \PHPUnit\Framework\MockObject\MockObject $cacheMock
+		 * @var Cache|\PHPUnit\Framework\MockObject\MockObject $cacheMock
 		 */
 		$cacheMock = $this->getMockBuilder(Cache::class)
 			->onlyMethods(['normalize'])
@@ -682,9 +678,8 @@ class CacheTest extends \Test\TestCase {
 
 	/**
 	 * Test bogus paths with leading or doubled slashes
-	 *
-	 * @dataProvider bogusPathNamesProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('bogusPathNamesProvider')]
 	public function testBogusPaths($bogusPath, $fixedBogusPath): void {
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
 		$parentId = $this->cache->getId('');
@@ -726,8 +721,8 @@ class CacheTest extends \Test\TestCase {
 
 	/**
 	 * @param string $name
-	 * @dataProvider escapingProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('escapingProvider')]
 	public function testEscaping($name): void {
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain'];
 		$this->cache->put($name, $data);

--- a/tests/lib/Files/Cache/HomeCacheTest.php
+++ b/tests/lib/Files/Cache/HomeCacheTest.php
@@ -58,7 +58,7 @@ class HomeCacheTest extends \Test\TestCase {
 	private $cache;
 
 	/**
-	 * @var \OC\User\User $user
+	 * @var User $user
 	 */
 	private $user;
 

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -386,11 +386,11 @@ class ScannerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestIsPartialFile
 	 *
 	 * @param string $path
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsPartialFile')]
 	public function testIsPartialFile($path, $expected): void {
 		$this->assertSame($expected,
 			$this->scanner->isPartialFile($path)

--- a/tests/lib/Files/Cache/SearchBuilderTest.php
+++ b/tests/lib/Files/Cache/SearchBuilderTest.php
@@ -178,11 +178,11 @@ class SearchBuilderTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider comparisonProvider
 	 *
 	 * @param ISearchOperator $operator
 	 * @param array $fileIds
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('comparisonProvider')]
 	public function testComparison(ISearchOperator $operator, array $fileIds): void {
 		$fileId = [];
 		$fileId[] = $this->addCacheEntry([

--- a/tests/lib/Files/Cache/UpdaterLegacyTest.php
+++ b/tests/lib/Files/Cache/UpdaterLegacyTest.php
@@ -8,7 +8,10 @@
 
 namespace Test\Files\Cache;
 
+use OC\Files\Cache\Cache;
+use OC\Files\Cache\Scanner;
 use OC\Files\Filesystem as Filesystem;
+use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OCP\Files\Mount\IMountManager;
@@ -24,17 +27,17 @@ use OCP\Server;
  */
 class UpdaterLegacyTest extends \Test\TestCase {
 	/**
-	 * @var \OC\Files\Storage\Storage $storage
+	 * @var Storage $storage
 	 */
 	private $storage;
 
 	/**
-	 * @var \OC\Files\Cache\Scanner $scanner
+	 * @var Scanner $scanner
 	 */
 	private $scanner;
 
 	/**
-	 * @var \OC\Files\Cache\Cache $cache
+	 * @var Cache $cache
 	 */
 	private $cache;
 

--- a/tests/lib/Files/Cache/UpdaterTest.php
+++ b/tests/lib/Files/Cache/UpdaterTest.php
@@ -8,10 +8,13 @@
 
 namespace Test\Files\Cache;
 
+use OC\Files\Cache\Cache;
 use OC\Files\Filesystem;
 use OC\Files\ObjectStore\ObjectStoreStorage;
 use OC\Files\ObjectStore\StorageObjectStore;
+use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
+use OC\Files\View;
 use OCP\Files\Storage\IStorage;
 
 /**
@@ -23,17 +26,17 @@ use OCP\Files\Storage\IStorage;
  */
 class UpdaterTest extends \Test\TestCase {
 	/**
-	 * @var \OC\Files\Storage\Storage
+	 * @var Storage
 	 */
 	protected $storage;
 
 	/**
-	 * @var \OC\Files\Cache\Cache
+	 * @var Cache
 	 */
 	protected $cache;
 
 	/**
-	 * @var \OC\Files\View
+	 * @var View
 	 */
 	protected $view;
 
@@ -313,9 +316,7 @@ class UpdaterTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider changeExtensionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('changeExtensionProvider')]
 	public function testChangeExtension(IStorage $storage) {
 		$updater = $storage->getUpdater();
 		$cache = $storage->getCache();

--- a/tests/lib/Files/Cache/WatcherTest.php
+++ b/tests/lib/Files/Cache/WatcherTest.php
@@ -9,6 +9,7 @@
 namespace Test\Files\Cache;
 
 use OC\Files\Cache\Watcher;
+use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 
 /**
@@ -20,7 +21,7 @@ use OC\Files\Storage\Temporary;
  */
 class WatcherTest extends \Test\TestCase {
 	/**
-	 * @var \OC\Files\Storage\Storage[] $storages
+	 * @var Storage[] $storages
 	 */
 	private $storages = [];
 
@@ -176,7 +177,7 @@ class WatcherTest extends \Test\TestCase {
 
 	/**
 	 * @param bool $scan
-	 * @return \OC\Files\Storage\Storage
+	 * @return Storage
 	 */
 	private function getTestStorage($scan = true) {
 		$storage = new Temporary([]);

--- a/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CacheJailTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Files\Cache\Wrapper;
 
+use OC\Files\Cache\Cache;
 use OC\Files\Cache\Wrapper\CacheJail;
 use OC\Files\Cache\Wrapper\CacheWrapper;
 use OC\Files\Search\SearchComparison;
@@ -28,7 +29,7 @@ use Test\Files\Cache\CacheTest;
  */
 class CacheJailTest extends CacheTest {
 	/**
-	 * @var \OC\Files\Cache\Cache $sourceCache
+	 * @var Cache $sourceCache
 	 */
 	protected $sourceCache;
 

--- a/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
+++ b/tests/lib/Files/Cache/Wrapper/CachePermissionsMaskTest.php
@@ -8,6 +8,7 @@
 
 namespace Test\Files\Cache\Wrapper;
 
+use OC\Files\Cache\Cache;
 use OC\Files\Cache\Wrapper\CachePermissionsMask;
 use OCP\Constants;
 use Test\Files\Cache\CacheTest;
@@ -21,7 +22,7 @@ use Test\Files\Cache\CacheTest;
  */
 class CachePermissionsMaskTest extends CacheTest {
 	/**
-	 * @var \OC\Files\Cache\Cache $sourceCache
+	 * @var Cache $sourceCache
 	 */
 	protected $sourceCache;
 
@@ -46,9 +47,9 @@ class CachePermissionsMaskTest extends CacheTest {
 	}
 
 	/**
-	 * @dataProvider maskProvider
 	 * @param int $mask
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
 	public function testGetMasked($mask): void {
 		$cache = $this->getMaskedCached($mask);
 		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'text/plain', 'permissions' => Constants::PERMISSION_ALL];
@@ -63,9 +64,9 @@ class CachePermissionsMaskTest extends CacheTest {
 	}
 
 	/**
-	 * @dataProvider maskProvider
 	 * @param int $mask
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
 	public function testGetFolderContentMasked($mask): void {
 		$this->storage->mkdir('foo');
 		$this->storage->file_put_contents('foo/bar', 'asd');
@@ -82,9 +83,9 @@ class CachePermissionsMaskTest extends CacheTest {
 	}
 
 	/**
-	 * @dataProvider maskProvider
 	 * @param int $mask
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('maskProvider')]
 	public function testSearchMasked($mask): void {
 		$this->storage->mkdir('foo');
 		$this->storage->file_put_contents('foo/bar', 'asd');

--- a/tests/lib/Files/FilenameValidatorTest.php
+++ b/tests/lib/Files/FilenameValidatorTest.php
@@ -48,9 +48,7 @@ class FilenameValidatorTest extends TestCase {
 		$this->database->method('supports4ByteText')->willReturn(true);
 	}
 
-	/**
-	 * @dataProvider dataValidateFilename
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateFilename')]
 	public function testValidateFilename(
 		string $filename,
 		array $forbiddenNames,
@@ -87,9 +85,7 @@ class FilenameValidatorTest extends TestCase {
 		$validator->validateFilename($filename);
 	}
 
-	/**
-	 * @dataProvider dataValidateFilename
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateFilename')]
 	public function testIsFilenameValid(
 		string $filename,
 		array $forbiddenNames,
@@ -189,9 +185,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider data4ByteUnicode
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('data4ByteUnicode')]
 	public function testDatabaseDoesNotSupport4ByteText($filename): void {
 		$database = $this->createMock(IDBConnection::class);
 		$database->expects($this->once())
@@ -209,9 +203,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataInvalidAsciiCharacters
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataInvalidAsciiCharacters')]
 	public function testInvalidAsciiCharactersAreAlwaysForbidden(string $filename): void {
 		$this->expectException(InvalidPathException::class);
 		$validator = new FilenameValidator($this->l10n, $this->database, $this->config, $this->logger);
@@ -255,9 +247,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataIsForbidden
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsForbidden')]
 	public function testIsForbidden(string $filename, array $forbiddenNames, bool $expected): void {
 		/** @var FilenameValidator&MockObject */
 		$validator = $this->getMockBuilder(FilenameValidator::class)
@@ -291,9 +281,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetForbiddenExtensions
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetForbiddenExtensions')]
 	public function testGetForbiddenExtensions(array $configValue, array $expectedValue): void {
 		$validator = new FilenameValidator($this->l10n, $this->database, $this->config, $this->logger);
 		$this->config
@@ -317,9 +305,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetForbiddenFilenames
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetForbiddenFilenames')]
 	public function testGetForbiddenFilenames(array $configValue, array $legacyValue, array $expectedValue): void {
 		$validator = new FilenameValidator($this->l10n, $this->database, $this->config, $this->logger);
 		$this->config
@@ -349,9 +335,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetForbiddenBasenames
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetForbiddenBasenames')]
 	public function testGetForbiddenBasenames(array $configValue, array $expectedValue): void {
 		$validator = new FilenameValidator($this->l10n, $this->database, $this->config, $this->logger);
 		$this->config
@@ -375,9 +359,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSanitizeFilename
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSanitizeFilename')]
 	public function testSanitizeFilename(
 		string $filename,
 		array $forbiddenNames,
@@ -452,9 +434,7 @@ class FilenameValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataSanitizeFilenameCharacterReplacement
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSanitizeFilenameCharacterReplacement')]
 	public function testSanitizeFilenameCharacterReplacement(
 		string $filename,
 		array $forbiddenCharacters,

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -16,6 +16,7 @@ use OC\User\NoUserException;
 use OCP\Files;
 use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IMountProviderCollection;
+use OCP\Files\Mount\IMountPoint;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\ITempManager;
@@ -38,7 +39,7 @@ class DummyMountProvider implements IMountProvider {
 	 *
 	 * @param IUser $user
 	 * @param IStorageFactory $loader
-	 * @return \OCP\Files\Mount\IMountPoint[]
+	 * @return IMountPoint[]
 	 */
 	public function getMountsForUser(IUser $user, IStorageFactory $loader) {
 		return isset($this->mounts[$user->getUID()]) ? $this->mounts[$user->getUID()] : [];
@@ -201,9 +202,7 @@ class FilesystemTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider normalizePathData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('normalizePathData')]
 	public function testNormalizePath($expected, $path, $stripTrailingSlash = true): void {
 		$this->assertEquals($expected, Filesystem::normalizePath($path, $stripTrailingSlash));
 	}
@@ -219,9 +218,7 @@ class FilesystemTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider normalizePathKeepUnicodeData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('normalizePathKeepUnicodeData')]
 	public function testNormalizePathKeepUnicode($expected, $path, $keepUnicode = false): void {
 		$this->assertEquals($expected, Filesystem::normalizePath($path, true, false, $keepUnicode));
 	}
@@ -260,9 +257,7 @@ class FilesystemTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider isValidPathData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('isValidPathData')]
 	public function testIsValidPath($path, $expected): void {
 		$this->assertSame($expected, Filesystem::isValidPath($path));
 	}
@@ -282,9 +277,7 @@ class FilesystemTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider isFileBlacklistedData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('isFileBlacklistedData')]
 	public function testIsFileBlacklisted($path, $expected): void {
 		$this->assertSame($expected, Filesystem::isFileBlacklisted($path));
 	}

--- a/tests/lib/Files/Node/FolderTest.php
+++ b/tests/lib/Files/Node/FolderTest.php
@@ -25,8 +25,10 @@ use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\Jail;
+use OC\Files\View;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
+use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
 use OCP\Files\NotFoundException;
@@ -71,7 +73,7 @@ class FolderTest extends NodeTestCase {
 	public function testGetDirectoryContent(): void {
 		$manager = $this->createMock(Manager::class);
 		/**
-		 * @var \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+		 * @var View|\PHPUnit\Framework\MockObject\MockObject $view
 		 */
 		$root = $this->getMockBuilder(Root::class)
 			->setConstructorArgs([$manager, $this->view, $this->user, $this->userMountCache, $this->logger, $this->userManager, $this->eventDispatcher, $this->cacheFactory])
@@ -694,9 +696,7 @@ class FolderTest extends NodeTestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider uniqueNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('uniqueNameProvider')]
 	public function testGetUniqueName($name, $existingFiles, $expected): void {
 		$manager = $this->createMock(Manager::class);
 		$folderPath = '/bar/foo';
@@ -730,7 +730,7 @@ class FolderTest extends NodeTestCase {
 			->onlyMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache, $this->logger, $this->userManager, $this->eventDispatcher, $this->cacheFactory])
 			->getMock();
-		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Files\FileInfo $folderInfo */
+		/** @var \PHPUnit\Framework\MockObject\MockObject|FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()->getMock();
 
@@ -799,7 +799,7 @@ class FolderTest extends NodeTestCase {
 			->onlyMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache, $this->logger, $this->userManager, $this->eventDispatcher, $this->cacheFactory])
 			->getMock();
-		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Files\FileInfo $folderInfo */
+		/** @var \PHPUnit\Framework\MockObject\MockObject|FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()->getMock();
 
@@ -866,7 +866,7 @@ class FolderTest extends NodeTestCase {
 			->onlyMethods(['getUser', 'getMountsIn', 'getMount'])
 			->setConstructorArgs([$manager, $view, $this->user, $this->userMountCache, $this->logger, $this->userManager, $this->eventDispatcher, $this->cacheFactory])
 			->getMock();
-		/** @var \PHPUnit\Framework\MockObject\MockObject|\OC\Files\FileInfo $folderInfo */
+		/** @var \PHPUnit\Framework\MockObject\MockObject|FileInfo $folderInfo */
 		$folderInfo = $this->getMockBuilder(FileInfo::class)
 			->disableOriginalConstructor()->getMock();
 
@@ -935,14 +935,14 @@ class FolderTest extends NodeTestCase {
 	}
 
 	/**
-	 * @dataProvider offsetLimitProvider
 	 * @param int $offset
 	 * @param int $limit
 	 * @param string[] $expectedPaths
 	 * @param ISearchOrder[] $ordering
 	 * @throws NotFoundException
-	 * @throws \OCP\Files\InvalidPathException
+	 * @throws InvalidPathException
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('offsetLimitProvider')]
 	public function testSearchSubStoragesLimitOffset(int $offset, int $limit, array $expectedPaths, array $ordering): void {
 		if (!$ordering) {
 			$ordering = [new SearchOrder(ISearchOrder::DIRECTION_ASCENDING, 'fileid')];

--- a/tests/lib/Files/Node/HookConnectorTest.php
+++ b/tests/lib/Files/Node/HookConnectorTest.php
@@ -153,8 +153,8 @@ class HookConnectorTest extends TestCase {
 	/**
 	 * @param callable $operation
 	 * @param string $expectedHook
-	 * @dataProvider viewToNodeProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('viewToNodeProvider')]
 	public function testViewToNode(callable $operation, $expectedHook, $expectedLegacyEvent, $expectedEvent): void {
 		$connector = new HookConnector($this->root, $this->view, $this->eventDispatcher, $this->logger);
 		$connector->viewToNode();
@@ -222,8 +222,8 @@ class HookConnectorTest extends TestCase {
 	/**
 	 * @param callable $operation
 	 * @param string $expectedHook
-	 * @dataProvider viewToNodeProviderCopyRename
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('viewToNodeProviderCopyRename')]
 	public function testViewToNodeCopyRename(callable $operation, $expectedHook, $expectedLegacyEvent, $expectedEvent): void {
 		$connector = new HookConnector($this->root, $this->view, $this->eventDispatcher, $this->logger);
 		$connector->viewToNode();

--- a/tests/lib/Files/Node/IntegrationTest.php
+++ b/tests/lib/Files/Node/IntegrationTest.php
@@ -9,6 +9,7 @@
 namespace Test\Files\Node;
 
 use OC\Files\Node\Root;
+use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\Memcache\ArrayCache;
@@ -37,12 +38,12 @@ class IntegrationTest extends \Test\TestCase {
 	private $root;
 
 	/**
-	 * @var \OC\Files\Storage\Storage[]
+	 * @var Storage[]
 	 */
 	private $storages;
 
 	/**
-	 * @var \OC\Files\View $view
+	 * @var View $view
 	 */
 	private $view;
 

--- a/tests/lib/Files/Node/NodeTestCase.php
+++ b/tests/lib/Files/Node/NodeTestCase.php
@@ -13,10 +13,13 @@ use OC\Files\Mount\Manager;
 use OC\Files\Node\File;
 use OC\Files\Node\Folder;
 use OC\Files\Node\Root;
+use OC\Files\Storage\Storage;
 use OC\Files\View;
 use OC\Memcache\ArrayCache;
+use OC\User\User;
 use OCP\Constants;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\InvalidPathException;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountPoint;
@@ -35,15 +38,15 @@ use Psr\Log\LoggerInterface;
  * @package Test\Files\Node
  */
 abstract class NodeTestCase extends \Test\TestCase {
-	/** @var \OC\User\User */
+	/** @var User */
 	protected $user;
 	/** @var \OC\Files\Mount\Manager */
 	protected $manager;
-	/** @var \OC\Files\View|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var View|\PHPUnit\Framework\MockObject\MockObject */
 	protected $view;
 	/** @var \OC\Files\Node\Root|\PHPUnit\Framework\MockObject\MockObject */
 	protected $root;
-	/** @var \OCP\Files\Config\IUserMountCache|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserMountCache|\PHPUnit\Framework\MockObject\MockObject */
 	protected $userMountCache;
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	protected $logger;
@@ -84,7 +87,7 @@ abstract class NodeTestCase extends \Test\TestCase {
 	}
 
 	/**
-	 * @return \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+	 * @return View|\PHPUnit\Framework\MockObject\MockObject $view
 	 */
 	protected function getRootViewMock() {
 		$view = $this->createMock(View::class);
@@ -341,7 +344,7 @@ abstract class NodeTestCase extends \Test\TestCase {
 			->method('getUser')
 			->willReturn($this->user);
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
+		 * @var Storage|\PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()
@@ -365,7 +368,7 @@ abstract class NodeTestCase extends \Test\TestCase {
 			->method('getUser')
 			->willReturn($this->user);
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
+		 * @var Storage|\PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()
@@ -514,7 +517,7 @@ abstract class NodeTestCase extends \Test\TestCase {
 		$this->expectException(NotPermittedException::class);
 
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
+		 * @var Storage|\PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->createMock('\OC\Files\Storage\Storage');
 
@@ -607,12 +610,12 @@ abstract class NodeTestCase extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider moveOrCopyProvider
 	 * @param string $operationMethod
 	 * @param string $viewMethod
 	 * @param string $preHookName
 	 * @param string $postHookName
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('moveOrCopyProvider')]
 	public function testMoveCopyHooks($operationMethod, $viewMethod, $preHookName, $postHookName): void {
 		/** @var IRootFolder|\PHPUnit\Framework\MockObject\MockObject $root */
 		$root = $this->getMockBuilder(Root::class)
@@ -707,7 +710,7 @@ abstract class NodeTestCase extends \Test\TestCase {
 		$this->expectException(NotFoundException::class);
 
 		/**
-		 * @var \OC\Files\Storage\Storage | \PHPUnit\Framework\MockObject\MockObject $storage
+		 * @var Storage|\PHPUnit\Framework\MockObject\MockObject $storage
 		 */
 		$storage = $this->createMock('\OC\Files\Storage\Storage');
 

--- a/tests/lib/Files/Node/RootTest.php
+++ b/tests/lib/Files/Node/RootTest.php
@@ -12,11 +12,14 @@ use OC\Files\FileInfo;
 use OC\Files\Mount\Manager;
 use OC\Files\Node\Folder;
 use OC\Files\Node\Root;
+use OC\Files\Storage\Storage;
 use OC\Files\View;
 use OC\Memcache\ArrayCache;
 use OC\User\NoUserException;
+use OC\User\User;
 use OCP\Cache\CappedMemoryCache;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Files\Config\IUserMountCache;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\ICacheFactory;
@@ -30,11 +33,11 @@ use Psr\Log\LoggerInterface;
  * @package Test\Files\Node
  */
 class RootTest extends \Test\TestCase {
-	/** @var \OC\User\User */
+	/** @var User */
 	private $user;
 	/** @var \OC\Files\Mount\Manager */
 	private $manager;
-	/** @var \OCP\Files\Config\IUserMountCache|\PHPUnit\Framework\MockObject\MockObject */
+	/** @var IUserMountCache|\PHPUnit\Framework\MockObject\MockObject */
 	private $userMountCache;
 	/** @var LoggerInterface|\PHPUnit\Framework\MockObject\MockObject */
 	private $logger;
@@ -66,7 +69,7 @@ class RootTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @return \OC\Files\View | \PHPUnit\Framework\MockObject\MockObject $view
+	 * @return View|\PHPUnit\Framework\MockObject\MockObject $view
 	 */
 	protected function getRootViewMock() {
 		$view = $this->createMock(View::class);
@@ -82,7 +85,7 @@ class RootTest extends \Test\TestCase {
 
 	public function testGet(): void {
 		/**
-		 * @var \OC\Files\Storage\Storage $storage
+		 * @var Storage $storage
 		 */
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()
@@ -115,7 +118,7 @@ class RootTest extends \Test\TestCase {
 		$this->expectException(NotFoundException::class);
 
 		/**
-		 * @var \OC\Files\Storage\Storage $storage
+		 * @var Storage $storage
 		 */
 		$storage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()

--- a/tests/lib/Files/ObjectStore/FailDeleteObjectStore.php
+++ b/tests/lib/Files/ObjectStore/FailDeleteObjectStore.php
@@ -11,10 +11,9 @@ namespace Test\Files\ObjectStore;
 use OCP\Files\ObjectStore\IObjectStore;
 
 class FailDeleteObjectStore implements IObjectStore {
-	private $objectStore;
-
-	public function __construct(IObjectStore $objectStore) {
-		$this->objectStore = $objectStore;
+	public function __construct(
+		private IObjectStore $objectStore,
+	) {
 	}
 
 	public function getStorageId() {

--- a/tests/lib/Files/ObjectStore/FailWriteObjectStore.php
+++ b/tests/lib/Files/ObjectStore/FailWriteObjectStore.php
@@ -11,10 +11,9 @@ namespace Test\Files\ObjectStore;
 use OCP\Files\ObjectStore\IObjectStore;
 
 class FailWriteObjectStore implements IObjectStore {
-	private $objectStore;
-
-	public function __construct(IObjectStore $objectStore) {
-		$this->objectStore = $objectStore;
+	public function __construct(
+		private IObjectStore $objectStore,
+	) {
 	}
 
 	public function getStorageId() {

--- a/tests/lib/Files/ObjectStore/LocalTest.php
+++ b/tests/lib/Files/ObjectStore/LocalTest.php
@@ -9,10 +9,11 @@ namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\StorageObjectStore;
 use OC\Files\Storage\Temporary;
+use OCP\Files\ObjectStore\IObjectStore;
 
 class LocalTest extends ObjectStoreTestCase {
 	/**
-	 * @return \OCP\Files\ObjectStore\IObjectStore
+	 * @return IObjectStore
 	 */
 	protected function getInstance() {
 		$storage = new Temporary();

--- a/tests/lib/Files/ObjectStore/MapperTest.php
+++ b/tests/lib/Files/ObjectStore/MapperTest.php
@@ -43,11 +43,11 @@ class MapperTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetBucket
 	 * @param string $username
 	 * @param int $numBuckets
 	 * @param string $expectedBucket
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetBucket')]
 	public function testGetBucket($username, $numBuckets, $bucketShift, $expectedBucket): void {
 		$this->user->expects($this->once())
 			->method('getUID')

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -73,9 +73,7 @@ class ObjectStoreStorageTest extends Storage {
 		$this->markTestSkipped('Detecting external changes is not supported on object storages');
 	}
 
-	/**
-	 * @dataProvider copyAndMoveProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
 	public function testMove($source, $target): void {
 		$this->initSourceAndTarget($source);
 		$sourceId = $this->instance->getCache()->getId(ltrim($source, '/'));

--- a/tests/lib/Files/ObjectStore/ObjectStoreStoragesDifferentBucketTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStoragesDifferentBucketTest.php
@@ -10,6 +10,7 @@ namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\StorageObjectStore;
 use OC\Files\Storage\Temporary;
+use OCP\Files\ObjectStore\IObjectStore;
 use Test\Files\Storage\StoragesTestCase;
 
 /**
@@ -17,12 +18,12 @@ use Test\Files\Storage\StoragesTestCase;
  */
 class ObjectStoreStoragesDifferentBucketTest extends StoragesTestCase {
 	/**
-	 * @var \OCP\Files\ObjectStore\IObjectStore
+	 * @var IObjectStore
 	 */
 	private $objectStore1;
 
 	/**
-	 * @var \OCP\Files\ObjectStore\IObjectStore
+	 * @var IObjectStore
 	 */
 	private $objectStore2;
 

--- a/tests/lib/Files/ObjectStore/ObjectStoreStoragesSameBucketTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStoragesSameBucketTest.php
@@ -10,6 +10,7 @@ namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\StorageObjectStore;
 use OC\Files\Storage\Temporary;
+use OCP\Files\ObjectStore\IObjectStore;
 use Test\Files\Storage\StoragesTestCase;
 
 /**
@@ -17,7 +18,7 @@ use Test\Files\Storage\StoragesTestCase;
  */
 class ObjectStoreStoragesSameBucketTest extends StoragesTestCase {
 	/**
-	 * @var \OCP\Files\ObjectStore\IObjectStore
+	 * @var IObjectStore
 	 */
 	private $objectStore;
 

--- a/tests/lib/Files/ObjectStore/ObjectStoreTestCase.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTestCase.php
@@ -7,6 +7,7 @@
 
 namespace Test\Files\ObjectStore;
 
+use OCP\Files\ObjectStore\IObjectStore;
 use Test\TestCase;
 
 abstract class ObjectStoreTestCase extends TestCase {
@@ -16,7 +17,7 @@ abstract class ObjectStoreTestCase extends TestCase {
 	private $instance = null;
 
 	/**
-	 * @return \OCP\Files\ObjectStore\IObjectStore
+	 * @return IObjectStore
 	 */
 	abstract protected function getInstance();
 

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -135,7 +135,7 @@ class S3Test extends ObjectStoreTestCase {
 		];
 	}
 
-	/** @dataProvider dataFileSizes */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileSizes')]
 	public function testFileSizes($size): void {
 		if (str_starts_with(PHP_VERSION, '8.3') && getenv('CI')) {
 			$this->markTestSkipped('Test is unreliable and skipped on 8.3');

--- a/tests/lib/Files/ObjectStore/SwiftTest.php
+++ b/tests/lib/Files/ObjectStore/SwiftTest.php
@@ -9,6 +9,7 @@
 namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\Swift;
+use OCP\Files\ObjectStore\IObjectStore;
 use OCP\IConfig;
 use OCP\Server;
 
@@ -17,7 +18,7 @@ use OCP\Server;
  */
 class SwiftTest extends ObjectStoreTestCase {
 	/**
-	 * @return \OCP\Files\ObjectStore\IObjectStore
+	 * @return IObjectStore
 	 */
 	protected function getInstance() {
 		$config = Server::get(IConfig::class)->getSystemValue('objectstore');

--- a/tests/lib/Files/PathVerificationTest.php
+++ b/tests/lib/Files/PathVerificationTest.php
@@ -23,7 +23,7 @@ use OCP\Server;
  */
 class PathVerificationTest extends \Test\TestCase {
 	/**
-	 * @var \OC\Files\View
+	 * @var View
 	 */
 	private $view;
 
@@ -42,9 +42,7 @@ class PathVerificationTest extends \Test\TestCase {
 	}
 
 
-	/**
-	 * @dataProvider providesEmptyFiles
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesEmptyFiles')]
 	public function testPathVerificationEmptyFileName($fileName): void {
 		$this->expectException(InvalidPathException::class);
 		$this->expectExceptionMessage('Empty filename is not allowed');
@@ -59,9 +57,7 @@ class PathVerificationTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesDotFiles
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesDotFiles')]
 	public function testPathVerificationDotFiles($fileName): void {
 		$this->expectException(InvalidPathException::class);
 		$this->expectExceptionMessage('Dot files are not allowed');
@@ -82,9 +78,7 @@ class PathVerificationTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesAstralPlane
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesAstralPlane')]
 	public function testPathVerificationAstralPlane($fileName): void {
 		$connection = Server::get(IDBConnection::class);
 
@@ -109,9 +103,7 @@ class PathVerificationTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesValidPosixPaths
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesValidPosixPaths')]
 	public function testPathVerificationValidPaths($fileName): void {
 		$storage = new Local(['datadir' => '']);
 

--- a/tests/lib/Files/Storage/HomeTest.php
+++ b/tests/lib/Files/Storage/HomeTest.php
@@ -50,7 +50,7 @@ class HomeTest extends Storage {
 	private $userId;
 
 	/**
-	 * @var \OC\User\User $user
+	 * @var User $user
 	 */
 	private $user;
 

--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -51,9 +51,7 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertTrue($this->instance->test());
 	}
 
-	/**
-	 * @dataProvider directoryProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('directoryProvider')]
 	public function testDirectories($directory): void {
 		$this->assertFalse($this->instance->file_exists('/' . $directory));
 
@@ -144,9 +142,8 @@ abstract class Storage extends \Test\TestCase {
 
 	/**
 	 * test the various uses of file_get_contents and file_put_contents
-	 *
-	 * @dataProvider loremFileProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('loremFileProvider')]
 	public function testGetPutContents($sourceFile): void {
 		$sourceText = file_get_contents($sourceFile);
 
@@ -212,9 +209,7 @@ abstract class Storage extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider copyAndMoveProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
 	public function testCopy($source, $target): void {
 		$this->initSourceAndTarget($source);
 
@@ -225,9 +220,7 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertTrue($this->instance->file_exists($source), $source . ' was deleted');
 	}
 
-	/**
-	 * @dataProvider copyAndMoveProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
 	public function testMove($source, $target): void {
 		$this->initSourceAndTarget($source);
 
@@ -239,9 +232,7 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertSameAsLorem($target);
 	}
 
-	/**
-	 * @dataProvider copyAndMoveProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
 	public function testCopyOverwrite($source, $target): void {
 		$this->initSourceAndTarget($source, $target);
 
@@ -253,9 +244,7 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertSameAsLorem($source);
 	}
 
-	/**
-	 * @dataProvider copyAndMoveProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
 	public function testMoveOverwrite($source, $target): void {
 		$this->initSourceAndTarget($source, $target);
 
@@ -352,9 +341,7 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertFalse($this->instance->file_exists('/lorem.txt'));
 	}
 
-	/**
-	 * @dataProvider fileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('fileNameProvider')]
 	public function testFOpen($fileName): void {
 		$textFile = \OC::$SERVERROOT . '/tests/data/lorem.txt';
 
@@ -424,9 +411,7 @@ abstract class Storage extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider hashProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hashProvider')]
 	public function testHash($data, $type): void {
 		$this->instance->file_put_contents('hash.txt', $data);
 		$this->assertEquals(hash($type, $data), $this->instance->hash($type, 'hash.txt'));
@@ -580,9 +565,7 @@ abstract class Storage extends \Test\TestCase {
 		$this->assertFalse($this->instance->instanceOfStorage('\OC'));
 	}
 
-	/**
-	 * @dataProvider copyAndMoveProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('copyAndMoveProvider')]
 	public function testCopyFromSameStorage($source, $target): void {
 		$this->initSourceAndTarget($source);
 

--- a/tests/lib/Files/Storage/StoragesTestCase.php
+++ b/tests/lib/Files/Storage/StoragesTestCase.php
@@ -8,16 +8,17 @@
 
 namespace Test\Files\Storage;
 
+use OC\Files\Storage\Storage;
 use Test\TestCase;
 
 abstract class StoragesTestCase extends TestCase {
 	/**
-	 * @var \OC\Files\Storage\Storage
+	 * @var Storage
 	 */
 	protected $storage1;
 
 	/**
-	 * @var \OC\Files\Storage\Storage
+	 * @var Storage
 	 */
 	protected $storage2;
 

--- a/tests/lib/Files/Storage/Wrapper/EncodingTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncodingTest.php
@@ -16,7 +16,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 	public const NFC_NAME = 'ümlaut';
 
 	/**
-	 * @var \OC\Files\Storage\Temporary
+	 * @var Temporary
 	 */
 	private $sourceStorage;
 
@@ -58,17 +58,13 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		];
 	}
 
-	/**
-	 * @dataProvider accessNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('accessNameProvider')]
 	public function testFputEncoding($accessName): void {
 		$this->sourceStorage->file_put_contents(self::NFD_NAME, 'bar');
 		$this->assertEquals('bar', $this->instance->file_get_contents($accessName));
 	}
 
-	/**
-	 * @dataProvider accessNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('accessNameProvider')]
 	public function testFopenReadEncoding($accessName): void {
 		$this->sourceStorage->file_put_contents(self::NFD_NAME, 'bar');
 		$fh = $this->instance->fopen($accessName, 'r');
@@ -77,9 +73,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals('bar', $data);
 	}
 
-	/**
-	 * @dataProvider accessNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('accessNameProvider')]
 	public function testFopenOverwriteEncoding($accessName): void {
 		$this->sourceStorage->file_put_contents(self::NFD_NAME, 'bar');
 		$fh = $this->instance->fopen($accessName, 'w');
@@ -90,17 +84,13 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		$this->assertFalse($this->sourceStorage->file_exists(self::NFC_NAME));
 	}
 
-	/**
-	 * @dataProvider accessNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('accessNameProvider')]
 	public function testFileExistsEncoding($accessName): void {
 		$this->sourceStorage->file_put_contents(self::NFD_NAME, 'bar');
 		$this->assertTrue($this->instance->file_exists($accessName));
 	}
 
-	/**
-	 * @dataProvider accessNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('accessNameProvider')]
 	public function testUnlinkEncoding($accessName): void {
 		$this->sourceStorage->file_put_contents(self::NFD_NAME, 'bar');
 		$this->assertTrue($this->instance->unlink($accessName));
@@ -122,9 +112,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		];
 	}
 
-	/**
-	 * @dataProvider encodedDirectoriesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('encodedDirectoriesProvider')]
 	public function testOperationInsideDirectory($sourceDir, $accessDir): void {
 		$this->sourceStorage->mkdir($sourceDir);
 		$this->instance->file_put_contents($accessDir . '/test.txt', 'bar');
@@ -163,9 +151,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		];
 	}
 
-	/**
-	 * @dataProvider sourceAndTargetDirectoryProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sourceAndTargetDirectoryProvider')]
 	public function testCopyAndMoveEncodedFolder($sourceDir, $targetDir): void {
 		$this->sourceStorage->mkdir($sourceDir);
 		$this->sourceStorage->mkdir($targetDir);
@@ -183,9 +169,7 @@ class EncodingTest extends \Test\Files\Storage\Storage {
 		$this->assertEquals('bar', $this->instance->file_get_contents(self::NFC_NAME . '2/test2.txt'));
 	}
 
-	/**
-	 * @dataProvider sourceAndTargetDirectoryProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sourceAndTargetDirectoryProvider')]
 	public function testCopyAndMoveFromStorageEncodedFolder($sourceDir, $targetDir): void {
 		$this->sourceStorage->mkdir($sourceDir);
 		$this->sourceStorage->mkdir($targetDir);

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -194,7 +194,6 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestGetMetaData
 	 *
 	 * @param string $path
 	 * @param array $metaData
@@ -203,6 +202,7 @@ class EncryptionTest extends Storage {
 	 * @param int $storedUnencryptedSize
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetMetaData')]
 	public function testGetMetaData($path, $metaData, $encrypted, $unencryptedSizeSet, $storedUnencryptedSize, $expected): void {
 		$sourceStorage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()->getMock();
@@ -328,13 +328,13 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestVerifyUnencryptedSize
 	 *
 	 * @param int $encryptedSize
 	 * @param int $unencryptedSize
 	 * @param bool $failure
 	 * @param int $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestVerifyUnencryptedSize')]
 	public function testVerifyUnencryptedSize($encryptedSize, $unencryptedSize, $failure, $expected): void {
 		$sourceStorage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()->getMock();
@@ -391,13 +391,13 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestCopyAndRename
 	 *
 	 * @param string $source
 	 * @param string $target
 	 * @param $encryptionEnabled
 	 * @param boolean $renameKeysReturn
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCopyAndRename')]
 	public function testRename($source,
 		$target,
 		$encryptionEnabled,
@@ -453,13 +453,13 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestRmdir
 	 *
 	 * @param string $path
 	 * @param boolean $rmdirResult
 	 * @param boolean $isExcluded
 	 * @param boolean $encryptionEnabled
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRmdir')]
 	public function testRmdir($path, $rmdirResult, $isExcluded, $encryptionEnabled): void {
 		$sourceStorage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()->getMock();
@@ -511,11 +511,11 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestCopyKeys
 	 *
 	 * @param boolean $excluded
 	 * @param boolean $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCopyKeys')]
 	public function testCopyKeys($excluded, $expected): void {
 		$this->util->expects($this->once())
 			->method('isExcluded')
@@ -540,12 +540,12 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestGetHeader
 	 *
 	 * @param string $path
 	 * @param bool $strippedPathExists
 	 * @param string $strippedPath
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetHeader')]
 	public function testGetHeader($path, $strippedPathExists, $strippedPath): void {
 		$sourceStorage = $this->getMockBuilder('\OC\Files\Storage\Storage')
 			->disableOriginalConstructor()->getMock();
@@ -632,9 +632,8 @@ class EncryptionTest extends Storage {
 	/**
 	 * test if getHeader adds the default module correctly to the header for
 	 * legacy files
-	 *
-	 * @dataProvider dataTestGetHeaderAddLegacyModule
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetHeaderAddLegacyModule')]
 	public function testGetHeaderAddLegacyModule($header, $isEncrypted, $strippedPathExists, $expected): void {
 		$sourceStorage = $this->getMockBuilder(\OC\Files\Storage\Storage::class)
 			->disableOriginalConstructor()->getMock();
@@ -762,12 +761,12 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataCopyBetweenStorage
 	 *
 	 * @param bool $encryptionEnabled
 	 * @param bool $mountPointEncryptionEnabled
 	 * @param bool $expectedEncrypted
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCopyBetweenStorage')]
 	public function testCopyBetweenStorage($encryptionEnabled, $mountPointEncryptionEnabled, $expectedEncrypted): void {
 		$storage2 = $this->createMock(\OC\Files\Storage\Storage::class);
 
@@ -822,13 +821,13 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestCopyBetweenStorageVersions
 	 *
 	 * @param string $sourceInternalPath
 	 * @param string $targetInternalPath
 	 * @param bool $copyResult
 	 * @param bool $encrypted
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCopyBetweenStorageVersions')]
 	public function testCopyBetweenStorageVersions($sourceInternalPath, $targetInternalPath, $copyResult, $encrypted): void {
 		$sourceStorage = $this->createMock(\OC\Files\Storage\Storage::class);
 
@@ -916,10 +915,10 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestIsVersion
 	 * @param string $path
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsVersion')]
 	public function testIsVersion($path, $expected): void {
 		$this->assertSame($expected,
 			$this->invokePrivate($this->instance, 'isVersion', [$path])
@@ -938,13 +937,13 @@ class EncryptionTest extends Storage {
 	}
 
 	/**
-	 * @dataProvider dataTestShouldEncrypt
 	 *
 	 * @param bool $encryptMountPoint
 	 * @param mixed $encryptionModule
 	 * @param bool $encryptionModuleShouldEncrypt
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShouldEncrypt')]
 	public function testShouldEncrypt(
 		$encryptMountPoint,
 		$encryptionModule,

--- a/tests/lib/Files/Storage/Wrapper/JailTest.php
+++ b/tests/lib/Files/Storage/Wrapper/JailTest.php
@@ -14,7 +14,7 @@ use OC\Files\Storage\Wrapper\Jail;
 
 class JailTest extends \Test\Files\Storage\Storage {
 	/**
-	 * @var \OC\Files\Storage\Temporary
+	 * @var Temporary
 	 */
 	private $sourceStorage;
 

--- a/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
+++ b/tests/lib/Files/Storage/Wrapper/PermissionsMaskTest.php
@@ -19,7 +19,7 @@ use OCP\Files\Cache\IScanner;
  */
 class PermissionsMaskTest extends \Test\Files\Storage\Storage {
 	/**
-	 * @var \OC\Files\Storage\Temporary
+	 * @var Temporary
 	 */
 	private $sourceStorage;
 

--- a/tests/lib/Files/Stream/EncryptionTest.php
+++ b/tests/lib/Files/Stream/EncryptionTest.php
@@ -101,9 +101,7 @@ class EncryptionTest extends \Test\TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataProviderStreamOpen()
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderStreamOpen')]
 	public function testStreamOpen(
 		$isMasterKeyUsed,
 		$mode,
@@ -277,9 +275,7 @@ class EncryptionTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataFilesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilesProvider')]
 	public function testWriteReadBigFile($testFile): void {
 		$expectedData = file_get_contents(\OC::$SERVERROOT . '/tests/data/' . $testFile);
 		// write it
@@ -314,9 +310,8 @@ class EncryptionTest extends \Test\TestCase {
 
 	/**
 	 * simulate a non-seekable storage
-	 *
-	 * @dataProvider dataFilesProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFilesProvider')]
 	public function testWriteToNonSeekableStorage($testFile): void {
 		$wrapper = $this->getMockBuilder(Encryption::class)
 			->onlyMethods(['parentStreamSeek'])

--- a/tests/lib/Files/Stream/HashWrapperTest.php
+++ b/tests/lib/Files/Stream/HashWrapperTest.php
@@ -12,9 +12,7 @@ use OC\Files\Stream\HashWrapper;
 use Test\TestCase;
 
 class HashWrapperTest extends TestCase {
-	/**
-	 * @dataProvider hashProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hashProvider')]
 	public function testHashStream($data, string $algo, string $hash): void {
 		if (!is_resource($data)) {
 			$tmpData = fopen('php://temp', 'r+');

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -47,11 +47,11 @@ class DetectionTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDetectPath
 	 *
 	 * @param string $path
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDetectPath')]
 	public function testDetectPath(string $path, string $expected): void {
 		$this->assertEquals($expected, $this->detection->detectPath($path));
 	}
@@ -67,11 +67,11 @@ class DetectionTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDetectContent
 	 *
 	 * @param string $path
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDetectContent')]
 	public function testDetectContent(string $path, string $expected): void {
 		$this->assertEquals($expected, $this->detection->detectContent(\OC::$SERVERROOT . '/tests/data' . $path));
 	}
@@ -87,11 +87,11 @@ class DetectionTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDetect
 	 *
 	 * @param string $path
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDetect')]
 	public function testDetect(string $path, string $expected): void {
 		$this->assertEquals($expected, $this->detection->detect(\OC::$SERVERROOT . '/tests/data' . $path));
 	}
@@ -111,11 +111,11 @@ class DetectionTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataMimeTypeCustom
 	 *
 	 * @param string $ext
 	 * @param string $mime
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataMimeTypeCustom')]
 	public function testDetectMimeTypeCustom(string $ext, string $mime): void {
 		$confDir = sys_get_temp_dir();
 		file_put_contents($confDir . '/mimetypemapping.dist.json', json_encode([]));
@@ -145,11 +145,11 @@ class DetectionTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetSecureMimeType
 	 *
 	 * @param string $mimeType
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetSecureMimeType')]
 	public function testGetSecureMimeType(string $mimeType, string $expected): void {
 		$this->assertEquals($expected, $this->detection->getSecureMimeType($mimeType));
 	}

--- a/tests/lib/Files/Utils/ScannerTest.php
+++ b/tests/lib/Files/Utils/ScannerTest.php
@@ -24,12 +24,12 @@ use Psr\Log\LoggerInterface;
 
 class TestScanner extends Scanner {
 	/**
-	 * @var \OC\Files\Mount\MountPoint[] $mounts
+	 * @var MountPoint[] $mounts
 	 */
 	private $mounts = [];
 
 	/**
-	 * @param \OC\Files\Mount\MountPoint $mount
+	 * @param MountPoint $mount
 	 */
 	public function addMount($mount) {
 		$this->mounts[] = $mount;
@@ -159,9 +159,9 @@ class ScannerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider invalidPathProvider
 	 * @param string $invalidPath
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidPathProvider')]
 	public function testInvalidPathScanning($invalidPath): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Invalid path to scan');

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -33,8 +33,10 @@ use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IStorageFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
+use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\ITempManager;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
@@ -95,7 +97,7 @@ class ViewTest extends \Test\TestCase {
 	use UserTrait;
 
 	/**
-	 * @var \OC\Files\Storage\Storage[] $storages
+	 * @var Storage[] $storages
 	 */
 	private $storages = [];
 
@@ -105,16 +107,16 @@ class ViewTest extends \Test\TestCase {
 	private $user;
 
 	/**
-	 * @var \OCP\IUser
+	 * @var IUser
 	 */
 	private $userObject;
 
 	/**
-	 * @var \OCP\IGroup
+	 * @var IGroup
 	 */
 	private $groupObject;
 
-	/** @var \OC\Files\Storage\Storage */
+	/** @var Storage */
 	private $tempStorage;
 
 	protected function setUp(): void {
@@ -318,9 +320,7 @@ class ViewTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider sharingDisabledPermissionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sharingDisabledPermissionProvider')]
 	public function testRemoveSharePermissionWhenSharingDisabledForUser($excludeGroups, $excludeGroupsList, $expectedShareable): void {
 		// Reset sharing disabled for users cache
 		self::invokePrivate(Server::get(ShareDisableChecker::class), 'sharingDisabledForUsersCache', [new CappedMemoryCache()]);
@@ -567,9 +567,7 @@ class ViewTest extends \Test\TestCase {
 		return [['rmdir'], ['unlink']];
 	}
 
-	/**
-	 * @dataProvider rmdirOrUnlinkDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('rmdirOrUnlinkDataProvider')]
 	public function testRmdir($method): void {
 		$storage1 = $this->getTestStorage();
 		Filesystem::mount($storage1, [], '/');
@@ -690,11 +688,11 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * @param bool $scan
 	 * @param string $class
-	 * @return \OC\Files\Storage\Storage
+	 * @return Storage
 	 */
 	private function getTestStorage($scan = true, $class = Temporary::class) {
 		/**
-		 * @var \OC\Files\Storage\Storage $storage
+		 * @var Storage $storage
 		 */
 		$storage = new $class([]);
 		$textData = "dummy file data\n";
@@ -776,9 +774,7 @@ class ViewTest extends \Test\TestCase {
 		\OC_Hook::clear('OC_Filesystem', 'post_write');
 	}
 
-	/**
-	 * @dataProvider resolvePathTestProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('resolvePathTestProvider')]
 	public function testResolvePath($expected, $pathToTest): void {
 		$storage1 = $this->getTestStorage();
 		Filesystem::mount($storage1, [], '/');
@@ -938,9 +934,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertNotEquals($newFolderInfo->getEtag(), $oldEtag);
 	}
 
-	/**
-	 * @dataProvider absolutePathProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('absolutePathProvider')]
 	public function testGetAbsolutePath($expectedPath, $relativePath): void {
 		$view = new View('/files');
 		$this->assertEquals($expectedPath, $view->getAbsolutePath($relativePath));
@@ -974,9 +968,7 @@ class ViewTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider chrootRelativePathProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('chrootRelativePathProvider')]
 	public function testChrootGetRelativePath($root, $absolutePath, $expectedPath): void {
 		$view = new View('/files');
 		$view->chroot($root);
@@ -987,9 +979,7 @@ class ViewTest extends \Test\TestCase {
 		return self::relativePathProvider('/');
 	}
 
-	/**
-	 * @dataProvider initRelativePathProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('initRelativePathProvider')]
 	public function testInitGetRelativePath($root, $absolutePath, $expectedPath): void {
 		$view = new View($root);
 		$this->assertEquals($expectedPath, $view->getRelativePath($absolutePath));
@@ -1086,9 +1076,7 @@ class ViewTest extends \Test\TestCase {
 		$this->assertEquals('foo', $view->file_get_contents(''));
 	}
 
-	/**
-	 * @dataProvider tooLongPathDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('tooLongPathDataProvider')]
 	public function testTooLongPath($operation, $param0 = null): void {
 		$this->expectException(InvalidPathException::class);
 
@@ -1274,9 +1262,9 @@ class ViewTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider directoryTraversalProvider
 	 * @param string $root
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('directoryTraversalProvider')]
 	public function testConstructDirectoryTraversalException($root): void {
 		$this->expectException(\Exception::class);
 
@@ -1299,7 +1287,7 @@ class ViewTest extends \Test\TestCase {
 	public function testSetMountOptionsInStorage(): void {
 		$mount = new MountPoint(Temporary::class, '/asd/', [[]], Filesystem::getLoader(), ['foo' => 'bar']);
 		Filesystem::getMountManager()->addMount($mount);
-		/** @var \OC\Files\Storage\Common $storage */
+		/** @var Common $storage */
 		$storage = $mount->getStorage();
 		$this->assertEquals($storage->getMountOption('foo'), 'bar');
 	}
@@ -1307,7 +1295,7 @@ class ViewTest extends \Test\TestCase {
 	public function testSetMountOptionsWatcherPolicy(): void {
 		$mount = new MountPoint(Temporary::class, '/asd/', [[]], Filesystem::getLoader(), ['filesystem_check_changes' => Watcher::CHECK_NEVER]);
 		Filesystem::getMountManager()->addMount($mount);
-		/** @var \OC\Files\Storage\Common $storage */
+		/** @var Common $storage */
 		$storage = $mount->getStorage();
 		$watcher = $storage->getWatcher();
 		$this->assertEquals(Watcher::CHECK_NEVER, $watcher->getPolicy());
@@ -1334,11 +1322,11 @@ class ViewTest extends \Test\TestCase {
 	 * e.g. reading from a folder that's being renamed
 	 *
 	 *
-	 * @dataProvider dataLockPaths
 	 *
 	 * @param string $rootPath
 	 * @param string $pathPrefix
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLockPaths')]
 	public function testReadFromWriteLockedPath($rootPath, $pathPrefix): void {
 		$this->expectException(LockedException::class);
 
@@ -1355,11 +1343,11 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Reading from a files_encryption folder that's being renamed
 	 *
-	 * @dataProvider dataLockPaths
 	 *
 	 * @param string $rootPath
 	 * @param string $pathPrefix
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLockPaths')]
 	public function testReadFromWriteUnlockablePath($rootPath, $pathPrefix): void {
 		$rootPath = str_replace('{folder}', 'files_encryption', $rootPath);
 		$pathPrefix = str_replace('{folder}', 'files_encryption', $pathPrefix);
@@ -1375,11 +1363,11 @@ class ViewTest extends \Test\TestCase {
 	 * e.g. writing a file that's being downloaded
 	 *
 	 *
-	 * @dataProvider dataLockPaths
 	 *
 	 * @param string $rootPath
 	 * @param string $pathPrefix
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLockPaths')]
 	public function testWriteToReadLockedFile($rootPath, $pathPrefix): void {
 		$this->expectException(LockedException::class);
 
@@ -1396,11 +1384,11 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Writing a file that's being downloaded
 	 *
-	 * @dataProvider dataLockPaths
 	 *
 	 * @param string $rootPath
 	 * @param string $pathPrefix
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLockPaths')]
 	public function testWriteToReadUnlockableFile($rootPath, $pathPrefix): void {
 		$rootPath = str_replace('{folder}', 'files_encryption', $rootPath);
 		$pathPrefix = str_replace('{folder}', 'files_encryption', $pathPrefix);
@@ -1523,9 +1511,7 @@ class ViewTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider pathRelativeToFilesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('pathRelativeToFilesProvider')]
 	public function testGetPathRelativeToFiles($path, $expectedPath): void {
 		$view = new View();
 		$this->assertEquals($expectedPath, $view->getPathRelativeToFiles($path));
@@ -1542,9 +1528,9 @@ class ViewTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider pathRelativeToFilesProviderExceptionCases
 	 * @param string $path
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('pathRelativeToFilesProviderExceptionCases')]
 	public function testGetPathRelativeToFilesWithInvalidArgument($path): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('$absolutePath must be relative to "files"');
@@ -1587,11 +1573,11 @@ class ViewTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider hookPathProvider
 	 * @param $root
 	 * @param $path
 	 * @param $shouldEmit
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hookPathProvider')]
 	public function testHookPaths($root, $path, $shouldEmit): void {
 		$filesystemReflection = new \ReflectionClass(Filesystem::class);
 		$defaultRootValue = $filesystemReflection->getProperty('defaultInstance');
@@ -1926,7 +1912,6 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Test whether locks are set before and after the operation
 	 *
-	 * @dataProvider basicOperationProviderForLocks
 	 *
 	 * @param string $operation operation name on the view
 	 * @param array $operationArgs arguments for the operation
@@ -1938,6 +1923,7 @@ class ViewTest extends \Test\TestCase {
 	 * @param int $expectedStrayLock expected lock after returning, should
 	 *                               be null (unlock) for most operations
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('basicOperationProviderForLocks')]
 	public function testLockBasicOperation(
 		$operation,
 		$operationArgs,
@@ -2087,12 +2073,12 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Test locks for fopen with fclose at the end
 	 *
-	 * @dataProvider basicOperationProviderForLocks
 	 *
 	 * @param string $operation operation name on the view
 	 * @param array $operationArgs arguments for the operation
 	 * @param string $path path of the locked item to check
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('basicOperationProviderForLocks')]
 	public function testLockBasicOperationUnlocksAfterException(
 		$operation,
 		$operationArgs,
@@ -2178,13 +2164,13 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Test locks for fopen with fclose at the end
 	 *
-	 * @dataProvider basicOperationProviderForLocks
 	 *
 	 * @param string $operation operation name on the view
 	 * @param array $operationArgs arguments for the operation
 	 * @param string $path path of the locked item to check
 	 * @param string $hookType hook type
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('basicOperationProviderForLocks')]
 	public function testLockBasicOperationUnlocksAfterCancelledHook(
 		$operation,
 		$operationArgs,
@@ -2223,12 +2209,12 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Test locks for rename or copy operation
 	 *
-	 * @dataProvider lockFileRenameOrCopyDataProvider
 	 *
 	 * @param string $operation operation to be done on the view
 	 * @param int $expectedLockTypeSourceDuring expected lock type on source file during
 	 *                                          the operation
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('lockFileRenameOrCopyDataProvider')]
 	public function testLockFileRename($operation, $expectedLockTypeSourceDuring): void {
 		$view = new View('/' . $this->user . '/files/');
 
@@ -2413,13 +2399,13 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * Test locks for rename or copy operation cross-storage
 	 *
-	 * @dataProvider lockFileRenameOrCopyCrossStorageDataProvider
 	 *
 	 * @param string $viewOperation operation to be done on the view
 	 * @param string $storageOperation operation to be mocked on the storage
 	 * @param int $expectedLockTypeSourceDuring expected lock type on source file during
 	 *                                          the operation
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('lockFileRenameOrCopyCrossStorageDataProvider')]
 	public function testLockFileRenameCrossStorage($viewOperation, $storageOperation, $expectedLockTypeSourceDuring): void {
 		$view = new View('/' . $this->user . '/files/');
 
@@ -2681,8 +2667,8 @@ class ViewTest extends \Test\TestCase {
 	/**
 	 * @param string $filter
 	 * @param string[] $expected
-	 * @dataProvider mimeFilterProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('mimeFilterProvider')]
 	public function testGetDirectoryContentMimeFilter($filter, $expected): void {
 		$storage1 = new Temporary();
 		$root = self::getUniqueID('/');

--- a/tests/lib/GlobalScale/ConfigTest.php
+++ b/tests/lib/GlobalScale/ConfigTest.php
@@ -48,12 +48,12 @@ class ConfigTest extends TestCase {
 
 
 	/**
-	 * @dataProvider dataTestOnlyInternalFederation
 	 *
 	 * @param bool $gsEnabled
 	 * @param string $gsFederation
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestOnlyInternalFederation')]
 	public function testOnlyInternalFederation($gsEnabled, $gsFederation, $expected): void {
 		$gsConfig = $this->getInstance(['isGlobalScaleEnabled']);
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -452,7 +452,7 @@ class ManagerTest extends TestCase {
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
-		/** @var \OC\User\User|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var User|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')
 			->willReturn('myUID');
@@ -482,7 +482,7 @@ class ManagerTest extends TestCase {
 		$manager = new \OC\Group\Manager($this->userManager, $this->dispatcher, $this->logger, $this->cache, $this->remoteIpAddress);
 		$manager->addBackend($backend);
 
-		/** @var \OC\User\User|\PHPUnit\Framework\MockObject\MockObject $user */
+		/** @var User|\PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->atLeastOnce())
 			->method('getUID')

--- a/tests/lib/HelperStorageTest.php
+++ b/tests/lib/HelperStorageTest.php
@@ -9,6 +9,7 @@
 namespace Test;
 
 use OC\Files\Filesystem;
+use OC\Files\Storage\Storage;
 use OC\Files\Storage\Temporary;
 use OC\Files\Storage\Wrapper\Quota;
 use OCP\Files\Mount\IMountManager;
@@ -26,9 +27,9 @@ class HelperStorageTest extends \Test\TestCase {
 
 	/** @var string */
 	private $user;
-	/** @var \OC\Files\Storage\Storage */
+	/** @var Storage */
 	private $storageMock;
-	/** @var \OC\Files\Storage\Storage */
+	/** @var Storage */
 	private $storage;
 	private bool $savedQuotaIncludeExternalStorage;
 
@@ -71,7 +72,7 @@ class HelperStorageTest extends \Test\TestCase {
 	 * free space
 	 *
 	 * @param int $freeSpace free space value
-	 * @return \OC\Files\Storage\Storage
+	 * @return Storage
 	 */
 	private function getStorageMock($freeSpace = 12) {
 		$this->storageMock = $this->getMockBuilder(Temporary::class)

--- a/tests/lib/Hooks/BasicEmitterTest.php
+++ b/tests/lib/Hooks/BasicEmitterTest.php
@@ -9,6 +9,7 @@
 namespace Test\Hooks;
 
 use OC\Hooks\BasicEmitter;
+use OC\Hooks\Emitter;
 
 /**
  * Class DummyEmitter
@@ -35,7 +36,7 @@ class EmittedException extends \Exception {
 
 class BasicEmitterTest extends \Test\TestCase {
 	/**
-	 * @var \OC\Hooks\Emitter $emitter
+	 * @var Emitter $emitter
 	 */
 	protected $emitter;
 

--- a/tests/lib/Http/Client/ClientTest.php
+++ b/tests/lib/Http/Client/ClientTest.php
@@ -151,9 +151,9 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPreventLocalAddress
 	 * @param string $uri
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPreventLocalAddress')]
 	public function testPreventLocalAddressDisabledByGlobalConfig(string $uri): void {
 		$this->config->expects($this->once())
 			->method('getSystemValueBool')
@@ -164,9 +164,9 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPreventLocalAddress
 	 * @param string $uri
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPreventLocalAddress')]
 	public function testPreventLocalAddressDisabledByOption(string $uri): void {
 		$this->config->expects($this->never())
 			->method('getSystemValueBool');
@@ -177,9 +177,9 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPreventLocalAddress
 	 * @param string $uri
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPreventLocalAddress')]
 	public function testPreventLocalAddressOnGet(string $uri): void {
 		$host = parse_url($uri, PHP_URL_HOST);
 		$this->expectException(LocalServerException::class);
@@ -192,9 +192,9 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPreventLocalAddress
 	 * @param string $uri
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPreventLocalAddress')]
 	public function testPreventLocalAddressOnHead(string $uri): void {
 		$host = parse_url($uri, PHP_URL_HOST);
 		$this->expectException(LocalServerException::class);
@@ -207,9 +207,9 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPreventLocalAddress
 	 * @param string $uri
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPreventLocalAddress')]
 	public function testPreventLocalAddressOnPost(string $uri): void {
 		$host = parse_url($uri, PHP_URL_HOST);
 		$this->expectException(LocalServerException::class);
@@ -222,9 +222,9 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPreventLocalAddress
 	 * @param string $uri
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPreventLocalAddress')]
 	public function testPreventLocalAddressOnPut(string $uri): void {
 		$host = parse_url($uri, PHP_URL_HOST);
 		$this->expectException(LocalServerException::class);
@@ -237,9 +237,9 @@ class ClientTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPreventLocalAddress
 	 * @param string $uri
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPreventLocalAddress')]
 	public function testPreventLocalAddressOnDelete(string $uri): void {
 		$host = parse_url($uri, PHP_URL_HOST);
 		$this->expectException(LocalServerException::class);

--- a/tests/lib/ImageTest.php
+++ b/tests/lib/ImageTest.php
@@ -281,12 +281,12 @@ class ImageTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider sampleProvider
 	 *
 	 * @param string $filename
 	 * @param int[] $asked
 	 * @param int[] $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sampleProvider')]
 	public function testFitIn($filename, $asked, $expected): void {
 		$img = new Image();
 		$img->loadFromFile(OC::$SERVERROOT . '/tests/data/' . $filename);
@@ -306,10 +306,10 @@ class ImageTest extends \Test\TestCase {
 	/**
 	 * Image should not be resized if it's already smaller than what is required
 	 *
-	 * @dataProvider sampleFilenamesProvider
 	 *
 	 * @param string $filename
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sampleFilenamesProvider')]
 	public function testScaleDownToFitWhenSmallerAlready($filename): void {
 		$img = new Image();
 		$img->loadFromFile(OC::$SERVERROOT . '/tests/data/' . $filename);
@@ -337,12 +337,12 @@ class ImageTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider largeSampleProvider
 	 *
 	 * @param string $filename
 	 * @param int[] $asked
 	 * @param int[] $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('largeSampleProvider')]
 	public function testScaleDownWhenBigger($filename, $asked, $expected): void {
 		$img = new Image();
 		$img->loadFromFile(OC::$SERVERROOT . '/tests/data/' . $filename);
@@ -360,9 +360,7 @@ class ImageTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider convertDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('convertDataProvider')]
 	public function testConvert($mimeType): void {
 		$img = new Image();
 		$img->loadFromFile(OC::$SERVERROOT . '/tests/data/testimage.png');

--- a/tests/lib/InfoXmlTest.php
+++ b/tests/lib/InfoXmlTest.php
@@ -50,10 +50,9 @@ class InfoXmlTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataApps
-	 *
 	 * @param string $app
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataApps')]
 	public function testClasses($app): void {
 		$appInfo = $this->appManager->getAppInfo($app);
 		$appPath = $this->appManager->getAppPath($app);

--- a/tests/lib/InitialStateServiceTest.php
+++ b/tests/lib/InitialStateServiceTest.php
@@ -49,9 +49,7 @@ class InitialStateServiceTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider staticData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('staticData')]
 	public function testStaticData(mixed $value): void {
 		$this->service->provideInitialState('test', 'key', $value);
 		$data = $this->service->getInitialStates();
@@ -88,9 +86,7 @@ class InitialStateServiceTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider staticData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('staticData')]
 	public function testLazyData(mixed $value): void {
 		$this->service->provideLazyInitialState('test', 'key', function () use ($value) {
 			return $value;

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -147,10 +147,10 @@ class InstallerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider updateArrayProvider
 	 * @param array $appArray
 	 * @param string|bool $updateAvailable
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('updateArrayProvider')]
 	public function testIsUpdateAvailable(array $appArray, $updateAvailable): void {
 		$this->appFetcher
 			->expects($this->once())

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -1079,8 +1079,8 @@ class CheckerTest extends TestCase {
 	/**
 	 * @param string $channel
 	 * @param bool $isCodeSigningEnforced
-	 * @dataProvider channelDataProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('channelDataProvider')]
 	public function testIsCodeCheckEnforced($channel, $isCodeSigningEnforced): void {
 		$this->serverVersion
 			->expects($this->once())
@@ -1097,8 +1097,8 @@ class CheckerTest extends TestCase {
 
 	/**
 	 * @param string $channel
-	 * @dataProvider channelDataProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('channelDataProvider')]
 	public function testIsCodeCheckEnforcedWithDisabledConfigSwitch($channel): void {
 		$this->serverVersion
 			->expects($this->once())

--- a/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
+++ b/tests/lib/IntegrityCheck/Iterator/ExcludeFileByNameFilterIteratorTest.php
@@ -36,10 +36,10 @@ class ExcludeFileByNameFilterIteratorTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider fileNameProvider
 	 * @param string $fileName
 	 * @param bool $expectedResult
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('fileNameProvider')]
 	public function testAcceptForFiles($fileName, $expectedResult): void {
 		$iteratorMock = $this->getMockBuilder(\RecursiveDirectoryIterator::class)
 			->disableOriginalConstructor()
@@ -58,10 +58,10 @@ class ExcludeFileByNameFilterIteratorTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider fileNameProvider
 	 * @param string $fileName
 	 * @param bool $expectedResult
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('fileNameProvider')]
 	public function testAcceptForDirs($fileName, $expectedResult): void {
 		$iteratorMock = $this->getMockBuilder(\RecursiveDirectoryIterator::class)
 			->disableOriginalConstructor()

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -278,10 +278,9 @@ class FactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFindAvailableLanguages
-	 *
 	 * @param string|null $app
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFindAvailableLanguages')]
 	public function testFindAvailableLanguages($app): void {
 		$factory = $this->getFactory(['findL10nDir']);
 		$factory->expects(self::once())
@@ -324,13 +323,13 @@ class FactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataLanguageExists
 	 *
 	 * @param string|null $app
 	 * @param string $lang
 	 * @param string[] $availableLanguages
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataLanguageExists')]
 	public function testLanguageExists($app, $lang, array $availableLanguages, $expected): void {
 		$factory = $this->getFactory(['findAvailableLanguages']);
 		$factory->expects(($lang === 'en') ? self::never() : self::once())
@@ -364,13 +363,13 @@ class FactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetLanguageFromRequest
 	 *
 	 * @param string|null $app
 	 * @param string $header
 	 * @param string[] $availableLanguages
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetLanguageFromRequest')]
 	public function testGetLanguageFromRequest($app, $header, array $availableLanguages, $expected): void {
 		$factory = $this->getFactory(['findAvailableLanguages', 'respectDefaultLanguage']);
 		$factory->expects(self::once())
@@ -409,11 +408,11 @@ class FactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetL10nFilesForApp
 	 *
 	 * @param string $app
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetL10nFilesForApp')]
 	public function testGetL10nFilesForApp($app, $lang, $expected): void {
 		$factory = $this->getFactory();
 		if (in_array($app, ['settings','files'])) {
@@ -442,11 +441,11 @@ class FactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFindL10NDir
 	 *
 	 * @param string $app
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFindL10NDir')]
 	public function testFindL10NDir($app, $expected): void {
 		$factory = $this->getFactory();
 		if (in_array($app, ['settings','files'])) {
@@ -479,12 +478,12 @@ class FactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataFindLanguage
 	 *
 	 * @param bool $loggedIn
 	 * @param array $availableLang
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFindLanguage')]
 	public function testFindLanguage($loggedIn, $availableLang, $expected): void {
 		$userLang = 'nl';
 		$browserLang = 'de';
@@ -671,13 +670,13 @@ class FactoryTest extends TestCase {
 	/**
 	 * test if we respect default language if possible
 	 *
-	 * @dataProvider dataTestRespectDefaultLanguage
 	 *
 	 * @param string $lang
 	 * @param string $defaultLanguage
 	 * @param bool $langExists
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestRespectDefaultLanguage')]
 	public function testRespectDefaultLanguage($lang, $defaultLanguage, $langExists, $expected): void {
 		$factory = $this->getFactory(['languageExists']);
 		$factory->expects(self::any())
@@ -703,13 +702,13 @@ class FactoryTest extends TestCase {
 	 * - if available languages set is not reduced to an empty set if
 	 *   the reduce config is an empty set
 	 *
-	 * @dataProvider dataTestReduceToLanguages
 	 *
 	 * @param string $lang
 	 * @param array $availableLanguages
 	 * @param array $reducedLanguageSet
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestReduceToLanguages')]
 	public function testReduceLanguagesByConfiguration(string $lang, array $availableLanguages, array $reducedLanguageSet, array $expected): void {
 		$factory = $this->getFactory(['findAvailableLanguages', 'languageExists']);
 		$factory->expects(self::any())
@@ -744,9 +743,7 @@ class FactoryTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider languageIteratorRequestProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('languageIteratorRequestProvider')]
 	public function testGetLanguageIterator(bool $hasSession, bool $mockUser): void {
 		$factory = $this->getFactory();
 		$user = null;
@@ -777,9 +774,7 @@ class FactoryTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetLanguageDirection
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetLanguageDirection')]
 	public function testGetLanguageDirection(string $language, string $expectedDirection) {
 		$factory = $this->getFactory();
 

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -31,9 +31,9 @@ class L10nTest extends TestCase {
 	 * @return Factory
 	 */
 	protected function getFactory() {
-		/** @var \OCP\IConfig $config */
+		/** @var IConfig $config */
 		$config = $this->createMock(IConfig::class);
-		/** @var \OCP\IRequest $request */
+		/** @var IRequest $request */
 		$request = $this->createMock(IRequest::class);
 		/** @var IUserSession $userSession */
 		$userSession = $this->createMock(IUserSession::class);
@@ -108,11 +108,11 @@ class L10nTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataPlaceholders
 	 *
 	 * @param $string
 	 * @param $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPlaceholders')]
 	public function testPlaceholders($string, $expected): void {
 		$transFile = \OC::$SERVERROOT . '/tests/data/l10n/de.json';
 		$l = new L10N($this->getFactory(), 'test', 'de', 'de_AT', [$transFile]);
@@ -156,9 +156,7 @@ class L10nTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider localizationData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('localizationData')]
 	public function testNumericStringLocalization($expectedDate, $lang, $locale, $type, $value): void {
 		$l = new L10N($this->getFactory(), 'test', $lang, $locale, []);
 		$this->assertSame($expectedDate, $l->l($type, $value));
@@ -172,11 +170,11 @@ class L10nTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider firstDayData
 	 * @param $expected
 	 * @param $lang
 	 * @param $locale
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('firstDayData')]
 	public function testFirstWeekDay($expected, $lang, $locale): void {
 		$l = new L10N($this->getFactory(), 'test', $lang, $locale, []);
 		$this->assertSame($expected, $l->l('firstday', 'firstday'));
@@ -190,11 +188,11 @@ class L10nTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider jsDateData
 	 * @param $expected
 	 * @param $lang
 	 * @param $locale
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('jsDateData')]
 	public function testJSDate($expected, $lang, $locale): void {
 		$l = new L10N($this->getFactory(), 'test', $lang, $locale, []);
 		$this->assertSame($expected, $l->l('jsdate', 'jsdate'));
@@ -216,10 +214,10 @@ class L10nTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider findLanguageFromLocaleData
 	 * @param $locale
 	 * @param $language
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('findLanguageFromLocaleData')]
 	public function testFindLanguageFromLocale($locale, $language): void {
 		$this->assertEquals(
 			$language,

--- a/tests/lib/L10N/LanguageIteratorTest.php
+++ b/tests/lib/L10N/LanguageIteratorTest.php
@@ -58,9 +58,7 @@ class LanguageIteratorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider languageSettingsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('languageSettingsProvider')]
 	public function testIterator($forcedLang, $userLang, $sysLang, $expectedValues): void {
 		$this->config->expects($this->any())
 			->method('getSystemValue')

--- a/tests/lib/LargeFileHelperGetFileSizeTest.php
+++ b/tests/lib/LargeFileHelperGetFileSizeTest.php
@@ -39,9 +39,7 @@ class LargeFileHelperGetFileSizeTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileNameProvider')]
 	public function XtestGetFileSizeViaCurl($filename, $fileSize) {
 		if (!extension_loaded('curl')) {
 			$this->markTestSkipped(
@@ -59,9 +57,7 @@ class LargeFileHelperGetFileSizeTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileNameProvider')]
 	public function testGetFileSizeViaExec($filename, $fileSize): void {
 		if (escapeshellarg('strängé') !== '\'strängé\'') {
 			$this->markTestSkipped('Your escapeshell args removes accents');
@@ -77,9 +73,7 @@ class LargeFileHelperGetFileSizeTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataFileNameProvider')]
 	public function testGetFileSizeNative($filename, $fileSize): void {
 		$this->assertSame(
 			$fileSize,

--- a/tests/lib/LegacyHelperTest.php
+++ b/tests/lib/LegacyHelperTest.php
@@ -116,9 +116,7 @@ class LegacyHelperTest extends \Test\TestCase {
 		$this->assertEquals('dir/filename(1) (2) (4).ext', OC_Helper::buildNotExistingFileNameForView('dir', 'filename(1) (2) (3).ext', $viewMock));
 	}
 
-	/**
-	 * @dataProvider streamCopyDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('streamCopyDataProvider')]
 	public function testStreamCopy($expectedCount, $expectedResult, $source, $target): void {
 		if (is_string($source)) {
 			$source = fopen($source, 'r');

--- a/tests/lib/Lock/DBLockingProviderTest.php
+++ b/tests/lib/Lock/DBLockingProviderTest.php
@@ -28,12 +28,12 @@ class DBLockingProviderTest extends LockingProvider {
 	protected $instance;
 
 	/**
-	 * @var \OCP\IDBConnection
+	 * @var IDBConnection
 	 */
 	protected $connection;
 
 	/**
-	 * @var \OCP\AppFramework\Utility\ITimeFactory
+	 * @var ITimeFactory
 	 */
 	protected $timeFactory;
 
@@ -51,7 +51,7 @@ class DBLockingProviderTest extends LockingProvider {
 	}
 
 	/**
-	 * @return \OCP\Lock\ILockingProvider
+	 * @return ILockingProvider
 	 */
 	protected function getInstance() {
 		$this->connection = Server::get(IDBConnection::class);

--- a/tests/lib/Lock/LockingProvider.php
+++ b/tests/lib/Lock/LockingProvider.php
@@ -14,12 +14,12 @@ use Test\TestCase;
 
 abstract class LockingProvider extends TestCase {
 	/**
-	 * @var \OCP\Lock\ILockingProvider
+	 * @var ILockingProvider
 	 */
 	protected $instance;
 
 	/**
-	 * @return \OCP\Lock\ILockingProvider
+	 * @return ILockingProvider
 	 */
 	abstract protected function getInstance();
 

--- a/tests/lib/Lock/MemcacheLockingProviderTest.php
+++ b/tests/lib/Lock/MemcacheLockingProviderTest.php
@@ -11,16 +11,18 @@ namespace Test\Lock;
 use OC\Lock\MemcacheLockingProvider;
 use OC\Memcache\ArrayCache;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IMemcache;
+use OCP\Lock\ILockingProvider;
 use OCP\Server;
 
 class MemcacheLockingProviderTest extends LockingProvider {
 	/**
-	 * @var \OCP\IMemcache
+	 * @var IMemcache
 	 */
 	private $memcache;
 
 	/**
-	 * @return \OCP\Lock\ILockingProvider
+	 * @return ILockingProvider
 	 */
 	protected function getInstance() {
 		$this->memcache = new ArrayCache();

--- a/tests/lib/Lock/NonCachingDBLockingProviderTest.php
+++ b/tests/lib/Lock/NonCachingDBLockingProviderTest.php
@@ -19,7 +19,7 @@ use OCP\Server;
  */
 class NonCachingDBLockingProviderTest extends DBLockingProviderTest {
 	/**
-	 * @return \OCP\Lock\ILockingProvider
+	 * @return ILockingProvider
 	 */
 	protected function getInstance() {
 		$this->connection = Server::get(IDBConnection::class);

--- a/tests/lib/Log/LogFactoryTest.php
+++ b/tests/lib/Log/LogFactoryTest.php
@@ -13,6 +13,7 @@ use OC\Log\LogFactory;
 use OC\Log\Syslog;
 use OC\Log\Systemdlog;
 use OC\SystemConfig;
+use OCP\AppFramework\QueryException;
 use OCP\IServerContainer;
 use Test\TestCase;
 
@@ -59,9 +60,9 @@ class LogFactoryTest extends TestCase {
 
 	/**
 	 * @param string $type
-	 * @dataProvider fileTypeProvider
-	 * @throws \OCP\AppFramework\QueryException
+	 * @throws QueryException
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('fileTypeProvider')]
 	public function testFile(string $type): void {
 		$datadir = \OC::$SERVERROOT . '/data';
 		$defaultLog = $datadir . '/nextcloud.log';
@@ -92,9 +93,9 @@ class LogFactoryTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider logFilePathProvider
-	 * @throws \OCP\AppFramework\QueryException
+	 * @throws QueryException
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('logFilePathProvider')]
 	public function testFileCustomPath($path, $expected): void {
 		$datadir = \OC::$SERVERROOT . '/data';
 		$defaultLog = $datadir . '/nextcloud.log';
@@ -113,7 +114,7 @@ class LogFactoryTest extends TestCase {
 	}
 
 	/**
-	 * @throws \OCP\AppFramework\QueryException
+	 * @throws QueryException
 	 */
 	public function testErrorLog(): void {
 		$log = $this->factory->get('errorlog');
@@ -121,7 +122,7 @@ class LogFactoryTest extends TestCase {
 	}
 
 	/**
-	 * @throws \OCP\AppFramework\QueryException
+	 * @throws QueryException
 	 */
 	public function testSystemLog(): void {
 		$this->c->expects($this->once())
@@ -134,7 +135,7 @@ class LogFactoryTest extends TestCase {
 	}
 
 	/**
-	 * @throws \OCP\AppFramework\QueryException
+	 * @throws QueryException
 	 */
 	public function testSystemdLog(): void {
 		$this->c->expects($this->once())

--- a/tests/lib/Log/PsrLoggerAdapterTest.php
+++ b/tests/lib/Log/PsrLoggerAdapterTest.php
@@ -28,9 +28,7 @@ class PsrLoggerAdapterTest extends TestCase {
 		$this->loggerAdapter = new PsrLoggerAdapter($this->logger);
 	}
 
-	/**
-	 * @dataProvider dataPsrLoggingLevels
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPsrLoggingLevels')]
 	public function testLoggingWithPsrLogLevels(string $level, int $expectedLevel): void {
 		$this->logger->expects(self::once())
 			->method('log')
@@ -38,9 +36,7 @@ class PsrLoggerAdapterTest extends TestCase {
 		$this->loggerAdapter->log($level, 'test message', ['app' => 'test']);
 	}
 
-	/**
-	 * @dataProvider dataPsrLoggingLevels
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataPsrLoggingLevels')]
 	public function testLogLevelToInt(string $level, int $expectedLevel): void {
 		$this->assertEquals($expectedLevel, PsrLoggerAdapter::logLevelToInt($level));
 	}
@@ -58,9 +54,7 @@ class PsrLoggerAdapterTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataInvalidLoggingLevel
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataInvalidLoggingLevel')]
 	public function testInvalidLoggingLevel($level): void {
 		$this->logger->expects(self::never())
 			->method('log');

--- a/tests/lib/LoggerTest.php
+++ b/tests/lib/LoggerTest.php
@@ -131,9 +131,7 @@ class LoggerTest extends TestCase implements IWriter {
 		];
 	}
 
-	/**
-	 * @dataProvider dataMatchesCondition
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataMatchesCondition')]
 	public function testMatchesCondition(string $userId, array $conditions, array $expectedLogs): void {
 		$this->config->expects($this->any())
 			->method('getValue')
@@ -195,9 +193,7 @@ class LoggerTest extends TestCase implements IWriter {
 		];
 	}
 
-	/**
-	 * @dataProvider userAndPasswordData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('userAndPasswordData')]
 	public function testDetectlogin(string $user, string $password): void {
 		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
@@ -218,9 +214,7 @@ class LoggerTest extends TestCase implements IWriter {
 		}
 	}
 
-	/**
-	 * @dataProvider userAndPasswordData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('userAndPasswordData')]
 	public function testDetectcheckPassword(string $user, string $password): void {
 		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
@@ -241,9 +235,7 @@ class LoggerTest extends TestCase implements IWriter {
 		}
 	}
 
-	/**
-	 * @dataProvider userAndPasswordData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('userAndPasswordData')]
 	public function testDetectvalidateUserPass(string $user, string $password): void {
 		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
@@ -264,9 +256,7 @@ class LoggerTest extends TestCase implements IWriter {
 		}
 	}
 
-	/**
-	 * @dataProvider userAndPasswordData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('userAndPasswordData')]
 	public function testDetecttryLogin(string $user, string $password): void {
 		$this->mockDefaultLogLevel();
 		$e = new \Exception('test');
@@ -287,9 +277,7 @@ class LoggerTest extends TestCase implements IWriter {
 		}
 	}
 
-	/**
-	 * @dataProvider userAndPasswordData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('userAndPasswordData')]
 	public function testDetectclosure(string $user, string $password): void {
 		$this->mockDefaultLogLevel();
 		$a = function ($user, $password): void {

--- a/tests/lib/Mail/MailerTest.php
+++ b/tests/lib/Mail/MailerTest.php
@@ -76,10 +76,10 @@ class MailerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider sendmailModeProvider
 	 * @param $sendmailMode
 	 * @param $binaryParam
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sendmailModeProvider')]
 	public function testGetSendmailInstanceSendMail($sendmailMode, $binaryParam): void {
 		$this->config
 			->expects($this->exactly(2))
@@ -99,10 +99,10 @@ class MailerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider sendmailModeProvider
 	 * @param $sendmailMode
 	 * @param $binaryParam
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('sendmailModeProvider')]
 	public function testGetSendmailInstanceSendMailQmail($sendmailMode, $binaryParam): void {
 		$this->config
 			->expects($this->exactly(2))
@@ -243,9 +243,7 @@ class MailerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider mailAddressProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('mailAddressProvider')]
 	public function testValidateMailAddress($email, $expected, $strict): void {
 		$this->config
 			->expects($this->atMost(1))

--- a/tests/lib/Mail/MessageTest.php
+++ b/tests/lib/Mail/MessageTest.php
@@ -72,11 +72,11 @@ class MessageTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider mailAddressProvider
 	 *
 	 * @param string $unconverted
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('mailAddressProvider')]
 	public function testConvertAddresses($unconverted, $expected): void {
 		$this->assertEquals($expected, self::invokePrivate($this->message, 'convertAddresses', [$unconverted]));
 	}

--- a/tests/lib/Memcache/Cache.php
+++ b/tests/lib/Memcache/Cache.php
@@ -8,9 +8,11 @@
 
 namespace Test\Memcache;
 
+use OCP\IMemcache;
+
 abstract class Cache extends \Test\Cache\TestCache {
 	/**
-	 * @var \OCP\IMemcache cache;
+	 * @var IMemcache cache;
 	 */
 	protected $instance;
 

--- a/tests/lib/Memcache/FactoryTest.php
+++ b/tests/lib/Memcache/FactoryTest.php
@@ -106,9 +106,7 @@ class FactoryTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider cacheAvailabilityProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('cacheAvailabilityProvider')]
 	public function testCacheAvailability($localCache, $distributedCache, $lockingCache,
 		$expectedLocalCache, $expectedDistributedCache, $expectedLockingCache): void {
 		$logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
@@ -119,9 +117,7 @@ class FactoryTest extends \Test\TestCase {
 		$this->assertTrue(is_a($factory->createLocking(), $expectedLockingCache));
 	}
 
-	/**
-	 * @dataProvider cacheUnavailableProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('cacheUnavailableProvider')]
 	public function testCacheNotAvailableException($localCache, $distributedCache): void {
 		$this->expectException(HintException::class);
 

--- a/tests/lib/MemoryInfoTest.php
+++ b/tests/lib/MemoryInfoTest.php
@@ -52,8 +52,8 @@ class MemoryInfoTest extends TestCase {
 	 *
 	 * @param string $iniValue The "memory_limit" ini data.
 	 * @param int|float $expected The expected detected memory limit.
-	 * @dataProvider getMemoryLimitTestData
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getMemoryLimitTestData')]
 	public function testMemoryLimit(string $iniValue, int|float $expected): void {
 		ini_set('memory_limit', $iniValue);
 		$memoryInfo = new MemoryInfo();
@@ -74,8 +74,8 @@ class MemoryInfoTest extends TestCase {
 	 *
 	 * @param int $memoryLimit The memory limit
 	 * @param bool $expected If the memory limit is sufficient.
-	 * @dataProvider getSufficientMemoryTestData
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getSufficientMemoryTestData')]
 	public function testIsMemoryLimitSufficient(int $memoryLimit, bool $expected): void {
 		/* @var MemoryInfo|MockObject $memoryInfo */
 		$memoryInfo = $this->getMockBuilder(MemoryInfo::class)

--- a/tests/lib/NaturalSortTest.php
+++ b/tests/lib/NaturalSortTest.php
@@ -12,9 +12,7 @@ use OC\NaturalSort;
 use OC\NaturalSort_DefaultCollator;
 
 class NaturalSortTest extends \Test\TestCase {
-	/**
-	 * @dataProvider naturalSortDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('naturalSortDataProvider')]
 	public function testNaturalSortCompare($array, $sorted): void {
 		if (!class_exists('Collator')) {
 			$this->markTestSkipped('The intl module is not available, natural sorting might not work as expected.');
@@ -25,9 +23,7 @@ class NaturalSortTest extends \Test\TestCase {
 		$this->assertEquals($sorted, $array);
 	}
 
-	/**
-	 * @dataProvider defaultCollatorDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('defaultCollatorDataProvider')]
 	public function testDefaultCollatorCompare($array, $sorted): void {
 		$comparator = new NaturalSort(new NaturalSort_DefaultCollator());
 		usort($array, [$comparator, 'compare']);

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -41,7 +41,7 @@ class NavigationManagerTest extends TestCase {
 
 	protected IEVentDispatcher|MockObject $dispatcher;
 
-	/** @var \OC\NavigationManager */
+	/** @var NavigationManager */
 	protected $navigationManager;
 	protected LoggerInterface $logger;
 
@@ -122,11 +122,11 @@ class NavigationManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider addArrayData
 	 *
 	 * @param array $entry
 	 * @param array $expectedEntry
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('addArrayData')]
 	public function testAddArray(array $entry, array $expectedEntry): void {
 		$this->assertEmpty($this->navigationManager->getAll('all'), 'Expected no navigation entry exists');
 		$this->navigationManager->add($entry);
@@ -140,11 +140,11 @@ class NavigationManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider addArrayData
 	 *
 	 * @param array $entry
 	 * @param array $expectedEntry
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('addArrayData')]
 	public function testAddClosure(array $entry, array $expectedEntry): void {
 		global $testAddClosureNumberOfCalls;
 		$testAddClosureNumberOfCalls = 0;
@@ -215,9 +215,7 @@ class NavigationManagerTest extends TestCase {
 		$this->assertEquals(0, $testAddClosureNumberOfCalls, 'Expected that the closure is not called by getAll()');
 	}
 
-	/**
-	 * @dataProvider providesNavigationConfig
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesNavigationConfig')]
 	public function testWithAppManager($expected, $navigation, $isAdmin = false): void {
 		$l = $this->createMock(IL10N::class);
 		$l->expects($this->any())->method('t')->willReturnCallback(function ($text, $parameters = []) {
@@ -731,9 +729,7 @@ class NavigationManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider provideDefaultEntries
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideDefaultEntries')]
 	public function testGetDefaultEntryIdForUser(string $defaultApps, string $userDefaultApps, string $userApporder, bool $withFallbacks, string $expectedApp): void {
 		$this->navigationManager->add([
 			'id' => 'files',

--- a/tests/lib/Net/HostnameClassifierTest.php
+++ b/tests/lib/Net/HostnameClassifierTest.php
@@ -32,9 +32,7 @@ class HostnameClassifierTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider localHostnamesData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('localHostnamesData')]
 	public function testLocalHostname(string $host): void {
 		$isLocal = $this->classifier->isLocalHostname($host);
 
@@ -51,9 +49,7 @@ class HostnameClassifierTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider publicHostnamesData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('publicHostnamesData')]
 	public function testPublicHostname(string $host): void {
 		$isLocal = $this->classifier->isLocalHostname($host);
 

--- a/tests/lib/Net/IpAddressClassifierTest.php
+++ b/tests/lib/Net/IpAddressClassifierTest.php
@@ -30,9 +30,7 @@ class IpAddressClassifierTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider publicIpAddressData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('publicIpAddressData')]
 	public function testPublicAddress(string $ip): void {
 		$isLocal = $this->classifier->isLocalAddress($ip);
 
@@ -54,9 +52,7 @@ class IpAddressClassifierTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider localIpAddressData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('localIpAddressData')]
 	public function testLocalAddress(string $ip): void {
 		$isLocal = $this->classifier->isLocalAddress($ip);
 

--- a/tests/lib/Notification/ActionTest.php
+++ b/tests/lib/Notification/ActionTest.php
@@ -30,9 +30,9 @@ class ActionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetLabel
 	 * @param string $label
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetLabel')]
 	public function testSetLabel($label): void {
 		$this->assertSame('', $this->action->getLabel());
 		$this->assertSame($this->action, $this->action->setLabel($label));
@@ -47,10 +47,10 @@ class ActionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetLabelInvalid
 	 * @param mixed $label
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetLabelInvalid')]
 	public function testSetLabelInvalid($label): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -66,9 +66,9 @@ class ActionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetParsedLabel
 	 * @param string $label
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetParsedLabel')]
 	public function testSetParsedLabel($label): void {
 		$this->assertSame('', $this->action->getParsedLabel());
 		$this->assertSame($this->action, $this->action->setParsedLabel($label));
@@ -82,10 +82,10 @@ class ActionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetParsedLabelInvalid
 	 * @param mixed $label
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetParsedLabelInvalid')]
 	public function testSetParsedLabelInvalid($label): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -102,10 +102,10 @@ class ActionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetLink
 	 * @param string $link
 	 * @param string $type
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetLink')]
 	public function testSetLink($link, $type): void {
 		$this->assertSame('', $this->action->getLink());
 		$this->assertSame($this->action, $this->action->setLink($link, $type));
@@ -125,11 +125,11 @@ class ActionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetLinkInvalid
 	 * @param mixed $link
 	 * @param mixed $type
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetLinkInvalid')]
 	public function testSetLinkInvalid($link, $type): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -144,9 +144,9 @@ class ActionTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetPrimary
 	 * @param bool $primary
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetPrimary')]
 	public function testSetPrimary($primary): void {
 		$this->assertSame(false, $this->action->isPrimary());
 		$this->assertSame($this->action, $this->action->setPrimary($primary));

--- a/tests/lib/Notification/ManagerTest.php
+++ b/tests/lib/Notification/ManagerTest.php
@@ -256,11 +256,11 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsFairUseOfFreePushService
 	 * @param bool $hasValidSubscription
 	 * @param int $userCount
 	 * @param bool $isFair
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsFairUseOfFreePushService')]
 	public function testIsFairUseOfFreePushService(bool $hasValidSubscription, int $userCount, bool $isFair): void {
 		$this->subscriptionRegistry->method('delegateHasValidSubscription')
 			->willReturn($hasValidSubscription);

--- a/tests/lib/Notification/NotificationTest.php
+++ b/tests/lib/Notification/NotificationTest.php
@@ -57,9 +57,9 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetApp
 	 * @param string $app
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetApp')]
 	public function testSetApp($app): void {
 		$this->assertSame('', $this->notification->getApp());
 		$this->assertSame($this->notification, $this->notification->setApp($app));
@@ -71,10 +71,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetAppInvalid
 	 * @param mixed $app
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetAppInvalid')]
 	public function testSetAppInvalid($app): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -87,9 +87,9 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetUser
 	 * @param string $user
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetUser')]
 	public function testSetUser($user): void {
 		$this->assertSame('', $this->notification->getUser());
 		$this->assertSame($this->notification, $this->notification->setUser($user));
@@ -101,10 +101,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetUserInvalid
 	 * @param mixed $user
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetUserInvalid')]
 	public function testSetUserInvalid($user): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -126,9 +126,9 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetDateTime
 	 * @param \DateTime $dateTime
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetDateTime')]
 	public function testSetDateTime(\DateTime $dateTime): void {
 		$this->assertSame(0, $this->notification->getDateTime()->getTimestamp());
 		$this->assertSame($this->notification, $this->notification->setDateTime($dateTime));
@@ -144,11 +144,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetDateTimeZero
 	 * @param \DateTime $dateTime
-	 *
 	 * @expectedMessage 'The given date time is invalid'
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetDateTimeZero')]
 	public function testSetDateTimeZero($dateTime): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -163,10 +162,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetObject
 	 * @param string $type
 	 * @param string $id
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetObject')]
 	public function testSetObject($type, $id): void {
 		$this->assertSame('', $this->notification->getObjectType());
 		$this->assertSame('', $this->notification->getObjectId());
@@ -187,11 +186,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetObjectIdInvalid
 	 * @param mixed $id
-	 *
 	 * @expectedMessage 'The given object id is invalid'
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetObjectIdInvalid')]
 	public function testSetObjectIdInvalid($id): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -207,10 +205,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetSubject
 	 * @param string $subject
 	 * @param array $parameters
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetSubject')]
 	public function testSetSubject($subject, $parameters): void {
 		$this->assertSame('', $this->notification->getSubject());
 		$this->assertSame([], $this->notification->getSubjectParameters());
@@ -224,10 +222,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetSubjectInvalidSubject
 	 * @param mixed $subject
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetSubjectInvalidSubject')]
 	public function testSetSubjectInvalidSubject($subject): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -239,9 +237,9 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetParsedSubject
 	 * @param string $subject
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetParsedSubject')]
 	public function testSetParsedSubject($subject): void {
 		$this->assertSame('', $this->notification->getParsedSubject());
 		$this->assertSame($this->notification, $this->notification->setParsedSubject($subject));
@@ -253,10 +251,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetParsedSubjectInvalid
 	 * @param mixed $subject
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetParsedSubjectInvalid')]
 	public function testSetParsedSubjectInvalid($subject): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -272,10 +270,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetMessage
 	 * @param string $message
 	 * @param array $parameters
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetMessage')]
 	public function testSetMessage($message, $parameters): void {
 		$this->assertSame('', $this->notification->getMessage());
 		$this->assertSame([], $this->notification->getMessageParameters());
@@ -289,10 +287,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetMessageInvalidMessage
 	 * @param mixed $message
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetMessageInvalidMessage')]
 	public function testSetMessageInvalidMessage($message): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -304,9 +302,9 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetParsedMessage
 	 * @param string $message
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetParsedMessage')]
 	public function testSetParsedMessage($message): void {
 		$this->assertSame('', $this->notification->getParsedMessage());
 		$this->assertSame($this->notification, $this->notification->setParsedMessage($message));
@@ -318,10 +316,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetParsedMessageInvalid
 	 * @param mixed $message
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetParsedMessageInvalid')]
 	public function testSetParsedMessageInvalid($message): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -333,9 +331,9 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetLink
 	 * @param string $link
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetLink')]
 	public function testSetLink($link): void {
 		$this->assertSame('', $this->notification->getLink());
 		$this->assertSame($this->notification, $this->notification->setLink($link));
@@ -347,10 +345,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetLinkInvalid
 	 * @param mixed $link
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetLinkInvalid')]
 	public function testSetLinkInvalid($link): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -362,9 +360,9 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetIcon
 	 * @param string $icon
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetIcon')]
 	public function testSetIcon($icon): void {
 		$this->assertSame('', $this->notification->getIcon());
 		$this->assertSame($this->notification, $this->notification->setIcon($icon));
@@ -376,10 +374,10 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSetIconInvalid
 	 * @param mixed $icon
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSetIconInvalid')]
 	public function testSetIconInvalid($icon): void {
 		$this->expectException(\InvalidArgumentException::class);
 
@@ -392,7 +390,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddAction(): void {
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->createMock(IAction::class);
 		$action->expects($this->once())
 			->method('isValid')
@@ -410,7 +408,7 @@ class NotificationTest extends TestCase {
 	public function testAddActionInvalid(): void {
 		$this->expectException(\InvalidArgumentException::class);
 
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->createMock(IAction::class);
 		$action->expects($this->once())
 			->method('isValid')
@@ -422,7 +420,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddActionSecondPrimary(): void {
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->createMock(IAction::class);
 		$action->expects($this->exactly(2))
 			->method('isValid')
@@ -438,7 +436,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddParsedAction(): void {
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->createMock(IAction::class);
 		$action->expects($this->once())
 			->method('isValidParsed')
@@ -456,7 +454,7 @@ class NotificationTest extends TestCase {
 	public function testAddParsedActionInvalid(): void {
 		$this->expectException(\InvalidArgumentException::class);
 
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->createMock(IAction::class);
 		$action->expects($this->once())
 			->method('isValidParsed')
@@ -468,7 +466,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddActionSecondParsedPrimary(): void {
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action = $this->createMock(IAction::class);
 		$action->expects($this->exactly(2))
 			->method('isValidParsed')
@@ -484,7 +482,7 @@ class NotificationTest extends TestCase {
 	}
 
 	public function testAddActionParsedPrimaryEnd(): void {
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action1 = $this->createMock(IAction::class);
 		$action1->expects($this->exactly(2))
 			->method('isValidParsed')
@@ -492,7 +490,7 @@ class NotificationTest extends TestCase {
 		$action1->expects($this->exactly(2))
 			->method('isPrimary')
 			->willReturn(false);
-		/** @var \OCP\Notification\IAction|\PHPUnit\Framework\MockObject\MockObject $action */
+		/** @var IAction|\PHPUnit\Framework\MockObject\MockObject $action */
 		$action2 = $this->createMock(IAction::class);
 		$action2->expects($this->once())
 			->method('isValidParsed')
@@ -518,14 +516,14 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsValid
 	 *
 	 * @param bool $isValidCommon
 	 * @param string $subject
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsValid')]
 	public function testIsValid($isValidCommon, $subject, $expected): void {
-		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
+		/** @var INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(Notification::class)
 			->onlyMethods([
 				'isValidCommon',
@@ -551,14 +549,14 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsValid
 	 *
 	 * @param bool $isValidCommon
 	 * @param string $subject
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsValid')]
 	public function testIsParsedValid($isValidCommon, $subject, $expected): void {
-		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
+		/** @var INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(Notification::class)
 			->onlyMethods([
 				'isValidCommon',
@@ -595,7 +593,6 @@ class NotificationTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsValidCommon
 	 *
 	 * @param string $app
 	 * @param string $user
@@ -604,8 +601,9 @@ class NotificationTest extends TestCase {
 	 * @param string $objectId
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsValidCommon')]
 	public function testIsValidCommon($app, $user, $timestamp, $objectType, $objectId, $expected): void {
-		/** @var \OCP\Notification\INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
+		/** @var INotification|\PHPUnit\Framework\MockObject\MockObject $notification */
 		$notification = $this->getMockBuilder(Notification::class)
 			->onlyMethods([
 				'getApp',

--- a/tests/lib/OCS/ApiHelperTest.php
+++ b/tests/lib/OCS/ApiHelperTest.php
@@ -34,9 +34,7 @@ class ApiHelperTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider versionDataScriptNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('versionDataScriptNameProvider')]
 	public function testIsV2(string $scriptName, bool $expected): void {
 		$request = $this->getMockBuilder(IRequest::class)
 			->disableOriginalConstructor()

--- a/tests/lib/OCS/DiscoveryServiceTest.php
+++ b/tests/lib/OCS/DiscoveryServiceTest.php
@@ -36,11 +36,11 @@ class DiscoveryServiceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestIsSafeUrl
 	 *
 	 * @param string $url
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestIsSafeUrl')]
 	public function testIsSafeUrl($url, $expected): void {
 		$result = $this->invokePrivate($this->discoveryService, 'isSafeUrl', [$url]);
 		$this->assertSame($expected, $result);
@@ -59,12 +59,12 @@ class DiscoveryServiceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestGetEndpoints
 	 *
 	 * @param array $decodedServices
 	 * @param string $service
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetEndpoints')]
 	public function testGetEndpoints($decodedServices, $service, $expected): void {
 		$result = $this->invokePrivate($this->discoveryService, 'getEndpoints', [$decodedServices, $service]);
 		$this->assertSame($expected, $result);

--- a/tests/lib/OCS/ProviderTest.php
+++ b/tests/lib/OCS/ProviderTest.php
@@ -9,12 +9,14 @@
 namespace Test\OCS;
 
 use OC\OCS\Provider;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
 
 class ProviderTest extends \Test\TestCase {
-	/** @var \OCP\IRequest */
+	/** @var IRequest */
 	private $request;
-	/** @var \OCP\App\IAppManager */
+	/** @var IAppManager */
 	private $appManager;
 	/** @var Provider */
 	private $ocsProvider;

--- a/tests/lib/Preview/GeneratorTest.php
+++ b/tests/lib/Preview/GeneratorTest.php
@@ -381,7 +381,6 @@ class GeneratorTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataSize
 	 *
 	 * @param int $maxX
 	 * @param int $maxY
@@ -392,6 +391,7 @@ class GeneratorTest extends \Test\TestCase {
 	 * @param int $expectedX
 	 * @param int $expectedY
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataSize')]
 	public function testCorrectSize($maxX, $maxY, $reqX, $reqY, $crop, $mode, $expectedX, $expectedY): void {
 		$file = $this->createMock(File::class);
 		$file->method('isReadable')

--- a/tests/lib/Preview/Provider.php
+++ b/tests/lib/Preview/Provider.php
@@ -15,6 +15,7 @@ use OC\Files\Storage\Temporary;
 use OC\Files\View;
 use OC\Preview\TXT;
 use OCP\Files\IRootFolder;
+use OCP\IImage;
 use OCP\IUserManager;
 use OCP\Server;
 
@@ -71,12 +72,12 @@ abstract class Provider extends \Test\TestCase {
 	/**
 	 * Launches all the tests we have
 	 *
-	 * @dataProvider dimensionsDataProvider
 	 * @requires extension imagick
 	 *
 	 * @param int $widthAdjustment
 	 * @param int $heightAdjustment
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dimensionsDataProvider')]
 	public function testGetThumbnail($widthAdjustment, $heightAdjustment): void {
 		$ratio = round($this->width / $this->height, 2);
 		$this->maxWidth = $this->width - $widthAdjustment;
@@ -120,7 +121,7 @@ abstract class Provider extends \Test\TestCase {
 	 *
 	 * @param \OC\Preview\Provider $provider
 	 *
-	 * @return bool|\OCP\IImage
+	 * @return bool|IImage
 	 */
 	private function getPreview($provider) {
 		$file = new File(Server::get(IRootFolder::class), $this->rootView, $this->imgPath);
@@ -139,7 +140,7 @@ abstract class Provider extends \Test\TestCase {
 	/**
 	 * Checks if the preview ratio matches the original ratio
 	 *
-	 * @param \OCP\IImage $preview
+	 * @param IImage $preview
 	 * @param int $ratio
 	 */
 	private function doesRatioMatch($preview, $ratio) {
@@ -150,7 +151,7 @@ abstract class Provider extends \Test\TestCase {
 	/**
 	 * Tests if a max size preview of smaller dimensions can be created
 	 *
-	 * @param \OCP\IImage $preview
+	 * @param IImage $preview
 	 */
 	private function doesPreviewFit($preview) {
 		$maxDimRatio = round($this->maxWidth / $this->maxHeight, 2);

--- a/tests/lib/Preview/SVGTest.php
+++ b/tests/lib/Preview/SVGTest.php
@@ -46,9 +46,9 @@ class SVGTest extends Provider {
 	}
 
 	/**
-	 * @dataProvider dataGetThumbnailSVGHref
 	 * @requires extension imagick
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetThumbnailSVGHref')]
 	public function testGetThumbnailSVGHref(string $content): void {
 		$handle = fopen('php://temp', 'w+');
 		fwrite($handle, '<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">

--- a/tests/lib/Profile/Actions/FediverseActionTest.php
+++ b/tests/lib/Profile/Actions/FediverseActionTest.php
@@ -105,7 +105,7 @@ class FediverseActionTest extends TestCase {
 		];
 	}
 
-	/** @dataProvider dataGetTitle */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetTitle')]
 	public function testGetTitle(string $value): void {
 		$property = $this->createMock(IAccountProperty::class);
 		$property->method('getValue')
@@ -154,7 +154,7 @@ class FediverseActionTest extends TestCase {
 		];
 	}
 
-	/** @dataProvider dataGetTarget */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetTarget')]
 	public function testGetTarget(?string $value, ?string $expected): void {
 		$user = $this->createMock(IUser::class);
 

--- a/tests/lib/Repair/ClearGeneratedAvatarCacheTest.php
+++ b/tests/lib/Repair/ClearGeneratedAvatarCacheTest.php
@@ -45,11 +45,11 @@ class ClearGeneratedAvatarCacheTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider shouldRunDataProvider
 	 *
 	 * @param string $from
 	 * @param boolean $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('shouldRunDataProvider')]
 	public function testShouldRun($from, $expected): void {
 		$this->config->expects($this->any())
 			->method('getSystemValueString')

--- a/tests/lib/Repair/RepairInvalidSharesTest.php
+++ b/tests/lib/Repair/RepairInvalidSharesTest.php
@@ -150,9 +150,8 @@ class RepairInvalidSharesTest extends TestCase {
 
 	/**
 	 * Test adjusting file share permissions
-	 *
-	 * @dataProvider fileSharePermissionsProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('fileSharePermissionsProvider')]
 	public function testFileSharePermissions($itemType, $testPerms, $expectedPerms): void {
 		$qb = $this->connection->getQueryBuilder();
 		$qb->insert('share')

--- a/tests/lib/RichObjectStrings/DefinitionsTest.php
+++ b/tests/lib/RichObjectStrings/DefinitionsTest.php
@@ -31,10 +31,10 @@ class DefinitionsTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetDefinition
 	 * @param string $type
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetDefinition')]
 	public function testGetDefinition($type, array $expected): void {
 		$definitions = new Definitions();
 		$definition = $definitions->getDefinition($type);

--- a/tests/lib/RichObjectStrings/ValidatorTest.php
+++ b/tests/lib/RichObjectStrings/ValidatorTest.php
@@ -80,9 +80,7 @@ class ValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataValidateParameterKeys
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateParameterKeys')]
 	public function testValidateParameterKeys(mixed $key, ?string $throws): void {
 
 		if ($throws !== null) {

--- a/tests/lib/Security/Bruteforce/Backend/MemoryCacheBackendTest.php
+++ b/tests/lib/Security/Bruteforce/Backend/MemoryCacheBackendTest.php
@@ -67,9 +67,7 @@ class MemoryCacheBackendTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetAttempts
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAttempts')]
 	public function testGetAttempts(int $maxAge, ?string $action, ?array $metadata, int $expected): void {
 		$this->cache
 			->expects($this->once())

--- a/tests/lib/Security/CSRF/CsrfTokenGeneratorTest.php
+++ b/tests/lib/Security/CSRF/CsrfTokenGeneratorTest.php
@@ -11,9 +11,10 @@ declare(strict_types=1);
 namespace Test\Security\CSRF;
 
 use OC\Security\CSRF\CsrfTokenGenerator;
+use OCP\Security\ISecureRandom;
 
 class CsrfTokenGeneratorTest extends \Test\TestCase {
-	/** @var \OCP\Security\ISecureRandom */
+	/** @var ISecureRandom */
 	private $random;
 	/** @var \OC\Security\CSRF\CsrfTokenGenerator */
 	private $csrfTokenGenerator;

--- a/tests/lib/Security/CSRF/TokenStorage/SessionStorageTest.php
+++ b/tests/lib/Security/CSRF/TokenStorage/SessionStorageTest.php
@@ -14,7 +14,7 @@ use OC\Security\CSRF\TokenStorage\SessionStorage;
 use OCP\ISession;
 
 class SessionStorageTest extends \Test\TestCase {
-	/** @var \OCP\ISession */
+	/** @var ISession */
 	private $session;
 	/** @var \OC\Security\CSRF\TokenStorage\SessionStorage */
 	private $sessionStorage;
@@ -42,9 +42,9 @@ class SessionStorageTest extends \Test\TestCase {
 
 	/**
 	 * @param string $token
-	 * @dataProvider getTokenDataProvider
 	 *
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getTokenDataProvider')]
 	public function testGetTokenWithEmptyToken($token): void {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Session does not contain a requesttoken');

--- a/tests/lib/Security/CertificateManagerTest.php
+++ b/tests/lib/Security/CertificateManagerTest.php
@@ -114,9 +114,9 @@ class CertificateManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dangerousFileProvider
 	 * @param string $filename
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dangerousFileProvider')]
 	public function testAddDangerousFile($filename): void {
 		$this->expectException(InvalidPathException::class);
 		$this->certificateManager->addCertificate(file_get_contents(__DIR__ . '/../../data/certificates/expiredCertificate.crt'), $filename);
@@ -136,13 +136,13 @@ class CertificateManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestNeedRebundling
 	 *
 	 * @param int $CaBundleMtime
 	 * @param int $targetBundleMtime
 	 * @param int $targetBundleExists
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestNeedRebundling')]
 	public function testNeedRebundling($CaBundleMtime,
 		$targetBundleMtime,
 		$targetBundleExists,

--- a/tests/lib/Security/CredentialsManagerTest.php
+++ b/tests/lib/Security/CredentialsManagerTest.php
@@ -17,9 +17,7 @@ use OCP\Server;
  * @group DB
  */
 class CredentialsManagerTest extends \Test\TestCase {
-	/**
-	 * @dataProvider credentialsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('credentialsProvider')]
 	public function testWithDB($userId, $identifier): void {
 		$credentialsManager = Server::get(ICredentialsManager::class);
 
@@ -34,9 +32,7 @@ class CredentialsManagerTest extends \Test\TestCase {
 		$this->assertSame(1, $removedRows);
 	}
 
-	/**
-	 * @dataProvider credentialsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('credentialsProvider')]
 	public function testUpdate($userId, $identifier): void {
 		$credentialsManager = Server::get(ICredentialsManager::class);
 

--- a/tests/lib/Security/CryptoTest.php
+++ b/tests/lib/Security/CryptoTest.php
@@ -31,9 +31,7 @@ class CryptoTest extends \Test\TestCase {
 		$this->crypto = new Crypto(Server::get(IConfig::class));
 	}
 
-	/**
-	 * @dataProvider defaultEncryptionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('defaultEncryptionProvider')]
 	public function testDefaultEncrypt($stringToEncrypt): void {
 		$ciphertext = $this->crypto->encrypt($stringToEncrypt);
 		$this->assertEquals($stringToEncrypt, $this->crypto->decrypt($ciphertext));

--- a/tests/lib/Security/HasherTest.php
+++ b/tests/lib/Security/HasherTest.php
@@ -124,18 +124,14 @@ class HasherTest extends \Test\TestCase {
 		$this->assertNotNull($hash);
 	}
 
-	/**
-	 * @dataProvider versionHashProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('versionHashProvider')]
 	public function testSplitHash($hash, $expected): void {
 		$relativePath = self::invokePrivate($this->hasher, 'splitHash', [$hash]);
 		$this->assertSame($expected, $relativePath);
 	}
 
 
-	/**
-	 * @dataProvider hashProviders70_71
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hashProviders70_71')]
 	public function testVerify($password, $hash, $expected): void {
 		$this->config
 			->expects($this->any())
@@ -151,9 +147,7 @@ class HasherTest extends \Test\TestCase {
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @dataProvider hashProviders72
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hashProviders72')]
 	public function testVerifyArgon2i($password, $hash, $expected): void {
 		if (!\defined('PASSWORD_ARGON2I')) {
 			$this->markTestSkipped('Need ARGON2 support to test ARGON2 hashes');
@@ -163,9 +157,7 @@ class HasherTest extends \Test\TestCase {
 		$this->assertSame($expected, $result);
 	}
 
-	/**
-	 * @dataProvider hashProviders73
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('hashProviders73')]
 	public function testVerifyArgon2id(string $password, string $hash, bool $expected): void {
 		if (!\defined('PASSWORD_ARGON2ID')) {
 			$this->markTestSkipped('Need ARGON2ID support to test ARGON2ID hashes');

--- a/tests/lib/Security/Ip/BruteforceAllowListTest.php
+++ b/tests/lib/Security/Ip/BruteforceAllowListTest.php
@@ -130,10 +130,9 @@ class BruteforceAllowListTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsBypassListed
-	 *
 	 * @param string[] $allowList
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsBypassListed')]
 	public function testIsBypassListed(
 		string $ip,
 		array $allowList,

--- a/tests/lib/Security/Ip/RemoteAddressTest.php
+++ b/tests/lib/Security/Ip/RemoteAddressTest.php
@@ -25,8 +25,8 @@ class RemoteAddressTest extends \Test\TestCase {
 
 	/**
 	 * @param mixed $allowedRanges
-	 * @dataProvider dataProvider
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProvider')]
 	public function testAllowedIps(string $remoteIp, $allowedRanges, bool $expected): void {
 		$this->request
 			->method('getRemoteAddress')

--- a/tests/lib/Security/Normalizer/IpAddressTest.php
+++ b/tests/lib/Security/Normalizer/IpAddressTest.php
@@ -55,11 +55,11 @@ class IpAddressTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider subnetDataProvider
 	 *
 	 * @param string $input
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('subnetDataProvider')]
 	public function testGetSubnet($input, $expected): void {
 		$this->assertSame($expected, (new IpAddress($input))->getSubnet());
 	}

--- a/tests/lib/Security/RemoteHostValidatorIntegrationTest.php
+++ b/tests/lib/Security/RemoteHostValidatorIntegrationTest.php
@@ -73,9 +73,7 @@ class RemoteHostValidatorIntegrationTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider localHostsData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('localHostsData')]
 	public function testLocalHostsWhenNotAllowed(string $host): void {
 		$this->config
 			->method('getSystemValueBool')
@@ -87,9 +85,7 @@ class RemoteHostValidatorIntegrationTest extends TestCase {
 		self::assertFalse($isValid);
 	}
 
-	/**
-	 * @dataProvider localHostsData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('localHostsData')]
 	public function testLocalHostsWhenAllowed(string $host): void {
 		$this->config
 			->method('getSystemValueBool')
@@ -111,9 +107,7 @@ class RemoteHostValidatorIntegrationTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider externalAddressesData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('externalAddressesData')]
 	public function testExternalHost(string $host): void {
 		$this->config
 			->method('getSystemValueBool')

--- a/tests/lib/Security/RemoteHostValidatorTest.php
+++ b/tests/lib/Security/RemoteHostValidatorTest.php
@@ -51,9 +51,7 @@ class RemoteHostValidatorTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataValid
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValid')]
 	public function testValid(string $host, bool $expected): void {
 		$this->hostnameClassifier
 			->method('isLocalHostname')

--- a/tests/lib/Security/SecureRandomTest.php
+++ b/tests/lib/Security/SecureRandomTest.php
@@ -40,34 +40,26 @@ class SecureRandomTest extends \Test\TestCase {
 		$this->rng = new SecureRandom();
 	}
 
-	/**
-	 * @dataProvider stringGenerationProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('stringGenerationProvider')]
 	public function testGetLowStrengthGeneratorLength($length, $expectedLength): void {
 		$generator = $this->rng;
 
 		$this->assertEquals($expectedLength, strlen($generator->generate($length)));
 	}
 
-	/**
-	 * @dataProvider stringGenerationProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('stringGenerationProvider')]
 	public function testMediumLowStrengthGeneratorLength($length, $expectedLength): void {
 		$generator = $this->rng;
 
 		$this->assertEquals($expectedLength, strlen($generator->generate($length)));
 	}
 
-	/**
-	 * @dataProvider stringGenerationProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('stringGenerationProvider')]
 	public function testUninitializedGenerate($length, $expectedLength): void {
 		$this->assertEquals($expectedLength, strlen($this->rng->generate($length)));
 	}
 
-	/**
-	 * @dataProvider charCombinations
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('charCombinations')]
 	public function testScheme($charName, $chars): void {
 		$generator = $this->rng;
 		$scheme = constant('OCP\Security\ISecureRandom::' . $charName);
@@ -83,9 +75,7 @@ class SecureRandomTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider invalidLengths
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('invalidLengths')]
 	public function testInvalidLengths($length): void {
 		$this->expectException(\LengthException::class);
 		$generator = $this->rng;

--- a/tests/lib/Security/TrustedDomainHelperTest.php
+++ b/tests/lib/Security/TrustedDomainHelperTest.php
@@ -27,11 +27,11 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider trustedDomainDataProvider
 	 * @param string $trustedDomains
 	 * @param string $testDomain
 	 * @param bool $result
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('trustedDomainDataProvider')]
 	public function testIsTrustedUrl($trustedDomains, $testDomain, $result): void {
 		$this->config->method('getSystemValue')
 			->willReturnMap([
@@ -44,11 +44,11 @@ class TrustedDomainHelperTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider trustedDomainDataProvider
 	 * @param string $trustedDomains
 	 * @param string $testDomain
 	 * @param bool $result
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('trustedDomainDataProvider')]
 	public function testIsTrustedDomain($trustedDomains, $testDomain, $result): void {
 		$this->config->method('getSystemValue')
 			->willReturnMap([

--- a/tests/lib/ServerTest.php
+++ b/tests/lib/ServerTest.php
@@ -21,7 +21,7 @@ use OCP\Comments\ICommentsManager;
  * @package Test
  */
 class ServerTest extends \Test\TestCase {
-	/** @var \OC\Server */
+	/** @var Server */
 	protected $server;
 
 
@@ -44,11 +44,11 @@ class ServerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataTestQuery
 	 *
 	 * @param string $serviceName
 	 * @param string $instanceOf
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestQuery')]
 	public function testQuery($serviceName, $instanceOf): void {
 		$this->assertInstanceOf($instanceOf, $this->server->query($serviceName), 'Service "' . $serviceName . '"" did not return the right class');
 	}

--- a/tests/lib/Session/CryptoSessionDataTest.php
+++ b/tests/lib/Session/CryptoSessionDataTest.php
@@ -10,13 +10,14 @@ namespace Test\Session;
 
 use OC\Session\CryptoSessionData;
 use OC\Session\Memory;
+use OCP\ISession;
 use OCP\Security\ICrypto;
 
 class CryptoSessionDataTest extends Session {
-	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\Security\ICrypto */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|ICrypto */
 	protected $crypto;
 
-	/** @var \OCP\ISession */
+	/** @var ISession */
 	protected $wrappedSession;
 
 	protected function setUp(): void {

--- a/tests/lib/Session/CryptoWrappingTest.php
+++ b/tests/lib/Session/CryptoWrappingTest.php
@@ -10,13 +10,14 @@ namespace Test\Session;
 
 use OC\Session\CryptoSessionData;
 use OCP\ISession;
+use OCP\Security\ICrypto;
 use Test\TestCase;
 
 class CryptoWrappingTest extends TestCase {
-	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\Security\ICrypto */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|ICrypto */
 	protected $crypto;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject|\OCP\ISession */
+	/** @var \PHPUnit\Framework\MockObject\MockObject|ISession */
 	protected $wrappedSession;
 
 	/** @var \OC\Session\CryptoSessionData */

--- a/tests/lib/Settings/DeclarativeManagerTest.php
+++ b/tests/lib/Settings/DeclarativeManagerTest.php
@@ -345,9 +345,7 @@ class DeclarativeManagerTest extends TestCase {
 		$this->assertFalse(isset($formIds[$app]) && in_array($schemaDuplicateFields['id'], $formIds[$app]));
 	}
 
-	/**
-	 * @dataProvider dataValidateSchema
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataValidateSchema')]
 	public function testValidateSchema(bool $expected, bool $expectException, string $app, array $schema): void {
 		if ($expectException) {
 			$this->expectException(\Exception::class);

--- a/tests/lib/SetupCheck/CheckServerResponseTraitTest.php
+++ b/tests/lib/SetupCheck/CheckServerResponseTraitTest.php
@@ -48,9 +48,7 @@ class CheckServerResponseTraitTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider dataNormalizeUrl
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataNormalizeUrl')]
 	public function testNormalizeUrl(string $url, bool $isRootRequest, string $expected): void {
 		$this->assertEquals($expected, $this->trait->normalizeUrl($url, $isRootRequest));
 	}
@@ -75,9 +73,7 @@ class CheckServerResponseTraitTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetTestUrls
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetTestUrls')]
 	public function testGetTestUrls(
 		string $url,
 		bool $isRootRequest,

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -129,10 +129,10 @@ class SetupTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider findWebRootProvider
 	 * @param $url
 	 * @param $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('findWebRootProvider')]
 	public function testFindWebRootCli($url, $expected): void {
 		$cliState = \OC::$CLI;
 

--- a/tests/lib/Share/HelperTest.php
+++ b/tests/lib/Share/HelperTest.php
@@ -36,21 +36,19 @@ class HelperTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider expireDateProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('expireDateProvider')]
 	public function testCalculateExpireDate($defaultExpireSettings, $creationTime, $userExpireDate, $expected): void {
 		$result = Helper::calculateExpireDate($defaultExpireSettings, $creationTime, $userExpireDate);
 		$this->assertSame($expected, $result);
 	}
 
 	/**
-	 * @dataProvider dataTestCompareServerAddresses
 	 *
 	 * @param string $server1
 	 * @param string $server2
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestCompareServerAddresses')]
 	public function testIsSameUserOnSameServer($user1, $server1, $user2, $server2, $expected): void {
 		$this->assertSame($expected,
 			Helper::isSameUserOnSameServer($user1, $server1, $user2, $server2)

--- a/tests/lib/Share/ShareTest.php
+++ b/tests/lib/Share/ShareTest.php
@@ -127,10 +127,10 @@ class ShareTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider urls
 	 * @param string $url
 	 * @param string $expectedResult
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('urls')]
 	public function testRemoveProtocolFromUrl($url, $expectedResult): void {
 		$share = new Share();
 		$result = self::invokePrivate($share, 'removeProtocolFromUrl', [$url]);
@@ -146,10 +146,10 @@ class ShareTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataProviderTestGroupItems
 	 * @param array $ungrouped
 	 * @param array $grouped
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataProviderTestGroupItems')]
 	public function testGroupItems($ungrouped, $grouped): void {
 		$result = DummyShareClass::groupItemsTest($ungrouped);
 

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -985,9 +985,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider storageAndFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('storageAndFileNameProvider')]
 	public function testGetSharedWithUser($storageStringId, $fileName1, $fileName2): void {
 		$storageId = $this->createTestStorageEntry($storageStringId);
 		$fileId = $this->createTestFileEntry($fileName1, $storageId);
@@ -1036,9 +1034,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals(IShare::TYPE_USER, $share->getShareType());
 	}
 
-	/**
-	 * @dataProvider storageAndFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('storageAndFileNameProvider')]
 	public function testGetSharedWithGroup($storageStringId, $fileName1, $fileName2): void {
 		$storageId = $this->createTestStorageEntry($storageStringId);
 		$fileId = $this->createTestFileEntry($fileName1, $storageId);
@@ -1110,9 +1106,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals(IShare::TYPE_GROUP, $share->getShareType());
 	}
 
-	/**
-	 * @dataProvider storageAndFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('storageAndFileNameProvider')]
 	public function testGetSharedWithGroupUserModified($storageStringId, $fileName1, $fileName2): void {
 		$storageId = $this->createTestStorageEntry($storageStringId);
 		$fileId = $this->createTestFileEntry($fileName1, $storageId);
@@ -1202,9 +1196,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertSame('userTarget', $share->getTarget());
 	}
 
-	/**
-	 * @dataProvider storageAndFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('storageAndFileNameProvider')]
 	public function testGetSharedWithUserWithNode($storageStringId, $fileName1, $fileName2): void {
 		$storageId = $this->createTestStorageEntry($storageStringId);
 		$fileId = $this->createTestFileEntry($fileName1, $storageId);
@@ -1244,9 +1236,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->assertEquals(IShare::TYPE_USER, $share->getShareType());
 	}
 
-	/**
-	 * @dataProvider storageAndFileNameProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('storageAndFileNameProvider')]
 	public function testGetSharedWithGroupWithNode($storageStringId, $fileName1, $fileName2): void {
 		$storageId = $this->createTestStorageEntry($storageStringId);
 		$fileId = $this->createTestFileEntry($fileName1, $storageId);
@@ -1296,9 +1286,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider shareTypesProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('shareTypesProvider')]
 	public function testGetSharedWithWithDeletedFile($shareType, $trashed): void {
 		if ($trashed) {
 			// exists in database but is in trash
@@ -2302,7 +2290,6 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDeleteUser
 	 *
 	 * @param int $type The shareType (user/group/link)
 	 * @param string $owner The owner of the share (uid)
@@ -2311,6 +2298,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	 * @param string $deletedUser The user that is deleted
 	 * @param bool $rowDeleted Is the row deleted in this setup
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteUser')]
 	public function testDeleteUser($type, $owner, $initiator, $recipient, $deletedUser, $rowDeleted): void {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
@@ -2350,7 +2338,6 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDeleteUserGroup
 	 *
 	 * @param string $owner The owner of the share (uid)
 	 * @param string $initiator The initiator of the share (uid)
@@ -2359,6 +2346,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	 * @param bool $groupShareDeleted
 	 * @param bool $userGroupShareDeleted
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteUserGroup')]
 	public function testDeleteUserGroup($owner, $initiator, $recipient, $deletedUser, $groupShareDeleted, $userGroupShareDeleted): void {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
@@ -2456,12 +2444,12 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGroupDeleted
 	 *
 	 * @param $shares
 	 * @param $groupToDelete
 	 * @param $shouldBeDeleted
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGroupDeleted')]
 	public function testGroupDeleted($shares, $groupToDelete, $shouldBeDeleted): void {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
@@ -2516,12 +2504,12 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	 * And a user specific group share with 'user1'.
 	 * User $user is deleted from group $gid.
 	 *
-	 * @dataProvider dataUserDeletedFromGroup
 	 *
 	 * @param string $group
 	 * @param string $user
 	 * @param bool $toDelete
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataUserDeletedFromGroup')]
 	public function testUserDeletedFromGroup($group, $user, $toDelete): void {
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -245,9 +245,7 @@ class ManagerTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataTestDelete
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestDelete')]
 	public function testDelete($shareType, $sharedWith): void {
 		$manager = $this->createManagerMock()
 			->onlyMethods(['getShareById', 'deleteChildren', 'promoteReshares'])
@@ -1000,12 +998,12 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGeneralChecks
 	 *
 	 * @param $share
 	 * @param $exceptionMessage
 	 * @param $exception
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGeneralChecks')]
 	public function testGeneralChecks($share, $exceptionMessage, $exception): void {
 		$thrown = null;
 
@@ -1076,9 +1074,7 @@ class ManagerTest extends \Test\TestCase {
 		return [[IShare::TYPE_USER], [IShare::TYPE_REMOTE], [IShare::TYPE_REMOTE_GROUP]];
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalInPast($shareType): void {
 		$this->expectException(GenericShareException::class);
 		$this->expectExceptionMessage('Expiration date is in the past');
@@ -1094,9 +1090,7 @@ class ManagerTest extends \Test\TestCase {
 		self::invokePrivate($this->manager, 'validateExpirationDateInternal', [$share]);
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalEnforceButNotSet($shareType): void {
 		$this->expectException(\InvalidArgumentException::class);
 		$this->expectExceptionMessage('Expiration date is enforced');
@@ -1121,9 +1115,7 @@ class ManagerTest extends \Test\TestCase {
 		self::invokePrivate($this->manager, 'validateExpirationDateInternal', [$share]);
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalEnforceButNotEnabledAndNotSet($shareType): void {
 		$share = $this->manager->newShare();
 		$share->setProviderId('foo')->setId('bar');
@@ -1146,9 +1138,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalEnforceButNotSetNewShare($shareType): void {
 		$share = $this->manager->newShare();
 		$share->setShareType($shareType);
@@ -1181,9 +1171,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalEnforceRelaxedDefaultButNotSetNewShare($shareType): void {
 		$share = $this->manager->newShare();
 		$share->setShareType($shareType);
@@ -1216,9 +1204,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalEnforceTooFarIntoFuture($shareType): void {
 		$this->expectException(GenericShareException::class);
 		$this->expectExceptionMessage('Cannot set expiration date more than 3 days in the future');
@@ -1249,9 +1235,7 @@ class ManagerTest extends \Test\TestCase {
 		self::invokePrivate($this->manager, 'validateExpirationDateInternal', [$share]);
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalEnforceValid($shareType): void {
 		$future = new \DateTime('now', $this->dateTimeZone->getTimeZone());
 		$future->add(new \DateInterval('P2D'));
@@ -1291,9 +1275,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalNoDefault($shareType): void {
 		$date = new \DateTime('now', $this->dateTimeZone->getTimeZone());
 		$date->add(new \DateInterval('P5D'));
@@ -1317,9 +1299,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalNoDateNoDefault($shareType): void {
 		$hookListener = $this->createMock(DummyShareManagerListener::class);
 		Util::connectHook('\OC\Share', 'verifyExpirationDate', $hookListener, 'listener');
@@ -1336,9 +1316,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertNull($share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalNoDateDefault($shareType): void {
 		$share = $this->manager->newShare();
 		$share->setShareType($shareType);
@@ -1375,9 +1353,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalDefault($shareType): void {
 		$future = new \DateTime('now', $this->timezone);
 		$future->add(new \DateInterval('P5D'));
@@ -1417,9 +1393,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($expected, $share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalHookModification($shareType): void {
 		$nextWeek = new \DateTime('now', $this->timezone);
 		$nextWeek->add(new \DateInterval('P7D'));
@@ -1443,9 +1417,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertEquals($save, $share->getExpirationDate());
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalHookException($shareType): void {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('Invalid date!');
@@ -1468,9 +1440,7 @@ class ManagerTest extends \Test\TestCase {
 		self::invokePrivate($this->manager, 'validateExpirationDateInternal', [$share]);
 	}
 
-	/**
-	 * @dataProvider validateExpirationDateInternalProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('validateExpirationDateInternalProvider')]
 	public function testValidateExpirationDateInternalExistingShareNoDefault($shareType): void {
 		$share = $this->manager->newShare();
 		$share->setShareType($shareType);
@@ -2356,7 +2326,6 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataIsSharingDisabledForUser
 	 *
 	 * @param string $excludeGroups
 	 * @param string $groupList
@@ -2364,6 +2333,7 @@ class ManagerTest extends \Test\TestCase {
 	 * @param string[] $groupIds
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataIsSharingDisabledForUser')]
 	public function testIsSharingDisabledForUser($excludeGroups, $groupList, $setList, $groupIds, $expected): void {
 		$user = $this->createMock(IUser::class);
 
@@ -2408,12 +2378,12 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataCanShare
 	 *
 	 * @param bool $expected
 	 * @param string $sharingEnabled
 	 * @param bool $disabledForUser
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCanShare')]
 	public function testCanShare($expected, $sharingEnabled, $disabledForUser): void {
 		$this->config->method('getAppValue')
 			->willReturnMap([
@@ -2960,7 +2930,7 @@ class ManagerTest extends \Test\TestCase {
 			->onlyMethods(['deleteShare'])
 			->getMock();
 
-		/** @var \OCP\Share\IShare[] $shares */
+		/** @var IShare[] $shares */
 		$shares = [];
 
 		/*
@@ -2983,7 +2953,7 @@ class ManagerTest extends \Test\TestCase {
 		$shares[4]->setExpirationDate($today);
 		$shares[5]->setExpirationDate($today);
 
-		/** @var \OCP\Share\IShare[] $i */
+		/** @var IShare[] $i */
 		$shares2 = [];
 		for ($i = 0; $i < 8; $i++) {
 			$shares2[] = clone $shares[$i];
@@ -4476,9 +4446,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->addToAssertionCount(1);
 	}
 
-	/**
-	 * @dataProvider dataTestShareProviderExists
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestShareProviderExists')]
 	public function testShareProviderExists($shareType, $expected): void {
 		$factory = $this->getMockBuilder('OCP\Share\IProviderFactory')->getMock();
 		$factory->expects($this->any())->method('getProviderForType')
@@ -4849,9 +4817,9 @@ class ManagerTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider dataCurrentUserCanEnumerateTargetUser
 	 * @param bool $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCurrentUserCanEnumerateTargetUser')]
 	public function testCurrentUserCanEnumerateTargetUser(bool $currentUserIsGuest, bool $allowEnumerationFullMatch, bool $allowEnumeration, bool $limitEnumerationToPhone, bool $limitEnumerationToGroups, bool $isKnownToUser, bool $haveCommonGroup, bool $expected): void {
 		/** @var IManager|MockObject $manager */
 		$manager = $this->createManagerMock()

--- a/tests/lib/Share20/ShareHelperTest.php
+++ b/tests/lib/Share20/ShareHelperTest.php
@@ -49,9 +49,7 @@ class ShareHelperTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetPathsForAccessList
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetPathsForAccessList')]
 	public function testGetPathsForAccessList(array $userList, array $userMap, $resolveUsers, array $remoteList, array $remoteMap, $resolveRemotes, array $expected): void {
 		$this->manager->expects($this->once())
 			->method('getAccessList')
@@ -102,12 +100,12 @@ class ShareHelperTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetPathsForUsers
 	 *
 	 * @param array $users
 	 * @param array $nodes
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetPathsForUsers')]
 	public function testGetPathsForUsers(array $users, array $nodes, array $expected): void {
 		$lastNode = null;
 		foreach ($nodes as $nodeId => $nodeName) {
@@ -159,12 +157,12 @@ class ShareHelperTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetPathsForRemotes
 	 *
 	 * @param array $remotes
 	 * @param array $nodes
 	 * @param array $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetPathsForRemotes')]
 	public function testGetPathsForRemotes(array $remotes, array $nodes, array $expected): void {
 		$lastNode = null;
 		foreach ($nodes as $nodeId => $nodePath) {
@@ -199,10 +197,10 @@ class ShareHelperTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataGetMountedPath
 	 * @param string $path
 	 * @param string $expected
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetMountedPath')]
 	public function testGetMountedPath($path, $expected): void {
 		/** @var Node|\PHPUnit\Framework\MockObject\MockObject $node */
 		$node = $this->createMock(Node::class);

--- a/tests/lib/Share20/ShareTest.php
+++ b/tests/lib/Share20/ShareTest.php
@@ -12,6 +12,7 @@ use OC\Share20\Share;
 use OCP\Files\IRootFolder;
 use OCP\IUserManager;
 use OCP\Share\Exceptions\IllegalIDChangeException;
+use OCP\Share\IShare;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -24,7 +25,7 @@ class ShareTest extends \Test\TestCase {
 	protected $rootFolder;
 	/** @var IUserManager|MockObject */
 	protected $userManager;
-	/** @var \OCP\Share\IShare */
+	/** @var IShare */
 	protected $share;
 
 	protected function setUp(): void {

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -13,7 +13,9 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Group\Events\SubAdminAddedEvent;
 use OCP\Group\Events\SubAdminRemovedEvent;
 use OCP\IDBConnection;
+use OCP\IGroup;
 use OCP\IGroupManager;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
 
@@ -21,22 +23,22 @@ use OCP\Server;
  * @group DB
  */
 class SubAdminTest extends \Test\TestCase {
-	/** @var \OCP\IUserManager */
+	/** @var IUserManager */
 	private $userManager;
 
-	/** @var \OCP\IGroupManager */
+	/** @var IGroupManager */
 	private $groupManager;
 
-	/** @var \OCP\IDBConnection */
+	/** @var IDBConnection */
 	private $dbConn;
 
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
-	/** @var \OCP\IUser[] */
+	/** @var IUser[] */
 	private $users;
 
-	/** @var \OCP\IGroup[] */
+	/** @var IGroup[] */
 	private $groups;
 
 	protected function setUp(): void {

--- a/tests/lib/Support/Subscription/RegistryTest.php
+++ b/tests/lib/Support/Subscription/RegistryTest.php
@@ -168,9 +168,7 @@ class RegistryTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataForUserLimitCheck
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataForUserLimitCheck')]
 	public function testDelegateIsHardUserLimitReachedWithoutSupportAppAndUserCount($userLimit, $userCount, $disabledUsers, $expectedResult): void {
 		$this->config->expects($this->once())
 			->method('getSystemValueBool')

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -96,9 +96,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider getAllTagsDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getAllTagsDataProvider')]
 	public function testGetAllTags($testTags): void {
 		$testTagsById = [];
 		foreach ($testTags as $testTag) {
@@ -205,9 +203,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider getAllTagsFilteredDataProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getAllTagsFilteredDataProvider')]
 	public function testGetAllTagsFiltered($testTags, $visibilityFilter, $nameSearch, $expectedResults): void {
 		foreach ($testTags as $testTag) {
 			$this->tagManager->createTag($testTag[0], $testTag[1], $testTag[2]);
@@ -238,9 +234,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider oneTagMultipleFlagsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('oneTagMultipleFlagsProvider')]
 	public function testCreateDuplicate($name, $userVisible, $userAssignable): void {
 		$this->expectException(TagAlreadyExistsException::class);
 
@@ -257,9 +251,7 @@ class SystemTagManagerTest extends TestCase {
 		$this->assertSame('Zona circundante do Palácio Nacional da Ajuda (Jardim das Damas', $tag->getName()); // 63 characters but 64 bytes due to "á"
 	}
 
-	/**
-	 * @dataProvider oneTagMultipleFlagsProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('oneTagMultipleFlagsProvider')]
 	public function testGetExistingTag($name, $userVisible, $userAssignable): void {
 		$tag1 = $this->tagManager->createTag($name, $userVisible, $userAssignable);
 		$tag2 = $this->tagManager->getTag($name, $userVisible, $userAssignable);
@@ -327,9 +319,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider updateTagProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('updateTagProvider')]
 	public function testUpdateTag($tagCreate, $tagUpdated): void {
 		$tag1 = $this->tagManager->createTag(
 			$tagCreate[0],
@@ -359,9 +349,7 @@ class SystemTagManagerTest extends TestCase {
 
 	}
 
-	/**
-	 * @dataProvider updateTagProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('updateTagProvider')]
 	public function testUpdateTagDuplicate($tagCreate, $tagUpdated): void {
 		$this->expectException(TagAlreadyExistsException::class);
 
@@ -436,9 +424,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider visibilityCheckProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('visibilityCheckProvider')]
 	public function testVisibilityCheck($userVisible, $userAssignable, $isAdmin, $expectedResult): void {
 		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->any())
@@ -483,9 +469,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider assignabilityCheckProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('assignabilityCheckProvider')]
 	public function testAssignabilityCheck($userVisible, $userAssignable, $isAdmin, $expectedResult, $userGroupIds = [], $tagGroupIds = []): void {
 		$user = $this->getMockBuilder(IUser::class)->getMock();
 		$user->expects($this->any())
@@ -542,9 +526,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider allowedToCreateProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('allowedToCreateProvider')]
 	public function testAllowedToCreateTag(bool $isCli, ?bool $isAdmin, bool $isRestricted): void {
 		$oldCli = \OC::$CLI;
 		\OC::$CLI = $isCli;
@@ -580,9 +562,7 @@ class SystemTagManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider disallowedToCreateProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('disallowedToCreateProvider')]
 	public function testDisallowedToCreateTag(?bool $isAdmin): void {
 		$oldCli = \OC::$CLI;
 		\OC::$CLI = false;

--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -12,6 +12,7 @@ use OC\Tagging\TagMapper;
 use OC\TagManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
+use OCP\ITagManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -25,14 +26,14 @@ use Psr\Log\LoggerInterface;
  */
 class TagsTest extends \Test\TestCase {
 	protected $objectType;
-	/** @var \OCP\IUser */
+	/** @var IUser */
 	protected $user;
-	/** @var \OCP\IUserSession */
+	/** @var IUserSession */
 	protected $userSession;
 	protected $backupGlobals = false;
 	/** @var \OC\Tagging\TagMapper */
 	protected $tagMapper;
-	/** @var \OCP\ITagManager */
+	/** @var ITagManager */
 	protected $tagMgr;
 
 	protected function setUp(): void {

--- a/tests/lib/Template/JSCombinerTest.php
+++ b/tests/lib/Template/JSCombinerTest.php
@@ -474,8 +474,8 @@ var b = \'world\';
 	 * @param $appName
 	 * @param $fileName
 	 * @param $result
-	 * @dataProvider dataGetCachedSCSS
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetCachedSCSS')]
 	public function testGetCachedSCSS($appName, $fileName, $result): void {
 		$this->urlGenerator->expects($this->once())
 			->method('linkToRoute')

--- a/tests/lib/TemplateLayoutTest.php
+++ b/tests/lib/TemplateLayoutTest.php
@@ -40,7 +40,7 @@ class TemplateLayoutTest extends \Test\TestCase {
 		$this->serverVersion = $this->createMock(ServerVersion::class);
 	}
 
-	/** @dataProvider dataVersionHash */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataVersionHash')]
 	public function testVersionHash($path, $file, $installed, $debug, $expected): void {
 		$this->appManager->expects(self::any())
 			->method('getAppVersion')

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -19,6 +19,7 @@ use OC\Files\Mount\LocalHomeMountProvider;
 use OC\Files\Mount\RootMountProvider;
 use OC\Files\ObjectStore\PrimaryObjectStoreConfig;
 use OC\Files\SetupManager;
+use OC\Files\View;
 use OC\Template\Base;
 use OCP\Command\IBus;
 use OCP\DB\QueryBuilder\IQueryBuilder;
@@ -493,7 +494,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Check if the given path is locked with a given type
 	 *
-	 * @param \OC\Files\View $view view
+	 * @param View $view view
 	 * @param string $path path to check
 	 * @param int $type lock type
 	 * @param bool $onMountPoint true to check the mount point instead of the

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -43,12 +43,12 @@ trait EncryptionTrait {
 	private $setupManager;
 
 	/**
-	 * @var \OCP\IConfig
+	 * @var IConfig
 	 */
 	private $config;
 
 	/**
-	 * @var \OCA\Encryption\AppInfo\Application
+	 * @var Application
 	 */
 	private $encryptionApp;
 

--- a/tests/lib/Traits/MountProviderTrait.php
+++ b/tests/lib/Traits/MountProviderTrait.php
@@ -10,6 +10,7 @@ namespace Test\Traits;
 
 use OC\Files\Mount\MountPoint;
 use OC\Files\Storage\StorageFactory;
+use OCP\Files\Config\IMountProvider;
 use OCP\Files\Config\IMountProviderCollection;
 use OCP\IUser;
 use OCP\Server;
@@ -19,7 +20,7 @@ use OCP\Server;
  */
 trait MountProviderTrait {
 	/**
-	 * @var \OCP\Files\Config\IMountProvider
+	 * @var IMountProvider
 	 */
 	protected $mountProvider;
 

--- a/tests/lib/Traits/UserTrait.php
+++ b/tests/lib/Traits/UserTrait.php
@@ -13,6 +13,7 @@ use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
+use OCP\UserInterface;
 
 class DummyUser extends User {
 	public function __construct(
@@ -31,7 +32,7 @@ class DummyUser extends User {
  */
 trait UserTrait {
 	/**
-	 * @var \Test\Util\User\Dummy|\OCP\UserInterface
+	 * @var \Test\Util\User\Dummy|UserInterface
 	 */
 	protected $userBackend;
 

--- a/tests/lib/Updater/ChangesCheckTest.php
+++ b/tests/lib/Updater/ChangesCheckTest.php
@@ -51,9 +51,7 @@ class ChangesCheckTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider statusCodeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('statusCodeProvider')]
 	public function testEvaluateResponse(int $statusCode, int $expected): void {
 		$response = $this->createMock(IResponse::class);
 		$response->expects($this->atLeastOnce())
@@ -271,9 +269,7 @@ class ChangesCheckTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider changesXMLProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('changesXMLProvider')]
 	public function testExtractData(string $body, array $expected): void {
 		$actual = $this->invokePrivate($this->checker, 'extractData', [$body]);
 		$this->assertSame($expected, $actual);
@@ -286,9 +282,7 @@ class ChangesCheckTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider etagProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('etagProvider')]
 	public function testQueryChangesServer(string $etag): void {
 		$uri = 'https://changes.nextcloud.server/?13.0.5';
 		$entry = $this->createMock(Changes::class);
@@ -323,9 +317,7 @@ class ChangesCheckTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider versionProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('versionProvider')]
 	public function testNormalizeVersion(string $input, string $expected): void {
 		$normalized = $this->checker->normalizeVersion($input);
 		$this->assertSame($expected, $normalized);
@@ -342,10 +334,7 @@ class ChangesCheckTest extends TestCase {
 		return array_merge($testDataFound, $testDataNotFound);
 	}
 
-	/**
-	 * @dataProvider changeDataProvider
-	 *
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('changeDataProvider')]
 	public function testGetChangesForVersion(string $inputVersion, string $normalizedVersion, bool $isFound): void {
 		$mocker = $this->mapper->expects($this->once())
 			->method('getChanges')

--- a/tests/lib/Updater/ReleaseMetadataTest.php
+++ b/tests/lib/Updater/ReleaseMetadataTest.php
@@ -41,11 +41,11 @@ class ReleaseMetadataTest extends \Test\TestCase {
 	}
 
 	/**
-	 * @dataProvider getMetadataUrlProvider
 	 *
 	 * @param string $version
 	 * @param string $url
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('getMetadataUrlProvider')]
 	public function testGetMetadata(string $version, string $url): void {
 		$client = $this->createMock(IClient::class);
 		$response = $this->createMock(IResponse::class);

--- a/tests/lib/UpdaterTest.php
+++ b/tests/lib/UpdaterTest.php
@@ -82,7 +82,6 @@ class UpdaterTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider versionCompatibilityTestData
 	 *
 	 * @param string $oldVersion
 	 * @param string $newVersion
@@ -91,6 +90,7 @@ class UpdaterTest extends TestCase {
 	 * @param bool $debug
 	 * @param string $vendor
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('versionCompatibilityTestData')]
 	public function testIsUpgradePossible($oldVersion, $newVersion, $allowedVersions, $result, $debug = false, $vendor = 'nextcloud'): void {
 		$this->config->expects($this->any())
 			->method('getSystemValueBool')

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -71,8 +71,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	/**
 	 * @small
 	 * test linkTo URL construction
-	 * @dataProvider provideDocRootAppUrlParts
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideDocRootAppUrlParts')]
 	public function testLinkToDocRoot($app, $file, $args, $expectedResult): void {
 		\OC::$WEBROOT = '';
 		$result = $this->urlGenerator->linkTo($app, $file, $args);
@@ -82,17 +82,15 @@ class UrlGeneratorTest extends \Test\TestCase {
 	/**
 	 * @small
 	 * test linkTo URL construction in sub directory
-	 * @dataProvider provideSubDirAppUrlParts
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideSubDirAppUrlParts')]
 	public function testLinkToSubDir($app, $file, $args, $expectedResult): void {
 		\OC::$WEBROOT = '/nextcloud';
 		$result = $this->urlGenerator->linkTo($app, $file, $args);
 		$this->assertEquals($expectedResult, $result);
 	}
 
-	/**
-	 * @dataProvider provideRoutes
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideRoutes')]
 	public function testLinkToRouteAbsolute($route, $expected): void {
 		$this->mockBaseUrl();
 		\OC::$WEBROOT = '/nextcloud';
@@ -135,8 +133,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	/**
 	 * @small
 	 * test absolute URL construction
-	 * @dataProvider provideDocRootURLs
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideDocRootURLs')]
 	public function testGetAbsoluteURLDocRoot($url, $expectedResult): void {
 		$this->mockBaseUrl();
 		\OC::$WEBROOT = '';
@@ -147,8 +145,8 @@ class UrlGeneratorTest extends \Test\TestCase {
 	/**
 	 * @small
 	 * test absolute URL construction
-	 * @dataProvider provideSubDirURLs
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideSubDirURLs')]
 	public function testGetAbsoluteURLSubDir($url, $expectedResult): void {
 		$this->mockBaseUrl();
 		\OC::$WEBROOT = '/nextcloud';
@@ -190,9 +188,7 @@ class UrlGeneratorTest extends \Test\TestCase {
 		$this->assertEquals(\OC::$WEBROOT, $actual);
 	}
 
-	/**
-	 * @dataProvider provideOCSRoutes
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('provideOCSRoutes')]
 	public function testLinkToOCSRouteAbsolute(string $route, bool $ignoreFrontController, string $expected): void {
 		$this->mockBaseUrl();
 		\OC::$WEBROOT = '/nextcloud';
@@ -277,9 +273,7 @@ class UrlGeneratorTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider imagePathProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('imagePathProvider')]
 	public function testImagePath(string $appName, string $file, string $result): void {
 		$this->assertSame($result, $this->urlGenerator->imagePath($appName, $file));
 	}

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -368,9 +368,7 @@ class ManagerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCreateUserInvalid
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataCreateUserInvalid')]
 	public function testCreateUserInvalid($uid, $password, $exception): void {
 		/** @var \Test\Util\User\Dummy|\PHPUnit\Framework\MockObject\MockObject $backend */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -112,9 +112,7 @@ class SessionTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider isLoggedInData
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('isLoggedInData')]
 	public function testIsLoggedIn($isLoggedIn): void {
 		$session = $this->createMock(Memory::class);
 

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -506,10 +506,10 @@ class UserTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider dataDeleteHooks
 	 * @param bool $result
 	 * @param int $expectedHooks
 	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataDeleteHooks')]
 	public function testDeleteHooks($result, $expectedHooks): void {
 		$hooksCalled = 0;
 		$test = $this;
@@ -659,9 +659,7 @@ class UserTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataGetCloudId
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetCloudId')]
 	public function testGetCloudId(string $absoluteUrl, string $cloudId): void {
 		/** @var Backend|MockObject $backend */
 		$backend = $this->createMock(\Test\Util\User\Dummy::class);

--- a/tests/lib/UtilCheckServerTest.php
+++ b/tests/lib/UtilCheckServerTest.php
@@ -8,6 +8,7 @@
 
 namespace Test;
 
+use OC\SystemConfig;
 use OCP\ISession;
 use OCP\ITempManager;
 use OCP\Server;
@@ -23,7 +24,7 @@ class UtilCheckServerTest extends \Test\TestCase {
 
 	/**
 	 * @param array $systemOptions
-	 * @return \OC\SystemConfig | \PHPUnit\Framework\MockObject\MockObject
+	 * @return SystemConfig|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	protected function getConfig($systemOptions) {
 		$systemOptions['datadirectory'] = $this->datadir;

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -341,9 +341,7 @@ class UtilTest extends \Test\TestCase {
 		$this->assertEquals('🙈', Util::shortenMultibyteString('🙈🙊🙉', 16, 2));
 	}
 
-	/**
-	 * @dataProvider humanFileSizeProvider
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('humanFileSizeProvider')]
 	public function testHumanFileSize($expected, $input): void {
 		$result = Util::humanFileSize($input);
 		$this->assertEquals($expected, $result);
@@ -361,9 +359,7 @@ class UtilTest extends \Test\TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider providesComputerFileSize
-	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider('providesComputerFileSize')]
 	public function testComputerFileSize($expected, $input): void {
 		$result = Util::computerFileSize($input);
 		$this->assertEquals($expected, $result);


### PR DESCRIPTION
phpunit removed the non-static dataproviders and the docblock based annotation for them