### PR TITLE
fix: handle dav external storage roots with spaces

### DIFF
--- a/lib/private/Files/Storage/DAV.php
+++ b/lib/private/Files/Storage/DAV.php
@@ -116,7 +116,7 @@ class DAV extends Common {
 				// inject mock for testing
 				$this->certManager = \OC::$server->getCertificateManager();
 			}
-			$this->root = $parameters['root'] ?? '/';
+			$this->root = rawurldecode($parameters['root'] ?? '/');
 			$this->root = '/' . ltrim($this->root, '/');
 			$this->root = rtrim($this->root, '/') . '/';
 		} else {
@@ -191,7 +191,7 @@ class DAV extends Common {
 		if ($this->secure) {
 			$baseUri .= 's';
 		}
-		$baseUri .= '://' . $this->host . $this->root;
+		$baseUri .= '://' . $this->host . $this->encodePath($this->root);
 		return $baseUri;
 	}
 


### PR DESCRIPTION
Allows configuring WebDAV external storage with a space (or other characters that require url encoding) in the "Remote subfolder"

- Make sure the root we work with isn't urlencoded
- Encode the general base url

Fixes https://github.com/nextcloud/server/issues/52863