### PR TITLE
fix: give target file all permissions on copy

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -16,6 +16,7 @@ use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\SystemConfig;
+use OCP\Constants;
 use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -1224,6 +1225,12 @@ class Cache implements ICache {
 			throw new \RuntimeException('Invalid source cache entry on copyFromCache');
 		}
 		$data = $this->cacheEntryToArray($sourceEntry);
+		// since we are essentially creating a new file, we don't have to obey the source permissions
+		if ($sourceEntry->getMimeType() === ICacheEntry::DIRECTORY_MIMETYPE) {
+			$data['permissions'] = Constants::PERMISSION_ALL;
+		} else {
+			$data['permissions'] = Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE;
+		}
 
 		// when moving from an encrypted storage to a non-encrypted storage remove the `encrypted` mark
 		if ($sourceCache instanceof Cache

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -44,8 +44,6 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 	private string $objectPrefix = 'urn:oid:';
 
 	private LoggerInterface $logger;
-
-	private bool $handleCopiesAsOwned;
 	protected bool $validateWrites = true;
 	private bool $preserveCacheItemsOnDelete = false;
 	private ?int $totalSizeLimit = null;
@@ -71,7 +69,6 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 		if (isset($parameters['validateWrites'])) {
 			$this->validateWrites = (bool)$parameters['validateWrites'];
 		}
-		$this->handleCopiesAsOwned = (bool)($parameters['handleCopiesAsOwned'] ?? false);
 		if (isset($parameters['totalSizeLimit'])) {
 			$this->totalSizeLimit = $parameters['totalSizeLimit'];
 		}
@@ -734,10 +731,6 @@ class ObjectStoreStorage extends Common implements IChunkedFileWrite {
 
 		try {
 			$this->objectStore->copyObject($sourceUrn, $targetUrn);
-			if ($this->handleCopiesAsOwned) {
-				// Copied the file thus we gain all permissions as we are the owner now ! warning while this aligns with local storage it should not be used and instead fix local storage !
-				$cache->update($targetId, ['permissions' => Constants::PERMISSION_ALL]);
-			}
 		} catch (\Exception $e) {
 			$cache->remove($to);
 

--- a/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreStorageTest.php
@@ -223,28 +223,8 @@ class ObjectStoreStorageTest extends Storage {
 		$this->assertEquals('3', $this->instance->file_get_contents('b/target/sub/3.txt'));
 	}
 
-	public function testCopyPreservesPermissions(): void {
-		$cache = $this->instance->getCache();
-
-		$this->instance->file_put_contents('test.txt', 'foo');
-		$this->assertTrue($cache->inCache('test.txt'));
-
-		$cache->update($cache->getId('test.txt'), ['permissions' => Constants::PERMISSION_READ]);
-		$this->assertEquals(Constants::PERMISSION_READ, $this->instance->getPermissions('test.txt'));
-
-		$this->assertTrue($this->instance->copy('test.txt', 'new.txt'));
-
-		$this->assertTrue($cache->inCache('new.txt'));
-		$this->assertEquals(Constants::PERMISSION_READ, $this->instance->getPermissions('new.txt'));
-	}
-
-	/**
-	 * Test that copying files will drop permissions like local storage does
-	 * TODO: Drop this and fix local storage
-	 */
 	public function testCopyGrantsPermissions(): void {
 		$config['objectstore'] = $this->objectStorage;
-		$config['handleCopiesAsOwned'] = true;
 		$instance = new ObjectStoreStorageOverwrite($config);
 
 		$cache = $instance->getCache();
@@ -258,7 +238,7 @@ class ObjectStoreStorageTest extends Storage {
 		$this->assertTrue($instance->copy('test.txt', 'new.txt'));
 
 		$this->assertTrue($cache->inCache('new.txt'));
-		$this->assertEquals(Constants::PERMISSION_ALL, $instance->getPermissions('new.txt'));
+		$this->assertEquals(Constants::PERMISSION_ALL - Constants::PERMISSION_CREATE, $instance->getPermissions('new.txt'));
 	}
 
 	public function testCopyFolderSize(): void {


### PR DESCRIPTION
Since the copy is spiritually a newly created file, the old permissions shouldn't affect it.

Fixes https://github.com/nextcloud/server/issues/52779