### PR TITLE
fix(ROS): Document hide-download option on files

### DIFF
--- a/lib/public/RichObjectStrings/Definitions.php
+++ b/lib/public/RichObjectStrings/Definitions.php
@@ -374,6 +374,12 @@ class Definitions {
 					'description' => 'The blurhash of the image',
 					'example' => 'LEHV9uae2yk8pyo0adR*.7kCMdnj',
 				],
+				'hide-download' => [
+					'since' => '31.0.5',
+					'required' => false,
+					'description' => 'Whether the download option should be hidden. If not set to `yes` the option can be shown',
+					'example' => 'yes',
+				],
 			],
 		],
 		'forms-form' => [

--- a/lib/public/RichObjectStrings/IValidator.php
+++ b/lib/public/RichObjectStrings/IValidator.php
@@ -26,6 +26,7 @@ namespace OCP\RichObjectStrings;
  *     path?: string,
  *     mimetype?: string,
  *     'preview-available'?: 'yes'|'no',
+ *     'hide-download'?: 'yes'|'no',
  *     mtime?: string,
  *     latitude?: string,
  *     longitude?: string,


### PR DESCRIPTION
- Feature was added between Talk and Richdocuments as part of the summit release, so that Talk does not show the download button when the share was down with "hide download".
- Ref https://github.com/nextcloud/spreed/pull/15095
- Ref https://github.com/nextcloud/richdocuments/pull/4772

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
