### PR TITLE
Log app version

### DIFF
--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -669,6 +669,7 @@ class Server extends ServerContainer implements IServerContainer {
 			$factory = new LogFactory($c, $this->get(SystemConfig::class));
 			$logger = $factory->get($logType);
 			$registry = $c->get(\OCP\Support\CrashReport\IRegistry::class);
+			$appManagerFactory = fn() => $c->get(IAppManager::class);
 
 			return new Log($logger, $this->get(SystemConfig::class), crashReporters: $registry);
 		});

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -674,6 +674,9 @@ class Server extends ServerContainer implements IServerContainer {
 		});
 		// PSR-3 logger
 		$this->registerAlias(LoggerInterface::class, PsrLoggerAdapter::class);
+		$this->registerService(PsrLoggerAdapter::class, function (Server $c) {
+			return new PsrLoggerAdapter(fn () => $c->get(Log::class));
+		});
 
 		$this->registerService(ILogFactory::class, function (Server $c) {
 			return new LogFactory($c, $this->get(SystemConfig::class));


### PR DESCRIPTION
If the `app` context is set, add the version of the app as it might help in debugging.

PR also makes the `Log` be loaded more lazily, which should have a tiny perf improvement, but mostly helps with breaking recursive dependencies.

