### PR TITLE
fix(syslog): open syslog channel on write

### DIFF
--- a/lib/private/Log/Syslog.php
+++ b/lib/private/Log/Syslog.php
@@ -20,15 +20,18 @@ class Syslog extends LogDetails implements IWriter {
 		ILogger::FATAL => LOG_CRIT,
 	];
 
+	private string $tag;
+
 	public function __construct(
 		SystemConfig $config,
 		?string $tag = null,
 	) {
 		parent::__construct($config);
 		if ($tag === null) {
-			$tag = $config->getValue('syslog_tag', 'Nextcloud');
+			$this->tag = $config->getValue('syslog_tag', 'Nextcloud');
+		} else {
+			$this->tag = $tag;
 		}
-		openlog($tag, LOG_PID | LOG_CONS, LOG_USER);
 	}
 
 	public function __destruct() {
@@ -41,6 +44,7 @@ class Syslog extends LogDetails implements IWriter {
 	 */
 	public function write(string $app, $message, int $level): void {
 		$syslog_level = $this->levels[$level];
+		openlog($this->tag, LOG_PID | LOG_CONS, LOG_USER);
 		syslog($syslog_level, $this->logDetailsAsJSON($app, $message, $level));
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #49831 <!-- related github issue -->

## Summary
This fixes a bug where only one tag gets used when multiple tags have been configured (e.g. different tags for 'syslog_tag' and 'syslog_tag_audit')

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
