### PR TITLE
chore(public): Remove unused union type for user mount events

### DIFF
--- a/lib/public/Files/Config/Event/UserMountAddedEvent.php
+++ b/lib/public/Files/Config/Event/UserMountAddedEvent.php
@@ -11,7 +11,6 @@ namespace OCP\Files\Config\Event;
 
 use OCP\EventDispatcher\Event;
 use OCP\Files\Config\ICachedMountInfo;
-use OCP\Files\Mount\IMountPoint;
 
 /**
  * Event emitted when a user mount was added.
@@ -20,7 +19,7 @@ use OCP\Files\Mount\IMountPoint;
  */
 class UserMountAddedEvent extends Event {
 	public function __construct(
-		public readonly IMountPoint|ICachedMountInfo $mountPoint,
+		public readonly ICachedMountInfo $mountPoint,
 	) {
 		parent::__construct();
 	}

--- a/lib/public/Files/Config/Event/UserMountRemovedEvent.php
+++ b/lib/public/Files/Config/Event/UserMountRemovedEvent.php
@@ -11,7 +11,6 @@ namespace OCP\Files\Config\Event;
 
 use OCP\EventDispatcher\Event;
 use OCP\Files\Config\ICachedMountInfo;
-use OCP\Files\Mount\IMountPoint;
 
 /**
  * Event emitted when a user mount was removed.
@@ -20,7 +19,7 @@ use OCP\Files\Mount\IMountPoint;
  */
 class UserMountRemovedEvent extends Event {
 	public function __construct(
-		public readonly IMountPoint|ICachedMountInfo $mountPoint,
+		public readonly ICachedMountInfo $mountPoint,
 	) {
 		parent::__construct();
 	}

--- a/lib/public/Files/Config/Event/UserMountUpdatedEvent.php
+++ b/lib/public/Files/Config/Event/UserMountUpdatedEvent.php
@@ -11,7 +11,6 @@ namespace OCP\Files\Config\Event;
 
 use OCP\EventDispatcher\Event;
 use OCP\Files\Config\ICachedMountInfo;
-use OCP\Files\Mount\IMountPoint;
 
 /**
  * Event emitted when a user mount was moved.
@@ -20,8 +19,8 @@ use OCP\Files\Mount\IMountPoint;
  */
 class UserMountUpdatedEvent extends Event {
 	public function __construct(
-		public readonly IMountPoint|ICachedMountInfo $oldMountPoint,
-		public readonly IMountPoint|ICachedMountInfo $newMountPoint,
+		public readonly ICachedMountInfo $oldMountPoint,
+		public readonly ICachedMountInfo $newMountPoint,
 	) {
 		parent::__construct();
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

I wrongly added these in https://github.com/nextcloud/server/pull/50157, but they can never happen.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
