### PR TITLE
fix(imip): add context to imip log messages

### DIFF
--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -509,7 +509,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains a UID');
+			->with('iMip message event does not contains a UID');
 		// construct parameters
 		$principalUri = 'principals/user/attendee1';
 		$sender = 'organizer@testing.com';
@@ -545,7 +545,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains an organizer');
+			->with('iMip message event does not contains an organizer');
 		// construct parameters
 		$principalUri = 'principals/user/attendee1';
 		$sender = 'organizer@testing.com';
@@ -581,7 +581,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains any attendees');
+			->with('iMip message event does not contains any attendees');
 		// construct parameters
 		$principalUri = 'principals/user/attendee1';
 		$sender = 'organizer@testing.com';
@@ -918,7 +918,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains a UID');
+			->with('iMip message event does not contains a UID');
 		// construct parameters
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
@@ -954,7 +954,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains an organizer');
+			->with('iMip message event does not contains an organizer');
 		// construct parameters
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
@@ -990,7 +990,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains any attendees');
+			->with('iMip message event does not contains any attendees');
 		// construct parameters
 		$principalUri = 'principals/user/linus';
 		$sender = 'pierre@general-store.com';
@@ -1325,7 +1325,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains a UID');
+			->with('iMip message event does not contains a UID');
 		// construct parameters
 		$principalUri = 'principals/user/pierre';
 		$sender = 'linus@stardew-tent-living.com';
@@ -1362,7 +1362,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains an organizer');
+			->with('iMip message event does not contains an organizer');
 		// construct parameters
 		$principalUri = 'principals/user/pierre';
 		$sender = 'linus@stardew-tent-living.com';
@@ -1399,7 +1399,7 @@ class ManagerTest extends TestCase {
 			->willReturn([$userCalendar]);
 		// construct logger returns
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event dose not contains any attendees');
+			->with('iMip message event does not contains any attendees');
 		// construct parameters
 		$principalUri = 'principals/user/pierre';
 		$sender = 'pierre@general-store.com';

--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -1078,7 +1078,7 @@ class ManagerTest extends TestCase {
 		$calendarData->add('METHOD', 'REPLY');
 		// construct logger return
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event could not be processed because no corresponding event was found in any calendar ' . $principalUri . 'and UID' . $calendarData->VEVENT->UID->getValue());
+			->with('iMip message event could not be processed because no corresponding event was found in any calendar');
 		// Act
 		$result = $manager->handleIMipReply($principalUri, $sender, $recipient, $calendarData->serialize());
 		// Assert


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Making the log messages regarding imip processing more useful by including additional context. 

Examples of the current state / without this patch

```json
{
  "reqId": "...",
  "level": 2,
  "time": "...",
  "remoteAddr": "",
  "user": "--",
  "app": "no app in context",
  "method": "",
  "url": "--",
  "message": "iMip message event could not be processed because recipient and ORGANIZER must be identical",
  "userAgent": "--",
  "version": "...",
  "data": []
}
{
  "reqId": "...",
  "level": 2,
  "time": "...",
  "remoteAddr": "",
  "user": "--",
  "app": "no app in context",
  "method": "",
  "url": "--",
  "message": "iMip message event dose not contains an organizer",
  "userAgent": "--",
  "version": "...",
  "data": []
}
{
  "reqId": "...",
  "level": 2,
  "time": "...",
  "remoteAddr": "",
  "user": "--",
  "app": "no app in context",
  "method": "",
  "url": "--",
  "message": "iMip message event does not contain a attendee that matches the recipient",
  "userAgent": "--",
  "version": "...",
  "data": []
}
```


## TODO

- [ ] Manual testing

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
