### PR TITLE
[TaskProcessing] Add audio-to-audio chat task type

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -842,6 +842,7 @@ return array(
     'OCP\\TaskProcessing\\ShapeDescriptor' => $baseDir . '/lib/public/TaskProcessing/ShapeDescriptor.php',
     'OCP\\TaskProcessing\\ShapeEnumValue' => $baseDir . '/lib/public/TaskProcessing/ShapeEnumValue.php',
     'OCP\\TaskProcessing\\Task' => $baseDir . '/lib/public/TaskProcessing/Task.php',
+    'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioChat' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php',
     'OCP\\TaskProcessing\\TaskTypes\\AudioToText' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToText.php',
     'OCP\\TaskProcessing\\TaskTypes\\ContextAgentInteraction' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php',
     'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -883,6 +883,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\ShapeDescriptor' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/ShapeDescriptor.php',
         'OCP\\TaskProcessing\\ShapeEnumValue' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/ShapeEnumValue.php',
         'OCP\\TaskProcessing\\Task' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/Task.php',
+        'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioChat' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php',
         'OCP\\TaskProcessing\\TaskTypes\\AudioToText' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToText.php',
         'OCP\\TaskProcessing\\TaskTypes\\ContextAgentInteraction' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php',
         'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -589,6 +589,7 @@ class Manager implements IManager {
 			\OCP\TaskProcessing\TaskTypes\ContextAgentInteraction::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\ContextAgentInteraction::class),
 			\OCP\TaskProcessing\TaskTypes\TextToTextProofread::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToTextProofread::class),
 			\OCP\TaskProcessing\TaskTypes\TextToSpeech::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToSpeech::class),
+			\OCP\TaskProcessing\TaskTypes\AudioToAudioChat::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\AudioToAudioChat::class),
 		];
 
 		foreach ($context->getTaskProcessingTaskTypes() as $providerServiceRegistration) {

--- a/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php
+++ b/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\TaskProcessing\TaskTypes;
+
+use OCP\IL10N;
+use OCP\L10N\IFactory;
+use OCP\TaskProcessing\EShapeType;
+use OCP\TaskProcessing\ITaskType;
+use OCP\TaskProcessing\ShapeDescriptor;
+
+/**
+ * This is the task processing task type for text chat
+ * @since 32.0.0
+ */
+class AudioToAudioChat implements ITaskType {
+	/**
+	 * @since 32.0.0
+	 */
+	public const ID = 'core:audio2audio:chat';
+
+	private IL10N $l;
+
+	/**
+	 * @param IFactory $l10nFactory
+	 * @since 32.0.0
+	 */
+	public function __construct(
+		IFactory $l10nFactory,
+	) {
+		$this->l = $l10nFactory->get('lib');
+	}
+
+
+	/**
+	 * @inheritDoc
+	 * @since 32.0.0
+	 */
+	public function getName(): string {
+		return $this->l->t('Audio chat');
+	}
+
+	/**
+	 * @inheritDoc
+	 * @since 32.0.0
+	 */
+	public function getDescription(): string {
+		return $this->l->t('Voice chat with the assistant');
+	}
+
+	/**
+	 * @return string
+	 * @since 32.0.0
+	 */
+	public function getId(): string {
+		return self::ID;
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 32.0.0
+	 */
+	public function getInputShape(): array {
+		return [
+			'system_prompt' => new ShapeDescriptor(
+				$this->l->t('System prompt'),
+				$this->l->t('Define rules and assumptions that the assistant should follow during the conversation.'),
+				EShapeType::Text
+			),
+			'input' => new ShapeDescriptor(
+				$this->l->t('Chat voice message'),
+				$this->l->t('Describe a task that you want the assistant to do or ask a question'),
+				EShapeType::Audio
+			),
+			'history' => new ShapeDescriptor(
+				$this->l->t('Chat history'),
+				$this->l->t('The history of chat messages before the current message, starting with a message by the user'),
+				EShapeType::ListOfTexts
+			)
+		];
+	}
+
+	/**
+	 * @return ShapeDescriptor[]
+	 * @since 32.0.0
+	 */
+	public function getOutputShape(): array {
+		return [
+			'input_transcript' => new ShapeDescriptor(
+				$this->l->t('Input transcript'),
+				$this->l->t('Transcription of the audio input'),
+				EShapeType::Text,
+			),
+			'output' => new ShapeDescriptor(
+				$this->l->t('Response voice message'),
+				$this->l->t('The generated voice response as part of the conversation'),
+				EShapeType::Audio
+			),
+			'output_transcript' => new ShapeDescriptor(
+				$this->l->t('Output transcript'),
+				$this->l->t('Transcription of the audio output'),
+				EShapeType::Text,
+			),
+		];
+	}
+}


### PR DESCRIPTION
This is going towards making it possible to have a voice interaction with the Assistant.
The Assistant chat interface will schedule such audio-to-audio chat tasks if Agency is not available.

This does not cover Agency for now. 
Do we make a `ContextAgentVoiceInteraction` task type that takes voice as input?
We just need to support voice input and voice output. In between, the interactions between the agent and the model are text-based. So the Context Agent app would most likely still schedule TextToTextChatWithTools tasks.
We can also go the easy road and do the 3 steps when Agency is involved: STT -> Context Agent -> TTS. So we would not need any change in Context Agent and no new task type.
To be discussed.