### PR TITLE
fix(files): better icon for the search scope

### DIFF
--- a/apps/files/src/components/FilesNavigationSearch.vue
+++ b/apps/files/src/components/FilesNavigationSearch.vue
@@ -4,7 +4,7 @@
 -->
 
 <script setup lang="ts">
-import { mdiMagnify, mdiSearchWeb } from '@mdi/js'
+import { mdiCog, mdiFilter, mdiMagnify, mdiSearchWeb } from '@mdi/js'
 import { t } from '@nextcloud/l10n'
 import { computed } from 'vue'
 import NcActions from '@nextcloud/vue/components/NcActions'
@@ -96,11 +96,11 @@ function onUpdateSearch(value: string) {
 		<template #actions>
 			<NcActions :aria-label="t('files', 'Search scope options')" :disabled="isSearchView">
 				<template #icon>
-					<NcIconSvgWrapper :path="searchStore.scope === 'globally' ? mdiSearchWeb : mdiMagnify" />
+					<NcIconSvgWrapper :path="mdiCog" />
 				</template>
 				<NcActionButton close-after-click @click="searchStore.scope = 'filter'">
 					<template #icon>
-						<NcIconSvgWrapper :path="mdiMagnify" />
+						<NcIconSvgWrapper :path="mdiFilter" />
 					</template>
 					{{ t('files', 'Filter in current view') }}
 				</NcActionButton>


### PR DESCRIPTION


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Follow up on #53662 

## Summary
This allows to better identify the current search scope based on the icon instead of only the label of the search box.

filter | local search | global search
---|---|---
![Screenshot 2025-07-02 at 14-09-31 All files - Nextcloud](https://github.com/user-attachments/assets/b04dcbde-bc2d-4792-96f8-37f134c8f824)| ![Screenshot 2025-07-02 at 14-09-39 All files - Nextcloud](https://github.com/user-attachments/assets/6f7b7a07-7e82-4bd9-9ab1-47e152f359d3) | ![Screenshot 2025-07-02 at 14-09-45 All files - Nextcloud](https://github.com/user-attachments/assets/65eb4323-1abd-4585-809b-3a138cd8dd43)


![Screenshot 2025-07-02 at 14-09-53 All files - Nextcloud](https://github.com/user-attachments/assets/a987be1f-fefc-4ce4-bf49-9a2a2ecde6c3)



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
