### PR TITLE
test(theming): Add unit test to check database query in theming backgroundjob

### DIFF
--- a/apps/theming/tests/Jobs/RestoreBackgroundImageColorTest.php
+++ b/apps/theming/tests/Jobs/RestoreBackgroundImageColorTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Theming\Tests\Jobs;
+
+use OCA\Theming\Jobs\RestoreBackgroundImageColor;
+use OCA\Theming\Service\BackgroundService;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJobList;
+use OCP\Files\IAppData;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class RestoreBackgroundImageColorTest extends TestCase {
+
+	protected ITimeFactory&MockObject $time;
+	protected IConfig&MockObject $config;
+	protected IAppData&MockObject $appData;
+	protected IJobList&MockObject $jobList;
+	protected IDBConnection $dbc;
+	protected LoggerInterface&MockObject $logger;
+	protected BackgroundService&MockObject $service;
+	protected RestoreBackgroundImageColor $job;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->time = $this->createMock(ITimeFactory::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->appData = $this->createMock(IAppData::class);
+		$this->jobList = $this->createMock(IJobList::class);
+		$this->dbc = Server::get(IDBConnection::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->service = $this->createMock(BackgroundService::class);
+		$this->job = new RestoreBackgroundImageColor(
+			$this->time,
+			$this->config,
+			$this->appData,
+			$this->jobList,
+			$this->dbc,
+			$this->logger,
+			$this->service,
+		);
+	}
+
+	public function testRunPreparation(): void {
+		$this->jobList->expects($this->once())
+			->method('add')
+			->with(RestoreBackgroundImageColor::class, ['stage' => RestoreBackgroundImageColor::STAGE_EXECUTE]);
+		self::invokePrivate($this->job, 'runPreparation');
+	}
+}


### PR DESCRIPTION
I observed the following error:
> Error while running background job OCA\\Theming\\Jobs\\RestoreBackgroundImageColor

```
An exception occurred while executing a query:
SQLSTATE[42601]: Syntax error: 7 ERROR:  
syntax error at or near
"" FROM "" LINE 1: ..."oc_preferences" "a" LEFT JOIN "oc_(SELECT "userid" FROM "oc...
                                                         ^
```

Now trying to see if it's only postgres


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
