### PR TITLE
fix(l10n): our default language is American English so adjust the spelling

### DIFF
--- a/lib/private/Profile/ProfileManager.php
+++ b/lib/private/Profile/ProfileManager.php
@@ -350,7 +350,7 @@ class ProfileManager implements IProfileManager {
 	}
 
 	/**
-	 * Return the profile config of the target user with additional medatata,
+	 * Return the profile config of the target user with additional metadata,
 	 * if a config does not already exist a default config is created and returned
 	 */
 	public function getProfileConfigWithMetadata(IUser $targetUser, ?IUser $visitingUser): array {
@@ -399,7 +399,7 @@ class ProfileManager implements IProfileManager {
 			],
 			IAccountManager::PROPERTY_ORGANISATION => [
 				'appId' => self::CORE_APP_ID,
-				'displayId' => $this->l10nFactory->get('lib')->t('Organisation'),
+				'displayId' => $this->l10nFactory->get('lib')->t('Organization'),
 			],
 			IAccountManager::PROPERTY_ROLE => [
 				'appId' => self::CORE_APP_ID,


### PR DESCRIPTION
## Summary
For British English we have the `en-GB` translations, so the default should be American English which spells it `organization` not `organisation`.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
