### PR TITLE
chore: use constants for metadata

### DIFF
--- a/apps/files_versions/lib/Listener/VersionAuthorListener.php
+++ b/apps/files_versions/lib/Listener/VersionAuthorListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Files_Versions\Listener;
 
 use OC\Files\Node\Folder;
+use OCA\Files_Versions\Sabre\Plugin;
 use OCA\Files_Versions\Versions\IMetadataVersionBackend;
 use OCA\Files_Versions\Versions\IVersionManager;
 use OCP\EventDispatcher\Event;
@@ -48,7 +49,7 @@ class VersionAuthorListener implements IEventListener {
 		// check if our version manager supports setting the metadata
 		if ($this->versionManager instanceof IMetadataVersionBackend) {
 			$author = $user->getUID();
-			$this->versionManager->setMetadataValue($node, $node->getMTime(), 'author', $author);
+			$this->versionManager->setMetadataValue($node, $node->getMTime(), Plugin::AUTHOR, $author);
 		}
 	}
 }

--- a/apps/files_versions/lib/Sabre/Plugin.php
+++ b/apps/files_versions/lib/Sabre/Plugin.php
@@ -24,6 +24,10 @@ use Sabre\HTTP\ResponseInterface;
 class Plugin extends ServerPlugin {
 	private Server $server;
 
+	public const LABEL = 'label';
+
+	public const AUTHOR = 'author';
+
 	public const VERSION_LABEL = '{http://nextcloud.org/ns}version-label';
 
 	public const VERSION_AUTHOR = '{http://nextcloud.org/ns}version-author'; // dav property for author
@@ -76,8 +80,8 @@ class Plugin extends ServerPlugin {
 
 	public function propFind(PropFind $propFind, INode $node): void {
 		if ($node instanceof VersionFile) {
-			$propFind->handle(self::VERSION_LABEL, fn () => $node->getMetadataValue('label'));
-			$propFind->handle(self::VERSION_AUTHOR, fn () => $node->getMetadataValue('author'));
+			$propFind->handle(self::VERSION_LABEL, fn () => $node->getMetadataValue(self::LABEL));
+			$propFind->handle(self::VERSION_AUTHOR, fn () => $node->getMetadataValue(self::AUTHOR));
 			$propFind->handle(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, fn () => $this->previewManager->isMimeSupported($node->getContentType()));
 		}
 	}
@@ -86,7 +90,7 @@ class Plugin extends ServerPlugin {
 		$node = $this->server->tree->getNodeForPath($path);
 
 		if ($node instanceof VersionFile) {
-			$propPatch->handle(self::VERSION_LABEL, fn (string $label) => $node->setMetadataValue('label', $label));
+			$propPatch->handle(self::VERSION_LABEL, fn (string $label) => $node->setMetadataValue(self::LABEL, $label));
 		}
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #52088 <!-- related github issue -->

## Summary

Use constants for file_versions metadata

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
