### PR TITLE
[TaskProcessing] Add agency audio-to-audio task type

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -844,6 +844,7 @@ return array(
     'OCP\\TaskProcessing\\Task' => $baseDir . '/lib/public/TaskProcessing/Task.php',
     'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioChat' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php',
     'OCP\\TaskProcessing\\TaskTypes\\AudioToText' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/AudioToText.php',
+    'OCP\\TaskProcessing\\TaskTypes\\ContextAgentAudioInteraction' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextAgentAudioInteraction.php',
     'OCP\\TaskProcessing\\TaskTypes\\ContextAgentInteraction' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php',
     'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',
     'OCP\\TaskProcessing\\TaskTypes\\GenerateEmoji' => $baseDir . '/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -885,6 +885,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\TaskProcessing\\Task' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/Task.php',
         'OCP\\TaskProcessing\\TaskTypes\\AudioToAudioChat' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToAudioChat.php',
         'OCP\\TaskProcessing\\TaskTypes\\AudioToText' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/AudioToText.php',
+        'OCP\\TaskProcessing\\TaskTypes\\ContextAgentAudioInteraction' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextAgentAudioInteraction.php',
         'OCP\\TaskProcessing\\TaskTypes\\ContextAgentInteraction' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextAgentInteraction.php',
         'OCP\\TaskProcessing\\TaskTypes\\ContextWrite' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/ContextWrite.php',
         'OCP\\TaskProcessing\\TaskTypes\\GenerateEmoji' => __DIR__ . '/../../..' . '/lib/public/TaskProcessing/TaskTypes/GenerateEmoji.php',

--- a/lib/private/TaskProcessing/Manager.php
+++ b/lib/private/TaskProcessing/Manager.php
@@ -590,6 +590,7 @@ class Manager implements IManager {
 			\OCP\TaskProcessing\TaskTypes\TextToTextProofread::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToTextProofread::class),
 			\OCP\TaskProcessing\TaskTypes\TextToSpeech::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\TextToSpeech::class),
 			\OCP\TaskProcessing\TaskTypes\AudioToAudioChat::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\AudioToAudioChat::class),
+			\OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction::ID => \OCP\Server::get(\OCP\TaskProcessing\TaskTypes\ContextAgentAudioInteraction::class),
 		];
 
 		foreach ($context->getTaskProcessingTaskTypes() as $providerServiceRegistration) {

--- a/lib/public/TaskProcessing/TaskTypes/ContextAgentAudioInteraction.php
+++ b/lib/public/TaskProcessing/TaskTypes/ContextAgentAudioInteraction.php
@@ -16,14 +16,11 @@ use OCP\TaskProcessing\ITaskType;
 use OCP\TaskProcessing\ShapeDescriptor;
 
 /**
- * This is the task processing task type for audio chat
+ * This is the task processing task type for Context Agent interaction
  * @since 32.0.0
  */
-class AudioToAudioChat implements ITaskType {
-	/**
-	 * @since 32.0.0
-	 */
-	public const ID = 'core:audio2audio:chat';
+class ContextAgentAudioInteraction implements ITaskType {
+	public const ID = 'core:contextagent:audio-interaction';
 
 	private IL10N $l;
 
@@ -37,13 +34,12 @@ class AudioToAudioChat implements ITaskType {
 		$this->l = $l10nFactory->get('lib');
 	}
 
-
 	/**
 	 * @inheritDoc
 	 * @since 32.0.0
 	 */
 	public function getName(): string {
-		return $this->l->t('Audio chat');
+		return 'ContextAgent audio'; // We do not translate this
 	}
 
 	/**
@@ -51,7 +47,7 @@ class AudioToAudioChat implements ITaskType {
 	 * @since 32.0.0
 	 */
 	public function getDescription(): string {
-		return $this->l->t('Voice chat with the assistant');
+		return $this->l->t('Chat by voice with an agent');
 	}
 
 	/**
@@ -68,21 +64,21 @@ class AudioToAudioChat implements ITaskType {
 	 */
 	public function getInputShape(): array {
 		return [
-			'system_prompt' => new ShapeDescriptor(
-				$this->l->t('System prompt'),
-				$this->l->t('Define rules and assumptions that the assistant should follow during the conversation.'),
-				EShapeType::Text
-			),
 			'input' => new ShapeDescriptor(
 				$this->l->t('Chat voice message'),
-				$this->l->t('Describe a task that you want the assistant to do or ask a question.'),
+				$this->l->t('Describe a task that you want the agent to do or ask a question.'),
 				EShapeType::Audio
 			),
-			'history' => new ShapeDescriptor(
-				$this->l->t('Chat history'),
-				$this->l->t('The history of chat messages before the current message, starting with a message by the user.'),
-				EShapeType::ListOfTexts
-			)
+			'confirmation' => new ShapeDescriptor(
+				$this->l->t('Confirmation'),
+				$this->l->t('Whether to confirm previously requested actions: 0 for denial and 1 for confirmation.'),
+				EShapeType::Number
+			),
+			'conversation_token' => new ShapeDescriptor(
+				$this->l->t('Conversation token'),
+				$this->l->t('A token representing the conversation.'),
+				EShapeType::Text
+			),
 		];
 	}
 
@@ -106,6 +102,16 @@ class AudioToAudioChat implements ITaskType {
 				$this->l->t('Output transcript'),
 				$this->l->t('Transcription of the audio output'),
 				EShapeType::Text,
+			),
+			'conversation_token' => new ShapeDescriptor(
+				$this->l->t('The new conversation token'),
+				$this->l->t('Send this along with the next interaction.'),
+				EShapeType::Text
+			),
+			'actions' => new ShapeDescriptor(
+				$this->l->t('Requested actions by the agent'),
+				$this->l->t('Actions that the agent would like to carry out in JSON format.'),
+				EShapeType::Text
 			),
 		];
 	}


### PR DESCRIPTION
Followup to #53759

This is adding a task type to have audio interaction with Agency.
* It takes audio as input (plus the same input as classic agency)
* and produces audio as output
    * plus the input transcript
    * plus the output transcript
    * plus the same output as classic agency

A provider will be implemented in Assistant to avoid making big changes in the context_agent app. This provider will take care of the STT and TTS parts and schedule a classic ContextAgentInteraction task.