### PR TITLE
build(deps): Bump php-http/guzzle7-adapter from 1.0.0 to 1.1.0

### DIFF
--- a/lib/private/Http/Client/DnsPinMiddleware.php
+++ b/lib/private/Http/Client/DnsPinMiddleware.php
@@ -13,23 +13,15 @@ use OCP\Http\Client\LocalServerException;
 use Psr\Http\Message\RequestInterface;
 
 class DnsPinMiddleware {
-	/** @var NegativeDnsCache */
-	private $negativeDnsCache;
-	private IpAddressClassifier $ipAddressClassifier;
 
 	public function __construct(
-		NegativeDnsCache $negativeDnsCache,
-		IpAddressClassifier $ipAddressClassifier,
+		private NegativeDnsCache $negativeDnsCache,
+		private IpAddressClassifier $ipAddressClassifier,
 	) {
-		$this->negativeDnsCache = $negativeDnsCache;
-		$this->ipAddressClassifier = $ipAddressClassifier;
 	}
 
 	/**
 	 * Fetch soa record for a target
-	 *
-	 * @param string $target
-	 * @return array|null
 	 */
 	private function soaRecord(string $target): ?array {
 		$labels = explode('.', $target);
@@ -99,7 +91,7 @@ class DnsPinMiddleware {
 		return \dns_get_record($hostname, $type);
 	}
 
-	public function addDnsPinning() {
+	public function addDnsPinning(): callable {
 		return function (callable $handler) {
 			return function (
 				RequestInterface $request,
@@ -109,7 +101,7 @@ class DnsPinMiddleware {
 					return $handler($request, $options);
 				}
 
-				$hostName = (string)$request->getUri()->getHost();
+				$hostName = $request->getUri()->getHost();
 				$port = $request->getUri()->getPort();
 
 				$ports = [


### PR DESCRIPTION
- for https://github.com/nextcloud/3rdparty/pull/1999

## Summary

- Add support for PHP 8.4, drop support for PHP version 7.2

## Updated dependencies

| Production Changes            | From   | To     | Compare                                                                         |
|-------------------------------|--------|--------|---------------------------------------------------------------------------------|
| php-http/guzzle7-adapter      | 1.0.0  | 1.1.0  | [...](https://github.com/php-http/guzzle7-adapter/compare/1.0.0...1.1.0)        |
| php-http/httplug              | 2.2.0  | 2.4.1  | [...](https://github.com/php-http/httplug/compare/2.2.0...2.4.1)                |
| php-http/promise              | 1.1.0  | 1.3.1  | [...](https://github.com/php-http/promise/compare/1.1.0...1.3.1)                |
| psr/http-message              | 1.1    | 2.0    | [...](https://github.com/php-fig/http-message/compare/1.1...2.0)                |
| symfony/deprecation-contracts | v3.5.1 | v3.6.0 | [...](https://github.com/symfony/deprecation-contracts/compare/v3.5.1...v3.6.0) |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
