### PR TITLE
perf(AppConfig): Cache loading the app config from the database

### DIFF
--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -42,7 +42,7 @@ class Factory implements ICacheFactory {
 	private IProfiler $profiler;
 
 	/**
-	 * @param Closure $globalPrefixClosure
+	 * @param Closure(self) $globalPrefixClosure
 	 * @param LoggerInterface $logger
 	 * @param ?class-string<ICache> $localCacheClass
 	 * @param ?class-string<ICache> $distributedCacheClass
@@ -110,7 +110,7 @@ class Factory implements ICacheFactory {
 
 	private function getGlobalPrefix(): ?string {
 		if (is_null($this->globalPrefix)) {
-			$this->globalPrefix = ($this->globalPrefixClosure)();
+			$this->globalPrefix = ($this->globalPrefixClosure)($this);
 		}
 		return $this->globalPrefix;
 	}
@@ -175,10 +175,14 @@ class Factory implements ICacheFactory {
 	 * @param string $prefix
 	 * @return ICache
 	 */
-	public function createLocal(string $prefix = ''): ICache {
-		$globalPrefix = $this->getGlobalPrefix();
-		if (is_null($globalPrefix)) {
-			return new ArrayCache($prefix);
+	public function createLocal(string $prefix = '', bool $disableGlobalPrefix = false): ICache {
+		if ($disableGlobalPrefix) {
+			$globalPrefix = '';
+		} else {
+			$globalPrefix = $this->getGlobalPrefix();
+			if (is_null($globalPrefix)) {
+				return new ArrayCache($prefix);
+			}
 		}
 
 		assert($this->localCacheClass !== null);

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -12,6 +12,7 @@ use OC\AppConfig;
 use OCP\Exceptions\AppConfigTypeConflictException;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 use OCP\IAppConfig;
+use OCP\ICacheFactory;
 use OCP\IDBConnection;
 use OCP\Security\ICrypto;
 use OCP\Server;
@@ -29,6 +30,7 @@ class AppConfigTest extends TestCase {
 	protected IDBConnection $connection;
 	private LoggerInterface $logger;
 	private ICrypto $crypto;
+	private ICacheFactory $cacheFactory;
 
 	private array $originalConfig;
 
@@ -91,6 +93,7 @@ class AppConfigTest extends TestCase {
 		$this->connection = Server::get(IDBConnection::class);
 		$this->logger = Server::get(LoggerInterface::class);
 		$this->crypto = Server::get(ICrypto::class);
+		$this->cacheFactory = Server::get(ICacheFactory::class);
 
 		// storing current config and emptying the data table
 		$sql = $this->connection->getQueryBuilder();
@@ -181,6 +184,7 @@ class AppConfigTest extends TestCase {
 			$this->connection,
 			$this->logger,
 			$this->crypto,
+			$this->cacheFactory,
 		);
 		$msg = ' generateAppConfig() failed to confirm cache status';
 


### PR DESCRIPTION
Resolves: https://github.com/nextcloud/server/issues/54157

## Summary

The entire AppConfig is loaded on every request to figure out the enabled apps and their versions (and other things as well). By putting the AppConfig into the local cache we can make the access much faster and reduce the overhead of each request. A very low TTL is used to avoid syncing issues in clustered setups. I also tested with a higher TTL, but it does not improve the performance (as long as the instance is hit by many requests per second).

During my testing of the AppConfig caching I had to disable the global cache prefix logic, as it had a circular dependency on the AppConfig. By using a hardcoded global cache prefix the performance improvement was a bit better than the final result, but it's not possible to do this on a production instance, so the global cache prefix logic had to be changed to not rely on the AppConfig.

In theory the global prefix calculation could be made even faster, by either checking if the setup is clustered (not sure if that is possible?) or by checking if no distributed cache is present. If either of them is true, then the mtimes of the appinfo/info.xml files could be used directly as the global cache prefix and it would not even be necessary to have a local cache for parsing the appinfo/info.xml. I tried this (just hardcoded, not with any of the mentioned checks) just to see if there is any actual improvement, but it was only about 1-2ms and could very well be noise in the data.

### Testing setup

```sh
docker run --rm -it --network host -e POSTGRES_PASSWORD=postgres postgres:17

rm -rf data config/config.php
./occ maintenance:install --admin-pass admin --database pgsql --database-name postgres --database-host localhost --database-user postgres --database-pass postgres
./occ config:system:set memcache.local --value '\OC\Memcache\APCu'
PHP_CLI_SERVER_WORKERS=100 php -S 0.0.0.0:8080

sudo tc qdisc add dev lo root handle 1:0 netem delay 10msec

k6 run -e BASEURI=http://localhost:8080 basic.js

sudo tc qdisc del dev lo root
```

### Measurements

https://github.com/come-nc/k6_nc_scripts/blob/main/basic.js (with timeout disabled)

| Branch                 | Added latency (ms) | Median request duration (ms) | Absolute improvement (ms) | Relative improvement (%) |
|------------------------|--------------------|------------------------------|---------------------------|--------------------------|
| master                 | 0                  | 56                           |                           |                          |
| perf/appconfig/caching | 0                  | 56                           | 0                         | 0                        |
| master                 | 1                  | 76                           |                           |                          |
| perf/appconfig/caching | 1                  | 68                           | 8                         | 11.8                     |
| master                 | 10                 | 233                          |                           |                          |
| perf/appconfig/caching | 10                 | 207                          | 26                        | 12.6                     |
| master                 | 100                | 2040                         |                           |                          |
| perf/appconfig/caching | 100                | 1640                         | 400                       | 24.4                     |


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
