### PR TITLE
chore: Add tests for DI with incorrect casing

### DIFF
--- a/tests/lib/AppFramework/DependencyInjection/DIIntergrationTests.php
+++ b/tests/lib/AppFramework/DependencyInjection/DIIntergrationTests.php
@@ -33,6 +33,14 @@ class ClassB {
 	}
 }
 
+class ClassC {
+	public function __construct(
+		// Intentional wrong casing to check that DI works in this case
+		public interface1 $interface1,
+	) {
+	}
+}
+
 class DIIntergrationTests extends TestCase {
 	/** @var DIContainer */
 	private $container;
@@ -58,8 +66,10 @@ class DIIntergrationTests extends TestCase {
 			);
 		});
 
-		/** @var ClassB $res */
 		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA1::class, get_class($res->interface1));
+
+		$res = $this->container->query(ClassC::class);
 		$this->assertSame(ClassA1::class, get_class($res->interface1));
 	}
 
@@ -74,8 +84,10 @@ class DIIntergrationTests extends TestCase {
 			);
 		});
 
-		/** @var ClassB $res */
 		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA1::class, get_class($res->interface1));
+
+		$res = $this->container->query(ClassC::class);
 		$this->assertSame(ClassA1::class, get_class($res->interface1));
 	}
 
@@ -94,8 +106,10 @@ class DIIntergrationTests extends TestCase {
 			);
 		});
 
-		/** @var ClassB $res */
 		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA2::class, get_class($res->interface1));
+
+		$res = $this->container->query(ClassC::class);
 		$this->assertSame(ClassA2::class, get_class($res->interface1));
 	}
 
@@ -114,8 +128,10 @@ class DIIntergrationTests extends TestCase {
 			);
 		});
 
-		/** @var ClassB $res */
 		$res = $this->container->query(ClassB::class);
+		$this->assertSame(ClassA1::class, get_class($res->interface1));
+
+		$res = $this->container->query(ClassC::class);
 		$this->assertSame(ClassA1::class, get_class($res->interface1));
 	}
 }


### PR DESCRIPTION
## Summary

It seems our DI supports classnames with wrong casing and apps rely upon
 it, add a test to check if that’s true on PHP 8.4 as well.

## TODO

- [ ] 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
