### PR TITLE
fix: Move getInstallPath to Installer class

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -171,10 +171,20 @@ class Installer {
 
 	/**
 	 * Get the path where to install apps
+	 *
+	 * @throws \RuntimeException if an app folder is marked as writable but is missing permissions
 	 */
 	public function getInstallPath(): ?string {
 		foreach (\OC::$APPSROOTS as $dir) {
 			if (isset($dir['writable']) && $dir['writable'] === true) {
+				// Check if there is a writable install folder.
+				if (!is_writable($dir['path'])
+					|| !is_readable($dir['path'])
+				) {
+					throw new \RuntimeException(
+						'Cannot write into "apps" directory. This can usually be fixed by giving the web server write access to the apps directory or disabling the App Store in the config file.'
+					);
+				}
 				return $dir['path'];
 			}
 		}

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -238,21 +238,6 @@ class OC_App {
 	}
 
 	/**
-	 * Get the path where to install apps
-	 */
-	public static function getInstallPath(): ?string {
-		foreach (OC::$APPSROOTS as $dir) {
-			if (isset($dir['writable']) && $dir['writable'] === true) {
-				return $dir['path'];
-			}
-		}
-
-		Server::get(LoggerInterface::class)->error('No application directories are marked as writable.', ['app' => 'core']);
-		return null;
-	}
-
-
-	/**
 	 * Find the apps root for an app id.
 	 *
 	 * If multiple copies are found, the apps root the latest version is returned.

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -345,9 +345,10 @@ class OC_Util {
 
 		// Check if there is a writable install folder.
 		if ($config->getValue('appstoreenabled', true)) {
-			if (OC_App::getInstallPath() === null
-				|| !is_writable(OC_App::getInstallPath())
-				|| !is_readable(OC_App::getInstallPath())
+			$installPath = \OCP\Server::get(\OC\Installer::class)->getInstallPath();
+			if ($installPath === null
+				|| !is_writable($installPath)
+				|| !is_readable($installPath)
 			) {
 				$errors[] = [
 					'error' => $l->t('Cannot write into "apps" directory.'),

--- a/lib/private/legacy/OC_Util.php
+++ b/lib/private/legacy/OC_Util.php
@@ -343,20 +343,6 @@ class OC_Util {
 			}
 		}
 
-		// Check if there is a writable install folder.
-		if ($config->getValue('appstoreenabled', true)) {
-			$installPath = \OCP\Server::get(\OC\Installer::class)->getInstallPath();
-			if ($installPath === null
-				|| !is_writable($installPath)
-				|| !is_readable($installPath)
-			) {
-				$errors[] = [
-					'error' => $l->t('Cannot write into "apps" directory.'),
-					'hint' => $l->t('This can usually be fixed by giving the web server write access to the apps directory'
-						. ' or disabling the App Store in the config file.')
-				];
-			}
-		}
 		// Create root dir.
 		if ($config->getValue('installed', false)) {
 			if (!is_dir($CONFIG_DATADIRECTORY)) {

--- a/tests/lib/InstallerTest.php
+++ b/tests/lib/InstallerTest.php
@@ -92,12 +92,7 @@ class InstallerTest extends TestCase {
 		// Read the current version of the app to check for bug #2572
 		Server::get(IAppManager::class)->getAppVersion('testapp', true);
 
-		// Extract app
-		$pathOfTestApp = __DIR__ . '/../data/testapp.zip';
-		$tar = new ZIP($pathOfTestApp);
-		$tar->extract(\OC_App::getInstallPath());
-
-		// Install app
+		// Build installer
 		$installer = new Installer(
 			Server::get(AppFetcher::class),
 			Server::get(IClientService::class),
@@ -106,6 +101,13 @@ class InstallerTest extends TestCase {
 			Server::get(IConfig::class),
 			false
 		);
+
+		// Extract app
+		$pathOfTestApp = __DIR__ . '/../data/testapp.zip';
+		$tar = new ZIP($pathOfTestApp);
+		$tar->extract($installer->getInstallPath());
+
+		// Install app
 		$this->assertNull(Server::get(IConfig::class)->getAppValue('testapp', 'enabled', null), 'Check that the app is not listed before installation');
 		$this->assertSame('testapp', $installer->installApp(self::$appid));
 		$this->assertSame('no', Server::get(IConfig::class)->getAppValue('testapp', 'enabled', null), 'Check that the app is listed after installation');


### PR DESCRIPTION
* See https://github.com/nextcloud/server/issues/8505

## Summary

This method does not need a public API for now, it’s only used internally.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
