### PR TITLE
Migrate calls to OC_App::loadApp to the IAppManager

### DIFF
--- a/apps/dav/lib/AppInfo/Application.php
+++ b/apps/dav/lib/AppInfo/Application.php
@@ -64,6 +64,7 @@ use OCA\DAV\SetupChecks\WebdavEndpoint;
 use OCA\DAV\UserMigration\CalendarMigrator;
 use OCA\DAV\UserMigration\ContactsMigrator;
 use OCP\Accounts\UserUpdatedEvent;
+use OCP\App\IAppManager;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -217,7 +218,7 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 		// Load all dav apps
-		\OC_App::loadApps(['dav']);
+		$context->getServerContainer()->get(IAppManager::class)->loadApps(['dav']);
 
 		$context->injectFn($this->registerContactsManager(...));
 		$context->injectFn($this->registerCalendarManager(...));

--- a/apps/dav/tests/unit/bootstrap.php
+++ b/apps/dav/tests/unit/bootstrap.php
@@ -1,18 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__ . '/../../../../lib/base.php';
+require_once __DIR__ . '/../../../../tests/autoload.php';
 
-\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);
-
-\OC_App::loadApp('dav');
-
-OC_Hook::clear();
+Server::get(IAppManager::class)->loadApp('dav');

--- a/apps/user_ldap/tests/Integration/ExceptionOnLostConnection.php
+++ b/apps/user_ldap/tests/Integration/ExceptionOnLostConnection.php
@@ -9,6 +9,8 @@ namespace OCA\User_LDAP\Tests\Integration;
 
 use OC\ServerNotAvailableException;
 use OCA\User_LDAP\LDAP;
+use OCP\App\IAppManager;
+use OCP\Server;
 
 /**
  * Class ExceptionOnLostConnection
@@ -63,7 +65,7 @@ class ExceptionOnLostConnection {
 	 */
 	public function setUp(): void {
 		require_once __DIR__ . '/../../../../lib/base.php';
-		\OC_App::loadApps(['user_ldap']);
+		Server::get(IAppManager::class)->loadApps(['user_ldap']);
 
 		$ch = $this->getCurl();
 		$proxyInfoJson = curl_exec($ch);

--- a/apps/user_status/tests/bootstrap.php
+++ b/apps/user_status/tests/bootstrap.php
@@ -6,14 +6,15 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
 
 require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
 
-\OC::$composerAutoloader->addPsr4('Test\\', OC::$SERVERROOT . '/tests/lib/', true);
-
-\OC_App::loadApp('user_status');
-
-OC_Hook::clear();
+Server::get(IAppManager::class)->loadApp('user_status');

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -209,7 +209,6 @@
       <code><![CDATA[IAppContainer]]></code>
     </DeprecatedInterface>
     <DeprecatedMethod>
-      <code><![CDATA[\OC_App::loadApps(['dav'])]]></code>
       <code><![CDATA[getServer]]></code>
       <code><![CDATA[getServer]]></code>
       <code><![CDATA[getURLGenerator]]></code>
@@ -2925,8 +2924,6 @@
   </file>
   <file src="core/Command/Db/ConvertType.php">
     <DeprecatedMethod>
-      <code><![CDATA[\OC_App::getAllApps()]]></code>
-      <code><![CDATA[\OC_App::loadApp($app)]]></code>
       <code><![CDATA[execute]]></code>
       <code><![CDATA[getName]]></code>
       <code><![CDATA[getPrimaryKeyColumns]]></code>
@@ -4471,14 +4468,6 @@
     <DeprecatedMethod>
       <code><![CDATA[getAppManager]]></code>
       <code><![CDATA[getRequest]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="ocs/v1.php">
-    <DeprecatedMethod>
-      <code><![CDATA[OC_App::loadApps()]]></code>
-      <code><![CDATA[OC_App::loadApps(['authentication'])]]></code>
-      <code><![CDATA[OC_App::loadApps(['extended_authentication'])]]></code>
-      <code><![CDATA[OC_App::loadApps(['session'])]]></code>
     </DeprecatedMethod>
   </file>
   <file src="public.php">

--- a/lib/private/Files/SetupManager.php
+++ b/lib/private/Files/SetupManager.php
@@ -21,12 +21,12 @@ use OC\Files\Storage\Wrapper\Quota;
 use OC\Lockdown\Filesystem\NullStorage;
 use OC\Share\Share;
 use OC\Share20\ShareDisableChecker;
-use OC_App;
 use OC_Hook;
 use OCA\Files_External\Config\ExternalMountPoint;
 use OCA\Files_Sharing\External\Mount;
 use OCA\Files_Sharing\ISharedMountPoint;
 use OCA\Files_Sharing\SharedMount;
+use OCP\App\IAppManager;
 use OCP\Constants;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -81,6 +81,7 @@ class SetupManager {
 		private LoggerInterface $logger,
 		private IConfig $config,
 		private ShareDisableChecker $shareDisableChecker,
+		private IAppManager $appManager,
 	) {
 		$this->cache = $cacheFactory->createDistributed('setupmanager::');
 		$this->listeningForProviders = false;
@@ -104,7 +105,7 @@ class SetupManager {
 		$this->setupBuiltinWrappersDone = true;
 
 		// load all filesystem apps before, so no setup-hook gets lost
-		OC_App::loadApps(['filesystem']);
+		$this->appManager->loadApps(['filesystem']);
 		$prevLogging = Filesystem::logWarningWhenAddingStorageWrapper(false);
 
 		Filesystem::addStorageWrapper('mount_options', function ($mountPoint, IStorage $storage, IMountPoint $mount) {

--- a/lib/private/Files/SetupManagerFactory.php
+++ b/lib/private/Files/SetupManagerFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\Files;
 
 use OC\Share20\ShareDisableChecker;
+use OCP\App\IAppManager;
 use OCP\Diagnostics\IEventLogger;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Config\IMountProviderCollection;
@@ -36,6 +37,7 @@ class SetupManagerFactory {
 		private LoggerInterface $logger,
 		private IConfig $config,
 		private ShareDisableChecker $shareDisableChecker,
+		private IAppManager $appManager,
 	) {
 		$this->setupManager = null;
 	}
@@ -55,6 +57,7 @@ class SetupManagerFactory {
 				$this->logger,
 				$this->config,
 				$this->shareDisableChecker,
+				$this->appManager,
 			);
 		}
 		return $this->setupManager;

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -2,14 +2,6 @@
 
 declare(strict_types=1);
 
-use OC\Route\Router;
-use OC\SystemConfig;
-use OC\User\LoginException;
-use OCP\IConfig;
-use OCP\IRequest;
-use OCP\IUserSession;
-use OCP\Server;
-
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -20,9 +12,17 @@ require_once __DIR__ . '/../lib/versioncheck.php';
 require_once __DIR__ . '/../lib/base.php';
 
 use OC\OCS\ApiHelper;
+use OC\Route\Router;
+use OC\SystemConfig;
+use OC\User\LoginException;
+use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\OCSController;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
 use OCP\Security\Bruteforce\MaxDelayReached;
+use OCP\Server;
 use OCP\Util;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
@@ -41,14 +41,15 @@ if (Util::needUpgrade()
  * Try the appframework routes
  */
 try {
-	OC_App::loadApps(['session']);
-	OC_App::loadApps(['authentication']);
-	OC_App::loadApps(['extended_authentication']);
+	$appManager = Server::get(IAppManager::class);
+	$appManager->loadApps(['session']);
+	$appManager->loadApps(['authentication']);
+	$appManager->loadApps(['extended_authentication']);
 
 	// load all apps to get all api routes properly setup
 	// FIXME: this should ideally appear after handleLogin but will cause
 	// side effects in existing apps
-	OC_App::loadApps();
+	$appManager->loadApps();
 
 	$request = Server::get(IRequest::class);
 	$request->throwDecodingExceptionIfAny();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,10 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
+use OCP\App\IAppManager;
+use OCP\Server;
+
 define('PHPUNIT_RUN', 1);
 
 $configDir = getenv('CONFIG_DIR');
@@ -18,11 +24,12 @@ require_once __DIR__ . '/autoload.php';
 \OC::$composerAutoloader->addPsr4('Tests\\', OC::$SERVERROOT . '/tests/', true);
 
 // load all apps
+$appManager = Server::get(IAppManager::class);
 foreach (new \DirectoryIterator(__DIR__ . '/../apps/') as $file) {
 	if ($file->isDot()) {
 		continue;
 	}
-	\OC_App::loadApp($file->getFilename());
+	$appManager->loadApp($file->getFilename());
 }
 
 OC_Hook::clear();

--- a/tests/lib/Traits/EncryptionTrait.php
+++ b/tests/lib/Traits/EncryptionTrait.php
@@ -15,6 +15,7 @@ use OCA\Encryption\AppInfo\Application;
 use OCA\Encryption\Crypto\Encryption;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
+use OCP\App\IAppManager;
 use OCP\Encryption\IManager;
 use OCP\IConfig;
 use OCP\IUserManager;
@@ -102,7 +103,7 @@ trait EncryptionTrait {
 		$this->userManager = Server::get(IUserManager::class);
 		$this->setupManager = Server::get(SetupManager::class);
 
-		\OC_App::loadApp('encryption');
+		Server::get(IAppManager::class)->loadApp('encryption');
 
 		$this->encryptionApp = new Application([], $isReady);
 


### PR DESCRIPTION
* See https://github.com/nextcloud/server/issues/8505

## Summary

Migrate remaining calls to OC_App::loadApp to the IAppManager instead.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
