### PR TITLE
fix(Krb): switch away from deprecated and broken KerberosApacheAuth()

### DIFF
--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -60,10 +60,7 @@ class SMB extends Backend {
 			->setLegacyAuthMechanism($legacyAuth);
 	}
 
-	/**
-	 * @return void
-	 */
-	public function manipulateStorageConfig(StorageConfig &$storage, ?IUser $user = null) {
+	public function manipulateStorageConfig(StorageConfig &$storage, ?IUser $user = null): void {
 		$auth = $storage->getAuthMechanism();
 		if ($auth->getScheme() === AuthMechanism::SCHEME_PASSWORD) {
 			if (!is_string($storage->getBackendOption('user')) || !is_string($storage->getBackendOption('password'))) {
@@ -93,26 +90,25 @@ class SMB extends Backend {
 					} else {
 						try {
 							$credentials = $credentialsStore->getLoginCredentials();
-							$user = $credentials->getLoginName();
+							$loginName = $credentials->getLoginName();
 							$pass = $credentials->getPassword();
-							preg_match('/(.*)@(.*)/', $user, $matches);
+							preg_match('/(.*)@(.*)/', $loginName, $matches);
 							$realm = $storage->getBackendOption('default_realm');
 							if (empty($realm)) {
 								$realm = 'WORKGROUP';
 							}
 							if (count($matches) === 0) {
-								$username = $user;
+								$username = $loginName;
 								$workgroup = $realm;
 							} else {
-								$username = $matches[1];
-								$workgroup = $matches[2];
+								[, $username, $workgroup] = $matches;
 							}
 							$smbAuth = new BasicAuth(
 								$username,
 								$workgroup,
 								$pass
 							);
-						} catch (\Exception $e) {
+						} catch (\Exception) {
 							throw new InsufficientDataForMeaningfulAnswerException('No session credentials saved');
 						}
 					}
@@ -126,7 +122,7 @@ class SMB extends Backend {
 		$storage->setBackendOption('auth', $smbAuth);
 	}
 
-	public function checkDependencies() {
+	public function checkDependencies(): array {
 		$system = \OCP\Server::get(SystemBridge::class);
 		if (NativeServer::available($system)) {
 			return [];

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -9,8 +9,8 @@
 namespace OCA\Files_External\Lib\Backend;
 
 use Icewind\SMB\BasicAuth;
-use Icewind\SMB\KerberosApacheAuth;
 use Icewind\SMB\KerberosAuth;
+use Icewind\SMB\KerberosTicket;
 use Icewind\SMB\Native\NativeServer;
 use Icewind\SMB\Wrapped\Server;
 use OCA\Files_External\Lib\Auth\AuthMechanism;
@@ -85,9 +85,10 @@ class SMB extends Backend {
 						throw new \InvalidArgumentException('invalid authentication backend');
 					}
 					$credentialsStore = $auth->getCredentialsStore();
-					$kerbAuth = new KerberosApacheAuth();
+					$kerbAuth = new KerberosAuth();
+					$kerbAuth->setTicket(KerberosTicket::fromEnv());
 					// check if a kerberos ticket is available, else fallback to session credentials
-					if ($kerbAuth->checkTicket()) {
+					if ($kerbAuth->getTicket()?->isValid()) {
 						$smbAuth = $kerbAuth;
 					} else {
 						try {

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1462,11 +1462,6 @@
       <code><![CDATA[class-string<IStorage>]]></code>
     </MoreSpecificReturnType>
   </file>
-  <file src="apps/files_external/lib/Lib/Backend/SMB.php">
-    <DeprecatedClass>
-      <code><![CDATA[new KerberosApacheAuth()]]></code>
-    </DeprecatedClass>
-  </file>
   <file src="apps/files_external/lib/Lib/Storage/SFTP.php">
     <InternalMethod>
       <code><![CDATA[put]]></code>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

The fallback logic that comes a place when a ticket is not valid stopped working with NC 31. Resolving the usage of deprecated `KerberosApacheAuth` solves this issue.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
