### PR TITLE
ci: test against MariaDB 11.8 (latest LTS)

### DIFF
--- a/.github/workflows/phpunit-mariadb.yml
+++ b/.github/workflows/phpunit-mariadb.yml
@@ -60,13 +60,13 @@ jobs:
       fail-fast: false
       matrix:
         php-versions: ['8.1']
-        mariadb-versions: ['10.3', '10.6', '10.11', '11.4']
+        mariadb-versions: ['10.3', '10.6', '10.11', '11.4', '11.8']
         include:
           - php-versions: '8.3'
             mariadb-versions: '10.11'
             coverage: ${{ github.event_name != 'pull_request' }}
           - php-versions: '8.4'
-            mariadb-versions: '11.4'
+            mariadb-versions: '11.8'
 
     name: MariaDB ${{ matrix.mariadb-versions }} (PHP ${{ matrix.php-versions }}) - database tests
 

--- a/apps/settings/lib/SetupChecks/SupportedDatabase.php
+++ b/apps/settings/lib/SetupChecks/SupportedDatabase.php
@@ -21,7 +21,7 @@ use OCP\SetupCheck\SetupResult;
 class SupportedDatabase implements ISetupCheck {
 
 	private const MIN_MARIADB = '10.6';
-	private const MAX_MARIADB = '11.4';
+	private const MAX_MARIADB = '11.8';
 	private const MIN_MYSQL = '8.0';
 	private const MAX_MYSQL = '8.4';
 	private const MIN_POSTGRES = '13';


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

https://mariadb.com/docs/release-notes/mariadb-community-server-release-notes/mariadb-11-8-series/what-is-mariadb-118
https://endoflife.date/mariadb

I suspect we can probably drop 10.3 finally for real since Ubuntu 20.04 is EoL, but leaving in for now.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
