### PR TITLE
fix: make sure default contact exists by default

### DIFF
--- a/build/integration/collaboration_features/autocomplete.feature
+++ b/build/integration/collaboration_features/autocomplete.feature
@@ -50,6 +50,7 @@ Feature: autocomplete
     Then get email autocomplete for "example"
       | id | source |
       | autocomplete | users |
+      | leon@example.com | emails |
       | user@example.com | emails |
     Then get email autocomplete for "auto"
       | id | source |
@@ -57,6 +58,7 @@ Feature: autocomplete
     Then get email autocomplete for "example"
       | id | source |
       | autocomplete | users |
+      | leon@example.com | emails |
       | user@example.com | emails |
     Then get email autocomplete for "autocomplete@example.com"
       | id | source |
@@ -72,12 +74,14 @@ Feature: autocomplete
     When parameter "shareapi_restrict_user_enumeration_full_match" of app "core" is set to "no"
     Then get email autocomplete for "example"
       | id | source |
+      | leon@example.com | emails |
       | user@example.com | emails |
     When parameter "shareapi_restrict_user_enumeration_full_match" of app "core" is set to "yes"
     Then get email autocomplete for "auto"
       | id | source |
     Then get email autocomplete for "example"
       | id | source |
+      | leon@example.com | emails |
       | user@example.com | emails |
     Then get email autocomplete for "autocomplete@example.com"
       | id | source |


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #53894

## Summary

Create default contact file when the first example contact is to be created.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
