### PR TITLE
feat(federated-share): forward notification only on remote reshare

### DIFF
--- a/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
+++ b/apps/federatedfilesharing/lib/OCM/CloudFederationProviderFiles.php
@@ -309,7 +309,10 @@ class CloudFederationProviderFiles implements ISignedCloudFederationProvider {
 
 		$this->verifyShare($share, $token);
 		$this->executeAcceptShare($share);
-		if ($share->getShareOwner() !== $share->getSharedBy()) {
+
+		if ($share->getShareOwner() !== $share->getSharedBy()
+			&& !$this->userManager->userExists($share->getSharedBy())) {
+			// only if share was initiated from another instance
 			[, $remote] = $this->addressHandler->splitUserRemote($share->getSharedBy());
 			$remoteId = $this->federatedShareProvider->getRemoteId($share);
 			$notification = $this->cloudFederationFactory->getCloudFederationNotification();


### PR DESCRIPTION
This patch will avoid sending a _shared-accepted_ notification to a non-existant remote instance when (federated) resharing a local share.