### PR TITLE
build: Update psalm baseline

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3089,7 +3089,6 @@
   <file src="core/Command/User/Setting.php">
     <DeprecatedMethod>
       <code><![CDATA[setEMailAddress]]></code>
-      <code><![CDATA[setEMailAddress]]></code>
     </DeprecatedMethod>
   </file>
   <file src="core/Controller/AppPasswordController.php">


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/pull/53887

## Summary

```
ERROR: UnusedBaselineEntry
at :0:0
Baseline for issue "DeprecatedMethod" has 1 extra entry. (see https://psalm.dev/316)
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
