### PR TITLE
fix(session): Clear user session cookies after failed remember me login

### DIFF
--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -864,10 +864,11 @@ class Session implements IUserSession, Emitter {
 		$tokens = $this->config->getUserKeys($uid, 'login_token');
 		// test cookies token against stored tokens
 		if (!in_array($currentToken, $tokens, true)) {
-			$this->logger->info('Tried to log in but could not verify token', [
+			$this->logger->info('Tried to log in with remember-me token but could not verify token. Clearing remember-me cookies', [
 				'app' => 'core',
 				'user' => $uid,
 			]);
+			$this->unsetMagicInCookie();
 			return false;
 		}
 		// replace successfully used token with a new one


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Helps clean up invalid cookies after https://github.com/nextcloud/server/issues/37492

## TODO

- [x] Do

## How to test
* Log into Nextcloud
* Run ``DELETE  FROM oc_preferences WHERE appid = 'login_token' AND userid = 'youruser'``
* Open the browser network console, navigate to storage (Firefox), then cookies, and delete the cookie with the name equal to the instanceid from config.php
* Reload the page **twice** or more

master: you will see ``Tried to log in but could not verify token`` every time you reload
here: you will see ``Tried to log in with remember-me token but could not verify token. Clearing remember-me cookies`` **just once**

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
