### PR TITLE
feat(config): return whether a user config was actually deleted

### DIFF
--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -1539,10 +1539,11 @@ class UserConfig implements IUserConfig {
 	 * @param string $userId id of the user
 	 * @param string $app id of the app
 	 * @param string $key config key
+	 * @return bool whether the value was deleted
 	 *
 	 * @since 31.0.0
 	 */
-	public function deleteUserConfig(string $userId, string $app, string $key): void {
+	public function deleteUserConfig(string $userId, string $app, string $key): bool {
 		$this->assertParams($userId, $app, $key);
 		$this->matchAndApplyLexiconDefinition($userId, $app, $key);
 
@@ -1551,11 +1552,13 @@ class UserConfig implements IUserConfig {
 			->where($qb->expr()->eq('userid', $qb->createNamedParameter($userId)))
 			->andWhere($qb->expr()->eq('appid', $qb->createNamedParameter($app)))
 			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($key)));
-		$qb->executeStatement();
+		$affectedRows = $qb->executeStatement();
 
 		unset($this->lazyCache[$userId][$app][$key]);
 		unset($this->fastCache[$userId][$app][$key]);
 		unset($this->valueDetails[$userId][$app][$key]);
+
+		return $affectedRows > 0;
 	}
 
 	/**

--- a/lib/unstable/Config/IUserConfig.php
+++ b/lib/unstable/Config/IUserConfig.php
@@ -687,10 +687,11 @@ interface IUserConfig {
 	 * @param string $userId id of the user
 	 * @param string $app id of the app
 	 * @param string $key config key
+	 * @return bool whether the value was deleted
 	 *
 	 * @experimental 31.0.0
 	 */
-	public function deleteUserConfig(string $userId, string $app, string $key): void;
+	public function deleteUserConfig(string $userId, string $app, string $key): bool;
 
 	/**
 	 * Delete config values from all users linked to a specific config keys

--- a/tests/lib/Config/UserConfigTest.php
+++ b/tests/lib/Config/UserConfigTest.php
@@ -1704,7 +1704,10 @@ class UserConfigTest extends TestCase {
 
 		$userConfig = $this->generateUserConfig($preload ?? []);
 		$this->assertEquals(true, $userConfig->hasKey($userId, $app, $key, $lazy));
-		$userConfig->deleteUserConfig($userId, $app, $key);
+		$deleted = $userConfig->deleteUserConfig($userId, $app, $key);
+		self::assertTrue($deleted, 'user config was deleted');
+		$deletedAgain = $userConfig->deleteUserConfig($userId, $app, $key);
+		self::assertFalse($deletedAgain, 'user config can not be deleted twice');
 		$this->assertEquals(false, $userConfig->hasKey($userId, $app, $key, $lazy));
 		$userConfig = $this->generateUserConfig($preload ?? []);
 		$this->assertEquals(false, $userConfig->hasKey($userId, $app, $key, $lazy));


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Needed to revive https://github.com/nextcloud/server/pull/40628 for 32+

## TODO

- [x] Do

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
