### PR TITLE
fix(federation): respect sharing.federation.allowSelfSignedCertificat…

### DIFF
--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -168,7 +168,8 @@ class SyncService {
 			'auth' => [$userName, $sharedSecret],
 			'body' => $this->buildSyncCollectionRequestBody($syncToken),
 			'headers' => ['Content-Type' => 'application/xml'],
-			'timeout' => $this->config->getSystemValueInt('carddav_sync_request_timeout', IClient::DEFAULT_REQUEST_TIMEOUT)
+			'timeout' => $this->config->getSystemValueInt('carddav_sync_request_timeout', IClient::DEFAULT_REQUEST_TIMEOUT),
+			'verify' => !$this->config->getSystemValue('sharing.federation.allowSelfSignedCertificates', false),
 		];
 
 		$response = $client->request(
@@ -189,6 +190,7 @@ class SyncService {
 
 		$options = [
 			'auth' => [$userName, $sharedSecret],
+			'verify' => !$this->config->getSystemValue('sharing.federation.allowSelfSignedCertificates', false),
 		];
 
 		$response = $client->get(


### PR DESCRIPTION
## Summary

…es for address book sync

The configuration option, to accept self-signed certificates, is now also used when syncing address books.

STR:

- Set `sharing.federation.allowSelfSignedCertificates` to `true`
- Setup federation between two instances using self-signed certificates
- Try to run `occ federation:sync-addressbooks`
- :boom: 

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
