### PR TITLE
feat(lexicon): optionally store in database returned default

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1642,7 +1642,10 @@ class AppConfig implements IAppConfig {
 		$lazy = $configValue->isLazy();
 		// only look for default if needed, default from Lexicon got priority
 		if ($default !== null) {
-			$default = $configValue->getDefault($this->getLexiconPreset()) ?? $default;
+			$default = $configValue->getDefault($this->getLexiconPreset(), $saveIt) ?? $default;
+			if ($saveIt ?? false) {
+				$this->setTypedValue($app, $key, $default, $lazy, $type);
+			}
 		}
 
 		if ($configValue->isFlagged(self::FLAG_SENSITIVE)) {

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -1936,7 +1936,10 @@ class UserConfig implements IUserConfig {
 
 		// only look for default if needed, default from Lexicon got priority if not overwritten by admin
 		if ($default !== null) {
-			$default = $this->getSystemDefault($app, $configValue) ?? $configValue->getDefault($this->getLexiconPreset()) ?? $default;
+			$default = $this->getSystemDefault($app, $configValue) ?? $configValue->getDefault($this->getLexiconPreset(), $saveIt) ?? $default;
+			if ($saveIt ?? false) {
+				$this->setTypedValue($userId, $app, $key, $default, $lazy, $flags, $type);
+			}
 		}
 
 		// returning false will make get() returning $default and set() not changing value in database

--- a/lib/unstable/Config/Lexicon/ConfigLexiconEntry.php
+++ b/lib/unstable/Config/Lexicon/ConfigLexiconEntry.php
@@ -130,7 +130,7 @@ class ConfigLexiconEntry {
 	 * @return string|null NULL if no default is set
 	 * @experimental 31.0.0
 	 */
-	public function getDefault(Preset $preset): ?string {
+	public function getDefault(Preset $preset, ?bool &$saveIt = null): ?string {
 		if ($this->default !== null) {
 			return $this->default;
 		}
@@ -139,9 +139,10 @@ class ConfigLexiconEntry {
 			return null;
 		}
 
+		$saveIt = false;
 		if ($this->defaultRaw instanceof Closure) {
 			/** @psalm-suppress MixedAssignment we expect closure to returns string|int|float|bool|array */
-			$this->defaultRaw = ($this->defaultRaw)($preset);
+			$this->defaultRaw = ($this->defaultRaw)($preset, $saveIt);
 		}
 
 		/** @psalm-suppress MixedArgument closure should be managed previously */


### PR DESCRIPTION
Adding a second parameter to the Closure that define current default in `ConfigLexiconEntry`.
If the parameter is used as a reference and set to `true` the value returned by the defined closure will be stored in the database.

The concept is to replace code like this:
```
public function getSomething(): string {
	if (!$this->appConfig->hasKey(Application::APP_ID, ConfigLexicon::SOMETHING)) {
		$this->appConfig->setValueString(Application::APP_ID, ConfigLexicon::SOMETHING, $this->secureRandom->generate(5, 'abcdefghijklmnopqrstuvwxyz0123456789'));
	}

	return $this->appConfig->getValueString(Application::APP_ID, ConfigLexicon::SOMETHING);
}
```
by this in the Lexicon:

```
new ConfigLexiconEntry(self::SOMETHING, ValueType::STRING, function (Preset $p, bool &$saveIt): string {
		$store = true;
		return $this->secureRandom->generate(5, 'abcdefghijklmnopqrstuvwxyz0123456789')
	},
	'test key'
),
```

on first _get_ on the value, default will be generated (randomly), stored in the database and re-used for the next _get_