### PR TITLE
fix(files_sharing): ensure share folder exists in the settings

### DIFF
--- a/apps/files_sharing/lib/Settings/Personal.php
+++ b/apps/files_sharing/lib/Settings/Personal.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\Files_Sharing\Settings;
 
 use OCA\Files_Sharing\AppInfo\Application;
+use OCA\Files_Sharing\Helper;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\IConfig;
@@ -25,16 +26,18 @@ class Personal implements ISettings {
 
 	public function getForm(): TemplateResponse {
 		$defaultAcceptSystemConfig = $this->config->getSystemValueBool('sharing.enable_share_accept', false) ? 'no' : 'yes';
-		$shareFolderSystemConfig = $this->config->getSystemValue('share_folder', '/');
+		$defaultShareFolder = $this->config->getSystemValue('share_folder', '/');
+		$userShareFolder = Helper::getShareFolder(userId: $this->userId);
 		$acceptDefault = $this->config->getUserValue($this->userId, Application::APP_ID, 'default_accept', $defaultAcceptSystemConfig) === 'yes';
 		$enforceAccept = $this->config->getSystemValueBool('sharing.force_share_accept', false);
 		$allowCustomDirectory = $this->config->getSystemValueBool('sharing.allow_custom_share_folder', true);
-		$shareFolderDefault = $this->config->getUserValue($this->userId, Application::APP_ID, 'share_folder', $shareFolderSystemConfig);
+
 		$this->initialState->provideInitialState('accept_default', $acceptDefault);
 		$this->initialState->provideInitialState('enforce_accept', $enforceAccept);
 		$this->initialState->provideInitialState('allow_custom_share_folder', $allowCustomDirectory);
-		$this->initialState->provideInitialState('share_folder', $shareFolderDefault);
-		$this->initialState->provideInitialState('default_share_folder', $shareFolderSystemConfig);
+		$this->initialState->provideInitialState('default_share_folder', $defaultShareFolder);
+		$this->initialState->provideInitialState('share_folder', $userShareFolder);
+
 		return new TemplateResponse('files_sharing', 'Settings/personal');
 	}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/46325

## Summary

Ensure that we return an existing share folder (just use the helper instead of directly access the user config).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
