### PR TITLE
feat(settings): Check for unused data directory

### DIFF
--- a/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
+++ b/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
@@ -79,7 +79,7 @@ class DataDirectoryProtected implements ISetupCheck {
 
 		// check for unused /data folder
 		$dataDirDefault = \OC::$SERVERROOT . '/data';
-		if (	$dataDirActual !== $dataDirDefault
+		if ($dataDirActual !== $dataDirDefault
 			&& file_exists($dataDirDefault)
 		) {
 			return SetupResult::info(

--- a/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
+++ b/apps/settings/lib/SetupChecks/DataDirectoryProtected.php
@@ -90,7 +90,6 @@ class DataDirectoryProtected implements ISetupCheck {
 			);
 		}
 
-		return SetupResult::success('Protected');
-
+		return SetupResult::success($this->l10n->t('Protected'));
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #3610 <!-- related github issue -->

## Summary

- Checks for unused `data/` folder in `SERVERROOT`
  - Avoids confusion when looking for logs/troubleshooting
- Minor cosmetic adjustments:
  - Moves DataDirectoryProtected check to `security` section of checks
  - Adds a verbose success message
- Minor code refactoring
  - clearer variable naming
  - formatting

## TODO

- [ ] Fix test(s) (oops)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
