### PR TITLE
fix(caldav): don't return cancelled events for upcoming events API

### DIFF
--- a/apps/dav/lib/CalDAV/UpcomingEventsService.php
+++ b/apps/dav/lib/CalDAV/UpcomingEventsService.php
@@ -47,7 +47,7 @@ class UpcomingEventsService {
 			$this->userManager->get($userId),
 		);
 
-		return array_map(function (array $event) use ($userId, $calendarAppEnabled) {
+		return array_filter(array_map(function (array $event) use ($userId, $calendarAppEnabled) {
 			$calendarAppUrl = null;
 
 			if ($calendarAppEnabled) {
@@ -67,6 +67,10 @@ class UpcomingEventsService {
 				$calendarAppUrl = $this->urlGenerator->linkToRouteAbsolute('calendar.view.indexdirect.edit', $arguments);
 			}
 
+			if (isset($event['objects'][0]['STATUS']) && $event['objects'][0]['STATUS'][0] === 'CANCELLED') {
+				return false;
+			}
+
 			return new UpcomingEvent(
 				$event['uri'],
 				($event['objects'][0]['RECURRENCE-ID'][0] ?? null)?->getTimeStamp(),
@@ -76,7 +80,7 @@ class UpcomingEventsService {
 				$event['objects'][0]['LOCATION'][0] ?? null,
 				$calendarAppUrl,
 			);
-		}, $events);
+		}, $events));
 	}
 
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Filter events that have status "CANCELLED" when returning upcoming events

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
