### PR TITLE
feat(appconfig): add searchKeys()

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -95,8 +95,9 @@ class AppConfig implements IAppConfig {
 	 * @inheritDoc
 	 *
 	 * @param string $app id of the app
-	 *
 	 * @return list<string> list of stored config keys
+	 * @see searchKeys to not load lazy config keys
+	 *
 	 * @since 29.0.0
 	 */
 	public function getKeys(string $app): array {
@@ -105,6 +106,32 @@ class AppConfig implements IAppConfig {
 		$keys = array_merge(array_keys($this->fastCache[$app] ?? []), array_keys($this->lazyCache[$app] ?? []));
 		sort($keys);
 
+		return array_values(array_unique($keys));
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @param string $app id of the app
+	 * @param string $prefix returns only keys starting with this value
+	 * @param bool $lazy TRUE to search in lazy config keys
+	 * @return list<string> list of stored config keys
+	 * @since 32.0.0
+	 */
+	public function searchKeys(string $app, string $prefix = '', bool $lazy = false): array {
+		$this->assertParams($app);
+		$this->loadConfig($app, $lazy);
+		if ($lazy) {
+			$keys = array_keys($this->lazyCache[$app] ?? []);
+		} else {
+			$keys = array_keys($this->fastCache[$app] ?? []);
+		}
+
+		if ($prefix !== '') {
+			$keys = array_filter($keys, static fn (string $key): bool => str_starts_with($key, $prefix));
+		}
+
+		sort($keys);
 		return array_values(array_unique($keys));
 	}
 

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -65,11 +65,25 @@ interface IAppConfig {
 	 * **WARNING:** ignore lazy filtering, all config values are loaded from database
 	 *
 	 * @param string $app id of the app
-	 *
 	 * @return list<string> list of stored config keys
+	 * @see searchKeys to avoid loading lazy config keys
+	 *
 	 * @since 29.0.0
 	 */
 	public function getKeys(string $app): array;
+
+	/**
+	 * Returns list of keys stored in database, related to an app.
+	 * Please note that the values are not returned.
+	 *
+	 * @param string $app id of the app
+	 * @param string $prefix returns only keys starting with this value
+	 * @param bool $lazy TRUE to search in lazy config keys
+	 *
+	 * @return list<string> list of stored config keys
+	 * @since 32.0.0
+	 */
+	public function searchKeys(string $app, string $prefix = '', bool $lazy = false): array;
 
 	/**
 	 * Check if a key exists in the list of stored config values.

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -47,6 +47,13 @@ class AppConfigTest extends TestCase {
 				'deletethis' => ['deletethis', 'deletethis'],
 				'key' => ['key', 'value']
 			],
+			'searchtest' => [
+				'search_key1' => ['search_key1', 'key1', IAppConfig::VALUE_STRING],
+				'search_key2' => ['search_key2', 'key2', IAppConfig::VALUE_STRING],
+				'search_key3' => ['search_key3', 'key3', IAppConfig::VALUE_STRING],
+				'searchnot_key4' => ['searchnot_key4', 'key4', IAppConfig::VALUE_STRING],
+				'search_key5_lazy' => ['search_key5_lazy', 'key5', IAppConfig::VALUE_STRING, true],
+			],
 			'someapp' => [
 				'key' => ['key', 'value'],
 				'otherkey' => ['otherkey', 'othervalue']
@@ -1452,6 +1459,23 @@ class AppConfigTest extends TestCase {
 		// Migrate to sensitive / encrypted
 		$appConfig->updateSensitive('testapp', $key, true);
 		$this->assertConfigValueNotEquals('testapp', $key, $secret);
+	}
+
+	public function testSearchKeyNoLazyLoading(): void {
+		$appConfig = $this->generateAppConfig();
+		$appConfig->searchKeys('searchtest', 'search_');
+		$status = $appConfig->statusCache();
+		$this->assertFalse($status['lazyLoaded'], 'searchKeys() loaded lazy config');
+	}
+
+	public function testSearchKeyFast(): void {
+		$appConfig = $this->generateAppConfig();
+		$this->assertEquals(['search_key1', 'search_key2', 'search_key3'], $appConfig->searchKeys('searchtest', 'search_'));
+	}
+
+	public function testSearchKeyLazy(): void {
+		$appConfig = $this->generateAppConfig();
+		$this->assertEquals(['search_key5_lazy'], $appConfig->searchKeys('searchtest', 'search_', true));
 	}
 
 	protected function loadConfigValueFromDatabase(string $app, string $key): string|false {


### PR DESCRIPTION
Some app stores data in appconfig with dynamic keys and uses `getKeys()` to read the data.
This method `searchKeys()` limit the load of lazy appconfig that is needed using `getKeys()`

- [x] tests

example of `searchKeys()`: #54007 