### PR TITLE
fix: Do not show password dialog when user can not validate password

### DIFF
--- a/lib/private/Template/JSConfigHelper.php
+++ b/lib/private/Template/JSConfigHelper.php
@@ -70,6 +70,8 @@ class JSConfigHelper {
 				$userBackendAllowsPasswordConfirmation = $backend->canConfirmPassword($uid) && $this->canUserValidatePassword();
 			} elseif (isset($this->excludedUserBackEnds[$this->currentUser->getBackendClassName()])) {
 				$userBackendAllowsPasswordConfirmation = false;
+			} else {
+				$userBackendAllowsPasswordConfirmation = $this->canUserValidatePassword();
 			}
 		} else {
 			$uid = null;


### PR DESCRIPTION
Follow up to #50465
Related to #53472

The password confirmation dialog (which [is used, for example, in external storages](https://github.com/nextcloud/server/commit/a2f2f7ce93e66f97827229de1d2b4cb233976096#diff-b7bbcd56baa0302a4ca9cff20014e99095fbbc1de3c91676df389d32d9f92174R9)) is always shown [unless the user backend does not allow password confirmation](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/blob/ee32f287f3eda20d527ad37e58fbfd1d75cee667/src/is-required.ts#L19). A user backend [may explicitly provide that information](https://github.com/nextcloud/server/blob/d0658e85eacc2f0ccea2bc68362b59f6145c03e9/lib/private/Template/JSConfigHelper.php#L69-L70), but even if it does not [that could have been defined in the authentication token with `IToken::SCOPE_SKIP_PASSWORD_VALIDATION`](https://github.com/nextcloud/user_oidc/blob/a715488e26d3851da0d7fdf0582703f0a3aea27c/lib/Controller/LoginController.php#L569-L576) (for example, when `user_oidc` is only used for authentication and user provision is done by another user backend).

## How to test

- Log in as an admin
- Enable external storages
- Open external storages in Administration settings
- Enable _Allow people to mount external storage_
- Install and enable [the _user_oidc_ app](https://github.com/nextcloud/user_oidc) (_OpenID Connect user backend_)
- [Disable auto provisioning in _user_oidc_](https://github.com/nextcloud/user_oidc/blob/8f1eb933a614c3dccadec7b271c27e7e018c20e2/README.md#auto-provisioning):
```
'user_oidc' => [
    'auto_provision' => false,
]
```
- Install Keycloack
- Configure Keycloack and user_oidc as described in https://web.archive.org/web/20240412121655/https://www.schiessle.org/articles/2023/07/04/nextcloud-and-openid-connect/
- Back in Nextcloud, add an account with the same account name as the ID (not username, ID) of the Keycloack user (otherwise `Failed to provision the user` would be shown when logging in, as _user_oidc_ is being used only for authentication and the user should be provisioned by another user backend)
- In a private window, log in Nextcloud with Keycloack
- Open the Settings
- Open the _External storage_ section
- Try to add an external storage

### Result with this pull request

No password confirmation dialog is shown and the external storage is saved

### Result without this pull request

A password confirmation dialog is shown
