### PR TITLE
fix(bruteforce): limit appconfig lazy loading

### DIFF
--- a/lib/private/Security/Ip/BruteforceAllowList.php
+++ b/lib/private/Security/Ip/BruteforceAllowList.php
@@ -36,10 +36,7 @@ class BruteforceAllowList {
 			return false;
 		}
 
-		$keys = $this->appConfig->getKeys('bruteForce');
-		$keys = array_filter($keys, static fn ($key): bool => str_starts_with($key, 'whitelist_'));
-
-		foreach ($keys as $key) {
+		foreach ($this->appConfig->searchKeys('bruteForce', 'whitelist_') as $key) {
 			$rangeString = $this->appConfig->getValueString('bruteForce', $key);
 			try {
 				$range = $this->factory->rangeFromString($rangeString);

--- a/tests/lib/Security/Ip/BruteforceAllowListTest.php
+++ b/tests/lib/Security/Ip/BruteforceAllowListTest.php
@@ -138,8 +138,8 @@ class BruteforceAllowListTest extends TestCase {
 		array $allowList,
 		bool $isAllowListed,
 	): void {
-		$this->appConfig->method('getKeys')
-			->with($this->equalTo('bruteForce'))
+		$this->appConfig->method('searchKeys')
+			->with($this->equalTo('bruteForce'), $this->equalTo('whitelist_'))
 			->willReturn(array_keys($allowList));
 
 		$this->appConfig->method('getValueString')


### PR DESCRIPTION
using `searchKeys()` instead of `getKeys()` to avoid useless loading of lazy config value

require: #54003 