### PR TITLE
fix: add unique index for users' mountpoints

### DIFF
--- a/core/Listener/AddMissingIndicesListener.php
+++ b/core/Listener/AddMissingIndicesListener.php
@@ -186,11 +186,14 @@ class AddMissingIndicesListener implements IEventListener {
 			'mounts_class_index',
 			['mount_provider_class']
 		);
-		$event->addMissingIndex(
+
+		$event->replaceIndex(
 			'mounts',
-			'mounts_user_root_path_index',
+			['mounts_user_root_path_index'],
+			'mounts_user_root_path_unique_i',
 			['user_id', 'root_id', 'mount_point'],
-			['lengths' => [null, null, 128]]
+			true,
+			['lengths' => [null, null, 128]],
 		);
 
 		$event->addMissingIndex(

--- a/core/Listener/AddMissingIndicesListener.php
+++ b/core/Listener/AddMissingIndicesListener.php
@@ -187,12 +187,10 @@ class AddMissingIndicesListener implements IEventListener {
 			['mount_provider_class']
 		);
 
-		$event->replaceIndex(
+		$event->addMissingUniqueIndex(
 			'mounts',
-			['mounts_user_root_path_index'],
-			'mounts_user_root_path_unique_i',
+			'mounts_user_root_path_index',
 			['user_id', 'root_id', 'mount_point'],
-			true,
 			['lengths' => [null, null, 128]],
 		);
 

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -121,7 +121,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['storage_id'], 'mounts_storage_index');
 			$table->addIndex(['root_id'], 'mounts_root_index');
 			$table->addIndex(['mount_id'], 'mounts_mount_id_index');
-			$table->addIndex(['user_id', 'root_id', 'mount_point'], 'mounts_user_root_path_index', [], ['lengths' => [null, null, 128]]);
+			$table->addUniqueIndex(['user_id', 'root_id', 'mount_point'], 'mounts_user_root_path_unique_i', ['lengths' => [null, null, 128]]);
 		} else {
 			$table = $schema->getTable('mounts');
 			if (!$table->hasColumn('mount_id')) {

--- a/core/Migrations/Version13000Date20170718121200.php
+++ b/core/Migrations/Version13000Date20170718121200.php
@@ -121,7 +121,7 @@ class Version13000Date20170718121200 extends SimpleMigrationStep {
 			$table->addIndex(['storage_id'], 'mounts_storage_index');
 			$table->addIndex(['root_id'], 'mounts_root_index');
 			$table->addIndex(['mount_id'], 'mounts_mount_id_index');
-			$table->addUniqueIndex(['user_id', 'root_id', 'mount_point'], 'mounts_user_root_path_unique_i', ['lengths' => [null, null, 128]]);
+			$table->addUniqueIndex(['user_id', 'root_id', 'mount_point'], 'mounts_user_root_path_index', ['lengths' => [null, null, 128]]);
 		} else {
 			$table = $schema->getTable('mounts');
 			if (!$table->hasColumn('mount_id')) {

--- a/core/Migrations/Version32000Date20250721125100.php
+++ b/core/Migrations/Version32000Date20250721125100.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\Attributes\AddIndex;
+use OCP\Migration\Attributes\DropIndex;
+use OCP\Migration\Attributes\IndexType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Replace user mounts index with a version with a unique constraint.
+ */
+#[DropIndex(table: 'mounts', type: IndexType::INDEX, description: 'remove non-unique user mounts index', notes: ['will be re-created to make it unique'])]
+#[AddIndex(table: 'mounts', type: IndexType::INDEX, description: 'new unique index for user mounts')]
+class Version32000Date20250721125100 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('mounts');
+		// replacing index with unique version, to avoid duplicate rows
+		if ($table->hasIndex('mounts_user_root_path_index')) {
+			$table->dropIndex('mounts_user_root_path_index');
+			$table->addUniqueIndex(
+				['user_id', 'root_id', 'mount_point'],
+				'mounts_user_root_path_index',
+				['lengths' => [null, null, 128]]
+			);
+		}
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
## Summary

In https://github.com/nextcloud/server/pull/32877 the unique index was dropped to allow users to have multiple entries for the same mount, but different mountpoints. This leads to rows being duplicated and causes performance issues if the amount of duplication and users are not negligible.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
