### PR TITLE
fix: group imip log messages by removing principal and uri

### DIFF
--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -403,7 +403,10 @@ class Manager implements IManager {
 		}
 
 		if (empty($found)) {
-			$this->logger->warning('iMip message event could not be processed because no corresponding event was found in any calendar ' . $principalUri . 'and UID' . $vEvent->{'UID'}->getValue());
+			$this->logger->warning('iMip message event could not be processed because no corresponding event was found in any calendar', [
+				'principalUri' => $principalUri,
+				'eventUid' => $vEvent->{'UID'}->getValue(),
+			]);
 			return false;
 		}
 
@@ -518,7 +521,10 @@ class Manager implements IManager {
 		}
 
 		if (empty($found)) {
-			$this->logger->warning('iMip message event could not be processed because no corresponding event was found in any calendar ' . $principalUri . 'and UID' . $vEvent->{'UID'}->getValue());
+			$this->logger->warning('iMip message event could not be processed because no corresponding event was found in any calendar', [
+				'principalUri' => $principalUri,
+				'eventUid' => $vEvent->{'UID'}->getValue(),
+			]);
 			return false;
 		}
 

--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -1075,7 +1075,7 @@ class ManagerTest extends TestCase {
 		$calendarData->add('METHOD', 'REPLY');
 		// construct logger return
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event could not be processed because no corresponding event was found in any calendar ' . $principalUri . 'and UID' . $calendarData->VEVENT->UID->getValue());
+			->with('iMip message event could not be processed because no corresponding event was found in any calendar', ['principalUri' => $principalUri, 'eventUid' => $calendarData->VEVENT->UID->getValue()]);
 		// Act
 		$result = $manager->handleIMipReply($principalUri, $sender, $recipient, $calendarData->serialize());
 		// Assert
@@ -1523,7 +1523,7 @@ class ManagerTest extends TestCase {
 		$calendarData->add('METHOD', 'CANCEL');
 		// construct logger return
 		$this->logger->expects(self::once())->method('warning')
-			->with('iMip message event could not be processed because no corresponding event was found in any calendar ' . $principalUri . 'and UID' . $calendarData->VEVENT->UID->getValue());
+			->with('iMip message event could not be processed because no corresponding event was found in any calendar', ['principalUri' => $principalUri, 'eventUid' => $calendarData->VEVENT->UID->getValue()]);
 		// Act
 		$result = $manager->handleIMipCancel($principalUri, $sender, $replyTo, $recipient, $calendarData->serialize());
 		// Assert


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

By logging principaluri and event uid as context, sentry should be able to group those warnings properly.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
