### PR TITLE
feat: add ICloudIdResolver

### DIFF
--- a/apps/federatedfilesharing/tests/AddressHandlerTest.php
+++ b/apps/federatedfilesharing/tests/AddressHandlerTest.php
@@ -34,11 +34,11 @@ class AddressHandlerTest extends \Test\TestCase {
 		$this->contactsManager = $this->createMock(IManager::class);
 
 		$this->cloudIdManager = new CloudIdManager(
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->urlGenerator,
 			$this->createMock(IUserManager::class),
-			$this->createMock(ICacheFactory::class),
-			$this->createMock(IEventDispatcher::class)
 		);
 
 		$this->addressHandler = new AddressHandler($this->urlGenerator, $this->il10n, $this->cloudIdManager);

--- a/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
+++ b/apps/federatedfilesharing/tests/Controller/MountPublicLinkControllerTest.php
@@ -64,11 +64,11 @@ class MountPublicLinkControllerTest extends \Test\TestCase {
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->contactsManager = $this->createMock(IContactsManager::class);
 		$this->cloudIdManager = new CloudIdManager(
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->createMock(IURLGenerator::class),
 			$this->userManager,
-			$this->createMock(ICacheFactory::class),
-			$this->createMock(IEventDispatcher::class)
 		);
 
 		$this->controller = new MountPublicLinkController(

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -74,11 +74,11 @@ class FederatedShareProviderTest extends \Test\TestCase {
 		$this->addressHandler = $this->createMock(AddressHandler::class);
 		$this->contactsManager = $this->createMock(IContactsManager::class);
 		$this->cloudIdManager = new CloudIdManager(
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->createMock(IURLGenerator::class),
 			$this->userManager,
-			$this->createMock(ICacheFactory::class),
-			$this->createMock(IEventDispatcher::class)
 		);
 		$this->gsConfig = $this->createMock(\OCP\GlobalScale\IConfig::class);
 

--- a/apps/files_sharing/tests/External/CacheTest.php
+++ b/apps/files_sharing/tests/External/CacheTest.php
@@ -54,11 +54,11 @@ class CacheTest extends TestCase {
 		$this->contactsManager = $this->createMock(IManager::class);
 
 		$this->cloudIdManager = new CloudIdManager(
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
-			$this->createMock(ICacheFactory::class),
-			$this->createMock(IEventDispatcher::class)
 		);
 		$this->remoteUser = $this->getUniqueID('remoteuser');
 

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -90,11 +90,11 @@ class ManagerTest extends TestCase {
 		$this->testMountProvider = new MountProvider(Server::get(IDBConnection::class), function () {
 			return $this->manager;
 		}, new CloudIdManager(
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->createMock(IURLGenerator::class),
 			$this->userManager,
-			$this->createMock(ICacheFactory::class),
-			$this->createMock(IEventDispatcher::class)
 		));
 
 		$group1 = $this->createMock(IGroup::class);

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -367,6 +367,7 @@ return array(
     'OCP\\Federation\\ICloudFederationShare' => $baseDir . '/lib/public/Federation/ICloudFederationShare.php',
     'OCP\\Federation\\ICloudId' => $baseDir . '/lib/public/Federation/ICloudId.php',
     'OCP\\Federation\\ICloudIdManager' => $baseDir . '/lib/public/Federation/ICloudIdManager.php',
+    'OCP\\Federation\\ICloudIdResolver' => $baseDir . '/lib/public/Federation/ICloudIdResolver.php',
     'OCP\\Files' => $baseDir . '/lib/public/Files.php',
     'OCP\\FilesMetadata\\AMetadataEvent' => $baseDir . '/lib/public/FilesMetadata/AMetadataEvent.php',
     'OCP\\FilesMetadata\\Event\\MetadataBackgroundEvent' => $baseDir . '/lib/public/FilesMetadata/Event/MetadataBackgroundEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -408,6 +408,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Federation\\ICloudFederationShare' => __DIR__ . '/../../..' . '/lib/public/Federation/ICloudFederationShare.php',
         'OCP\\Federation\\ICloudId' => __DIR__ . '/../../..' . '/lib/public/Federation/ICloudId.php',
         'OCP\\Federation\\ICloudIdManager' => __DIR__ . '/../../..' . '/lib/public/Federation/ICloudIdManager.php',
+        'OCP\\Federation\\ICloudIdResolver' => __DIR__ . '/../../..' . '/lib/public/Federation/ICloudIdResolver.php',
         'OCP\\Files' => __DIR__ . '/../../..' . '/lib/public/Files.php',
         'OCP\\FilesMetadata\\AMetadataEvent' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/AMetadataEvent.php',
         'OCP\\FilesMetadata\\Event\\MetadataBackgroundEvent' => __DIR__ . '/../../..' . '/lib/public/FilesMetadata/Event/MetadataBackgroundEvent.php',

--- a/lib/private/Federation/CloudIdManager.php
+++ b/lib/private/Federation/CloudIdManager.php
@@ -14,6 +14,7 @@ use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Federation\ICloudId;
 use OCP\Federation\ICloudIdManager;
+use OCP\Federation\ICloudIdResolver;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IURLGenerator;
@@ -31,6 +32,8 @@ class CloudIdManager implements ICloudIdManager {
 	private ICache $displayNameCache;
 	/** @var array[] */
 	private array $cache = [];
+	/** @var ICloudIdResolver[] */
+	private array $cloudIdResolvers = [];
 
 	public function __construct(
 		IManager $contactsManager,
@@ -80,6 +83,12 @@ class CloudIdManager implements ICloudIdManager {
 	 */
 	public function resolveCloudId(string $cloudId): ICloudId {
 		// TODO magic here to get the url and user instead of just splitting on @
+		
+		foreach ($this->cloudIdResolvers as $resolver) {
+			if ($resolver->isValidCloudId($cloudId)) {
+				return $resolver->resolveCloudId($cloudId);
+			}
+		}
 
 		if (!$this->isValidCloudId($cloudId)) {
 			throw new \InvalidArgumentException('Invalid cloud id');
@@ -251,6 +260,45 @@ class CloudIdManager implements ICloudIdManager {
 	 * @return bool
 	 */
 	public function isValidCloudId(string $cloudId): bool {
-		return str_contains($cloudId, '@');
+		foreach ($this->cloudIdResolvers as $resolver) {
+			if ($resolver->isValidCloudId($cloudId)) {
+				return true;
+			}
+		}
+
+		return strpos($cloudId, '@') !== false;
+	}
+
+	/**
+	 * @param string $id,
+	 * @param string $user
+	 * @param string $remote
+	 * @param ?string $displayName
+	 * @return ICloudId
+	 * 
+	 * @since 32.0.0
+	 */
+	public function createCloudId(string $id, string $user, string $remote, ?string $displayName = null): ICloudId {
+		return new CloudId($id, $user, $remote, $displayName);
+	}
+
+	/**
+	 * @param ICloudIdResolver $resolver
+	 * 
+	 * @since 32.0.0
+	 */
+	public function registerCloudIdResolver(ICloudIdResolver $resolver) {
+		array_unshift($this->cloudIdResolvers, $resolver);
+	}
+
+	/**
+	 * @param ICloudIdResolver $resolver
+	 * 
+	 * @since 32.0.0
+	 */
+	public function unregisterCloudIdResolver(ICloudIdResolver $resolver) {
+		if (($key = array_search($resolver, $this->cloudIdResolvers)) !== false) {
+			array_splice($this->cloudIdResolvers, $key, 1);
+		}
 	}
 }

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1161,11 +1161,11 @@ class Server extends ServerContainer implements IServerContainer {
 
 		$this->registerService(ICloudIdManager::class, function (ContainerInterface $c) {
 			return new CloudIdManager(
+				$c->get(ICacheFactory::class),
+				$c->get(IEventDispatcher::class),
 				$c->get(\OCP\Contacts\IManager::class),
 				$c->get(IURLGenerator::class),
 				$c->get(IUserManager::class),
-				$c->get(ICacheFactory::class),
-				$c->get(IEventDispatcher::class),
 			);
 		});
 

--- a/lib/public/Federation/ICloudIdManager.php
+++ b/lib/public/Federation/ICloudIdManager.php
@@ -8,11 +8,14 @@ declare(strict_types=1);
  */
 namespace OCP\Federation;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * Interface for resolving federated cloud ids
  *
  * @since 12.0.0
  */
+#[Consumable(since: '12.0.0')]
 interface ICloudIdManager {
 	/**
 	 * @param string $cloudId
@@ -57,27 +60,26 @@ interface ICloudIdManager {
 	public function removeProtocolFromUrl(string $url, bool $httpsOnly = false): string;
 
 	/**
-	 * @param string $id,
-	 * @param string $user
-	 * @param string $remote
-	 * @param ?string $displayName
-	 * @return ICloudId
+	 * @param string $id The remote cloud id
+	 * @param string $user The user id on the remote server
+	 * @param string $remote The base address of the remote server
+	 * @param ?string $displayName The displayname of the remote user
 	 *
 	 * @since 32.0.0
 	 */
 	public function createCloudId(string $id, string $user, string $remote, ?string $displayName = null): ICloudId;
 
 	/**
-	 * @param ICloudIdResolver $resolver
+	 * @param $resolver The cloud id resolver to register
 	 *
 	 * @since 32.0.0
 	 */
-	public function registerCloudIdResolver(ICloudIdResolver $resolver);
+	public function registerCloudIdResolver(ICloudIdResolver $resolver): void;
 
 	/**
-	 * @param ICloudIdResolver $resolver
+	 * @param $resolver The cloud id resolver to unregister
 	 *
 	 * @since 32.0.0
 	 */
-	public function unregisterCloudIdResolver(ICloudIdResolver $resolver);
+	public function unregisterCloudIdResolver(ICloudIdResolver $resolver): void;
 }

--- a/lib/public/Federation/ICloudIdManager.php
+++ b/lib/public/Federation/ICloudIdManager.php
@@ -55,4 +55,29 @@ interface ICloudIdManager {
 	 * @since 30.0.0 - Optional parameter $httpsOnly was added
 	 */
 	public function removeProtocolFromUrl(string $url, bool $httpsOnly = false): string;
+
+	/**
+	 * @param string $id,
+	 * @param string $user
+	 * @param string $remote
+	 * @param ?string $displayName
+	 * @return ICloudId
+	 *
+	 * @since 32.0.0
+	 */
+	public function createCloudId(string $id, string $user, string $remote, ?string $displayName = null): ICloudId;
+
+	/**
+	 * @param ICloudIdResolver $resolver
+	 *
+	 * @since 32.0.0
+	 */
+	public function registerCloudIdResolver(ICloudIdResolver $resolver);
+
+	/**
+	 * @param ICloudIdResolver $resolver
+	 *
+	 * @since 32.0.0
+	 */
+	public function unregisterCloudIdResolver(ICloudIdResolver $resolver);
 }

--- a/lib/public/Federation/ICloudIdResolver.php
+++ b/lib/public/Federation/ICloudIdResolver.php
@@ -8,11 +8,16 @@ declare(strict_types=1);
  */
 namespace OCP\Federation;
 
+use OCP\AppFramework\Attribute\Consumable;
+use OCP\AppFramework\Attribute\Implementable;
+
 /**
  * Interface for resolving federated cloud ids
  *
  * @since 32.0.0
  */
+#[Consumable(since: '32.0.0')]
+#[Implementable(since: '32.0.0')]
 interface ICloudIdResolver {
 	/**
 	 * @param string $cloudId

--- a/lib/public/Federation/ICloudIdResolver.php
+++ b/lib/public/Federation/ICloudIdResolver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OCP\Federation;
+
+/**
+ * Interface for resolving federated cloud ids
+ *
+ * @since 32.0.0
+ */
+interface ICloudIdResolver {
+	/**
+	 * @param string $cloudId
+	 * @return ICloudId
+	 * @throws \InvalidArgumentException
+	 *
+	 * @since 32.0.0
+	 */
+	public function resolveCloudId(string $cloudId): ICloudId;
+
+	/**
+	 * Check if the input is a correctly formatted cloud id
+	 *
+	 * @param string $cloudId
+	 * @return bool
+	 *
+	 * @since 32.0.0
+	 */
+	public function isValidCloudId(string $cloudId): bool;
+}

--- a/tests/lib/Collaboration/Collaborators/MailPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/MailPluginTest.php
@@ -64,11 +64,11 @@ class MailPluginTest extends TestCase {
 		$this->userSession = $this->createMock(IUserSession::class);
 		$this->mailer = $this->createMock(IMailer::class);
 		$this->cloudIdManager = new CloudIdManager(
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
-			$this->createMock(ICacheFactory::class),
-			$this->createMock(IEventDispatcher::class)
 		);
 
 		$this->searchResult = new SearchResult();

--- a/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/RemotePluginTest.php
@@ -49,11 +49,11 @@ class RemotePluginTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 		$this->contactsManager = $this->createMock(IManager::class);
 		$this->cloudIdManager = new CloudIdManager(
+			$this->createMock(ICacheFactory::class),
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->createMock(IURLGenerator::class),
 			$this->createMock(IUserManager::class),
-			$this->createMock(ICacheFactory::class),
-			$this->createMock(IEventDispatcher::class)
 		);
 		$this->searchResult = new SearchResult();
 	}

--- a/tests/lib/Federation/CloudIdManagerTest.php
+++ b/tests/lib/Federation/CloudIdManagerTest.php
@@ -47,11 +47,11 @@ class CloudIdManagerTest extends TestCase {
 			->willReturn(new ArrayCache(''));
 
 		$this->cloudIdManager = new CloudIdManager(
+			$this->cacheFactory,
+			$this->createMock(IEventDispatcher::class),
 			$this->contactsManager,
 			$this->urlGenerator,
 			$this->userManager,
-			$this->cacheFactory,
-			$this->createMock(IEventDispatcher::class)
 		);
 		$this->overwriteService(ICloudIdManager::class, $this->cloudIdManager);
 	}


### PR DESCRIPTION
* copy of https://github.com/nextcloud/server/pull/52993

## Summary
An application requires group ids that contain slashes and colons. Full reasoning given:

 >   Cloud Ids consist of username and remote parts. Usernames can also be group names. Federated groups are required to have "prefixes" to distinguish them from regular groups. Here group ids (gids) are written as Uniform Resource Names (URNs) that have colons and slashes as part of the uri scheme. We need to allow these characters as part of group names. Keep in mind that groups in Nextcloud can already contain these characters anyway.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
