### PR TITLE
fix(ConnectionFactory): Apply Oracle connection fix to primary and replica params as well

### DIFF
--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -121,21 +121,9 @@ class ConnectionFactory {
 
 			case 'oci':
 				$eventManager->addEventSubscriber(new OracleSessionInit);
-				// the driverOptions are unused in dbal and need to be mapped to the parameters
-				if (isset($connectionParams['driverOptions'])) {
-					$connectionParams = array_merge($connectionParams, $connectionParams['driverOptions']);
-				}
-				$host = $connectionParams['host'];
-				$port = $connectionParams['port'] ?? null;
-				$dbName = $connectionParams['dbname'];
-
-				// we set the connect string as dbname and unset the host to coerce doctrine into using it as connect string
-				if ($host === '') {
-					$connectionParams['dbname'] = $dbName; // use dbname as easy connect name
-				} else {
-					$connectionParams['dbname'] = '//' . $host . (!empty($port) ? ":{$port}" : '') . '/' . $dbName;
-				}
-				unset($connectionParams['host']);
+				$connectionParams = $this->forceConnectionStringOracle($connectionParams);
+				$connectionParams['primary'] = $this->forceConnectionStringOracle($connectionParams['primary']);
+				$connectionParams['replica'] = array_map([$this, 'forceConnectionStringOracle'], $connectionParams['replica']);
 				break;
 
 			case 'sqlite3':
@@ -264,5 +252,25 @@ class ConnectionFactory {
 		}
 
 		return $params;
+	}
+
+	protected function forceConnectionStringOracle(array $connectionParams): array {
+		// the driverOptions are unused in dbal and need to be mapped to the parameters
+		if (isset($connectionParams['driverOptions'])) {
+			$connectionParams = array_merge($connectionParams, $connectionParams['driverOptions']);
+		}
+		$host = $connectionParams['host'];
+		$port = $connectionParams['port'] ?? null;
+		$dbName = $connectionParams['dbname'];
+
+		// we set the connect string as dbname and unset the host to coerce doctrine into using it as connect string
+		if ($host === '') {
+			$connectionParams['dbname'] = $dbName; // use dbname as easy connect name
+		} else {
+			$connectionParams['dbname'] = '//' . $host . (!empty($port) ? ":{$port}" : '') . '/' . $dbName;
+		}
+		unset($connectionParams['host']);
+
+		return $connectionParams;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary
The ConnectionFactory code applies some array plumbing to make Doctrine connect to Oracle for some reason. Since nc 29, we also have primary and replica entries, however, where this plumbing also needs to be applied.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
