### PR TITLE
fix(\OC\DB\Adapter): Ensure insertIfNotExist is atomic

### DIFF
--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -103,7 +103,10 @@ class Adapter {
 		$query .= ' HAVING COUNT(*) = 0';
 
 		try {
-			return $this->conn->executeUpdate($query, $inserts);
+			$this->conn->beginTransaction();
+			$rows = $this->conn->executeUpdate($query, $inserts);
+			$this->conn->commit();
+			return $rows;
 		} catch (UniqueConstraintViolationException $e) {
 			// This exception indicates a concurrent insert happened between
 			// the insert and the sub-select in the insert, which is safe to ignore.


### PR DESCRIPTION
## Summary

`INSERT ... SELECT ...` are not guaranteed to be atomic, at least in MySQL and PostgreSQL. I didn't check the other databases, since one problematic one is already enough.

This should fix the root cause of https://github.com/nextcloud/server/pull/54014.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
