### PR TITLE
fix(files_external): ignore unsatisfied optional dependencies

### DIFF
--- a/apps/files_external/lib/Controller/StoragesController.php
+++ b/apps/files_external/lib/Controller/StoragesController.php
@@ -140,7 +140,7 @@ abstract class StoragesController extends Controller {
 		$backend = $storage->getBackend();
 		/** @var AuthMechanism */
 		$authMechanism = $storage->getAuthMechanism();
-		if ($backend->checkDependencies()) {
+		if ($backend->checkRequiredDependencies()) {
 			// invalid backend
 			return new DataResponse(
 				[

--- a/apps/files_external/lib/Lib/DependencyTrait.php
+++ b/apps/files_external/lib/Lib/DependencyTrait.php
@@ -15,11 +15,23 @@ namespace OCA\Files_External\Lib;
 trait DependencyTrait {
 
 	/**
-	 * Check if object is valid for use
+	 * Check if object has unsatisfied required or optional dependencies
 	 *
 	 * @return MissingDependency[] Unsatisfied dependencies
 	 */
 	public function checkDependencies() {
 		return []; // no dependencies by default
+	}
+
+	/**
+	 * Check if object has unsatisfied required dependencies
+	 *
+	 * @return MissingDependency[] Unsatisfied required dependencies
+	 */
+	public function checkRequiredDependencies() {
+		return array_filter(
+			$this->checkDependencies(),
+			fn (MissingDependency $dependency) => !$dependency->isOptional()
+		);
 	}
 }

--- a/apps/files_external/lib/Service/BackendService.php
+++ b/apps/files_external/lib/Service/BackendService.php
@@ -14,7 +14,6 @@ use OCA\Files_External\Lib\Auth\AuthMechanism;
 use OCA\Files_External\Lib\Backend\Backend;
 use OCA\Files_External\Lib\Config\IAuthMechanismProvider;
 use OCA\Files_External\Lib\Config\IBackendProvider;
-use OCA\Files_External\Lib\MissingDependency;
 use OCP\EventDispatcher\GenericEvent;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IAppConfig;
@@ -179,10 +178,7 @@ class BackendService {
 	 * @return Backend[]
 	 */
 	public function getAvailableBackends() {
-		return array_filter($this->getBackends(), function ($backend) {
-			$missing = array_filter($backend->checkDependencies(), fn (MissingDependency $dependency) => !$dependency->isOptional());
-			return count($missing) === 0;
-		});
+		return array_filter($this->getBackends(), fn (Backend $backend) => !$backend->checkRequiredDependencies());
 	}
 
 	/**

--- a/apps/files_external/tests/Service/BackendServiceTest.php
+++ b/apps/files_external/tests/Service/BackendServiceTest.php
@@ -175,11 +175,11 @@ class BackendServiceTest extends \Test\TestCase {
 
 		$backendAvailable = $this->getBackendMock('\Backend\Available');
 		$backendAvailable->expects($this->once())
-			->method('checkDependencies')
+			->method('checkRequiredDependencies')
 			->willReturn([]);
 		$backendNotAvailable = $this->getBackendMock('\Backend\NotAvailable');
 		$backendNotAvailable->expects($this->once())
-			->method('checkDependencies')
+			->method('checkRequiredDependencies')
 			->willReturn([
 				$this->getMockBuilder('\OCA\Files_External\Lib\MissingDependency')
 					->disableOriginalConstructor()


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54047

## Summary
Fix setup of external storage with unsatisfied *optional* dependencies (which were introduced in #52681)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
