### PR TITLE
fix(appmanager): ignore null appinfo

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -920,7 +920,7 @@ class AppManager implements IAppManager {
 
 	public function isBackendRequired(string $backend): bool {
 		foreach ($this->appInfos as $appInfo) {
-			foreach ($appInfo['dependencies']['backend'] as $appBackend) {
+			foreach ($appInfo['dependencies']['backend'] ?? [] as $appBackend) {
 				if ($backend === $appBackend) {
 					return true;
 				}


### PR DESCRIPTION
fix regression from https://github.com/nextcloud/server/pull/52777

since the key `core` in `$this->appinfos[]` generated in `getAppInfo()` is NULL, we have this in the logs:
```
{
  "level": 2,
  "method": "GET",
  "url": "/index.php/settings/admin/security",
  "message": "foreach() argument must be of type array|object, null given at /home/maxence/sites/nc32/nextcloud/lib/private/App/AppManager.php#926",
  "version": "32.0.0.1",
  "data": {
    "app": "PHP"
  }
}
```