### PR TITLE
feat(preset): add lexicon entry for custom share tokens

### DIFF
--- a/core/AppInfo/ConfigLexicon.php
+++ b/core/AppInfo/ConfigLexicon.php
@@ -10,6 +10,7 @@ namespace OC\Core\AppInfo;
 
 use OCP\Config\Lexicon\Entry;
 use OCP\Config\Lexicon\ILexicon;
+use OCP\Config\Lexicon\Preset;
 use OCP\Config\Lexicon\Strictness;
 use OCP\Config\ValueType;
 
@@ -20,6 +21,7 @@ use OCP\Config\ValueType;
  */
 class ConfigLexicon implements ILexicon {
 	public const SHAREAPI_ALLOW_FEDERATION_ON_PUBLIC_SHARES = 'shareapi_allow_federation_on_public_shares';
+	public const SHARE_CUSTOM_TOKEN = 'shareapi_allow_custom_tokens';
 
 	public function getStrictness(): Strictness {
 		return Strictness::IGNORE;
@@ -33,6 +35,17 @@ class ConfigLexicon implements ILexicon {
 				defaultRaw: true,
 				definition: 'adds share permission to public shares to allow adding them to your Nextcloud (federation)',
 				lazy: true,
+			),
+			new Entry(
+				key: self::SHARE_CUSTOM_TOKEN,
+				type: ValueType::BOOL,
+				defaultRaw: fn (Preset $p): bool => match ($p) {
+					Preset::FAMILY, Preset::PRIVATE => true,
+					default => false,
+				},
+				definition: 'Allow users to set custom share link tokens',
+				lazy: true,
+				note: 'Shares with guessable tokens may be accessed easily. Shares with custom tokens will continue to be accessible after this setting has been disabled.',
 			),
 		];
 	}

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -170,6 +170,8 @@ class Base extends Command implements CompletionAwareInterface {
 			return 'true';
 		} elseif ($value === null) {
 			return $returnNull ? null : 'null';
+		} if ($value instanceof \UnitEnum) {
+			return $value->value;
 		} else {
 			return $value;
 		}

--- a/core/Command/Config/App/GetConfig.php
+++ b/core/Command/Config/App/GetConfig.php
@@ -38,6 +38,12 @@ class GetConfig extends Base {
 				'returns complete details about the app config value'
 			)
 			->addOption(
+				'--key-details',
+				null,
+				InputOption::VALUE_NONE,
+				'returns complete details about the app config key'
+			)
+			->addOption(
 				'default-value',
 				null,
 				InputOption::VALUE_OPTIONAL,
@@ -62,6 +68,12 @@ class GetConfig extends Base {
 			$details = $this->appConfig->getDetails($appName, $configName);
 			$details['type'] = $details['typeString'];
 			unset($details['typeString']);
+			$this->writeArrayInOutputFormat($input, $output, $details);
+			return 0;
+		}
+
+		if ($input->getOption('key-details')) {
+			$details = $this->appConfig->getKeyDetails($appName, $configName);
 			$this->writeArrayInOutputFormat($input, $output, $details);
 			return 0;
 		}

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -199,6 +199,11 @@ class SetConfig extends Base {
 					$current['lazy'] ? 'lazy cache' : 'fast cache'
 				)
 			);
+			$keyDetails = $this->appConfig->getKeyDetails($appName, $configName);
+			if (($keyDetails['note'] ?? '') !== '') {
+				$output->writeln('<comment>Note:</comment> ' . $keyDetails['note']);
+			}
+
 		} else {
 			$output->writeln('<info>Config value were not updated</info>');
 		}

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -7,6 +7,7 @@
  */
 namespace OC\Share20;
 
+use OC\Core\AppInfo\ConfigLexicon;
 use OC\Files\Mount\MoveableMount;
 use OC\KnownUser\KnownUserService;
 use OC\Share20\Exception\ProviderException;
@@ -1939,7 +1940,7 @@ class Manager implements IManager {
 	}
 
 	public function allowCustomTokens(): bool {
-		return $this->appConfig->getValueBool('core', 'shareapi_allow_custom_tokens', false);
+		return $this->appConfig->getValueBool('core', ConfigLexicon::SHARE_CUSTOM_TOKEN);
 	}
 
 	public function allowViewWithoutDownload(): bool {

--- a/lib/public/Config/Lexicon/Entry.php
+++ b/lib/public/Config/Lexicon/Entry.php
@@ -23,16 +23,20 @@ class Entry {
 	public const RENAME_INVERT_BOOLEAN = 1;
 
 	private string $definition = '';
+	private string $note = '';
 	private ?string $default = null;
 
 	/**
-	 * @param string $key config key, can only contain alphanumerical chars and -._
+	 * @param string $key config key; can only contain alphanumerical chars and underscore "_"
 	 * @param ValueType $type type of config value
+	 * @param string|int|float|bool|array|Closure|null $defaultRaw default value to be used in case none known
 	 * @param string $definition optional description of config key available when using occ command
 	 * @param bool $lazy set config value as lazy
 	 * @param int $flags set flags
-	 * @param string|null $rename previous config key to migrate config value from
 	 * @param bool $deprecated set config key as deprecated
+	 * @param string|null $rename source in case of a rename of a config key.
+	 * @param int $options additional bitflag options {@see self::RENAME_INVERT_BOOLEAN}
+	 * @param string $note additional note and warning related to the use of the config key.
 	 *
 	 * @since 32.0.0
 	 * @psalm-suppress PossiblyInvalidCast
@@ -48,6 +52,7 @@ class Entry {
 		private readonly bool $deprecated = false,
 		private readonly ?string $rename = null,
 		private readonly int $options = 0,
+		string $note = '',
 	) {
 		// key can only contain alphanumeric chars and underscore "_"
 		if (preg_match('/[^[:alnum:]_]/', $key)) {
@@ -57,6 +62,7 @@ class Entry {
 		/** @psalm-suppress UndefinedClass */
 		if (\OC::$CLI) { // only store definition if ran from CLI
 			$this->definition = $definition;
+			$this->note = $note;
 		}
 	}
 
@@ -185,6 +191,16 @@ class Entry {
 	 */
 	public function getDefinition(): string {
 		return $this->definition;
+	}
+
+	/**
+	 * returns eventual note
+	 *
+	 * @return string
+	 * @since 32.0.0
+	 */
+	public function getNote(): string {
+		return $this->note;
 	}
 
 	/**

--- a/lib/public/IAppConfig.php
+++ b/lib/public/IAppConfig.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCP;
 
+use OCP\Config\ValueType;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 
 /**
@@ -448,6 +449,33 @@ interface IAppConfig {
 	 * @since 29.0.0
 	 */
 	public function getDetails(string $app, string $key): array;
+
+	/**
+	 * returns an array containing details about a config key.
+	 * key/value pair are available only if it exists.
+	 *
+	 * ```
+	 * [
+	 *   "app" => "myapp",
+	 *   "key" => "mykey",
+	 *   "value" => "current_value",
+	 *   "default" => "default_if_available",
+	 *   "definition" => "this is what it does",
+	 *   "note" => "enabling this is not compatible with that",
+	 *   "lazy" => false,
+	 *   "type" => 4,
+	 *   "typeString" => "string",
+	 *   'sensitive' => false
+	 * ]
+	 * ```
+	 *
+	 * @param string $app id of the app
+	 * @param string $key config key
+	 *
+	 * @return array{app: string, key: string, lazy?: bool, valueType?: ValueType, valueTypeName?: string, sensitive?: bool, default?: string, definition?: string, note?: string}
+	 * @since 32.0.0
+	 */
+	public function getKeyDetails(string $app, string $key): array;
 
 	/**
 	 * Convert string like 'string', 'integer', 'float', 'bool' or 'array' to


### PR DESCRIPTION
- moving `'shareapi_allow_custom_tokens'` to Lexicon.
- adding the param _(string)_ `note:` to `__constructor()` in Lexicon `Entry`
- displaying optional _note_ when setting via occ

<img width="1451" height="59" alt="image" src="https://github.com/user-attachments/assets/8916e505-987c-4681-a2b4-ffaad0a19317" />
