### PR TITLE
fix(auth): Correct max password length in config.sample.php

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -474,21 +474,20 @@ $CONFIG = [
 'auth.webauthn.enabled' => true,
 
 /**
- * Whether encrypted passwords should be stored in the database
+ * By default, the passwords are stored (encrypted) in the database, but this can be
+ * explicitly disabled by admins with special requirements (with various caveats).
  *
- * The passwords are only decrypted using the login token stored uniquely in the
- * clients and allow connecting to external storages, autoconfiguring mail accounts in
- * the mail app, and periodically checking if the password is still valid.
+ * The passwords are only decrypted using the login token stored uniquely in each
+ * client. The passwords allow connecting to external storages, autoconfiguring mail 
+ * accounts in the mail app, and periodically checking if the password is still valid.
  *
- * This might be desirable to disable this functionality when using one-time
- * passwords or when having a password policy enforcing long passwords (> 300
- * characters).
- *
- * By default, the passwords are stored encrypted in the database.
+ * It may be desirable to disable this functionality when using one-time passwords
+ * or when enforcing extremely long passwords (>469 bytes aka: 
+ * `IUserManager::MAX_PASSWORD_LENGTH`).
  *
  * WARNING: If disabled, password changes on the user backend (e.g., on LDAP) no
- * longer log connected clients out automatically. Users can still disconnect
- * the clients by deleting the app token from the security settings.
+ * longer will log clients out automatically. Users can still disconnect a client by 
+ * manually deleting the app token from the security settings.
  */
 'auth.storeCryptedPassword' => true,
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

The max password length is 469 bytes.

Ref: #33110

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
