### PR TITLE
fix(files): clamp future-dated mtimes to now

### DIFF
--- a/apps/files/src/services/DropServiceUtils.ts
+++ b/apps/files/src/services/DropServiceUtils.ts
@@ -54,14 +54,11 @@ export class Directory extends File {
 	 * @param directory the directory to traverse
 	 */
 	_computeDirectoryMtime(directory: Directory): number {
+		const now = Date.now();
 		return directory.contents.reduce((acc, file) => {
-			return file.lastModified > acc
-				// If the file is a directory, the lastModified will
-				// also return the results of its _computeDirectoryMtime method
-				// Fancy recursion, huh?
-				? file.lastModified
-				: acc
-		}, 0)
+			const m = Math.min(file.lastModified, now);
+			return m > acc ? m : acc;
+ 		}, 0);
 	}
 
 	/**

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -277,10 +277,10 @@ class Updater implements IUpdater {
 		$parent = dirname($internalPath);
 		if ($parentId != -1) {
 			$mtime = $this->storage->filemtime($parent);
-            $now = time();
-            if ($mtime !== false && $mtime > $now) {
-                $mtime = $now;
-            }
+			$now = time();
+			if ($mtime !== false && $mtime > $now) {
+				$mtime = $now;
+			}
 			if ($mtime !== false) {
 				try {
 					$this->cache->update($parentId, ['storage_mtime' => $mtime]);

--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -277,6 +277,10 @@ class Updater implements IUpdater {
 		$parent = dirname($internalPath);
 		if ($parentId != -1) {
 			$mtime = $this->storage->filemtime($parent);
+            $now = time();
+            if ($mtime !== false && $mtime > $now) {
+                $mtime = $now;
+            }
 			if ($mtime !== false) {
 				try {
 					$this->cache->update($parentId, ['storage_mtime' => $mtime]);


### PR DESCRIPTION
## Description
This pull request ensures that no directory ever shows a modification timestamp in the future by clamping any file or directory mtime that exceeds the current time back down to **now** before it gets written into the cache or sent to the UI.

Previously, if a synced file on disk had its mtime set in the future, Nextcloud would propagate that future timestamp up the folder hierarchy and display e.g. “Modified in 5 months.” With these changes we:

1. **Backend (PHP)**  
   In `lib/private/Files/Cache/Updater.php`, clamp the parent folder’s `storage_mtime` to `time()` if it would otherwise be greater.

2. **Frontend (TypeScript)**  
   In `apps/files/src/services/DropServiceUtils.ts`, clamp computed directory mtimes so the UI never receives a timestamp > `Date.now()`.

## Related Issue
Closes #54090 (“Folder updated in the future - shows ‘Modified in 5 months’”)

## Changes
- **lib/private/Files/Cache/Updater.php**  
  - After retrieving `$mtime = $this->storage->filemtime($parent)`, compare to `time()` and reduce it if necessary.  
- **apps/files/src/services/DropServiceUtils.ts**  
  - In `_computeDirectoryMtime()`, wrap each file’s `lastModified` in `Math.min(file.lastModified, Date.now())` so no value exceeds the current moment.

## How to Test
1. Create or “touch” a file with a future modification timestamp, e.g.:
   ```bash
   touch -d "+1 month" future.txt
   ```
2. Sync it into Nextcloud (local storage or external).  
3. Browse to its parent folder in the web UI.  
4. Confirm the **Modified** column shows “a few seconds ago” (or your current time), **not** “in X months.”

Repeat by nesting folders containing future-dated files to verify proper propagation.

## Backward Compatibility
This change only affects how mtimes are clamped and does not alter on-disk files or existing timestamps in the database beyond preventing “future” values. All normal sync/update flows remain unchanged.

## Checklist
- [x] PHP unit tests pass  
- [x] JavaScript/TypeScript linting and UI tests pass  
- [x] Manual testing with future-dated files and folders  
- [x] PR title follows conventional commits (`fix(files): …`)  
- [x] References issue #54090 in description  