### PR TITLE
fix: Make some strings in CodeIntegrity.php translatable

### DIFF
--- a/apps/settings/lib/SetupChecks/CodeIntegrity.php
+++ b/apps/settings/lib/SetupChecks/CodeIntegrity.php
@@ -50,13 +50,13 @@ class CodeIntegrity implements ISetupCheck {
 					'link1' => [
 						'type' => 'highlight',
 						'id' => 'getFailedIntegrityCheckFiles',
-						'name' => 'List of invalid files…',
+						'name' => $this->l10n->t('List of invalid files…'),
 						'link' => $this->urlGenerator->linkToRoute('settings.CheckSetup.getFailedIntegrityCheckFiles'),
 					],
 					'link2' => [
 						'type' => 'highlight',
 						'id' => 'rescanFailedIntegrityCheck',
-						'name' => 'Rescan…',
+						'name' => $this->l10n->t('Rescan…'),
 						'link' => $this->urlGenerator->linkToRoute('settings.CheckSetup.rescanFailedIntegrityCheck'),
 					],
 				],


### PR DESCRIPTION
## Summary
Make it possible to translate strings
## TODO

- [x] ...

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
