### PR TITLE
fix(metadata): Correct filesize limit calculation for metadata genera…

### DIFF
--- a/core/BackgroundJobs/GenerateMetadataJob.php
+++ b/core/BackgroundJobs/GenerateMetadataJob.php
@@ -98,7 +98,7 @@ class GenerateMetadataJob extends TimedJob {
 			// Files are loaded in memory so very big files can lead to an OOM on the server
 			$nodeSize = $node->getSize();
 			$nodeLimit = $this->config->getSystemValueInt('metadata_max_filesize', self::DEFAULT_MAX_FILESIZE);
-			if ($nodeSize > $nodeLimit * 1000000) {
+			if ($nodeSize > $nodeLimit * 1024 * 1024) {
 				$this->logger->debug('Skipping generating metadata for fileid ' . $node->getId() . " as its size exceeds configured 'metadata_max_filesize'.");
 				continue;
 			}


### PR DESCRIPTION
…tion

## Summary
The value of the `metadata_max_filesize` parameter (or its default value), which is expressed in megabytes, is compared to the file size in bytes for which metadata needs to be generated. However, the conversion from megabytes to bytes is performed by multiplying by 1000000 (1000 * 1000) instead of 1048576 (1024 * 1024).

This means that we believe, by default, the system generates metadata for files smaller than 268435456 bytes (256 MB), when in fact, it's for files up to 256000000 bytes (244 MB).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
