### PR TITLE
fix(user_ldap): Avoid unnecessary ldap queries

### DIFF
--- a/apps/user_ldap/lib/Access.php
+++ b/apps/user_ldap/lib/Access.php
@@ -695,7 +695,8 @@ class Access extends LDAPUtility {
 		foreach ($ldapObjects as $ldapObject) {
 			$nameByLDAP = $ldapObject[$nameAttribute][0] ?? null;
 
-			$ncName = $this->dn2ocname($ldapObject['dn'][0], $nameByLDAP, $isUsers);
+			$newlyMapped = false;
+			$ncName = $this->dn2ocname($ldapObject['dn'][0], $nameByLDAP, $isUsers, $newlyMapped, $ldapObject);
 			if ($ncName) {
 				$nextcloudNames[] = $ncName;
 				if ($isUsers) {
@@ -930,7 +931,8 @@ class Access extends LDAPUtility {
 				// displayName is obligatory
 				continue;
 			}
-			$ocName = $this->dn2ocname($userRecord['dn'][0], null, true);
+			$newlyMapped = false;
+			$ocName = $this->dn2ocname($userRecord['dn'][0], null, true, $newlyMapped, $userRecord);
 			if ($ocName === false) {
 				continue;
 			}


### PR DESCRIPTION
## Summary
In `ldap2NextcloudNames` method: When we call `dn2ocname`, if no `$record` is passed, it would execute:
```
$record = $this->readAttributes($fdn, $attributesToRead, $filter);
```
But we already have this data in `$ldapObject` from the original search?

In `batchApplyUserAttributes` method: Similarly, when calling `dn2ocname`, it would re-fetch:
```
$record = $this->readAttributes($fdn, $attributesToRead, $filter);
```
But we already have this data in `$userRecord` from the batch processing?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
