### PR TITLE
fix: Ensure CLOUD key exists before resolving Cloud ID

### DIFF
--- a/lib/private/Collaboration/Collaborators/MailPlugin.php
+++ b/lib/private/Collaboration/Collaborators/MailPlugin.php
@@ -159,6 +159,9 @@ class MailPlugin implements ISearchPlugin {
 
 						if ($this->shareeEnumeration) {
 							try {
+								if (!isset($contact['CLOUD'])) {
+									continue;
+								}
 								$cloud = $this->cloudIdManager->resolveCloudId($contact['CLOUD'][0] ?? '');
 							} catch (\InvalidArgumentException $e) {
 								continue;


### PR DESCRIPTION
## Summary
When the Nextcloud server is configured to use an LDAP server whose users are synchronized with the system address book, any user search for sharing a conversation (spreed), a calendar (calendar), or a board (deck) generates exceptions of the form:

```
"Exception: Argument 1 passed to OC\Federation\CloudIdManager::resolveCloudId() must be of the type string, null given, called in /var/www/nextcloud/lib/private/Collaboration/Collaborators/MailPlugin.php on line 185 in file '/var/www/nextcloud/lib/private/Federation/CloudIdManager.php' line 58"
"Error: Trying to access array offset on value of type null at /var/www/nextcloud/lib/private/Collaboration/Collaborators/MailPlugin.php#185"
"Error: Undefined index: CLOUD at /var/www/nextcloud/lib/private/Collaboration/Collaborators/MailPlugin.php#185"
```

The line number generating the exception may differ from one Nextcloud version to another.
Each exception is linked to a contact from LDAP. If the search results only contain manually created contacts (present in a personal address book), there are no exceptions.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
