### PR TITLE
fix(search): Fix SearchComposer.php filtering logic

### DIFF
--- a/lib/private/Search/SearchComposer.php
+++ b/lib/private/Search/SearchComposer.php
@@ -118,7 +118,7 @@ class SearchComposer {
 			}
 		}
 
-		$this->providers = $this->filterProviders($this->providers);
+		$this->filterProviders();
 
 		$this->loadFilters();
 	}
@@ -211,19 +211,21 @@ class SearchComposer {
 
 	/**
 	 * Filter providers based on 'unified_search.providers_allowed' core app config array
-	 * @param array $providers
-	 * @return array
+	 * Will remove providers that are not in the allowed list
 	 */
-	private function filterProviders(array $providers): array {
+	private function filterProviders(): void {
 		$allowedProviders = $this->appConfig->getValueArray('core', 'unified_search.providers_allowed');
 
 		if (empty($allowedProviders)) {
-			return $providers;
+			return;
 		}
 
-		return array_values(array_filter($providers, function ($p) use ($allowedProviders) {
-			return in_array($p['id'], $allowedProviders);
-		}));
+		foreach (array_keys($this->providers) as $providerId) {
+			if (!in_array($providerId, $allowedProviders, true)) {
+				unset($this->providers[$providerId]);
+				unset($this->handlers[$providerId]);
+			}
+		}
 	}
 
 	private function fetchIcon(string $appId, string $providerId): string {

--- a/tests/lib/Search/SearchComposerTest.php
+++ b/tests/lib/Search/SearchComposerTest.php
@@ -215,6 +215,28 @@ class SearchComposerTest extends TestCase {
 		$this->assertEmpty($providers);
 	}
 
+	public function testGetProvidersWithMixedOrderValues(): void {
+		$providerConfigs = [
+			'provider1' => ['service' => 'provider1_service', 'appId' => 'app1', 'order' => 100],
+			'provider2' => ['service' => 'provider2_service', 'appId' => 'app2', 'order' => 1],
+			'provider3' => ['service' => 'provider3_service', 'appId' => 'app3', 'order' => 50],
+		];
+
+		$mockData = $this->createMockProvidersAndRegistrations($providerConfigs);
+		$this->setupRegistrationContextWithProviders($mockData['registrations']);
+		$this->setupAppConfigForAllowedProviders();
+
+		$providers = $this->searchComposer->getProviders('/test/route', []);
+
+		$this->assertCount(3, $providers);
+		$this->assertProvidersAreSortedByOrder($providers);
+
+		// Verify correct ordering: provider2 (1), provider3 (50), provider1 (100)
+		$this->assertEquals('provider2', $providers[0]['id']);
+		$this->assertEquals('provider3', $providers[1]['id']);
+		$this->assertEquals('provider1', $providers[2]['id']);
+	}
+
 	public function testProviderIconGeneration(): void {
 		$providerConfigs = [
 			'provider1' => ['service' => 'provider1_service', 'appId' => 'app1', 'order' => 10],

--- a/tests/lib/Search/SearchComposerTest.php
+++ b/tests/lib/Search/SearchComposerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace Test\Search;
+
+use OC\AppFramework\Bootstrap\Coordinator;
+use OC\Search\SearchComposer;
+use OCP\IAppConfig;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class SearchComposerTest extends TestCase {
+	private Coordinator&MockObject $bootstrapCoordinator;
+	private ContainerInterface&MockObject $container;
+	private IURLGenerator&MockObject $urlGenerator;
+	private LoggerInterface&MockObject $logger;
+	private IAppConfig&MockObject $appConfig;
+	private SearchComposer $searchComposer;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->bootstrapCoordinator = $this->createMock(Coordinator::class);
+		$this->container = $this->createMock(ContainerInterface::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->appConfig = $this->createMock(IAppConfig::class);
+
+		$this->searchComposer = new SearchComposer(
+			$this->bootstrapCoordinator,
+			$this->container,
+			$this->urlGenerator,
+			$this->logger,
+			$this->appConfig
+		);
+	}
+
+	private function setupEmptyRegistrationContext(): void {
+		$this->bootstrapCoordinator->expects($this->once())
+			->method('getRegistrationContext')
+			->willReturn(null);
+	}
+
+	public function testGetProvidersWithNoRegisteredProviders(): void {
+		$this->setupEmptyRegistrationContext();
+
+		$providers = $this->searchComposer->getProviders('/test/route', []);
+
+		$this->assertIsArray($providers);
+		$this->assertEmpty($providers);
+	}
+}

--- a/tests/lib/Search/SearchComposerTest.php
+++ b/tests/lib/Search/SearchComposerTest.php
@@ -156,6 +156,22 @@ class SearchComposerTest extends TestCase {
 		]);
 	}
 
+	public function testProviderIconGeneration(): void {
+		$providerConfigs = [
+			'provider1' => ['service' => 'provider1_service', 'appId' => 'app1', 'order' => 10],
+		];
+
+		$mockData = $this->createMockProvidersAndRegistrations($providerConfigs);
+		$this->setupRegistrationContextWithProviders($mockData['registrations']);
+		$this->setupAppConfigForAllowedProviders();
+
+		$providers = $this->searchComposer->getProviders('/test/route', []);
+
+		$this->assertCount(1, $providers);
+		$this->assertArrayHasKey('icon', $providers[0]);
+		$this->assertStringContainsString('/apps/provider1/img/provider1.svg', $providers[0]['icon']);
+	}
+
 	/**
 	 * Assert providers array structure and expected sorting
 	 */

--- a/tests/lib/Search/SearchComposerTest.php
+++ b/tests/lib/Search/SearchComposerTest.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace Test\Search;
 
+use InvalidArgumentException;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Search\SearchComposer;
 use OCP\IAppConfig;
 use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\Search\ISearchQuery;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -57,5 +60,17 @@ class SearchComposerTest extends TestCase {
 
 		$this->assertIsArray($providers);
 		$this->assertEmpty($providers);
+	}
+
+	public function testSearchWithUnknownProvider(): void {
+		$this->setupEmptyRegistrationContext();
+
+		$user = $this->createMock(IUser::class);
+		$query = $this->createMock(ISearchQuery::class);
+
+		$this->expectException(InvalidArgumentException::class);
+		$this->expectExceptionMessage('Provider unknown_provider is unknown');
+
+		$this->searchComposer->search($user, 'unknown_provider', $query);
 	}
 }


### PR DESCRIPTION
## Summary

keep the $this->providers types

Test via 
```shell
./occ config:app:set --value '["files","settings"]' --type array core unified_search.providers_allowed
```

should be part of 8e570041

Tests can be executed via
```shell
 composer run test -- tests/lib/Search/SearchComposerTest.php
 ```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
