### PR TITLE
Add a 'stdlog' log type.

### DIFF
--- a/lib/private/Log/LogFactory.php
+++ b/lib/private/Log/LogFactory.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -26,6 +25,7 @@ class LogFactory implements ILogFactory {
 	public function get(string $type):IWriter {
 		return match (strtolower($type)) {
 			'errorlog' => new Errorlog($this->systemConfig),
+			'stdlog' => new Stdlog($this->systemConfig),
 			'syslog' => $this->c->resolve(Syslog::class),
 			'systemd' => $this->c->resolve(Systemdlog::class),
 			'file' => $this->buildLogFile(),
@@ -36,6 +36,7 @@ class LogFactory implements ILogFactory {
 	protected function createNewLogger(string $type, string $tag, string $path): IWriter {
 		return match (strtolower($type)) {
 			'errorlog' => new Errorlog($this->systemConfig, $tag),
+			'stdlog' => new Stdlog($this->systemConfig, $tag),
 			'syslog' => new Syslog($this->systemConfig, $tag),
 			'systemd' => new Systemdlog($this->systemConfig, $tag),
 			default => $this->buildLogFile($path),

--- a/lib/private/Log/Stdlog.php
+++ b/lib/private/Log/Stdlog.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Log;
+
+use OC\SystemConfig;
+use OCP\Log\IWriter;
+
+class Stdlog extends LogDetails implements IWriter {
+	public function __construct(
+		SystemConfig $config,
+		protected string $tag = 'nextcloud',
+	) {
+		parent::__construct($config);
+	}
+
+	/**
+	 * Write a message in the log
+	 *
+	 * @param string|array $message
+	 */
+	public function write(string $app, $message, int $level): void {
+	    $detailsJson = $this->logDetailsAsJSON($app, $message, $level);
+	    $details = json_decode($detailsJson, true);
+
+	    if (json_last_error() !== JSON_ERROR_NONE || !is_array($details)) {
+		return;
+	    }
+
+	    $logEntry = array_merge([
+		'tag' => $this->tag,
+		'app' => $app,
+		'level' => $level,
+	    ], $details);
+	    // Check if 'message' field exists and is a string
+	    if (isset($logEntry['message']) && is_string($logEntry['message'])) {
+		$msg = $logEntry['message'];
+
+		if (strlen($msg) > 0 && $msg[0] === '{') {
+		    // Try decoding JSON
+		    $decoded = json_decode($msg, true);
+
+		    if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+			// Remove original 'message' field
+			unset($logEntry['message']);
+
+			// Flatten decoded JSON into top-level logEntry
+			// This will overwrite existing keys if there are
+			// conflicts
+			$logEntry = array_merge($logEntry, $decoded);
+		    }
+		}
+	    }
+
+	    $json = json_encode($logEntry, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+	    if ($json !== false) {
+		file_put_contents('php://stderr', $json . PHP_EOL);
+	    }
+	}
+}

--- a/lib/private/Log/Stdlog.php
+++ b/lib/private/Log/Stdlog.php
@@ -36,6 +36,17 @@ class Stdlog extends LogDetails implements IWriter {
 		'app' => $app,
 		'level' => $level,
 	    ], $details);
+	    $traceparent = $_SERVER['HTTP_TRACEPARENT'];
+	    if (preg_match('/^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/', $traceparent, $matches)) {
+		$gcp = getenv('GOOGLE_CLOUD_PROJECT');
+		if (!empty($gcp)) {
+		    $logEntry['logging.googleapis.com/trace'] = 'projects/' . $gcp . '/traces/' . $matches[1];
+		    $logEntry['logging.googleapis.com/spanId'] = $matches[2];
+		} else {
+		    $logEntry['traceId'] = $matches[1];
+		    $logEntry['spanId'] = $matches[2];
+		}
+	    }
 	    // Check if 'message' field exists and is a string
 	    if (isset($logEntry['message']) && is_string($logEntry['message'])) {
 		$msg = $logEntry['message'];

--- a/lib/private/Log/Stdlog.php
+++ b/lib/private/Log/Stdlog.php
@@ -36,7 +36,7 @@ class Stdlog extends LogDetails implements IWriter {
 		'app' => $app,
 		'level' => $level,
 	    ], $details);
-	    $traceparent = $_SERVER['HTTP_TRACEPARENT'];
+	    $traceparent = $_SERVER['HTTP_TRACEPARENT'] ?? '';
 	    if (preg_match('/^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/', $traceparent, $matches)) {
 		$gcp = getenv('GOOGLE_CLOUD_PROJECT');
 		if (!empty($gcp)) {


### PR DESCRIPTION
The stdlog log type is similar to the errorlog log type, but it does output to stderr and makes sure the output is formatted as JSON. This is in particular useful for environments running in docker containers, with the stderr being collected by log aggregation services like Grafana or Google Cloud logging.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
