### PR TITLE
Log error for plugins doing queries per-file during propfind

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -216,6 +216,7 @@ return array(
     'OCA\\DAV\\Connector\\Sabre\\Node' => $baseDir . '/../lib/Connector/Sabre/Node.php',
     'OCA\\DAV\\Connector\\Sabre\\ObjectTree' => $baseDir . '/../lib/Connector/Sabre/ObjectTree.php',
     'OCA\\DAV\\Connector\\Sabre\\Principal' => $baseDir . '/../lib/Connector/Sabre/Principal.php',
+    'OCA\\DAV\\Connector\\Sabre\\PropFindMonitorPlugin' => $baseDir . '/../lib/Connector/Sabre/PropFindMonitorPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\PropfindCompressionPlugin' => $baseDir . '/../lib/Connector/Sabre/PropfindCompressionPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\PublicAuth' => $baseDir . '/../lib/Connector/Sabre/PublicAuth.php',
     'OCA\\DAV\\Connector\\Sabre\\QuotaPlugin' => $baseDir . '/../lib/Connector/Sabre/QuotaPlugin.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -231,6 +231,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Connector\\Sabre\\Node' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Node.php',
         'OCA\\DAV\\Connector\\Sabre\\ObjectTree' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ObjectTree.php',
         'OCA\\DAV\\Connector\\Sabre\\Principal' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Principal.php',
+        'OCA\\DAV\\Connector\\Sabre\\PropFindMonitorPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PropFindMonitorPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\PropfindCompressionPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PropfindCompressionPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\PublicAuth' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PublicAuth.php',
         'OCA\\DAV\\Connector\\Sabre\\QuotaPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/QuotaPlugin.php',

--- a/apps/dav/lib/Connector/Sabre/PropFindMonitorPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/PropFindMonitorPlugin.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Connector\Sabre;
+
+use Sabre\DAV\Server as SabreServer;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+
+/**
+ * This plugin runs after requests and logs an error if a plugin is detected
+ * to be doing too many SQL requests.
+ */
+class PropFindMonitorPlugin extends ServerPlugin {
+
+	/**
+	 * A Plugin can scan up to this amount of nodes without an error being
+	 * reported.
+	 */
+	public const THRESHOLD_NODES = 50;
+
+	/**
+	 * A plugin can use up to this amount of queries per node.
+	 */
+	public const THRESHOLD_QUERY_FACTOR = 1;
+
+	private SabreServer $server;
+
+	public function initialize(SabreServer $server): void {
+		$this->server = $server;
+		$this->server->on('afterResponse', [$this, 'afterResponse']);
+	}
+
+	public function afterResponse(
+		RequestInterface $request,
+		ResponseInterface $response): void {
+		if (!$this->server instanceof Server) {
+			return;
+		}
+
+		$pluginQueries = $this->server->getPluginQueries();
+		if (empty($pluginQueries)) {
+			return;
+		}
+		$maxDepth = max(0, ...array_keys($pluginQueries));
+		// entries at the top are usually not interesting
+		unset($pluginQueries[$maxDepth]);
+
+		$logger = $this->server->getLogger();
+		foreach ($pluginQueries as $depth => $propFinds) {
+			foreach ($propFinds as $pluginName => $propFind) {
+				[
+					'queries' => $queries,
+					'nodes' => $nodes
+				] = $propFind;
+				if ($queries === 0 || $nodes > $queries || $nodes < self::THRESHOLD_NODES
+					|| $queries < $nodes * self::THRESHOLD_QUERY_FACTOR) {
+					continue;
+				}
+				$logger->error(
+					'{name} scanned {scans} nodes with {count} queries in depth {depth}/{maxDepth}. This is bad for performance, please report to the plugin developer!', [
+						'name' => $pluginName,
+						'scans' => $nodes,
+						'count' => $queries,
+						'depth' => $depth,
+						'maxDepth' => $maxDepth,
+					]
+				);
+			}
+		}
+	}
+}

--- a/apps/dav/tests/unit/Connector/Sabre/PropFindMonitorPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PropFindMonitorPluginTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\PropFindMonitorPlugin;
+use OCA\DAV\Connector\Sabre\Server;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Sabre\HTTP\Request;
+use Sabre\HTTP\Response;
+use Test\TestCase;
+
+class PropFindMonitorPluginTest extends TestCase {
+
+	private PropFindMonitorPlugin $plugin;
+	private Server&MockObject $server;
+	private LoggerInterface&MockObject $logger;
+	private Request&MockObject $request;
+	private Response&MockObject $response;
+
+	public static function dataTest(): array {
+		$minQueriesTrigger = PropFindMonitorPlugin::THRESHOLD_QUERY_FACTOR
+			* PropFindMonitorPlugin::THRESHOLD_NODES;
+		return [
+			'No queries logged' => [[], 0],
+			'Plugins with queries in less than threshold nodes should not be logged' => [
+				[
+					[
+						'PluginName' => ['queries' => 100, 'nodes'
+							=> PropFindMonitorPlugin::THRESHOLD_NODES - 1]
+					],
+					[],
+				],
+				0
+			],
+			'Plugins with query-to-node ratio less than threshold should not be logged' => [
+				[
+					[
+						'PluginName' => [
+							'queries' => $minQueriesTrigger - 1,
+							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES ],
+					],
+					[],
+				],
+				0
+			],
+			'Plugins with more nodes scanned than queries executed should not be logged' => [
+				[
+					[
+						'PluginName' => [
+							'queries' => $minQueriesTrigger,
+							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES * 2],
+					],
+					[],
+				],
+				0
+			],
+			'Plugins with queries only in highest depth level should not be logged' => [
+				[
+					[
+						'PluginName' => [
+							'queries' => $minQueriesTrigger,
+							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES - 1
+						]
+					],
+					[
+						'PluginName' => [
+							'queries' => $minQueriesTrigger * 2,
+							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES
+						]
+					]
+				],
+				0
+			],
+			'Plugins with too many queries should be logged' => [
+				[
+					[
+						'FirstPlugin' => [
+							'queries' => $minQueriesTrigger,
+							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES,
+						],
+						'SecondPlugin' => [
+							'queries' => $minQueriesTrigger,
+							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES,
+						]
+					],
+					[]
+				],
+				2
+			]
+		];
+	}
+
+	/**
+	 * @dataProvider dataTest
+	 */
+	public function test(array $queries, $expectedLogCalls): void {
+		$this->plugin->initialize($this->server);
+		$this->server->expects($this->once())->method('getPluginQueries')
+			->willReturn($queries);
+
+		$this->server->expects(empty($queries) ? $this->never() : $this->once())
+			->method('getLogger')
+			->willReturn($this->logger);
+
+		$this->logger->expects($this->exactly($expectedLogCalls))->method('error');
+		$this->plugin->afterResponse($this->request, $this->response);
+	}
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->plugin = new PropFindMonitorPlugin();
+		$this->server = $this->createMock(Server::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->request = $this->createMock(Request::class);
+		$this->response = $this->createMock(Response::class);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54114

## Summary

Plugins should avoid querying properties per-file and rather eager load them per directory to avoid doing too many round-trips to the database, which cost time.

To ease troubleshooting, this PR adds logging that triggers when loading properties runs queries for every node it scans.

## Implementation

At the moment, loading properties from the DB happens when each node is serialized into XML to respond to the client, unless pre-loaded. For this reason, detection is implemented as a wrapper for the `on/once` methods in our Server connector, for the `propFind` event. This event is triggered at least once for every node returned in the response.

**Note:** due to the fact that `propFind` is called _at least_ once per node, the detection of how many nodes have caused a read from the DB is not the same to the unique number of nodes treated by the propfind. For example: `CorePlugin` registers three `on` handlers for the `propFind` event and, if they all read properties from the DB, will count each node three times.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
