### PR TITLE
refactor(occ): misc tidying of `preview:generate` command

### DIFF
--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -76,11 +76,11 @@ class Generate extends Command {
 		$fileInput = $input->getArgument('file');
 		$node = $this->fileUtils->getNode($fileInput);
 		if (!$node) {
-			$output->writeln("<error>File ($file) does not exist</error>");
+			$output->writeln("<error>File ($fileInput) does not exist</error>");
 			return self::FAILURE;
 		}
 		if (!$node instanceof File) {
-			$output->writeln("<error>specified file ($file) is not a file (did you specify a folder by accident?)</error>");
+			$output->writeln("<error>specified file ($fileInput) is not a file (did you specify a folder by accident?)</error>");
 			return self::INVALID;
 		}
 		// No point in continuing if there isn't a configured preview provider for the file

--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -75,7 +75,7 @@ class Generate extends Command {
 		// parse and check `file` argument value (can be a file id or path to a specific file relative to the data directory
 		$fileInput = $input->getArgument('file');
 		$node = $this->fileUtils->getNode($fileInput);
-		if (!node) {
+		if (!$node) {
 			$output->writeln("<error>File ($file) does not exist</error>");
 			return self::FAILURE;
 		}

--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -101,7 +101,7 @@ class Generate extends Command {
 			}
 			if (!is_numeric($sizeParts[0]) || !is_numeric($sizeParts[1] ?? null)) {
 				// output error here to be able to inform which one size entry caused it
-				$output->writeln("<error>Size ($size) is invalid</error>"); 
+				$output->writeln("<error>Size ($size) is invalid</error>");
 				return null;
 			}
 			return array_map('intval', $sizeParts);
@@ -110,10 +110,10 @@ class Generate extends Command {
 			// error output already provided so no need for it here
 			return self::FAILURE;
 		}
-		
+
 		// parse the `crop` option value
 		$crop = $input->getOption('crop');
-		
+
 		// parse and check the `mode` option value
 		$mode = $input->getOption('mode');
 		if ($mode !== IPreview::MODE_FILL && $mode !== IPreview::MODE_COVER) {
@@ -136,7 +136,7 @@ class Generate extends Command {
 
 		// inform the user what we did if we were successful
 		$output->writeln('Generated <info>' . count($specifications) . '</info> preview(s)');
-		
+
 		return self::SUCCESS;
 	}
 }

--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -12,8 +12,6 @@ use OC\Core\Command\Info\FileUtils;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
-use OCP\Files\Node;
-use OCP\Files\NotFoundException;
 use OCP\IPreview;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;

--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OC\Core\Command\Preview;
 
+use OC\Core\Command\Info\FileUtils;
 use OCP\Files\Config\IUserMountCache;
 use OCP\Files\File;
 use OCP\Files\IRootFolder;
@@ -20,66 +21,107 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Generate a preview for a file from the command-line.
+ *
+ * Useful in automations and for troubleshooting preview generation issues.
+ *
+ * @since 27.0.0
+ */
 class Generate extends Command {
 	public function __construct(
 		private IRootFolder $rootFolder,
 		private IUserMountCache $userMountCache,
 		private IPreview $previewManager,
+		private FileUtils $fileUtils,
 	) {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
 		$this
 			->setName('preview:generate')
-			->setDescription('generate a preview for a file')
-			->addArgument('file', InputArgument::REQUIRED, 'path or fileid of the file to generate the preview for')
-			->addOption('size', 's', InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED, 'size to generate the preview for in pixels, defaults to 64x64', ['64x64'])
-			->addOption('crop', 'c', InputOption::VALUE_NONE, 'crop the previews instead of maintaining aspect ratio')
-			->addOption('mode', 'm', InputOption::VALUE_REQUIRED, "mode for generating uncropped previews, 'cover' or 'fill'", IPreview::MODE_FILL);
+			->setDescription('Generates a preview for a file')
+			->setHelp('Generates a preview for an individual file for automation or troubleshooting purposes.')
+			->addArgument(
+				'file',
+				InputArgument::REQUIRED,
+				'file id or Nextcloud path'
+			)
+			->addOption(
+				'size',
+				's',
+				InputOption::VALUE_IS_ARRAY | InputOption::VALUE_REQUIRED,
+				'preview size(s) to generate in pixels, defaults to 64x64',
+				['64x64']
+			)
+			->addOption(
+				'crop',
+				'c',
+				InputOption::VALUE_NONE,
+				'crop the previews instead of maintaining aspect ratio'
+			)
+			->addOption(
+				'mode',
+				'm',
+				InputOption::VALUE_REQUIRED,
+				'mode for generating uncropped previews, \'cover\' or \'fill\'',
+				IPreview::MODE_FILL
+			)
+		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
+		// parse and check `file` argument value (can be a file id or path to a specific file relative to the data directory
 		$fileInput = $input->getArgument('file');
-		$sizes = $input->getOption('size');
-		$sizes = array_map(function (string $size) use ($output) {
+		$node = $this->fileUtils->getNode($fileInput);
+		if (!node) {
+			$output->writeln("<error>File ($file) does not exist</error>");
+			return self::FAILURE;
+		}
+		if (!$node instanceof File) {
+			$output->writeln("<error>specified file ($file) is not a file (did you specify a folder by accident?)</error>");
+			return self::INVALID;
+		}
+		// No point in continuing if there isn't a configured preview provider for the file
+		if (!$this->previewManager->isAvailable($node)) {
+			$output->writeln('<error>File of type ' . $node->getMimetype() . ' does not have a preview generator configured.</error>');
+			return self::FAILURE;
+		}
+
+		// parse and check `size` option value(s) ("64x64" if not specified)
+		$sizeInput = $input->getOption('size');
+		// parse size option value(s)
+		//	(e.g. ["128"] or ["128x128"] or even ["64x64", "128x128"])
+		$sizes = array_map(function (string $size) use ($output): array|null {
 			if (str_contains($size, 'x')) {
 				$sizeParts = explode('x', $size, 2);
 			} else {
 				$sizeParts = [$size, $size];
 			}
 			if (!is_numeric($sizeParts[0]) || !is_numeric($sizeParts[1] ?? null)) {
-				$output->writeln("<error>Invalid size $size</error>");
+				// output error here to be able to inform which one size entry caused it
+				$output->writeln("<error>Size ($size) is invalid</error>"); 
 				return null;
 			}
-
 			return array_map('intval', $sizeParts);
-		}, $sizes);
+		}, $sizeInput);
 		if (in_array(null, $sizes)) {
-			return 1;
+			// error output already provided so no need for it here
+			return self::FAILURE;
 		}
-
+		
+		// parse the `crop` option value
+		$crop = $input->getOption('crop');
+		
+		// parse and check the `mode` option value
 		$mode = $input->getOption('mode');
 		if ($mode !== IPreview::MODE_FILL && $mode !== IPreview::MODE_COVER) {
-			$output->writeln("<error>Invalid mode $mode</error>");
-			return 1;
-		}
-		$crop = $input->getOption('crop');
-		$file = $this->getFile($fileInput);
-		if (!$file) {
-			$output->writeln("<error>File $fileInput not found</error>");
-			return 1;
-		}
-		if (!$file instanceof File) {
-			$output->writeln("<error>Can't generate previews for folders</error>");
-			return 1;
+			$output->writeln("<error>Mode ($mode) is invalid</error>");
+			return self::INVALID;
 		}
 
-		if (!$this->previewManager->isAvailable($file)) {
-			$output->writeln('<error>No preview generator available for file of type' . $file->getMimetype() . '</error>');
-			return 1;
-		}
-
+		// generate the specifification(s) of the preview size(s) generate
 		$specifications = array_map(function (array $sizes) use ($crop, $mode) {
 			return [
 				'width' => $sizes[0],
@@ -89,30 +131,12 @@ class Generate extends Command {
 			];
 		}, $sizes);
 
-		$this->previewManager->generatePreviews($file, $specifications);
-		if (count($specifications) > 1) {
-			$output->writeln('generated <info>' . count($specifications) . '</info> previews');
-		} else {
-			$output->writeln('preview generated');
-		}
-		return 0;
-	}
+		// generate the actual requested previews
+		$this->previewManager->generatePreviews($node, $specifications);
 
-	private function getFile(string $fileInput): ?Node {
-		if (is_numeric($fileInput)) {
-			$mounts = $this->userMountCache->getMountsForFileId((int)$fileInput);
-			if (!$mounts) {
-				return null;
-			}
-			$mount = $mounts[0];
-			$userFolder = $this->rootFolder->getUserFolder($mount->getUser()->getUID());
-			return $userFolder->getFirstNodeById((int)$fileInput);
-		} else {
-			try {
-				return $this->rootFolder->get($fileInput);
-			} catch (NotFoundException $e) {
-				return null;
-			}
-		}
+		// inform the user what we did if we were successful
+		$output->writeln('Generated <info>' . count($specifications) . '</info> preview(s)');
+		
+		return self::SUCCESS;
 	}
 }

--- a/core/Command/Preview/Generate.php
+++ b/core/Command/Preview/Generate.php
@@ -78,7 +78,7 @@ class Generate extends Command {
 			return self::FAILURE;
 		}
 		if (!$node instanceof File) {
-			$output->writeln("<error>specified file ($fileInput) is not a file (did you specify a folder by accident?)</error>");
+			$output->writeln("<error>File ($fileInput) is not a file (did you specify a folder by accident?)</error>");
 			return self::INVALID;
 		}
 		// No point in continuing if there isn't a configured preview provider for the file


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Code re-use
- Re-use `FileUtils` instead of dedicated code
- Tweak variable naming, code formatting, comments, constants use, and functionality grouping for readability/maintenance
- Tidy up output messages for usability

## TODO


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
