### PR TITLE
fix: hide guests group from overall principals

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Principal.php
+++ b/apps/dav/lib/Connector/Sabre/Principal.php
@@ -186,6 +186,9 @@ class Principal implements BackendInterface {
 		if ($this->hasGroups || $needGroups) {
 			$userGroups = $this->groupManager->getUserGroups($user);
 			foreach ($userGroups as $userGroup) {
+				if ($userGroup->hideFromCollaboration()) {
+					continue;
+				}
 				$groups[] = 'principals/groups/' . urlencode($userGroup->getGID());
 			}
 		}


### PR DESCRIPTION
Resolves #52958 
Resolves https://github.com/nextcloud/calendar/issues/7161 
Resolves https://github.com/nextcloud/guests/issues/1359

## Summary

Follow-up for #52914 and #53369

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
