### PR TITLE
feat(occ): add default help text with docs link to all commands

### DIFF
--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -29,7 +29,7 @@ class Base extends Command implements CompletionAwareInterface {
 		// Some of our commands do not extend this class; and some of those that do do not call parent::configure()
 		$defaultHelp = 'More extensive and thorough documentation may be found at ' . \OCP\Server::get(\OCP\Defaults::class)->getDocBaseUrl() . PHP_EOL;
 		$this
-			->setHelp($this->defaultHelp)
+			->setHelp($defaultHelp)
 			->addOption(
 				'output',
 				null,

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -24,9 +24,11 @@ class Base extends Command implements CompletionAwareInterface {
 	protected string $defaultOutputFormat = self::OUTPUT_FORMAT_PLAIN;
 	private bool $php_pcntl_signal = false;
 	private bool $interrupted = false;
+	public string $defaultHelp = 'More extensive and thorough documentation may be found at https://docs.nextcloud.com' . PHP_EOL; // TODO: link to appropriately versioned/themed Admin Manual
 
 	protected function configure() {
 		$this
+			->setHelp($this->defaultHelp)
 			->addOption(
 				'output',
 				null,

--- a/core/Command/Base.php
+++ b/core/Command/Base.php
@@ -24,9 +24,10 @@ class Base extends Command implements CompletionAwareInterface {
 	protected string $defaultOutputFormat = self::OUTPUT_FORMAT_PLAIN;
 	private bool $php_pcntl_signal = false;
 	private bool $interrupted = false;
-	public string $defaultHelp = 'More extensive and thorough documentation may be found at https://docs.nextcloud.com' . PHP_EOL; // TODO: link to appropriately versioned/themed Admin Manual
 
 	protected function configure() {
+		// Some of our commands do not extend this class; and some of those that do do not call parent::configure()
+		$defaultHelp = 'More extensive and thorough documentation may be found at ' . \OCP\Server::get(\OCP\Defaults::class)->getDocBaseUrl() . PHP_EOL;
 		$this
 			->setHelp($this->defaultHelp)
 			->addOption(


### PR DESCRIPTION
Commands that define their own help can still override as needed.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

### BEFORE

```
www-data@c34cb6a66eb1:~/html$ ./occ config:list --help
Description:
  List all configs

Usage:
  config:list [options] [--] [<app>]

Arguments:
  app                    Name of the app ("system" to get the config.php values, "all" for all apps and system) [default: "all"]

Options:
      --output[=OUTPUT]  Output format (plain, json or json_pretty, default is plain) [default: "json_pretty"]
      --private          Use this option when you want to include sensitive configs like passwords, salts, ...
  -h, --help             Display help for the given command. When no command is given display help for the list command
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi|--no-ansi   Force (or disable --no-ansi) ANSI output
  -n, --no-interaction   Do not ask any interactive question
      --no-warnings      Skip global warnings, show command output only
  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

www-data@c34cb6a66eb1:~/html$ 
```

### AFTER

```
www-data@c34cb6a66eb1:~/html$ ./occ config:list --help
Description:
  List all configs

Usage:
  config:list [options] [--] [<app>]

Arguments:
  app                    Name of the app ("system" to get the config.php values, "all" for all apps and system) [default: "all"]

Options:
      --output[=OUTPUT]  Output format (plain, json or json_pretty, default is plain) [default: "json_pretty"]
      --private          Use this option when you want to include sensitive configs like passwords, salts, ...
  -h, --help             Display help for the given command. When no command is given display help for the list command
  -q, --quiet            Do not output any message
  -V, --version          Display this application version
      --ansi|--no-ansi   Force (or disable --no-ansi) ANSI output
  -n, --no-interaction   Do not ask any interactive question
      --no-warnings      Skip global warnings, show command output only
  -v|vv|vvv, --verbose   Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  More extensive and thorough documentation may be found at https://docs.nextcloud.com

www-data@c34cb6a66eb1:~/html$ 
```

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
