### PR TITLE
test: add env option to disable loading all installed apps during tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,13 +23,16 @@ require_once __DIR__ . '/autoload.php';
 
 \OC::$composerAutoloader->addPsr4('Tests\\', OC::$SERVERROOT . '/tests/', true);
 
-// load all apps
-$appManager = Server::get(IAppManager::class);
-foreach (new \DirectoryIterator(__DIR__ . '/../apps/') as $file) {
-	if ($file->isDot()) {
-		continue;
+$dontLoadApps = getenv('TEST_DONT_LOAD_APPS');
+if (!$dontLoadApps) {
+	// load all apps
+	$appManager = Server::get(IAppManager::class);
+	foreach (new \DirectoryIterator(__DIR__ . '/../apps/') as $file) {
+		if ($file->isDot()) {
+			continue;
+		}
+		$appManager->loadApp($file->getFilename());
 	}
-	$appManager->loadApp($file->getFilename());
 }
 
 OC_Hook::clear();


### PR DESCRIPTION
Automatically loading all apps can lead to issues with local testing the dev has a lot of apps checked out which might not all be compatible with the current server version.

This adds an option to disable to autoloading by setting an env var