### PR TITLE
fix: fix oci string length with empty strings

### DIFF
--- a/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
+++ b/lib/private/DB/QueryBuilder/FunctionBuilder/OCIFunctionBuilder.php
@@ -81,12 +81,12 @@ class OCIFunctionBuilder extends FunctionBuilder {
 	public function octetLength($field, $alias = ''): IQueryFunction {
 		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
 		$quotedName = $this->helper->quoteColumnName($field);
-		return new QueryFunction('LENGTHB(' . $quotedName . ')' . $alias);
+		return new QueryFunction('COALESCE(LENGTHB(' . $quotedName . '), 0)' . $alias);
 	}
 
 	public function charLength($field, $alias = ''): IQueryFunction {
 		$alias = $alias ? (' AS ' . $this->helper->quoteColumnName($alias)) : '';
 		$quotedName = $this->helper->quoteColumnName($field);
-		return new QueryFunction('LENGTH(' . $quotedName . ')' . $alias);
+		return new QueryFunction('COALESCE(LENGTH(' . $quotedName . '), 0)' . $alias);
 	}
 }

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -367,6 +367,7 @@ class FunctionBuilderTest extends TestCase {
 		$result = $query->execute();
 		$column = $result->fetchOne();
 		$result->closeCursor();
+		$this->assertNotNull($column);
 		$this->assertEquals($bytes, $column);
 	}
 


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/server/pull/51074

Since in oracle, empty strings are `null` and `length(null) = null`, we need to do some null coalescing to get consistent behavior between database servers.