### PR TITLE
Cache IdentityProof keys

### DIFF
--- a/tests/lib/Security/IdentityProof/ManagerTest.php
+++ b/tests/lib/Security/IdentityProof/ManagerTest.php
@@ -16,6 +16,8 @@ use OC\Security\IdentityProof\Manager;
 use OCP\Files\IAppData;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\ICache;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IUser;
 use OCP\Security\ICrypto;
@@ -24,18 +26,14 @@ use Psr\Log\LoggerInterface;
 use Test\TestCase;
 
 class ManagerTest extends TestCase {
-	/** @var Factory|MockObject */
-	private $factory;
-	/** @var IAppData|MockObject */
-	private $appData;
-	/** @var ICrypto|MockObject */
-	private $crypto;
-	/** @var Manager|MockObject */
-	private $manager;
-	/** @var IConfig|MockObject */
-	private $config;
-	/** @var LoggerInterface|MockObject */
-	private $logger;
+	private Factory&MockObject $factory;
+	private IAppData&MockObject $appData;
+	private ICrypto&MockObject $crypto;
+	private Manager&MockObject $manager;
+	private IConfig&MockObject $config;
+	private LoggerInterface&MockObject $logger;
+	private ICacheFactory&MockObject $cacheFactory;
+	private ICache&MockObject $cache;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -49,6 +47,12 @@ class ManagerTest extends TestCase {
 			->with('identityproof')
 			->willReturn($this->appData);
 		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cache = $this->createMock(ICache::class);
+
+		$this->cacheFactory->expects($this->any())
+			->method('createDistributed')
+			->willReturn($this->cache);
 
 		$this->crypto = $this->createMock(ICrypto::class);
 		$this->manager = $this->getManager(['generateKeyPair']);
@@ -66,7 +70,8 @@ class ManagerTest extends TestCase {
 				$this->factory,
 				$this->crypto,
 				$this->config,
-				$this->logger
+				$this->logger,
+				$this->cacheFactory,
 			);
 		} else {
 			return $this->getMockBuilder(Manager::class)
@@ -74,7 +79,8 @@ class ManagerTest extends TestCase {
 					$this->factory,
 					$this->crypto,
 					$this->config,
-					$this->logger
+					$this->logger,
+					$this->cacheFactory,
 				])
 				->onlyMethods($setMethods)
 				->getMock();
@@ -115,6 +121,33 @@ class ManagerTest extends TestCase {
 			->method('getFolder')
 			->with('user-MyUid')
 			->willReturn($folder);
+		$this->cache
+			->expects($this->exactly(2))
+			->method('get')
+			->willReturn(null);
+
+		$expected = new Key('MyPublicKey', 'MyPrivateKey');
+		$this->assertEquals($expected, $this->manager->getKey($user));
+	}
+
+	public function testGetKeyWithExistingKeyCached(): void {
+		$user = $this->createMock(IUser::class);
+		$user
+			->expects($this->once())
+			->method('getUID')
+			->willReturn('MyUid');
+		$this->crypto
+			->expects($this->once())
+			->method('decrypt')
+			->with('EncryptedPrivateKey')
+			->willReturn('MyPrivateKey');
+		$this->cache
+			->expects($this->exactly(2))
+			->method('get')
+			->willReturnMap([
+				['user-MyUid-public', 'MyPublicKey'],
+				['user-MyUid-private', 'EncryptedPrivateKey'],
+			]);
 
 		$expected = new Key('MyPublicKey', 'MyPrivateKey');
 		$this->assertEquals($expected, $this->manager->getKey($user));


### PR DESCRIPTION
## Summary

Currently all keys are always loaded from the file system, this is especially noticeable when push notifications are created. Since the keys are (usually) only generated once and do not change over time, we can also cache them and therefore prevent filesystem access.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
