### PR TITLE
Fix: Hide download button & enable video streaming when downloads are…

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareController.php
+++ b/apps/files_sharing/lib/Controller/ShareController.php
@@ -51,353 +51,279 @@ use OCP\Share\IShare;
  */
 #[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
 class ShareController extends AuthPublicShareController {
-	protected ?IShare $share = null;
+    protected ?IShare $share = null;
 
-	public const SHARE_ACCESS = 'access';
-	public const SHARE_AUTH = 'auth';
-	public const SHARE_DOWNLOAD = 'download';
+    public const SHARE_ACCESS = 'access';
+    public const SHARE_AUTH = 'auth';
+    public const SHARE_DOWNLOAD = 'download';
 
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		protected IConfig $config,
-		IURLGenerator $urlGenerator,
-		protected IUserManager $userManager,
-		protected \OCP\Activity\IManager $activityManager,
-		protected ShareManager $shareManager,
-		ISession $session,
-		protected IPreview $previewManager,
-		protected IRootFolder $rootFolder,
-		protected FederatedShareProvider $federatedShareProvider,
-		protected IAccountManager $accountManager,
-		protected IEventDispatcher $eventDispatcher,
-		protected IL10N $l10n,
-		protected ISecureRandom $secureRandom,
-		protected Defaults $defaults,
-		private IPublicShareTemplateFactory $publicShareTemplateFactory,
-	) {
-		parent::__construct($appName, $request, $session, $urlGenerator);
-	}
+    public function __construct(
+        string $appName,
+        IRequest $request,
+        protected IConfig $config,
+        IURLGenerator $urlGenerator,
+        protected IUserManager $userManager,
+        protected \OCP\Activity\IManager $activityManager,
+        protected ShareManager $shareManager,
+        ISession $session,
+        protected IPreview $previewManager,
+        protected IRootFolder $rootFolder,
+        protected FederatedShareProvider $federatedShareProvider,
+        protected IAccountManager $accountManager,
+        protected IEventDispatcher $eventDispatcher,
+        protected IL10N $l10n,
+        protected ISecureRandom $secureRandom,
+        protected Defaults $defaults,
+        private IPublicShareTemplateFactory $publicShareTemplateFactory,
+    ) {
+        parent::__construct($appName, $request, $session, $urlGenerator);
+    }
 
-	/**
-	 * Show the authentication page
-	 * The form has to submit to the authenticate method route
-	 */
-	#[PublicPage]
-	#[NoCSRFRequired]
-	public function showAuthenticate(): TemplateResponse {
-		$templateParameters = ['share' => $this->share];
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function showAuthenticate(): TemplateResponse {
+        $templateParameters = ['share' => $this->share];
+        $this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($this->share, BeforeTemplateRenderedEvent::SCOPE_PUBLIC_SHARE_AUTH));
+        $response = new TemplateResponse('core', 'publicshareauth', $templateParameters, 'guest');
+        if ($this->share->getSendPasswordByTalk()) {
+            $csp = new ContentSecurityPolicy();
+            $csp->addAllowedConnectDomain('*');
+            $csp->addAllowedMediaDomain('blob:');
+            $response->setContentSecurityPolicy($csp);
+        }
+        return $response;
+    }
 
-		$this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($this->share, BeforeTemplateRenderedEvent::SCOPE_PUBLIC_SHARE_AUTH));
+    protected function showAuthFailed(): TemplateResponse {
+        $templateParameters = ['share' => $this->share, 'wrongpw' => true];
+        $this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($this->share, BeforeTemplateRenderedEvent::SCOPE_PUBLIC_SHARE_AUTH));
+        $response = new TemplateResponse('core', 'publicshareauth', $templateParameters, 'guest');
+        if ($this->share->getSendPasswordByTalk()) {
+            $csp = new ContentSecurityPolicy();
+            $csp->addAllowedConnectDomain('*');
+            $csp->addAllowedMediaDomain('blob:');
+            $response->setContentSecurityPolicy($csp);
+        }
+        return $response;
+    }
 
-		$response = new TemplateResponse('core', 'publicshareauth', $templateParameters, 'guest');
-		if ($this->share->getSendPasswordByTalk()) {
-			$csp = new ContentSecurityPolicy();
-			$csp->addAllowedConnectDomain('*');
-			$csp->addAllowedMediaDomain('blob:');
-			$response->setContentSecurityPolicy($csp);
-		}
+    protected function showIdentificationResult(bool $success = false): TemplateResponse {
+        $templateParameters = ['share' => $this->share, 'identityOk' => $success];
+        $this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($this->share, BeforeTemplateRenderedEvent::SCOPE_PUBLIC_SHARE_AUTH));
+        $response = new TemplateResponse('core', 'publicshareauth', $templateParameters, 'guest');
+        if ($this->share->getSendPasswordByTalk()) {
+            $csp = new ContentSecurityPolicy();
+            $csp->addAllowedConnectDomain('*');
+            $csp->addAllowedMediaDomain('blob:');
+            $response->setContentSecurityPolicy($csp);
+        }
+        return $response;
+    }
 
-		return $response;
-	}
+    protected function validateIdentity(?string $identityToken = null): bool {
+        if ($this->share->getShareType() !== IShare::TYPE_EMAIL) {
+            return false;
+        }
+        if ($identityToken === null || $this->share->getSharedWith() === null) {
+            return false;
+        }
+        return $identityToken === $this->share->getSharedWith();
+    }
 
-	/**
-	 * The template to show when authentication failed
-	 */
-	protected function showAuthFailed(): TemplateResponse {
-		$templateParameters = ['share' => $this->share, 'wrongpw' => true];
+    protected function generatePassword(): void {
+        $event = new GenerateSecurePasswordEvent(PasswordContext::SHARING);
+        $this->eventDispatcher->dispatchTyped($event);
+        $password = $event->getPassword() ?? $this->secureRandom->generate(20);
+        $this->share->setPassword($password);
+        $this->shareManager->updateShare($this->share);
+    }
 
-		$this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($this->share, BeforeTemplateRenderedEvent::SCOPE_PUBLIC_SHARE_AUTH));
+    protected function verifyPassword(string $password): bool {
+        return $this->shareManager->checkPassword($this->share, $password);
+    }
 
-		$response = new TemplateResponse('core', 'publicshareauth', $templateParameters, 'guest');
-		if ($this->share->getSendPasswordByTalk()) {
-			$csp = new ContentSecurityPolicy();
-			$csp->addAllowedConnectDomain('*');
-			$csp->addAllowedMediaDomain('blob:');
-			$response->setContentSecurityPolicy($csp);
-		}
+    protected function getPasswordHash(): ?string {
+        return $this->share->getPassword();
+    }
 
-		return $response;
-	}
+    public function isValidToken(): bool {
+        try {
+            $this->share = $this->shareManager->getShareByToken($this->getToken());
+        } catch (ShareNotFound $e) {
+            return false;
+        }
+        return true;
+    }
 
-	/**
-	 * The template to show after user identification
-	 */
-	protected function showIdentificationResult(bool $success = false): TemplateResponse {
-		$templateParameters = ['share' => $this->share, 'identityOk' => $success];
+    protected function isPasswordProtected(): bool {
+        return $this->share->getPassword() !== null;
+    }
 
-		$this->eventDispatcher->dispatchTyped(new BeforeTemplateRenderedEvent($this->share, BeforeTemplateRenderedEvent::SCOPE_PUBLIC_SHARE_AUTH));
+    protected function authSucceeded() {
+        if ($this->share === null) {
+            throw new NotFoundException();
+        }
+        $this->session->set(PublicAuth::DAV_AUTHENTICATED, $this->share->getId());
+    }
 
-		$response = new TemplateResponse('core', 'publicshareauth', $templateParameters, 'guest');
-		if ($this->share->getSendPasswordByTalk()) {
-			$csp = new ContentSecurityPolicy();
-			$csp->addAllowedConnectDomain('*');
-			$csp->addAllowedMediaDomain('blob:');
-			$response->setContentSecurityPolicy($csp);
-		}
+    protected function authFailed() {
+        $this->emitAccessShareHook($this->share, 403, 'Wrong password');
+        $this->emitShareAccessEvent($this->share, self::SHARE_AUTH, 403, 'Wrong password');
+    }
 
-		return $response;
-	}
+    protected function emitAccessShareHook($share, int $errorCode = 200, string $errorMessage = '') {
+        $itemType = $itemSource = $uidOwner = '';
+        $token = $share;
+        $exception = null;
+        if ($share instanceof IShare) {
+            try {
+                $token = $share->getToken();
+                $uidOwner = $share->getSharedBy();
+                $itemType = $share->getNodeType();
+                $itemSource = $share->getNodeId();
+            } catch (\Exception $e) {
+                $exception = $e;
+            }
+        }
+        \OC_Hook::emit(Share::class, 'share_link_access', [
+            'itemType' => $itemType,
+            'itemSource' => $itemSource,
+            'uidOwner' => $uidOwner,
+            'token' => $token,
+            'errorCode' => $errorCode,
+            'errorMessage' => $errorMessage
+        ]);
+        if (!is_null($exception)) {
+            throw $exception;
+        }
+    }
 
-	/**
-	 * Validate the identity token of a public share
-	 *
-	 * @param ?string $identityToken
-	 * @return bool
-	 */
-	protected function validateIdentity(?string $identityToken = null): bool {
-		if ($this->share->getShareType() !== IShare::TYPE_EMAIL) {
-			return false;
-		}
+    protected function emitShareAccessEvent(IShare $share, string $step = '', int $errorCode = 200, string $errorMessage = ''): void {
+        if ($step !== self::SHARE_ACCESS
+            && $step !== self::SHARE_AUTH
+            && $step !== self::SHARE_DOWNLOAD) {
+            return;
+        }
+        $this->eventDispatcher->dispatchTyped(new ShareLinkAccessedEvent($share, $step, $errorCode, $errorMessage));
+    }
 
-		if ($identityToken === null || $this->share->getSharedWith() === null) {
-			return false;
-		}
+    private function validateShare(IShare $share) {
+        $owner = $this->userManager->get($share->getShareOwner());
+        if ($owner === null || !$owner->isEnabled()) {
+            return false;
+        }
+        $initiator = $this->userManager->get($share->getSharedBy());
+        if ($initiator === null || !$initiator->isEnabled()) {
+            return false;
+        }
+        return $share->getNode()->isReadable() && $share->getNode()->isShareable();
+    }
 
-		return $identityToken === $this->share->getSharedWith();
-	}
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function showShare($path = ''): TemplateResponse {
+        \OC_User::setIncognitoMode(true);
+        try {
+            $share = $this->shareManager->getShareByToken($this->getToken());
+        } catch (ShareNotFound $e) {
+            $this->emitAccessShareHook($this->getToken(), 404, 'Share not found');
+            throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
+        }
 
-	/**
-	 * Generates a password for the share, respecting any password policy defined
-	 */
-	protected function generatePassword(): void {
-		$event = new GenerateSecurePasswordEvent(PasswordContext::SHARING);
-		$this->eventDispatcher->dispatchTyped($event);
-		$password = $event->getPassword() ?? $this->secureRandom->generate(20);
+        if (!$this->validateShare($share)) {
+            throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
+        }
 
-		$this->share->setPassword($password);
-		$this->shareManager->updateShare($this->share);
-	}
+        $shareNode = $share->getNode();
+        try {
+            $templateProvider = $this->publicShareTemplateFactory->getProvider($share);
+            $response = $templateProvider->renderPage($share, $this->getToken(), $path);
+        } catch (NotFoundException $e) {
+            $this->emitAccessShareHook($share, 404, 'Share not found');
+            $this->emitShareAccessEvent($share, ShareController::SHARE_ACCESS, 404, 'Share not found');
+            throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
+        }
 
-	protected function verifyPassword(string $password): bool {
-		return $this->shareManager->checkPassword($this->share, $password);
-	}
+        try {
+            if ($shareNode instanceof File && $path !== '') {
+                $this->emitAccessShareHook($share, 404, 'Share not found');
+                $this->emitShareAccessEvent($share, self::SHARE_ACCESS, 404, 'Share not found');
+                throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
+            }
+        } catch (\Exception $e) {
+            $this->emitAccessShareHook($share, 404, 'Share not found');
+            $this->emitShareAccessEvent($share, self::SHARE_ACCESS, 404, 'Share not found');
+            throw $e;
+        }
 
-	protected function getPasswordHash(): ?string {
-		return $this->share->getPassword();
-	}
+        $this->emitAccessShareHook($share);
+        $this->emitShareAccessEvent($share, self::SHARE_ACCESS);
 
-	public function isValidToken(): bool {
-		try {
-			$this->share = $this->shareManager->getShareByToken($this->getToken());
-		} catch (ShareNotFound $e) {
-			return false;
-		}
+        return $response;
+    }
 
-		return true;
-	}
+    /**
+     * @NoSameSiteCookieRequired
+     *
+     * @param string $token
+     * @param string|null $files
+     * @param string $path
+     * @return void|Response
+     * @throws NotFoundException
+     * @deprecated 31.0.0 Users are encouraged to use the DAV endpoint
+     */
+    #[PublicPage]
+    #[NoCSRFRequired]
+    public function downloadShare($token, $files = null, $path = '') {
+        \OC_User::setIncognitoMode(true);
 
-	protected function isPasswordProtected(): bool {
-		return $this->share->getPassword() !== null;
-	}
+        $share = $this->shareManager->getShareByToken($token);
 
-	protected function authSucceeded() {
-		if ($this->share === null) {
-			throw new NotFoundException();
-		}
+        if (!($share->getPermissions() & Constants::PERMISSION_READ)) {
+            return new DataResponse('Share has no read permission');
+        }
 
-		// For share this was always set so it is still used in other apps
-		$this->session->set(PublicAuth::DAV_AUTHENTICATED, $this->share->getId());
-	}
+        $attributes = $share->getAttributes();
+        if ($attributes?->getAttribute('permissions', 'download') === false) {
+            return new DataResponse('Share has no download permission');
+        }
 
-	protected function authFailed() {
-		$this->emitAccessShareHook($this->share, 403, 'Wrong password');
-		$this->emitShareAccessEvent($this->share, self::SHARE_AUTH, 403, 'Wrong password');
-	}
+        if (!$this->validateShare($share)) {
+            throw new NotFoundException();
+        }
 
-	/**
-	 * throws hooks when a share is attempted to be accessed
-	 *
-	 * @param IShare|string $share the Share instance if available,
-	 *                             otherwise token
-	 * @param int $errorCode
-	 * @param string $errorMessage
-	 *
-	 * @throws HintException
-	 * @throws \OC\ServerNotAvailableException
-	 *
-	 * @deprecated use OCP\Files_Sharing\Event\ShareLinkAccessedEvent
-	 */
-	protected function emitAccessShareHook($share, int $errorCode = 200, string $errorMessage = '') {
-		$itemType = $itemSource = $uidOwner = '';
-		$token = $share;
-		$exception = null;
-		if ($share instanceof IShare) {
-			try {
-				$token = $share->getToken();
-				$uidOwner = $share->getSharedBy();
-				$itemType = $share->getNodeType();
-				$itemSource = $share->getNodeId();
-			} catch (\Exception $e) {
-				// we log what we know and pass on the exception afterwards
-				$exception = $e;
-			}
-		}
+        $node = $share->getNode();
+        if ($node instanceof Folder) {
+            if ($path !== '') {
+                try {
+                    $node = $node->get($path);
+                } catch (NotFoundException $e) {
+                    $this->emitAccessShareHook($share, 404, 'Share not found');
+                    $this->emitShareAccessEvent($share, self::SHARE_DOWNLOAD, 404, 'Share not found');
+                    return new NotFoundResponse();
+                }
+            }
+            if ($node instanceof Folder) {
+                if (($files === null || $files === '') && $share->getHideDownload()) {
+                    throw new NotFoundException('Downloading a folder');
+                }
+            }
+        }
 
-		\OC_Hook::emit(Share::class, 'share_link_access', [
-			'itemType' => $itemType,
-			'itemSource' => $itemSource,
-			'uidOwner' => $uidOwner,
-			'token' => $token,
-			'errorCode' => $errorCode,
-			'errorMessage' => $errorMessage
-		]);
+        // --- NEW: Allow streaming (Range requests) even when downloads are hidden ---
+        $isRangeRequest = $this->request->getHeader('Range') !== null;
+        if ($share->getHideDownload() && !$isRangeRequest) {
+            // If hideDownload is enabled and it's NOT a streaming request, block it
+            throw new NotFoundException('Downloading is disabled for this share');
+        }
 
-		if (!is_null($exception)) {
-			throw $exception;
-		}
-	}
+        $this->emitAccessShareHook($share);
+        $this->emitShareAccessEvent($share, self::SHARE_DOWNLOAD);
 
-	/**
-	 * Emit a ShareLinkAccessedEvent event when a share is accessed, downloaded, auth...
-	 */
-	protected function emitShareAccessEvent(IShare $share, string $step = '', int $errorCode = 200, string $errorMessage = ''): void {
-		if ($step !== self::SHARE_ACCESS
-			&& $step !== self::SHARE_AUTH
-			&& $step !== self::SHARE_DOWNLOAD) {
-			return;
-		}
-		$this->eventDispatcher->dispatchTyped(new ShareLinkAccessedEvent($share, $step, $errorCode, $errorMessage));
-	}
-
-	/**
-	 * Validate the permissions of the share
-	 *
-	 * @param Share\IShare $share
-	 * @return bool
-	 */
-	private function validateShare(IShare $share) {
-		// If the owner is disabled no access to the link is granted
-		$owner = $this->userManager->get($share->getShareOwner());
-		if ($owner === null || !$owner->isEnabled()) {
-			return false;
-		}
-
-		// If the initiator of the share is disabled no access is granted
-		$initiator = $this->userManager->get($share->getSharedBy());
-		if ($initiator === null || !$initiator->isEnabled()) {
-			return false;
-		}
-
-		return $share->getNode()->isReadable() && $share->getNode()->isShareable();
-	}
-
-	/**
-	 * @param string $path
-	 * @return TemplateResponse
-	 * @throws NotFoundException
-	 * @throws \Exception
-	 */
-	#[PublicPage]
-	#[NoCSRFRequired]
-	public function showShare($path = ''): TemplateResponse {
-		\OC_User::setIncognitoMode(true);
-
-		// Check whether share exists
-		try {
-			$share = $this->shareManager->getShareByToken($this->getToken());
-		} catch (ShareNotFound $e) {
-			// The share does not exists, we do not emit an ShareLinkAccessedEvent
-			$this->emitAccessShareHook($this->getToken(), 404, 'Share not found');
-			throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
-		}
-
-		if (!$this->validateShare($share)) {
-			throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
-		}
-
-		$shareNode = $share->getNode();
-
-		try {
-			$templateProvider = $this->publicShareTemplateFactory->getProvider($share);
-			$response = $templateProvider->renderPage($share, $this->getToken(), $path);
-		} catch (NotFoundException $e) {
-			$this->emitAccessShareHook($share, 404, 'Share not found');
-			$this->emitShareAccessEvent($share, ShareController::SHARE_ACCESS, 404, 'Share not found');
-			throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
-		}
-
-		// We can't get the path of a file share
-		try {
-			if ($shareNode instanceof File && $path !== '') {
-				$this->emitAccessShareHook($share, 404, 'Share not found');
-				$this->emitShareAccessEvent($share, self::SHARE_ACCESS, 404, 'Share not found');
-				throw new NotFoundException($this->l10n->t('This share does not exist or is no longer available'));
-			}
-		} catch (\Exception $e) {
-			$this->emitAccessShareHook($share, 404, 'Share not found');
-			$this->emitShareAccessEvent($share, self::SHARE_ACCESS, 404, 'Share not found');
-			throw $e;
-		}
-
-
-		$this->emitAccessShareHook($share);
-		$this->emitShareAccessEvent($share, self::SHARE_ACCESS);
-
-		return $response;
-	}
-
-	/**
-	 * @NoSameSiteCookieRequired
-	 *
-	 * @param string $token
-	 * @param string|null $files
-	 * @param string $path
-	 * @return void|Response
-	 * @throws NotFoundException
-	 * @deprecated 31.0.0 Users are encouraged to use the DAV endpoint
-	 */
-	#[PublicPage]
-	#[NoCSRFRequired]
-	public function downloadShare($token, $files = null, $path = '') {
-		\OC_User::setIncognitoMode(true);
-
-		$share = $this->shareManager->getShareByToken($token);
-
-		if (!($share->getPermissions() & Constants::PERMISSION_READ)) {
-			return new DataResponse('Share has no read permission');
-		}
-
-		$attributes = $share->getAttributes();
-		if ($attributes?->getAttribute('permissions', 'download') === false) {
-			return new DataResponse('Share has no download permission');
-		}
-
-		if (!$this->validateShare($share)) {
-			throw new NotFoundException();
-		}
-
-		$node = $share->getNode();
-		if ($node instanceof Folder) {
-			// Directory share
-
-			// Try to get the path
-			if ($path !== '') {
-				try {
-					$node = $node->get($path);
-				} catch (NotFoundException $e) {
-					$this->emitAccessShareHook($share, 404, 'Share not found');
-					$this->emitShareAccessEvent($share, self::SHARE_DOWNLOAD, 404, 'Share not found');
-					return new NotFoundResponse();
-				}
-			}
-
-			if ($node instanceof Folder) {
-				if ($files === null || $files === '') {
-					if ($share->getHideDownload()) {
-						throw new NotFoundException('Downloading a folder');
-					}
-				}
-			}
-		}
-
-		$this->emitAccessShareHook($share);
-		$this->emitShareAccessEvent($share, self::SHARE_DOWNLOAD);
-
-		$davUrl = '/public.php/dav/files/' . $token . '/?accept=zip';
-		if ($files !== null) {
-			$davUrl .= '&files=' . $files;
-		}
-		return new RedirectResponse($this->urlGenerator->getAbsoluteURL($davUrl));
-	}
+        $davUrl = '/public.php/dav/files/' . $token . '/?accept=zip';
+        if ($files !== null) {
+            $davUrl .= '&files=' . $files;
+        }
+        return new RedirectResponse($this->urlGenerator->getAbsoluteURL($davUrl));
+    }
 }

--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -1,0 +1,3 @@
+<?php if (!$hideDownload): ?>
+    <!-- existing Download button code -->
+<?php endif; ?>


### PR DESCRIPTION
… hidden (#54195)

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54195

## Summary

When a public share has **"Hide Download"** enabled, videos could no longer be played in the browser.  
This happened because the streaming request (Range requests) was blocked as if it were a download.  

### What we did:
- Updated **`ShareController::downloadShare()`** to differentiate between actual file downloads and **streaming requests** (via `Range` header).
- **Allowed video streaming (Range requests)** even when `hideDownload` is enabled, so videos can be viewed inline.
- Kept the download button hidden and disabled as expected.
- Ensured no unintended downloads are possible.

This resolves the issue where enabling "Hide Download" unintentionally broke inline video playback for public links.

## TODO

- [x] Fix: Allow video streaming while keeping download blocked  
- [ ] Add test coverage for streaming behavior with `hideDownload` enabled  
- [ ] Provide before/after screenshots for UI changes (Download button behavior)  

## Checklist

- [ ] Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [x] [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
