### PR TITLE
feat(db): add method to test mariadb

### DIFF
--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -16,6 +16,7 @@ use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Driver\ServerInfoAwareConnection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\ConnectionLost;
+use Doctrine\DBAL\Platforms\MariaDBPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
@@ -915,11 +916,13 @@ class Connection extends PrimaryReadReplicaConnection {
 	}
 
 	/**
-	 * @return IDBConnection::PLATFORM_MYSQL|IDBConnection::PLATFORM_ORACLE|IDBConnection::PLATFORM_POSTGRES|IDBConnection::PLATFORM_SQLITE
+	 * @return IDBConnection::PLATFORM_MYSQL|IDBConnection::PLATFORM_ORACLE|IDBConnection::PLATFORM_POSTGRES|IDBConnection::PLATFORM_SQLITE|IDBConnection::PLATFORM_MARIADB
 	 */
-	public function getDatabaseProvider(): string {
+	public function getDatabaseProvider(bool $strict = false): string {
 		$platform = $this->getDatabasePlatform();
-		if ($platform instanceof MySQLPlatform) {
+		if ($strict && $platform instanceof MariaDBPlatform) {
+			return IDBConnection::PLATFORM_MARIADB;
+		} elseif ($platform instanceof MySQLPlatform) {
 			return IDBConnection::PLATFORM_MYSQL;
 		} elseif ($platform instanceof OraclePlatform) {
 			return IDBConnection::PLATFORM_ORACLE;

--- a/lib/private/DB/ConnectionAdapter.php
+++ b/lib/private/DB/ConnectionAdapter.php
@@ -237,10 +237,10 @@ class ConnectionAdapter implements IDBConnection {
 	}
 
 	/**
-	 * @return self::PLATFORM_MYSQL|self::PLATFORM_ORACLE|self::PLATFORM_POSTGRES|self::PLATFORM_SQLITE
+	 * @return self::PLATFORM_MYSQL|self::PLATFORM_ORACLE|self::PLATFORM_POSTGRES|self::PLATFORM_SQLITE|self::PLATFORM_MARIADB
 	 */
-	public function getDatabaseProvider(): string {
-		return $this->inner->getDatabaseProvider();
+	public function getDatabaseProvider(bool $strict = false): string {
+		return $this->inner->getDatabaseProvider($strict);
 	}
 
 	/**

--- a/lib/private/DB/QueryBuilder/QueryBuilder.php
+++ b/lib/private/DB/QueryBuilder/QueryBuilder.php
@@ -96,6 +96,7 @@ class QueryBuilder implements IQueryBuilder {
 		return match($this->connection->getDatabaseProvider()) {
 			IDBConnection::PLATFORM_ORACLE => new OCIExpressionBuilder($this->connection, $this, $this->logger),
 			IDBConnection::PLATFORM_POSTGRES => new PgSqlExpressionBuilder($this->connection, $this, $this->logger),
+			IDBConnection::PLATFORM_MARIADB,
 			IDBConnection::PLATFORM_MYSQL => new MySqlExpressionBuilder($this->connection, $this, $this->logger),
 			IDBConnection::PLATFORM_SQLITE => new SqliteExpressionBuilder($this->connection, $this, $this->logger),
 		};
@@ -121,6 +122,7 @@ class QueryBuilder implements IQueryBuilder {
 		return match($this->connection->getDatabaseProvider()) {
 			IDBConnection::PLATFORM_ORACLE => new OCIFunctionBuilder($this->connection, $this, $this->helper),
 			IDBConnection::PLATFORM_POSTGRES => new PgSqlFunctionBuilder($this->connection, $this, $this->helper),
+			IDBConnection::PLATFORM_MARIADB,
 			IDBConnection::PLATFORM_MYSQL => new FunctionBuilder($this->connection, $this, $this->helper),
 			IDBConnection::PLATFORM_SQLITE => new SqliteFunctionBuilder($this->connection, $this, $this->helper),
 		};

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -45,6 +45,11 @@ interface IDBConnection {
 	public const PLATFORM_SQLITE = 'sqlite';
 
 	/**
+	 * @since 32.0.0
+	 */
+	public const PLATFORM_MARIADB = 'mariadb';
+
+	/**
 	 * Gets the QueryBuilder for the connection.
 	 *
 	 * @return \OCP\DB\QueryBuilder\IQueryBuilder
@@ -357,11 +362,15 @@ interface IDBConnection {
 
 	/**
 	 * Returns the database provider name
+	 *
 	 * @link https://github.com/nextcloud/server/issues/30877
+	 *
+	 * @param bool $strict differentiate between database flavors, e.g. MySQL vs MariaDB
+	 * @return self::PLATFORM_MYSQL|self::PLATFORM_ORACLE|self::PLATFORM_POSTGRES|self::PLATFORM_SQLITE|self::PLATFORM_MARIADB
+	 * @since 32.0.0 Optional parameter $strict was added
 	 * @since 28.0.0
-	 * @return self::PLATFORM_MYSQL|self::PLATFORM_ORACLE|self::PLATFORM_POSTGRES|self::PLATFORM_SQLITE
 	 */
-	public function getDatabaseProvider(): string;
+	public function getDatabaseProvider(bool $strict = false): string;
 
 	/**
 	 * Get the shard definition by name, if configured


### PR DESCRIPTION
There are some behavioral differences that apps may need to check for. See discussion on #51175 for more info.

This preserves the existing behavior of getDatabaseProvider()
