### PR TITLE
fix(encryption): Ignore shared files in encrypt-all command

### DIFF
--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -12,6 +12,7 @@ use OC\Files\View;
 use OCA\Encryption\KeyManager;
 use OCA\Encryption\Users\Setup;
 use OCA\Encryption\Util;
+use OCP\Files\FileInfo;
 use OCP\IConfig;
 use OCP\IL10N;
 use OCP\IUser;
@@ -203,14 +204,18 @@ class EncryptAll {
 			$content = $this->rootView->getDirectoryContent($root);
 			foreach ($content as $file) {
 				$path = $root . '/' . $file['name'];
-				if ($this->rootView->is_dir($path)) {
+				if ($file->isShared()) {
+					$progress->setMessage("Skip shared file/folder $path");
+					$progress->advance();
+					continue;
+				} elseif ($file->getType() === FileInfo::TYPE_FOLDER) {
 					$directories[] = $path;
 					continue;
 				} else {
 					$progress->setMessage("encrypt files for user $userCount: $path");
 					$progress->advance();
 					try {
-						if ($this->encryptFile($path) === false) {
+						if ($this->encryptFile($file, $path) === false) {
 							$progress->setMessage("encrypt files for user $userCount: $path (already encrypted)");
 							$progress->advance();
 						}
@@ -231,17 +236,9 @@ class EncryptAll {
 		}
 	}
 
-	/**
-	 * encrypt file
-	 *
-	 * @param string $path
-	 * @return bool
-	 */
-	protected function encryptFile($path) {
-
+	protected function encryptFile(FileInfo $fileInfo, string $path): bool {
 		// skip already encrypted files
-		$fileInfo = $this->rootView->getFileInfo($path);
-		if ($fileInfo !== false && $fileInfo->isEncrypted()) {
+		if ($fileInfo->isEncrypted()) {
 			return true;
 		}
 

--- a/apps/encryption/lib/Crypto/EncryptAll.php
+++ b/apps/encryption/lib/Crypto/EncryptAll.php
@@ -203,7 +203,7 @@ class EncryptAll {
 		while ($root = array_pop($directories)) {
 			$content = $this->rootView->getDirectoryContent($root);
 			foreach ($content as $file) {
-				$path = $root . '/' . $file['name'];
+				$path = $root . '/' . $file->getName();
 				if ($file->isShared()) {
 					$progress->setMessage("Skip shared file/folder $path");
 					$progress->advance();

--- a/tests/Core/Command/Encryption/EncryptAllTest.php
+++ b/tests/Core/Command/Encryption/EncryptAllTest.php
@@ -13,59 +13,36 @@ use OCP\App\IAppManager;
 use OCP\Encryption\IEncryptionModule;
 use OCP\Encryption\IManager;
 use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
 
 class EncryptAllTest extends TestCase {
-	/** @var \PHPUnit\Framework\MockObject\MockObject|IConfig */
-	protected $config;
+	private IConfig&MockObject $config;
+	private IManager&MockObject $encryptionManager;
+	private IAppManager&MockObject $appManager;
+	private InputInterface&MockObject $consoleInput;
+	private OutputInterface&MockObject $consoleOutput;
+	private QuestionHelper&MockObject $questionHelper;
+	private IEncryptionModule&MockObject $encryptionModule;
 
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \OCP\Encryption\IManager */
-	protected $encryptionManager;
-
-	/** @var \PHPUnit\Framework\MockObject\MockObject|IAppManager */
-	protected $appManager;
-
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Input\InputInterface */
-	protected $consoleInput;
-
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Output\OutputInterface */
-	protected $consoleOutput;
-
-	/** @var \PHPUnit\Framework\MockObject\MockObject | \Symfony\Component\Console\Helper\QuestionHelper */
-	protected $questionHelper;
-
-	/** @var \PHPUnit\Framework\MockObject\MockObject|IEncryptionModule */
-	protected $encryptionModule;
-
-	/** @var EncryptAll */
-	protected $command;
+	private EncryptAll $command;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->config = $this->getMockBuilder(IConfig::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->encryptionManager = $this->getMockBuilder(IManager::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->appManager = $this->getMockBuilder(IAppManager::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->encryptionModule = $this->getMockBuilder(IEncryptionModule::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->questionHelper = $this->getMockBuilder(QuestionHelper::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$this->consoleInput = $this->getMockBuilder(InputInterface::class)->getMock();
+		$this->config = $this->createMock(IConfig::class);
+		$this->encryptionManager = $this->createMock(IManager::class);
+		$this->appManager = $this->createMock(IAppManager::class);
+		$this->encryptionModule = $this->createMock(IEncryptionModule::class);
+		$this->questionHelper = $this->createMock(QuestionHelper::class);
+		$this->consoleInput = $this->createMock(InputInterface::class);
 		$this->consoleInput->expects($this->any())
 			->method('isInteractive')
 			->willReturn(true);
-		$this->consoleOutput = $this->getMockBuilder(OutputInterface::class)->getMock();
+		$this->consoleOutput = $this->createMock(OutputInterface::class);
 	}
 
 	public function testEncryptAll(): void {


### PR DESCRIPTION
## Summary

Copying and renaming a share will not encrypt it anyway. It will get encrypted when the owner’s files get encrypted.
This change should improve performance a bit on real world usecase, and may also avoid issues caused by uselessly renaming shares.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
