### PR TITLE
refactor(AppFramework): drop unused spreed/Talk fallback

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -50,19 +50,8 @@ class App {
 		if (isset($appInfo['namespace'])) {
 			self::$nameSpaceCache[$appId] = trim($appInfo['namespace']);
 		} else {
-			if ($appId !== 'spreed') {
-				// if the tag is not found, fall back to uppercasing the first letter
-				self::$nameSpaceCache[$appId] = ucfirst($appId);
-			} else {
-				// For the Talk app (appid spreed) the above fallback doesn't work.
-				// This leads to a problem when trying to install it freshly,
-				// because the apps namespace is already registered before the
-				// app is downloaded from the appstore, because of the hackish
-				// global route index.php/call/{token} which is registered via
-				// the core/routes.php so it does not have the app namespace.
-				// @ref https://github.com/nextcloud/server/pull/19433
-				self::$nameSpaceCache[$appId] = 'Talk';
-			}
+			// if the tag is not found, fall back to uppercasing the first letter
+			self::$nameSpaceCache[$appId] = ucfirst($appId);
 		}
 
 		return $topNamespace . self::$nameSpaceCache[$appId];


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

No longer needed from what I can tell since #20114 & nextcloud/spreed#3134

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
