### PR TITLE
feat(trashbin): keep hierarchy when deleting folders

### DIFF
--- a/apps/files_trashbin/lib/Sabre/AbstractTrashFolder.php
+++ b/apps/files_trashbin/lib/Sabre/AbstractTrashFolder.php
@@ -19,6 +19,13 @@ abstract class AbstractTrashFolder extends AbstractTrash implements ICollection,
 		$entries = $this->trashManager->listTrashFolder($this->data);
 
 		$children = array_map(function (ITrashItem $entry) {
+			if (str_starts_with($entry->getTrashPath(), '/' . $entry->getOriginalLocation())) {
+				// parent folder is a fake trash folder
+				if ($entry->getType() === FileInfo::TYPE_FOLDER) {
+					return new TrashFolder($this->trashManager, $entry);
+				}
+				return new TrashFile($this->trashManager, $entry);
+			}
 			if ($entry->getType() === FileInfo::TYPE_FOLDER) {
 				return new TrashFolderFolder($this->trashManager, $entry);
 			}

--- a/apps/files_trashbin/lib/Sabre/TrashFolder.php
+++ b/apps/files_trashbin/lib/Sabre/TrashFolder.php
@@ -12,6 +12,10 @@ use OCA\Files_Trashbin\Trashbin;
 
 class TrashFolder extends AbstractTrashFolder {
 	public function getName(): string {
-		return Trashbin::getTrashFilename($this->data->getName(), $this->getDeletionTime());
+		if ($this->getDeletionTime() === 0) {
+			return $this->data->getName();
+		} else {
+			return Trashbin::getTrashFilename($this->data->getName(), $this->getDeletionTime());
+		}
 	}
 }

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -45,12 +45,12 @@ class LegacyTrashBackend implements ITrashBackend {
 			}
 			/** @psalm-suppress UndefinedInterfaceMethod */
 			$deletedBy = $this->userManager->get($file['deletedBy']) ?? $parent?->getDeletedBy();
-			$trashFilename = Trashbin::getTrashFilename($file->getName(), $file->getMtime());
+			$trashFilename = $file->getMtime() === 0 ? $file->getName() : Trashbin::getTrashFilename($file->getName(), $file->getMtime());
 			return new TrashItem(
 				$this,
 				$originalLocation,
 				$file->getMTime(),
-				$parentTrashPath . '/' . ($isRoot ? $trashFilename : $file->getName()),
+				$parentTrashPath . '/' . $trashFilename,
 				$file,
 				$user,
 				$deletedBy,

--- a/apps/files_trashbin/lib/Trash/TrashItem.php
+++ b/apps/files_trashbin/lib/Trash/TrashItem.php
@@ -39,7 +39,7 @@ class TrashItem implements ITrashItem {
 	}
 
 	public function isRootItem(): bool {
-		return substr_count($this->getTrashPath(), '/') === 1;
+		return substr_count($this->getTrashPath(), '/') === 1 || str_ends_with($this->trashPath, strval($this->deletedTime));
 	}
 
 	public function getUser(): IUser {

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -264,8 +264,20 @@ class Trashbin implements IEventListener {
 		$lockingProvider = Server::get(ILockingProvider::class);
 
 		// disable proxy to prevent recursive calls
-		$trashPath = '/files_trashbin/files/' . static::getTrashFilename($filename, $timestamp);
+		$trashPath = '/files_trashbin/files/' . $location . '/' . static::getTrashFilename($filename, $timestamp);
 		$gotLock = false;
+
+		// Reproduce folder hierarchy of deleted file in trash
+		$parentDirs = explode('/', $location);
+		$pathPrefix = '/files_trashbin/files/';
+		foreach ($parentDirs as $parentDir) {
+			$pathPrefix .= $parentDir . '/';
+			if ($ownerView->is_dir($pathPrefix)) {
+				continue;
+			}
+
+			$ownerView->mkdir($pathPrefix);
+		}
 
 		do {
 			/** @var ILockingStorage & IStorage $trashStorage */
@@ -279,7 +291,7 @@ class Trashbin implements IEventListener {
 
 				$timestamp = $timestamp + 1;
 
-				$trashPath = '/files_trashbin/files/' . static::getTrashFilename($filename, $timestamp);
+				$trashPath = '/files_trashbin/files/' . $location . static::getTrashFilename($filename, $timestamp);
 			}
 		} while (!$gotLock);
 


### PR DESCRIPTION
- resolves https://github.com/nextcloud/server/issues/31200

## Summary

Instead of storing every deleted files and folders in a flat hierarchy inside the trashbin, store them in a folder with the same hierarchy as before. This prevents having to list to many files in the trashbin.

## TODO

**Still very early do not review yet, stuff is broken :)**

- [x] Deleting a nested folder/file will recreate parent structure in trash bin
- [x] Opening file in trashbin
- [ ] Restoring (oc_files_trash entry is not removed)
- [ ] Permanently deleting (oc_files_trash entry is not removed)
- [ ] Delete parent folders when all sub-entries are deleted
- [ ] Make sure both old files and new files work correcntly in all situation
- [ ] Cleanup the code, it's currently so messy...
- [ ] Migration of the old files in the trash???

## Filecache organization

Current when deleting a file located at `Media/photo-1.jpeg`, we create in the filecache the following entry:

- `files_trashbin/files/photo-1.jpeg.d1754323366`

With this change, we would then create:

- `files_trashbin/files/Media/` 
- `files_trashbin/files/Media/photo-1.jpeg.d1754323366`

Similarly when deleting a folder named `Document`, with one file doc file inside, we create in the filecache the following entries:

- `files_trashbin/files/Document.d1754323366`
- `files_trashbin/files/Document.d1754323366/document.txt`

with this change this should remain unchanged as it was not nested

Similarly when deleting a folder named `admin` inside a `Important` folder, with one file doc file inside, we create in the filecache the following entries:

- `files_trashbin/files/admin.d1754323366`
- `files_trashbin/files/admin.d1754323366/document.txt`

with this change this will now be:

- `files_trashbin/files/Important/`
- `files_trashbin/files/Important/admin.d1754323366`
- `files_trashbin/files/Important/admin.d1754323366/document.txt`

<!--
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)

-->
