### PR TITLE
[stable29] fix(lib): get fileinfo before locking

### DIFF
--- a/lib/private/legacy/OC_Files.php
+++ b/lib/private/legacy/OC_Files.php
@@ -144,7 +144,6 @@ class OC_Files {
 				}
 			}
 
-			self::lockFiles($view, $dir, $files);
 			$numberOfFiles = 0;
 			$fileSize = 0;
 
@@ -167,7 +166,11 @@ class OC_Files {
 				}
 			}
 
-			//Dispatch an event to see if any apps have problem with download
+			// Lock the files AFTER we retrieved the files infos
+			// this allows us to ensure they're still available
+			self::lockFiles($view, $dir, $files);
+
+			// Dispatch an event to see if any apps have problem with download
 			$event = new BeforeZipCreatedEvent($dir, is_array($files) ? $files : [$files]);
 			$dispatcher = \OCP\Server::get(IEventDispatcher::class);
 			$dispatcher->dispatchTyped($event);


### PR DESCRIPTION
Fixes #53659

When you try to download files from which at least one has been removed from it's federated source, the `lockFiles` method will mark the storage as unavailable and lock the file in a stale state preventing any further operations. 

By getting the fileInfos before, we are able to set-up the mounts before and removing federated shares (mounts) if they are unavailable.

Since 31, the ajax plugin has been removed and the download path have changed, this is only for 29 and 30.

Here is two json stacktrace that show how it used to behave before this patch and how it is supposed to (if you download the file via remote.php/dav, without the zip plugin)
https://gist.github.com/skjnldsv/c8ae6b701f5467984ce0f552e22c5953