### PR TITLE
feat(taskprocessing): add cleanup flag to tasks

### DIFF
--- a/core/Command/TaskProcessing/Cleanup.php
+++ b/core/Command/TaskProcessing/Cleanup.php
@@ -9,16 +9,25 @@ declare(strict_types=1);
 namespace OC\Core\Command\TaskProcessing;
 
 use OC\Core\Command\Base;
+use OC\TaskProcessing\Db\TaskMapper;
 use OC\TaskProcessing\Manager;
+use OCP\Files\AppData\IAppDataFactory;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class Cleanup extends Base {
+	private \OCP\Files\IAppData $appData;
+
 	public function __construct(
 		protected Manager $taskProcessingManager,
+		private TaskMapper $taskMapper,
+		private LoggerInterface $logger,
+		IAppDataFactory $appDataFactory,
 	) {
 		parent::__construct();
+		$this->appData = $appDataFactory->get('core');
 	}
 
 	protected function configure() {
@@ -37,20 +46,48 @@ class Cleanup extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maxAgeSeconds = $input->getArgument('maxAgeSeconds') ?? Manager::MAX_TASK_AGE_SECONDS;
 		$output->writeln('<comment>Cleanup up tasks older than ' . $maxAgeSeconds . ' seconds and the related output files</comment>');
-		$cleanupResult = $this->taskProcessingManager->cleanupOldTasks($maxAgeSeconds);
-		foreach ($cleanupResult as $entry) {
-			if (isset($entry['task_id'], $entry['file_id'], $entry['file_name'])) {
-				$output->writeln("<info>\t - " . 'Deleted appData/core/TaskProcessing/' . $entry['file_name'] . ' (fileId: ' . $entry['file_id'] . ', taskId: ' . $entry['task_id'] . ')</info>');
-			} elseif (isset($entry['directory_name'])) {
-				$output->writeln("<info>\t - " . 'Deleted appData/core/' . $entry['directory_name'] . '/' . $entry['file_name'] . '</info>');
-			} elseif (isset($entry['deleted_task_count'])) {
-				$output->writeln("<comment>\t - " . 'Deleted ' . $entry['deleted_task_count'] . ' tasks from the database</comment>');
-			} elseif (isset($entry['deleted_task_id_list'])) {
-				foreach ($entry['deleted_task_id_list'] as $taskId) {
-					$output->writeln("<info>\t - " . 'Deleted task ' . $taskId . ' from the database</info>');
-				}
+
+		$taskIdsToCleanup = [];
+		try {
+			$fileCleanupGenerator = $this->taskProcessingManager->cleanupTaskProcessingTaskFiles($maxAgeSeconds);
+			foreach ($fileCleanupGenerator as $cleanedUpEntry) {
+				$output->writeln(
+					"<info>\t - " . 'Deleted appData/core/TaskProcessing/' . $cleanedUpEntry['file_name']
+					. ' (fileId: ' . $cleanedUpEntry['file_id'] . ', taskId: ' . $cleanedUpEntry['task_id'] . ')</info>'
+				);
 			}
+			$taskIdsToCleanup = $fileCleanupGenerator->getReturn();
+		} catch (\Exception $e) {
+			$this->logger->warning('Failed to delete stale task processing tasks files', ['exception' => $e]);
+			$output->writeln('<warning>Failed to delete stale task processing tasks files</warning>');
 		}
+		try {
+			$deletedTaskCount = $this->taskMapper->deleteOlderThan($maxAgeSeconds);
+			foreach ($taskIdsToCleanup as $taskId) {
+				$output->writeln("<info>\t - " . 'Deleted task ' . $taskId . ' from the database</info>');
+			}
+			$output->writeln("<comment>\t - " . 'Deleted ' . $deletedTaskCount . ' tasks from the database</comment>');
+		} catch (\OCP\DB\Exception $e) {
+			$this->logger->warning('Failed to delete stale task processing tasks', ['exception' => $e]);
+			$output->writeln('<warning>Failed to delete stale task processing tasks</warning>');
+		}
+		try {
+			$textToImageDeletedFileNames = $this->taskProcessingManager->clearFilesOlderThan($this->appData->getFolder('text2image'), $maxAgeSeconds);
+			foreach ($textToImageDeletedFileNames as $entry) {
+				$output->writeln("<info>\t - " . 'Deleted appData/core/text2image/' . $entry . '</info>');
+			}
+		} catch (\OCP\Files\NotFoundException $e) {
+			// noop
+		}
+		try {
+			$audioToTextDeletedFileNames = $this->taskProcessingManager->clearFilesOlderThan($this->appData->getFolder('audio2text'), $maxAgeSeconds);
+			foreach ($audioToTextDeletedFileNames as $entry) {
+				$output->writeln("<info>\t - " . 'Deleted appData/core/audio2text/' . $entry . '</info>');
+			}
+		} catch (\OCP\Files\NotFoundException $e) {
+			// noop
+		}
+
 		return 0;
 	}
 }

--- a/core/Command/TaskProcessing/Cleanup.php
+++ b/core/Command/TaskProcessing/Cleanup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/core/Command/TaskProcessing/Cleanup.php
+++ b/core/Command/TaskProcessing/Cleanup.php
@@ -34,15 +34,19 @@ class Cleanup extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maxAgeSeconds = $input->getArgument('maxAgeSeconds') ?? Manager::MAX_TASK_AGE_SECONDS;
-		$output->writeln('Cleanup up tasks older than '. $maxAgeSeconds . ' seconds and the related output files');
+		$output->writeln('<comment>Cleanup up tasks older than '. $maxAgeSeconds . ' seconds and the related output files</comment>');
 		$cleanupResult = $this->taskProcessingManager->cleanupOldTasks($maxAgeSeconds);
 		foreach ($cleanupResult as $entry) {
 			if (isset($entry['task_id'], $entry['file_id'], $entry['file_name'])) {
-				$output->writeln("\t - " . 'Deleted appData/core/TaskProcessing/' . $entry['file_name'] . '(fileId: ' . $entry['file_id'] . ', taskId: ' . $entry['task_id'] . ')');
+				$output->writeln("<info>\t - " . 'Deleted appData/core/TaskProcessing/' . $entry['file_name'] . ' (fileId: ' . $entry['file_id'] . ', taskId: ' . $entry['task_id'] . ')</info>');
 			} elseif (isset($entry['directory_name'])) {
-				$output->writeln("\t - " . 'Deleted appData/core/'. $entry['directory_name'] . '/' . $entry['file_name']);
+				$output->writeln("<info>\t - " . 'Deleted appData/core/'. $entry['directory_name'] . '/' . $entry['file_name'] . '</info>');
 			} elseif (isset($entry['deleted_task_count'])) {
-				$output->writeln("\t - " . 'Deleted '. $entry['deleted_task_count'] . ' tasks from the database');
+				$output->writeln("<comment>\t - " . 'Deleted '. $entry['deleted_task_count'] . ' tasks from the database</comment>');
+			} elseif (isset($entry['deleted_task_id_list'])) {
+				foreach ($entry['deleted_task_id_list'] as $taskId) {
+					$output->writeln("<info>\t - " . 'Deleted task '. $taskId . ' from the database</info>');
+				}
 			}
 		}
 		return 0;

--- a/core/Command/TaskProcessing/Cleanup.php
+++ b/core/Command/TaskProcessing/Cleanup.php
@@ -34,18 +34,18 @@ class Cleanup extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maxAgeSeconds = $input->getArgument('maxAgeSeconds') ?? Manager::MAX_TASK_AGE_SECONDS;
-		$output->writeln('<comment>Cleanup up tasks older than '. $maxAgeSeconds . ' seconds and the related output files</comment>');
+		$output->writeln('<comment>Cleanup up tasks older than ' . $maxAgeSeconds . ' seconds and the related output files</comment>');
 		$cleanupResult = $this->taskProcessingManager->cleanupOldTasks($maxAgeSeconds);
 		foreach ($cleanupResult as $entry) {
 			if (isset($entry['task_id'], $entry['file_id'], $entry['file_name'])) {
 				$output->writeln("<info>\t - " . 'Deleted appData/core/TaskProcessing/' . $entry['file_name'] . ' (fileId: ' . $entry['file_id'] . ', taskId: ' . $entry['task_id'] . ')</info>');
 			} elseif (isset($entry['directory_name'])) {
-				$output->writeln("<info>\t - " . 'Deleted appData/core/'. $entry['directory_name'] . '/' . $entry['file_name'] . '</info>');
+				$output->writeln("<info>\t - " . 'Deleted appData/core/' . $entry['directory_name'] . '/' . $entry['file_name'] . '</info>');
 			} elseif (isset($entry['deleted_task_count'])) {
-				$output->writeln("<comment>\t - " . 'Deleted '. $entry['deleted_task_count'] . ' tasks from the database</comment>');
+				$output->writeln("<comment>\t - " . 'Deleted ' . $entry['deleted_task_count'] . ' tasks from the database</comment>');
 			} elseif (isset($entry['deleted_task_id_list'])) {
 				foreach ($entry['deleted_task_id_list'] as $taskId) {
-					$output->writeln("<info>\t - " . 'Deleted task '. $taskId . ' from the database</info>');
+					$output->writeln("<info>\t - " . 'Deleted task ' . $taskId . ' from the database</info>');
 				}
 			}
 		}

--- a/core/Command/TaskProcessing/Cleanup.php
+++ b/core/Command/TaskProcessing/Cleanup.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Core\Command\TaskProcessing;
+
+use OC\Core\Command\Base;
+use OC\TaskProcessing\Manager;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Cleanup extends Base {
+	public function __construct(
+		protected Manager $taskProcessingManager,
+	) {
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('taskprocessing:task:cleanup')
+			->setDescription('cleanup old tasks')
+			->addArgument(
+				'maxAgeSeconds',
+				InputArgument::OPTIONAL,
+				// default is not defined as an argument default value because we want to show a nice "4 months" value
+				'delete tasks that are older than this number of seconds, defaults to ' . Manager::MAX_TASK_AGE_SECONDS . ' (4 months)',
+			);
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$maxAgeSeconds = $input->getArgument('maxAgeSeconds') ?? Manager::MAX_TASK_AGE_SECONDS;
+		$output->writeln('Cleanup up tasks older than '. $maxAgeSeconds . ' seconds and the related output files');
+		$cleanupResult = $this->taskProcessingManager->cleanupOldTasks($maxAgeSeconds);
+		foreach ($cleanupResult as $entry) {
+			if (isset($entry['task_id'], $entry['file_id'], $entry['file_name'])) {
+				$output->writeln("\t - " . 'Deleted appData/core/TaskProcessing/' . $entry['file_name'] . '(fileId: ' . $entry['file_id'] . ', taskId: ' . $entry['task_id'] . ')');
+			} elseif (isset($entry['directory_name'])) {
+				$output->writeln("\t - " . 'Deleted appData/core/'. $entry['directory_name'] . '/' . $entry['file_name']);
+			} elseif (isset($entry['deleted_task_count'])) {
+				$output->writeln("\t - " . 'Deleted '. $entry['deleted_task_count'] . ' tasks from the database');
+			}
+		}
+		return 0;
+	}
+}

--- a/core/Command/TaskProcessing/EnabledCommand.php
+++ b/core/Command/TaskProcessing/EnabledCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/core/Command/TaskProcessing/GetCommand.php
+++ b/core/Command/TaskProcessing/GetCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/core/Command/TaskProcessing/ListCommand.php
+++ b/core/Command/TaskProcessing/ListCommand.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/core/Command/TaskProcessing/Statistics.php
+++ b/core/Command/TaskProcessing/Statistics.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later

--- a/core/Controller/TaskProcessingApiController.php
+++ b/core/Controller/TaskProcessingApiController.php
@@ -391,7 +391,7 @@ class TaskProcessingApiController extends OCSController {
 	 * @return StreamResponse<Http::STATUS_OK, array{}>|DataResponse<Http::STATUS_INTERNAL_SERVER_ERROR|Http::STATUS_NOT_FOUND, array{message: string}, array{}>
 	 */
 	private function getFileContentsInternal(Task $task, int $fileId): StreamResponse|DataResponse {
-		$ids = $this->extractFileIdsFromTask($task);
+		$ids = $this->taskProcessingManager->extractFileIdsFromTask($task);
 		if (!in_array($fileId, $ids)) {
 			return new DataResponse(['message' => $this->l->t('Not found')], Http::STATUS_NOT_FOUND);
 		}
@@ -426,45 +426,6 @@ class TaskProcessingApiController extends OCSController {
 		);
 		$response->addHeader('Content-Type', $contentType);
 		return $response;
-	}
-
-	/**
-	 * @param Task $task
-	 * @return list<int>
-	 * @throws NotFoundException
-	 */
-	private function extractFileIdsFromTask(Task $task): array {
-		$ids = [];
-		$taskTypes = $this->taskProcessingManager->getAvailableTaskTypes();
-		if (!isset($taskTypes[$task->getTaskTypeId()])) {
-			throw new NotFoundException('Could not find task type');
-		}
-		$taskType = $taskTypes[$task->getTaskTypeId()];
-		foreach ($taskType['inputShape'] + $taskType['optionalInputShape'] as $key => $descriptor) {
-			if (in_array(EShapeType::getScalarType($descriptor->getShapeType()), [EShapeType::File, EShapeType::Image, EShapeType::Audio, EShapeType::Video], true)) {
-				/** @var int|list<int> $inputSlot */
-				$inputSlot = $task->getInput()[$key];
-				if (is_array($inputSlot)) {
-					$ids = array_merge($inputSlot, $ids);
-				} else {
-					$ids[] = $inputSlot;
-				}
-			}
-		}
-		if ($task->getOutput() !== null) {
-			foreach ($taskType['outputShape'] + $taskType['optionalOutputShape'] as $key => $descriptor) {
-				if (in_array(EShapeType::getScalarType($descriptor->getShapeType()), [EShapeType::File, EShapeType::Image, EShapeType::Audio, EShapeType::Video], true)) {
-					/** @var int|list<int> $outputSlot */
-					$outputSlot = $task->getOutput()[$key];
-					if (is_array($outputSlot)) {
-						$ids = array_merge($outputSlot, $ids);
-					} else {
-						$ids[] = $outputSlot;
-					}
-				}
-			}
-		}
-		return $ids;
 	}
 
 	/**

--- a/core/Controller/TaskProcessingApiController.php
+++ b/core/Controller/TaskProcessingApiController.php
@@ -31,7 +31,6 @@ use OCP\Files\NotPermittedException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\Lock\LockedException;
-use OCP\TaskProcessing\EShapeType;
 use OCP\TaskProcessing\Exception\Exception;
 use OCP\TaskProcessing\Exception\NotFoundException;
 use OCP\TaskProcessing\Exception\PreConditionNotMetException;

--- a/core/Migrations/Version32000Date20250806110519.php
+++ b/core/Migrations/Version32000Date20250806110519.php
@@ -19,7 +19,7 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  *
  */
-#[AddColumn(table: 'taskprocessing_tasks', name: 'cleanup', type: ColumnType::SMALLINT)]
+#[AddColumn(table: 'taskprocessing_tasks', name: 'allow_cleanup', type: ColumnType::SMALLINT)]
 class Version32000Date20250806110519 extends SimpleMigrationStep {
 
 	/**
@@ -34,8 +34,8 @@ class Version32000Date20250806110519 extends SimpleMigrationStep {
 
 		if ($schema->hasTable('taskprocessing_tasks')) {
 			$table = $schema->getTable('taskprocessing_tasks');
-			if (!$table->hasColumn('cleanup')) {
-				$table->addColumn('cleanup', Types::SMALLINT, [
+			if (!$table->hasColumn('allow_cleanup')) {
+				$table->addColumn('allow_cleanup', Types::SMALLINT, [
 					'notnull' => true,
 					'default' => 1,
 					'unsigned' => true,

--- a/core/Migrations/Version32000Date20250806110519.php
+++ b/core/Migrations/Version32000Date20250806110519.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OC\Core\Migrations;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\Attributes\AddColumn;
+use OCP\Migration\Attributes\ColumnType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ *
+ */
+#[AddColumn(table: 'taskprocessing_tasks', name: 'cleanup', type: ColumnType::SMALLINT)]
+class Version32000Date20250806110519 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('taskprocessing_tasks')) {
+			$table = $schema->getTable('taskprocessing_tasks');
+			if (!$table->hasColumn('cleanup')) {
+				$table->addColumn('cleanup', Types::SMALLINT, [
+					'notnull' => true,
+					'default' => 1,
+					'unsigned' => true,
+				]);
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+}

--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -200,7 +200,7 @@ namespace OC\Core;
  *     scheduledAt: ?int,
  *     startedAt: ?int,
  *     endedAt: ?int,
- *     cleanup: bool,
+ *     allowCleanup: bool,
  * }
  *
  * @psalm-type CoreProfileAction = array{

--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -200,6 +200,7 @@ namespace OC\Core;
  *     scheduledAt: ?int,
  *     startedAt: ?int,
  *     endedAt: ?int,
+ *     cleanup: bool,
  * }
  *
  * @psalm-type CoreProfileAction = array{

--- a/core/openapi-ex_app.json
+++ b/core/openapi-ex_app.json
@@ -146,7 +146,7 @@
                     "scheduledAt",
                     "startedAt",
                     "endedAt",
-                    "cleanup"
+                    "allowCleanup"
                 ],
                 "properties": {
                     "id": {
@@ -218,7 +218,7 @@
                         "format": "int64",
                         "nullable": true
                     },
-                    "cleanup": {
+                    "allowCleanup": {
                         "type": "boolean"
                     }
                 }

--- a/core/openapi-ex_app.json
+++ b/core/openapi-ex_app.json
@@ -145,7 +145,8 @@
                     "progress",
                     "scheduledAt",
                     "startedAt",
-                    "endedAt"
+                    "endedAt",
+                    "cleanup"
                 ],
                 "properties": {
                     "id": {
@@ -216,6 +217,9 @@
                         "type": "integer",
                         "format": "int64",
                         "nullable": true
+                    },
+                    "cleanup": {
+                        "type": "boolean"
                     }
                 }
             }

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -639,7 +639,8 @@
                     "progress",
                     "scheduledAt",
                     "startedAt",
-                    "endedAt"
+                    "endedAt",
+                    "cleanup"
                 ],
                 "properties": {
                     "id": {
@@ -710,6 +711,9 @@
                         "type": "integer",
                         "format": "int64",
                         "nullable": true
+                    },
+                    "cleanup": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -640,7 +640,7 @@
                     "scheduledAt",
                     "startedAt",
                     "endedAt",
-                    "cleanup"
+                    "allowCleanup"
                 ],
                 "properties": {
                     "id": {
@@ -712,7 +712,7 @@
                         "format": "int64",
                         "nullable": true
                     },
-                    "cleanup": {
+                    "allowCleanup": {
                         "type": "boolean"
                     }
                 }

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -639,7 +639,8 @@
                     "progress",
                     "scheduledAt",
                     "startedAt",
-                    "endedAt"
+                    "endedAt",
+                    "cleanup"
                 ],
                 "properties": {
                     "id": {
@@ -710,6 +711,9 @@
                         "type": "integer",
                         "format": "int64",
                         "nullable": true
+                    },
+                    "cleanup": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -640,7 +640,7 @@
                     "scheduledAt",
                     "startedAt",
                     "endedAt",
-                    "cleanup"
+                    "allowCleanup"
                 ],
                 "properties": {
                     "id": {
@@ -712,7 +712,7 @@
                         "format": "int64",
                         "nullable": true
                     },
-                    "cleanup": {
+                    "allowCleanup": {
                         "type": "boolean"
                     }
                 }

--- a/core/register_command.php
+++ b/core/register_command.php
@@ -253,6 +253,7 @@ if ($config->getSystemValueBool('installed', false)) {
 	$application->add(Server::get(EnabledCommand::class));
 	$application->add(Server::get(Command\TaskProcessing\ListCommand::class));
 	$application->add(Server::get(Statistics::class));
+	$application->add(Server::get(Command\TaskProcessing\Cleanup::class));
 
 	$application->add(Server::get(RedisCommand::class));
 	$application->add(Server::get(DistributedClear::class));

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1512,6 +1512,7 @@ return array(
     'OC\\Core\\Migrations\\Version31000Date20250213102442' => $baseDir . '/core/Migrations/Version31000Date20250213102442.php',
     'OC\\Core\\Migrations\\Version32000Date20250620081925' => $baseDir . '/core/Migrations/Version32000Date20250620081925.php',
     'OC\\Core\\Migrations\\Version32000Date20250731062008' => $baseDir . '/core/Migrations/Version32000Date20250731062008.php',
+    'OC\\Core\\Migrations\\Version32000Date20250806110519' => $baseDir . '/core/Migrations/Version32000Date20250806110519.php',
     'OC\\Core\\Notification\\CoreNotifier' => $baseDir . '/core/Notification/CoreNotifier.php',
     'OC\\Core\\ResponseDefinitions' => $baseDir . '/core/ResponseDefinitions.php',
     'OC\\Core\\Service\\LoginFlowV2Service' => $baseDir . '/core/Service/LoginFlowV2Service.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1346,6 +1346,7 @@ return array(
     'OC\\Core\\Command\\SystemTag\\Delete' => $baseDir . '/core/Command/SystemTag/Delete.php',
     'OC\\Core\\Command\\SystemTag\\Edit' => $baseDir . '/core/Command/SystemTag/Edit.php',
     'OC\\Core\\Command\\SystemTag\\ListCommand' => $baseDir . '/core/Command/SystemTag/ListCommand.php',
+    'OC\\Core\\Command\\TaskProcessing\\Cleanup' => $baseDir . '/core/Command/TaskProcessing/Cleanup.php',
     'OC\\Core\\Command\\TaskProcessing\\EnabledCommand' => $baseDir . '/core/Command/TaskProcessing/EnabledCommand.php',
     'OC\\Core\\Command\\TaskProcessing\\GetCommand' => $baseDir . '/core/Command/TaskProcessing/GetCommand.php',
     'OC\\Core\\Command\\TaskProcessing\\ListCommand' => $baseDir . '/core/Command/TaskProcessing/ListCommand.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1387,6 +1387,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Command\\SystemTag\\Delete' => __DIR__ . '/../../..' . '/core/Command/SystemTag/Delete.php',
         'OC\\Core\\Command\\SystemTag\\Edit' => __DIR__ . '/../../..' . '/core/Command/SystemTag/Edit.php',
         'OC\\Core\\Command\\SystemTag\\ListCommand' => __DIR__ . '/../../..' . '/core/Command/SystemTag/ListCommand.php',
+        'OC\\Core\\Command\\TaskProcessing\\Cleanup' => __DIR__ . '/../../..' . '/core/Command/TaskProcessing/Cleanup.php',
         'OC\\Core\\Command\\TaskProcessing\\EnabledCommand' => __DIR__ . '/../../..' . '/core/Command/TaskProcessing/EnabledCommand.php',
         'OC\\Core\\Command\\TaskProcessing\\GetCommand' => __DIR__ . '/../../..' . '/core/Command/TaskProcessing/GetCommand.php',
         'OC\\Core\\Command\\TaskProcessing\\ListCommand' => __DIR__ . '/../../..' . '/core/Command/TaskProcessing/ListCommand.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1553,6 +1553,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Core\\Migrations\\Version31000Date20250213102442' => __DIR__ . '/../../..' . '/core/Migrations/Version31000Date20250213102442.php',
         'OC\\Core\\Migrations\\Version32000Date20250620081925' => __DIR__ . '/../../..' . '/core/Migrations/Version32000Date20250620081925.php',
         'OC\\Core\\Migrations\\Version32000Date20250731062008' => __DIR__ . '/../../..' . '/core/Migrations/Version32000Date20250731062008.php',
+        'OC\\Core\\Migrations\\Version32000Date20250806110519' => __DIR__ . '/../../..' . '/core/Migrations/Version32000Date20250806110519.php',
         'OC\\Core\\Notification\\CoreNotifier' => __DIR__ . '/../../..' . '/core/Notification/CoreNotifier.php',
         'OC\\Core\\ResponseDefinitions' => __DIR__ . '/../../..' . '/core/ResponseDefinitions.php',
         'OC\\Core\\Service\\LoginFlowV2Service' => __DIR__ . '/../../..' . '/core/Service/LoginFlowV2Service.php',

--- a/lib/private/TaskProcessing/Db/Task.php
+++ b/lib/private/TaskProcessing/Db/Task.php
@@ -45,8 +45,8 @@ use OCP\TaskProcessing\Task as OCPTask;
  * @method int getStartedAt()
  * @method setEndedAt(int $endedAt)
  * @method int getEndedAt()
- * @method setCleanup(int $cleanup)
- * @method int getCleanup()
+ * @method setAllowCleanup(int $allowCleanup)
+ * @method int getAllowCleanup()
  */
 class Task extends Entity {
 	protected $lastUpdated;
@@ -65,17 +65,17 @@ class Task extends Entity {
 	protected $scheduledAt;
 	protected $startedAt;
 	protected $endedAt;
-	protected $cleanup;
+	protected $allowCleanup;
 
 	/**
 	 * @var string[]
 	 */
-	public static array $columns = ['id', 'last_updated', 'type', 'input', 'output', 'status', 'user_id', 'app_id', 'custom_id', 'completion_expected_at', 'error_message', 'progress', 'webhook_uri', 'webhook_method', 'scheduled_at', 'started_at', 'ended_at', 'cleanup'];
+	public static array $columns = ['id', 'last_updated', 'type', 'input', 'output', 'status', 'user_id', 'app_id', 'custom_id', 'completion_expected_at', 'error_message', 'progress', 'webhook_uri', 'webhook_method', 'scheduled_at', 'started_at', 'ended_at', 'allow_cleanup'];
 
 	/**
 	 * @var string[]
 	 */
-	public static array $fields = ['id', 'lastUpdated', 'type', 'input', 'output', 'status', 'userId', 'appId', 'customId', 'completionExpectedAt', 'errorMessage', 'progress', 'webhookUri', 'webhookMethod', 'scheduledAt', 'startedAt', 'endedAt', 'cleanup'];
+	public static array $fields = ['id', 'lastUpdated', 'type', 'input', 'output', 'status', 'userId', 'appId', 'customId', 'completionExpectedAt', 'errorMessage', 'progress', 'webhookUri', 'webhookMethod', 'scheduledAt', 'startedAt', 'endedAt', 'allowCleanup'];
 
 
 	public function __construct() {
@@ -97,7 +97,7 @@ class Task extends Entity {
 		$this->addType('scheduledAt', 'integer');
 		$this->addType('startedAt', 'integer');
 		$this->addType('endedAt', 'integer');
-		$this->addType('cleanup', 'integer');
+		$this->addType('allowCleanup', 'integer');
 	}
 
 	public function toRow(): array {
@@ -126,7 +126,7 @@ class Task extends Entity {
 			'scheduledAt' => $task->getScheduledAt(),
 			'startedAt' => $task->getStartedAt(),
 			'endedAt' => $task->getEndedAt(),
-			'cleanup' => $task->getCleanup(),
+			'allowCleanup' => $task->getAllowCleanup(),
 		]);
 		return $taskEntity;
 	}
@@ -149,7 +149,7 @@ class Task extends Entity {
 		$task->setScheduledAt($this->getScheduledAt());
 		$task->setStartedAt($this->getStartedAt());
 		$task->setEndedAt($this->getEndedAt());
-		$task->setCleanup($this->getCleanup() !== 0);
+		$task->setAllowCleanup($this->getAllowCleanup() !== 0);
 		return $task;
 	}
 }

--- a/lib/private/TaskProcessing/Db/Task.php
+++ b/lib/private/TaskProcessing/Db/Task.php
@@ -126,7 +126,7 @@ class Task extends Entity {
 			'scheduledAt' => $task->getScheduledAt(),
 			'startedAt' => $task->getStartedAt(),
 			'endedAt' => $task->getEndedAt(),
-			'allowCleanup' => $task->getAllowCleanup(),
+			'allowCleanup' => $task->getAllowCleanup() ? 1 : 0,
 		]);
 		return $taskEntity;
 	}

--- a/lib/private/TaskProcessing/Db/Task.php
+++ b/lib/private/TaskProcessing/Db/Task.php
@@ -45,6 +45,8 @@ use OCP\TaskProcessing\Task as OCPTask;
  * @method int getStartedAt()
  * @method setEndedAt(int $endedAt)
  * @method int getEndedAt()
+ * @method setCleanup(int $cleanup)
+ * @method int getCleanup()
  */
 class Task extends Entity {
 	protected $lastUpdated;
@@ -63,16 +65,17 @@ class Task extends Entity {
 	protected $scheduledAt;
 	protected $startedAt;
 	protected $endedAt;
+	protected $cleanup;
 
 	/**
 	 * @var string[]
 	 */
-	public static array $columns = ['id', 'last_updated', 'type', 'input', 'output', 'status', 'user_id', 'app_id', 'custom_id', 'completion_expected_at', 'error_message', 'progress', 'webhook_uri', 'webhook_method', 'scheduled_at', 'started_at', 'ended_at'];
+	public static array $columns = ['id', 'last_updated', 'type', 'input', 'output', 'status', 'user_id', 'app_id', 'custom_id', 'completion_expected_at', 'error_message', 'progress', 'webhook_uri', 'webhook_method', 'scheduled_at', 'started_at', 'ended_at', 'cleanup'];
 
 	/**
 	 * @var string[]
 	 */
-	public static array $fields = ['id', 'lastUpdated', 'type', 'input', 'output', 'status', 'userId', 'appId', 'customId', 'completionExpectedAt', 'errorMessage', 'progress', 'webhookUri', 'webhookMethod', 'scheduledAt', 'startedAt', 'endedAt'];
+	public static array $fields = ['id', 'lastUpdated', 'type', 'input', 'output', 'status', 'userId', 'appId', 'customId', 'completionExpectedAt', 'errorMessage', 'progress', 'webhookUri', 'webhookMethod', 'scheduledAt', 'startedAt', 'endedAt', 'cleanup'];
 
 
 	public function __construct() {
@@ -94,6 +97,7 @@ class Task extends Entity {
 		$this->addType('scheduledAt', 'integer');
 		$this->addType('startedAt', 'integer');
 		$this->addType('endedAt', 'integer');
+		$this->addType('cleanup', 'integer');
 	}
 
 	public function toRow(): array {
@@ -122,6 +126,7 @@ class Task extends Entity {
 			'scheduledAt' => $task->getScheduledAt(),
 			'startedAt' => $task->getStartedAt(),
 			'endedAt' => $task->getEndedAt(),
+			'cleanup' => $task->getCleanup(),
 		]);
 		return $taskEntity;
 	}
@@ -144,6 +149,7 @@ class Task extends Entity {
 		$task->setScheduledAt($this->getScheduledAt());
 		$task->setStartedAt($this->getStartedAt());
 		$task->setEndedAt($this->getEndedAt());
+		$task->setCleanup($this->getCleanup() !== 0);
 		return $task;
 	}
 }

--- a/lib/private/TaskProcessing/Db/TaskMapper.php
+++ b/lib/private/TaskProcessing/Db/TaskMapper.php
@@ -183,7 +183,7 @@ class TaskMapper extends QBMapper {
 
 	/**
 	 * @param int $timeout
-	 * @param bool $force If true, ignore the cleanup flag
+	 * @param bool $force If true, ignore the allow_cleanup flag
 	 * @return int the number of deleted tasks
 	 * @throws Exception
 	 */
@@ -192,14 +192,14 @@ class TaskMapper extends QBMapper {
 		$qb->delete($this->tableName)
 			->where($qb->expr()->lt('last_updated', $qb->createPositionalParameter($this->timeFactory->getDateTime()->getTimestamp() - $timeout)));
 		if (!$force) {
-			$qb->andWhere($qb->expr()->eq('cleanup', $qb->createPositionalParameter(1, IQueryBuilder::PARAM_INT)));
+			$qb->andWhere($qb->expr()->eq('allow_cleanup', $qb->createPositionalParameter(1, IQueryBuilder::PARAM_INT)));
 		}
 		return $qb->executeStatement();
 	}
 
 	/**
 	 * @param int $timeout
-	 * @param bool $force If true, ignore the cleanup flag
+	 * @param bool $force If true, ignore the allow_cleanup flag
 	 * @return \Generator<Task>
 	 * @throws Exception
 	 */
@@ -209,7 +209,7 @@ class TaskMapper extends QBMapper {
 			->from($this->tableName)
 			->where($qb->expr()->lt('last_updated', $qb->createPositionalParameter($this->timeFactory->getDateTime()->getTimestamp() - $timeout)));
 		if (!$force) {
-			$qb->andWhere($qb->expr()->eq('cleanup', $qb->createPositionalParameter(1, IQueryBuilder::PARAM_INT)));
+			$qb->andWhere($qb->expr()->eq('allow_cleanup', $qb->createPositionalParameter(1, IQueryBuilder::PARAM_INT)));
 		}
 		foreach ($this->yieldEntities($qb) as $entity) {
 			yield $entity;

--- a/lib/private/TaskProcessing/Db/TaskMapper.php
+++ b/lib/private/TaskProcessing/Db/TaskMapper.php
@@ -183,14 +183,36 @@ class TaskMapper extends QBMapper {
 
 	/**
 	 * @param int $timeout
+	 * @param bool $force If true, ignore the cleanup flag
 	 * @return int the number of deleted tasks
 	 * @throws Exception
 	 */
-	public function deleteOlderThan(int $timeout): int {
+	public function deleteOlderThan(int $timeout, bool $force = false): int {
 		$qb = $this->db->getQueryBuilder();
 		$qb->delete($this->tableName)
 			->where($qb->expr()->lt('last_updated', $qb->createPositionalParameter($this->timeFactory->getDateTime()->getTimestamp() - $timeout)));
+		if (!$force) {
+			$qb->andWhere($qb->expr()->eq('cleanup', $qb->createPositionalParameter(1, IQueryBuilder::PARAM_INT)));
+		}
 		return $qb->executeStatement();
+	}
+
+	/**
+	 * @param int $timeout
+	 * @param bool $force If true, ignore the cleanup flag
+	 * @return \Generator<Task>
+	 * @throws Exception
+	 */
+	public function getTasksToCleanup(int $timeout, bool $force = false): \Generator {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select($this->tableName)
+			->where($qb->expr()->lt('last_updated', $qb->createPositionalParameter($this->timeFactory->getDateTime()->getTimestamp() - $timeout)));
+		if (!$force) {
+			$qb->andWhere($qb->expr()->eq('cleanup', $qb->createPositionalParameter(1, IQueryBuilder::PARAM_INT)));
+		}
+		foreach ($this->yieldEntities($qb) as $entity) {
+			yield $entity;
+		};
 	}
 
 	public function update(Entity $entity): Entity {

--- a/lib/private/TaskProcessing/Db/TaskMapper.php
+++ b/lib/private/TaskProcessing/Db/TaskMapper.php
@@ -205,7 +205,8 @@ class TaskMapper extends QBMapper {
 	 */
 	public function getTasksToCleanup(int $timeout, bool $force = false): \Generator {
 		$qb = $this->db->getQueryBuilder();
-		$qb->select($this->tableName)
+		$qb->select(Task::$columns)
+			->from($this->tableName)
 			->where($qb->expr()->lt('last_updated', $qb->createPositionalParameter($this->timeFactory->getDateTime()->getTimestamp() - $timeout)));
 		if (!$force) {
 			$qb->andWhere($qb->expr()->eq('cleanup', $qb->createPositionalParameter(1, IQueryBuilder::PARAM_INT)));

--- a/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
+++ b/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
@@ -9,10 +9,15 @@ namespace OC\TaskProcessing;
 use OC\TaskProcessing\Db\TaskMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\DB\Exception;
 use OCP\Files\AppData\IAppDataFactory;
+use OCP\Files\File;
+use OCP\Files\InvalidPathException;
+use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\SimpleFS\ISimpleFolder;
+use OCP\TaskProcessing\IManager;
 use Psr\Log\LoggerInterface;
 
 class RemoveOldTasksBackgroundJob extends TimedJob {
@@ -22,6 +27,8 @@ class RemoveOldTasksBackgroundJob extends TimedJob {
 	public function __construct(
 		ITimeFactory $timeFactory,
 		private TaskMapper $taskMapper,
+		private IManager $taskProcessingManager,
+		private IRootFolder $rootFolder,
 		private LoggerInterface $logger,
 		IAppDataFactory $appDataFactory,
 	) {
@@ -38,6 +45,11 @@ class RemoveOldTasksBackgroundJob extends TimedJob {
 	 */
 	protected function run($argument): void {
 		try {
+			$this->cleanupTaskProcessingTaskFiles();
+		} catch (\Exception $e) {
+			$this->logger->warning('Failed to delete stale task processing tasks files', ['exception' => $e]);
+		}
+		try {
 			$this->taskMapper->deleteOlderThan(self::MAX_TASK_AGE_SECONDS);
 		} catch (\OCP\DB\Exception $e) {
 			$this->logger->warning('Failed to delete stale task processing tasks', ['exception' => $e]);
@@ -49,11 +61,6 @@ class RemoveOldTasksBackgroundJob extends TimedJob {
 		}
 		try {
 			$this->clearFilesOlderThan($this->appData->getFolder('audio2text'), self::MAX_TASK_AGE_SECONDS);
-		} catch (NotFoundException $e) {
-			// noop
-		}
-		try {
-			$this->clearFilesOlderThan($this->appData->getFolder('TaskProcessing'), self::MAX_TASK_AGE_SECONDS);
 		} catch (NotFoundException $e) {
 			// noop
 		}
@@ -76,4 +83,29 @@ class RemoveOldTasksBackgroundJob extends TimedJob {
 		}
 	}
 
+	/**
+	 * @return void
+	 * @throws InvalidPathException
+	 * @throws NotFoundException
+	 * @throws \JsonException
+	 * @throws Exception
+	 * @throws \OCP\TaskProcessing\Exception\NotFoundException
+	 */
+	private function cleanupTaskProcessingTaskFiles(): void {
+		foreach ($this->taskMapper->getTasksToCleanup(self::MAX_TASK_AGE_SECONDS) as $task) {
+			$ocpTask = $task->toPublicTask();
+			$fileIds = $this->taskProcessingManager->extractFileIdsFromTask($ocpTask);
+			foreach ($fileIds as $fileId) {
+				// only look for output files stored in appData/TaskProcessing/
+				$file = $this->rootFolder->getFirstNodeByIdInPath($fileId, '/' . $this->rootFolder->getAppDataDirectoryName() . '/TaskProcessing/');
+				if ($file instanceof File) {
+					try {
+						$file->delete();
+					} catch (NotPermittedException $e) {
+						$this->logger->warning('Failed to delete a stale task processing file', ['exception' => $e]);
+					}
+				}
+			}
+		}
+	}
 }

--- a/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
+++ b/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
@@ -6,106 +6,25 @@
  */
 namespace OC\TaskProcessing;
 
-use OC\TaskProcessing\Db\TaskMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
-use OCP\DB\Exception;
-use OCP\Files\AppData\IAppDataFactory;
-use OCP\Files\File;
-use OCP\Files\InvalidPathException;
-use OCP\Files\IRootFolder;
-use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
-use OCP\Files\SimpleFS\ISimpleFolder;
-use OCP\TaskProcessing\IManager;
-use Psr\Log\LoggerInterface;
 
 class RemoveOldTasksBackgroundJob extends TimedJob {
-	public const MAX_TASK_AGE_SECONDS = 60 * 60 * 24 * 30 * 4; // 4 months
-	private \OCP\Files\IAppData $appData;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
-		private TaskMapper $taskMapper,
-		private IManager $taskProcessingManager,
-		private IRootFolder $rootFolder,
-		private LoggerInterface $logger,
-		IAppDataFactory $appDataFactory,
+		private Manager $taskProcessingManager,
 	) {
 		parent::__construct($timeFactory);
 		$this->setInterval(60 * 60 * 24);
 		// can be deferred to maintenance window
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
-		$this->appData = $appDataFactory->get('core');
 	}
-
 
 	/**
 	 * @inheritDoc
 	 */
 	protected function run($argument): void {
-		try {
-			$this->cleanupTaskProcessingTaskFiles();
-		} catch (\Exception $e) {
-			$this->logger->warning('Failed to delete stale task processing tasks files', ['exception' => $e]);
-		}
-		try {
-			$this->taskMapper->deleteOlderThan(self::MAX_TASK_AGE_SECONDS);
-		} catch (\OCP\DB\Exception $e) {
-			$this->logger->warning('Failed to delete stale task processing tasks', ['exception' => $e]);
-		}
-		try {
-			$this->clearFilesOlderThan($this->appData->getFolder('text2image'), self::MAX_TASK_AGE_SECONDS);
-		} catch (NotFoundException $e) {
-			// noop
-		}
-		try {
-			$this->clearFilesOlderThan($this->appData->getFolder('audio2text'), self::MAX_TASK_AGE_SECONDS);
-		} catch (NotFoundException $e) {
-			// noop
-		}
-	}
-
-	/**
-	 * @param ISimpleFolder $folder
-	 * @param int $ageInSeconds
-	 * @return void
-	 */
-	private function clearFilesOlderThan(ISimpleFolder $folder, int $ageInSeconds): void {
-		foreach ($folder->getDirectoryListing() as $file) {
-			if ($file->getMTime() < time() - $ageInSeconds) {
-				try {
-					$file->delete();
-				} catch (NotPermittedException $e) {
-					$this->logger->warning('Failed to delete a stale task processing file', ['exception' => $e]);
-				}
-			}
-		}
-	}
-
-	/**
-	 * @return void
-	 * @throws InvalidPathException
-	 * @throws NotFoundException
-	 * @throws \JsonException
-	 * @throws Exception
-	 * @throws \OCP\TaskProcessing\Exception\NotFoundException
-	 */
-	private function cleanupTaskProcessingTaskFiles(): void {
-		foreach ($this->taskMapper->getTasksToCleanup(self::MAX_TASK_AGE_SECONDS) as $task) {
-			$ocpTask = $task->toPublicTask();
-			$fileIds = $this->taskProcessingManager->extractFileIdsFromTask($ocpTask);
-			foreach ($fileIds as $fileId) {
-				// only look for output files stored in appData/TaskProcessing/
-				$file = $this->rootFolder->getFirstNodeByIdInPath($fileId, '/' . $this->rootFolder->getAppDataDirectoryName() . '/TaskProcessing/');
-				if ($file instanceof File) {
-					try {
-						$file->delete();
-					} catch (NotPermittedException $e) {
-						$this->logger->warning('Failed to delete a stale task processing file', ['exception' => $e]);
-					}
-				}
-			}
-		}
+		iterator_to_array($this->taskProcessingManager->cleanupOldTasks());
 	}
 }

--- a/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
+++ b/lib/private/TaskProcessing/RemoveOldTasksBackgroundJob.php
@@ -6,25 +6,52 @@
  */
 namespace OC\TaskProcessing;
 
+use OC\TaskProcessing\Db\TaskMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\TimedJob;
+use OCP\Files\AppData\IAppDataFactory;
+use Psr\Log\LoggerInterface;
 
 class RemoveOldTasksBackgroundJob extends TimedJob {
+	private \OCP\Files\IAppData $appData;
 
 	public function __construct(
 		ITimeFactory $timeFactory,
 		private Manager $taskProcessingManager,
+		private TaskMapper $taskMapper,
+		private LoggerInterface $logger,
+		IAppDataFactory $appDataFactory,
 	) {
 		parent::__construct($timeFactory);
 		$this->setInterval(60 * 60 * 24);
 		// can be deferred to maintenance window
 		$this->setTimeSensitivity(self::TIME_INSENSITIVE);
+		$this->appData = $appDataFactory->get('core');
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	protected function run($argument): void {
-		iterator_to_array($this->taskProcessingManager->cleanupOldTasks());
+		try {
+			iterator_to_array($this->taskProcessingManager->cleanupTaskProcessingTaskFiles());
+		} catch (\Exception $e) {
+			$this->logger->warning('Failed to delete stale task processing tasks files', ['exception' => $e]);
+		}
+		try {
+			$this->taskMapper->deleteOlderThan(Manager::MAX_TASK_AGE_SECONDS);
+		} catch (\OCP\DB\Exception $e) {
+			$this->logger->warning('Failed to delete stale task processing tasks', ['exception' => $e]);
+		}
+		try {
+			iterator_to_array($this->taskProcessingManager->clearFilesOlderThan($this->appData->getFolder('text2image')));
+		} catch (\OCP\Files\NotFoundException $e) {
+			// noop
+		}
+		try {
+			iterator_to_array($this->taskProcessingManager->clearFilesOlderThan($this->appData->getFolder('audio2text')));
+		} catch (\OCP\Files\NotFoundException $e) {
+			// noop
+		}
 	}
 }

--- a/lib/public/TaskProcessing/IManager.php
+++ b/lib/public/TaskProcessing/IManager.php
@@ -234,4 +234,14 @@ interface IManager {
 	 * @since 30.0.0
 	 */
 	public function setTaskStatus(Task $task, int $status): void;
+
+	/**
+	 * Extract all input and output file IDs from a task
+	 *
+	 * @param Task $task
+	 * @return list<int>
+	 * @throws NotFoundException
+	 * @since 32.0.0
+	 */
+	public function extractFileIdsFromTask(Task $task): array;
 }

--- a/lib/public/TaskProcessing/Task.php
+++ b/lib/public/TaskProcessing/Task.php
@@ -66,6 +66,7 @@ final class Task implements \JsonSerializable {
 	protected ?int $scheduledAt = null;
 	protected ?int $startedAt = null;
 	protected ?int $endedAt = null;
+	protected bool $cleanup = true;
 
 	/**
 	 * @param string $taskTypeId
@@ -253,7 +254,23 @@ final class Task implements \JsonSerializable {
 	}
 
 	/**
-	 * @psalm-return array{id: int, lastUpdated: int, type: string, status: 'STATUS_CANCELLED'|'STATUS_FAILED'|'STATUS_SUCCESSFUL'|'STATUS_RUNNING'|'STATUS_SCHEDULED'|'STATUS_UNKNOWN', userId: ?string, appId: string, input: array<string, list<numeric|string>|numeric|string>, output: ?array<string, list<numeric|string>|numeric|string>, customId: ?string, completionExpectedAt: ?int, progress: ?float, scheduledAt: ?int, startedAt: ?int, endedAt: ?int}
+	 * @return bool
+	 * @since 32.0.0
+	 */
+	final public function getCleanup(): bool {
+		return $this->cleanup;
+	}
+
+	/**
+	 * @param bool $cleanup
+	 * @since 32.0.0
+	 */
+	final public function setCleanup(bool $cleanup): void {
+		$this->cleanup = $cleanup;
+	}
+
+	/**
+	 * @psalm-return array{id: int, lastUpdated: int, type: string, status: 'STATUS_CANCELLED'|'STATUS_FAILED'|'STATUS_SUCCESSFUL'|'STATUS_RUNNING'|'STATUS_SCHEDULED'|'STATUS_UNKNOWN', userId: ?string, appId: string, input: array<string, list<numeric|string>|numeric|string>, output: ?array<string, list<numeric|string>|numeric|string>, customId: ?string, completionExpectedAt: ?int, progress: ?float, scheduledAt: ?int, startedAt: ?int, endedAt: ?int, cleanup: bool}
 	 * @since 30.0.0
 	 */
 	final public function jsonSerialize(): array {
@@ -272,6 +289,7 @@ final class Task implements \JsonSerializable {
 			'scheduledAt' => $this->getScheduledAt(),
 			'startedAt' => $this->getStartedAt(),
 			'endedAt' => $this->getEndedAt(),
+			'cleanup' => $this->getCleanup(),
 		];
 	}
 

--- a/lib/public/TaskProcessing/Task.php
+++ b/lib/public/TaskProcessing/Task.php
@@ -66,7 +66,7 @@ final class Task implements \JsonSerializable {
 	protected ?int $scheduledAt = null;
 	protected ?int $startedAt = null;
 	protected ?int $endedAt = null;
-	protected bool $cleanup = true;
+	protected bool $allowCleanup = true;
 
 	/**
 	 * @param string $taskTypeId
@@ -257,20 +257,20 @@ final class Task implements \JsonSerializable {
 	 * @return bool
 	 * @since 32.0.0
 	 */
-	final public function getCleanup(): bool {
-		return $this->cleanup;
+	final public function getAllowCleanup(): bool {
+		return $this->allowCleanup;
 	}
 
 	/**
-	 * @param bool $cleanup
+	 * @param bool $allowCleanup
 	 * @since 32.0.0
 	 */
-	final public function setCleanup(bool $cleanup): void {
-		$this->cleanup = $cleanup;
+	final public function setAllowCleanup(bool $allowCleanup): void {
+		$this->allowCleanup = $allowCleanup;
 	}
 
 	/**
-	 * @psalm-return array{id: int, lastUpdated: int, type: string, status: 'STATUS_CANCELLED'|'STATUS_FAILED'|'STATUS_SUCCESSFUL'|'STATUS_RUNNING'|'STATUS_SCHEDULED'|'STATUS_UNKNOWN', userId: ?string, appId: string, input: array<string, list<numeric|string>|numeric|string>, output: ?array<string, list<numeric|string>|numeric|string>, customId: ?string, completionExpectedAt: ?int, progress: ?float, scheduledAt: ?int, startedAt: ?int, endedAt: ?int, cleanup: bool}
+	 * @psalm-return array{id: int, lastUpdated: int, type: string, status: 'STATUS_CANCELLED'|'STATUS_FAILED'|'STATUS_SUCCESSFUL'|'STATUS_RUNNING'|'STATUS_SCHEDULED'|'STATUS_UNKNOWN', userId: ?string, appId: string, input: array<string, list<numeric|string>|numeric|string>, output: ?array<string, list<numeric|string>|numeric|string>, customId: ?string, completionExpectedAt: ?int, progress: ?float, scheduledAt: ?int, startedAt: ?int, endedAt: ?int, allowCleanup: bool}
 	 * @since 30.0.0
 	 */
 	final public function jsonSerialize(): array {
@@ -289,7 +289,7 @@ final class Task implements \JsonSerializable {
 			'scheduledAt' => $this->getScheduledAt(),
 			'startedAt' => $this->getStartedAt(),
 			'endedAt' => $this->getEndedAt(),
-			'cleanup' => $this->getCleanup(),
+			'allowCleanup' => $this->getAllowCleanup(),
 		];
 	}
 

--- a/openapi.json
+++ b/openapi.json
@@ -677,7 +677,8 @@
                     "progress",
                     "scheduledAt",
                     "startedAt",
-                    "endedAt"
+                    "endedAt",
+                    "cleanup"
                 ],
                 "properties": {
                     "id": {
@@ -748,6 +749,9 @@
                         "type": "integer",
                         "format": "int64",
                         "nullable": true
+                    },
+                    "cleanup": {
+                        "type": "boolean"
                     }
                 }
             },

--- a/openapi.json
+++ b/openapi.json
@@ -678,7 +678,7 @@
                     "scheduledAt",
                     "startedAt",
                     "endedAt",
-                    "cleanup"
+                    "allowCleanup"
                 ],
                 "properties": {
                     "id": {
@@ -750,7 +750,7 @@
                         "format": "int64",
                         "nullable": true
                     },
-                    "cleanup": {
+                    "allowCleanup": {
                         "type": "boolean"
                     }
                 }

--- a/tests/lib/TaskProcessing/TaskProcessingTest.php
+++ b/tests/lib/TaskProcessing/TaskProcessingTest.php
@@ -972,11 +972,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		// run background job
 		$bgJob = new RemoveOldTasksBackgroundJob(
 			$timeFactory,
-			$this->taskMapper,
 			$this->manager,
-			Server::get(IRootFolder::class),
-			Server::get(LoggerInterface::class),
-			Server::get(IAppDataFactory::class),
 		);
 		$bgJob->setArgument([]);
 		$bgJob->start($this->jobList);

--- a/tests/lib/TaskProcessing/TaskProcessingTest.php
+++ b/tests/lib/TaskProcessing/TaskProcessingTest.php
@@ -973,6 +973,8 @@ class TaskProcessingTest extends \Test\TestCase {
 		$bgJob = new RemoveOldTasksBackgroundJob(
 			$timeFactory,
 			$this->taskMapper,
+			$this->manager,
+			Server::get(IRootFolder::class),
 			Server::get(LoggerInterface::class),
 			Server::get(IAppDataFactory::class),
 		);

--- a/tests/lib/TaskProcessing/TaskProcessingTest.php
+++ b/tests/lib/TaskProcessing/TaskProcessingTest.php
@@ -943,11 +943,6 @@ class TaskProcessingTest extends \Test\TestCase {
 		$timeFactory->expects($this->any())->method('getDateTime')->willReturnCallback(fn () => $currentTime);
 		$timeFactory->expects($this->any())->method('getTime')->willReturnCallback(fn () => $currentTime->getTimestamp());
 
-		$this->taskMapper = new TaskMapper(
-			Server::get(IDBConnection::class),
-			$timeFactory,
-		);
-
 		$this->registrationContext->expects($this->any())->method('getTaskProcessingProviders')->willReturn([
 			new ServiceRegistration('test', SuccessfulSyncProvider::class)
 		]);
@@ -968,11 +963,34 @@ class TaskProcessingTest extends \Test\TestCase {
 
 		$task = $this->manager->getTask($task->getId());
 
+		$taskMapper = new TaskMapper(
+			Server::get(IDBConnection::class),
+			$timeFactory,
+		);
+		$manager = new Manager(
+			$this->appConfig,
+			$this->coordinator,
+			$this->serverContainer,
+			Server::get(LoggerInterface::class),
+			$taskMapper,
+			$this->jobList,
+			Server::get(IEventDispatcher::class),
+			Server::get(IAppDataFactory::class),
+			Server::get(IRootFolder::class),
+			Server::get(\OC\TextToImage\Manager::class),
+			$this->userMountCache,
+			Server::get(IClientService::class),
+			Server::get(IAppManager::class),
+			Server::get(IUserManager::class),
+			Server::get(IUserSession::class),
+			Server::get(ICacheFactory::class),
+		);
 		$currentTime = $currentTime->add(new \DateInterval('P1Y'));
 		// run background job
 		$bgJob = new RemoveOldTasksBackgroundJob(
 			$timeFactory,
-			$this->manager,
+			// use a locally defined manager to make sure the taskMapper uses the mocked timeFactory
+			$manager,
 		);
 		$bgJob->setArgument([]);
 		$bgJob->start($this->jobList);

--- a/version.php
+++ b/version.php
@@ -9,7 +9,7 @@
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch level
 // when updating major/minor version number.
 
-$OC_Version = [32, 0, 0, 2];
+$OC_Version = [32, 0, 0, 3];
 
 // The human-readable string
 $OC_VersionString = '32.0.0 dev';


### PR DESCRIPTION
## Summary

This is useful for the assistant audio chat for example. We don't cleanup the chat message history so we need to prevent cleaning up the AudioChat tasks. Those tasks are deleted when the chat history is deleted.

## Changes proposed in this PR:
* Move `TaskProcessingApiController::extractFileIdsFromTask` to `OCP\TaskProcessing\IManager` to be able to use it elsewhere
* Add the cleanup column to oc_taskprocessing_tasks
* Adjust the `OC\TaskProcessing\Db\Task` entity class
* Change the cleanup logic: It used to delete the old tasks and then the old files (based on their MTime) in `appData/TaskProcessing`. It now gets the list of old tasks to cleanup, gets the list of output files for those tasks and delete them. It then deletes the old tasks.
* Bump NC version number
* Generate autoload files
* Implement a `taskprocessing:task:cleanup` occ command
* Move the cleanup methods from the bg job class to the manager so they can be used by the command and the bg job

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
