### PR TITLE
feat(filecache): Scale DB query created when deleting file from filecache

### DIFF
--- a/apps/files/lib/AppInfo/Application.php
+++ b/apps/files/lib/AppInfo/Application.php
@@ -37,7 +37,7 @@ use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Collaboration\Reference\RenderReferenceEvent;
 use OCP\Collaboration\Resources\IProviderManager;
-use OCP\Files\Cache\CacheEntryRemovedEvent;
+use OCP\Files\Cache\CacheEntriesRemovedEvent;
 use OCP\Files\Events\Node\BeforeNodeCopiedEvent;
 use OCP\Files\Events\Node\BeforeNodeDeletedEvent;
 use OCP\Files\Events\Node\BeforeNodeRenamedEvent;
@@ -115,7 +115,7 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(RenderReferenceEvent::class, RenderReferenceEventListener::class);
 		$context->registerEventListener(BeforeNodeRenamedEvent::class, SyncLivePhotosListener::class);
 		$context->registerEventListener(BeforeNodeDeletedEvent::class, SyncLivePhotosListener::class);
-		$context->registerEventListener(CacheEntryRemovedEvent::class, SyncLivePhotosListener::class, 1); // Ensure this happen before the metadata are deleted.
+		$context->registerEventListener(CacheEntriesRemovedEvent::class, SyncLivePhotosListener::class, 1); // Ensure this happen before the metadata are deleted.
 		$context->registerEventListener(BeforeNodeCopiedEvent::class, SyncLivePhotosListener::class);
 		$context->registerEventListener(NodeCopiedEvent::class, SyncLivePhotosListener::class);
 		$context->registerEventListener(LoadSearchPlugins::class, LoadSearchPluginsListener::class);

--- a/apps/files/lib/Service/LivePhotosService.php
+++ b/apps/files/lib/Service/LivePhotosService.php
@@ -33,4 +33,22 @@ class LivePhotosService {
 
 		return (int)$metadata->getString('files-live-photo');
 	}
+
+	/**
+	 * Get the associated live photo for multiple file ids
+	 * @param int[] $fileIds
+	 * @return int[]
+	 */
+	public function getLivePhotoPeerIds(array $fileIds): array {
+		$metadata = $this->filesMetadataManager->getMetadataForFiles($fileIds);
+		$peersIds = [];
+		foreach ($metadata as $item) {
+			if (!$item->hasKey('files-live-photo')) {
+				continue;
+			}
+
+			$peersIds[] = (int)$item->getString('files-live-photo');
+		}
+		return $peersIds;
+	}
 }

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -403,6 +403,7 @@ return array(
     'OCP\\Files\\AlreadyExistsException' => $baseDir . '/lib/public/Files/AlreadyExistsException.php',
     'OCP\\Files\\AppData\\IAppDataFactory' => $baseDir . '/lib/public/Files/AppData/IAppDataFactory.php',
     'OCP\\Files\\Cache\\AbstractCacheEvent' => $baseDir . '/lib/public/Files/Cache/AbstractCacheEvent.php',
+    'OCP\\Files\\Cache\\CacheEntriesRemovedEvent' => $baseDir . '/lib/public/Files/Cache/CacheEntriesRemovedEvent.php',
     'OCP\\Files\\Cache\\CacheEntryInsertedEvent' => $baseDir . '/lib/public/Files/Cache/CacheEntryInsertedEvent.php',
     'OCP\\Files\\Cache\\CacheEntryRemovedEvent' => $baseDir . '/lib/public/Files/Cache/CacheEntryRemovedEvent.php',
     'OCP\\Files\\Cache\\CacheEntryUpdatedEvent' => $baseDir . '/lib/public/Files/Cache/CacheEntryUpdatedEvent.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -444,6 +444,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Files\\AlreadyExistsException' => __DIR__ . '/../../..' . '/lib/public/Files/AlreadyExistsException.php',
         'OCP\\Files\\AppData\\IAppDataFactory' => __DIR__ . '/../../..' . '/lib/public/Files/AppData/IAppDataFactory.php',
         'OCP\\Files\\Cache\\AbstractCacheEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/AbstractCacheEvent.php',
+        'OCP\\Files\\Cache\\CacheEntriesRemovedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/CacheEntriesRemovedEvent.php',
         'OCP\\Files\\Cache\\CacheEntryInsertedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/CacheEntryInsertedEvent.php',
         'OCP\\Files\\Cache\\CacheEntryRemovedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/CacheEntryRemovedEvent.php',
         'OCP\\Files\\Cache\\CacheEntryUpdatedEvent' => __DIR__ . '/../../..' . '/lib/public/Files/Cache/CacheEntryUpdatedEvent.php',

--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -20,7 +20,7 @@ use OCP\DB\Exception;
 use OCP\DB\Exception as DBException;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
-use OCP\Files\Cache\CacheEntryRemovedEvent;
+use OCP\Files\Cache\CacheEntriesRemovedEvent;
 use OCP\Files\Events\Node\NodeWrittenEvent;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Node;
@@ -214,6 +214,20 @@ class FilesMetadataManager implements IFilesMetadataManager {
 		}
 	}
 
+	public function deleteMetadataForFiles(array $fileIds): void {
+		try {
+			$this->metadataRequestService->dropMetadataForFiles($fileIds);
+		} catch (Exception $e) {
+			$this->logger->warning('issue while deleteMetadata', ['exception' => $e, 'fileIds' => $fileIds]);
+		}
+
+		try {
+			$this->indexRequestService->dropIndexForFiles($fileIds);
+		} catch (Exception $e) {
+			$this->logger->warning('issue while deleteMetadata', ['exception' => $e, 'fileIds' => $fileIds]);
+		}
+	}
+
 	/**
 	 * @param IQueryBuilder $qb
 	 * @param string $fileTableAlias alias of the table that contains data about files
@@ -301,6 +315,6 @@ class FilesMetadataManager implements IFilesMetadataManager {
 	 */
 	public static function loadListeners(IEventDispatcher $eventDispatcher): void {
 		$eventDispatcher->addServiceListener(NodeWrittenEvent::class, MetadataUpdate::class);
-		$eventDispatcher->addServiceListener(CacheEntryRemovedEvent::class, MetadataDelete::class);
+		$eventDispatcher->addServiceListener(CacheEntriesRemovedEvent::class, MetadataDelete::class);
 	}
 }

--- a/lib/private/FilesMetadata/FilesMetadataManager.php
+++ b/lib/private/FilesMetadata/FilesMetadataManager.php
@@ -214,9 +214,9 @@ class FilesMetadataManager implements IFilesMetadataManager {
 		}
 	}
 
-	public function deleteMetadataForFiles(array $fileIds): void {
+	public function deleteMetadataForFiles(int $storage, array $fileIds): void {
 		try {
-			$this->metadataRequestService->dropMetadataForFiles($fileIds);
+			$this->metadataRequestService->dropMetadataForFiles($storage, $fileIds);
 		} catch (Exception $e) {
 			$this->logger->warning('issue while deleteMetadata', ['exception' => $e, 'fileIds' => $fileIds]);
 		}

--- a/lib/private/FilesMetadata/Listener/MetadataDelete.php
+++ b/lib/private/FilesMetadata/Listener/MetadataDelete.php
@@ -33,18 +33,21 @@ class MetadataDelete implements IEventListener {
 		}
 
 		$entries = $event->getCacheEntryRemovedEvents();
-		$fileIds = [];
+		$storageToFileIds = [];
 
 		foreach ($entries as $entry) {
 			try {
-				$fileIds[] = $entry->getFileId();
+				$storageToFileIds[$entry->getStorageId()] ??= [];
+				$storageToFileIds[$entry->getStorageId()][] = $entry->getFileId();
 			} catch (Exception $e) {
 				$this->logger->warning('issue while running MetadataDelete', ['exception' => $e]);
 			}
 		}
 
 		try {
-			$this->filesMetadataManager->deleteMetadataForFiles($fileIds);
+			foreach ($storageToFileIds as $storageId => $fileIds) {
+				$this->filesMetadataManager->deleteMetadataForFiles($storageId, $fileIds);
+			}
 		} catch (Exception $e) {
 			$this->logger->warning('issue while running MetadataDelete', ['exception' => $e]);
 		}

--- a/lib/private/FilesMetadata/Listener/MetadataDelete.php
+++ b/lib/private/FilesMetadata/Listener/MetadataDelete.php
@@ -11,14 +11,14 @@ namespace OC\FilesMetadata\Listener;
 use Exception;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\Files\Cache\CacheEntryRemovedEvent;
+use OCP\Files\Cache\CacheEntriesRemovedEvent;
 use OCP\FilesMetadata\IFilesMetadataManager;
 use Psr\Log\LoggerInterface;
 
 /**
  * Handle file deletion event and remove stored metadata related to the deleted file
  *
- * @template-implements IEventListener<CacheEntryRemovedEvent>
+ * @template-implements IEventListener<CacheEntriesRemovedEvent>
  */
 class MetadataDelete implements IEventListener {
 	public function __construct(
@@ -28,15 +28,23 @@ class MetadataDelete implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!($event instanceof CacheEntryRemovedEvent)) {
+		if (!($event instanceof CacheEntriesRemovedEvent)) {
 			return;
 		}
 
-		try {
-			$nodeId = $event->getFileId();
-			if ($nodeId > 0) {
-				$this->filesMetadataManager->deleteMetadata($nodeId);
+		$entries = $event->getCacheEntryRemovedEvents();
+		$fileIds = [];
+
+		foreach ($entries as $entry) {
+			try {
+				$fileIds[] = $entry->getFileId();
+			} catch (Exception $e) {
+				$this->logger->warning('issue while running MetadataDelete', ['exception' => $e]);
 			}
+		}
+
+		try {
+			$this->filesMetadataManager->deleteMetadataForFiles($fileIds);
 		} catch (Exception $e) {
 			$this->logger->warning('issue while running MetadataDelete', ['exception' => $e]);
 		}

--- a/lib/private/FilesMetadata/Service/MetadataRequestService.php
+++ b/lib/private/FilesMetadata/Service/MetadataRequestService.php
@@ -147,16 +147,16 @@ class MetadataRequestService {
 
 	/**
 	 * @param int[] $fileIds
-	 * @return void
 	 * @throws Exception
 	 */
-	public function dropMetadataForFiles(array $fileIds): void {
+	public function dropMetadataForFiles(int $storage, array $fileIds): void {
 		$chunks = array_chunk($fileIds, 1000);
 
 		foreach ($chunks as $chunk) {
 			$qb = $this->dbConnection->getQueryBuilder();
 			$qb->delete(self::TABLE_METADATA)
-				->where($qb->expr()->in('file_id', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)));
+				->where($qb->expr()->in('file_id', $qb->createNamedParameter($fileIds, IQueryBuilder::PARAM_INT_ARRAY)))
+				->hintShardKey('storage', $storage);
 			$qb->executeStatement();
 		}
 	}

--- a/lib/public/Files/Cache/CacheEntriesRemovedEvent.php
+++ b/lib/public/Files/Cache/CacheEntriesRemovedEvent.php
@@ -8,26 +8,28 @@ declare(strict_types=1);
  */
 namespace OCP\Files\Cache;
 
+use OCP\AppFramework\Attribute\Listenable;
 use OCP\EventDispatcher\Event;
 
 /**
  * Meta-event wrapping multiple CacheEntryRemovedEvent for when an existing
  * entry in the cache gets removed.
  *
- * @since 32.0.0
+ * @since 34.0.0
  */
-#[\OCP\AppFramework\Attribute\Listenable(since: '32.0.0')]
+#[Listenable(since: '34.0.0')]
 class CacheEntriesRemovedEvent extends Event {
 	/**
-	 * @param CacheEntryRemovedEvent[] $cacheEntryRemovedEvents
+	 * @param ICacheEvent[] $cacheEntryRemovedEvents
 	 */
 	public function __construct(
 		private readonly array $cacheEntryRemovedEvents,
 	) {
+		Event::__construct();
 	}
 
 	/**
-	 * @return CacheEntryRemovedEvent[]
+	 * @return ICacheEvent[]
 	 */
 	public function getCacheEntryRemovedEvents(): array {
 		return $this->cacheEntryRemovedEvents;

--- a/lib/public/Files/Cache/CacheEntriesRemovedEvent.php
+++ b/lib/public/Files/Cache/CacheEntriesRemovedEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Files\Cache;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Meta-event wrapping multiple CacheEntryRemovedEvent for when an existing
+ * entry in the cache gets removed.
+ *
+ * @since 32.0.0
+ */
+#[\OCP\AppFramework\Attribute\Listenable(since: '32.0.0')]
+class CacheEntriesRemovedEvent extends Event {
+	/**
+	 * @param CacheEntryRemovedEvent[] $cacheEntryRemovedEvents
+	 */
+	public function __construct(
+		private readonly array $cacheEntryRemovedEvents,
+	) {
+	}
+
+	/**
+	 * @return CacheEntryRemovedEvent[]
+	 */
+	public function getCacheEntryRemovedEvents(): array {
+		return $this->cacheEntryRemovedEvents;
+	}
+}

--- a/lib/public/Files/Cache/CacheEntryRemovedEvent.php
+++ b/lib/public/Files/Cache/CacheEntryRemovedEvent.php
@@ -11,7 +11,7 @@ namespace OCP\Files\Cache;
 /**
  * Event for when an existing entry in the cache gets removed
  *
- * Prefer using \c CacheEntriesRemovedEvent as it is more efficient when deleting
+ * Prefer using CacheEntriesRemovedEvent as it is more efficient when deleting
  * multiple files at the same time.
  *
  * @since 21.0.0

--- a/lib/public/Files/Cache/CacheEntryRemovedEvent.php
+++ b/lib/public/Files/Cache/CacheEntryRemovedEvent.php
@@ -11,7 +11,11 @@ namespace OCP\Files\Cache;
 /**
  * Event for when an existing entry in the cache gets removed
  *
+ * Prefer using \c CacheEntriesRemovedEvent as it is more efficient when deleting
+ * multiple files at the same time.
+ *
  * @since 21.0.0
+ * @see CacheEntriesRemovedEvent
  */
 class CacheEntryRemovedEvent extends AbstractCacheEvent implements ICacheEvent {
 }

--- a/lib/public/FilesMetadata/IFilesMetadataManager.php
+++ b/lib/public/FilesMetadata/IFilesMetadataManager.php
@@ -103,11 +103,12 @@ interface IFilesMetadataManager {
 	/**
 	 * Delete metadata and its indexes of multiple file ids
 	 *
+	 * @param int $storage The storage id coresponding to the $fileIds
 	 * @param array<int> $fileIds file ids
 	 * @return void
 	 * @since 32.0.0
 	 */
-	public function deleteMetadataForFiles(array $fileIds): void;
+	public function deleteMetadataForFiles(int $storage, array $fileIds): void;
 
 	/**
 	 * generate and return a MetadataQuery to help building sql queries

--- a/lib/public/FilesMetadata/IFilesMetadataManager.php
+++ b/lib/public/FilesMetadata/IFilesMetadataManager.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCP\FilesMetadata;
 
+use OCP\AppFramework\Attribute\Consumable;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Node;
 use OCP\FilesMetadata\Exceptions\FilesMetadataException;
@@ -20,6 +21,7 @@ use OCP\FilesMetadata\Model\IMetadataValueWrapper;
  *
  * @since 28.0.0
  */
+#[Consumable(since: '28.0.0')]
 interface IFilesMetadataManager {
 	/** @since 28.0.0 */
 	public const PROCESS_LIVE = 1;
@@ -97,6 +99,15 @@ interface IFilesMetadataManager {
 	 * @since 28.0.0
 	 */
 	public function deleteMetadata(int $fileId): void;
+
+	/**
+	 * Delete metadata and its indexes of multiple file ids
+	 *
+	 * @param array<int> $fileIds file ids
+	 * @return void
+	 * @since 32.0.0
+	 */
+	public function deleteMetadataForFiles(array $fileIds): void;
 
 	/**
 	 * generate and return a MetadataQuery to help building sql queries


### PR DESCRIPTION
Instead of creating a CacheEntryRemovedEvent for each deleted files, create a single CacheEntriesRemovedEvent which wrap multiple CacheEntryRemovedEvent.

This allow listener to optimize the query they do when multiple files are deleted at the same time (e.g. when deleting a folder).

* Resolves: #54274 

## Summary

Instead of creating a CacheEntryRemovedEvent for each deleted files, create a single CacheEntriesRemovedEvent which wrap multiple CacheEntryRemovedEvent.

This allow listener to optimize the query they do when multiple files are deleted at the same time (e.g. when deleting a folder).

For a folder with 10 files inside, the number of query created by the DELETE http request went from 72-75 to 42

<img width="913" height="606" alt="image" src="https://github.com/user-attachments/assets/a86ed634-4ca9-4521-b187-6e585ab750b4" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
