### PR TITLE
fix(container): Don't use deprecated things to set up controllers for apps

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -134,8 +134,7 @@ class App {
 		$eventLogger->start('app:controller:dispatcher', 'Initialize dispatcher and pre-middleware');
 
 		// initialize the dispatcher and run all the middleware before the controller
-		/** @var Dispatcher $dispatcher */
-		$dispatcher = $container['Dispatcher'];
+		$dispatcher = $container->get(Dispatcher::class);
 
 		$eventLogger->end('app:controller:dispatcher');
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -63,7 +63,7 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 class DIContainer extends SimpleContainer implements IAppContainer {
-	private string $appName;
+	protected string $appName;
 	private array $middleWares = [];
 	private ServerContainer $server;
 

--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -152,7 +152,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 		$this->registerDeprecatedAlias('Dispatcher', Dispatcher::class);
 		$this->registerService(Dispatcher::class, function (ContainerInterface $c) {
 			return new Dispatcher(
-				$c->get('Protocol'),
+				$c->get(Http::class),
 				$c->get(MiddlewareDispatcher::class),
 				$c->get(IControllerMethodReflector::class),
 				$c->get(IRequest::class),

--- a/lib/private/AppFramework/Utility/SimpleContainer.php
+++ b/lib/private/AppFramework/Utility/SimpleContainer.php
@@ -196,7 +196,9 @@ class SimpleContainer implements ArrayAccess, ContainerInterface, IContainer {
 		$this->registerService($alias, function (ContainerInterface $container) use ($target, $alias): mixed {
 			try {
 				$logger = $container->get(LoggerInterface::class);
-				$logger->debug('The requested alias "' . $alias . '" is deprecated. Please request "' . $target . '" directly. This alias will be removed in a future Nextcloud version.', ['app' => 'serverDI']);
+				$logger->debug('The requested alias "' . $alias . '" is deprecated. Please request "' . $target . '" directly. This alias will be removed in a future Nextcloud version.', [
+					'app' => $this->appName ?? 'serverDI',
+				]);
 			} catch (ContainerExceptionInterface $e) {
 				// Could not get logger. Continue
 			}


### PR DESCRIPTION
### Before
<img width="1818" height="500" alt="grafik" src="https://github.com/user-attachments/assets/9c88e2b6-57bc-4350-9123-5d205376f64c" />

### With app being logged
<img width="1818" height="500" alt="grafik" src="https://github.com/user-attachments/assets/acc056aa-0202-4e9f-aed9-aba0586091b2" />


### After fixing Dispatcher
<img width="1818" height="426" alt="grafik" src="https://github.com/user-attachments/assets/94486c4b-4db6-44b7-bd66-0beae2eaaa21" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
