### PR TITLE
refactor(App): \OC\AppFramework\App clean-up

### DIFF
--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -71,7 +71,6 @@ class App {
 		return null;
 	}
 
-
 	/**
 	 * Shortcut for calling a controller method and printing the result
 	 *
@@ -82,7 +81,12 @@ class App {
 	 * @param array $urlParams list of URL parameters (optional)
 	 * @throws HintException
 	 */
-	public static function main(string $controllerName, string $methodName, DIContainer $container, ?array $urlParams = null) {
+	public static function main(
+		string $controllerName,
+		string $methodName,
+		DIContainer $container,
+		?array $urlParams = null,
+	): void {
 		/** @var IProfiler $profiler */
 		$profiler = $container->get(IProfiler::class);
 		$eventLogger = $container->get(IEventLogger::class);
@@ -210,26 +214,5 @@ class App {
 				$io->setOutput($output);
 			}
 		}
-	}
-
-	/**
-	 * Shortcut for calling a controller method and printing the result.
-	 * Similar to App:main except that no headers will be sent.
-	 *
-	 * @param string $controllerName the name of the controller under which it is
-	 *                               stored in the DI container
-	 * @param string $methodName the method that you want to call
-	 * @param array $urlParams an array with variables extracted from the routes
-	 * @param DIContainer $container an instance of a pimple container.
-	 */
-	public static function part(string $controllerName, string $methodName, array $urlParams,
-		DIContainer $container) {
-		$container['urlParams'] = $urlParams;
-		$controller = $container[$controllerName];
-
-		$dispatcher = $container['Dispatcher'];
-
-		[, , $output] = $dispatcher->dispatch($controller, $methodName);
-		return $output;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #n/a<!-- related github issue -->

## Summary

* Dead code removal: 
  - `part()` method
    - not used anywhere
    - has also been broken for >10 years (since the [return layout array](https://github.com/nextcloud/server/blob/5660a73a3d4afe8bfd891cd1a9fc32a6bb3aa575/lib/private/AppFramework/Http/Dispatcher.php#L95-L99) changed on `dispatcher()`)
    - Ref: 0481390
* Code formatting

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
