### PR TITLE
fix: use correct return value for `has-preview` dav property

### DIFF
--- a/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
@@ -104,8 +104,8 @@ class TrashbinPlugin extends ServerPlugin {
 			return $node->getFileId();
 		});
 
-		$propFind->handle(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, function () use ($node) {
-			return $this->previewManager->isAvailable($node->getFileInfo());
+		$propFind->handle(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, function () use ($node): string {
+			return $this->previewManager->isAvailable($node->getFileInfo()) ? 'true' : 'false';
 		});
 
 		$propFind->handle(FilesPlugin::MOUNT_TYPE_PROPERTYNAME, function () {

--- a/apps/files_versions/lib/Sabre/Plugin.php
+++ b/apps/files_versions/lib/Sabre/Plugin.php
@@ -82,7 +82,10 @@ class Plugin extends ServerPlugin {
 		if ($node instanceof VersionFile) {
 			$propFind->handle(self::VERSION_LABEL, fn () => $node->getMetadataValue(self::LABEL));
 			$propFind->handle(self::VERSION_AUTHOR, fn () => $node->getMetadataValue(self::AUTHOR));
-			$propFind->handle(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, fn () => $this->previewManager->isMimeSupported($node->getContentType()));
+			$propFind->handle(
+				FilesPlugin::HAS_PREVIEW_PROPERTYNAME,
+				fn (): string => $this->previewManager->isMimeSupported($node->getContentType()) ? 'true' : 'false',
+			);
 		}
 	}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/54255

## Summary

The DAV property must have the value `true` or `false`, but for the trashbin and the versions we did not correctly return it.
Instead we just returned the boolean value, but a boolean in PHP will be casted to an integer of either 1 or 0.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
