### PR TITLE
fix(trashbin): Fix n+1 issue in propfind in trash root

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -264,6 +264,7 @@ return array(
     'OCA\\DAV\\Controller\\UpcomingEventsController' => $baseDir . '/../lib/Controller/UpcomingEventsController.php',
     'OCA\\DAV\\DAV\\CustomPropertiesBackend' => $baseDir . '/../lib/DAV/CustomPropertiesBackend.php',
     'OCA\\DAV\\DAV\\GroupPrincipalBackend' => $baseDir . '/../lib/DAV/GroupPrincipalBackend.php',
+    'OCA\\DAV\\DAV\\ICacheableDirectory' => $baseDir . '/../lib/DAV/ICacheableDirectory.php',
     'OCA\\DAV\\DAV\\PublicAuth' => $baseDir . '/../lib/DAV/PublicAuth.php',
     'OCA\\DAV\\DAV\\RemoteUserPrincipalBackend' => $baseDir . '/../lib/DAV/RemoteUserPrincipalBackend.php',
     'OCA\\DAV\\DAV\\Sharing\\Backend' => $baseDir . '/../lib/DAV/Sharing/Backend.php',

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -268,6 +268,7 @@ return array(
     'OCA\\DAV\\Controller\\UpcomingEventsController' => $baseDir . '/../lib/Controller/UpcomingEventsController.php',
     'OCA\\DAV\\DAV\\CustomPropertiesBackend' => $baseDir . '/../lib/DAV/CustomPropertiesBackend.php',
     'OCA\\DAV\\DAV\\GroupPrincipalBackend' => $baseDir . '/../lib/DAV/GroupPrincipalBackend.php',
+    'OCA\\DAV\\DAV\\ICacheableDirectory' => $baseDir . '/../lib/DAV/ICacheableDirectory.php',
     'OCA\\DAV\\DAV\\PublicAuth' => $baseDir . '/../lib/DAV/PublicAuth.php',
     'OCA\\DAV\\DAV\\RemoteUserPrincipalBackend' => $baseDir . '/../lib/DAV/RemoteUserPrincipalBackend.php',
     'OCA\\DAV\\DAV\\Security\\RateLimiting' => $baseDir . '/../lib/DAV/Security/RateLimiting.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -279,6 +279,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Controller\\UpcomingEventsController' => __DIR__ . '/..' . '/../lib/Controller/UpcomingEventsController.php',
         'OCA\\DAV\\DAV\\CustomPropertiesBackend' => __DIR__ . '/..' . '/../lib/DAV/CustomPropertiesBackend.php',
         'OCA\\DAV\\DAV\\GroupPrincipalBackend' => __DIR__ . '/..' . '/../lib/DAV/GroupPrincipalBackend.php',
+        'OCA\\DAV\\DAV\\ICacheableDirectory' => __DIR__ . '/..' . '/../lib/DAV/ICacheableDirectory.php',
         'OCA\\DAV\\DAV\\PublicAuth' => __DIR__ . '/..' . '/../lib/DAV/PublicAuth.php',
         'OCA\\DAV\\DAV\\RemoteUserPrincipalBackend' => __DIR__ . '/..' . '/../lib/DAV/RemoteUserPrincipalBackend.php',
         'OCA\\DAV\\DAV\\Sharing\\Backend' => __DIR__ . '/..' . '/../lib/DAV/Sharing/Backend.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -283,6 +283,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Controller\\UpcomingEventsController' => __DIR__ . '/..' . '/../lib/Controller/UpcomingEventsController.php',
         'OCA\\DAV\\DAV\\CustomPropertiesBackend' => __DIR__ . '/..' . '/../lib/DAV/CustomPropertiesBackend.php',
         'OCA\\DAV\\DAV\\GroupPrincipalBackend' => __DIR__ . '/..' . '/../lib/DAV/GroupPrincipalBackend.php',
+        'OCA\\DAV\\DAV\\ICacheableDirectory' => __DIR__ . '/..' . '/../lib/DAV/ICacheableDirectory.php',
         'OCA\\DAV\\DAV\\PublicAuth' => __DIR__ . '/..' . '/../lib/DAV/PublicAuth.php',
         'OCA\\DAV\\DAV\\RemoteUserPrincipalBackend' => __DIR__ . '/..' . '/../lib/DAV/RemoteUserPrincipalBackend.php',
         'OCA\\DAV\\DAV\\Security\\RateLimiting' => __DIR__ . '/..' . '/../lib/DAV/Security/RateLimiting.php',

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -48,8 +48,7 @@ class Directory extends Node implements
 	\Sabre\DAV\IMoveTarget,
 	\Sabre\DAV\ICopyTarget,
 	INodeByPath,
-	ICacheableDirectory
-{
+	ICacheableDirectory {
 	/**
 	 * Cached directory content
 	 * @var FileInfo[]

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -14,6 +14,7 @@ use OCA\DAV\AppInfo\Application;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\DAV\ICacheableDirectory;
 use OCA\DAV\Storage\PublicShareWrapper;
 use OCP\App\IAppManager;
 use OCP\Constants;
@@ -46,7 +47,9 @@ class Directory extends Node implements
 	\Sabre\DAV\IQuota,
 	\Sabre\DAV\IMoveTarget,
 	\Sabre\DAV\ICopyTarget,
-	INodeByPath {
+	INodeByPath,
+	ICacheableDirectory
+{
 	/**
 	 * Cached directory content
 	 * @var FileInfo[]
@@ -562,5 +565,9 @@ class Directory extends Node implements
 		}
 
 		return $node;
+	}
+
+	public function getCacheableDirectories(): array {
+		return [$this->getNode()];
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -14,6 +14,7 @@ use OCA\DAV\AppInfo\Application;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
 use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\DAV\Connector\Sabre\Exception\InvalidPath;
+use OCA\DAV\DAV\ICacheableDirectory;
 use OCA\DAV\Storage\PublicShareWrapper;
 use OCP\App\IAppManager;
 use OCP\Constants;
@@ -47,7 +48,9 @@ class Directory extends Node implements
 	\Sabre\DAV\IQuota,
 	\Sabre\DAV\IMoveTarget,
 	\Sabre\DAV\ICopyTarget,
-	INodeByPath {
+	INodeByPath,
+	ICacheableDirectory
+{
 	/**
 	 * Cached directory content
 	 * @var FileInfo[]
@@ -572,5 +575,9 @@ class Directory extends Node implements
 		}
 
 		return $node;
+	}
+
+	public function getCacheableDirectories(): array {
+		return [$this->getNode()];
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -49,8 +49,7 @@ class Directory extends Node implements
 	\Sabre\DAV\IMoveTarget,
 	\Sabre\DAV\ICopyTarget,
 	INodeByPath,
-	ICacheableDirectory
-{
+	ICacheableDirectory {
 	/**
 	 * Cached directory content
 	 * @var FileInfo[]
@@ -577,6 +576,7 @@ class Directory extends Node implements
 		return $node;
 	}
 
+	#[\Override]
 	public function getCacheableDirectories(): array {
 		return [$this->getNode()];
 	}

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -19,8 +19,6 @@ use OCA\DAV\CalDAV\Outbox;
 use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Db\PropertyMapper;
-use OCA\DAV\Connector\Sabre\FilesPlugin;
-use OCA\Files_Trashbin\Sabre\TrashRoot;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Folder;
 use OCP\IDBConnection;
@@ -211,12 +209,10 @@ class CustomPropertiesBackend implements BackendInterface {
 		}
 
 		$node = $this->tree->getNodeForPath($path);
-		if (($node instanceof Directory) && $propFind->getDepth() !== 0) {
-			$this->cacheDirectory($path, $node->getNode());
-		} else if ($node instanceof TrashRoot) {
-			$trashNodes = $node->getTrashRoots();
-			foreach ($trashNodes as $trashNode) {
-				$this->cacheDirectory($path, $trashNode);
+		if (($node instanceof ICacheableDirectory) && $propFind->getDepth() !== 0) {
+			$directoriesToPrefetch = $node->getCacheableDirectories();
+			foreach ($directoriesToPrefetch as $directory) {
+				$this->cacheDirectory($path, $directory);
 			}
 		}
 

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -19,8 +19,6 @@ use OCA\DAV\CalDAV\Outbox;
 use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Db\PropertyMapper;
-use OCA\DAV\Connector\Sabre\FilesPlugin;
-use OCA\Files_Trashbin\Sabre\TrashRoot;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Files\Folder;
 use OCP\IDBConnection;
@@ -242,12 +240,10 @@ class CustomPropertiesBackend implements BackendInterface {
 		}
 
 		$node = $this->tree->getNodeForPath($path);
-		if (($node instanceof Directory) && $propFind->getDepth() !== 0) {
-			$this->cacheDirectory($path, $node->getNode());
-		} else if ($node instanceof TrashRoot) {
-			$trashNodes = $node->getTrashRoots();
-			foreach ($trashNodes as $trashNode) {
-				$this->cacheDirectory($path, $trashNode);
+		if (($node instanceof ICacheableDirectory) && $propFind->getDepth() !== 0) {
+			$directoriesToPrefetch = $node->getCacheableDirectories();
+			foreach ($directoriesToPrefetch as $directory) {
+				$this->cacheDirectory($path, $directory);
 			}
 		}
 

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -19,7 +19,10 @@ use OCA\DAV\CalDAV\Outbox;
 use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Db\PropertyMapper;
+use OCA\DAV\Connector\Sabre\FilesPlugin;
+use OCA\Files_Trashbin\Sabre\TrashRoot;
 use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\Folder;
 use OCP\IDBConnection;
 use OCP\IUser;
 use Override;
@@ -239,8 +242,13 @@ class CustomPropertiesBackend implements BackendInterface {
 		}
 
 		$node = $this->tree->getNodeForPath($path);
-		if ($node instanceof Directory && $propFind->getDepth() !== 0) {
-			$this->cacheDirectory($path, $node);
+		if (($node instanceof Directory) && $propFind->getDepth() !== 0) {
+			$this->cacheDirectory($path, $node->getNode());
+		} else if ($node instanceof TrashRoot) {
+			$trashNodes = $node->getTrashRoots();
+			foreach ($trashNodes as $trashNode) {
+				$this->cacheDirectory($path, $trashNode);
+			}
 		}
 
 		if ($node instanceof CalendarHome && $propFind->getDepth() !== 0) {
@@ -387,18 +395,17 @@ class CustomPropertiesBackend implements BackendInterface {
 	/**
 	 * Prefetch all user properties in a directory
 	 */
-	private function cacheDirectory(string $path, Directory $node): void {
+	private function cacheDirectory(string $path, Folder $node): void {
 		$prefix = ltrim($path . '/', '/');
 		$query = $this->connection->getQueryBuilder();
 		$query->select('name', 'p.propertypath', 'p.propertyname', 'p.propertyvalue', 'p.valuetype')
 			->from('filecache', 'f')
-			->hintShardKey('storage', $node->getNode()->getMountPoint()->getNumericStorageId())
+			->hintShardKey('storage', $node->getMountPoint()->getNumericStorageId())
 			->leftJoin('f', 'properties', 'p', $query->expr()->eq('p.propertypath', $query->func()->concat(
 				$query->createNamedParameter($prefix),
 				'f.name'
-			)),
-			)
-			->where($query->expr()->eq('parent', $query->createNamedParameter($node->getInternalFileId(), IQueryBuilder::PARAM_INT)))
+			)))
+			->where($query->expr()->eq('parent', $query->createNamedParameter($node->getId(), IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->orX(
 				$query->expr()->eq('p.userid', $query->createNamedParameter($this->user->getUID())),
 				$query->expr()->isNull('p.userid'),

--- a/apps/dav/lib/DAV/ICacheableDirectory.php
+++ b/apps/dav/lib/DAV/ICacheableDirectory.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OCA\DAV\DAV;
+
+use OCP\Files\Folder;
+
+interface ICacheableDirectory {
+	/**
+	 * @return Folder[]
+	 */
+	public function getCacheableDirectories(): array;
+}

--- a/apps/dav/lib/DAV/ICacheableDirectory.php
+++ b/apps/dav/lib/DAV/ICacheableDirectory.php
@@ -1,5 +1,11 @@
 <?php
 
+declare (strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
 namespace OCA\DAV\DAV;
 
 use OCP\Files\Folder;

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -13,12 +13,18 @@ use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\FileInfo;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IUser;
+use OCP\Server;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
 
 class TrashRoot implements ICollection {
+	private ?Folder $trashFilesRoot = null;
 
 	public function __construct(
 		private IUser $user,
@@ -89,5 +95,12 @@ class TrashRoot implements ICollection {
 
 	public function getLastModified(): int {
 		return 0;
+	}
+
+	/**
+	 * @return Folder[]
+	 */
+	public function getTrashRoots(): array {
+		return $this->trashManager->getTrashRootsForUser($this->user);
 	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -8,24 +8,19 @@ declare(strict_types=1);
  */
 namespace OCA\Files_Trashbin\Sabre;
 
+use OCA\DAV\DAV\ICacheableDirectory;
 use OCA\Files_Trashbin\Service\ConfigService;
 use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
-use OCP\Files\IRootFolder;
-use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
 use OCP\IUser;
-use OCP\Server;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
 
-class TrashRoot implements ICollection {
-	private ?Folder $trashFilesRoot = null;
-
+class TrashRoot implements ICollection, ICacheableDirectory {
 	public function __construct(
 		private IUser $user,
 		private ITrashManager $trashManager,
@@ -100,7 +95,7 @@ class TrashRoot implements ICollection {
 	/**
 	 * @return Folder[]
 	 */
-	public function getTrashRoots(): array {
-		return $this->trashManager->getTrashRootsForUser($this->user);
+	public function getCacheableDirectories(): array {
+		return $this->trashManager->getCacheableRootsForUser($this->user);
 	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -15,7 +15,6 @@ use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\FileInfo;
-use OCP\Files\Folder;
 use OCP\IUser;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
@@ -102,9 +101,7 @@ class TrashRoot implements ICollection, ICacheableDirectory {
 		return 0;
 	}
 
-	/**
-	 * @return Folder[]
-	 */
+	#[\Override]
 	public function getCacheableDirectories(): array {
 		return $this->trashManager->getCacheableRootsForUser($this->user);
 	}

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -14,12 +14,18 @@ use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\FileInfo;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IUser;
+use OCP\Server;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
 
 class TrashRoot implements ICollection {
+	private ?Folder $trashFilesRoot = null;
 
 	public function __construct(
 		private IUser $user,
@@ -99,5 +105,12 @@ class TrashRoot implements ICollection {
 	#[\Override]
 	public function getLastModified(): int {
 		return 0;
+	}
+
+	/**
+	 * @return Folder[]
+	 */
+	public function getTrashRoots(): array {
+		return $this->trashManager->getTrashRootsForUser($this->user);
 	}
 }

--- a/apps/files_trashbin/lib/Sabre/TrashRoot.php
+++ b/apps/files_trashbin/lib/Sabre/TrashRoot.php
@@ -9,24 +9,19 @@ declare(strict_types=1);
 
 namespace OCA\Files_Trashbin\Sabre;
 
+use OCA\DAV\DAV\ICacheableDirectory;
 use OCA\Files_Trashbin\Service\ConfigService;
 use OCA\Files_Trashbin\Trash\ITrashItem;
 use OCA\Files_Trashbin\Trash\ITrashManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Files\FileInfo;
 use OCP\Files\Folder;
-use OCP\Files\IRootFolder;
-use OCP\Files\NotFoundException;
-use OCP\Files\NotPermittedException;
 use OCP\IUser;
-use OCP\Server;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
 
-class TrashRoot implements ICollection {
-	private ?Folder $trashFilesRoot = null;
-
+class TrashRoot implements ICollection, ICacheableDirectory {
 	public function __construct(
 		private IUser $user,
 		private ITrashManager $trashManager,
@@ -110,7 +105,7 @@ class TrashRoot implements ICollection {
 	/**
 	 * @return Folder[]
 	 */
-	public function getTrashRoots(): array {
-		return $this->trashManager->getTrashRootsForUser($this->user);
+	public function getCacheableDirectories(): array {
+		return $this->trashManager->getCacheableRootsForUser($this->user);
 	}
 }

--- a/apps/files_trashbin/lib/Trash/ITrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/ITrashBackend.php
@@ -67,8 +67,11 @@ interface ITrashBackend {
 	public function getTrashNodeById(IUser $user, int $fileId);
 
 	/**
+	 * Returns a non-exhaustive list of folder which can then be used to pre-fetch some metadata
+	 * * for the trash root.
+	 *
 	 * @return Folder[]
 	 * @since 32.0.0
 	 */
-	public function getTrashRootsForUser(IUser $user): array;
+	public function getCacheableRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/ITrashBackend.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Trashbin\Trash;
 
+use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\Files\Storage\IStorage;
 use OCP\IUser;
@@ -64,4 +65,10 @@ interface ITrashBackend {
 	 * @return Node|null
 	 */
 	public function getTrashNodeById(IUser $user, int $fileId);
+
+	/**
+	 * @return Folder[]
+	 * @since 32.0.0
+	 */
+	public function getTrashRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/ITrashBackend.php
@@ -68,10 +68,10 @@ interface ITrashBackend {
 
 	/**
 	 * Returns a non-exhaustive list of folder which can then be used to pre-fetch some metadata
-	 * * for the trash root.
+	 * for the trash root.
 	 *
 	 * @return Folder[]
-	 * @since 32.0.0
+	 * @since 34.0.0
 	 */
 	public function getCacheableRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/ITrashBackend.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OCA\Files_Trashbin\Trash;
 
+use OCP\Files\Folder;
 use OCP\Files\Node;
 use OCP\Files\Storage\IStorage;
 use OCP\IUser;
@@ -67,4 +68,10 @@ interface ITrashBackend {
 	 * @return Node|null
 	 */
 	public function getTrashNodeById(IUser $user, int $fileId);
+
+	/**
+	 * @return Folder[]
+	 * @since 32.0.0
+	 */
+	public function getTrashRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/ITrashBackend.php
@@ -71,10 +71,10 @@ interface ITrashBackend {
 
 	/**
 	 * Returns a non-exhaustive list of folder which can then be used to pre-fetch some metadata
-	 * * for the trash root.
+	 * for the trash root.
 	 *
 	 * @return Folder[]
-	 * @since 32.0.0
+	 * @since 35.0.0
 	 */
 	public function getCacheableRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/ITrashBackend.php
@@ -70,8 +70,11 @@ interface ITrashBackend {
 	public function getTrashNodeById(IUser $user, int $fileId);
 
 	/**
+	 * Returns a non-exhaustive list of folder which can then be used to pre-fetch some metadata
+	 * * for the trash root.
+	 *
 	 * @return Folder[]
 	 * @since 32.0.0
 	 */
-	public function getTrashRootsForUser(IUser $user): array;
+	public function getCacheableRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashManager.php
+++ b/apps/files_trashbin/lib/Trash/ITrashManager.php
@@ -38,4 +38,9 @@ interface ITrashManager extends ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function resumeTrash();
+
+	/**
+	 * @since 32.0.0
+	 */
+	public function getTrashRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashManager.php
+++ b/apps/files_trashbin/lib/Trash/ITrashManager.php
@@ -38,9 +38,4 @@ interface ITrashManager extends ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function resumeTrash();
-
-	/**
-	 * @since 32.0.0
-	 */
-	public function getTrashRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashManager.php
+++ b/apps/files_trashbin/lib/Trash/ITrashManager.php
@@ -42,9 +42,4 @@ interface ITrashManager extends ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function resumeTrash();
-
-	/**
-	 * @since 32.0.0
-	 */
-	public function getTrashRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/ITrashManager.php
+++ b/apps/files_trashbin/lib/Trash/ITrashManager.php
@@ -42,4 +42,9 @@ interface ITrashManager extends ITrashBackend {
 	 * @since 15.0.0
 	 */
 	public function resumeTrash();
+
+	/**
+	 * @since 32.0.0
+	 */
+	public function getTrashRootsForUser(IUser $user): array;
 }

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -4,9 +4,11 @@
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Files_Trashbin\Trash;
 
 use OC\Files\Filesystem;
+use OC\Files\Node\LazyFolder;
 use OC\Files\View;
 use OCA\Files_Trashbin\Helper;
 use OCA\Files_Trashbin\Storage;
@@ -16,8 +18,10 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
+use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
 
 class LegacyTrashBackend implements ITrashBackend {
 	/** @var array */
@@ -119,8 +123,29 @@ class LegacyTrashBackend implements ITrashBackend {
 		}
 	}
 
-	public function getTrashRootsForUser(IUser $user): array {
+	public function getCacheableRootsForUser(IUser $user): array {
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
-		return [$userFolder->getParent()->get('files_trashbin/files')];
+		$connection = Server::get(IDBConnection::class);
+		$qb = $connection->getQueryBuilder();
+		$qb->select('fileid', 'storage')
+			->from('filecache')
+			->hintShardKey('storage', $userFolder->getMountPoint()->getNumericStorageId())
+			->where($qb->expr()->eq('path_hash', $qb->createNamedParameter(md5('files_trashbin/files'))));
+		$result = $qb->executeQuery()->fetchAll();
+
+		if (count($result) === 0) {
+			return [];
+		}
+
+		return [
+			new LazyFolder(
+				$this->rootFolder,
+				fn () => $userFolder->getParent()->get('files_trashbin/files'),
+				[
+					'fileid' => $result[0]['fileid'],
+					'mountpoint_numericStorageId' => $result[0]['storage'],
+				]
+			)
+		];
 	}
 }

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -118,4 +118,9 @@ class LegacyTrashBackend implements ITrashBackend {
 			return null;
 		}
 	}
+
+	public function getTrashRootsForUser(IUser $user): array {
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		return [$userFolder->getParent()->get('files_trashbin/files')];
+	}
 }

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -125,4 +125,9 @@ class LegacyTrashBackend implements ITrashBackend {
 			return null;
 		}
 	}
+
+	public function getTrashRootsForUser(IUser $user): array {
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		return [$userFolder->getParent()->get('files_trashbin/files')];
+	}
 }

--- a/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
+++ b/apps/files_trashbin/lib/Trash/LegacyTrashBackend.php
@@ -8,6 +8,7 @@
 namespace OCA\Files_Trashbin\Trash;
 
 use OC\Files\Filesystem;
+use OC\Files\Node\LazyFolder;
 use OC\Files\View;
 use OCA\Files_Trashbin\Helper;
 use OCA\Files_Trashbin\Storage;
@@ -17,8 +18,10 @@ use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\Storage\IStorage;
+use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\Server;
 
 class LegacyTrashBackend implements ITrashBackend {
 	/** @var array */
@@ -126,8 +129,30 @@ class LegacyTrashBackend implements ITrashBackend {
 		}
 	}
 
-	public function getTrashRootsForUser(IUser $user): array {
+	#[\Override]
+	public function getCacheableRootsForUser(IUser $user): array {
 		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
-		return [$userFolder->getParent()->get('files_trashbin/files')];
+		$connection = Server::get(IDBConnection::class);
+		$qb = $connection->getQueryBuilder();
+		$qb->select('fileid', 'storage')
+			->from('filecache')
+			->hintShardKey('storage', $userFolder->getMountPoint()->getNumericStorageId())
+			->where($qb->expr()->eq('path_hash', $qb->createNamedParameter(md5('files_trashbin/files'))));
+		$result = $qb->executeQuery()->fetchAll();
+
+		if (count($result) === 0) {
+			return [];
+		}
+
+		return [
+			new LazyFolder(
+				$this->rootFolder,
+				fn () => $userFolder->getParent()->get('files_trashbin/files'),
+				[
+					'fileid' => $result[0]['fileid'],
+					'mountpoint_numericStorageId' => $result[0]['storage'],
+				]
+			)
+		];
 	}
 }

--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -108,4 +108,10 @@ class TrashManager implements ITrashManager {
 	public function resumeTrash() {
 		$this->trashPaused = false;
 	}
+
+	public function getTrashRootsForUser(IUser $user): array {
+		return array_reduce($this->getBackends(), function (array $items, ITrashBackend $backend) use ($user) {
+			return array_merge($items, $backend->getTrashRootsForUser($user));
+		}, []);
+	}
 }

--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -109,9 +109,8 @@ class TrashManager implements ITrashManager {
 		$this->trashPaused = false;
 	}
 
-	public function getTrashRootsForUser(IUser $user): array {
-		return array_reduce($this->getBackends(), function (array $items, ITrashBackend $backend) use ($user) {
-			return array_merge($items, $backend->getTrashRootsForUser($user));
-		}, []);
+	public function getCacheableRootsForUser(IUser $user): array {
+		return array_reduce($this->getBackends(),
+			fn (array $items, ITrashBackend $backend) => array_merge($items, $backend->getCacheableRootsForUser($user)), []);
 	}
 }

--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -119,9 +119,8 @@ class TrashManager implements ITrashManager {
 		$this->trashPaused = false;
 	}
 
-	public function getTrashRootsForUser(IUser $user): array {
-		return array_reduce($this->getBackends(), function (array $items, ITrashBackend $backend) use ($user) {
-			return array_merge($items, $backend->getTrashRootsForUser($user));
-		}, []);
+	public function getCacheableRootsForUser(IUser $user): array {
+		return array_reduce($this->getBackends(),
+			fn (array $items, ITrashBackend $backend) => array_merge($items, $backend->getCacheableRootsForUser($user)), []);
 	}
 }

--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -118,4 +118,10 @@ class TrashManager implements ITrashManager {
 	public function resumeTrash() {
 		$this->trashPaused = false;
 	}
+
+	public function getTrashRootsForUser(IUser $user): array {
+		return array_reduce($this->getBackends(), function (array $items, ITrashBackend $backend) use ($user) {
+			return array_merge($items, $backend->getTrashRootsForUser($user));
+		}, []);
+	}
 }

--- a/apps/files_trashbin/lib/Trash/TrashManager.php
+++ b/apps/files_trashbin/lib/Trash/TrashManager.php
@@ -119,6 +119,7 @@ class TrashManager implements ITrashManager {
 		$this->trashPaused = false;
 	}
 
+	#[\Override]
 	public function getCacheableRootsForUser(IUser $user): array {
 		return array_reduce($this->getBackends(),
 			fn (array $items, ITrashBackend $backend) => array_merge($items, $backend->getCacheableRootsForUser($user)), []);

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1739,6 +1739,7 @@ return array(
     'OC\\Files\\Lock\\LockManager' => $baseDir . '/lib/private/Files/Lock/LockManager.php',
     'OC\\Files\\Mount\\CacheMountProvider' => $baseDir . '/lib/private/Files/Mount/CacheMountProvider.php',
     'OC\\Files\\Mount\\HomeMountPoint' => $baseDir . '/lib/private/Files/Mount/HomeMountPoint.php',
+    'OC\\Files\\Mount\\LazyMountPoint' => $baseDir . '/lib/private/Files/Mount/LazyMountPoint.php',
     'OC\\Files\\Mount\\LocalHomeMountProvider' => $baseDir . '/lib/private/Files/Mount/LocalHomeMountProvider.php',
     'OC\\Files\\Mount\\Manager' => $baseDir . '/lib/private/Files/Mount/Manager.php',
     'OC\\Files\\Mount\\MountPoint' => $baseDir . '/lib/private/Files/Mount/MountPoint.php',

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1777,6 +1777,7 @@ return array(
     'OC\\Files\\Lock\\LockManager' => $baseDir . '/lib/private/Files/Lock/LockManager.php',
     'OC\\Files\\Mount\\CacheMountProvider' => $baseDir . '/lib/private/Files/Mount/CacheMountProvider.php',
     'OC\\Files\\Mount\\HomeMountPoint' => $baseDir . '/lib/private/Files/Mount/HomeMountPoint.php',
+    'OC\\Files\\Mount\\LazyMountPoint' => $baseDir . '/lib/private/Files/Mount/LazyMountPoint.php',
     'OC\\Files\\Mount\\LocalHomeMountProvider' => $baseDir . '/lib/private/Files/Mount/LocalHomeMountProvider.php',
     'OC\\Files\\Mount\\Manager' => $baseDir . '/lib/private/Files/Mount/Manager.php',
     'OC\\Files\\Mount\\MountPoint' => $baseDir . '/lib/private/Files/Mount/MountPoint.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1780,6 +1780,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Files\\Lock\\LockManager' => __DIR__ . '/../../..' . '/lib/private/Files/Lock/LockManager.php',
         'OC\\Files\\Mount\\CacheMountProvider' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/CacheMountProvider.php',
         'OC\\Files\\Mount\\HomeMountPoint' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/HomeMountPoint.php',
+        'OC\\Files\\Mount\\LazyMountPoint' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/LazyMountPoint.php',
         'OC\\Files\\Mount\\LocalHomeMountProvider' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/LocalHomeMountProvider.php',
         'OC\\Files\\Mount\\Manager' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/Manager.php',
         'OC\\Files\\Mount\\MountPoint' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/MountPoint.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1818,6 +1818,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Files\\Lock\\LockManager' => __DIR__ . '/../../..' . '/lib/private/Files/Lock/LockManager.php',
         'OC\\Files\\Mount\\CacheMountProvider' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/CacheMountProvider.php',
         'OC\\Files\\Mount\\HomeMountPoint' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/HomeMountPoint.php',
+        'OC\\Files\\Mount\\LazyMountPoint' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/LazyMountPoint.php',
         'OC\\Files\\Mount\\LocalHomeMountProvider' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/LocalHomeMountProvider.php',
         'OC\\Files\\Mount\\Manager' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/Manager.php',
         'OC\\Files\\Mount\\MountPoint' => __DIR__ . '/../../..' . '/lib/private/Files/Mount/MountPoint.php',

--- a/lib/private/Files/Mount/LazyMountPoint.php
+++ b/lib/private/Files/Mount/LazyMountPoint.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+namespace OC\Files\Mount;
+
+use OCP\Files\Mount\IMountPoint;
+
+class LazyMountPoint implements IMountPoint {
+	private ?IMountPoint $mountPoint = null;
+
+	/**
+	 * @param \Closure(): IMountPoint $mountPointClosure
+	 */
+	public function __construct(
+		private readonly \Closure $mountPointClosure,
+		private readonly array $data,
+	) {
+	}
+
+	private function getRealMountPoint(): IMountPoint {
+		if ($this->mountPoint === null) {
+			$this->mountPoint = call_user_func($this->mountPointClosure);
+		}
+		return $this->mountPoint;
+	}
+
+	public function __call($method, $args) {
+		return call_user_func_array([$this->getRealMountPoint(), $method], $args);
+	}
+
+	public function getMountPoint() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function setMountPoint($mountPoint) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	private function createStorage() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getStorage() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getStorageId(): ?string {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getNumericStorageId(): int {
+		if (isset($this->data['numericStorageId'])) {
+			return $this->data['numericStorageId'];
+		}
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getInternalPath($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function wrapStorage($wrapper): void {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getOption($name, $default) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getOptions(): array {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getStorageRootId(): int {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getMountId() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getMountType() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	public function getMountProvider(): string {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+}

--- a/lib/private/Files/Mount/LazyMountPoint.php
+++ b/lib/private/Files/Mount/LazyMountPoint.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OC\Files\Mount;
+
+use OCP\Files\Mount\IMountPoint;
+
+class LazyMountPoint implements IMountPoint {
+	private ?IMountPoint $mountPoint = null;
+
+	/**
+	 * @param \Closure(): IMountPoint $mountPointClosure
+	 */
+	public function __construct(
+		private readonly \Closure $mountPointClosure,
+		private readonly array $data,
+	) {
+	}
+
+	private function getRealMountPoint(): IMountPoint {
+		if ($this->mountPoint === null) {
+			$this->mountPoint = call_user_func($this->mountPointClosure);
+		}
+		return $this->mountPoint;
+	}
+
+	public function __call($method, $args) {
+		return call_user_func_array([$this->getRealMountPoint(), $method], $args);
+	}
+
+	#[\Override]
+	public function getMountPoint() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function setMountPoint($mountPoint) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	private function createStorage() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getStorage() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getStorageId(): ?string {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getNumericStorageId(): int {
+		if (isset($this->data['numericStorageId'])) {
+			return $this->data['numericStorageId'];
+		}
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getInternalPath($path) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function wrapStorage($wrapper): void {
+		$this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getOption($name, $default) {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getOptions(): array {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getStorageRootId(): int {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getMountId() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getMountType() {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+
+	#[\Override]
+	public function getMountProvider(): string {
+		return $this->__call(__FUNCTION__, func_get_args());
+	}
+}

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace OC\Files\Node;
 
 use OC\Files\Filesystem;
+use OC\Files\Mount\LazyMountPoint;
 use OC\Files\Utils\PathHelper;
 use OCP\Constants;
 use OCP\Files\Folder;
@@ -373,7 +374,15 @@ class LazyFolder implements Folder {
 	 * @inheritDoc
 	 */
 	public function getMountPoint() {
-		return $this->__call(__FUNCTION__, func_get_args());
+		if (array_any(array_keys($this->data), fn ($key) => str_starts_with($key, 'mountpoint_'))) {
+			return new LazyMountPoint(function () {
+				return $this->__call('getMountPoint', func_get_args());
+			}, [
+				'numericStorageId' => $this->data['mountpoint_numericStorageId'],
+			]);
+		} else {
+			return $this->__call(__FUNCTION__, func_get_args());
+		}
 	}
 
 	/**

--- a/lib/private/Files/Node/LazyFolder.php
+++ b/lib/private/Files/Node/LazyFolder.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\Files\Node;
 
 use OC\Files\Filesystem;
+use OC\Files\Mount\LazyMountPoint;
 use OC\Files\Utils\PathHelper;
 use OCP\Constants;
 use OCP\Files\Cache\ICacheEntry;
@@ -401,7 +402,15 @@ class LazyFolder implements Folder {
 	 */
 	#[\Override]
 	public function getMountPoint() {
-		return $this->__call(__FUNCTION__, func_get_args());
+		if (array_any(array_keys($this->data), fn ($key) => str_starts_with($key, 'mountpoint_'))) {
+			return new LazyMountPoint(function () {
+				return $this->__call('getMountPoint', func_get_args());
+			}, [
+				'numericStorageId' => $this->data['mountpoint_numericStorageId'],
+			]);
+		} else {
+			return $this->__call(__FUNCTION__, func_get_args());
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

CustomPropertiesBackend is already able to cache the custom properties of a folder content. But the trash root is not a Directory but instead just a ICollection, so extend CacheEntry to also handle a TrashEntry.

DB queries before (with around 30 entries in trash, around half from a groupfolder):

<img width="1170" height="162" alt="image" src="https://github.com/user-attachments/assets/9d56af38-629c-4801-9cf3-fb6057ff46d9" />

DB queries after:

<img width="1090" height="155" alt="image" src="https://github.com/user-attachments/assets/879058fb-a384-4d74-8401-9e7bd972e79d" />

## TODO

- [x] https://github.com/nextcloud/groupfolders/pull/3913
- [ ] Check if we have any other ITrashBackend implementation 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
