### PR TITLE
Feat/54115/emit preload collection event

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -217,6 +217,7 @@ return array(
     'OCA\\DAV\\Connector\\Sabre\\ObjectTree' => $baseDir . '/../lib/Connector/Sabre/ObjectTree.php',
     'OCA\\DAV\\Connector\\Sabre\\Principal' => $baseDir . '/../lib/Connector/Sabre/Principal.php',
     'OCA\\DAV\\Connector\\Sabre\\PropFindMonitorPlugin' => $baseDir . '/../lib/Connector/Sabre/PropFindMonitorPlugin.php',
+    'OCA\\DAV\\Connector\\Sabre\\PropFindPreloadNotifyPlugin' => $baseDir . '/../lib/Connector/Sabre/PropFindPreloadNotifyPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\PropfindCompressionPlugin' => $baseDir . '/../lib/Connector/Sabre/PropfindCompressionPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\PublicAuth' => $baseDir . '/../lib/Connector/Sabre/PublicAuth.php',
     'OCA\\DAV\\Connector\\Sabre\\QuotaPlugin' => $baseDir . '/../lib/Connector/Sabre/QuotaPlugin.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -232,6 +232,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Connector\\Sabre\\ObjectTree' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ObjectTree.php',
         'OCA\\DAV\\Connector\\Sabre\\Principal' => __DIR__ . '/..' . '/../lib/Connector/Sabre/Principal.php',
         'OCA\\DAV\\Connector\\Sabre\\PropFindMonitorPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PropFindMonitorPlugin.php',
+        'OCA\\DAV\\Connector\\Sabre\\PropFindPreloadNotifyPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PropFindPreloadNotifyPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\PropfindCompressionPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PropfindCompressionPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\PublicAuth' => __DIR__ . '/..' . '/../lib/Connector/Sabre/PublicAuth.php',
         'OCA\\DAV\\Connector\\Sabre\\QuotaPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/QuotaPlugin.php',

--- a/apps/dav/lib/CalDAV/EmbeddedCalDavServer.php
+++ b/apps/dav/lib/CalDAV/EmbeddedCalDavServer.php
@@ -20,6 +20,7 @@ use OCA\DAV\Connector\Sabre\DavAclPlugin;
 use OCA\DAV\Connector\Sabre\ExceptionLoggerPlugin;
 use OCA\DAV\Connector\Sabre\LockPlugin;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
+use OCA\DAV\Connector\Sabre\PropFindPreloadNotifyPlugin;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\DAV\RootCollection;
 use OCA\Theming\ThemingDefaults;
@@ -95,6 +96,9 @@ class EmbeddedCalDavServer {
 		if ($appConfig->getValueString('dav', 'sendInvitations', 'yes') === 'yes') {
 			$this->server->addPlugin(Server::get(\OCA\DAV\CalDAV\Schedule\IMipPlugin::class));
 		}
+
+		// collection preload plugin
+		$this->server->addPlugin(new PropFindPreloadNotifyPlugin());
 
 		// wait with registering these until auth is handled and the filesystem is setup
 		$this->server->on('beforeMethod:*', function () use ($root): void {

--- a/apps/dav/lib/Connector/Sabre/PropFindPreloadNotifyPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/PropFindPreloadNotifyPlugin.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types = 1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Connector\Sabre;
+
+use Sabre\DAV\ICollection;
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+
+/**
+ * This plugin asks other plugins to preload data for a collection, so that
+ * subsequent PROPFIND handlers for children do not query the DB on a per-node
+ * basis.
+ */
+class PropFindPreloadNotifyPlugin extends ServerPlugin {
+
+	private Server $server;
+
+	public function initialize(Server $server): void {
+		$this->server = $server;
+		$this->server->on('propFind', [$this, 'collectionPreloadNotifier' ], 1);
+	}
+
+	/**
+	 * Uses the server instance to emit a `preloadCollection` event to signal
+	 * to interested plugins that a collection can be preloaded.
+	 *
+	 * NOTE: this can be emitted several times, so ideally every plugin
+	 * should cache what they need and check if a cache exists before
+	 * re-fetching.
+	 */
+	public function collectionPreloadNotifier(PropFind $propFind, INode $node): bool {
+		if (!$this->shouldPreload($propFind, $node)) {
+			return true;
+		}
+
+		return $this->server->emit('preloadCollection', [$propFind, $node]);
+	}
+
+	private function shouldPreload(
+		PropFind $propFind,
+		INode $node,
+	): bool {
+		$depth = $propFind->getDepth();
+		return $node instanceof ICollection
+			&& ($depth === Server::DEPTH_INFINITY || $depth > 0);
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -94,6 +94,8 @@ class ServerFactory {
 			$server->debugEnabled = $debugEnabled;
 			$server->addPlugin(new PropFindMonitorPlugin());
 		}
+
+		$server->addPlugin(new PropFindPreloadNotifyPlugin());
 		// FIXME: The following line is a workaround for legacy components relying on being able to send a GET to /
 		$server->addPlugin(new DummyGetResponsePlugin());
 		$server->addPlugin(new ExceptionLoggerPlugin('webdav', $this->logger));

--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -98,28 +98,28 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 		];
 
 		foreach ($requestedShareTypes as $requestedShareType) {
-			$result = array_merge($result, $this->shareManager->getSharesBy(
+			$result[] = $this->shareManager->getSharesBy(
 				$this->userId,
 				$requestedShareType,
 				$node,
 				false,
 				-1
-			));
+			);
 
 			// Also check for shares where the user is the recipient
 			try {
-				$result = array_merge($result, $this->shareManager->getSharedWith(
+				$result[] = $this->shareManager->getSharedWith(
 					$this->userId,
 					$requestedShareType,
 					$node,
 					-1
-				));
+				);
 			} catch (BackendError $e) {
 				// ignore
 			}
 		}
 
-		return $result;
+		return array_merge(...$result);
 	}
 
 	/**

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -46,6 +46,7 @@ use OCA\DAV\Connector\Sabre\LockPlugin;
 use OCA\DAV\Connector\Sabre\MaintenancePlugin;
 use OCA\DAV\Connector\Sabre\PropfindCompressionPlugin;
 use OCA\DAV\Connector\Sabre\PropFindMonitorPlugin;
+use OCA\DAV\Connector\Sabre\PropFindPreloadNotifyPlugin;
 use OCA\DAV\Connector\Sabre\QuotaPlugin;
 use OCA\DAV\Connector\Sabre\RequestIdHeaderPlugin;
 use OCA\DAV\Connector\Sabre\SharesPlugin;
@@ -237,6 +238,7 @@ class Server {
 			\OCP\Server::get(IUserSession::class)
 		));
 
+		// performance improvement plugins
 		$this->server->addPlugin(new CopyEtagHeaderPlugin());
 		$this->server->addPlugin(new RequestIdHeaderPlugin(\OCP\Server::get(IRequest::class)));
 		$this->server->addPlugin(new UploadAutoMkcolPlugin());
@@ -248,6 +250,7 @@ class Server {
 			$eventDispatcher,
 		));
 		$this->server->addPlugin(\OCP\Server::get(PaginatePlugin::class));
+		$this->server->addPlugin(new PropFindPreloadNotifyPlugin());
 
 		// allow setup of additional plugins
 		$eventDispatcher->dispatch('OCA\DAV\Connector\Sabre::addPlugin', $event);

--- a/apps/dav/tests/unit/Connector/Sabre/PropFindMonitorPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PropFindMonitorPluginTest.php
@@ -29,66 +29,76 @@ class PropFindMonitorPluginTest extends TestCase {
 			'No queries logged' => [[], 0],
 			'Plugins with queries in less than threshold nodes should not be logged' => [
 				[
-					[
-						'PluginName' => ['queries' => 100, 'nodes'
-							=> PropFindMonitorPlugin::THRESHOLD_NODES - 1]
-					],
-					[],
+					'propFind' => [
+						[
+							'PluginName' => [
+								'queries' => 100,
+								'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES - 1]
+						],
+						[],
+					]
 				],
 				0
 			],
 			'Plugins with query-to-node ratio less than threshold should not be logged' => [
 				[
-					[
-						'PluginName' => [
-							'queries' => $minQueriesTrigger - 1,
-							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES ],
-					],
-					[],
+					'propFind' => [
+						[
+							'PluginName' => [
+								'queries' => $minQueriesTrigger - 1,
+								'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES ],
+						],
+						[],
+					]
 				],
 				0
 			],
 			'Plugins with more nodes scanned than queries executed should not be logged' => [
 				[
-					[
-						'PluginName' => [
-							'queries' => $minQueriesTrigger,
-							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES * 2],
-					],
-					[],
+					'propFind' => [
+						[
+							'PluginName' => [
+								'queries' => $minQueriesTrigger,
+								'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES * 2],
+						],
+						[],]
 				],
 				0
 			],
 			'Plugins with queries only in highest depth level should not be logged' => [
 				[
-					[
-						'PluginName' => [
-							'queries' => $minQueriesTrigger,
-							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES - 1
-						]
-					],
-					[
-						'PluginName' => [
-							'queries' => $minQueriesTrigger * 2,
-							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES
-						]
+					'propFind' => [
+						[
+							'PluginName' => [
+								'queries' => $minQueriesTrigger,
+								'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES - 1
+							]
+						],
+						[
+							'PluginName' => [
+								'queries' => $minQueriesTrigger * 2,
+								'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES
+							]
+						],
 					]
 				],
 				0
 			],
 			'Plugins with too many queries should be logged' => [
 				[
-					[
-						'FirstPlugin' => [
-							'queries' => $minQueriesTrigger,
-							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES,
+					'propFind' => [
+						[
+							'FirstPlugin' => [
+								'queries' => $minQueriesTrigger,
+								'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES,
+							],
+							'SecondPlugin' => [
+								'queries' => $minQueriesTrigger,
+								'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES,
+							]
 						],
-						'SecondPlugin' => [
-							'queries' => $minQueriesTrigger,
-							'nodes' => PropFindMonitorPlugin::THRESHOLD_NODES,
-						]
-					],
-					[]
+						[],
+					]
 				],
 				2
 			]

--- a/apps/dav/tests/unit/Connector/Sabre/PropFindPreloadNotifyPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/PropFindPreloadNotifyPluginTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\PropFindPreloadNotifyPlugin;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\ICollection;
+use Sabre\DAV\IFile;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Test\TestCase;
+
+class PropFindPreloadNotifyPluginTest extends TestCase {
+
+	private Server&MockObject $server;
+	private PropFindPreloadNotifyPlugin $plugin;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->server = $this->createMock(Server::class);
+		$this->plugin = new PropFindPreloadNotifyPlugin();
+	}
+
+	public function testInitialize(): void {
+		$this->server
+			->expects(self::once())
+			->method('on')
+			->with('propFind',
+				$this->anything(), 1);
+		$this->plugin->initialize($this->server);
+	}
+
+	public static function dataTestCollectionPreloadNotifier(): array {
+		return [
+			'When node is not a collection, should not emit' => [
+				IFile::class,
+				1,
+				false,
+				true
+			],
+			'When node is a collection but depth is zero, should not emit' => [
+				ICollection::class,
+				0,
+				false,
+				true
+			],
+			'When node is a collection, and depth > 0, should emit' => [
+				ICollection::class,
+				1,
+				true,
+				true
+			],
+			'When node is a collection, and depth is infinite, should emit'
+			=> [
+				ICollection::class,
+				Server::DEPTH_INFINITY,
+				true,
+				true
+			],
+			'When called called handler returns false, it should be returned'
+			=> [
+				ICollection::class,
+				1,
+				true,
+				false
+			]
+		];
+	}
+
+	#[DataProvider(methodName: 'dataTestCollectionPreloadNotifier')]
+	public function testCollectionPreloadNotifier(string $nodeType, int $depth, bool $shouldEmit, bool $emitReturns):
+	void {
+		$this->plugin->initialize($this->server);
+		$propFind = $this->createMock(PropFind::class);
+		$propFind->expects(self::any())->method('getDepth')->willReturn($depth);
+		$node = $this->createMock($nodeType);
+
+		$expectation = $shouldEmit ? self::once() : self::never();
+		$this->server->expects($expectation)->method('emit')->with('preloadCollection',
+			[$propFind, $node])->willReturn($emitReturns);
+		$return = $this->plugin->collectionPreloadNotifier($propFind, $node);
+		$this->assertEquals($emitReturns, $return);
+	}
+}

--- a/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/SharesPluginTest.php
@@ -223,6 +223,7 @@ class SharesPluginTest extends \Test\TestCase {
 			0
 		);
 
+		$this->server->emit('preloadCollection', [$propFindRoot, $sabreNode]);
 		$this->plugin->handleGetProperties(
 			$propFindRoot,
 			$sabreNode

--- a/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/TagsPluginTest.php
@@ -147,6 +147,8 @@ class TagsPluginTest extends \Test\TestCase {
 			0
 		);
 
+		$this->server->emit('preloadCollection', [$propFindRoot, $node]);
+
 		$this->plugin->handleGetProperties(
 			$propFindRoot,
 			$node


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54115  <!-- related github issue -->

## Summary

This PR:

- is based off the work in #54114
- updates reporting that will be introduced from the above issue to track collection preload queries
- emits a new event `preloadCollection` in the DAV server to notify interested plugins that they can preload properties for a collection if needed.
- updates existing core plugins to use the `preloadCollection`

## TODO

- [ ] Add documentation
- [x] Add tests

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
