### PR TITLE
feat(lexicon): get value type from lexicon

### DIFF
--- a/apps/provisioning_api/lib/Controller/AppConfigController.php
+++ b/apps/provisioning_api/lib/Controller/AppConfigController.php
@@ -10,6 +10,7 @@ namespace OCA\Provisioning_API\Controller;
 
 use OC\AppConfig;
 use OC\AppFramework\Middleware\Security\Exceptions\NotAdminException;
+use OC\Config\ConfigManager;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\Attribute\NoAdminRequired;
@@ -38,6 +39,7 @@ class AppConfigController extends OCSController {
 		private IGroupManager $groupManager,
 		private IManager $settingManager,
 		private IAppManager $appManager,
+		private readonly ConfigManager $configManager,
 	) {
 		parent::__construct($appName, $request);
 	}
@@ -147,11 +149,11 @@ class AppConfigController extends OCSController {
 
 		/** @psalm-suppress InternalMethod */
 		match ($type) {
-			IAppConfig::VALUE_BOOL, ValueType::BOOL => $this->appConfig->setValueBool($app, $key, (bool)$value),
-			IAppConfig::VALUE_FLOAT, ValueType::FLOAT => $this->appConfig->setValueFloat($app, $key, (float)$value),
-			IAppConfig::VALUE_INT, ValueType::INT => $this->appConfig->setValueInt($app, $key, (int)$value),
+			IAppConfig::VALUE_BOOL, ValueType::BOOL => $this->appConfig->setValueBool($app, $key, $this->configManager->convertToBool($value)),
+			IAppConfig::VALUE_FLOAT, ValueType::FLOAT => $this->appConfig->setValueFloat($app, $key, $this->configManager->convertToFloat($value)),
+			IAppConfig::VALUE_INT, ValueType::INT => $this->appConfig->setValueInt($app, $key, $this->configManager->convertToInt($value)),
 			IAppConfig::VALUE_STRING, ValueType::STRING => $this->appConfig->setValueString($app, $key, $value),
-			IAppConfig::VALUE_ARRAY, ValueType::ARRAY => $this->appConfig->setValueArray($app, $key, \json_decode($value, true)),
+			IAppConfig::VALUE_ARRAY, ValueType::ARRAY => $this->appConfig->setValueArray($app, $key, $this->configManager->convertToArray($value)),
 			default => $this->appConfig->setValueMixed($app, $key, $value),
 		};
 

--- a/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
+++ b/apps/provisioning_api/tests/Controller/AppConfigControllerTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace OCA\Provisioning_API\Tests\Controller;
 
 use OC\AppConfig;
+use OC\Config\ConfigManager;
 use OCA\Provisioning_API\Controller\AppConfigController;
 use OCP\App\IAppManager;
 use OCP\AppFramework\Http;
@@ -38,6 +39,7 @@ class AppConfigControllerTest extends TestCase {
 	private IManager&MockObject $settingManager;
 	private IGroupManager&MockObject $groupManager;
 	private IAppManager $appManager;
+	private ConfigManager $configManager;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -48,6 +50,7 @@ class AppConfigControllerTest extends TestCase {
 		$this->settingManager = $this->createMock(IManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->appManager = Server::get(IAppManager::class);
+		$this->configManager = Server::get(ConfigManager::class);
 	}
 
 	/**
@@ -67,6 +70,7 @@ class AppConfigControllerTest extends TestCase {
 				$this->groupManager,
 				$this->settingManager,
 				$this->appManager,
+				$this->configManager,
 			);
 		} else {
 			return $this->getMockBuilder(AppConfigController::class)
@@ -79,6 +83,7 @@ class AppConfigControllerTest extends TestCase {
 					$this->groupManager,
 					$this->settingManager,
 					$this->appManager,
+					$this->configManager,
 				])
 				->onlyMethods($methods)
 				->getMock();


### PR DESCRIPTION
- get expected type when setting value from front-end
- convert instead of cast, so that 'yes' is considered boolean