### PR TITLE
views/UnifiedSearch: trigger on `f` input rather than qwerty keycode

### DIFF
--- a/core/src/views/UnifiedSearch.vue
+++ b/core/src/views/UnifiedSearch.vue
@@ -129,7 +129,7 @@ export default defineComponent({
 		 * @param event The keyboard event
 		 */
 		onKeyDown(event: KeyboardEvent) {
-			if (event.ctrlKey && event.code === 'KeyF') {
+			if (event.ctrlKey && event.key === 'f') {
 				// only handle search if not already open - in this case the browser native search should be used
 				if (!this.showLocalSearch && !this.showUnifiedSearch) {
 					event.preventDefault()


### PR DESCRIPTION
Before, search would trigger based on the physical keycode of the pressed key; whether that key would _represent_ f on a qwerty keyboard.

Anyone not typing qwerty will have search trigger on the same physical button, regardless of whether that button actually types `f` in their respective layout.

In my case, I use neo_qwerty which has a layer where the arrow keys are on ESDF. Attempting to jump forward word-wise using `C-<right>` causes global search to open because `<right>` is where f would be on qwerty.

Any user with a keyboard layout other than qwerty should be affected by this bug.

This makes it so that you have to press the `f` key of your particular layout; wherever that may be.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
