### PR TITLE
Add check for temp file

### DIFF
--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -241,6 +241,10 @@ class Installer {
 
 				// Download the release
 				$tempFile = $this->tempManager->getTemporaryFile('.tar.gz');
+				if ($tempFile === false) {
+					throw new \RuntimeException('Could not create temporary file for downloading app archive.');
+				}
+				
 				$timeout = $this->isCLI ? 0 : 120;
 				$client = $this->clientService->newClient();
 				$client->get($app['releases'][0]['download'], ['sink' => $tempFile, 'timeout' => $timeout]);


### PR DESCRIPTION
## Summary

After upgrade nextcloud v29.0.16 to v30.0.13 I've noticed that some apps were deactivated and couldn't be updated. After running the cli commands I've got the error "Error: sink must not be a boolean".

```
$ php occ app:update spreed -vvv
spreed new version available: 20.1.9
spreed couldn't be updated
$ php occ app:install spreed
Error: sink must not be a boolean
```

The log tells me the reason for this error:

```json
{
  "exception": {
    "Exception": "GuzzleHttp\\Exception\\InvalidArgumentException",
    "Message": "sink must not be a boolean",
    "Code": 0,
    "Trace": [
      [...]
    ],
    "File": "[redacted]/nextcloud/3rdparty/guzzlehttp/guzzle/src/Client.php",
    "Line": 438,
    "message": "sink must not be a boolean",
    "exception": [],
    "CustomMessage": "sink must not be a boolean"
  }
}
```

<details><summary>Detailed error log</summary>

```json
{
  "reqId": "aJiyFr7ys6gPt1pipcv5YgAAzSE",
  "level": 3,
  "time": "2025-08-10T14:52:06+00:00",
  "remoteAddr": "[redacted]",
  "user": "[redacted]",
  "app": "no app in context",
  "method": "GET",
  "url": "/settings/apps/update/spreed",
  "message": "sink must not be a boolean",
  "userAgent": "[redacted]",
  "version": "30.0.13.1",
  "exception": {
    "Exception": "GuzzleHttp\\Exception\\InvalidArgumentException",
    "Message": "sink must not be a boolean",
    "Code": 0,
    "Trace": [
      {
        "file": "[redacted]/nextcloud/3rdparty/guzzlehttp/guzzle/src/Client.php",
        "line": 328,
        "function": "applyOptions",
        "class": "GuzzleHttp\\Client",
        "type": "->",
        "args": [
          {
            "__class__": "GuzzleHttp\\Psr7\\Request"
          },
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "[redacted]/nextcloud/3rdparty/guzzlehttp/guzzle/src/Client.php",
        "line": 169,
        "function": "transfer",
        "class": "GuzzleHttp\\Client",
        "type": "->",
        "args": [
          {
            "__class__": "GuzzleHttp\\Psr7\\Request"
          },
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "[redacted]/nextcloud/3rdparty/guzzlehttp/guzzle/src/Client.php",
        "line": 189,
        "function": "requestAsync",
        "class": "GuzzleHttp\\Client",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/private/Http/Client/Client.php",
        "line": 205,
        "function": "request",
        "class": "GuzzleHttp\\Client",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***",
          "*** sensitive parameters replaced ***",
          {
            "verify": "[redacted]/nextcloud/resources/config/ca-bundle.crt",
            "timeout": 120,
            "allow_redirects": {
              "on_redirect": {
                "__class__": "Closure"
              }
            },
            "sink": false,
            "nextcloud": {
              "allow_local_address": false
            },
            "headers": {
              "User-Agent": "Nextcloud Server Crawler",
              "Accept-Encoding": "gzip"
            },
            "synchronous": true
          }
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/private/Installer.php",
        "line": 246,
        "function": "get",
        "class": "OC\\Http\\Client\\Client",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/private/Installer.php",
        "line": 144,
        "function": "downloadApp",
        "class": "OC\\Installer",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***",
          false
        ]
      },
      {
        "file": "[redacted]/nextcloud/apps/settings/lib/Controller/AppSettingsController.php",
        "line": 612,
        "function": "updateAppstoreApp",
        "class": "OC\\Installer",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 208,
        "function": "updateApp",
        "class": "OCA\\Settings\\Controller\\AppSettingsController",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 114,
        "function": "executeController",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Settings\\Controller\\AppSettingsController"
          },
          "updateApp"
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/private/AppFramework/App.php",
        "line": 161,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->",
        "args": [
          {
            "__class__": "OCA\\Settings\\Controller\\AppSettingsController"
          },
          "updateApp"
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/private/Route/Router.php",
        "line": 303,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::",
        "args": [
          "OCA\\Settings\\Controller\\AppSettingsController",
          "updateApp",
          {
            "__class__": "OC\\AppFramework\\DependencyInjection\\DIContainer"
          },
          {
            "appId": "*** sensitive parameters replaced ***",
            "_route": "settings.appsettings.updateapp"
          }
        ]
      },
      {
        "file": "[redacted]/nextcloud/lib/base.php",
        "line": 1010,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->",
        "args": [
          "/settings/apps/update/spreed"
        ]
      },
      {
        "file": "[redacted]/nextcloud/index.php",
        "line": 24,
        "function": "handleRequest",
        "class": "OC",
        "type": "::",
        "args": []
      }
    ],
    "File": "[redacted]/nextcloud/3rdparty/guzzlehttp/guzzle/src/Client.php",
    "Line": 438,
    "message": "sink must not be a boolean",
    "exception": [],
    "CustomMessage": "sink must not be a boolean"
  },
  "id": "[redacted]"
}
```

</details> 

This exception is thrown by Guzzle, see https://github.com/guzzle/guzzle/blob/7.9.3/src/Client.php#L438

```php
            if (\is_bool($options['sink'])) {
                throw new InvalidArgumentException('sink must not be a boolean');
            }
```

(For unknown reasons, my tmp folder suddenly became unwritable. I solved this problem with `chmod`)

This PR adds a type check for `$tempFile` similar to #52911.

## TODO

- [ ] Create fix for branch `nextcloud:stable31`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
