### PR TITLE
chore(CODEOWNERS): ensure every file change has at least 2 reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@ package-lock.json                             @nextcloud/server-dependabot
 /apps/webhook_listeners/appinfo/info.xml      @come-nc @julien-nc
 /apps/workflowengine/appinfo/info.xml         @blizzz @juliusknorr
 
-# Frontend expertise
+# Files frontend expertise
 /apps/files/src*                    @skjnldsv @nextcloud/server-frontend
 /apps/files_external/src*           @skjnldsv @nextcloud/server-frontend
 /apps/files_reminders/src*          @skjnldsv @nextcloud/server-frontend
@@ -91,17 +91,19 @@ ResponseDefinitions.php             @provokateurin @nextcloud/server-backend
 /lib/public/OCM                     @nickvergessen @nextcloud/talk-backend @nextcloud/server-backend
 /lib/public/Talk                    @nickvergessen @nextcloud/talk-backend
 /lib/public/UserStatus              @nickvergessen @nextcloud/talk-backend
+*/Notifications/*                   @nickvergessen @nextcloud/talk-backend
 
-# Groupware
-/build/integration/dav_features/caldav.feature   @st3iny @SebastianKrupinski @tcitworld
-/build/integration/dav_features/carddav.feature  @hamza221 @SebastianKrupinski
-/lib/private/Calendar                            @st3iny @SebastianKrupinski @tcitworld
-/lib/private/Contacts                            @hamza221 @SebastianKrupinski
-/lib/public/Calendar                             @st3iny @SebastianKrupinski @tcitworld
-/lib/public/Contacts                             @hamza221 @SebastianKrupinski
+# Groupware team
+/build/integration/dav_features/caldav.feature            @st3iny @SebastianKrupinski @tcitworld
+/build/integration/dav_features/carddav.feature           @hamza221 @SebastianKrupinski
+/lib/private/Calendar                                     @st3iny @SebastianKrupinski @tcitworld
+/lib/private/Contacts                                     @hamza221 @SebastianKrupinski
+/lib/public/Calendar                                      @st3iny @SebastianKrupinski @tcitworld
+/lib/public/Contacts                                      @hamza221 @SebastianKrupinski
+
+# Desktop client teamn
+/apps/dav/lib/Connector/Sabre/BlockLegacyClientPlugin.php @nextcloud/desktop
 
 # Personal interest
 */Activity/*                                     @nickvergessen @nextcloud/server-backend
-*/Notifications/*                                @nickvergessen @nextcloud/talk-backend
-/apps/workflowengine/lib                         @nickvergessen
-
+/apps/workflowengine/lib                         @nickvergessen @blizzz


### PR DESCRIPTION
## Summary

For proper review every PR needs 2 reviews, so every file needs at least 2 codeowners. Thus @blizzz is added for `workflowengine` as the app maintainer.

Additionally added the desktop client team for changes related to them.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
