### PR TITLE
fix: increase how long we cache display names

### DIFF
--- a/lib/private/User/DisplayNameCache.php
+++ b/lib/private/User/DisplayNameCache.php
@@ -25,6 +25,8 @@ use OCP\User\Events\UserDeletedEvent;
  * @template-implements IEventListener<UserChangedEvent|UserDeletedEvent>
  */
 class DisplayNameCache implements IEventListener {
+	private const CACHE_TTL = 24 * 60 * 60; // 1 day
+
 	private array $cache = [];
 	private ICache $memCache;
 	private IUserManager $userManager;
@@ -56,7 +58,7 @@ class DisplayNameCache implements IEventListener {
 			$displayName = null;
 		}
 		$this->cache[$userId] = $displayName;
-		$this->memCache->set($userId, $displayName, 60 * 10); // 10 minutes
+		$this->memCache->set($userId, $displayName, self::CACHE_TTL);
 
 		return $displayName;
 	}
@@ -71,7 +73,7 @@ class DisplayNameCache implements IEventListener {
 			$userId = $event->getUser()->getUID();
 			$newDisplayName = $event->getValue();
 			$this->cache[$userId] = $newDisplayName;
-			$this->memCache->set($userId, $newDisplayName, 60 * 10); // 10 minutes
+			$this->memCache->set($userId, $newDisplayName, self::CACHE_TTL);
 		}
 		if ($event instanceof UserDeletedEvent) {
 			$userId = $event->getUser()->getUID();


### PR DESCRIPTION
Since display names rarely change and we already listen to internal changes, it should be fine to cache them for a day.