### PR TITLE
fix: Fix getting trusted server other than the first

### DIFF
--- a/apps/federation/lib/TrustedServers.php
+++ b/apps/federation/lib/TrustedServers.php
@@ -116,12 +116,13 @@ class TrustedServers {
 			$this->trustedServersCache = $this->dbHandler->getAllServer();
 		}
 
-		$server = array_filter($this->trustedServersCache, fn ($server) => $server['id'] === $id);
-		if (empty($server)) {
-			throw new \Exception('No server found with ID: ' . $id);
+		foreach ($this->trustedServersCache as $server) {
+			if ($server['id'] === $id) {
+				return $server;
+			}
 		}
 
-		return $server[0];
+		throw new \Exception('No server found with ID: ' . $id);
 	}
 
 	/**

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -144,6 +144,64 @@ class TrustedServersTest extends TestCase {
 		);
 	}
 
+	public static function dataTestGetServer() {
+		return [
+			[
+				15,
+				[
+					'id' => 15,
+					'otherData' => 'first server',
+				]
+			],
+			[
+				16,
+				[
+					'id' => 16,
+					'otherData' => 'second server',
+				]
+			],
+			[
+				42,
+				[
+					'id' => 42,
+					'otherData' => 'last server',
+				]
+			],
+			[
+				108,
+				null
+			],
+		];
+	}
+
+	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetServer')]
+	public function testGetServer(int $id, ?array $expectedServer): void {
+		$servers = [
+			[
+				'id' => 15,
+				'otherData' => 'first server',
+			],
+			[
+				'id' => 16,
+				'otherData' => 'second server',
+			],
+			[
+				'id' => 42,
+				'otherData' => 'last server',
+			],
+		];
+		$this->dbHandler->expects($this->once())->method('getAllServer')->willReturn($servers);
+
+		if ($expectedServer === null) {
+			$this->expectException(\Exception::class);
+			$this->expectExceptionMessage('No server found with ID: ' . $id);
+		}
+
+		$this->assertEquals(
+			$expectedServer,
+			$this->trustedServers->getServer($id)
+		);
+	}
 
 	public function testIsTrustedServer(): void {
 		$this->dbHandler->expects($this->once())


### PR DESCRIPTION
Fixes a regression introduced in #49973 (specifically, in 669e6cadd6bcb73df3f2cf8774e8ee2e3bfb7c77)

[`array_filter` preserves the keys](https://www.php.net/manual/en/function.array-filter.php), so after the trusted servers were filtered `$server[0]` existed only if the server to get was the first one in the original array.

## How to test

- Open the _Sharing_ section in Nextcloud administration settings
- Add two trusted servers
- Remove the last one added

### Result with this pull request

No errors are logged

### Result without this pull request

An error with message `Undefined array key 0 at...` is logged
