### PR TITLE
ci: adjust update desktop version workflow to assign correct team

### DIFF
--- a/.github/workflows/update-min-supported-desktop.yml
+++ b/.github/workflows/update-min-supported-desktop.yml
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
+# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
+
 name: Update min supported desktop version
 
 on:
@@ -124,4 +125,4 @@ jobs:
             client: 💻 desktop
             automated
             3. to review
-          reviewers: tobiasKaminsky, camilasan, claucambra
+          reviewers: '@nextcloud/desktop'


### PR DESCRIPTION
## Summary

2 of 3 persons that were assigned are not working in that area anymore. So just assign the team.
Moreover the date was wrong as the file was created 2025.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
