### PR TITLE
feat: indicate reason for preloading notifications

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -701,6 +701,7 @@ return array(
     'OCP\\Notification\\IncompleteNotificationException' => $baseDir . '/lib/public/Notification/IncompleteNotificationException.php',
     'OCP\\Notification\\IncompleteParsedNotificationException' => $baseDir . '/lib/public/Notification/IncompleteParsedNotificationException.php',
     'OCP\\Notification\\InvalidValueException' => $baseDir . '/lib/public/Notification/InvalidValueException.php',
+    'OCP\\Notification\\NotificationPreloadReason' => $baseDir . '/lib/public/Notification/NotificationPreloadReason.php',
     'OCP\\Notification\\UnknownNotificationException' => $baseDir . '/lib/public/Notification/UnknownNotificationException.php',
     'OCP\\OCM\\Events\\ResourceTypeRegisterEvent' => $baseDir . '/lib/public/OCM/Events/ResourceTypeRegisterEvent.php',
     'OCP\\OCM\\Exceptions\\OCMArgumentException' => $baseDir . '/lib/public/OCM/Exceptions/OCMArgumentException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -742,6 +742,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Notification\\IncompleteNotificationException' => __DIR__ . '/../../..' . '/lib/public/Notification/IncompleteNotificationException.php',
         'OCP\\Notification\\IncompleteParsedNotificationException' => __DIR__ . '/../../..' . '/lib/public/Notification/IncompleteParsedNotificationException.php',
         'OCP\\Notification\\InvalidValueException' => __DIR__ . '/../../..' . '/lib/public/Notification/InvalidValueException.php',
+        'OCP\\Notification\\NotificationPreloadReason' => __DIR__ . '/../../..' . '/lib/public/Notification/NotificationPreloadReason.php',
         'OCP\\Notification\\UnknownNotificationException' => __DIR__ . '/../../..' . '/lib/public/Notification/UnknownNotificationException.php',
         'OCP\\OCM\\Events\\ResourceTypeRegisterEvent' => __DIR__ . '/../../..' . '/lib/public/OCM/Events/ResourceTypeRegisterEvent.php',
         'OCP\\OCM\\Exceptions\\OCMArgumentException' => __DIR__ . '/../../..' . '/lib/public/OCM/Exceptions/OCMArgumentException.php',

--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -22,6 +22,7 @@ use OCP\Notification\IncompleteParsedNotificationException;
 use OCP\Notification\INotification;
 use OCP\Notification\INotifier;
 use OCP\Notification\IPreloadableNotifier;
+use OCP\Notification\NotificationPreloadReason;
 use OCP\Notification\UnknownNotificationException;
 use OCP\RichObjectStrings\IRichTextFormatter;
 use OCP\RichObjectStrings\IValidator;
@@ -391,14 +392,18 @@ class Manager implements IManager {
 		return $notification;
 	}
 
-	public function preloadDataForParsing(array $notifications, string $languageCode): void {
+	public function preloadDataForParsing(
+		array $notifications,
+		string $languageCode,
+		NotificationPreloadReason $reason,
+	): void {
 		$notifiers = $this->getNotifiers();
 		foreach ($notifiers as $notifier) {
 			if (!($notifier instanceof IPreloadableNotifier)) {
 				continue;
 			}
 
-			$notifier->preloadDataForParsing($notifications, $languageCode);
+			$notifier->preloadDataForParsing($notifications, $languageCode, $reason);
 		}
 	}
 

--- a/lib/public/Notification/IPreloadableNotifier.php
+++ b/lib/public/Notification/IPreloadableNotifier.php
@@ -26,6 +26,11 @@ interface IPreloadableNotifier extends INotifier {
 	 *
 	 * @param INotification[] $notifications The notifications which are about to be prepared in the next step.
 	 * @param string $languageCode The code of the language that should be used to prepare the notification.
+	 * @param NotificationPreloadReason $reason The reason for preloading the given notifications to facilitate smarter decisions about what data to preload.
 	 */
-	public function preloadDataForParsing(array $notifications, string $languageCode): void;
+	public function preloadDataForParsing(
+		array $notifications,
+		string $languageCode,
+		NotificationPreloadReason $reason,
+	): void;
 }

--- a/lib/public/Notification/NotificationPreloadReason.php
+++ b/lib/public/Notification/NotificationPreloadReason.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Notification;
+
+use OCP\AppFramework\Attribute\Consumable;
+
+/**
+ * Indicates the reason for preloading notifications to facilitate smarter decisions about what data
+ * to preload.
+ */
+#[Consumable(since: '32.0.0')]
+enum NotificationPreloadReason {
+	/**
+	 * Preparing a single notification for many users.
+	 *
+	 * @since 32.0.0
+	 */
+	case Push;
+
+	/**
+	 * Preparing many notifications for many users.
+	 *
+	 * @since 32.0.0
+	 */
+	case Email;
+
+	/**
+	 * Preparing many notifications for a single user.
+	 *
+	 * @since 32.0.0
+	 */
+	case EndpointController;
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

Follow-up to #54231 

As suggested by Joas in https://github.com/nextcloud/notifications/pull/2452#discussion_r2255062064.

This makes it easier for implementations/apps to decide on what data to preload.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
