### PR TITLE
fix: use stable route for comment search results

### DIFF
--- a/apps/comments/lib/Search/CommentsSearchProvider.php
+++ b/apps/comments/lib/Search/CommentsSearchProvider.php
@@ -69,6 +69,7 @@ class CommentsSearchProvider implements IProvider {
 		$result = [];
 		$numComments = 50;
 		$offset = 0;
+		$limit = $numComments;
 
 		while (count($result) < $numComments) {
 			$comments = $this->commentsManager->search(
@@ -77,7 +78,7 @@ class CommentsSearchProvider implements IProvider {
 				'',
 				'comment',
 				$offset,
-				$numComments
+				$limit,
 			);
 
 			foreach ($comments as $comment) {
@@ -121,13 +122,13 @@ class CommentsSearchProvider implements IProvider {
 				$result[] = $searchResultEntry;
 			}
 
-			if (count($comments) < $numComments) {
+			if (count($comments) < $limit) {
 				// Didn't find more comments when we tried to get, so there are no more comments.
 				break;
 			}
 
-			$offset += $numComments;
-			$numComments = 50 - count($result);
+			$offset += $limit;
+			$limit = $numComments - count($result);
 		}
 
 		return $result;

--- a/apps/comments/lib/Search/CommentsSearchProvider.php
+++ b/apps/comments/lib/Search/CommentsSearchProvider.php
@@ -134,11 +134,11 @@ class CommentsSearchProvider implements IProvider {
 	}
 
 	private function getFileForComment(Folder $userFolder, IComment $comment): Node {
-		$nodes = $userFolder->getById((int)$comment->getObjectId());
-		if (empty($nodes)) {
+		$node = $userFolder->getFirstNodeById((int)$comment->getObjectId());
+		if ($node === null) {
 			throw new NotFoundException('File not found');
 		}
 
-		return array_shift($nodes);
+		return $node;
 	}
 }

--- a/apps/comments/lib/Search/CommentsSearchProvider.php
+++ b/apps/comments/lib/Search/CommentsSearchProvider.php
@@ -6,8 +6,15 @@ declare(strict_types=1);
  * SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Comments\Search;
 
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\Files\NotFoundException;
 use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\IUser;
@@ -16,15 +23,16 @@ use OCP\Search\IProvider;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
-use function array_map;
-use function pathinfo;
+use Psr\Log\LoggerInterface;
 
 class CommentsSearchProvider implements IProvider {
 	public function __construct(
 		private IUserManager $userManager,
 		private IL10N $l10n,
 		private IURLGenerator $urlGenerator,
-		private LegacyProvider $legacyProvider,
+		private ICommentsManager $commentsManager,
+		private IRootFolder $rootFolder,
+		private LoggerInterface $logger,
 	) {
 	}
 
@@ -45,27 +53,92 @@ class CommentsSearchProvider implements IProvider {
 	}
 
 	public function search(IUser $user, ISearchQuery $query): SearchResult {
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$result = $this->findCommentsBySearchQuery($query, $userFolder);
+
 		return SearchResult::complete(
 			$this->l10n->t('Comments'),
-			array_map(function (Result $result) {
-				$path = $result->path;
-				$pathInfo = pathinfo($path);
-				$isUser = $this->userManager->userExists($result->authorId);
-				$avatarUrl = $isUser
-					? $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $result->authorId, 'size' => 42])
-					: $this->urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => $result->authorId, 'size' => 42]);
-				return new SearchResultEntry(
-					$avatarUrl,
-					$result->name,
-					$path,
-					$this->urlGenerator->linkToRouteAbsolute('files.view.index', [
-						'dir' => $pathInfo['dirname'],
-						'scrollto' => $pathInfo['basename'],
-					]),
-					'',
-					true
-				);
-			}, $this->legacyProvider->search($query->getTerm()))
+			$result
 		);
+	}
+
+	/**
+	 * @return list<SearchResultEntry>
+	 */
+	private function findCommentsBySearchQuery(ISearchQuery $query, Folder $userFolder): array {
+		$result = [];
+		$numComments = 50;
+		$offset = 0;
+
+		while (count($result) < $numComments) {
+			$comments = $this->commentsManager->search(
+				$query->getTerm(),
+				'files',
+				'',
+				'comment',
+				$offset,
+				$numComments
+			);
+
+			foreach ($comments as $comment) {
+				if ($comment->getActorType() !== 'users') {
+					continue;
+				}
+
+				try {
+					$node = $this->getFileForComment($userFolder, $comment);
+				} catch (\Throwable $e) {
+					$this->logger->debug('Found comment for a file, but obtaining the file thrown an exception', ['exception' => $e]);
+					continue;
+				}
+
+				$actorId = $comment->getActorId();
+				$isUser = $this->userManager->userExists($actorId);
+
+				$avatarUrl = $isUser
+					? $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $actorId, 'size' => 42])
+					: $this->urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => $actorId, 'size' => 42]);
+
+				$path = $userFolder->getRelativePath($node->getPath());
+
+				// Use shortened link to centralize the various
+				// files/folder url redirection in files.View.showFile
+				$link = $this->urlGenerator->linkToRoute(
+					'files.View.showFile',
+					['fileid' => $node->getId()]
+				);
+
+				$searchResultEntry = new SearchResultEntry(
+					$avatarUrl,
+					$comment->getMessage(),
+					ltrim($path, '/'),
+					$this->urlGenerator->getAbsoluteURL($link),
+					'',
+				);
+				$searchResultEntry->addAttribute('fileId', (string)$node->getId());
+				$searchResultEntry->addAttribute('path', $path);
+
+				$result[] = $searchResultEntry;
+			}
+
+			if (count($comments) < $numComments) {
+				// Didn't find more comments when we tried to get, so there are no more comments.
+				break;
+			}
+
+			$offset += $numComments;
+			$numComments = 50 - count($result);
+		}
+
+		return $result;
+	}
+
+	private function getFileForComment(Folder $userFolder, IComment $comment): Node {
+		$nodes = $userFolder->getById((int)$comment->getObjectId());
+		if (empty($nodes)) {
+			throw new NotFoundException('File not found');
+		}
+
+		return array_shift($nodes);
 	}
 }

--- a/apps/comments/tests/Unit/Search/CommentsSearchProviderTest.php
+++ b/apps/comments/tests/Unit/Search/CommentsSearchProviderTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Comments\Tests\Unit\Search;
+
+use OC\Comments\Comment;
+use OCA\Comments\Search\CommentsSearchProvider;
+use OCP\Comments\IComment;
+use OCP\Comments\ICommentsManager;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\Search\IFilter;
+use OCP\Search\ISearchQuery;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
+use Test\TestCase;
+
+class CommentsSearchProviderTest extends TestCase {
+
+	private IUserManager&MockObject $userManager;
+	private IL10N&MockObject $l10n;
+	private IURLGenerator&MockObject $urlGenerator;
+	private ICommentsManager&MockObject $commentsManager;
+	private IRootFolder&MockObject $rootFolder;
+	private CommentsSearchProvider $provider;
+
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->l10n = $this->createMock(IL10N::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->commentsManager = $this->createMock(ICommentsManager::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('getFirstNodeById')->willReturnCallback(function (int $id) {
+			if ($id % 4 === 0) {
+				// Returning null for every fourth file to simulate a file not found case.
+				return null;
+			}
+			$node = $this->createMock(File::class);
+			$node->method('getId')->willReturn($id);
+			$node->method('getPath')->willReturn('/' . $id . '.txt');
+			return $node;
+		});
+		$userFolder->method('getRelativePath')->willReturnArgument(0);
+		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
+
+		$this->userManager->method('userExists')->willReturn(true);
+
+		$this->l10n->method('t')->willReturnArgument(0);
+
+		$this->provider = new CommentsSearchProvider(
+			$this->userManager,
+			$this->l10n,
+			$this->urlGenerator,
+			$this->commentsManager,
+			$this->rootFolder,
+			new NullLogger(),
+		);
+	}
+
+	public function testGetId(): void {
+		$this->assertEquals('comments', $this->provider->getId());
+	}
+
+	public function testGetName(): void {
+		$this->l10n->expects($this->once())
+			->method('t')
+			->with('Comments')
+			->willReturnArgument(0);
+
+		$this->assertEquals('Comments', $this->provider->getName());
+	}
+
+	public function testSearch(): void {
+		$this->commentsManager->method('search')->willReturnCallback(function (string $search, string $objectType, string $objectId, string $verb, int $offset, int $limit = 50) {
+			// The search method is call until 50 comments are found or there are no more comments to search.
+			$comments = [];
+			for ($i = 1; $i <= $limit; $i++) {
+				$comments[] = $this->mockComment(($offset + $i));
+			}
+			return $comments;
+		});
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$searchTermFilter = $this->createMock(IFilter::class);
+		$searchTermFilter->method('get')->willReturn('search term');
+		$searchQuery = $this->createMock(ISearchQuery::class);
+		$searchQuery->method('getFilter')->willReturnCallback(function ($name) use ($searchTermFilter) {
+			return match ($name) {
+				'term' => $searchTermFilter,
+				default => null,
+			};
+		});
+
+		$result = $this->provider->search($user, $searchQuery);
+		$data = $result->jsonSerialize();
+
+		$this->assertCount(50, $data['entries']);
+	}
+
+	public function testSearchNoMoreComments(): void {
+		$this->commentsManager->method('search')->willReturnCallback(function (string $search, string $objectType, string $objectId, string $verb, int $offset, int $limit = 50) {
+			// Decrease the limit to simulate no more comments to search -> the break case.
+			if ($offset > 0) {
+				$limit--;
+			}
+			$comments = [];
+			for ($i = 1; $i <= $limit; $i++) {
+				$comments[] = $this->mockComment(($offset + $i));
+			}
+			return $comments;
+		});
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$searchTermFilter = $this->createMock(IFilter::class);
+		$searchTermFilter->method('get')->willReturn('search term');
+		$searchQuery = $this->createMock(ISearchQuery::class);
+		$searchQuery->method('getFilter')->willReturnCallback(function ($name) use ($searchTermFilter) {
+			return match ($name) {
+				'term' => $searchTermFilter,
+				default => null,
+			};
+		});
+
+
+		$result = $this->provider->search($user, $searchQuery);
+		$data = $result->jsonSerialize();
+
+		$this->assertCount(46, $data['entries']);
+	}
+
+	private function mockComment(int $id): IComment {
+		return new Comment([
+			'id' => (string)$id,
+			'parent_id' => '0',
+			'topmost_parent_id' => '0',
+			'children_count' => 0,
+			'actor_type' => 'users',
+			'actor_id' => 'user' . $id,
+			'message' => 'Comment ' . $id,
+			'verb' => 'comment',
+			'creation_timestamp' => new \DateTime(),
+			'latest_child_timestamp' => null,
+			'object_type' => 'files',
+			'object_id' => (string)$id
+		]);
+	}
+
+}

--- a/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
@@ -269,14 +269,14 @@ class EventsSearchProviderTest extends TestCase {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('john.doe');
 		$query = $this->createMock(ISearchQuery::class);
-		$seachTermFilter = $this->createMock(IFilter::class);
-		$query->method('getFilter')->willReturnCallback(function ($name) use ($seachTermFilter) {
+		$searchTermFilter = $this->createMock(IFilter::class);
+		$query->method('getFilter')->willReturnCallback(function ($name) use ($searchTermFilter) {
 			return match ($name) {
-				'term' => $seachTermFilter,
+				'term' => $searchTermFilter,
 				default => null,
 			};
 		});
-		$seachTermFilter->method('get')->willReturn('search term');
+		$searchTermFilter->method('get')->willReturn('search term');
 		$query->method('getLimit')->willReturn(5);
 		$query->method('getCursor')->willReturn(20);
 		$this->appManager->expects($this->once())

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -63,18 +63,6 @@
       <code><![CDATA[CommentsEvent::EVENT_PRE_UPDATE]]></code>
     </DeprecatedConstant>
   </file>
-  <file src="apps/comments/lib/Search/CommentsSearchProvider.php">
-    <DeprecatedClass>
-      <code><![CDATA[Result]]></code>
-    </DeprecatedClass>
-    <DeprecatedProperty>
-      <code><![CDATA[$result->authorId]]></code>
-      <code><![CDATA[$result->authorId]]></code>
-      <code><![CDATA[$result->authorId]]></code>
-      <code><![CDATA[$result->name]]></code>
-      <code><![CDATA[$result->path]]></code>
-    </DeprecatedProperty>
-  </file>
   <file src="apps/comments/lib/Search/LegacyProvider.php">
     <DeprecatedClass>
       <code><![CDATA[Provider]]></code>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/54378

## Summary

The old version with files.view.index (with dir and scrollto) is opening the folder, but does not open the file or scroll to it.

The recommended way to reference a file is files.view.showFile as done by the files search provider and the activites app.

OCA\Comments\Search\LegacyProvider and OCA\Comments\Search\Result are deprecated since 20 and thus I took the opportunity to migrate away from it.


## TODO

- [ ] Check if the logic to obtain the comments was migrated correctly 
- [ ] Adding tests
- [ ] Remove the deprecated and now unused classes right away
- [ ] I assume we are loading the comments in a loop until 50 comments because there's no way, api wise, to obtain only comments with actor_type = users. If we are touching this anyway, then we should consider adding a new api for it to simplify the implementation and save database queries. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
