### PR TITLE
feat(AppConfig): cache the config if local cache is available

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3314,11 +3314,6 @@
       <code><![CDATA[version_compare($first, $second, $operator)]]></code>
     </NullableReturnStatement>
   </file>
-  <file src="lib/private/AppConfig.php">
-    <NullableReturnStatement>
-      <code><![CDATA[$this->fastCache[$app][$key] ?? $default]]></code>
-    </NullableReturnStatement>
-  </file>
   <file src="lib/private/AppFramework/Bootstrap/FunctionInjector.php">
     <UndefinedMethod>
       <code><![CDATA[getName]]></code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3298,11 +3298,6 @@
       <code><![CDATA[ActivitySettings[]]]></code>
     </MoreSpecificReturnType>
   </file>
-  <file src="lib/private/AllConfig.php">
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$key]]></code>
-    </MoreSpecificImplementedParamType>
-  </file>
   <file src="lib/private/App/DependencyAnalyzer.php">
     <InvalidNullableReturnType>
       <code><![CDATA[bool]]></code>

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -2980,9 +2980,6 @@
       <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[setAppValue]]></code>
     </DeprecatedMethod>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
   </file>
   <file src="core/Command/Encryption/MigrateKeyStorage.php">
     <DeprecatedClass>
@@ -4010,9 +4007,6 @@
       <code><![CDATA[false]]></code>
       <code><![CDATA[false]]></code>
     </InvalidArgument>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
   </file>
   <file src="lib/private/IntegrityCheck/Checker.php">
     <InvalidArrayAccess>
@@ -4389,9 +4383,6 @@
     <InvalidArgument>
       <code><![CDATA[$groupsList]]></code>
     </InvalidArgument>
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
   </file>
   <file src="lib/private/legacy/OC_Helper.php">
     <InvalidArrayOffset>

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1793,6 +1793,15 @@ $CONFIG = [
 'cache_chunk_gc_ttl' => 60*60*24,
 
 /**
+ * Enable caching of the app config values.
+ * If enabled the app config will be cached locally for a short TTL,
+ * reducing database load significatly on larger setups.
+ *
+ * Defaults to ``true``
+ */
+'cache_app_config' => true,
+
+/**
  * Using Object Store with Nextcloud
  */
 

--- a/core/Command/Encryption/Enable.php
+++ b/core/Command/Encryption/Enable.php
@@ -42,8 +42,8 @@ class Enable extends Command {
 			$output->writeln('<error>No encryption module is loaded</error>');
 			return 1;
 		}
-		$defaultModule = $this->config->getAppValue('core', 'default_encryption_module', null);
-		if ($defaultModule === null) {
+		$defaultModule = $this->config->getAppValue('core', 'default_encryption_module');
+		if ($defaultModule === '') {
 			$output->writeln('<error>No default module is set</error>');
 			return 1;
 		}

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -246,3 +246,16 @@ Cypress.Commands.add('userFileExists', (user: string, path: string) => {
 	return cy.runCommand(`stat --printf="%s" "data/${user}/files/${path}"`, { failOnNonZeroExit: true })
 		.then((exec) => Number.parseInt(exec.stdout || '0'))
 })
+
+Cypress.Commands.add('runOccCommand', (command: string, options?: Partial<Cypress.ExecOptions>) => {
+	return cy.runCommand(`php ./occ ${command}`, options)
+		.then((context) =>
+			// OCC cannot clear the APCu cache
+			// eslint-disable-next-line cypress/no-unnecessary-waiting
+			cy.wait(
+				command.startsWith('app:') || command.startsWith('config:')
+					? 3000 // clear APCu cache
+					: 0,
+			).then(() => context),
+		)
+})

--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -195,7 +195,7 @@ class AllConfig implements IConfig {
 	 * @deprecated 29.0.0 Use {@see IAppConfig} directly
 	 */
 	public function getAppValue($appName, $key, $default = '') {
-		return \OC::$server->get(AppConfig::class)->getValue($appName, $key, $default);
+		return \OC::$server->get(AppConfig::class)->getValue($appName, $key, $default) ?? $default;
 	}
 
 	/**

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1386,15 +1386,15 @@ class AppConfig implements IAppConfig {
 	 *
 	 * @param string $app app
 	 * @param string $key key
-	 * @param string $default = null, default value if the key does not exist
+	 * @param string $default - Default value if the key does not exist
 	 *
-	 * @return ?string the value or $default
+	 * @return string the value or $default
 	 * @deprecated 29.0.0 use getValue*()
 	 *
 	 * This function gets a value from the appconfig table. If the key does
 	 * not exist the default value will be returned
 	 */
-	public function getValue($app, $key, $default = null) {
+	public function getValue($app, $key, $default = '') {
 		$this->loadConfig($app);
 		$this->matchAndApplyLexiconDefinition($app, $key);
 

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -14,6 +14,7 @@ use JsonException;
 use OC\AppFramework\Bootstrap\Coordinator;
 use OC\Config\ConfigManager;
 use OC\Config\PresetManager;
+use OC\Memcache\Factory as CacheFactory;
 use OCP\Config\Lexicon\Entry;
 use OCP\Config\Lexicon\Strictness;
 use OCP\Config\ValueType;
@@ -79,10 +80,12 @@ class AppConfig implements IAppConfig {
 		private readonly PresetManager $presetManager,
 		protected LoggerInterface $logger,
 		protected ICrypto $crypto,
-		readonly ICacheFactory $cacheFactory,
+		readonly CacheFactory $cacheFactory,
 	) {
 		if ($config->getSystemValueBool('cache_app_config', true) && $cacheFactory->isLocalCacheAvailable()) {
-			$this->localCache = $cacheFactory->createLocal();
+			$cacheFactory->withServerVersionPrefix(function (ICacheFactory $factory) {
+				$this->localCache = $factory->createLocal();
+			});
 		}
 	}
 

--- a/lib/private/Installer.php
+++ b/lib/private/Installer.php
@@ -546,7 +546,7 @@ class Installer {
 				while (false !== ($filename = readdir($dir))) {
 					if ($filename[0] !== '.' and is_dir($app_dir['path'] . "/$filename")) {
 						if (file_exists($app_dir['path'] . "/$filename/appinfo/info.xml")) {
-							if ($config->getAppValue($filename, 'installed_version', null) === null) {
+							if ($config->getAppValue($filename, 'installed_version') === '') {
 								$enabled = $appManager->isDefaultEnabled($filename);
 								if (($enabled || in_array($filename, $appManager->getAlwaysEnabledApps()))
 									  && $config->getAppValue($filename, 'enabled') !== 'no') {

--- a/lib/private/Memcache/Factory.php
+++ b/lib/private/Memcache/Factory.php
@@ -7,72 +7,65 @@
  */
 namespace OC\Memcache;
 
-use Closure;
+use OC\SystemConfig;
 use OCP\Cache\CappedMemoryCache;
+use OCP\IAppConfig;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IMemcache;
 use OCP\Profiler\IProfiler;
+use OCP\ServerVersion;
 use Psr\Log\LoggerInterface;
 
 class Factory implements ICacheFactory {
 	public const NULL_CACHE = NullCache::class;
 
-	private ?string $globalPrefix = null;
-
-	private LoggerInterface $logger;
-
+	protected ?string $globalPrefix = null;
 	/**
-	 * @var ?class-string<ICache> $localCacheClass
+	 * @var class-string<ICache> $localCacheClass
 	 */
-	private ?string $localCacheClass;
+	protected string $localCacheClass;
 
 	/**
-	 * @var ?class-string<ICache> $distributedCacheClass
+	 * @var class-string<ICache> $distributedCacheClass
 	 */
-	private ?string $distributedCacheClass;
+	protected string $distributedCacheClass;
 
 	/**
-	 * @var ?class-string<IMemcache> $lockingCacheClass
+	 * @var class-string<IMemcache> $lockingCacheClass
 	 */
-	private ?string $lockingCacheClass;
-
-	private string $logFile;
-
-	private IProfiler $profiler;
+	protected string $lockingCacheClass;
 
 	/**
-	 * @param Closure $globalPrefixClosure
-	 * @param LoggerInterface $logger
 	 * @param ?class-string<ICache> $localCacheClass
 	 * @param ?class-string<ICache> $distributedCacheClass
 	 * @param ?class-string<IMemcache> $lockingCacheClass
-	 * @param string $logFile
 	 */
 	public function __construct(
-		private Closure $globalPrefixClosure,
-		LoggerInterface $logger,
-		IProfiler $profiler,
+		protected LoggerInterface $logger,
+		protected IProfiler $profiler,
+		protected ServerVersion $serverVersion,
 		?string $localCacheClass = null,
 		?string $distributedCacheClass = null,
 		?string $lockingCacheClass = null,
-		string $logFile = '',
+		protected string $logFile = '',
 	) {
-		$this->logFile = $logFile;
-
 		if (!$localCacheClass) {
 			$localCacheClass = self::NULL_CACHE;
 		}
 		$localCacheClass = ltrim($localCacheClass, '\\');
+
 		if (!$distributedCacheClass) {
 			$distributedCacheClass = $localCacheClass;
 		}
-
 		$distributedCacheClass = ltrim($distributedCacheClass, '\\');
 
 		$missingCacheMessage = 'Memcache {class} not available for {use} cache';
 		$missingCacheHint = 'Is the matching PHP module installed and enabled?';
-		if (!class_exists($localCacheClass) || !$localCacheClass::isAvailable()) {
+		if (!class_exists($localCacheClass)
+			|| !is_a($localCacheClass, ICache::class, true)
+			|| !$localCacheClass::isAvailable()
+		) {
 			if (\OC::$CLI && !defined('PHPUNIT_RUN') && $localCacheClass === APCu::class) {
 				// CLI should not fail if APCu is not available but fallback to NullCache.
 				// This can be the case if APCu is used without apc.enable_cli=1.
@@ -84,7 +77,11 @@ class Factory implements ICacheFactory {
 				]), $missingCacheHint);
 			}
 		}
-		if (!class_exists($distributedCacheClass) || !$distributedCacheClass::isAvailable()) {
+
+		if (!class_exists($distributedCacheClass)
+			|| !is_a($distributedCacheClass, ICache::class, true)
+			|| !$distributedCacheClass::isAvailable()
+		) {
 			if (\OC::$CLI && !defined('PHPUNIT_RUN') && $distributedCacheClass === APCu::class) {
 				// CLI should not fail if APCu is not available but fallback to NullCache.
 				// This can be the case if APCu is used without apc.enable_cli=1.
@@ -96,23 +93,49 @@ class Factory implements ICacheFactory {
 				]), $missingCacheHint);
 			}
 		}
-		if (!($lockingCacheClass && class_exists($lockingCacheClass) && $lockingCacheClass::isAvailable())) {
+
+		if (!$lockingCacheClass
+			|| !class_exists($lockingCacheClass)
+			|| !is_a($lockingCacheClass, IMemcache::class, true)
+			|| !$lockingCacheClass::isAvailable()
+		) {
 			// don't fall back since the fallback might not be suitable for storing lock
 			$lockingCacheClass = self::NULL_CACHE;
 		}
+		/** @var class-string<IMemcache> */
 		$lockingCacheClass = ltrim($lockingCacheClass, '\\');
 
 		$this->localCacheClass = $localCacheClass;
 		$this->distributedCacheClass = $distributedCacheClass;
 		$this->lockingCacheClass = $lockingCacheClass;
-		$this->profiler = $profiler;
 	}
 
-	private function getGlobalPrefix(): ?string {
-		if (is_null($this->globalPrefix)) {
-			$this->globalPrefix = ($this->globalPrefixClosure)();
+	protected function getGlobalPrefix(): string {
+		if ($this->globalPrefix === null) {
+			$config = \OCP\Server::get(SystemConfig::class);
+			$versions = [];
+			if ($config->getValue('installed', false)) {
+				$appConfig = \OCP\Server::get(IAppConfig::class);
+				$versions = $appConfig->getAppInstalledVersions();
+			}
+			$versions['core'] = implode('.', $this->serverVersion->getVersion());
+			$this->globalPrefix = hash('xxh128', implode(',', $versions));
 		}
 		return $this->globalPrefix;
+	}
+
+	/**
+	 * Override the global prefix for a specific closure.
+	 * This should only be used internally for bootstrapping purpose!
+	 *
+	 * @param string $globalPrefix - The prefix to use during the closure execution
+	 * @param \Closure $closure - The closure with the cache factory as the first parameter
+	 */
+	public function withServerVersionPrefix(\Closure $closure): void {
+		$backupPrefix = $this->globalPrefix;
+		$this->globalPrefix = hash('xxh128', implode('.', $this->serverVersion->getVersion()));
+		$closure($this);
+		$this->globalPrefix = $backupPrefix;
 	}
 
 	/**
@@ -122,22 +145,17 @@ class Factory implements ICacheFactory {
 	 * @return IMemcache
 	 */
 	public function createLocking(string $prefix = ''): IMemcache {
-		$globalPrefix = $this->getGlobalPrefix();
-		if (is_null($globalPrefix)) {
-			return new ArrayCache($prefix);
-		}
+		$cache = new $this->lockingCacheClass($this->getGlobalPrefix() . '/' . $prefix);
+		if ($this->lockingCacheClass === Redis::class) {
+			if ($this->profiler->isEnabled()) {
+				// We only support the profiler with Redis
+				$cache = new ProfilerWrapperCache($cache, 'Locking');
+				$this->profiler->add($cache);
+			}
 
-		assert($this->lockingCacheClass !== null);
-		$cache = new $this->lockingCacheClass($globalPrefix . '/' . $prefix);
-		if ($this->lockingCacheClass === Redis::class && $this->profiler->isEnabled()) {
-			// We only support the profiler with Redis
-			$cache = new ProfilerWrapperCache($cache, 'Locking');
-			$this->profiler->add($cache);
-		}
-
-		if ($this->lockingCacheClass === Redis::class
-			&& $this->logFile !== '' && is_writable(dirname($this->logFile)) && (!file_exists($this->logFile) || is_writable($this->logFile))) {
-			$cache = new LoggerWrapperCache($cache, $this->logFile);
+			if ($this->logFile !== '' && is_writable(dirname($this->logFile)) && (!file_exists($this->logFile) || is_writable($this->logFile))) {
+				$cache = new LoggerWrapperCache($cache, $this->logFile);
+			}
 		}
 		return $cache;
 	}
@@ -149,22 +167,17 @@ class Factory implements ICacheFactory {
 	 * @return ICache
 	 */
 	public function createDistributed(string $prefix = ''): ICache {
-		$globalPrefix = $this->getGlobalPrefix();
-		if (is_null($globalPrefix)) {
-			return new ArrayCache($prefix);
-		}
+		$cache = new $this->distributedCacheClass($this->getGlobalPrefix() . '/' . $prefix);
+		if ($this->distributedCacheClass === Redis::class) {
+			if ($this->profiler->isEnabled()) {
+				// We only support the profiler with Redis
+				$cache = new ProfilerWrapperCache($cache, 'Distributed');
+				$this->profiler->add($cache);
+			}
 
-		assert($this->distributedCacheClass !== null);
-		$cache = new $this->distributedCacheClass($globalPrefix . '/' . $prefix);
-		if ($this->distributedCacheClass === Redis::class && $this->profiler->isEnabled()) {
-			// We only support the profiler with Redis
-			$cache = new ProfilerWrapperCache($cache, 'Distributed');
-			$this->profiler->add($cache);
-		}
-
-		if ($this->distributedCacheClass === Redis::class && $this->logFile !== ''
-			&& is_writable(dirname($this->logFile)) && (!file_exists($this->logFile) || is_writable($this->logFile))) {
-			$cache = new LoggerWrapperCache($cache, $this->logFile);
+			if ($this->logFile !== '' && is_writable(dirname($this->logFile)) && (!file_exists($this->logFile) || is_writable($this->logFile))) {
+				$cache = new LoggerWrapperCache($cache, $this->logFile);
+			}
 		}
 		return $cache;
 	}
@@ -176,22 +189,17 @@ class Factory implements ICacheFactory {
 	 * @return ICache
 	 */
 	public function createLocal(string $prefix = ''): ICache {
-		$globalPrefix = $this->getGlobalPrefix();
-		if (is_null($globalPrefix)) {
-			return new ArrayCache($prefix);
-		}
+		$cache = new $this->localCacheClass($this->getGlobalPrefix() . '/' . $prefix);
+		if ($this->localCacheClass === Redis::class) {
+			if ($this->profiler->isEnabled()) {
+				// We only support the profiler with Redis
+				$cache = new ProfilerWrapperCache($cache, 'Local');
+				$this->profiler->add($cache);
+			}
 
-		assert($this->localCacheClass !== null);
-		$cache = new $this->localCacheClass($globalPrefix . '/' . $prefix);
-		if ($this->localCacheClass === Redis::class && $this->profiler->isEnabled()) {
-			// We only support the profiler with Redis
-			$cache = new ProfilerWrapperCache($cache, 'Local');
-			$this->profiler->add($cache);
-		}
-
-		if ($this->localCacheClass === Redis::class && $this->logFile !== ''
-			&& is_writable(dirname($this->logFile)) && (!file_exists($this->logFile) || is_writable($this->logFile))) {
-			$cache = new LoggerWrapperCache($cache, $this->logFile);
+			if ($this->logFile !== '' && is_writable(dirname($this->logFile)) && (!file_exists($this->logFile) || is_writable($this->logFile))) {
+				$cache = new LoggerWrapperCache($cache, $this->logFile);
+			}
 		}
 		return $cache;
 	}
@@ -216,5 +224,12 @@ class Factory implements ICacheFactory {
 	 */
 	public function isLocalCacheAvailable(): bool {
 		return $this->localCacheClass !== self::NULL_CACHE;
+	}
+
+	public function clearAll(): void {
+		$this->createLocal()->clear();
+		$this->createDistributed()->clear();
+		$this->createLocking()->clear();
+		$this->createInMemory()->clear();
 	}
 }

--- a/lib/private/legacy/OC_App.php
+++ b/lib/private/legacy/OC_App.php
@@ -685,7 +685,7 @@ class OC_App {
 		//set remote/public handlers
 		if (array_key_exists('ocsid', $appData)) {
 			\OC::$server->getConfig()->setAppValue($appId, 'ocsid', $appData['ocsid']);
-		} elseif (\OC::$server->getConfig()->getAppValue($appId, 'ocsid', null) !== null) {
+		} elseif (\OC::$server->getConfig()->getAppValue($appId, 'ocsid') !== '') {
 			\OC::$server->getConfig()->deleteAppValue($appId, 'ocsid');
 		}
 		foreach ($appData['remote'] as $name => $path) {

--- a/lib/public/IConfig.php
+++ b/lib/public/IConfig.php
@@ -112,8 +112,8 @@ interface IConfig {
 	 * Writes a new app wide value
 	 *
 	 * @param string $appName the appName that we want to store the value under
-	 * @param string|float|int $key the key of the value, under which will be saved
-	 * @param string $value the value that should be stored
+	 * @param string $key the key of the value, under which will be saved
+	 * @param string|float|int $value the value that should be stored
 	 * @return void
 	 * @since 6.0.0
 	 * @deprecated 29.0.0 Use {@see IAppConfig} directly

--- a/tests/Core/Command/Encryption/EnableTest.php
+++ b/tests/Core/Command/Encryption/EnableTest.php
@@ -48,9 +48,9 @@ class EnableTest extends TestCase {
 
 	public static function dataEnable(): array {
 		return [
-			['no', null, [], true, 'Encryption enabled', 'No encryption module is loaded'],
-			['yes', null, [], false, 'Encryption is already enabled', 'No encryption module is loaded'],
-			['no', null, ['OC_TEST_MODULE' => []], true, 'Encryption enabled', 'No default module is set'],
+			['no', '', [], true, 'Encryption enabled', 'No encryption module is loaded'],
+			['yes', '', [], false, 'Encryption is already enabled', 'No encryption module is loaded'],
+			['no', '', ['OC_TEST_MODULE' => []], true, 'Encryption enabled', 'No default module is set'],
 			['no', 'OC_NO_MODULE', ['OC_TEST_MODULE' => []], true, 'Encryption enabled', 'The current default module does not exist: OC_NO_MODULE'],
 			['no', 'OC_TEST_MODULE', ['OC_TEST_MODULE' => []], true, 'Encryption enabled', 'Default module: OC_TEST_MODULE'],
 		];
@@ -79,7 +79,7 @@ class EnableTest extends TestCase {
 				->method('getAppValue')
 				->willReturnMap([
 					['core', 'encryption_enabled', 'no', $oldStatus],
-					['core', 'default_encryption_module', null, $defaultModule],
+					['core', 'default_encryption_module', '', $defaultModule],
 				]);
 		}
 

--- a/tests/lib/AppConfigIntegrationTest.php
+++ b/tests/lib/AppConfigIntegrationTest.php
@@ -11,10 +11,10 @@ use InvalidArgumentException;
 use OC\AppConfig;
 use OC\Config\ConfigManager;
 use OC\Config\PresetManager;
+use OC\Memcache\Factory as CacheFactory;
 use OCP\Exceptions\AppConfigTypeConflictException;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 use OCP\IAppConfig;
-use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Security\ICrypto;
@@ -35,7 +35,7 @@ class AppConfigIntegrationTest extends TestCase {
 	private PresetManager $presetManager;
 	private LoggerInterface $logger;
 	private ICrypto $crypto;
-	private ICacheFactory&MockObject $cacheFactory;
+	private CacheFactory&MockObject $cacheFactory;
 
 	private array $originalConfig;
 
@@ -108,7 +108,7 @@ class AppConfigIntegrationTest extends TestCase {
 		$this->presetManager = Server::get(PresetManager::class);
 		$this->logger = Server::get(LoggerInterface::class);
 		$this->crypto = Server::get(ICrypto::class);
-		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cacheFactory = $this->createMock(CacheFactory::class);
 		$this->cacheFactory->method('isLocalCacheAvailable')->willReturn(false);
 
 		// storing current config and emptying the data table

--- a/tests/lib/AppConfigIntegrationTest.php
+++ b/tests/lib/AppConfigIntegrationTest.php
@@ -14,20 +14,20 @@ use OC\Config\PresetManager;
 use OCP\Exceptions\AppConfigTypeConflictException;
 use OCP\Exceptions\AppConfigUnknownKeyException;
 use OCP\IAppConfig;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Security\ICrypto;
 use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 
 /**
- * Class AppConfigTest
- *
  * @group DB
  *
  * @package Test
  */
-class AppConfigTest extends TestCase {
+class AppConfigIntegrationTest extends TestCase {
 	protected IAppConfig $appConfig;
 	protected IDBConnection $connection;
 	private IConfig $config;
@@ -35,6 +35,7 @@ class AppConfigTest extends TestCase {
 	private PresetManager $presetManager;
 	private LoggerInterface $logger;
 	private ICrypto $crypto;
+	private ICacheFactory&MockObject $cacheFactory;
 
 	private array $originalConfig;
 
@@ -107,6 +108,8 @@ class AppConfigTest extends TestCase {
 		$this->presetManager = Server::get(PresetManager::class);
 		$this->logger = Server::get(LoggerInterface::class);
 		$this->crypto = Server::get(ICrypto::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cacheFactory->method('isLocalCacheAvailable')->willReturn(false);
 
 		// storing current config and emptying the data table
 		$sql = $this->connection->getQueryBuilder();
@@ -200,6 +203,7 @@ class AppConfigTest extends TestCase {
 			$this->presetManager,
 			$this->logger,
 			$this->crypto,
+			$this->cacheFactory,
 		);
 		$msg = ' generateAppConfig() failed to confirm cache status';
 

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace Test;
+
+use OC\AppConfig;
+use OC\Config\ConfigManager;
+use OC\Config\PresetManager;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Security\ICrypto;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Class AppConfigTest
+ *
+ * @package Test
+ */
+class AppConfigTest extends TestCase {
+	private IConfig&MockObject $config;
+	private IDBConnection&MockObject $connection;
+	private ConfigManager&MockObject $configManager;
+	private PresetManager&MockObject $presetManager;
+	private LoggerInterface&MockObject $logger;
+	private ICrypto&MockObject $crypto;
+	private ICacheFactory&MockObject $cacheFactory;
+	private ICache&MockObject $localCache;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->connection = $this->createMock(IDBConnection::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->configManager = $this->createMock(ConfigManager::class);
+		$this->presetManager = $this->createMock(PresetManager::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->crypto = $this->createMock(ICrypto::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->localCache = $this->createMock(ICache::class);
+	}
+
+	protected function getAppConfig($cached = false): AppConfig {
+		$this->config->method('getSystemValueBool')
+			->with('cache_app_config', $cached)
+			->willReturn(true);
+		$this->cacheFactory->method('isLocalCacheAvailable')->willReturn($cached);
+		if ($cached) {
+			$this->cacheFactory->method('createLocal')->willReturn($this->localCache);
+		}
+
+		return new AppConfig(
+			$this->connection,
+			$this->config,
+			$this->configManager,
+			$this->presetManager,
+			$this->logger,
+			$this->crypto,
+			$this->cacheFactory,
+		);
+	}
+
+	public function testCachedRead(): void {
+		$this->localCache->expects(self::once())
+			->method('get')
+			->with('OC\\AppConfig')
+			->willReturn([
+				'fastCache' => [
+					'appid' => [
+						'some-key' => 'some-value',
+						'other-key' => 'other value'
+					],
+				],
+				'valueTypes' => [
+					'appid' => [
+						'some-key' => AppConfig::VALUE_STRING,
+						'other-key' => AppConfig::VALUE_STRING,
+					],
+				],
+			]);
+
+		$this->connection->expects(self::never())->method('getQueryBuilder');
+		$config = $this->getAppConfig(true);
+
+
+		$this->assertSame('some-value', $config->getValueString('appid', 'some-key'));
+		$this->assertSame('other value', $config->getValueString('appid', 'other-key'));
+		$this->assertSame(AppConfig::VALUE_STRING, $config->getValueType('appid', 'some-key', false));
+	}
+
+	public function testCachedLazyRead(): void {
+		$this->localCache->expects(self::once())
+			->method('get')
+			->with('OC\\AppConfig')
+			->willReturn([
+				'fastCache' => [
+					'appid' => [
+						'fast-key' => 'fast value',
+					],
+				],
+				'lazyCache' => [
+					'appid' => [
+						'lazy-key' => 'lazy value',
+					],
+				],
+				'valueTypes' => [
+					'appid' => [
+						'some-key' => AppConfig::VALUE_STRING,
+						'lazy-key' => AppConfig::VALUE_STRING,
+					],
+				],
+			]);
+
+		$this->connection->expects(self::never())->method('getQueryBuilder');
+		$config = $this->getAppConfig(true);
+
+
+		$this->assertSame('fast value', $config->getValueString('appid', 'fast-key'));
+		$this->assertSame('lazy value', $config->getValueString('appid', 'lazy-key', '', true));
+	}
+
+	public function testOnlyFastKeyCached(): void {
+		$this->localCache->expects(self::atLeastOnce())
+			->method('get')
+			->with('OC\\AppConfig')
+			->willReturn([
+				'fastCache' => [
+					'appid' => [
+						'fast-key' => 'fast value',
+					],
+				],
+				'valueTypes' => [
+					'appid' => [
+						'fast-key' => AppConfig::VALUE_STRING,
+					],
+				],
+			]);
+
+		$result = $this->createMock(IResult::class);
+		$result->method('fetchAll')->willReturn([
+			['lazy' => 1, 'appid' => 'appid', 'configkey' => 'lazy-key', 'configvalue' => 'lazy value'],
+		]);
+		$expression = $this->createMock(IExpressionBuilder::class);
+		$queryBuilder = $this->createMock(IQueryBuilder::class);
+		$queryBuilder->method('from')->willReturn($queryBuilder);
+		$queryBuilder->method('expr')->willReturn($expression);
+		$queryBuilder->method('executeQuery')->willReturn($result);
+
+		$this->connection->expects(self::once())->method('getQueryBuilder')->willReturn($queryBuilder);
+		$config = $this->getAppConfig(true);
+
+
+		$this->assertSame('fast value', $config->getValueString('appid', 'fast-key'));
+		$this->assertSame('lazy value', $config->getValueString('appid', 'lazy-key', '', true));
+	}
+
+	public function testWritesAreCached(): void {
+		$this->localCache->expects(self::atLeastOnce())
+			->method('get')
+			->with('OC\\AppConfig')
+			->willReturn([
+				'fastCache' => [
+					'appid' => [
+						'first-key' => 'first value',
+					],
+				],
+				'valueTypes' => [
+					'appid' => [
+						'first-key' => AppConfig::VALUE_STRING,
+					],
+				],
+			]);
+
+		$expression = $this->createMock(IExpressionBuilder::class);
+		$queryBuilder = $this->createMock(IQueryBuilder::class);
+		$queryBuilder->expects(self::once())
+			->method('update')
+			->with('appconfig', null)
+			->willReturn($queryBuilder);
+		$queryBuilder->method('set')->willReturn($queryBuilder);
+		$queryBuilder->method('where')->willReturn($queryBuilder);
+		$queryBuilder->method('andWhere')->willReturn($queryBuilder);
+		$queryBuilder->method('expr')->willReturn($expression);
+		$this->connection->expects(self::once())->method('getQueryBuilder')->willReturn($queryBuilder);
+
+		$config = $this->getAppConfig(true);
+
+		$this->assertSame('first value', $config->getValueString('appid', 'first-key'));
+		$config->setValueString('appid', 'first-key', 'new value');
+		$this->assertSame('new value', $config->getValueString('appid', 'first-key'));
+	}
+}

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -10,11 +10,11 @@ namespace Test;
 use OC\AppConfig;
 use OC\Config\ConfigManager;
 use OC\Config\PresetManager;
+use OC\Memcache\Factory as CacheFactory;
 use OCP\DB\IResult;
 use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\ICache;
-use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\Security\ICrypto;
@@ -33,7 +33,7 @@ class AppConfigTest extends TestCase {
 	private PresetManager&MockObject $presetManager;
 	private LoggerInterface&MockObject $logger;
 	private ICrypto&MockObject $crypto;
-	private ICacheFactory&MockObject $cacheFactory;
+	private CacheFactory&MockObject $cacheFactory;
 	private ICache&MockObject $localCache;
 
 	protected function setUp(): void {
@@ -45,7 +45,7 @@ class AppConfigTest extends TestCase {
 		$this->presetManager = $this->createMock(PresetManager::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->crypto = $this->createMock(ICrypto::class);
-		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cacheFactory = $this->createMock(CacheFactory::class);
 		$this->localCache = $this->createMock(ICache::class);
 	}
 
@@ -55,6 +55,9 @@ class AppConfigTest extends TestCase {
 			->willReturn(true);
 		$this->cacheFactory->method('isLocalCacheAvailable')->willReturn($cached);
 		if ($cached) {
+			$this->cacheFactory->method('withServerVersionPrefix')->willReturnCallback(function (\Closure $closure): void {
+				$closure($this->cacheFactory);
+			});
 			$this->cacheFactory->method('createLocal')->willReturn($this->localCache);
 		}
 

--- a/tests/lib/Memcache/FactoryTest.php
+++ b/tests/lib/Memcache/FactoryTest.php
@@ -12,6 +12,7 @@ use OC\Memcache\Factory;
 use OC\Memcache\NullCache;
 use OCP\HintException;
 use OCP\Profiler\IProfiler;
+use OCP\ServerVersion;
 use Psr\Log\LoggerInterface;
 
 class Test_Factory_Available_Cache1 extends NullCache {
@@ -111,7 +112,8 @@ class FactoryTest extends \Test\TestCase {
 		$expectedLocalCache, $expectedDistributedCache, $expectedLockingCache): void {
 		$logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$profiler = $this->getMockBuilder(IProfiler::class)->getMock();
-		$factory = new Factory(fn () => 'abc', $logger, $profiler, $localCache, $distributedCache, $lockingCache);
+		$serverVersion = $this->createMock(ServerVersion::class);
+		$factory = new Factory($logger, $profiler, $serverVersion, $localCache, $distributedCache, $lockingCache);
 		$this->assertTrue(is_a($factory->createLocal(), $expectedLocalCache));
 		$this->assertTrue(is_a($factory->createDistributed(), $expectedDistributedCache));
 		$this->assertTrue(is_a($factory->createLocking(), $expectedLockingCache));
@@ -123,13 +125,15 @@ class FactoryTest extends \Test\TestCase {
 
 		$logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$profiler = $this->getMockBuilder(IProfiler::class)->getMock();
-		new Factory(fn () => 'abc', $logger, $profiler, $localCache, $distributedCache);
+		$serverVersion = $this->createMock(ServerVersion::class);
+		new Factory($logger, $profiler, $serverVersion, $localCache, $distributedCache);
 	}
 
 	public function testCreateInMemory(): void {
 		$logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
 		$profiler = $this->getMockBuilder(IProfiler::class)->getMock();
-		$factory = new Factory(fn () => 'abc', $logger, $profiler, null, null, null);
+		$serverVersion = $this->createMock(ServerVersion::class);
+		$factory = new Factory($logger, $profiler, $serverVersion, null, null, null);
 
 		$cache = $factory->createInMemory();
 		$cache->set('test', 48);


### PR DESCRIPTION
## Summary

- resolves https://github.com/nextcloud/server/issues/54157

## Benchmark

Tested flow:
- login
- move from dashboard to files app
- upload a folder with 1 subfolder and each 3 files
- in personal settings change the language
- back in files share the uploaded folder to another user
- add a comment on the uploaded folder
- log out

Queries on the app config table:
- Without caching: 140 queries (+-5)
- With caching:
  - TTL of 3s: 25 queries (+-3)
  - TTL of 120s: 9 queries (+-1)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
