### PR TITLE
fix(performance): Fix n+1 issue when fetching calendar properties

### DIFF
--- a/apps/dav/lib/CalDAV/Calendar.php
+++ b/apps/dav/lib/CalDAV/Calendar.php
@@ -36,7 +36,7 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 
 	public function __construct(
 		BackendInterface $caldavBackend,
-		$calendarInfo,
+		array $calendarInfo,
 		IL10N $l10n,
 		private IConfig $config,
 		private LoggerInterface $logger,
@@ -58,6 +58,10 @@ class Calendar extends \Sabre\CalDAV\Calendar implements IRestorable, IShareable
 			$this->calendarInfo['{DAV:}displayname'] = $l10n->t('Personal');
 		}
 		$this->l10n = $l10n;
+	}
+
+	public function getUri(): string {
+		return $this->calendarInfo['uri'];
 	}
 
 	/**

--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -72,7 +72,7 @@ class CalendarProvider implements ICalendarProvider {
 			$calendars[$user][] = 'calendars/' . $user . '/' . $uri['uri'];
 		}
 
-		$properties = $this->propertyMapper->findPropertiesByPaths($calendars);
+		$properties = $this->propertyMapper->findPropertiesByPathsAndUsers($calendars);
 
 		$list = [];
 		foreach ($properties as $property) {

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -14,6 +14,7 @@ use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\CalDAV\Proxy\ProxyMapper;
 use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCA\DAV\DAV\ViewOnlyPlugin;
+use OCA\DAV\Db\PropertyMapper;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
 use OCA\DAV\Files\Sharing\RootCollection;
 use OCA\DAV\Upload\CleanupService;
@@ -226,6 +227,7 @@ class ServerFactory {
 							$tree,
 							$this->databaseConnection,
 							$this->userSession->getUser(),
+							\OCP\Server::get(PropertyMapper::class),
 							\OCP\Server::get(DefaultCalendarValidator::class),
 						)
 					)

--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -383,7 +383,7 @@ class CustomPropertiesBackend implements BackendInterface {
 		$this->userCache = array_merge($this->userCache, $propsByPath);
 	}
 
-	private function cacheCalendars(CalendarHome $node): void {
+	private function cacheCalendars(CalendarHome $node, array $requestedProperties): void {
 		$calendars = $node->getChildren();
 
 		$users = [];
@@ -421,6 +421,10 @@ class CustomPropertiesBackend implements BackendInterface {
 		$this->userCache = array_merge($this->userCache, $propsByPath);
 
 		// published properties
+		$allowedProps = array_intersect(self::PUBLISHED_READ_ONLY_PROPERTIES, $requestedProperties);
+		if (empty($allowedProps)) {
+			return;
+		}
 		$paths = [];
 		foreach ($users as $nestedPaths) {
 			$paths = array_merge($paths, $nestedPaths);
@@ -428,7 +432,7 @@ class CustomPropertiesBackend implements BackendInterface {
 		$paths = array_unique($paths);
 
 		$propsByPath = array_fill_keys(array_values($paths), []);
-		$properties = $this->propertyMapper->findPropertiesByPaths($paths);
+		$properties = $this->propertyMapper->findPropertiesByPaths($paths, $allowedProps);
 		foreach ($properties as $property) {
 			$propsByPath[$property->getPropertypath()][$property->getPropertyname()] = $this->decodeValueFromDatabase($property->getPropertyvalue(), $property->getValuetype());
 		}

--- a/apps/dav/lib/Db/Property.php
+++ b/apps/dav/lib/Db/Property.php
@@ -16,6 +16,7 @@ use OCP\AppFramework\Db\Entity;
  * @method string getPropertypath()
  * @method string getPropertyname()
  * @method string getPropertyvalue()
+ * @method int getValuetype()
  */
 class Property extends Entity {
 

--- a/apps/dav/lib/Db/PropertyMapper.php
+++ b/apps/dav/lib/Db/PropertyMapper.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace OCA\DAV\Db;
 
 use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 /**
@@ -39,17 +40,19 @@ class PropertyMapper extends QBMapper {
 	}
 
 	/**
+	 * @param string $userId
+	 * @param string[] $paths
 	 * @return Property[]
+	 * @throws \OCP\DB\Exception
 	 */
-	public function findPropertiesByPath(string $userId, string $path): array {
+	public function findPropertiesByPaths(string $userId, array $paths): array {
 		$selectQb = $this->db->getQueryBuilder();
 		$selectQb->select('*')
 			->from(self::TABLE_NAME)
 			->where(
 				$selectQb->expr()->eq('userid', $selectQb->createNamedParameter($userId)),
-				$selectQb->expr()->eq('propertypath', $selectQb->createNamedParameter($path)),
+				$selectQb->expr()->in('propertypath', $selectQb->createNamedParameter($paths, IQueryBuilder::PARAM_STR_ARRAY)),
 			);
 		return $this->findEntities($selectQb);
 	}
-
 }

--- a/apps/dav/lib/Db/PropertyMapper.php
+++ b/apps/dav/lib/Db/PropertyMapper.php
@@ -44,17 +44,34 @@ class PropertyMapper extends QBMapper {
 	 * @return Property[]
 	 * @throws \OCP\DB\Exception
 	 */
-	public function findPropertiesByPaths(array $calendars): array {
+	public function findPropertiesByPathsAndUsers(array $calendars): array {
 		$selectQb = $this->db->getQueryBuilder();
 		$selectQb->select('*')
 			->from(self::TABLE_NAME);
 
 		foreach ($calendars as $user => $paths) {
-			$selectQb->andWhere(
-				$selectQb->expr()->eq('userid', $selectQb->createNamedParameter($user)),
-				$selectQb->expr()->in('propertypath', $selectQb->createNamedParameter($paths, IQueryBuilder::PARAM_STR_ARRAY)),
+			$selectQb->orWhere(
+				$selectQb->expr()->andX(
+					$selectQb->expr()->eq('userid', $selectQb->createNamedParameter($user)),
+					$selectQb->expr()->in('propertypath', $selectQb->createNamedParameter($paths, IQueryBuilder::PARAM_STR_ARRAY)),
+				)
 			);
 		}
+
+		return $this->findEntities($selectQb);
+	}
+
+	/**
+	 * @param string[] $calendars
+	 * @return Property[]
+	 * @throws \OCP\DB\Exception
+	 */
+	public function findPropertiesByPaths(array $calendars): array {
+		$selectQb = $this->db->getQueryBuilder();
+		$selectQb->select('*')
+			->from(self::TABLE_NAME)
+			->where($selectQb->expr()->in('propertypath', $selectQb->createNamedParameter($calendars, IQueryBuilder::PARAM_STR_ARRAY)));
+
 		return $this->findEntities($selectQb);
 	}
 }

--- a/apps/dav/lib/Db/PropertyMapper.php
+++ b/apps/dav/lib/Db/PropertyMapper.php
@@ -40,19 +40,21 @@ class PropertyMapper extends QBMapper {
 	}
 
 	/**
-	 * @param string $userId
-	 * @param string[] $paths
+	 * @param array<string, string[]> $calendars
 	 * @return Property[]
 	 * @throws \OCP\DB\Exception
 	 */
-	public function findPropertiesByPaths(string $userId, array $paths): array {
+	public function findPropertiesByPaths(array $calendars): array {
 		$selectQb = $this->db->getQueryBuilder();
 		$selectQb->select('*')
-			->from(self::TABLE_NAME)
-			->where(
-				$selectQb->expr()->eq('userid', $selectQb->createNamedParameter($userId)),
+			->from(self::TABLE_NAME);
+
+		foreach ($calendars as $user => $paths) {
+			$selectQb->andWhere(
+				$selectQb->expr()->eq('userid', $selectQb->createNamedParameter($user)),
 				$selectQb->expr()->in('propertypath', $selectQb->createNamedParameter($paths, IQueryBuilder::PARAM_STR_ARRAY)),
 			);
+		}
 		return $this->findEntities($selectQb);
 	}
 }

--- a/apps/dav/lib/Db/PropertyMapper.php
+++ b/apps/dav/lib/Db/PropertyMapper.php
@@ -63,14 +63,19 @@ class PropertyMapper extends QBMapper {
 
 	/**
 	 * @param string[] $calendars
+	 * @param string[] $allowedProperties
 	 * @return Property[]
 	 * @throws \OCP\DB\Exception
 	 */
-	public function findPropertiesByPaths(array $calendars): array {
+	public function findPropertiesByPaths(array $calendars, array $allowedProperties = []): array {
 		$selectQb = $this->db->getQueryBuilder();
 		$selectQb->select('*')
 			->from(self::TABLE_NAME)
 			->where($selectQb->expr()->in('propertypath', $selectQb->createNamedParameter($calendars, IQueryBuilder::PARAM_STR_ARRAY)));
+
+		if ($allowedProperties) {
+			$selectQb->andWhere($selectQb->expr()->in('propertyname', $selectQb->createNamedParameter($allowedProperties, IQueryBuilder::PARAM_STR_ARRAY)));
+		}
 
 		return $this->findEntities($selectQb);
 	}

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -54,6 +54,7 @@ use OCA\DAV\Connector\Sabre\ZipFolderPlugin;
 use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCA\DAV\DAV\PublicAuth;
 use OCA\DAV\DAV\ViewOnlyPlugin;
+use OCA\DAV\Db\PropertyMapper;
 use OCA\DAV\Events\SabrePluginAddEvent;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\DAV\Files\BrowserErrorPagePlugin;
@@ -306,6 +307,7 @@ class Server {
 							$this->server->tree,
 							\OCP\Server::get(IDBConnection::class),
 							\OCP\Server::get(IUserSession::class)->getUser(),
+							\OCP\Server::get(PropertyMapper::class),
 							\OCP\Server::get(DefaultCalendarValidator::class),
 						)
 					)

--- a/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CustomPropertiesBackendTest.php
@@ -12,6 +12,7 @@ use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\File;
 use OCA\DAV\DAV\CustomPropertiesBackend;
+use OCA\DAV\Db\PropertyMapper;
 use OCP\IDBConnection;
 use OCP\IUser;
 use OCP\Server;
@@ -52,6 +53,7 @@ class CustomPropertiesBackendTest extends \Test\TestCase {
 			$this->tree,
 			Server::get(IDBConnection::class),
 			$this->user,
+			Server::get(PropertyMapper::class),
 			$this->defaultCalendarValidator,
 		);
 	}

--- a/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
+++ b/apps/dav/tests/unit/DAV/CustomPropertiesBackendTest.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\Tests\unit\DAV;
 use OCA\DAV\CalDAV\Calendar;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\DAV\CustomPropertiesBackend;
+use OCA\DAV\Db\PropertyMapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
@@ -36,6 +37,7 @@ class CustomPropertiesBackendTest extends TestCase {
 	private IUser&MockObject $user;
 	private DefaultCalendarValidator&MockObject $defaultCalendarValidator;
 	private CustomPropertiesBackend $backend;
+	private PropertyMapper $propertyMapper;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -49,6 +51,7 @@ class CustomPropertiesBackendTest extends TestCase {
 			->with()
 			->willReturn('dummy_user_42');
 		$this->dbConnection = \OCP\Server::get(IDBConnection::class);
+		$this->propertyMapper = \OCP\Server::get(PropertyMapper::class);
 		$this->defaultCalendarValidator = $this->createMock(DefaultCalendarValidator::class);
 
 		$this->backend = new CustomPropertiesBackend(
@@ -56,6 +59,7 @@ class CustomPropertiesBackendTest extends TestCase {
 			$this->tree,
 			$this->dbConnection,
 			$this->user,
+			$this->propertyMapper,
 			$this->defaultCalendarValidator,
 		);
 	}
@@ -129,6 +133,7 @@ class CustomPropertiesBackendTest extends TestCase {
 			$this->tree,
 			$db,
 			$this->user,
+			$this->propertyMapper,
 			$this->defaultCalendarValidator,
 		);
 


### PR DESCRIPTION
## Summary

Fix issue where we are requesting for each calendar individually the properties while we could query the properties for each calendar at the same time.

Before (with only 3 calendars):

<img width="1089" height="224" alt="image" src="https://github.com/user-attachments/assets/e427d926-481a-4a38-94b8-5d2a209f1ec6" />

After:

<img width="730" height="245" alt="image" src="https://github.com/user-attachments/assets/5546ee59-7d02-4c84-b4f9-47ca81432c75" />

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
