### PR TITLE
fix(files_sharing): use user defined passwords

### DIFF
--- a/apps/files_sharing/src/components/SharingEntryLink.vue
+++ b/apps/files_sharing/src/components/SharingEntryLink.vue
@@ -77,7 +77,7 @@
 			<NcActionInput v-if="pendingEnforcedPassword || isPasswordProtected"
 				class="share-link-password"
 				:label="t('files_sharing', 'Enter a password')"
-				:value.sync="share.newPassword"
+				:value.sync="share.password"
 				:disabled="saving"
 				:required="config.enableLinkPasswordByDefault || config.enforcePasswordForPublicLink"
 				:minlength="isPasswordPolicyEnabled && config.passwordPolicy.minLength"


### PR DESCRIPTION
* Resolves: #54398 

## Summary

A previous MR(54055) resulted in the NcActionInput component responsible for creating file shares discarding user provided passwords, in favor of the system generated one.

This was caused by drift between the component and the underlying Share model, resulting in the component calling .sync on a non-existent attribute, which meant the password was never updated.

To reproduce (with password_policy enabled):
* Under a files "External Shares", click "Create public link"
* Supply a password to the password field, e.g., "testing-password_123"
* Click "Create share"
* Attempt to navigate to the generated share link and access the shared file with the password you provided at the time of creating the share.
* The provided password will be rejected, as it was never updated from the system generated one.

## TODO

N/A

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
