### PR TITLE
fix(ZipFolderPlugin): set mtime of directories in archive

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
@@ -67,15 +67,16 @@ class ZipFolderPlugin extends ServerPlugin {
 		// Remove the root path from the filename to make it relative to the requested folder
 		$filename = str_replace($rootPath, '', $node->getPath());
 
+		$mtime = $node->getMTime();
 		if ($node instanceof NcFile) {
 			$resource = $node->fopen('rb');
 			if ($resource === false) {
 				$this->logger->info('Cannot read file for zip stream', ['filePath' => $node->getPath()]);
 				throw new \Sabre\DAV\Exception\ServiceUnavailable('Requested file can currently not be accessed.');
 			}
-			$streamer->addFileFromStream($resource, $filename, $node->getSize(), $node->getMTime());
+			$streamer->addFileFromStream($resource, $filename, $node->getSize(), $mtime);
 		} elseif ($node instanceof NcFolder) {
-			$streamer->addEmptyDir($filename);
+			$streamer->addEmptyDir($filename, $mtime);
 			$content = $node->getDirectoryListing();
 			foreach ($content as $subNode) {
 				$this->streamNode($streamer, $subNode, $rootPath);

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -170,11 +170,16 @@ class Streamer {
 	/**
 	 * Add an empty directory entry to the archive.
 	 *
-	 * @param string $dirName Directory Path and name to be added to the archive.
-	 * @return bool $success
+	 * @param $dirName - Directory Path and name to be added to the archive.
+	 * @param $timestamp - Modification time of the directory (defaults to current time)
 	 */
-	public function addEmptyDir($dirName) {
-		return $this->streamerInstance->addEmptyDir($dirName);
+	public function addEmptyDir(string $dirName, int $timestamp = 0): bool {
+		$options = null;
+		if ($timestamp > 0) {
+			$options = ['timestamp' => $timestamp];
+		}
+
+		return $this->streamerInstance->addEmptyDir($dirName, $options);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Directories should also have the correct mtime set and not the current time. For this the `Streamer` class needs to support passing a time attribute for creating folders, the underlying library already supports this.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
