### PR TITLE
fix(Streamer): use localtime for ZIP files

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -27,6 +27,7 @@ use OCP\Files\IFilenameValidator;
 use OCP\Files\IRootFolder;
 use OCP\Files\Mount\IMountManager;
 use OCP\IConfig;
+use OCP\IDateTimeZone;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IL10N;
@@ -105,6 +106,7 @@ class ServerFactory {
 			$tree,
 			$this->logger,
 			$this->eventDispatcher,
+			\OCP\Server::get(IDateTimeZone::class),
 		));
 
 		// Some WebDAV clients do require Class 2 WebDAV support (locking), since

--- a/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
@@ -15,6 +15,7 @@ use OCP\Files\Events\BeforeZipCreatedEvent;
 use OCP\Files\File as NcFile;
 use OCP\Files\Folder as NcFolder;
 use OCP\Files\Node as NcNode;
+use OCP\IDateTimeZone;
 use Psr\Log\LoggerInterface;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
@@ -41,6 +42,7 @@ class ZipFolderPlugin extends ServerPlugin {
 		private Tree $tree,
 		private LoggerInterface $logger,
 		private IEventDispatcher $eventDispatcher,
+		private IDateTimeZone $timezoneFactory,
 	) {
 	}
 
@@ -163,7 +165,7 @@ class ZipFolderPlugin extends ServerPlugin {
 			// Full folder is loaded to rename the archive to the folder name
 			$archiveName = $folder->getName();
 		}
-		$streamer = new Streamer($tarRequest, -1, count($content));
+		$streamer = new Streamer($tarRequest, -1, count($content), $this->timezoneFactory);
 		$streamer->sendHeaders($archiveName);
 		// For full folder downloads we also add the folder itself to the archive
 		if (empty($files)) {

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -81,6 +81,7 @@ use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IAppConfig;
 use OCP\ICacheFactory;
 use OCP\IConfig;
+use OCP\IDateTimeZone;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
 use OCP\IPreview;
@@ -246,6 +247,7 @@ class Server {
 			$this->server->tree,
 			$logger,
 			$eventDispatcher,
+			\OCP\Server::get(IDateTimeZone::class),
 		));
 		$this->server->addPlugin(\OCP\Server::get(PaginatePlugin::class));
 

--- a/lib/private/Streamer.php
+++ b/lib/private/Streamer.php
@@ -41,7 +41,12 @@ class Streamer {
 	 * @param int $numberOfFiles The number of files (and directories) that will
 	 *                           be included in the streamed file
 	 */
-	public function __construct(IRequest|bool $preferTar, int|float $size, int $numberOfFiles) {
+	public function __construct(
+		IRequest|bool $preferTar,
+		int|float $size,
+		int $numberOfFiles,
+		private IDateTimeZone $timezoneFactory,
+	) {
 		if ($preferTar instanceof IRequest) {
 			$preferTar = self::isUserAgentPreferTar($preferTar);
 		}
@@ -197,7 +202,7 @@ class Streamer {
 		if ($this->streamerInstance instanceof ZipStreamer) {
 			// Zip does not support any timezone information
 			// while tar is interpreted as Unix time the Zip time is interpreted as local time of the user...
-			$zone = \OCP\Server::get(IDateTimeZone::class)->getTimeZone($timestamp);
+			$zone = $this->timezoneFactory->getTimeZone($timestamp);
 			$timestamp += $zone->getOffset(new \DateTimeImmutable('@' . (string)$timestamp));
 		}
 		return $timestamp;

--- a/lib/public/AppFramework/Http/ZipResponse.php
+++ b/lib/public/AppFramework/Http/ZipResponse.php
@@ -9,6 +9,7 @@ namespace OCP\AppFramework\Http;
 
 use OC\Streamer;
 use OCP\AppFramework\Http;
+use OCP\IDateTimeZone;
 use OCP\IRequest;
 
 /**
@@ -65,7 +66,7 @@ class ZipResponse extends Response implements ICallbackResponse {
 			$size += $resource['size'];
 		}
 
-		$zip = new Streamer($this->request, $size, $files);
+		$zip = new Streamer($this->request, $size, $files, \OCP\Server::get(IDateTimeZone::class));
 		$zip->sendHeaders($this->name);
 
 		foreach ($this->resources as $resource) {


### PR DESCRIPTION
- [x] follow up on https://github.com/nextcloud/server/pull/54401
- Resolves https://github.com/nextcloud/server/issues/54311

## Summary

ZIP does not use a proper timestamp but uses something called "DOS time".
This is a weird old format with some limitations like accuracy of only
2 seconds, but also no timezone information.
Also unlike UNIX time it is not relative to some specific point in time
with timezone information, but is always considered to be the local
time. Meaning we need to convert it first to the users local time.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
