### PR TITLE
perf(properties): Remove useless calendar-enabled rows

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -439,7 +439,7 @@ class CustomPropertiesBackend implements BackendInterface {
 				];
 
 				// If it was null, we need to delete the property
-				if (is_null($propertyValue)) {
+				if (is_null($propertyValue) || ($propertyName === '{http://owncloud.org/ns}calendar-enabled' && $propertyValue === '1')) {
 					if (array_key_exists($propertyName, $existing)) {
 						$deleteQuery = $deleteQuery ?? $this->createDeleteQuery();
 						$deleteQuery


### PR DESCRIPTION
## Summary

Instead of setting calendar-enabled to true, delete the row as true is the default value anyway. This should make the oc_properties table a bit smaller as calendar-enabled is the properties the most often set.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
