### PR TITLE
perf(comments): Add a way to get comments for multiple objects at the same time

### DIFF
--- a/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/CommentsPropertiesPluginTest.php
@@ -104,8 +104,8 @@ class CommentsPropertiesPluginTest extends \Test\TestCase {
 			->willReturn($user);
 
 		$this->commentsManager->expects($this->any())
-			->method('getNumberOfCommentsForObject')
-			->willReturn(42);
+			->method('getNumberOfUnreadCommentsForObjects')
+			->willReturn(['4567' => 42]);
 
 		$unread = $this->plugin->getUnreadCount($node);
 		if (is_null($user)) {

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -632,7 +632,7 @@ class Manager implements ICommentsManager {
 	/** @inheritDoc */
 	public function getNumberOfCommentsForObjects(string $objectType, array $objectIds, ?\DateTime $notOlderThan = null, string $verb = ''): array {
 		$qb = $this->dbConn->getQueryBuilder();
-		$query = $qb->select($qb->func()->count('id'), 'object_id')
+		$query = $qb->select($qb->func()->count('id', 'num_comments'), 'object_id')
 			->from('comments')
 			->where($qb->expr()->eq('object_type', $qb->createNamedParameter($objectType, IQueryBuilder::PARAM_STR)))
 			->andWhere($qb->expr()->in('object_id', $qb->createNamedParameter($objectIds, IQueryBuilder::PARAM_STR_ARRAY)));
@@ -651,7 +651,7 @@ class Manager implements ICommentsManager {
 		$comments = array_fill_keys($objectIds, 0);
 		$resultStatement = $query->execute();
 		while ($data = $resultStatement->fetch()) {
-			$comments[$data[1]] = (int)$data[0];
+			$comments[$data['object_id']] = (int)$data['num_comments'];
 		}
 		$resultStatement->closeCursor();
 

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -191,7 +191,7 @@ interface ICommentsManager {
 	 * @param $objectIds string[] the ids of the object
 	 * @param \DateTime|null $notOlderThan optional, timestamp of the oldest comments
 	 *                                     that may be returned
-	 * @param string $verb Limit the verb of the comment - Added in 14.0.0
+	 * @param string $verb Limit the verb of the comment
 	 * @return array<string, int>
 	 * @since 32.0.0
 	 */

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -187,6 +187,17 @@ interface ICommentsManager {
 	public function getNumberOfCommentsForObject($objectType, $objectId, ?\DateTime $notOlderThan = null, $verb = '');
 
 	/**
+	 * @param $objectType string the object type, e.g. 'files'
+	 * @param $objectIds string[] the ids of the object
+	 * @param \DateTime|null $notOlderThan optional, timestamp of the oldest comments
+	 *                                     that may be returned
+	 * @param string $verb Limit the verb of the comment - Added in 14.0.0
+	 * @return array<string, int>
+	 * @since 32.0.0
+	 */
+	public function getNumberOfCommentsForObjects(string $objectType, array $objectIds, ?\DateTime $notOlderThan = null, string $verb = '');
+
+	/**
 	 * @param string $objectType the object type, e.g. 'files'
 	 * @param string[] $objectIds the id of the object
 	 * @param IUser $user

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -59,6 +59,10 @@ class FakeManager implements ICommentsManager {
 	public function getNumberOfCommentsForObject($objectType, $objectId, ?\DateTime $notOlderThan = null, $verb = '') {
 	}
 
+	public function getNumberOfCommentsForObjects(string $objectType, array $objectIds, ?\DateTime $notOlderThan = null, string $verb = '') :array {
+		return array_fill_keys($objectIds, 0);
+	}
+
 	public function search(string $search, string $objectType, string $objectId, string $verb, int $offset, int $limit = 50): array {
 		return [];
 	}


### PR DESCRIPTION
## Summary

Required for https://github.com/nextcloud/deck/pull/7164

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
