### PR TITLE
feat(preset): compare default for all preset

### DIFF
--- a/apps/settings/appinfo/routes.php
+++ b/apps/settings/appinfo/routes.php
@@ -56,6 +56,7 @@ return [
 		['name' => 'TwoFactorSettings#index', 'url' => '/settings/api/admin/twofactorauth', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'TwoFactorSettings#update', 'url' => '/settings/api/admin/twofactorauth', 'verb' => 'PUT' , 'root' => ''],
 		['name' => 'AISettings#update', 'url' => '/settings/api/admin/ai', 'verb' => 'PUT' , 'root' => ''],
+		['name' => 'Preset#getPreset', 'url' => '/settings/preset', 'verb' => 'GET' , 'root' => ''],
 
 		['name' => 'Help#help', 'url' => '/settings/help/{mode}', 'verb' => 'GET', 'defaults' => ['mode' => ''] , 'root' => ''],
 

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -32,6 +32,7 @@ return array(
     'OCA\\Settings\\Controller\\LogSettingsController' => $baseDir . '/../lib/Controller/LogSettingsController.php',
     'OCA\\Settings\\Controller\\MailSettingsController' => $baseDir . '/../lib/Controller/MailSettingsController.php',
     'OCA\\Settings\\Controller\\PersonalSettingsController' => $baseDir . '/../lib/Controller/PersonalSettingsController.php',
+    'OCA\\Settings\\Controller\\PresetController' => $baseDir . '/../lib/Controller/PresetController.php',
     'OCA\\Settings\\Controller\\ReasonsController' => $baseDir . '/../lib/Controller/ReasonsController.php',
     'OCA\\Settings\\Controller\\TwoFactorSettingsController' => $baseDir . '/../lib/Controller/TwoFactorSettingsController.php',
     'OCA\\Settings\\Controller\\UsersController' => $baseDir . '/../lib/Controller/UsersController.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -47,6 +47,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\Controller\\LogSettingsController' => __DIR__ . '/..' . '/../lib/Controller/LogSettingsController.php',
         'OCA\\Settings\\Controller\\MailSettingsController' => __DIR__ . '/..' . '/../lib/Controller/MailSettingsController.php',
         'OCA\\Settings\\Controller\\PersonalSettingsController' => __DIR__ . '/..' . '/../lib/Controller/PersonalSettingsController.php',
+        'OCA\\Settings\\Controller\\PresetController' => __DIR__ . '/..' . '/../lib/Controller/PresetController.php',
         'OCA\\Settings\\Controller\\ReasonsController' => __DIR__ . '/..' . '/../lib/Controller/ReasonsController.php',
         'OCA\\Settings\\Controller\\TwoFactorSettingsController' => __DIR__ . '/..' . '/../lib/Controller/TwoFactorSettingsController.php',
         'OCA\\Settings\\Controller\\UsersController' => __DIR__ . '/..' . '/../lib/Controller/UsersController.php',

--- a/apps/settings/lib/Controller/PresetController.php
+++ b/apps/settings/lib/Controller/PresetController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\Controller;
+
+use OC\Config\PresetManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\Attribute\OpenAPI;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IRequest;
+
+#[OpenAPI(scope: OpenAPI::SCOPE_IGNORE)]
+class PresetController extends Controller {
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		private readonly PresetManager $presetManager,
+	) {
+		parent::__construct($appName, $request);
+	}
+
+	public function getPreset(): DataResponse {
+		return new DataResponse($this->presetManager->retrieveLexiconPreset());
+	}
+
+}

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1791,7 +1791,13 @@ class AppConfig implements IAppConfig {
 		return $this->configLexiconDetails[$appId];
 	}
 
-	private function getLexiconEntry(string $appId, string $key): ?Entry {
+	/**
+	 * get Lexicon Entry using appId and config key entry
+	 *
+	 * @return Entry|null NULL if entry does not exist in app's Lexicon
+	 * @internal
+	 */
+	public function getLexiconEntry(string $appId, string $key): ?Entry {
 		return $this->getConfigDetailsFromLexicon($appId)['entries'][$key] ?? null;
 	}
 

--- a/lib/private/Config/PresetManager.php
+++ b/lib/private/Config/PresetManager.php
@@ -9,10 +9,9 @@ declare(strict_types=1);
 namespace OC\Config;
 
 use OC\App\AppManager;
+use OC\AppConfig;
 use OC\Installer;
 use OCP\App\AppPathNotFoundException;
-use OCP\App\IAppManager;
-use OC\AppConfig;
 use OCP\App\IAppManager;
 use OCP\Config\Lexicon\Preset;
 use OCP\Exceptions\AppConfigUnknownKeyException;
@@ -20,7 +19,6 @@ use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
-use OCP\Server;
 
 /**
  * tools to manage the Preset feature

--- a/lib/private/Config/PresetManager.php
+++ b/lib/private/Config/PresetManager.php
@@ -12,10 +12,15 @@ use OC\App\AppManager;
 use OC\Installer;
 use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
+use OC\AppConfig;
+use OCP\App\IAppManager;
 use OCP\Config\Lexicon\Preset;
+use OCP\Exceptions\AppConfigUnknownKeyException;
+use OCP\IAppConfig;
 use OCP\IConfig;
 use OCP\Server;
 use Psr\Log\LoggerInterface;
+use OCP\Server;
 
 /**
  * tools to manage the Preset feature
@@ -55,6 +60,67 @@ class PresetManager {
 		}
 
 		return $this->configLexiconPreset;
+	}
+
+	/**
+	 * get lexicon config entries affected by Preset and its default values
+	 *
+	 * **Warning** This method MUST be considered resource-needy!
+	 *
+	 * @return array<string, list<array{defaults: array{CLUB: null|string, FAMILY: null|string, LARGE: null|string, MEDIUM: null|string, NONE: null|string, PRIVATE: null|string, SCHOOL: null|string, SHARED: null|string, SMALL: null|string, UNIVERSITY: null|string}, entry: array{definition: string, deprecated: bool, key: string, lazy: bool, note: string, type: 'ARRAY'|'BOOL'|'FLOAT'|'INT'|'MIXED'|'STRING'}, value?: mixed}>>
+	 */
+	public function retrieveLexiconPreset(?string $appId = null): array {
+		if ($appId === null) {
+			$apps = [];
+			foreach (['core'] + Server::get(IAppManager::class)->getEnabledApps() as $app) {
+				$preset = $this->retrieveLexiconPreset($app);
+				$apps[$app] = $preset[$app];
+			}
+			return $apps;
+		}
+
+		/** @var AppConfig|null $appConfig */
+		$appConfig = Server::get(IAppConfig::class);
+		$lexicon = $appConfig->getConfigDetailsFromLexicon($appId);
+		$presets = [];
+		foreach ($lexicon['entries'] as $entry) {
+			$defaults = [];
+			foreach (Preset::cases() as $case) {
+				// for each case, we need to use a fresh IAppConfig with clear cache
+				// cloning to avoid conflict while emulating preset
+				$newConfig = clone $appConfig;
+				$newConfig->clearCache(); // needed to ignore cache and rebuild default
+				$newLexicon = $newConfig->getLexiconEntry($appId, $entry->getKey());
+				$defaults[$case->name] = $newLexicon?->getDefault($case);
+			}
+
+			// compare all value from $defaults, if more than 1 exist we have a preset
+			$uniqueness = array_unique($defaults);
+			if (count($uniqueness) < 2) {
+				continue;
+			}
+
+			$details = [
+				'entry' => [
+					'key' => $entry->getKey(),
+					'type' => $entry->getValueType()->name,
+					'definition' => $entry->getDefinition(),
+					'lazy' => $entry->isLazy(),
+					'deprecated' => $entry->isDeprecated(),
+					'note' => $entry->getNote(),
+				],
+				'defaults' => $defaults
+			];
+
+			try {
+				$details['value'] = $appConfig->getDetails($appId, $entry->getKey())['value'];
+			} catch (AppConfigUnknownKeyException) {
+			}
+
+			$presets[] = $details;
+		}
+
+		return [$appId => $presets];
 	}
 
 	/**


### PR DESCRIPTION
For all enabled apps, get lexicon and filters entries that returns different default value based on Preset

```

$ ./occ config:preset --compare
+------+------------------------------+-------+--------+-------+--------+------------+--------+------+--------+---------+------+
| app  | config key                   | LARGE | MEDIUM | SMALL | SHARED | UNIVERSITY | SCHOOL | CLUB | FAMILY | PRIVATE | NONE |
+------+------------------------------+-------+--------+-------+--------+------------+--------+------+--------+---------+------+
| core | shareapi_allow_custom_tokens | 0     | 0      | 0     | 0      | 0          | 0      | 0    | 1      | 1       | 0    |
+------+------------------------------+-------+--------+-------+--------+------------+--------+------+--------+---------+------+
```


Also, admin endpoint: 
```
$ curl https://cloud.example.net/settings/preset -X GET | jq .
{
  "core": [
    {
      "entry": {
        "key": "shareapi_allow_custom_tokens",
        "type": "BOOL",
        "definition": "",
        "lazy": true,
        "deprecated": false,
        "note": ""
      },
      "defaults": {
        "LARGE": "0",
        "MEDIUM": "0",
        "SMALL": "0",
        "SHARED": "0",
        "UNIVERSITY": "0",
        "SCHOOL": "0",
        "CLUB": "0",
        "FAMILY": "1",
        "PRIVATE": "1",
        "NONE": "0"
      }
    }
  ],
  "cloud_federation_api": [],
  "comments": [],
  "contactsinteraction": [],
  "dashboard": [],
  "dav": [],
  "federatedfilesharing": [],
  "federation": [],
  "files": [],
  "files_reminders": [],
  "files_sharing": [],
  "files_trashbin": [],
  "files_versions": [],
  "lookup_server_connector": [],
  "oauth2": [],
  "profile": [],
  "provisioning_api": [],
  "settings": [],
  "sharebymail": [],
  "systemtags": [],
  "theming": [],
  "twofactor_backupcodes": [],
  "updatenotification": [],
  "user_status": [],
  "viewer": [],
  "weather_status": [],
  "webhook_listeners": [],
  "workflowengine": []
}
```

