### PR TITLE
fix: add more transparency to the header icon gradient

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -79,9 +79,9 @@
   --header-menu-item-height: 44px;
   /* An alpha mask to be applied to all icons on the navigation bar (header menu).
    * Icons are have a size of 20px but usually we use MDI which have a content of 16px so 2px padding top bottom,
-   * for better gradient we set those 2px (10% of height) as start and stop positions, this is also somewhat size agnostic as we only depend on the percentage.
+   * for better gradient we must at first begin at those 2px (10% of height) as start and stop positions.
    */
-  --header-menu-icon-mask: linear-gradient(var(--color-background-plain-text) 10%, color-mix(in srgb, var(--color-background-plain-text), 25% transparent) 90%) alpha;
+  --header-menu-icon-mask: linear-gradient(var(--color-background-plain-text) 25%, color-mix(in srgb, var(--color-background-plain-text), 55% transparent) 90%) alpha;
 
   --navigation-width: 300px;
   --sidebar-min-width: 300px;

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -196,9 +196,9 @@ class DefaultTheme implements ITheme {
 			'--header-menu-item-height' => '44px',
 			/* An alpha mask to be applied to all icons on the navigation bar (header menu).
 			 * Icons are have a size of 20px but usually we use MDI which have a content of 16px so 2px padding top bottom,
-			 * for better gradient we set those 2px (10% of height) as start and stop positions, this is also somewhat size agnostic as we only depend on the percentage.
+			 * for better gradient we must at first begin at those 2px (10% of height) as start and stop positions.
 			 */
-			'--header-menu-icon-mask' => 'linear-gradient(var(--color-background-plain-text) 10%, color-mix(in srgb, var(--color-background-plain-text), 25% transparent) 90%) alpha',
+			'--header-menu-icon-mask' => 'linear-gradient(var(--color-background-plain-text) 25%, color-mix(in srgb, var(--color-background-plain-text), 55% transparent) 90%) alpha',
 
 			// various structure data
 			'--navigation-width' => '300px',


### PR DESCRIPTION
## Summary

before | after
---|---
<img width="1208" height="428" alt="current" src="https://github.com/user-attachments/assets/1de498d8-8be5-46a6-9cc8-5fcc8c9682d4" />|<img width="1208" height="428" alt="most" src="https://github.com/user-attachments/assets/182e5aa2-fb20-4840-8905-53c3d8256c4c" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
