### PR TITLE
perf(calendar): Disable custom properties for individual calendar events

### DIFF
--- a/apps/dav/lib/DAV/CustomPropertiesBackend.php
+++ b/apps/dav/lib/DAV/CustomPropertiesBackend.php
@@ -10,6 +10,7 @@ namespace OCA\DAV\DAV;
 
 use Exception;
 use OCA\DAV\CalDAV\Calendar;
+use OCA\DAV\CalDAV\CalendarObject;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\Connector\Sabre\Directory;
 use OCA\DAV\Connector\Sabre\FilesPlugin;
@@ -222,6 +223,11 @@ class CustomPropertiesBackend implements BackendInterface {
 		$node = $this->tree->getNodeForPath($path);
 		if ($node instanceof Directory && $propFind->getDepth() !== 0) {
 			$this->cacheDirectory($path, $node);
+		}
+
+		if ($node instanceof CalendarObject) {
+			// No custom properties supported on individual events
+			return;
 		}
 
 		// First fetch the published properties (set by another user), then get the ones set by


### PR DESCRIPTION
## Summary

Save a query per event stored in the calendar and at least on the production instance, there is no entries in the table for the events.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
