### PR TITLE
fix(dav): clean up user's addressbook shares on deletion

### DIFF
--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -1092,6 +1092,13 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 	}
 
 	/**
+	 * Delete all of a user's shares
+	 */
+	public function deleteAllSharesByUser(string $principaluri): void {
+		$this->sharingBackend->deleteAllSharesByUser($principaluri);
+	}
+
+	/**
 	 * Search contacts in a specific address-book
 	 *
 	 * @param int $addressBookId

--- a/apps/dav/lib/Listener/UserEventsListener.php
+++ b/apps/dav/lib/Listener/UserEventsListener.php
@@ -122,6 +122,7 @@ class UserEventsListener implements IEventListener {
 			);
 		}
 		$this->calDav->deleteAllSharesByUser('principals/users/' . $uid);
+		$this->cardDav->deleteAllSharesByUser('principals/users/' . $uid);
 
 		foreach ($this->addressBooksToDelete[$uid] as $addressBook) {
 			$this->cardDav->deleteAddressBook($addressBook['id']);

--- a/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
+++ b/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
@@ -132,7 +132,7 @@ class UserEventsListenerTest extends TestCase {
 		$this->userEventsListener->firstLogin($user);
 	}
 
-	public function testDeleteCalendar(): void {
+	public function testDeleteUser(): void {
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getUID')->willReturn('newUser');
 
@@ -148,6 +148,7 @@ class UserEventsListenerTest extends TestCase {
 		$this->calDavBackend->expects($this->once())->method('deleteCalendar')->with('personal');
 		$this->calDavBackend->expects($this->once())->method('deleteSubscription')->with('some-subscription');
 		$this->calDavBackend->expects($this->once())->method('deleteAllSharesByUser');
+		$this->cardDavBackend->expects($this->once())->method('deleteAllSharesByUser');
 
 		$this->cardDavBackend->expects($this->once())->method('getUsersOwnAddressBooks')->willReturn([
 			['id' => 'personal']


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Deleting a user cleans up their addressbooks but leaves the shares. This is now fixed.

## TODO

- [x] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
