### PR TITLE
perf(caldav): preload publish statuses for a whole calendar home at once

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -78,6 +78,7 @@ $calDavBackend = new CalDavBackend(
 	$config,
 	Server::get(\OCA\DAV\CalDAV\Sharing\Backend::class),
 	Server::get(FederatedCalendarMapper::class),
+	Server::get(\OCP\ICacheFactory::class),
 	true
 );
 

--- a/apps/dav/lib/CalDAV/Publishing/PublishPlugin.php
+++ b/apps/dav/lib/CalDAV/Publishing/PublishPlugin.php
@@ -6,7 +6,9 @@
  */
 namespace OCA\DAV\CalDAV\Publishing;
 
+use OCA\DAV\CalDAV\CalDavBackend;
 use OCA\DAV\CalDAV\Calendar;
+use OCA\DAV\CalDAV\CalendarHome;
 use OCA\DAV\CalDAV\Publishing\Xml\Publisher;
 use OCP\AppFramework\Http;
 use OCP\IConfig;
@@ -91,6 +93,20 @@ class PublishPlugin extends ServerPlugin {
 	}
 
 	public function propFind(PropFind $propFind, INode $node) {
+		if ($node instanceof CalendarHome && $propFind->getDepth() === 1) {
+			$backend = $node->getCalDAVBackend();
+			if ($backend instanceof CalDavBackend) {
+				$calendars = array_filter(
+					$node->getChildren(),
+					static fn ($child) => $child instanceof Calendar,
+				);
+				$resourceIds = array_map(
+					static fn (Calendar $calendar) => $calendar->getResourceId(),
+					$calendars,
+				);
+				$backend->preloadPublishStatuses($resourceIds);
+			}
+		}
 		if ($node instanceof Calendar) {
 			$propFind->handle('{' . self::NS_CALENDARSERVER . '}publish-url', function () use ($node) {
 				if ($node->getPublishStatus()) {

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -16,6 +16,7 @@ use OCA\DAV\Connector\Sabre\Principal;
 use OCP\Accounts\IAccountManager;
 use OCP\App\IAppManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -82,6 +83,7 @@ class CreateCalendar extends Command {
 			$config,
 			Server::get(Backend::class),
 			Server::get(FederatedCalendarMapper::class),
+			Server::get(ICacheFactory::class),
 		);
 		$caldav->createCalendar("principals/users/$user", $name, []);
 		return self::SUCCESS;

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -36,6 +36,7 @@ use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Comments\ICommentsManager;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\IRootFolder;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -108,6 +109,7 @@ class RootCollection extends SimpleCollection {
 			$config,
 			$calendarSharingBackend,
 			Server::get(FederatedCalendarMapper::class),
+			Server::get(ICacheFactory::class),
 			false,
 		);
 		$userCalendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users', $logger, $l10n, $config, $federatedCalendarFactory);

--- a/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
+++ b/apps/dav/tests/unit/CalDAV/AbstractCalDavBackend.php
@@ -59,6 +59,8 @@ abstract class AbstractCalDavBackend extends TestCase {
 	protected RemoteUserPrincipalBackend&MockObject $remoteUserPrincipalBackend;
 	protected FederationSharingService&MockObject $federationSharingService;
 	protected FederatedCalendarMapper&MockObject $federatedCalendarMapper;
+	protected ICacheFactory $cacheFactory;
+
 	public const UNIT_TEST_USER = 'principals/users/caldav-unit-test';
 	public const UNIT_TEST_USER1 = 'principals/users/caldav-unit-test1';
 	public const UNIT_TEST_GROUP = 'principals/groups/caldav-unit-test-group';
@@ -110,6 +112,7 @@ abstract class AbstractCalDavBackend extends TestCase {
 			new Service(new SharingMapper($this->db)),
 			$this->federationSharingService,
 			$this->logger);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$this->backend = new CalDavBackend(
 			$this->db,
 			$this->principal,
@@ -120,6 +123,7 @@ abstract class AbstractCalDavBackend extends TestCase {
 			$this->config,
 			$this->sharingBackend,
 			$this->federatedCalendarMapper,
+			$this->cacheFactory,
 			false,
 		);
 

--- a/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
+++ b/apps/dav/tests/unit/CalDAV/PublicCalendarRootTest.php
@@ -14,6 +14,7 @@ use OCA\DAV\CalDAV\PublicCalendar;
 use OCA\DAV\CalDAV\PublicCalendarRoot;
 use OCA\DAV\Connector\Sabre\Principal;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IGroupManager;
@@ -43,6 +44,7 @@ class PublicCalendarRootTest extends TestCase {
 	protected IConfig&MockObject $config;
 	private ISecureRandom $random;
 	private LoggerInterface&MockObject $logger;
+	protected ICacheFactory&MockObject $cacheFactory;
 
 	protected FederatedCalendarMapper&MockObject $federatedCalendarMapper;
 
@@ -56,6 +58,7 @@ class PublicCalendarRootTest extends TestCase {
 		$this->random = Server::get(ISecureRandom::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->federatedCalendarMapper = $this->createMock(FederatedCalendarMapper::class);
+		$this->cacheFactory = $this->createMock(ICacheFactory::class);
 		$dispatcher = $this->createMock(IEventDispatcher::class);
 		$config = $this->createMock(IConfig::class);
 		$sharingBackend = $this->createMock(\OCA\DAV\CalDAV\Sharing\Backend::class);
@@ -78,6 +81,7 @@ class PublicCalendarRootTest extends TestCase {
 			$config,
 			$sharingBackend,
 			$this->federatedCalendarMapper,
+			$this->cacheFactory,
 			false,
 		);
 		$this->l10n = $this->createMock(IL10N::class);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

This is the last big duplicated query I could find.

The logic follows how we preload shares once for a whole calendar home. Instead of loading the publish statuses one by one for each calendar inside it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
