### PR TITLE
fix(caldav): encode calendar URLs properly when formatting search results

### DIFF
--- a/apps/dav/lib/Search/EventsSearchProvider.php
+++ b/apps/dav/lib/Search/EventsSearchProvider.php
@@ -199,7 +199,7 @@ class EventsSearchProvider extends ACalendarSearchProvider implements IFiltering
 		[,, $principalId] = explode('/', $principalUri, 3);
 
 		return $this->urlGenerator->linkTo('', 'remote.php') . '/dav/calendars/'
-			. $principalId . '/'
+			. rawurlencode($principalId) . '/'
 			. $calendarUri . '/'
 			. $calendarObjectUri;
 	}

--- a/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
+++ b/apps/dav/tests/unit/Search/EventsSearchProviderTest.php
@@ -18,6 +18,7 @@ use OCP\Search\IFilter;
 use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Sabre\VObject\Reader;
 use Test\TestCase;
@@ -399,7 +400,18 @@ class EventsSearchProviderTest extends TestCase {
 		$this->assertFalse($result2Data['rounded']);
 	}
 
-	public function testGetDeepLinkToCalendarApp(): void {
+	public static function provideDeepLinkData(): array {
+		return [
+			['principals/users/john.doe', 'bGluay10by1yZW1vdGUucGhwL2Rhdi9jYWxlbmRhcnMvam9obi5kb2UvZm9vL2Jhci5pY3M='],
+			['principals/users/John Doe', 'bGluay10by1yZW1vdGUucGhwL2Rhdi9jYWxlbmRhcnMvSm9obiUyMERvZS9mb28vYmFyLmljcw=='],
+		];
+	}
+
+	#[DataProvider('provideDeepLinkData')]
+	public function testGetDeepLinkToCalendarApp(
+		string $principalUri,
+		string $expectedBase64DavUrl,
+	): void {
 		$this->urlGenerator->expects($this->once())
 			->method('linkTo')
 			->with('', 'remote.php')
@@ -410,10 +422,14 @@ class EventsSearchProviderTest extends TestCase {
 			->willReturn('link-to-route-calendar/');
 		$this->urlGenerator->expects($this->once())
 			->method('getAbsoluteURL')
-			->with('link-to-route-calendar/edit/bGluay10by1yZW1vdGUucGhwL2Rhdi9jYWxlbmRhcnMvam9obi5kb2UvZm9vL2Jhci5pY3M=')
+			->with("link-to-route-calendar/edit/$expectedBase64DavUrl")
 			->willReturn('absolute-url-to-route');
 
-		$actual = self::invokePrivate($this->provider, 'getDeepLinkToCalendarApp', ['principals/users/john.doe', 'foo', 'bar.ics']);
+		$actual = self::invokePrivate($this->provider, 'getDeepLinkToCalendarApp', [
+			$principalUri,
+			'foo',
+			'bar.ics',
+		]);
 
 		$this->assertEquals('absolute-url-to-route', $actual);
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54430 

## Summary

Need to encode user IDs properly before including them in URLs.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
