### PR TITLE
Add INodeByPath to Directory

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -8,6 +8,7 @@
 namespace OCA\DAV\Connector\Sabre;
 
 use OC\Files\Mount\MoveableMount;
+use OC\Files\Utils\PathHelper;
 use OC\Files\View;
 use OCA\DAV\AppInfo\Application;
 use OCA\DAV\Connector\Sabre\Exception\FileLocked;
@@ -38,8 +39,14 @@ use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\Exception\ServiceUnavailable;
 use Sabre\DAV\IFile;
 use Sabre\DAV\INode;
+use Sabre\DAV\INodeByPath;
 
-class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuota, \Sabre\DAV\IMoveTarget, \Sabre\DAV\ICopyTarget {
+class Directory extends Node implements
+	\Sabre\DAV\ICollection,
+	\Sabre\DAV\IQuota,
+	\Sabre\DAV\IMoveTarget,
+	\Sabre\DAV\ICopyTarget,
+	INodeByPath {
 	/**
 	 * Cached directory content
 	 * @var FileInfo[]
@@ -489,5 +496,80 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 
 	public function getNode(): Folder {
 		return $this->node;
+	}
+
+	public function getNodeForPath($path): INode {
+		$storage = $this->info->getStorage();
+		$allowDirectory = false;
+
+		// Checking if we're in a file drop
+		// If we are, then only PUT and MKCOL are allowed (see plugin)
+		// so we are safe to return the directory without a risk of
+		// leaking files and folders structure.
+		if ($storage->instanceOfStorage(PublicShareWrapper::class)) {
+			$share = $storage->getShare();
+			$allowDirectory = ($share->getPermissions() & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ;
+		}
+
+		// For file drop we need to be allowed to read the directory with the nickname
+		if (!$allowDirectory && !$this->info->isReadable()) {
+			// avoid detecting files through this way
+			throw new NotFound();
+		}
+
+		$destinationPath = PathHelper::normalizePath($this->getPath() . '/' . $path);
+		$destinationDir = dirname($destinationPath);
+
+		try {
+			$info = $this->getNode()->get($path);
+		} catch (NotFoundException $e) {
+			throw new \Sabre\DAV\Exception\NotFound('File with name ' . $destinationPath
+				. ' could not be located');
+		} catch (StorageNotAvailableException $e) {
+			throw new \Sabre\DAV\Exception\ServiceUnavailable($e->getMessage(), 0, $e);
+		} catch (NotPermittedException $ex) {
+			throw new InvalidPath($ex->getMessage(), false, $ex);
+		}
+
+		// if not in a public share with no read permissions, throw Forbidden
+		if (!$allowDirectory && !$info->isReadable()) {
+			if (Server::get(IAppManager::class)->isEnabledForAnyone('files_accesscontrol')) {
+				throw new Forbidden('No read permissions. This might be caused by files_accesscontrol, check your configured rules');
+			}
+
+			throw new Forbidden('No read permissions');
+		}
+
+		if ($info->getMimeType() === FileInfo::MIMETYPE_FOLDER) {
+			$node = new \OCA\DAV\Connector\Sabre\Directory($this->fileView, $info, $this->tree, $this->shareManager);
+		} else {
+			// In case reading a directory was allowed but it turns out the node was a not a directory, reject it now.
+			if (!$this->info->isReadable()) {
+				throw new NotFound();
+			}
+
+			$node = new File($this->fileView, $info, $this->shareManager);
+		}
+		$this->tree?->cacheNode($node);
+
+		// recurse upwards until the root and check for read permissions to keep
+		// ACL checks working in files_accesscontrol
+		if (!$allowDirectory && $destinationDir !== '') {
+			$scanPath = $destinationPath;
+			while (($scanPath = dirname($scanPath)) !== '/') {
+				// fileView can get the parent info in a cheaper way compared
+				// to the node API
+				/** @psalm-suppress InternalMethod */
+				$info = $this->fileView->getFileInfo($scanPath, false);
+				$directory = new Directory($this->fileView, $info, $this->tree, $this->shareManager);
+				$readable = $directory->getNode()->isReadable();
+				if (!$readable) {
+					throw new \Sabre\DAV\Exception\NotFound('File with name ' . $destinationPath
+						. ' could not be located');
+				}
+			}
+		}
+
+		return $node;
 	}
 }


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Sabre has an interface `INodeByPath` that allows nodes to fetch a specific node by its path. This was not implemented in our `Directory` class, leading to any file query to fetch all parent nodes until the file node was reached. This PR makes `Directory` implement that interface, extends makes the NC `Node` class extend the `Node` class from Sabre (required step).

Before:
<img width="1365" height="281" alt="Screenshot From 2025-08-15 18-52-24" src="https://github.com/user-attachments/assets/b9ac9565-5999-4058-b39b-23c0ce380f99" />

After:
<img width="1365" height="281" alt="Screenshot From 2025-08-15 18-50-51" src="https://github.com/user-attachments/assets/321d4e5a-e6ba-495d-b026-8030b0a3905e" />

- Part of https://github.com/nextcloud/server/issues/54562

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
