### PR TITLE
View.php's rename method modified to check permissions before allowin…

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -500,6 +500,7 @@
  - Tomasz Grobelny <tomasz@grobelny.net>
  - Tomasz Paluszkiewicz <tomasz.paluszkiewicz@gmail.com>
  - Tor Lillqvist <tml@collabora.com>
+ - Troy Morgan <tmorg@umich.edu>
  - UmbrellaCodr <umbrella@biohazard.cc>
  - Unknown <anpz.asutp@gmail.com>
  - Unpublished <unpublished@gmx.net>

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -732,6 +732,11 @@ class View {
 			if ($source == null || $target == null) {
 				return false;
 			}
+			$sourceInfo = $this->getFileInfo($source);
+			if ($sourceInfo && !($sourceInfo->getPermissions() & \OCP\Constants::PERMISSION_UPDATE)) {
+
+			    throw new ForbiddenException('You do not have permission to move this item', false);
+			}
 
 			try {
 				$this->verifyPath(dirname($target), basename($target));
@@ -869,6 +874,10 @@ class View {
 		$l = \OC::$server->get(IFactory::class)->get('files');
 		foreach ($mounts as $mount) {
 			$sourcePath = $this->getRelativePath($mount->getMountPoint());
+<<<<<<< HEAD
+=======
+
+>>>>>>> e65e10d6cd0 (View.php's rename method modified to check permissions before allowing move RE:issue#53041 signed off by tmorg@umich, Troy Morgan)
 			if ($sourcePath) {
 				$sourcePath = trim($sourcePath, '/');
 			} else {

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2900,4 +2900,49 @@ class ViewTest extends \Test\TestCase {
 		$viewUser1->copy('foo.txt', 'bar.txt');
 		$this->assertEquals('foo', $viewUser1->file_get_contents('bar.txt'));
 	}
+
+	public function testSingleFileReadOnlySharePermissions(): void {
+	    $userManager = Server::get(IUserManager::class);
+	    $shareManager = Server::get(IShareManager::class);
+	    $rootFolder = Server::get(\OCP\Files\IRootFolder::class);
+
+	    $recipient = 'recipient';
+	    $recipientUserObject = $userManager->createUser($recipient, 'testpass');
+
+	    self::loginAsUser($this->user);
+	    $ownerView = new View('/' . $this->user . '/files/');
+
+	    $testFile = 'fileToShare.txt';
+	    $ownerView->file_put_contents($testFile, 'content for sharing');
+	    $node = $rootFolder->getUserFolder($this->user)->get($testFile);
+
+	    $share = $shareManager->newShare();
+	    $share->setSharedWith($recipient)
+	          ->setSharedBy($this->user)
+	          ->setShareType(IShare::TYPE_USER)
+	          ->setPermissions(\OCP\Constants::PERMISSION_READ)  // read-only share
+	          ->setNode($node);
+	    $shareManager->createShare($share);
+
+	    $fileInfo = $ownerView->getFileInfo($testFile);
+	    $this->assertInstanceOf(\OCP\Files\FileInfo::class, $fileInfo, "Owner failed to fetch fileInfo");
+
+	    self::loginAsUser($recipient);
+	    $recipientView = new View('/' . $recipient . '/files/');
+
+	    $sharedFileInfo = $recipientView->getFileInfo($testFile);
+
+	    $canRename = false;
+	    try {
+	        $canRename = $recipientView->rename($testFile, 'moved.txt');
+	    } catch (\Exception $e) {
+	        $canRename = false;
+	    }
+
+	    $this->assertFalse($canRename, "Recipient is falsely able to move/rename a read-only shared file");
+
+	    self::loginAsUser($this->user);
+	    $shareManager->deleteShare($share);
+	    $recipientUserObject->delete();
+	}
 }


### PR DESCRIPTION
I implemented a three line check in lib/private/Files/View.php which aimed at addressing an issue where if Alice shares a file with Bob and sets his permissions to read-only, he is able to go beyond his permissions to the file, which are SGD, missing NV flags:<[oc:permissions]>SGD</oc:permissions>

autotest.sh passes with my added test to ViewTest.php, which creates a recipient and asserts that they are not able to move the file. The style passes tests as well.