### PR TITLE
fix: handle UID collisions on thunderbird PUT requests gracefully

### DIFF
--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -229,6 +229,7 @@ return array(
     'OCA\\DAV\\Connector\\Sabre\\SharesPlugin' => $baseDir . '/../lib/Connector/Sabre/SharesPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\TagList' => $baseDir . '/../lib/Connector/Sabre/TagList.php',
     'OCA\\DAV\\Connector\\Sabre\\TagsPlugin' => $baseDir . '/../lib/Connector/Sabre/TagsPlugin.php',
+    'OCA\\DAV\\Connector\\Sabre\\ThunderbirdPutInvitationQuirkPlugin' => $baseDir . '/../lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php',
     'OCA\\DAV\\Connector\\Sabre\\ZipFolderPlugin' => $baseDir . '/../lib/Connector/Sabre/ZipFolderPlugin.php',
     'OCA\\DAV\\Controller\\BirthdayCalendarController' => $baseDir . '/../lib/Controller/BirthdayCalendarController.php',
     'OCA\\DAV\\Controller\\DirectController' => $baseDir . '/../lib/Controller/DirectController.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -244,6 +244,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\Connector\\Sabre\\SharesPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/SharesPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\TagList' => __DIR__ . '/..' . '/../lib/Connector/Sabre/TagList.php',
         'OCA\\DAV\\Connector\\Sabre\\TagsPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/TagsPlugin.php',
+        'OCA\\DAV\\Connector\\Sabre\\ThunderbirdPutInvitationQuirkPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php',
         'OCA\\DAV\\Connector\\Sabre\\ZipFolderPlugin' => __DIR__ . '/..' . '/../lib/Connector/Sabre/ZipFolderPlugin.php',
         'OCA\\DAV\\Controller\\BirthdayCalendarController' => __DIR__ . '/..' . '/../lib/Controller/BirthdayCalendarController.php',
         'OCA\\DAV\\Controller\\DirectController' => __DIR__ . '/..' . '/../lib/Controller/DirectController.php',

--- a/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Connector\Sabre;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Sabre\VObject\Component\VCalendar;
+use Sabre\VObject\Reader as VObjectReader;
+
+/**
+ * Consider the following situation: A user is invited and tries to accept or decline from the
+ * invitation email in Thunderbird before the personal calendar was synced.
+ *
+ * Thunderbird attempts to PUT the accepted ics to an invalid name, because it doesn't know the name
+ * on the remote Nextcloud/CalDAV server (yet). The Nextcloud server responds with an error, as the
+ * UID is already existing because the invitation was already added to the invitees personal
+ * calendar by Sabre.
+ *
+ * If Thunderbird knows about the URI of the user's own copy of the event, it will PUT the correct
+ * event directly.
+ *
+ * This plugin attempts to handle this situation gracefully by simply replacing the URI of the event
+ * with the actual one before handing off the request to the CalDAV server.
+ */
+class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
+	private ?Server $server = null;
+
+	public function __construct(
+		private readonly IDBConnection $db,
+	) {
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function initialize(Server $server) {
+		$this->server = $server;
+
+		// Run right after the ACL plugin to make sure that the current user principal is available
+		$server->on('beforeMethod:PUT', $this->beforePut(...), 21);
+	}
+
+	public function beforePut(RequestInterface $request, ResponseInterface $response): void {
+		$userAgent = $request->getHeader('User-Agent');
+		if (!$userAgent || !$this->isThunderbirdUserAgent($userAgent)) {
+			return;
+		}
+
+		if (!str_starts_with($request->getPath(), 'calendars/')) {
+			return;
+		}
+
+		if (!str_contains($request->getHeader('Content-Type') ?? '', 'text/calendar')) {
+			return;
+		}
+
+		$currentUserPrincipal = $this->getCurrentUserPrincipal();
+		if ($currentUserPrincipal === null) {
+			return;
+		}
+
+		// Need to set the body again here so that other handlers are able to read it afterward
+		$requestBody = $request->getBodyAsString();
+		$request->setBody($requestBody);
+
+		try {
+			$vCalendar = VObjectReader::read($requestBody);
+		} catch (\Throwable $e) {
+			return;
+		}
+		if (!($vCalendar instanceof VCalendar)) {
+			return;
+		}
+
+		/** @var string|null $uid */
+		$uid = $vCalendar->getBaseComponent('VEVENT')?->UID?->getValue();
+		if ($uid === null) {
+			return;
+		}
+
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('co.uri')
+			->from('calendarobjects', 'co')
+			->join('co', 'calendars', 'c', $qb->expr()->eq('co.calendarid', 'c.id'))
+			->where(
+				$qb->expr()->eq(
+					'c.principaluri',
+					$qb->createNamedParameter($currentUserPrincipal, IQueryBuilder::PARAM_STR),
+					IQueryBuilder::PARAM_STR,
+				),
+				$qb->expr()->eq(
+					'co.uid',
+					$qb->createNamedParameter($uid, IQueryBuilder::PARAM_STR),
+					IQueryBuilder::PARAM_STR,
+				),
+			);
+		$result = $qb->executeQuery();
+		$rows = $result->fetchAll();
+		$result->closeCursor();
+
+		if (count($rows) !== 1) {
+			// Either no collision or too many collisions
+			return;
+		}
+
+		$requestUrl = $request->getUrl();
+		[$prefix] = \Sabre\Uri\split($requestUrl);
+		$objectUri = $rows[0]['uri'];
+		$request->setUrl("$prefix/$objectUri");
+	}
+
+	private function isThunderbirdUserAgent(string $userAgent): bool {
+		return str_contains($userAgent, 'Thunderbird/');
+	}
+
+	private function getCurrentUserPrincipal(): ?string {
+		/** @var \Sabre\DAV\Auth\Plugin $authPlugin */
+		$authPlugin = $this->server?->getPlugin('auth');
+		return $authPlugin?->getCurrentPrincipal();
+	}
+}

--- a/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
@@ -41,9 +41,6 @@ class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
 	) {
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	public function initialize(Server $server) {
 		$this->server = $server;
 

--- a/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ThunderbirdPutInvitationQuirkPlugin.php
@@ -19,19 +19,19 @@ use Sabre\VObject\Component\VCalendar;
 use Sabre\VObject\Reader as VObjectReader;
 
 /**
- * Consider the following situation: A user is invited and tries to accept or decline from the
- * invitation email in Thunderbird before the personal calendar was synced.
+ * Consider the following situation: A user is invited and tries to accept or decline the event
+ * attached to the invitation email in Thunderbird before the personal calendar was synced.
  *
  * Thunderbird attempts to PUT the accepted ics to an invalid name, because it doesn't know the name
  * on the remote Nextcloud/CalDAV server (yet). The Nextcloud server responds with an error, as the
  * UID is already existing because the invitation was already added to the invitees personal
  * calendar by Sabre.
  *
- * If Thunderbird knows about the URI of the user's own copy of the event, it will PUT the correct
- * event directly.
- *
  * This plugin attempts to handle this situation gracefully by simply replacing the URI of the event
  * with the actual one before handing off the request to the CalDAV server.
+ *
+ * Note: If Thunderbird knows about the URI of the user's own copy of the event, it will PUT the
+ * correct event directly. This is the case after syncing the personal calendar.
  */
 class ThunderbirdPutInvitationQuirkPlugin extends ServerPlugin {
 	private ?Server $server = null;

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -51,6 +51,7 @@ use OCA\DAV\Connector\Sabre\QuotaPlugin;
 use OCA\DAV\Connector\Sabre\RequestIdHeaderPlugin;
 use OCA\DAV\Connector\Sabre\SharesPlugin;
 use OCA\DAV\Connector\Sabre\TagsPlugin;
+use OCA\DAV\Connector\Sabre\ThunderbirdPutInvitationQuirkPlugin;
 use OCA\DAV\Connector\Sabre\ZipFolderPlugin;
 use OCA\DAV\DAV\CustomPropertiesBackend;
 use OCA\DAV\DAV\PublicAuth;
@@ -130,6 +131,9 @@ class Server {
 		$this->server->addPlugin(new MaintenancePlugin(\OCP\Server::get(IConfig::class), \OC::$server->getL10N('dav')));
 
 		$this->server->addPlugin(new AppleQuirksPlugin());
+		$this->server->addPlugin(new ThunderbirdPutInvitationQuirkPlugin(
+			\OCP\Server::get(IDBConnection::class),
+		));
 
 		// Backends
 		$authBackend = new Auth(

--- a/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
@@ -343,7 +343,7 @@ END:VEVENT
 END:VCALENDAR
 EOF;
 
-	$noVEvent = <<<EOF
+		$noVEvent = <<<EOF
 BEGIN:VCALENDAR
 VERSION:2.0
 PRODID:-//Sabre//Sabre VObject 4.5.6//EN
@@ -369,7 +369,7 @@ END:VTIMEZONE
 END:VCALENDAR
 EOF;
 
-	$noVCalendar = <<<EOF
+		$noVCalendar = <<<EOF
 BEGIN:VTIMEZONE
 TZID:Europe/Berlin
 BEGIN:DAYLIGHT

--- a/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/ThunderbirdPutInvitationQuirkPluginTest.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\ThunderbirdPutInvitationQuirkPlugin;
+use OCP\DB\IResult;
+use OCP\DB\QueryBuilder\IExpressionBuilder;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Sabre\DAV\Server;
+use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
+use Test\TestCase;
+
+class ThunderbirdPutInvitationQuirkPluginTest extends TestCase {
+	private readonly ThunderbirdPutInvitationQuirkPlugin $plugin;
+
+	private readonly Server&MockObject $server;
+	private readonly IDBConnection&MockObject $db;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->server = $this->createMock(Server::class);
+		$this->db = $this->createMock(IDBConnection::class);
+
+		$this->plugin = new ThunderbirdPutInvitationQuirkPlugin(
+			$this->db,
+		);
+	}
+
+	public function testInitialize(): void {
+		$this->server->expects(self::once())
+			->method('on')
+			->with('beforeMethod:PUT', $this->plugin->beforePut(...), 21);
+
+		$this->plugin->initialize($this->server);
+	}
+
+	public static function provideBeforePutData(): array {
+		return [
+			// No collision
+			[[], false],
+			// Many collisions
+			[
+				[
+					['uri' => 'sabredav-3dd349f8-58e0-483d-921f-70bc9f02366b.ics'],
+					['uri' => 'sabredav-19a50615-2db0-4046-a537-000979925e16.ics'],
+				],
+				false,
+			],
+			// Exactly one collision
+			[
+				[
+					['uri' => 'sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics'],
+				],
+				true,
+			],
+		];
+	}
+
+	#[DataProvider('provideBeforePutData')]
+	public function testBeforePut(array $rows, bool $expectUrlChange): void {
+		$ics = <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.6//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+CREATED:20250817T094141Z
+LAST-MODIFIED:20250817T094211Z
+SEQUENCE:2
+UID:cc5d41aa-7dbc-4278-8ffd-4fb5d626397c
+DTSTART;TZID=Europe/Berlin:20250819T030000
+DTEND;TZID=Europe/Berlin:20250819T080000
+STATUS:CONFIRMED
+SUMMARY:thunderbird-put-test
+ATTENDEE;CN=user a;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICI
+ PANT;RSVP=TRUE;LANGUAGE=en:mailto:usera@imap.localhost
+ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost
+DTSTAMP:20250817T094211Z
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+		$request->expects(self::once())
+			->method('getBodyAsString')
+			->willReturn($ics);
+		$request->expects(self::once())
+			->method('setBody')
+			->with($ics);
+		if ($expectUrlChange) {
+			$request->expects(self::once())
+				->method('getUrl')
+				->willReturn('remote.php/dav/calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+			$request->expects(self::once())
+				->method('setUrl')
+				->with('remote.php/dav/calendars/usera/personal/sabredav-ab2dd681-c265-4b1e-8a20-e9d356f2c33c.ics');
+		} else {
+			$request->expects(self::never())
+				->method('getUrl');
+			$request->expects(self::never())
+				->method('setUrl');
+		}
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn('principals/users/usera');
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('select')
+			->willReturnSelf();
+		$qb->method('from')
+			->willReturnSelf();
+		$qb->method('join')
+			->willReturnSelf();
+		$qb->method('where')
+			->willReturnSelf();
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$qb->method('expr')
+			->willReturn($expr);
+		$this->db->expects(self::once())
+			->method('getQueryBuilder')
+			->willReturn($qb);
+
+		$result = $this->createMock(IResult::class);
+		$result->expects(self::once())
+			->method('fetchAll')
+			->willReturn($rows);
+		$result->expects(self::once())
+			->method('closeCursor');
+		$qb->expects(self::once())
+			->method('executeQuery')
+			->willReturn($result);
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithInvalidUserAgent(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::once())
+			->method('getHeader')
+			->with('User-Agent')
+			->willReturn('curl/8.14.1');
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithUnrelatedRequestPath(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::once())
+			->method('getHeader')
+			->with('User-Agent')
+			->willReturn('Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2');
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('foo/bar/baz');
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithInvalidContentType(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'foo/bar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithoutCurrentUserPrincipal(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn(null);
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public function testBeforePutWithoutAuthPlugin(): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn(null);
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+
+	public static function provideInvalidIcsData(): array {
+		$noUid = <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.6//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+CREATED:20250817T094141Z
+LAST-MODIFIED:20250817T094211Z
+SEQUENCE:2
+DTSTART;TZID=Europe/Berlin:20250819T030000
+DTEND;TZID=Europe/Berlin:20250819T080000
+STATUS:CONFIRMED
+SUMMARY:thunderbird-put-test
+ATTENDEE;CN=user a;CUTYPE=INDIVIDUAL;PARTSTAT=NEEDS-ACTION;ROLE=REQ-PARTICI
+ PANT;RSVP=TRUE;LANGUAGE=en:mailto:usera@imap.localhost
+ORGANIZER;CN=Admin Account:mailto:admin@imap.localhost
+DTSTAMP:20250817T094211Z
+END:VEVENT
+END:VCALENDAR
+EOF;
+
+	$noVEvent = <<<EOF
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Sabre//Sabre VObject 4.5.6//EN
+CALSCALE:GREGORIAN
+METHOD:REQUEST
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+END:VCALENDAR
+EOF;
+
+	$noVCalendar = <<<EOF
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+TZNAME:CEST
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+TZNAME:CET
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+EOF;
+
+		return [
+			[$noUid],
+			[$noVEvent],
+			[$noVCalendar],
+		];
+	}
+
+	#[DataProvider('provideInvalidIcsData')]
+	public function testBeforePutWithInvalidIcs(string $ics): void {
+		$request = $this->createMock(RequestInterface::class);
+		$request->expects(self::exactly(2))
+			->method('getHeader')
+			->willReturnMap([
+				['User-Agent', 'Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101 Thunderbird/38.2.0 Lightning/4.0.2'],
+				['Content-Type', 'text/calendar; charset=utf-8'],
+			]);
+		$request->expects(self::once())
+			->method('getPath')
+			->willReturn('calendars/usera/personal/cc5d41aa-7dbc-4278-8ffd-4fb5d626397c.ics');
+		$request->expects(self::once())
+			->method('getBodyAsString')
+			->willReturn($ics);
+		$request->expects(self::once())
+			->method('setBody')
+			->with($ics);
+
+		$authPlugin = $this->createMock(\Sabre\DAV\Auth\Plugin::class);
+		$authPlugin->expects(self::once())
+			->method('getCurrentPrincipal')
+			->willReturn('principals/users/usera');
+		$this->server->expects(self::once())
+			->method('getPlugin')
+			->with('auth')
+			->willReturn($authPlugin);
+
+		$request->expects(self::never())
+			->method('setUrl');
+		$this->db->expects(self::never())
+			->method('getQueryBuilder');
+
+		$response = $this->createMock(ResponseInterface::class);
+
+		$this->plugin->initialize($this->server);
+		$this->plugin->beforePut($request, $response);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/17915

## Summary

I added a plugin that changes the request URI to the actual event if Thunderbird doesn't seem to know about it yet. This prevents the UID collision as proposed in https://github.com/nextcloud/server/issues/17915#issuecomment-1894010422.

I'm not sure how Thunderbird will behave, when it sync the next time and the actual event appears under a new URI. I have to test a bit more.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
