### PR TITLE
chore(CODEOWNERS): remove dependabot team from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 # this will override the backend code owners if needed
 /__mocks__                                    @nextcloud/server-frontend
 /__tests__                                    @nextcloud/server-frontend
+/dist                                         @nextcloud/server-frontend
 /cypress                                      @nextcloud/server-frontend
 **/css                                        @nextcloud/server-frontend
 **/js                                         @nextcloud/server-frontend
@@ -19,7 +20,6 @@
 # dependency management
 package.json                                  @nextcloud/server-dependabot @nextcloud/server-frontend
 package-lock.json                             @nextcloud/server-dependabot
-/dist                                         @nextcloud/server-dependabot
 
 # App maintainers
 /apps/admin_audit/appinfo/info.xml            @luka-nextcloud @blizzz


### PR DESCRIPTION
## Summary

The dependabot team should not be pinged for every frontend PR.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
