### PR TITLE
feat(IDateTimeZone): allow to fetch timezone of specified user

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3611,11 +3611,6 @@
       <code><![CDATA[string]]></code>
     </InvalidReturnType>
   </file>
-  <file src="lib/private/DateTimeZone.php">
-    <InvalidScalarArgument>
-      <code><![CDATA[$timestamp]]></code>
-    </InvalidScalarArgument>
-  </file>
   <file src="lib/private/Diagnostics/Query.php">
     <ImplementedReturnTypeMismatch>
       <code><![CDATA[float]]></code>

--- a/lib/public/IDateTimeZone.php
+++ b/lib/public/IDateTimeZone.php
@@ -13,10 +13,27 @@ namespace OCP;
  * @since 8.0.0
  */
 interface IDateTimeZone {
+
 	/**
+	 * Get the timezone for a given user.
+	 * If a timestamp is passed the timezone for that given timestamp is retrieved (might differ due to DST).
+	 * If no userId is passed the current user is used.
+	 *
 	 * @param bool|int $timestamp
+	 * @param ?string $userId - The user to fetch the timezone for (defaults to current user)
 	 * @return \DateTimeZone
-	 * @since 8.0.0 - parameter $timestamp was added in 8.1.0
+	 * @since 8.0.0
+	 * @since 8.1.0 - parameter $timestamp was added
+	 * @since 32.0.0 - parameter $userId was added
 	 */
-	public function getTimeZone($timestamp = false);
+	public function getTimeZone($timestamp = false, ?string $userId = null);
+
+	/**
+	 * Get the timezone configured as the default for this Nextcloud server.
+	 * While the PHP timezone is always set to UTC in Nextcloud this is the timezone
+	 * to use for all time offset calculations if no user value is specified.
+	 *
+	 * @since 32.0.0
+	 */
+	public function getDefaultTimeZone(): \DateTimeZone;
 }


### PR DESCRIPTION
## Summary

This allows to use the class for consistent timezone access.
Because currently it could only be used for the current user and not for other users.
As a follow up we then can refactor a lot of placed where we manually fetch the timezones of other users - e.g. the contacts menu for timezone offset between two users.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
