### PR TITLE
fix: exclude \Sabre\DAVACL\Plugin from prop find monitoring

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Server.php
+++ b/apps/dav/lib/Connector/Sabre/Server.php
@@ -86,6 +86,11 @@ class Server extends \Sabre\DAV\Server {
 			$parentFn($eventName, $callBack, $priority);
 			return;
 		}
+		// The \Sabre\DAVACL\Plugin needs to excluded as it relies on removeListener()
+		if ($pluginName === \Sabre\DAVACL\Plugin::class) {
+			$parentFn($eventName, $callBack, $priority);
+			return;
+		}
 
 		$callback = $this->getMonitoredCallback($callBack, $pluginName, $eventName);
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_
* Partial revert of https://github.com/nextcloud/server/pull/54153

## Summary

Fixes creating events with attendees on the same server.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
