### PR TITLE
fix(ldap): Refresh user ldap attributes on login

### DIFF
--- a/apps/user_ldap/lib/LoginListener.php
+++ b/apps/user_ldap/lib/LoginListener.php
@@ -10,6 +10,7 @@ namespace OCA\User_LDAP;
 
 use OCA\User_LDAP\Db\GroupMembership;
 use OCA\User_LDAP\Db\GroupMembershipMapper;
+use OCP\Authentication\IApacheBackend;
 use OCP\DB\Exception;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventDispatcher;
@@ -49,6 +50,10 @@ class LoginListener implements IEventListener {
 			]
 		);
 		$this->updateGroups($user);
+		$backend = $user->getBackend();
+		if ($backend instanceof IApacheBackend) {
+			$backend->loginName2UserName($user->getUID(), true);
+		}
 	}
 
 	private function updateGroups(IUser $userObject): void {

--- a/apps/user_ldap/lib/User_Proxy.php
+++ b/apps/user_ldap/lib/User_Proxy.php
@@ -221,9 +221,9 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IUserLDAP
 	 * @param string $loginName
 	 * @return string|false
 	 */
-	public function loginName2UserName($loginName) {
+	public function loginName2UserName($loginName, bool $forceLdapRefetch = false) {
 		$id = 'LOGINNAME,' . $loginName;
-		return $this->handleRequest($id, 'loginName2UserName', [$loginName]);
+		return $this->handleRequest($id, 'loginName2UserName', [$loginName, $forceLdapRefetch]);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

> [!WARNING]
> This is untested, if someone with a working SAML setup could check that this is indeed called, it would really helpful 

Otherwise when authentificating via SAML an user in the LDAP database, this is not done.

## TODO

- [ ] Test this

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
