### PR TITLE
feat: allow filtering sharing:delete-orphan-shares by share owner or target

### DIFF
--- a/apps/files_sharing/lib/Command/DeleteOrphanShares.php
+++ b/apps/files_sharing/lib/Command/DeleteOrphanShares.php
@@ -32,12 +32,16 @@ class DeleteOrphanShares extends Base {
 				'f',
 				InputOption::VALUE_NONE,
 				'delete the shares without asking'
-			);
+			)
+			->addOption('owner', null, InputOption::VALUE_REQUIRED, 'Only check shares owned by a specific user')
+			->addOption('with', null, InputOption::VALUE_REQUIRED, 'Only check shares with a specific user');
 	}
 
 	public function execute(InputInterface $input, OutputInterface $output): int {
 		$force = $input->getOption('force');
-		$shares = $this->orphanHelper->getAllShares();
+		$owner = $input->getOption('owner') ?: null;
+		$with = $input->getOption('with') ?: null;
+		$shares = $this->orphanHelper->getAllShares($owner, $with);
 
 		$orphans = [];
 		foreach ($shares as $share) {

--- a/apps/files_sharing/lib/OrphanHelper.php
+++ b/apps/files_sharing/lib/OrphanHelper.php
@@ -54,11 +54,19 @@ class OrphanHelper {
 	/**
 	 * @return \Traversable<int, array{id: int, owner: string, fileid: int, target: string}>
 	 */
-	public function getAllShares() {
+	public function getAllShares(?string $owner = null, ?string $with = null) {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('id', 'file_source', 'uid_owner', 'file_target')
 			->from('share')
 			->where($query->expr()->in('item_type', $query->createNamedParameter(['file', 'folder'], IQueryBuilder::PARAM_STR_ARRAY)));
+
+		if ($owner !== null) {
+			$query->andWhere($query->expr()->eq('uid_owner', $query->createNamedParameter($owner)));
+		}
+		if ($with !== null) {
+			$query->andWhere($query->expr()->eq('share_with', $query->createNamedParameter($with)));
+		}
+
 		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			yield [


### PR DESCRIPTION
Adds `--owner` and `--with` option to filter what shares `occ sharing:delete-orphan-shares` checks, this can be both useful if checking all shares is to expensive or the list of orphan shares is to large to reason about in one go.