### PR TITLE
fix: propfind query monitor breaking removeListener and removeAllList…

### DIFF
--- a/apps/dav/tests/unit/Connector/ServerTest.php
+++ b/apps/dav/tests/unit/Connector/ServerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCA\DAV\Tests\unit\Connector\Sabre;
+
+use OCA\DAV\Connector\Sabre\Server;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Test\TestCase;
+
+class ServerTest extends TestCase {
+
+	private Server $server;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->server = new Server();
+		$this->server->debugEnabled = true;
+	}
+
+	public function testRemoveListener(): void {
+		$listener = static function () {
+			return false;
+		};
+		$this->server->on('propFind', $listener);
+		$this->server->removeListener('propFind', $listener);
+
+		$propFind = $this->createMock(PropFind::class);
+		$iNode = $this->createMock(INode::class);
+
+		$return = $this->server->emit('propFind', [$propFind, $iNode]);
+		$this->assertTrue($return);
+	}
+
+	public static function removeAllListenersData(): array {
+		return [
+			'all listeners' => [null], 'propFind listeners' => ['propFind'],
+		];
+	}
+
+	#[DataProvider('removeAllListenersData')]
+	public function testRemoveAllListeners(?string $removeEventName): void {
+		$listener = static function () {
+			return false;
+		};
+		$this->server->on('propFind', $listener);
+		$this->server->on('otherEvent', $listener);
+
+		$this->server->removeAllListeners($removeEventName);
+
+		$propFind = $this->createMock(PropFind::class);
+		$iNode = $this->createMock(INode::class);
+
+		$propFindReturn = $this->server->emit('propFind', [$propFind, $iNode]);
+		$this->assertTrue($propFindReturn);
+		$otherEventReturn = $this->server->emit('otherEvent', [$propFind,
+			$iNode]);
+		// if listeners are not removed when they should, emit will return false
+		$this->assertEquals($removeEventName === null, $otherEventReturn);
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54501

## Summary

This PR fixes the issue that when debug mode is enabled, `removeListener` and `removeAllListeners` stop working on Connector\Sabre\Server instances.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
