### PR TITLE
feat(preset): compare userconfig lexicon entries

### DIFF
--- a/core/Command/Config/Preset.php
+++ b/core/Command/Config/Preset.php
@@ -44,10 +44,10 @@ class Preset extends Base {
 			$list = $this->presetManager->retrieveLexiconPreset();
 			if ($input->getOption('output') === 'plain') {
 				$table = new Table($output);
-				$table->setHeaders(['app', 'config key', 'value', ...array_map(static fn (ConfigLexiconPreset $p): string => $p->name, ConfigLexiconPreset::cases())]);
+				$table->setHeaders(['app', 'config', 'config key', 'value', ...array_map(static fn (ConfigLexiconPreset $p): string => $p->name, ConfigLexiconPreset::cases())]);
 				foreach ($list as $appId => $entries) {
 					foreach ($entries as $item) {
-						$table->addRow([$appId, $item['entry']['key'], '<comment>' . ($item['value'] ?? '') . '</comment>', ...($item['defaults'] ?? [])]);
+						$table->addRow([$appId, $item['config'], $item['entry']['key'], '<comment>' . ($item['value'] ?? '') . '</comment>', ...($item['defaults'] ?? [])]);
 					}
 				}
 				$table->render();

--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -1232,6 +1232,7 @@ class AppConfig implements IAppConfig {
 	 *
 	 * @param bool $reload set to TRUE to refill cache instantly after clearing it
 	 *
+	 * @internal
 	 * @since 29.0.0
 	 */
 	public function clearCache(bool $reload = false): void {

--- a/lib/private/Config/UserConfig.php
+++ b/lib/private/Config/UserConfig.php
@@ -1999,8 +1999,7 @@ class UserConfig implements IUserConfig {
 	 * @param string $appId
 	 *
 	 * @return array{entries: array<string, Entry>, aliases: array<string, string>, strictness: Strictness}
-	 *@internal
-	 *
+	 * @internal
 	 */
 	public function getConfigDetailsFromLexicon(string $appId): array {
 		if (!array_key_exists($appId, $this->configLexiconDetails)) {
@@ -2024,7 +2023,13 @@ class UserConfig implements IUserConfig {
 		return $this->configLexiconDetails[$appId];
 	}
 
-	private function getLexiconEntry(string $appId, string $key): ?Entry {
+	/**
+	 * get Lexicon Entry using appId and config key entry
+	 *
+	 * @return Entry|null NULL if entry does not exist in user's Lexicon
+	 * @internal
+	 */
+	public function getLexiconEntry(string $appId, string $key): ?Entry {
 		return $this->getConfigDetailsFromLexicon($appId)['entries'][$key] ?? null;
 	}
 


### PR DESCRIPTION
- added the missing userconfig entries when retrieving preset from lexicon.
- adding the entry 'config' to the returned array which can be 'app' or 'user'