### PR TITLE
fix: changelog generation workflow

### DIFF
--- a/.github/workflows/generate-release-changelog.yml
+++ b/.github/workflows/generate-release-changelog.yml
@@ -47,8 +47,13 @@ jobs:
           TAGS=$(git log --decorate --oneline | egrep 'tag: ' | sed -r 's/^.+tag: ([^,\)]+)[,\)].+$/\1/g')
           CURRENT_TAG=$(echo "$TAGS" | head -n 1)
 
+          # If current tag is the first beta, we use the previous major RC1
+          if echo "$CURRENT_TAG" | grep -q 'beta1'; then
+            MAJOR=$(echo "$CURRENT_TAG" | sed -E 's/^v([0-9]+).*/\1/')
+            PREV=$((MAJOR - 1))
+            PREVIOUS_TAG="v${PREV}.0.0rc1"
           # Get the previous tag - filter pre-releases only if current tag is stable
-          if echo "$CURRENT_TAG" | grep -q 'rc\|beta\|alpha'; then
+          elif echo "$CURRENT_TAG" | grep -q 'rc\|beta\|alpha'; then
             # Current tag is pre-release, don't filter
             PREVIOUS_TAG=$(echo "$TAGS" | sed -n '2p')
           else


### PR DESCRIPTION
Found on https://github.com/nextcloud-releases/server/actions/runs/17075907085

First beta always requires us to use the previous major RC1
<img width="812" height="179" alt="image" src="https://github.com/user-attachments/assets/42094ca2-a7ef-4c25-85f6-4063a8459a91" />
