### PR TITLE
fix(core): Don't set samesite cookies on status.php

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -548,10 +548,11 @@ class OC {
 			return;
 		}
 
+		$requestUri = $request->getScriptName();
+		$processingScript = explode('/', $requestUri);
+		$processingScript = $processingScript[count($processingScript) - 1];
+
 		if (count($_COOKIE) > 0) {
-			$requestUri = $request->getScriptName();
-			$processingScript = explode('/', $requestUri);
-			$processingScript = $processingScript[count($processingScript) - 1];
 
 			if ($processingScript === 'index.php' // index.php routes are handled in the middleware
 				|| $processingScript === 'cron.php' // and cron.php does not need any authentication at all
@@ -573,7 +574,12 @@ class OC {
 					exit();
 				}
 			}
-		} elseif (!isset($_COOKIE['nc_sameSiteCookielax']) || !isset($_COOKIE['nc_sameSiteCookiestrict'])) {
+		} else {
+			// Session not started for status.php, skip setting SS cookies
+			if ($processingScript === 'status.php') {
+				return;
+			}
+			// set nc_sameSiteCookielax and nc_sameSiteCookiestrict
 			self::sendSameSiteCookies();
 		}
 	}


### PR DESCRIPTION

* Resolves: #54227

## Summary

Fixes an issue where samesite cookies are sent on status.php before session is started; cookies with webroots other than '/' therefore have the wrong name and lead to samesite cookie validation failures.
