### PR TITLE
Change "core.ProfilePage.index" to lowercase

### DIFF
--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -442,8 +442,8 @@ class Router implements IRouter {
 		if ($routeName === 'cloud_federation_api.requesthandlercontroller.receivenotification') {
 			return 'cloud_federation_api.requesthandler.receivenotification';
 		}
-		if ($routeName === 'core.ProfilePage.index') {
-			return 'profile.ProfilePage.index';
+		if ($routeName === 'core.profilepage.index') {
+			return 'profile.profilepage.index';
 		}
 		return $routeName;
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->
 
* Resolves: # <!-- related github issue -->

## Summary

Hi, as an app developer, when I generate a link to a user profile, my button redirects me to the instance root instead of the user profile.
To fix this issue, we need to pass core.ProfilePage in lowercase.

Please, if you merge this PR, could you also backport it to stable31?

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
