### PR TITLE
fix(Dispatcher): Catch TypeErrors and turn them into bad request responses

### DIFF
--- a/lib/private/AppFramework/Utility/ControllerMethodReflector.php
+++ b/lib/private/AppFramework/Utility/ControllerMethodReflector.php
@@ -18,6 +18,8 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 	private $types = [];
 	private $parameters = [];
 	private array $ranges = [];
+	private int $startLine = 0;
+	private string $file = '';
 
 	/**
 	 * @param object $object an object or classname
@@ -25,6 +27,9 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 	 */
 	public function reflect($object, string $method) {
 		$reflection = new \ReflectionMethod($object, $method);
+		$this->startLine = $reflection->getStartLine();
+		$this->file = $reflection->getFileName();
+
 		$docs = $reflection->getDocComment();
 
 		if ($docs !== false) {
@@ -133,5 +138,13 @@ class ControllerMethodReflector implements IControllerMethodReflector {
 		}
 
 		return '';
+	}
+
+	public function getStartLine(): int {
+		return $this->startLine;
+	}
+
+	public function getFile(): string {
+		return $this->file;
 	}
 }


### PR DESCRIPTION
Prevents error messages like this:
```
{"reqId":"ojXF2BwODOOk6tps9fW5","level":3,"time":"2025-08-20T11:32:03+00:00","remoteAddr":"::1","user":"admin","app":"no app in context","method":"DELETE","url":"/ocs/v2.php/cloud/users/admin/subadmins","message":"OCA\\Provisioning_API\\Controller\\UsersController::removeSubAdmin(): Argument #2 ($groupid) must be of type string, null given, called in /home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php on line 204 in file '/home/jld3103/src/github.com/nextcloud/server/apps/provisioning_api/lib/Controller/UsersController.php' line 1730","userAgent":"curl/8.15.0","version":"32.0.0.4","exception":{"Exception":"Exception","Message":"OCA\\Provisioning_API\\Controller\\UsersController::removeSubAdmin(): Argument #2 ($groupid) must be of type string, null given, called in /home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php on line 204 in file '/home/jld3103/src/github.com/nextcloud/server/apps/provisioning_api/lib/Controller/UsersController.php' line 1730","Code":0,"Trace":[{"file":"/home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/App.php","line":153,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/home/jld3103/src/github.com/nextcloud/server/lib/private/Route/Router.php","line":321,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"/home/jld3103/src/github.com/nextcloud/server/ocs/v1.php","line":61,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"/home/jld3103/src/github.com/nextcloud/server/ocs/v2.php","line":8,"args":["/home/jld3103/src/github.com/nextcloud/server/ocs/v1.php"],"function":"require_once"}],"File":"/home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php","Line":150,"Previous":{"Exception":"TypeError","Message":"OCA\\Provisioning_API\\Controller\\UsersController::removeSubAdmin(): Argument #2 ($groupid) must be of type string, null given, called in /home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php on line 204","Code":0,"Trace":[{"file":"/home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php","line":204,"function":"removeSubAdmin","class":"OCA\\Provisioning_API\\Controller\\UsersController","type":"->"},{"file":"/home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php","line":118,"function":"executeController","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/App.php","line":153,"function":"dispatch","class":"OC\\AppFramework\\Http\\Dispatcher","type":"->"},{"file":"/home/jld3103/src/github.com/nextcloud/server/lib/private/Route/Router.php","line":321,"function":"main","class":"OC\\AppFramework\\App","type":"::"},{"file":"/home/jld3103/src/github.com/nextcloud/server/ocs/v1.php","line":61,"function":"match","class":"OC\\Route\\Router","type":"->"},{"file":"/home/jld3103/src/github.com/nextcloud/server/ocs/v2.php","line":8,"args":["/home/jld3103/src/github.com/nextcloud/server/ocs/v1.php"],"function":"require_once"}],"File":"/home/jld3103/src/github.com/nextcloud/server/apps/provisioning_api/lib/Controller/UsersController.php","Line":1730},"message":"OCA\\Provisioning_API\\Controller\\UsersController::removeSubAdmin(): Argument #2 ($groupid) must be of type string, null given, called in /home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php on line 204 in file '/home/jld3103/src/github.com/nextcloud/server/apps/provisioning_api/lib/Controller/UsersController.php' line 1730","exception":{},"CustomMessage":"OCA\\Provisioning_API\\Controller\\UsersController::removeSubAdmin(): Argument #2 ($groupid) must be of type string, null given, called in /home/jld3103/src/github.com/nextcloud/server/lib/private/AppFramework/Http/Dispatcher.php on line 204 in file '/home/jld3103/src/github.com/nextcloud/server/apps/provisioning_api/lib/Controller/UsersController.php' line 1730"}}
```

The server is not doing anything wrong in this case and there is nothing the admin can do about it, because client is not sending a valid request to the endpoint.