### PR TITLE
fix(caldav): handle read-only boolean and int values

### DIFF
--- a/apps/dav/lib/CalDAV/CalDavBackend.php
+++ b/apps/dav/lib/CalDAV/CalDavBackend.php
@@ -411,7 +411,10 @@ class CalDavBackend extends AbstractBackend implements SyncSupport, Subscription
 						continue;
 					}
 					if (isset($calendars[$row['id']][$readOnlyPropertyName])
-						&& $calendars[$row['id']][$readOnlyPropertyName] === 0) {
+						&& (
+							$calendars[$row['id']][$readOnlyPropertyName] === 0
+							|| $calendars[$row['id']][$readOnlyPropertyName] === false
+						)) {
 						// Old share is already read-write, no more permissions can be gained
 						continue;
 					}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

Previously, the read-only was an integer (either 0 or 1). However, recently it can also be a boolean. We should handle both cases in the CalDavBackend.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
