### PR TITLE
chore: increase cypress runners to 10

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -102,10 +102,10 @@ jobs:
       matrix:
         # Run multiple copies of the current job in parallel
         # Please increase the number or runners as your tests suite grows (0 based index for e2e tests)
-        containers: ['component', 'setup', '0', '1', '2', '3', '4', '5', '6', '7']
+        containers: ['component', 'setup', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
         # Hack as strategy.job-total includes the component and GitHub does not allow math expressions
         # Always align this number with the total of e2e runners (max. index + 1)
-        total-containers: [8]
+        total-containers: [10]
 
     services:
       mysql:


### PR DESCRIPTION
We keep adding more and more tests. It's been a while since we increased.