### PR TITLE
Dispatch new event when invalidating an authentication token

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -157,6 +157,7 @@ return array(
     'OCP\\App\\ManagerEvent' => $baseDir . '/lib/public/App/ManagerEvent.php',
     'OCP\\Authentication\\Events\\AnyLoginFailedEvent' => $baseDir . '/lib/public/Authentication/Events/AnyLoginFailedEvent.php',
     'OCP\\Authentication\\Events\\LoginFailedEvent' => $baseDir . '/lib/public/Authentication/Events/LoginFailedEvent.php',
+    'OCP\\Authentication\\Events\\TokenInvalidatedEvent' => $baseDir . '/lib/public/Authentication/Events/TokenInvalidatedEvent.php',
     'OCP\\Authentication\\Exceptions\\CredentialsUnavailableException' => $baseDir . '/lib/public/Authentication/Exceptions/CredentialsUnavailableException.php',
     'OCP\\Authentication\\Exceptions\\ExpiredTokenException' => $baseDir . '/lib/public/Authentication/Exceptions/ExpiredTokenException.php',
     'OCP\\Authentication\\Exceptions\\InvalidTokenException' => $baseDir . '/lib/public/Authentication/Exceptions/InvalidTokenException.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -198,6 +198,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\App\\ManagerEvent' => __DIR__ . '/../../..' . '/lib/public/App/ManagerEvent.php',
         'OCP\\Authentication\\Events\\AnyLoginFailedEvent' => __DIR__ . '/../../..' . '/lib/public/Authentication/Events/AnyLoginFailedEvent.php',
         'OCP\\Authentication\\Events\\LoginFailedEvent' => __DIR__ . '/../../..' . '/lib/public/Authentication/Events/LoginFailedEvent.php',
+        'OCP\\Authentication\\Events\\TokenInvalidatedEvent' => __DIR__ . '/../../..' . '/lib/public/Authentication/Events/TokenInvalidatedEvent.php',
         'OCP\\Authentication\\Exceptions\\CredentialsUnavailableException' => __DIR__ . '/../../..' . '/lib/public/Authentication/Exceptions/CredentialsUnavailableException.php',
         'OCP\\Authentication\\Exceptions\\ExpiredTokenException' => __DIR__ . '/../../..' . '/lib/public/Authentication/Exceptions/ExpiredTokenException.php',
         'OCP\\Authentication\\Exceptions\\InvalidTokenException' => __DIR__ . '/../../..' . '/lib/public/Authentication/Exceptions/InvalidTokenException.php',

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -279,7 +279,7 @@ class PublicKeyTokenProvider implements IProvider {
 		$this->mapper->invalidate($this->hashTokenWithEmptySecret($token));
 		$this->cacheInvalidHash($tokenHash);
 		if ($tokenEntry !== null) {
-			$this->eventDispatcher->dispatchTyped(new TokenInvalidatedEvent($tokenEntry->getUID(), $tokenEntry->getId()));
+			$this->eventDispatcher->dispatchTyped(new TokenInvalidatedEvent($tokenEntry));
 		}
 	}
 
@@ -290,7 +290,7 @@ class PublicKeyTokenProvider implements IProvider {
 		}
 		$this->mapper->invalidate($token->getToken());
 		$this->cacheInvalidHash($token->getToken());
-		$this->eventDispatcher->dispatchTyped(new TokenInvalidatedEvent($uid, $id));
+		$this->eventDispatcher->dispatchTyped(new TokenInvalidatedEvent($token));
 	}
 
 	public function invalidateOldTokens() {

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -273,7 +273,8 @@ class PublicKeyTokenProvider implements IProvider {
 		$tokenEntry = null;
 		try {
 			$tokenEntry = $this->mapper->getToken($tokenHash);
-		} catch (DoesNotExistException) {}
+		} catch (DoesNotExistException) {
+		}
 		$this->mapper->invalidate($this->hashToken($token));
 		$this->mapper->invalidate($this->hashTokenWithEmptySecret($token));
 		$this->cacheInvalidHash($tokenHash);

--- a/lib/private/Authentication/Token/PublicKeyTokenProvider.php
+++ b/lib/private/Authentication/Token/PublicKeyTokenProvider.php
@@ -270,9 +270,16 @@ class PublicKeyTokenProvider implements IProvider {
 
 	public function invalidateToken(string $token) {
 		$tokenHash = $this->hashToken($token);
+		$tokenEntry = null;
+		try {
+			$tokenEntry = $this->mapper->getToken($tokenHash);
+		} catch (DoesNotExistException) {}
 		$this->mapper->invalidate($this->hashToken($token));
 		$this->mapper->invalidate($this->hashTokenWithEmptySecret($token));
 		$this->cacheInvalidHash($tokenHash);
+		if ($tokenEntry !== null) {
+			$this->eventDispatcher->dispatchTyped(new TokenInvalidatedEvent($tokenEntry->getUID(), $tokenEntry->getId()));
+		}
 	}
 
 	public function invalidateTokenById(string $uid, int $id) {

--- a/lib/public/Authentication/Events/TokenInvalidatedEvent.php
+++ b/lib/public/Authentication/Events/TokenInvalidatedEvent.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OCP\Authentication\Events;
 
+use OCP\Authentication\Token\IToken;
 use OCP\EventDispatcher\Event;
 
 /**
@@ -21,27 +22,17 @@ class TokenInvalidatedEvent extends Event {
 	 * @since 32.0.0
 	 */
 	public function __construct(
-		private string $userId,
-		private int $tokenId,
+		private IToken $token,
 	) {
 		parent::__construct();
 	}
 
 	/**
-	 * returns the uid of the user associated with the invalidated token
+	 * returns the token that has been invalidated
 	 *
 	 * @since 32.0.0
 	 */
-	public function getUserId(): string {
-		return $this->userId;
-	}
-
-	/**
-	 * returns the ID of the token that is being invalidated
-	 *
-	 * @since 32.0.0
-	 */
-	public function getTokenId(): int {
-		return $this->tokenId;
+	public function getToken(): IToken {
+		return $this->token;
 	}
 }

--- a/lib/public/Authentication/Events/TokenInvalidatedEvent.php
+++ b/lib/public/Authentication/Events/TokenInvalidatedEvent.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Authentication\Events;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Emitted when an authentication token is invalidated
+ *
+ * @since 32.0.0
+ */
+class TokenInvalidatedEvent extends Event {
+
+	/**
+	 * @since 32.0.0
+	 */
+	public function __construct(
+		private string $userId,
+		private int $tokenId,
+	) {
+		parent::__construct();
+	}
+
+	/**
+	 * returns the uid of the user associated with the invalidated token
+	 *
+	 * @since 32.0.0
+	 */
+	public function getUserId(): string {
+		return $this->userId;
+	}
+
+	/**
+	 * returns the ID of the token that is being invalidated
+	 *
+	 * @since 32.0.0
+	 */
+	public function getTokenId(): int {
+		return $this->tokenId;
+	}
+}

--- a/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenProviderTest.php
@@ -18,6 +18,7 @@ use OC\Authentication\Token\PublicKeyTokenProvider;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\Token\IToken;
+use OCP\EventDispatcher\IEventDispatcher;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IDBConnection;
@@ -49,6 +50,8 @@ class PublicKeyTokenProviderTest extends TestCase {
 	private $cacheFactory;
 	/** @var int */
 	private $time;
+	/** @var IEventDispatcher */
+	private $eventDispatcher;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -72,6 +75,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 		$this->timeFactory->method('getTime')
 			->willReturn($this->time);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->eventDispatcher = Server::get(IEventDispatcher::class);
 
 		$this->tokenProvider = new PublicKeyTokenProvider(
 			$this->mapper,
@@ -82,6 +86,7 @@ class PublicKeyTokenProviderTest extends TestCase {
 			$this->timeFactory,
 			$this->hasher,
 			$this->cacheFactory,
+			$this->eventDispatcher,
 		);
 	}
 


### PR DESCRIPTION
Dispatch a new `OCP\Authentication\Events\TokenInvalidatedEvent` event in `OC\Authentication\Token\PublicKeyTokenProvider::invalidateToken` and `OC\Authentication\Token\PublicKeyTokenProvider::invalidateTokenById` after having actually invalidated a token.

This is one solution to help with https://github.com/nextcloud/user_oidc/pull/1181 in which we need to know when a user session is revoked to terminate the session on the external identity provider side (if needed).

Doc PR: https://github.com/nextcloud/documentation/pull/13522