### PR TITLE
Config value to allow to extend .user.ini on update

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2461,6 +2461,14 @@ $CONFIG = [
 'upgrade.cli-upgrade-link' => '',
 
 /**
+ * Additional line(s) (string or array of strings)
+ * that will be added to .user.ini on each update by the updater.
+ *
+ * Defaults to ``''`` (empty string)
+ */
+'user_ini_additional_lines' => '',
+
+/**
  * Customize the server logs documentation link for exception handling.
  */
 'documentation_url.server_logs' => '',


### PR DESCRIPTION
When running nextcloud with a web hoster it might be necessary to extend `.user.ini` after each update (e.g. adding memory_limit). To automate this step, an additional config entry may be provided in `config.php` that specifies the lines to be added to `.user.ini`.

If the config option 'user_ini_additional_lines' exists, the provided value (string or array of strings) will be added to the file `.user.ini`. This config option has to be processed by the updater.
This is related to https://github.com/nextcloud/updater/pull/471


<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->



## Summary
Improved update for users with a web hoster

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are not required 
- [x] Screenshots before/after for front-end are not required
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
