### PR TITLE
WIP: nextcloud-calendar/#7234 [not tested]

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
@@ -25,14 +25,6 @@ class Connection {
 	}
 
 	/**
- 	 * look for ics feeds hosted on O365 servers.  These can be picky about UA string
-     */
-	private static function isO365Url($url) {
-	    $host = parse_url($url, PHP_URL_HOST);
-	    return $host === 'outlook.office365.com';
-	}   
-	
-	/**
 	 * gets webcal feed from remote server
 	 */
 	public function queryWebcalFeed(array $subscription): ?string {

--- a/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
@@ -44,7 +44,7 @@ class Connection {
 
 		// calendar/#7234 - ICS feeds hosted on O365 can return HTTP 500 when the UA string isn't satisfactory..
 		$uaString = 'Nextcloud Webcal Service';
-		if (isO365Url($url)) {
+		if (Connection::isO365Url($url)) {
 			// 2025/08/20 - the required format/values here are not documented; this string based on research 
 			// from: https://github.com/bitfireAT/icsx5/discussions/654#discussioncomment-14158051
 			$uaString = 'NextCloud (Android 16) like Chrome/30';

--- a/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
@@ -47,7 +47,7 @@ class Connection {
 		if (Connection::isO365Url($url)) {
 			// 2025/08/20 - the required format/values here are not documented; this string based on research 
 			// from: https://github.com/bitfireAT/icsx5/discussions/654#discussioncomment-14158051
-			$uaString = 'NextCloud (Android 16) like Chrome/30';
+			$uaString = 'Nextcloud (Linux) Chrome/66';
 		}
 		
 		$allowLocalAccess = $this->config->getValueString('dav', 'webcalAllowLocalAccess', 'no');

--- a/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
@@ -36,7 +36,7 @@ class Connection {
 
 		// calendar/#7234 - ICS feeds hosted on O365 can return HTTP 500 when the UA string isn't satisfactory..
 		$uaString = 'Nextcloud Webcal Service';
-		if (Connection::isO365Url($url)) {
+		if (parse_url($url, PHP_URL_HOST) === 'outlook.office365.com') {
 			// 2025/08/20 - the required format/values here are not documented; this string based on research 
 			// from: https://github.com/bitfireAT/icsx5/discussions/654#discussioncomment-14158051
 			$uaString = 'Nextcloud (Linux) Chrome/66';

--- a/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
@@ -47,7 +47,7 @@ class Connection {
 		if (isO365Url($url)) {
 			// 2025/08/20 - the required format/values here are not documented; this string based on research 
 			// from: https://github.com/bitfireAT/icsx5/discussions/654#discussioncomment-14158051
-			$uaString = 'NextCloud/30.x (Linux Android 16) like Chrome/30';
+			$uaString = 'NextCloud (Android 16) like Chrome/30';
 		}
 		
 		$allowLocalAccess = $this->config->getValueString('dav', 'webcalAllowLocalAccess', 'no');


### PR DESCRIPTION
* Resolves:  https://github.com/nextcloud/calendar/issues/7234

## Summary
In Nextcloud/calendar/7234, users observe that downloading public ICS feeds from some Office365 tenants started returning HTTP 500.  In further testing, it was observed that Microsoft is now parsing the HTTP UserAgent request header and looking for certain values.  The NextCloud WebDAV module was sending a reasonable UserAgent string, but not one that some Microsoft O365 tenants would accept.  

## TODO

- I don't have an NC build/test environment setup yet.  And I am not a php Developer.  So this code might be embarassingly broken :)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
