### PR TITLE
fix: use appropriate user agent string when syncing Outlook calendar subscriptions

### DIFF
--- a/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
+++ b/apps/dav/lib/CalDAV/WebcalCaching/Connection.php
@@ -34,6 +34,16 @@ class Connection {
 			return null;
 		}
 
+		// ICS feeds hosted on O365 can return HTTP 500 when the UA string isn't satisfactory
+		// Ref https://github.com/nextcloud/calendar/issues/7234
+		$uaString = 'Nextcloud Webcal Service';
+		if (parse_url($url, PHP_URL_HOST) === 'outlook.office365.com') {
+			// The required format/values here are not documented.
+			// Instead, this string based on research.
+			// Ref https://github.com/bitfireAT/icsx5/discussions/654#discussioncomment-14158051
+			$uaString = 'Nextcloud (Linux) Chrome/66';
+		}
+
 		$allowLocalAccess = $this->config->getValueString('dav', 'webcalAllowLocalAccess', 'no');
 
 		$params = [
@@ -41,7 +51,7 @@ class Connection {
 				'allow_local_address' => $allowLocalAccess === 'yes',
 			],
 			RequestOptions::HEADERS => [
-				'User-Agent' => 'Nextcloud Webcal Service',
+				'User-Agent' => $uaString,
 				'Accept' => 'text/calendar, application/calendar+json, application/calendar+xml',
 			],
 		];


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves https://github.com/nextcloud/calendar/issues/7234
* Closes https://github.com/nextcloud/server/pull/54564

## Summary

Imported from https://github.com/nextcloud/server/pull/54564

Some Outlook tenants block our user agent when syncing calendar subscriptions. Hence, we need to fake a Chrome browser.

For the investigation please have a look at https://github.com/bitfireAT/icsx5/discussions/654#discussioncomment-14158051

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
