### PR TITLE
fix: read true or false value realtime and do not depend on cache

### DIFF
--- a/lib/private/Notification/Manager.php
+++ b/lib/private/Notification/Manager.php
@@ -284,18 +284,12 @@ class Manager implements IManager {
 	 * {@inheritDoc}
 	 */
 	public function isFairUseOfFreePushService(): bool {
-		$pushAllowed = $this->cache->get('push_fair_use');
-		if ($pushAllowed === null) {
-			/**
-			 * We want to keep offering our push notification service for free, but large
-			 * users overload our infrastructure. For this reason we have to rate-limit the
-			 * use of push notifications. If you need this feature, consider using Nextcloud Enterprise.
-			 */
-			$isFairUse = $this->subscription->delegateHasValidSubscription() || $this->userManager->countSeenUsers() < 1000;
-			$pushAllowed = $isFairUse ? 'yes' : 'no';
-			$this->cache->set('push_fair_use', $pushAllowed, 3600);
-		}
-		return $pushAllowed === 'yes';
+		/**
+		 * We want to keep offering our push notification service for free, but large
+		 * users overload our infrastructure. For this reason we have to rate-limit the
+		 * use of push notifications. If you need this feature, consider using Nextcloud Enterprise.
+		 */
+		return $this->subscription->delegateHasValidSubscription() || $this->userManager->countSeenUsers() < 1000;
 	}
 
 	/**


### PR DESCRIPTION
fix: read true or false value realtime and do not depend on cache value which could be misleading to a false yes/no

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
