### PR TITLE
fix moving cache items from cache jail with sharding

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheWrapper.php
+++ b/lib/private/Files/Cache/Wrapper/CacheWrapper.php
@@ -37,7 +37,10 @@ class CacheWrapper extends Cache {
 		}
 	}
 
-	protected function getCache() {
+	public function getCache(): ICache {
+		if (!$this->cache) {
+			throw new \Exception('Source cache not initialized');
+		}
 		return $this->cache;
 	}
 
@@ -202,7 +205,12 @@ class CacheWrapper extends Cache {
 	 * remove all entries for files that are stored on the storage from the cache
 	 */
 	public function clear() {
-		$this->getCache()->clear();
+		$cache = $this->getCache();
+		if ($cache instanceof Cache) {
+			$cache->clear();
+		} else {
+			$cache->remove('');
+		}
 	}
 
 	/**
@@ -252,7 +260,9 @@ class CacheWrapper extends Cache {
 	 * @return int[]
 	 */
 	public function getAll() {
-		return $this->getCache()->getAll();
+		/** @var Cache $cache */
+		$cache = $this->getCache();
+		return $cache->getAll();
 	}
 
 	/**

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -10,6 +10,7 @@ namespace Test\Files\Cache;
 
 use OC\Files\Cache\Cache;
 use OC\Files\Cache\CacheEntry;
+use OC\Files\Cache\Wrapper\CacheJail;
 use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Temporary;
@@ -519,6 +520,24 @@ class CacheTest extends \Test\TestCase {
 
 		$this->assertTrue($this->cache->inCache('targetfolder'));
 		$this->assertTrue($this->cache->inCache('targetfolder/sub'));
+	}
+
+	public function testMoveFromCacheJail(): void {
+		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'foo/bar'];
+		$folderData = ['size' => 100, 'mtime' => 50, 'mimetype' => ICacheEntry::DIRECTORY_MIMETYPE];
+
+		$this->cache2->put('folder', $folderData);
+		$this->cache2->put('folder/sub', $data);
+
+		$jail = new CacheJail($this->cache2, 'folder');
+
+		$this->cache->moveFromCache($jail, 'sub', 'targetsub');
+
+		$this->assertTrue($this->cache2->inCache('folder'));
+		$this->assertFalse($this->cache2->inCache('folder/sub'));
+
+		$this->assertTrue($this->cache->inCache('targetsub'));
+		$this->assertEquals($this->cache->getId(''), $this->cache->get('targetsub')->getParentId());
 	}
 
 	public function testGetIncomplete(): void {


### PR DESCRIPTION
The low-level `oc_filecache` access `moveFromStorageSharded` doesn't take cache jails into account, so we need to resolve those first.