### PR TITLE
fix(2fa): Fix 2FA session setup when ephemeral session is used

### DIFF
--- a/lib/private/AppFramework/Middleware/FlowV2EphemeralSessionsMiddleware.php
+++ b/lib/private/AppFramework/Middleware/FlowV2EphemeralSessionsMiddleware.php
@@ -13,6 +13,7 @@ use OC\Core\Controller\TwoFactorChallengeController;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\Attribute\PublicPage;
 use OCP\AppFramework\Middleware;
+use OCP\Authentication\TwoFactorAuth\ALoginSetupController;
 use OCP\ISession;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
@@ -41,7 +42,8 @@ class FlowV2EphemeralSessionsMiddleware extends Middleware {
 			return;
 		}
 
-		if ($controller instanceof TwoFactorChallengeController) {
+		if ($controller instanceof TwoFactorChallengeController
+			|| $controller instanceof ALoginSetupController) {
 			return;
 		}
 


### PR DESCRIPTION
- Enable 2FA
- Enforce 2FA
- As a user that did not yet setup 2FA start a login flow v2 (e.g. files desktop client)

## Before
<img width="1167" height="535" alt="Bildschirmfoto vom 2025-08-25 10-43-22" src="https://github.com/user-attachments/assets/7fed30d3-ce31-4cc5-b00a-6a7a5922ade4" />

<img width="1668" height="458" alt="image" src="https://github.com/user-attachments/assets/a2366c4f-863a-4d62-a205-96ce87ae35ba" />

## After

<img width="1235" height="860" alt="Bildschirmfoto vom 2025-08-25 10-42-34" src="https://github.com/user-attachments/assets/3c8d71ed-7c91-4da5-b22c-011000d99904" />



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
