### PR TITLE
fix(encryption): Fix TypeError when trying to decrypt unencrypted file

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -683,6 +683,8 @@ class Encryption extends Wrapper {
 				}
 			}
 		} else {
+			$source = false;
+			$target = false;
 			try {
 				$source = $sourceStorage->fopen($sourceInternalPath, 'r');
 				$target = $this->fopen($targetInternalPath, 'w');
@@ -692,10 +694,10 @@ class Encryption extends Wrapper {
 					[, $result] = Files::streamCopy($source, $target, true);
 				}
 			} finally {
-				if (isset($source) && $source !== false) {
+				if ($source !== false) {
 					fclose($source);
 				}
-				if (isset($target) && $target !== false) {
+				if ($target !== false) {
 					fclose($target);
 				}
 			}

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -1205,6 +1205,9 @@ class ViewTest extends \Test\TestCase {
 		$storage2->method('writeStream')
 			->willThrowException(new GenericFileException('Failed to copy stream'));
 
+		$storage2->method('fopen')
+			->willReturn(false);
+
 		$storage1->mkdir('sub');
 		$storage1->file_put_contents('foo.txt', '0123456789ABCDEFGH');
 		$storage1->mkdir('dirtomove');


### PR DESCRIPTION
* Resolves: #54594 

## Summary

`$source` is used above to store a string, so if the first fopen throws it was trying to `fclose` a string.
Thanks @manuels for the clear bug report.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
