### PR TITLE
fix(oauth2): Limit allowed grant_type values in getToken

### DIFF
--- a/apps/oauth2/lib/Controller/OauthApiController.php
+++ b/apps/oauth2/lib/Controller/OauthApiController.php
@@ -54,7 +54,7 @@ class OauthApiController extends Controller {
 	/**
 	 * Get a token
 	 *
-	 * @param string $grant_type Token type that should be granted
+	 * @param 'authorization_code'|'refresh_token' $grant_type Token type that should be granted
 	 * @param ?string $code Code of the flow
 	 * @param ?string $refresh_token Refresh token
 	 * @param ?string $client_id Client ID

--- a/apps/oauth2/openapi.json
+++ b/apps/oauth2/openapi.json
@@ -128,6 +128,10 @@
                                 "properties": {
                                     "grant_type": {
                                         "type": "string",
+                                        "enum": [
+                                            "authorization_code",
+                                            "refresh_token"
+                                        ],
                                         "description": "Token type that should be granted"
                                     },
                                     "code": {

--- a/openapi.json
+++ b/openapi.json
@@ -22834,6 +22834,10 @@
                                 "properties": {
                                     "grant_type": {
                                         "type": "string",
+                                        "enum": [
+                                            "authorization_code",
+                                            "refresh_token"
+                                        ],
                                         "description": "Token type that should be granted"
                                     },
                                     "code": {


### PR DESCRIPTION
grant_type is already limited in the code: https://github.com/nextcloud/server/blob/1091e59b90ed7aa3960cc19e1ede91a6e2e81fed/apps/oauth2/lib/Controller/OauthApiController.php#L77-L83