### PR TITLE
build: Add OpenAPI fuzzer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,5 @@ cypress/snapshots
 cypress/videos
 
 /.direnv
+
+/.hypothesis/

--- a/build/openapi-fuzzer.sh
+++ b/build/openapi-fuzzer.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage ./build/openapi-fuzzer.sh <user> <path/to/openapi.json>"
+    exit 1
+fi
+
+user="$1"
+spec="$(readlink -f "$2")"
+
+python -m venv venv
+source venv/bin/activate
+pip install schemathesis==4.9.5
+
+rm data config/config.php -rf
+
+./occ maintenance:install --admin-pass admin
+./occ config:system:set auth.bruteforce.protection.enabled --value=false --type=boolean
+
+app="$(echo "$spec" | pcregrep -o1 -e "^.+\/apps[^\/]*\/([a-z_]+)\/openapi[a-z-]*\.json$" || echo "")"
+if [[ "$app" != "" ]]; then
+	./occ app:enable "$app"
+fi
+
+if [[ "$user" != "admin" ]]; then
+	is_password_policy_available="$(./occ app:list --output json | jq -r .enabled.password_policy)"
+
+	if [[ "$is_password_policy_available" != "null" ]]; then
+		./occ app:disable password_policy
+	fi
+
+	NC_PASS="$user" ./occ user:add "$user" --password-from-env
+
+	if [[ "$is_password_policy_available" != "null" ]]; then
+		./occ app:enable password_policy
+	fi
+fi
+
+app_password="$(echo "$user" | ./occ user:auth-tokens:add "$user" | tail -n 1)"
+
+# Ensure enough workers will be available to handle all requests
+NEXTCLOUD_WORKERS=100 composer serve &> /dev/null &
+pid=$!
+function cleanup() {
+    kill "$pid"
+}
+trap cleanup EXIT
+
+until curl -s -o /dev/null http://localhost:8080/status.php; do sleep 1s; done
+
+schemathesis run \
+	"$spec" \
+	--checks all \
+	--exclude-checks missing_required_header,unsupported_method \
+	--workers auto \
+	--url http://localhost:8080 \
+	-H "OCS-APIRequest: true" \
+	-H "Accept: application/json" \
+	-H "Authorization: Bearer $app_password"


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/47825

## Summary

A script I used to fuzz Nextcloud APIs and find errors both in the backend and the specifications. It's not perfect, but definitely finds some real issues that can be fixed.

## TODO

- [x] Allow enabling extra apps, so they can be fuzzed too.
- [x] Wait for https://github.com/schemathesis/schemathesis/issues/3052 to be resolved and enable `ignored_auth` check again.
- [x] ~Check if `missing_required_header` and `unsupported_method` can be enabled (and get handled properly in the backend)~
- [ ] Maybe a better way to install schemathesis?

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
