### PR TITLE
fix(AppConfig#setTypedValue): Catch AppConfigUnknownKeyException

### DIFF
--- a/lib/private/AppConfig.php
+++ b/lib/private/AppConfig.php
@@ -876,8 +876,12 @@ class AppConfig implements IAppConfig {
 				$type |= self::VALUE_SENSITIVE;
 			}
 
-			if ($lazy !== $this->isLazy($app, $key)) {
-				$refreshCache = true;
+			try {
+				if ($lazy !== $this->isLazy($app, $key)) {
+					$refreshCache = true;
+				}
+			} catch (AppConfigUnknownKeyException) {
+				// pass
 			}
 
 			$update = $this->connection->getQueryBuilder();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/issues/45633

## Summary
Fixes the following error:
```
In AppConfig.php line 221:
                                                 
  [OCP\Exceptions\AppConfigUnknownKeyException]  
  unknown config key                             
                                                 
Exception trace:
  at /home/runner/work/context_chat/context_chat/lib/private/AppConfig.php:221
 OC\AppConfig->isLazy() at /home/runner/work/context_chat/context_chat/lib/private/AppConfig.php:879
 OC\AppConfig->setTypedValue() at /home/runner/work/context_chat/context_chat/lib/private/AppConfig.php:1429
 OC\AppConfig->setValue() at /home/runner/work/context_chat/context_chat/lib/private/AllConfig.php:185
 OC\AllConfig->setAppValue() at /home/runner/work/context_chat/context_chat/lib/private/BackgroundJob/JobList.php:354
 OC\BackgroundJob\JobList->setLastJob()
```

## TODO

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
