### PR TITLE
fix(settings): adjust colors used by legacy setup checks ui

### DIFF
--- a/apps/settings/css/settings.scss
+++ b/apps/settings/css/settings.scss
@@ -645,15 +645,15 @@ table.grid td.date {
 		}
 
 		&.icon-checkmark-white {
-			background-color: var(--color-success);
+			background-color: var(--color-border-success);
 		}
 
 		&.icon-error-white {
-			background-color: var(--color-warning);
+			background-color: var(--color-warning-text);
 		}
 
 		&.icon-close-white {
-			background-color: var(--color-error);
+			background-color: var(--color-border-error);
 		}
 	}
 }
@@ -871,9 +871,8 @@ doesnotexist:-o-prefocus, .strengthify-wrapper {
 }
 
 .settings-hint {
-	margin-top: -12px;
-	margin-bottom: 12px;
-	opacity: .7;
+	color: var(--color-text-maxcontrast);
+	margin-block: -12px 12px;
 }
 
 .animated {


### PR DESCRIPTION
## Summary

Even if the rule is `background-color` in reality it is the color of the icon thus needs the text color.

before|after
---|---
<img width="2502" height="2070" alt="Screenshot 2025-08-25 at 14-23-57 Overview - Administration settings - Nextcloud" src="https://github.com/user-attachments/assets/72bee130-25c4-4dad-be46-391d6e0e9fcf" />|<img width="2502" height="2070" alt="Screenshot 2025-08-25 at 14-29-02 Overview - Administration settings - Nextcloud" src="https://github.com/user-attachments/assets/7202a18a-0b96-4b56-95b2-0719814a8c98" />

Not that the "hint" above (and on the bottom) now is readable as well as the icon is now visible.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
