### PR TITLE
fix(theming): add missing `color-text-success` variable

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -19,6 +19,7 @@
   --color-text-maxcontrast-default: #6b6b6b;
   --color-text-maxcontrast-background-blur: #595959;
   --color-text-error: #c90000;
+  --color-text-success: #066e03;
   /** @deprecated use ` --color-main-text` instead */
   --color-text-light: var(--color-main-text);
   /** @deprecated use `--color-text-maxcontrast` instead */

--- a/apps/theming/lib/Themes/DarkHighContrastTheme.php
+++ b/apps/theming/lib/Themes/DarkHighContrastTheme.php
@@ -67,8 +67,7 @@ class DarkHighContrastTheme extends DarkTheme implements ITheme {
 				'--color-text-maxcontrast' => $colorMainText,
 				'--color-text-maxcontrast-background-blur' => $colorMainText,
 				'--color-text-error' => $this->util->lighten($colorError, 65),
-				'--color-text-light' => $colorMainText,
-				'--color-text-lighter' => $colorMainText,
+				'--color-text-success' => $this->util->lighten($colorSuccess, 65),
 
 				'--color-error' => $colorError,
 				'--color-error-rgb' => join(',', $this->util->hexToRGB($colorError)),

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -83,8 +83,7 @@ class DarkTheme extends DefaultTheme implements ITheme {
 				'--color-text-maxcontrast-default' => $colorTextMaxcontrast,
 				'--color-text-maxcontrast-background-blur' => $this->util->lighten($colorTextMaxcontrast, 6),
 				'--color-text-error' => $colorErrorElement,
-				'--color-text-light' => 'var(--color-main-text)', // deprecated
-				'--color-text-lighter' => 'var(--color-text-maxcontrast)', // deprecated
+				'--color-text-success' => $this->util->lighten($colorSuccessElement, 10),
 
 				'--color-error' => $colorError,
 				'--color-error-hover' => $this->util->lighten($colorError, 10),

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -129,6 +129,7 @@ class DefaultTheme implements ITheme {
 			'--color-text-maxcontrast-default' => $colorTextMaxcontrast,
 			'--color-text-maxcontrast-background-blur' => $this->util->darken($colorTextMaxcontrast, 7),
 			'--color-text-error' => $colorErrorElement,
+			'--color-text-success' => $this->util->darken($colorSuccessElement, 10),
 			'--color-text-light' => 'var(--color-main-text)', // deprecated
 			'--color-text-lighter' => 'var(--color-text-maxcontrast)', // deprecated
 

--- a/apps/theming/lib/Themes/HighContrastTheme.php
+++ b/apps/theming/lib/Themes/HighContrastTheme.php
@@ -70,8 +70,7 @@ class HighContrastTheme extends DefaultTheme implements ITheme {
 				'--color-text-maxcontrast' => $colorMainText,
 				'--color-text-maxcontrast-background-blur' => $colorMainText,
 				'--color-text-error' => $this->util->darken($colorError, 65),
-				'--color-text-light' => $colorMainText,
-				'--color-text-lighter' => $colorMainText,
+				'--color-text-success' => $this->util->darken($colorSuccess, 70),
 
 				'--color-error' => $colorError,
 				'--color-error-rgb' => join(',', $this->util->hexToRGB($colorError)),

--- a/apps/theming/tests/Themes/AccessibleThemeTestCase.php
+++ b/apps/theming/tests/Themes/AccessibleThemeTestCase.php
@@ -150,6 +150,7 @@ class AccessibleThemeTestCase extends TestCase {
 			'error-text-on-background' => [
 				[
 					'--color-text-error',
+					'--color-text-success',
 				],
 				[
 					'--color-main-background',


### PR DESCRIPTION
* follow up on #54439 

## Summary
This was planned to be added and already documented. The use case is some rare occurrences where we use success like text.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
