### PR TITLE
 fix(OCS): Add IRequest::getFormat to determine the response Content-Type the same way everywhere

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3330,11 +3330,6 @@
       <code><![CDATA[\OCP\IServerContainer]]></code>
     </InvalidReturnType>
   </file>
-  <file src="lib/private/AppFramework/Http/Dispatcher.php">
-    <NullArgument>
-      <code><![CDATA[null]]></code>
-    </NullArgument>
-  </file>
   <file src="lib/private/AppFramework/Http/Output.php">
     <InvalidReturnStatement>
       <code><![CDATA[@readfile($path)]]></code>

--- a/lib/private/AppFramework/Http/Dispatcher.php
+++ b/lib/private/AppFramework/Http/Dispatcher.php
@@ -210,14 +210,7 @@ class Dispatcher {
 
 		// format response
 		if ($response instanceof DataResponse || !($response instanceof Response)) {
-			// get format from the url format or request format parameter
-			$format = $this->request->getParam('format');
-
-			// if none is given try the first Accept header
-			if ($format === null) {
-				$headers = $this->request->getHeader('Accept');
-				$format = $controller->getResponderByHTTPHeader($headers, null);
-			}
+			$format = $this->request->getFormat();
 
 			if ($format !== null) {
 				$response = $controller->buildResponse($response, $format);

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -877,4 +877,23 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 
 		return \is_array($trustedProxies) && $this->isTrustedProxy($trustedProxies, $remoteAddress);
 	}
+
+	public function getFormat(): ?string {
+		$format = $this->getParam('format');
+		if ($format !== null) {
+			return $format;
+		}
+
+		$prefix = 'application/';
+		$headers = explode(',', $this->getHeader('Accept'));
+		foreach ($headers as $header) {
+			$header = strtolower(trim($header));
+
+			if (str_starts_with($header, $prefix)) {
+				return substr($header, strlen($prefix));
+			}
+		}
+
+		return null;
+	}
 }

--- a/lib/private/AppFramework/Middleware/OCSMiddleware.php
+++ b/lib/private/AppFramework/Middleware/OCSMiddleware.php
@@ -110,7 +110,7 @@ class OCSMiddleware extends Middleware {
 	 * @return V1Response|V2Response
 	 */
 	private function buildNewResponse(Controller $controller, $code, $message) {
-		$format = $this->getFormat($controller);
+		$format = $this->request->getFormat() ?? 'xml';
 
 		$data = new DataResponse();
 		$data->setStatus($code);
@@ -121,22 +121,5 @@ class OCSMiddleware extends Middleware {
 		}
 
 		return $response;
-	}
-
-	/**
-	 * @param Controller $controller
-	 * @return string
-	 */
-	private function getFormat(Controller $controller) {
-		// get format from the url format or request format parameter
-		$format = $this->request->getParam('format');
-
-		// if none is given try the first Accept header
-		if ($format === null) {
-			$headers = $this->request->getHeader('Accept');
-			$format = $controller->getResponderByHTTPHeader($headers, 'xml');
-		}
-
-		return $format;
 	}
 }

--- a/lib/private/OCS/ApiHelper.php
+++ b/lib/private/OCS/ApiHelper.php
@@ -25,7 +25,8 @@ class ApiHelper {
 	 */
 	public static function respond(int $statusCode, string $statusMessage, array $headers = [], ?int $overrideHttpStatusCode = null): void {
 		$request = Server::get(IRequest::class);
-		$format = $request->getParam('format', 'xml');
+		$format = $request->getFormat() ?? 'xml';
+
 		if (self::isV2($request)) {
 			$response = new V2Response(new DataResponse([], $statusCode, $headers), $format, $statusMessage);
 		} else {
@@ -58,7 +59,7 @@ class ApiHelper {
 	 * Based on the requested format the response content type is set
 	 */
 	public static function setContentType(?string $format = null): void {
-		$format ??= Server::get(IRequest::class)->getParam('format', 'xml');
+		$format ??= Server::get(IRequest::class)->getFormat() ?? 'xml';
 		if ($format === 'xml') {
 			header('Content-type: text/xml; charset=UTF-8');
 			return;

--- a/lib/public/AppFramework/Controller.php
+++ b/lib/public/AppFramework/Controller.php
@@ -89,6 +89,7 @@ abstract class Controller {
 	 * @return string the responder type
 	 * @since 7.0.0
 	 * @since 9.1.0 Added default parameter
+	 * @deprecated 33.0.0 Use {@see \OCP\IRequest::getFormat} instead
 	 */
 	public function getResponderByHTTPHeader($acceptHeader, $default = 'json') {
 		$headers = explode(',', $acceptHeader);

--- a/lib/public/IRequest.php
+++ b/lib/public/IRequest.php
@@ -315,4 +315,14 @@ interface IRequest {
 	 * @since 32.0.0
 	 */
 	public function throwDecodingExceptionIfAny(): void;
+
+	/**
+	 * Returns the format of the response to this request.
+	 *
+	 * The `Accept` header and the `format` query parameter control the format.
+	 *
+	 * @return string|null
+	 * @since 33.0.0
+	 */
+	public function getFormat(): ?string;
 }


### PR DESCRIPTION
The OCSMiddleware handles the `?format=json` query parameter and `Accept: application/json` request header, but [`ocs/v1.php` uses `ApiHelper::respond`](https://github.com/nextcloud/server/blob/714a97655c19f2b6f965c09612955ab9f8d72cdb/ocs/v1.php#L67) which only handles `?format=json` so far.