### PR TITLE
fix(theming): use IAppConfig instead of IConfig to set theming config

### DIFF
--- a/apps/theming/lib/ThemingDefaults.php
+++ b/apps/theming/lib/ThemingDefaults.php
@@ -433,7 +433,7 @@ class ThemingDefaults extends \OC_Defaults {
 	 * @param string $value
 	 */
 	public function set($setting, $value): void {
-		$this->config->setAppValue('theming', $setting, $value);
+		$this->appConfig->setValueString('theming', $setting, $value);
 		$this->increaseCacheBuster();
 	}
 

--- a/apps/theming/tests/ThemingDefaultsTest.php
+++ b/apps/theming/tests/ThemingDefaultsTest.php
@@ -476,18 +476,14 @@ class ThemingDefaultsTest extends TestCase {
 	}
 
 	public function testSet(): void {
-		$expectedCalls = [
-			['theming', 'MySetting', 'MyValue'],
-			['theming', 'cachebuster', 16],
-		];
-		$i = 0;
 		$this->config
-			->expects($this->exactly(2))
+			->expects($this->once())
 			->method('setAppValue')
-			->willReturnCallback(function () use ($expectedCalls, &$i): void {
-				$this->assertEquals($expectedCalls[$i], func_get_args());
-				$i++;
-			});
+			->with('theming', 'cachebuster', 16);
+		$this->appConfig
+			->expects($this->once())
+			->method('setValueString')
+			->with('theming', 'MySetting', 'MyValue');
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54626 

## Summary

The web UI uses IAppConfig to set the theming configuration, which stores the values with their type information. The occ command uses the `ThemingDefaults` which use the IConfig, which uses mixed instead of the appropriate type, which now fails.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
