### PR TITLE
fix(trashbin): Fix errors in the log on MOVE operations

### DIFF
--- a/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
+++ b/apps/files_trashbin/lib/Sabre/TrashbinPlugin.php
@@ -20,6 +20,7 @@ use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
+use Sabre\Uri;
 
 class TrashbinPlugin extends ServerPlugin {
 	public const TRASHBIN_FILENAME = '{http://nextcloud.org/ns}trashbin-filename';
@@ -146,7 +147,8 @@ class TrashbinPlugin extends ServerPlugin {
 	public function beforeMove(string $sourcePath, string $destinationPath): bool {
 		try {
 			$node = $this->server->tree->getNodeForPath($sourcePath);
-			$destinationNodeParent = $this->server->tree->getNodeForPath(dirname($destinationPath));
+			[$destinationDir, ] = Uri\split($destinationPath);
+			$destinationNodeParent = $this->server->tree->getNodeForPath($destinationDir);
 		} catch (\Sabre\DAV\Exception $e) {
 			\OCP\Server::get(LoggerInterface::class)
 				->error($e->getMessage(), ['app' => 'files_trashbin', 'exception' => $e]);


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Since https://github.com/nextcloud/server/pull/52752 there are errors in the integration tests logs that says `"Dot files are not allowed"` when a move is done for a file in the root folder.
This is because dirname will return '.' for files at the root, which will cause an Exception that gets logged.
Instead use `\Sabre\Uri\split` like other sabre plugins, to get an empty string for root directory.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
