### PR TITLE
fix(carddav): IAddressBook::getKey() should return a string

### DIFF
--- a/apps/dav/lib/CardDAV/AddressBookImpl.php
+++ b/apps/dav/lib/CardDAV/AddressBookImpl.php
@@ -41,7 +41,7 @@ class AddressBookImpl implements IAddressBookEnabled {
 	 * @since 5.0.0
 	 */
 	public function getKey() {
-		return $this->addressBookInfo['id'];
+		return (string)$this->addressBookInfo['id'];
 	}
 
 	/**

--- a/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
+++ b/apps/dav/tests/unit/CardDAV/AddressBookImplTest.php
@@ -53,7 +53,8 @@ class AddressBookImplTest extends TestCase {
 	}
 
 	public function testGetKey(): void {
-		$this->assertSame($this->addressBookInfo['id'],
+		$this->assertIsString($this->addressBookImpl->getKey());
+		$this->assertSame((string)$this->addressBookInfo['id'],
 			$this->addressBookImpl->getKey());
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Discovered while developing https://github.com/nextcloud/contacts/issues/4632.

It returns an int but should return a string (according to the PHPDoc annotation).

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
