### PR TITLE
fix: Avoid internal error when logging in with the wrong account to verify email address

### DIFF
--- a/apps/provisioning_api/lib/Controller/VerificationController.php
+++ b/apps/provisioning_api/lib/Controller/VerificationController.php
@@ -51,11 +51,18 @@ class VerificationController extends Controller {
 	#[NoAdminRequired]
 	#[NoCSRFRequired]
 	public function showVerifyMail(string $token, string $userId, string $key): TemplateResponse {
-		if ($this->userSession->getUser()->getUID() !== $userId) {
-			// not a public page, hence getUser() must return an IUser
-			throw new InvalidArgumentException('Logged in account is not mail address owner');
+		try {
+			if ($this->userSession->getUser()?->getUID() !== $userId) {
+				// not a public page, hence getUser() must return an IUser
+				throw new InvalidArgumentException($this->l10n->t('Logged in account is not mail address owner'));
+			}
+			$email = $this->crypto->decrypt($key);
+		} catch (\Exception $e) {
+			return new TemplateResponse(
+				'core', 'error', [
+					'errors' => [['error' => $e->getMessage()]]
+				], TemplateResponse::RENDER_AS_GUEST);
 		}
-		$email = $this->crypto->decrypt($key);
 
 		return new TemplateResponse(
 			'core', 'confirmation', [
@@ -73,8 +80,8 @@ class VerificationController extends Controller {
 	public function verifyMail(string $token, string $userId, string $key): TemplateResponse {
 		$throttle = false;
 		try {
-			if ($this->userSession->getUser()->getUID() !== $userId) {
-				throw new InvalidArgumentException('Logged in account is not mail address owner');
+			if ($this->userSession->getUser()?->getUID() !== $userId) {
+				throw new InvalidArgumentException($this->l10n->t('Logged in account is not mail address owner'));
 			}
 			$email = $this->crypto->decrypt($key);
 			$ref = \substr(hash('sha256', $email), 0, 8);

--- a/apps/provisioning_api/lib/Controller/VerificationController.php
+++ b/apps/provisioning_api/lib/Controller/VerificationController.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace OCA\Provisioning_API\Controller;
 
-use InvalidArgumentException;
 use OC\Security\Crypto;
 use OCP\Accounts\IAccountManager;
 use OCP\AppFramework\Controller;
@@ -18,6 +17,7 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\HintException;
 use OCP\IL10N;
 use OCP\IRequest;
 use OCP\IUserManager;
@@ -54,13 +54,16 @@ class VerificationController extends Controller {
 		try {
 			if ($this->userSession->getUser()?->getUID() !== $userId) {
 				// not a public page, hence getUser() must return an IUser
-				throw new InvalidArgumentException($this->l10n->t('Logged in account is not mail address owner'));
+				throw new HintException(
+					'Logged in account is not mail address owner',
+					$this->l10n->t('Logged in account is not mail address owner'),
+				);
 			}
 			$email = $this->crypto->decrypt($key);
-		} catch (\Exception $e) {
+		} catch (HintException $e) {
 			return new TemplateResponse(
 				'core', 'error', [
-					'errors' => [['error' => $e->getMessage()]]
+					'errors' => [['error' => $e->getHint()]]
 				], TemplateResponse::RENDER_AS_GUEST);
 		}
 
@@ -81,7 +84,10 @@ class VerificationController extends Controller {
 		$throttle = false;
 		try {
 			if ($this->userSession->getUser()?->getUID() !== $userId) {
-				throw new InvalidArgumentException($this->l10n->t('Logged in account is not mail address owner'));
+				throw new HintException(
+					'Logged in account is not mail address owner',
+					$this->l10n->t('Logged in account is not mail address owner'),
+				);
 			}
 			$email = $this->crypto->decrypt($key);
 			$ref = \substr(hash('sha256', $email), 0, 8);
@@ -94,7 +100,10 @@ class VerificationController extends Controller {
 				->getPropertyByValue($email);
 
 			if ($emailProperty === null) {
-				throw new InvalidArgumentException($this->l10n->t('Email was already removed from account and cannot be confirmed anymore.'));
+				throw new HintException(
+					'Email was already removed from account and cannot be confirmed anymore.',
+					$this->l10n->t('Email was already removed from account and cannot be confirmed anymore.'),
+				);
 			}
 			$emailProperty->setLocallyVerified(IAccountManager::VERIFIED);
 			$this->accountManager->updateAccount($userAccount);
@@ -106,8 +115,8 @@ class VerificationController extends Controller {
 				$throttle = true;
 				$error = $this->l10n->t('Could not verify mail because the token is invalid.');
 			}
-		} catch (InvalidArgumentException $e) {
-			$error = $e->getMessage();
+		} catch (HintException $e) {
+			$error = $e->getHint();
 		} catch (\Exception $e) {
 			$error = $this->l10n->t('An unexpected error occurred. Please contact your admin.');
 		}


### PR DESCRIPTION
* Resolves: # <!-- related github issue -->

## Summary

Avoid internal error when logging in with the wrong account to verify email address

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
