### PR TITLE
feat(repair): Migrate oc_properties.propertyvalue to the correct type if needed

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1981,6 +1981,7 @@ return array(
     'OC\\Repair\\Owncloud\\CleanPreviewsBackgroundJob' => $baseDir . '/lib/private/Repair/Owncloud/CleanPreviewsBackgroundJob.php',
     'OC\\Repair\\Owncloud\\DropAccountTermsTable' => $baseDir . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
     'OC\\Repair\\Owncloud\\MigrateOauthTables' => $baseDir . '/lib/private/Repair/Owncloud/MigrateOauthTables.php',
+    'OC\\Repair\\Owncloud\\MigratePropertiesTable' => $baseDir . '/lib/private/Repair/Owncloud/MigratePropertiesTable.php',
     'OC\\Repair\\Owncloud\\MoveAvatars' => $baseDir . '/lib/private/Repair/Owncloud/MoveAvatars.php',
     'OC\\Repair\\Owncloud\\MoveAvatarsBackgroundJob' => $baseDir . '/lib/private/Repair/Owncloud/MoveAvatarsBackgroundJob.php',
     'OC\\Repair\\Owncloud\\SaveAccountsTableData' => $baseDir . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -2022,6 +2022,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Repair\\Owncloud\\CleanPreviewsBackgroundJob' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/CleanPreviewsBackgroundJob.php',
         'OC\\Repair\\Owncloud\\DropAccountTermsTable' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/DropAccountTermsTable.php',
         'OC\\Repair\\Owncloud\\MigrateOauthTables' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/MigrateOauthTables.php',
+        'OC\\Repair\\Owncloud\\MigratePropertiesTable' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/MigratePropertiesTable.php',
         'OC\\Repair\\Owncloud\\MoveAvatars' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/MoveAvatars.php',
         'OC\\Repair\\Owncloud\\MoveAvatarsBackgroundJob' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/MoveAvatarsBackgroundJob.php',
         'OC\\Repair\\Owncloud\\SaveAccountsTableData' => __DIR__ . '/../../..' . '/lib/private/Repair/Owncloud/SaveAccountsTableData.php',

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -46,6 +46,7 @@ use OC\Repair\OldGroupMembershipShares;
 use OC\Repair\Owncloud\CleanPreviews;
 use OC\Repair\Owncloud\DropAccountTermsTable;
 use OC\Repair\Owncloud\MigrateOauthTables;
+use OC\Repair\Owncloud\MigratePropertiesTable;
 use OC\Repair\Owncloud\MoveAvatars;
 use OC\Repair\Owncloud\SaveAccountsTableData;
 use OC\Repair\Owncloud\UpdateLanguageCodes;
@@ -167,6 +168,7 @@ class Repair implements IOutput {
 				\OC::$server->getUserManager(),
 				\OC::$server->getConfig()
 			),
+			\OCP\Server::get(MigratePropertiesTable::class),
 			\OC::$server->get(MigrateOauthTables::class),
 			new UpdateLanguageCodes(\OC::$server->getDatabaseConnection(), \OC::$server->getConfig()),
 			new AddLogRotateJob(\OC::$server->getJobList()),

--- a/lib/private/Repair/Owncloud/MigratePropertiesTable.php
+++ b/lib/private/Repair/Owncloud/MigratePropertiesTable.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OC\Repair\Owncloud;
+
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Type;
+use OC\DB\Connection;
+use OC\DB\SchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class MigratePropertiesTable implements IRepairStep {
+
+	public function __construct(
+		private Connection $db,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Migrate oc_properties table to nextcloud schema';
+	}
+
+	public function run(IOutput $output): void {
+		$schema = new SchemaWrapper($this->db);
+		if (!$schema->hasTable('oc_properties')) {
+			$output->info('oc_properties table does not exist.');
+			return;
+		}
+
+		$output->info('Update the oc_properties table schema.');
+		$table = $schema->getTable('oc_properties');
+		$column = $table->getColumn('propertyvalue');
+		if ($column->getType() instanceof StringType) {
+			$column->setType(Type::getType('text'));
+			$column->setLength(null);
+		}
+
+		// Regenerate schema after migrating to it
+		$this->db->migrateToSchema($schema->getWrappedSchema());
+	}
+}


### PR DESCRIPTION
## Summary

This is sometimes needed when migration from owncloud

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
