### PR TITLE
Port away from IQueryBuilder::execute in lib/ and tests/ and fix invalid usage of UniqueConstraintViolationException

### DIFF
--- a/lib/private/Collaboration/Resources/Collection.php
+++ b/lib/private/Collaboration/Resources/Collection.php
@@ -95,7 +95,7 @@ class Collection implements ICollection {
 			]);
 
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (ConstraintViolationException $e) {
 			throw new ResourceException('Already part of the collection');
 		}

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
  */
 namespace OC\Collaboration\Resources;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OCP\Collaboration\Resources\CollectionException;
 use OCP\Collaboration\Resources\ICollection;
 use OCP\Collaboration\Resources\IManager;
@@ -16,6 +15,7 @@ use OCP\Collaboration\Resources\IProvider;
 use OCP\Collaboration\Resources\IProviderManager;
 use OCP\Collaboration\Resources\IResource;
 use OCP\Collaboration\Resources\ResourceException;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 use OCP\IUser;
@@ -351,7 +351,10 @@ class Manager implements IManager {
 			]);
 		try {
 			$query->executeStatement();
-		} catch (UniqueConstraintViolationException $e) {
+		} catch (Exception $e) {
+			if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				throw $e;
+			}
 		}
 	}
 
@@ -367,7 +370,10 @@ class Manager implements IManager {
 			]);
 		try {
 			$query->executeStatement();
-		} catch (UniqueConstraintViolationException $e) {
+		} catch (Exception $e) {
+			if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				throw $e;
+			}
 		}
 	}
 

--- a/lib/private/Collaboration/Resources/Manager.php
+++ b/lib/private/Collaboration/Resources/Manager.php
@@ -45,7 +45,7 @@ class Manager implements IManager {
 		$query->select('*')
 			->from(self::TABLE_COLLECTIONS)
 			->where($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -74,7 +74,7 @@ class Manager implements IManager {
 				)
 			)
 			->where($query->expr()->eq('c.id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -116,7 +116,7 @@ class Manager implements IManager {
 			$query->andWhere($query->expr()->iLike('c.name', $query->createNamedParameter('%' . $this->connection->escapeLikeParameter($filter) . '%')));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$collections = [];
 
 		$foundResults = 0;
@@ -146,7 +146,7 @@ class Manager implements IManager {
 			->values([
 				'name' => $query->createNamedParameter($name),
 			]);
-		$query->execute();
+		$query->executeStatement();
 
 		return new Collection($this, $this->connection, $query->getLastInsertId(), $name);
 	}
@@ -178,7 +178,7 @@ class Manager implements IManager {
 			)
 			->where($query->expr()->eq('r.resource_type', $query->createNamedParameter($type, IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('r.resource_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_STR)));
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -215,7 +215,7 @@ class Manager implements IManager {
 			->where($query->expr()->eq('r.collection_id', $query->createNamedParameter($collection->getId(), IQueryBuilder::PARAM_INT)));
 
 		$resources = [];
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$access = $row['access'] === null ? null : (bool)$row['access'];
 			$resources[] = new Resource($this, $this->connection, $row['resource_type'], $row['resource_id'], $user, $access);
@@ -309,7 +309,7 @@ class Manager implements IManager {
 			->setMaxResults(1);
 
 		$hasAccess = null;
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($row = $result->fetch()) {
 			$hasAccess = (bool)$row['access'];
 		}
@@ -329,7 +329,7 @@ class Manager implements IManager {
 			->setMaxResults(1);
 
 		$hasAccess = null;
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		if ($row = $result->fetch()) {
 			$hasAccess = (bool)$row['access'];
 		}
@@ -350,7 +350,7 @@ class Manager implements IManager {
 				'access' => $query->createNamedParameter($access, IQueryBuilder::PARAM_BOOL),
 			]);
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 		}
 	}
@@ -366,7 +366,7 @@ class Manager implements IManager {
 				'access' => $query->createNamedParameter($access, IQueryBuilder::PARAM_BOOL),
 			]);
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 		}
 	}
@@ -377,7 +377,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForResource(IResource $resource): void {
@@ -386,7 +386,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())))
 			->andWhere($query->expr()->eq('resource_type', $query->createNamedParameter($resource->getType(), IQueryBuilder::PARAM_STR)));
-		$query->execute();
+		$query->executeStatement();
 
 		foreach ($resource->getCollections() as $collection) {
 			$this->invalidateAccessCacheForCollection($collection);
@@ -398,7 +398,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->neq('collection_id', $query->createNamedParameter(0)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForCollection(ICollection $collection): void {
@@ -406,7 +406,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($collection->getId())));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForProvider(IProvider $provider): void {
@@ -414,7 +414,7 @@ class Manager implements IManager {
 
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($provider->getType(), IQueryBuilder::PARAM_STR)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForResourceByUser(IResource $resource, ?IUser $user): void {
@@ -424,7 +424,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_id', $query->createNamedParameter($resource->getId())))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 
 		foreach ($resource->getCollections() as $collection) {
 			$this->invalidateAccessCacheForCollectionByUser($collection, $user);
@@ -438,7 +438,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('collection_id', $query->createNamedParameter($collection->getId())))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function invalidateAccessCacheForProviderByUser(IProvider $provider, ?IUser $user): void {
@@ -448,7 +448,7 @@ class Manager implements IManager {
 		$query->delete(self::TABLE_ACCESS_CACHE)
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($provider->getType(), IQueryBuilder::PARAM_STR)))
 			->andWhere($query->expr()->eq('user_id', $query->createNamedParameter($userId)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function registerResourceProvider(string $provider): void {

--- a/lib/private/Collaboration/Resources/Resource.php
+++ b/lib/private/Collaboration/Resources/Resource.php
@@ -102,7 +102,7 @@ class Resource implements IResource {
 			->where($query->expr()->eq('resource_type', $query->createNamedParameter($this->getType())))
 			->andWhere($query->expr()->eq('resource_id', $query->createNamedParameter($this->getId())));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$collections[] = $this->manager->getCollection((int)$row['collection_id']);
 		}

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -15,6 +15,7 @@ use OCP\Comments\IComment;
 use OCP\Comments\ICommentsEventHandler;
 use OCP\Comments\ICommentsManager;
 use OCP\Comments\NotFoundException;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\FileInfo;
@@ -176,7 +177,7 @@ class Manager implements ICommentsManager {
 			->where($qb->expr()->eq('parent_id', $qb->createParameter('id')))
 			->setParameter('id', $id);
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		$data = $resultStatement->fetch(\PDO::FETCH_NUM);
 		$resultStatement->closeCursor();
 		$children = (int)$data[0];
@@ -250,7 +251,7 @@ class Manager implements ICommentsManager {
 			->from('comments')
 			->where($qb->expr()->eq('id', $qb->createParameter('id')))
 			->setParameter('id', $id, IQueryBuilder::PARAM_INT)
-			->execute();
+			->executeQuery();
 
 		$data = $resultStatement->fetch();
 		$resultStatement->closeCursor();
@@ -286,7 +287,7 @@ class Manager implements ICommentsManager {
 			$query->setFirstResult($offset);
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -345,7 +346,7 @@ class Manager implements ICommentsManager {
 				->setParameter('notOlderThan', $notOlderThan, 'datetime');
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -507,7 +508,7 @@ class Manager implements ICommentsManager {
 			}
 		}
 
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -533,7 +534,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->eq('object_id', $query->createNamedParameter($objectId)))
 			->andWhere($query->expr()->eq('id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetch();
 		$result->closeCursor();
 
@@ -605,7 +606,7 @@ class Manager implements ICommentsManager {
 		}
 
 		$comments = [];
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($data = $result->fetch()) {
 			$comment = $this->getCommentFromData($data);
 			$this->cache($comment);
@@ -649,7 +650,7 @@ class Manager implements ICommentsManager {
 
 		$query->groupBy('object_id');
 		$comments = array_fill_keys($objectIds, 0);
-		$resultStatement = $query->execute();
+		$resultStatement = $query->executeQuery();
 		while ($data = $resultStatement->fetch()) {
 			$comments[$data['object_id']] = (int)$data['num_comments'];
 		}
@@ -767,7 +768,7 @@ class Manager implements ICommentsManager {
 			$query->andWhere($query->expr()->eq('verb', $query->createNamedParameter($verb)));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$data = $result->fetch();
 		$result->closeCursor();
 
@@ -804,7 +805,7 @@ class Manager implements ICommentsManager {
 			->andWhere($query->expr()->in('actor_id', $query->createNamedParameter($actors, IQueryBuilder::PARAM_STR_ARRAY)))
 			->groupBy('actor_id');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$lastComments[$row['actor_id']] = $this->timeFactory->getDateTime($row['last_comment']);
 		}
@@ -886,7 +887,7 @@ class Manager implements ICommentsManager {
 			->setParameter('id', $id);
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 			$this->uncache($id);
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
@@ -1138,7 +1139,7 @@ class Manager implements ICommentsManager {
 
 		$affectedRows = $qb->insert('comments')
 			->values($values)
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows > 0) {
 			$comment->setId((string)$qb->getLastInsertId());
@@ -1278,56 +1279,42 @@ class Manager implements ICommentsManager {
 	}
 
 	/**
-	 * removes references to specific actor (e.g. on user delete) of a comment.
-	 * The comment itself must not get lost/deleted.
-	 *
-	 * @param string $actorType the actor type (e.g. 'users')
-	 * @param string $actorId a user id
-	 * @return boolean
-	 * @since 9.0.0
+	 * @inheritDoc
 	 */
-	public function deleteReferencesOfActor($actorType, $actorId) {
+	public function deleteReferencesOfActor($actorType, $actorId): bool {
 		$this->checkRoleParameters('Actor', $actorType, $actorId);
 
 		$qb = $this->dbConn->getQueryBuilder();
-		$affectedRows = $qb
-			->update('comments')
+		$qb->update('comments')
 			->set('actor_type', $qb->createNamedParameter(ICommentsManager::DELETED_USER))
 			->set('actor_id', $qb->createNamedParameter(ICommentsManager::DELETED_USER))
 			->where($qb->expr()->eq('actor_type', $qb->createParameter('type')))
 			->andWhere($qb->expr()->eq('actor_id', $qb->createParameter('id')))
 			->setParameter('type', $actorType)
-			->setParameter('id', $actorId)
-			->execute();
+			->setParameter('id', $actorId);
 
+		$affectedRows = $qb->executeStatement();
 		$this->commentsCache = [];
-
-		return is_int($affectedRows);
+		return true;
 	}
 
 	/**
-	 * deletes all comments made of a specific object (e.g. on file delete)
-	 *
-	 * @param string $objectType the object type (e.g. 'files')
-	 * @param string $objectId e.g. the file id
-	 * @return boolean
-	 * @since 9.0.0
+	 * @inheritDoc
 	 */
-	public function deleteCommentsAtObject($objectType, $objectId) {
+	public function deleteCommentsAtObject($objectType, $objectId): bool {
 		$this->checkRoleParameters('Object', $objectType, $objectId);
 
 		$qb = $this->dbConn->getQueryBuilder();
-		$affectedRows = $qb
+		$qb
 			->delete('comments')
 			->where($qb->expr()->eq('object_type', $qb->createParameter('type')))
 			->andWhere($qb->expr()->eq('object_id', $qb->createParameter('id')))
 			->setParameter('type', $objectType)
-			->setParameter('id', $objectId)
-			->execute();
+			->setParameter('id', $objectId);
 
+		$affectedRows = $qb->executeStatement();
 		$this->commentsCache = [];
-
-		return is_int($affectedRows);
+		return true;
 	}
 
 	/**
@@ -1344,7 +1331,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID());
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
 				'exception' => $e,
@@ -1389,7 +1376,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
 			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
-			->execute();
+			->executeStatement();
 
 		if ($affectedRows > 0) {
 			return;
@@ -1397,7 +1384,7 @@ class Manager implements ICommentsManager {
 
 		$qb->insert('comments_read_markers')
 			->values($values)
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -1421,7 +1408,7 @@ class Manager implements ICommentsManager {
 			->setParameter('user_id', $user->getUID(), IQueryBuilder::PARAM_STR)
 			->setParameter('object_type', $objectType, IQueryBuilder::PARAM_STR)
 			->setParameter('object_id', $objectId, IQueryBuilder::PARAM_STR)
-			->execute();
+			->executeQuery();
 
 		$data = $resultStatement->fetch();
 		$resultStatement->closeCursor();
@@ -1451,7 +1438,7 @@ class Manager implements ICommentsManager {
 			->setParameter('object_id', $objectId);
 
 		try {
-			$affectedRows = $query->execute();
+			$affectedRows = $query->executeStatement();
 		} catch (DriverException $e) {
 			$this->logger->error($e->getMessage(), [
 				'exception' => $e,

--- a/lib/private/DB/QueryBuilder/Sharded/CrossShardMoveHelper.php
+++ b/lib/private/DB/QueryBuilder/Sharded/CrossShardMoveHelper.php
@@ -90,7 +90,7 @@ class CrossShardMoveHelper {
 		$results = [];
 		foreach ($chunks as $chunk) {
 			$query->setParameter('keys', $chunk, IQueryBuilder::PARAM_INT_ARRAY);
-			$results = array_merge($results, $query->execute()->fetchAll());
+			$results = array_merge($results, $query->executeQuery()->fetchAll());
 		}
 
 		return $results;

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -289,7 +289,7 @@ class Cache implements ICache {
 				$builder->setValue($column, $builder->createNamedParameter($value));
 			}
 
-			if ($builder->execute()) {
+			if ($builder->executeStatement()) {
 				$fileId = $builder->getLastInsertId();
 
 				if (count($extensionValues)) {
@@ -376,7 +376,7 @@ class Cache implements ICache {
 					$query->setValue($column, $query->createNamedParameter($value));
 				}
 
-				$query->execute();
+				$query->executeStatement();
 			} catch (UniqueConstraintViolationException $e) {
 				$query = $this->getQueryBuilder();
 				$query->update('filecache_extended')

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -7,7 +7,6 @@
  */
 namespace OC\Files\Cache;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\DB\Exceptions\DbalException;
 use OC\DB\QueryBuilder\Sharded\ShardDefinition;
 use OC\Files\Cache\Wrapper\CacheJail;
@@ -16,6 +15,7 @@ use OC\Files\Search\SearchComparison;
 use OC\Files\Search\SearchQuery;
 use OC\Files\Storage\Wrapper\Encryption;
 use OC\SystemConfig;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Cache\CacheEntryInsertedEvent;
@@ -249,7 +249,7 @@ class Cache implements ICache {
 	 * @param array $data
 	 *
 	 * @return int file id
-	 * @throws \RuntimeException
+	 * @throws \RuntimeException|Exception
 	 */
 	public function insert($file, array $data) {
 		// normalize file
@@ -309,15 +309,19 @@ class Cache implements ICache {
 				$this->eventDispatcher->dispatchTyped($event);
 				return $fileId;
 			}
-		} catch (UniqueConstraintViolationException $e) {
-			// entry exists already
-			if ($this->connection->inTransaction()) {
-				$this->connection->commit();
-				$this->connection->beginTransaction();
+		} catch (Exception $e) {
+			if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				// entry exists already
+				if ($this->connection->inTransaction()) {
+					$this->connection->commit();
+					$this->connection->beginTransaction();
+				}
+			} else {
+				throw $e;
 			}
 		}
 
-		// The file was created in the mean time
+		// The file was created in the meantime
 		if (($id = $this->getId($file)) > -1) {
 			$this->update($id, $data);
 			return $id;
@@ -377,7 +381,10 @@ class Cache implements ICache {
 				}
 
 				$query->executeStatement();
-			} catch (UniqueConstraintViolationException $e) {
+			} catch (Exception $e) {
+				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					throw $e;
+				}
 				$query = $this->getQueryBuilder();
 				$query->update('filecache_extended')
 					->whereFileId($id)

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -71,10 +71,10 @@ class Database extends ABackend implements
 		try {
 			// Add group
 			$builder = $this->dbConn->getQueryBuilder();
-			$result = $builder->insert('groups')
+			$builder->insert('groups')
 				->setValue('gid', $builder->createNamedParameter($gid))
 				->setValue('displayname', $builder->createNamedParameter($name))
-				->execute();
+				->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 			return null;
 		}

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -7,8 +7,8 @@
  */
 namespace OC\Group;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\User\LazyUser;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\Group\Backend\ABackend;
 use OCP\Group\Backend\IAddToGroupBackend;
@@ -75,8 +75,12 @@ class Database extends ABackend implements
 				->setValue('gid', $builder->createNamedParameter($gid))
 				->setValue('displayname', $builder->createNamedParameter($name))
 				->executeStatement();
-		} catch (UniqueConstraintViolationException $e) {
-			return null;
+		} catch (Exception $e) {
+			if ($e->getReason() === Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+				return null;
+			} else {
+				throw $e;
+			}
 		}
 
 		// Add to cache

--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -121,7 +121,7 @@ class SaveAccountsTableData implements IRepairStep {
 			$query->setFirstResult($offset);
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$update = $this->db->getQueryBuilder();
 		$update->update('users')
@@ -175,7 +175,7 @@ class SaveAccountsTableData implements IRepairStep {
 		if ($userdata['display_name'] !== null) {
 			$update->setParameter('displayname', $userdata['display_name'])
 				->setParameter('userid', $userdata['user_id']);
-			$update->execute();
+			$update->executeStatement();
 		}
 	}
 }

--- a/lib/private/Repair/Owncloud/UpdateLanguageCodes.php
+++ b/lib/private/Repair/Owncloud/UpdateLanguageCodes.php
@@ -64,7 +64,7 @@ class UpdateLanguageCodes implements IRepairStep {
 				->where($qb->expr()->eq('appid', $qb->createNamedParameter('core')))
 				->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter('lang')))
 				->andWhere($qb->expr()->eq('configvalue', $qb->createNamedParameter($oldCode), IQueryBuilder::PARAM_STR))
-				->execute();
+				->executeStatement();
 
 			$output->info('Changed ' . $affectedRows . ' setting(s) from "' . $oldCode . '" to "' . $newCode . '" in preferences table.');
 		}

--- a/lib/private/Repair/RepairDavShares.php
+++ b/lib/private/Repair/RepairDavShares.php
@@ -52,7 +52,7 @@ class RepairDavShares implements IRepairStep {
 			->set('principaluri', $updateQuery->createParameter('updatedPrincipalUri'))
 			->where($updateQuery->expr()->eq('id', $updateQuery->createParameter('shareId')));
 
-		$statement = $qb->execute();
+		$statement = $qb->executeQuery();
 		while ($share = $statement->fetch()) {
 			$gid = substr($share['principaluri'], strlen(self::GROUP_PRINCIPAL_PREFIX));
 			$decodedGid = urldecode($gid);
@@ -81,7 +81,7 @@ class RepairDavShares implements IRepairStep {
 				$updateQuery
 					->setParameter('updatedPrincipalUri', $fixedPrincipal)
 					->setParameter('shareId', $share['id'])
-					->execute();
+					->executeStatement();
 				$this->logger->info('Repaired principal for dav share {id} from {old} to {new}', $logParameters);
 			} catch (Exception $e) {
 				$logParameters['message'] = $e->getMessage();

--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -53,7 +53,7 @@ class RepairMimeTypes implements IRepairStep {
 
 		if (empty($this->folderMimeTypeId)) {
 			$query->setParameter('mimetype', 'httpd/unix-directory');
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$this->folderMimeTypeId = (int)$result->fetchOne();
 			$result->closeCursor();
 		}
@@ -71,21 +71,21 @@ class RepairMimeTypes implements IRepairStep {
 		foreach ($updatedMimetypes as $extension => $mimetype) {
 			// get target mimetype id
 			$query->setParameter('mimetype', $mimetype);
-			$result = $query->execute();
+			$result = $query->executeQuery();
 			$mimetypeId = (int)$result->fetchOne();
 			$result->closeCursor();
 
 			if (!$mimetypeId) {
 				// insert mimetype
 				$insert->setParameter('mimetype', $mimetype);
-				$insert->execute();
+				$insert->executeStatement();
 				$mimetypeId = $insert->getLastInsertId();
 			}
 
 			// change mimetype for files with x extension
 			$update->setParameter('mimetype', $mimetypeId)
 				->setParameter('name', '%' . $this->connection->escapeLikeParameter('.' . $extension));
-			$count += $update->execute();
+			$count += $update->executeStatement();
 		}
 
 		return $count;

--- a/lib/private/Setup/PostgreSQL.php
+++ b/lib/private/Setup/PostgreSQL.php
@@ -34,7 +34,7 @@ class PostgreSQL extends AbstractDatabase {
 					->andWhere($builder->expr()->eq('rolname', $builder->createNamedParameter($this->dbUser)));
 
 				try {
-					$result = $query->execute();
+					$result = $query->executeQuery();
 					$canCreateRoles = $result->rowCount() > 0;
 				} catch (DatabaseException $e) {
 					$canCreateRoles = false;
@@ -106,7 +106,7 @@ class PostgreSQL extends AbstractDatabase {
 			//The database does not exists... let's create it
 			$query = $connection->prepare('CREATE DATABASE ' . addslashes($this->dbName) . ' OWNER "' . addslashes($this->dbUser) . '"');
 			try {
-				$query->execute();
+				$query->executeStatement();
 			} catch (DatabaseException $e) {
 				$this->logger->error('Error while trying to create database', [
 					'exception' => $e,
@@ -115,7 +115,7 @@ class PostgreSQL extends AbstractDatabase {
 		} else {
 			$query = $connection->prepare('REVOKE ALL PRIVILEGES ON DATABASE ' . addslashes($this->dbName) . ' FROM PUBLIC');
 			try {
-				$query->execute();
+				$query->executeStatement();
 			} catch (DatabaseException $e) {
 				$this->logger->error('Error while trying to restrict database permissions', [
 					'exception' => $e,
@@ -155,10 +155,10 @@ class PostgreSQL extends AbstractDatabase {
 
 			// create the user
 			$query = $connection->prepare('CREATE USER "' . addslashes($this->dbUser) . "\" CREATEDB PASSWORD '" . addslashes($this->dbPassword) . "'");
-			$query->execute();
+			$query->executeStatement();
 			if ($this->databaseExists($connection)) {
 				$query = $connection->prepare('GRANT CONNECT ON DATABASE ' . addslashes($this->dbName) . ' TO "' . addslashes($this->dbUser) . '"');
-				$query->execute();
+				$query->executeStatement();
 			}
 		} catch (DatabaseException $e) {
 			$this->logger->error('Error while trying to create database user', [

--- a/lib/private/SystemTag/SystemTagManager.php
+++ b/lib/private/SystemTag/SystemTagManager.php
@@ -74,7 +74,7 @@ class SystemTagManager implements ISystemTagManager {
 			->addOrderBy('editable', 'ASC')
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$tag = $this->createSystemTagFromRow($row);
 			if ($user && !$this->canUserSeeTag($tag, $user)) {
@@ -137,7 +137,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('name', $truncatedTagName)
 			->setParameter('visibility', $userVisible ? 1 : 0)
 			->setParameter('editable', $userAssignable ? 1 : 0)
-			->execute();
+			->executeQuery();
 
 		$row = $result->fetch();
 		$result->closeCursor();
@@ -176,7 +176,7 @@ class SystemTagManager implements ISystemTagManager {
 			]);
 
 		try {
-			$query->execute();
+			$query->executeStatement();
 		} catch (UniqueConstraintViolationException $e) {
 			throw new TagAlreadyExistsException(
 				'Tag ("' . $truncatedTagName . '", ' . $userVisible . ', ' . $userAssignable . ') already exists',
@@ -257,7 +257,7 @@ class SystemTagManager implements ISystemTagManager {
 			->setParameter('color', $color);
 
 		try {
-			if ($query->execute() === 0) {
+			if ($query->executeStatement() === 0) {
 				throw new TagNotFoundException(
 					'Tag does not exist', 0, null, [$tagId]
 				);
@@ -303,13 +303,13 @@ class SystemTagManager implements ISystemTagManager {
 		$query->delete(SystemTagObjectMapper::RELATION_TABLE)
 			->where($query->expr()->in('systemtagid', $query->createParameter('tagids')))
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		$query = $this->connection->getQueryBuilder();
 		$query->delete(self::TAG_TABLE)
 			->where($query->expr()->in('id', $query->createParameter('tagids')))
 			->setParameter('tagids', $tagIds, IQueryBuilder::PARAM_INT_ARRAY)
-			->execute();
+			->executeStatement();
 
 		foreach ($tags as $tag) {
 			$this->dispatcher->dispatch(ManagerEvent::EVENT_DELETE, new ManagerEvent(
@@ -404,7 +404,7 @@ class SystemTagManager implements ISystemTagManager {
 			$query = $this->connection->getQueryBuilder();
 			$query->delete(self::TAG_GROUP_TABLE)
 				->where($query->expr()->eq('systemtagid', $query->createNamedParameter($tag->getId())))
-				->execute();
+				->executeStatement();
 
 			// add each group id
 			$query = $this->connection->getQueryBuilder();
@@ -418,7 +418,7 @@ class SystemTagManager implements ISystemTagManager {
 					continue;
 				}
 				$query->setParameter('gid', $groupId);
-				$query->execute();
+				$query->executeStatement();
 			}
 
 			$this->connection->commit();
@@ -436,7 +436,7 @@ class SystemTagManager implements ISystemTagManager {
 			->where($query->expr()->eq('systemtagid', $query->createNamedParameter($tag->getId())))
 			->orderBy('gid');
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		while ($row = $result->fetch()) {
 			$groupIds[] = $row['gid'];
 		}

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -149,7 +149,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		foreach ($tagIds as $tagId) {
 			try {
 				$query->setParameter('tagid', $tagId);
-				$query->execute();
+				$query->executeStatement();
 				$tagsAssigned[] = $tagId;
 			} catch (UniqueConstraintViolationException $e) {
 				// ignore existing relations
@@ -213,7 +213,7 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 		$query->update('systemtag')
 			->set('etag', $query->createNamedParameter($md5))
 			->where($query->expr()->in('id', $query->createNamedParameter($tagIds, IQueryBuilder::PARAM_INT_ARRAY)));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	/**

--- a/lib/private/SystemTag/SystemTagObjectMapper.php
+++ b/lib/private/SystemTag/SystemTagObjectMapper.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  */
 namespace OC\SystemTag;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\IDBConnection;
@@ -151,7 +151,10 @@ class SystemTagObjectMapper implements ISystemTagObjectMapper {
 				$query->setParameter('tagid', $tagId);
 				$query->executeStatement();
 				$tagsAssigned[] = $tagId;
-			} catch (UniqueConstraintViolationException $e) {
+			} catch (Exception $e) {
+				if ($e->getReason() !== Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION) {
+					throw $e;
+				}
 				// ignore existing relations
 			}
 		}

--- a/lib/private/TagManager.php
+++ b/lib/private/TagManager.php
@@ -75,7 +75,7 @@ class TagManager implements ITagManager, IEventListener {
 			->andWhere($query->expr()->eq('c.type', $query->createNamedParameter($objectType)))
 			->andWhere($query->expr()->eq('c.category', $query->createNamedParameter(ITags::TAG_FAVORITE)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$users = $result->fetchAll(\PDO::FETCH_COLUMN);
 		$result->closeCursor();
 

--- a/lib/private/User/Manager.php
+++ b/lib/private/User/Manager.php
@@ -589,7 +589,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			->andWhere($queryBuilder->expr()->eq('configvalue', $queryBuilder->createNamedParameter('false'), IQueryBuilder::PARAM_STR));
 
 
-		$result = $queryBuilder->execute();
+		$result = $queryBuilder->executeQuery();
 		$count = $result->fetchOne();
 		$result->closeCursor();
 
@@ -615,7 +615,7 @@ class Manager extends PublicEmitter implements IUserManager {
 			->where($queryBuilder->expr()->eq('appid', $queryBuilder->createNamedParameter('login')))
 			->andWhere($queryBuilder->expr()->eq('configkey', $queryBuilder->createNamedParameter('lastLogin')));
 
-		$query = $queryBuilder->execute();
+		$query = $queryBuilder->executeQuery();
 
 		$result = (int)$query->fetchOne();
 		$query->closeCursor();
@@ -661,7 +661,7 @@ class Manager extends PublicEmitter implements IUserManager {
 		if ($offset !== null) {
 			$queryBuilder->setFirstResult($offset);
 		}
-		$query = $queryBuilder->execute();
+		$query = $queryBuilder->executeQuery();
 		$result = [];
 
 		while ($row = $query->fetch()) {

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -366,7 +366,7 @@ interface ICommentsManager {
 	public function save(IComment $comment);
 
 	/**
-	 * removes references to specific actor (e.g. on user delete) of a comment.
+	 * Deletes all references to specific actor (e.g. on user delete) of a comment.
 	 * The comment itself must not get lost/deleted.
 	 *
 	 * A 'users' type actor (type and id) should get replaced by the
@@ -374,17 +374,17 @@ interface ICommentsManager {
 	 *
 	 * @param string $actorType the actor type (e.g. 'users')
 	 * @param string $actorId a user id
-	 * @return boolean
+	 * @return boolean whether the deletion was successful
 	 * @since 9.0.0
 	 */
 	public function deleteReferencesOfActor($actorType, $actorId);
 
 	/**
-	 * deletes all comments made of a specific object (e.g. on file delete)
+	 * Deletes all comments made of a specific object (e.g. on file delete).
 	 *
 	 * @param string $objectType the object type (e.g. 'files')
 	 * @param string $objectId e.g. the file id
-	 * @return boolean
+	 * @return boolean whether the deletion was successful
 	 * @since 9.0.0
 	 */
 	public function deleteCommentsAtObject($objectType, $objectId);

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -146,7 +146,7 @@ interface IDBConnection {
 	 * @return int number of inserted rows
 	 * @throws Exception used to be the removed dbal exception, since 21.0.0 it's \OCP\DB\Exception
 	 * @since 6.0.0 - parameter $compare was added in 8.1.0, return type changed from boolean in 8.1.0
-	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (UniqueConstraintViolationException $e) {}" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
+	 * @deprecated 15.0.0 - use unique index and "try { $db->insert() } catch (\OCP\DB\Exception $e) { if ($e->getReason() === \OCP\DB\Exception::REASON_CONSTRAINT_VIOLATION) {} }" instead, because it is more reliable and does not have the risk for deadlocks - see https://github.com/nextcloud/server/pull/12371
 	 */
 	public function insertIfNotExist(string $table, array $input, ?array $compare = null);
 

--- a/tests/lib/Authentication/Token/ManagerTest.php
+++ b/tests/lib/Authentication/Token/ManagerTest.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 
 namespace Test\Authentication\Token;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IToken;
 use OC\Authentication\Token\Manager;
 use OC\Authentication\Token\PublicKeyToken;
 use OC\Authentication\Token\PublicKeyTokenProvider;
+use OCP\DB\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -62,8 +62,9 @@ class ManagerTest extends TestCase {
 	}
 
 	public function testGenerateConflictingToken(): void {
-		/** @var MockObject|UniqueConstraintViolationException $exception */
-		$exception = $this->createMock(UniqueConstraintViolationException::class);
+		/** @var MockObject|Exception $exception */
+		$exception = $this->createMock(Exception::class);
+		$exception->method('getReason')->willReturn(Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION);
 
 		$token = new PublicKeyToken();
 		$token->setUid('uid');

--- a/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
+++ b/tests/lib/Authentication/Token/PublicKeyTokenMapperTest.php
@@ -43,7 +43,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 
 	private function resetDatabase() {
 		$qb = $this->dbConnection->getQueryBuilder();
-		$qb->delete('authtoken')->execute();
+		$qb->delete('authtoken')->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user1'),
 			'login_name' => $qb->createNamedParameter('User1'),
@@ -56,7 +56,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'public_key' => $qb->createNamedParameter('public key'),
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user2'),
 			'login_name' => $qb->createNamedParameter('User2'),
@@ -69,7 +69,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'public_key' => $qb->createNamedParameter('public key'),
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user1'),
 			'login_name' => $qb->createNamedParameter('User1'),
@@ -82,7 +82,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'public_key' => $qb->createNamedParameter('public key'),
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user3'),
 			'login_name' => $qb->createNamedParameter('User3'),
@@ -96,7 +96,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
 			'password_invalid' => $qb->createNamedParameter(1),
-		])->execute();
+		])->executeStatement();
 		$qb->insert('authtoken')->values([
 			'uid' => $qb->createNamedParameter('user3'),
 			'login_name' => $qb->createNamedParameter('User3'),
@@ -110,14 +110,14 @@ class PublicKeyTokenMapperTest extends TestCase {
 			'private_key' => $qb->createNamedParameter('private key'),
 			'version' => $qb->createNamedParameter(2),
 			'password_invalid' => $qb->createNamedParameter(1),
-		])->execute();
+		])->executeStatement();
 	}
 
 	private function getNumberOfTokens() {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$result = $qb->select($qb->func()->count('*', 'count'))
 			->from('authtoken')
-			->execute()
+			->executeQuery()
 			->fetch();
 		return (int)$result['count'];
 	}
@@ -240,7 +240,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 		$qb->select('id')
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206')));
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$id = $result->fetch()['id'];
 
 		$token = $this->mapper->getTokenById((int)$id);
@@ -252,7 +252,7 @@ class PublicKeyTokenMapperTest extends TestCase {
 		$qb->select('name')
 			->from('authtoken')
 			->where($qb->expr()->eq('token', $qb->createNamedParameter('9c5a2e661482b65597408a6bb6c4a3d1af36337381872ac56e445a06cdb7fea2b1039db707545c11027a4966919918b19d875a8b774840b18c6cbb7ae56fe206')));
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$name = $result->fetch()['name'];
 		$this->mapper->deleteByName($name);
 		$this->assertEquals(4, $this->getNumberOfTokens());

--- a/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
+++ b/tests/lib/Authentication/TwoFactorAuth/Db/ProviderUserAssignmentDaoTest.php
@@ -30,7 +30,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 		$this->dbConn = Server::get(IDBConnection::class);
 		$qb = $this->dbConn->getQueryBuilder();
 		$q = $qb->delete(ProviderUserAssignmentDao::TABLE_NAME);
-		$q->execute();
+		$q->executeStatement();
 
 		$this->dao = new ProviderUserAssignmentDao($this->dbConn);
 	}
@@ -42,13 +42,13 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			'uid' => $qb->createNamedParameter('user123'),
 			'enabled' => $qb->createNamedParameter(1),
 		]);
-		$q1->execute();
+		$q1->executeStatement();
 		$q2 = $qb->insert(ProviderUserAssignmentDao::TABLE_NAME)->values([
 			'provider_id' => $qb->createNamedParameter('twofactor_totp'),
 			'uid' => $qb->createNamedParameter('user123'),
 			'enabled' => $qb->createNamedParameter(0),
 		]);
-		$q2->execute();
+		$q2->executeStatement();
 		$expected = [
 			'twofactor_u2f' => true,
 			'twofactor_totp' => false,
@@ -70,7 +70,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter('twofactor_totp')))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(0)));
-		$res = $q->execute();
+		$res = $q->executeQuery();
 		$data = $res->fetchAll();
 		$res->closeCursor();
 		$this->assertCount(1, $data);
@@ -88,7 +88,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter('twofactor_totp')))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(1)));
-		$res = $q->execute();
+		$res = $q->executeQuery();
 		$data = $res->fetchAll();
 		$res->closeCursor();
 
@@ -107,7 +107,7 @@ class ProviderUserAssignmentDaoTest extends TestCase {
 			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter('twofactor_totp')))
 			->andWhere($qb->expr()->eq('uid', $qb->createNamedParameter('user123')))
 			->andWhere($qb->expr()->eq('enabled', $qb->createNamedParameter(1)));
-		$res = $q->execute();
+		$res = $q->executeQuery();
 		$data = $res->fetchAll();
 		$res->closeCursor();
 

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -58,7 +58,7 @@ class JobListTest extends TestCase {
 	protected function clearJobsList() {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('jobs');
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	protected function getAllSorted() {

--- a/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
+++ b/tests/lib/Calendar/ResourcesRoomsUpdaterTest.php
@@ -62,10 +62,10 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 
 	protected function tearDown(): void {
 		$query = self::$realDatabase->getQueryBuilder();
-		$query->delete('calendar_resources')->execute();
-		$query->delete('calendar_resources_md')->execute();
-		$query->delete('calendar_rooms')->execute();
-		$query->delete('calendar_rooms_md')->execute();
+		$query->delete('calendar_resources')->executeStatement();
+		$query->delete('calendar_resources_md')->executeStatement();
+		$query->delete('calendar_rooms')->executeStatement();
+		$query->delete('calendar_rooms_md')->executeStatement();
 	}
 
 	/**
@@ -215,7 +215,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 
 		$rows = [];
 		$ids = [];
-		$stmt = $query->execute();
+		$stmt = $query->executeQuery();
 		while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
 			$ids[$row['backend_id'] . '::' . $row['resource_id']] = $row['id'];
 			unset($row['id']);
@@ -285,7 +285,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 		$query2->select('*')->from('calendar_resources_md');
 
 		$rows2 = [];
-		$stmt = $query2->execute();
+		$stmt = $query2->executeQuery();
 		while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
 			unset($row['id']);
 			$rows2[] = $row;
@@ -345,7 +345,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 				'displayname' => $query->createNamedParameter('Beamer1'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 
 		$query->insert('calendar_resources')
 			->values([
@@ -355,7 +355,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 				'displayname' => $query->createNamedParameter('TV1'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 
 		$query->insert('calendar_resources')
 			->values([
@@ -365,7 +365,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 				'displayname' => $query->createNamedParameter('Beamer2'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 		$id3 = $query->getLastInsertId();
 
 		$query->insert('calendar_resources')
@@ -376,7 +376,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 				'displayname' => $query->createNamedParameter('TV2'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 		$id4 = $query->getLastInsertId();
 
 		$query->insert('calendar_resources')
@@ -387,7 +387,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 				'displayname' => $query->createNamedParameter('Beamer3'),
 				'group_restrictions' => $query->createNamedParameter('[]'),
 			])
-			->execute();
+			->executeStatement();
 
 		$query->insert('calendar_resources')
 			->values([
@@ -397,7 +397,7 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 				'displayname' => $query->createNamedParameter('Pointer'),
 				'group_restrictions' => $query->createNamedParameter('["foo", "bar"]'),
 			])
-			->execute();
+			->executeStatement();
 		$id6 = $query->getLastInsertId();
 
 		$query->insert('calendar_resources_md')
@@ -406,34 +406,34 @@ class ResourcesRoomsUpdaterTest extends TestCase {
 				'key' => $query->createNamedParameter('meta1'),
 				'value' => $query->createNamedParameter('value1')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert('calendar_resources_md')
 			->values([
 				'resource_id' => $query->createNamedParameter($id3),
 				'key' => $query->createNamedParameter('meta2'),
 				'value' => $query->createNamedParameter('value2')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert('calendar_resources_md')
 			->values([
 				'resource_id' => $query->createNamedParameter($id4),
 				'key' => $query->createNamedParameter('meta1'),
 				'value' => $query->createNamedParameter('value1')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert('calendar_resources_md')
 			->values([
 				'resource_id' => $query->createNamedParameter($id4),
 				'key' => $query->createNamedParameter('meta3'),
 				'value' => $query->createNamedParameter('value3-old')
 			])
-			->execute();
+			->executeStatement();
 		$query->insert('calendar_resources_md')
 			->values([
 				'resource_id' => $query->createNamedParameter($id6),
 				'key' => $query->createNamedParameter('meta99'),
 				'value' => $query->createNamedParameter('value99')
 			])
-			->execute();
+			->executeStatement();
 	}
 }

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -26,7 +26,7 @@ class AdapterTest extends TestCase {
 		$qb->delete('appconfig')
 			->from('appconfig')
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter($this->appId)))
-			->execute();
+			->executeStatement();
 	}
 
 	public function testInsertIgnoreOnConflictDuplicate(): void {
@@ -63,7 +63,7 @@ class AdapterTest extends TestCase {
 			->from('appconfig')
 			->where($qb->expr()->eq('appid', $qb->createNamedParameter($this->appId)))
 			->andWhere($qb->expr()->eq('configkey', $qb->createNamedParameter($configKey)))
-			->execute()
+			->executeQuery()
 			->fetchAll();
 	}
 }

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderDBTest.php
@@ -61,7 +61,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->from('users')
 			->where($query->expr()->like($query->createNamedParameter($param1), $query->createNamedParameter($param2)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($match, $column);
@@ -98,7 +98,7 @@ class ExpressionBuilderDBTest extends TestCase {
 			->from('users')
 			->where($query->expr()->iLike($query->createNamedParameter($param1), $query->createNamedParameter($param2)));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($match, $column);
@@ -204,7 +204,7 @@ class ExpressionBuilderDBTest extends TestCase {
 				'configkey' => $query->createNamedParameter((string)$key),
 				'configvalue' => $query->createNamedParameter((string)$value),
 			])
-			->execute();
+			->executeStatement();
 	}
 
 	protected function prepareTestingTable(): void {

--- a/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/ExpressionBuilderTest.php
@@ -407,7 +407,7 @@ class ExpressionBuilderTest extends TestCase {
 			$query->andWhere(call_user_func([$query->expr(), $function], 'configkey', 'configvalue', IQueryBuilder::PARAM_STR));
 		}
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 
 		$this->assertEquals(['count' => $expected], $result->fetch());
 		$result->closeCursor();
@@ -415,7 +415,7 @@ class ExpressionBuilderTest extends TestCase {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter($appId)))
-			->execute();
+			->executeStatement();
 	}
 
 	protected function createConfig($appId, $key, $value) {
@@ -426,6 +426,6 @@ class ExpressionBuilderTest extends TestCase {
 				'configkey' => $query->createNamedParameter((string)$key),
 				'configvalue' => $query->createNamedParameter((string)$value),
 			])
-			->execute();
+			->executeStatement();
 	}
 }

--- a/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
+++ b/tests/lib/DB/QueryBuilder/FunctionBuilderTest.php
@@ -44,7 +44,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($return, $column);
@@ -120,7 +120,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString(',', $column);
@@ -136,7 +136,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString('#', $column);
@@ -152,7 +152,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString("'", $column);
@@ -168,7 +168,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString('"', $column);
@@ -209,7 +209,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('systemtag')
 			->where($query->expr()->eq('name', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString(',', $column);
@@ -225,7 +225,7 @@ class FunctionBuilderTest extends TestCase {
 			->from('systemtag')
 			->where($query->expr()->eq('name', $query->createNamedParameter('group_concat')));
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertStringContainsString('#', $column);
@@ -240,7 +240,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(md5('foobar'), $column);
@@ -253,7 +253,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals('oo', $column);
@@ -266,7 +266,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals('oobar', $column);
@@ -279,7 +279,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals('foobar', $column);
@@ -292,7 +292,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(3, $column);
@@ -305,7 +305,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(1, $column);
@@ -318,7 +318,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertGreaterThan(1, $column);
@@ -341,7 +341,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals($bytes, $column);
@@ -364,7 +364,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$column = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertNotNull($column);
@@ -380,7 +380,7 @@ class FunctionBuilderTest extends TestCase {
 				'configkey' => $query->createNamedParameter(uniqid()),
 				'configvalue' => $query->createNamedParameter((string)$value),
 			]);
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	private function clearMinMax() {
@@ -388,7 +388,7 @@ class FunctionBuilderTest extends TestCase {
 
 		$query->delete('appconfig')
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')));
-		$query->execute();
+		$query->executeStatement();
 	}
 
 	public function testMaxEmpty(): void {
@@ -401,7 +401,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(null, $row);
@@ -417,7 +417,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(null, $row);
@@ -436,7 +436,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(20, $row);
@@ -455,7 +455,7 @@ class FunctionBuilderTest extends TestCase {
 			->where($query->expr()->eq('appid', $query->createNamedParameter('minmax')))
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(10, $row);
@@ -468,7 +468,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(2, $row);
@@ -481,7 +481,7 @@ class FunctionBuilderTest extends TestCase {
 		$query->from('appconfig')
 			->setMaxResults(1);
 
-		$result = $query->execute();
+		$result = $query->executeQuery();
 		$row = $result->fetchOne();
 		$result->closeCursor();
 		$this->assertEquals(1, $row);

--- a/tests/lib/Files/Cache/ScannerTest.php
+++ b/tests/lib/Files/Cache/ScannerTest.php
@@ -343,7 +343,7 @@ class ScannerTest extends TestCase {
 		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('filecache')
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($oldFolderId)));
-		$query->execute();
+		$query->executeStatement();
 
 		$cachedData = $this->cache->get('folder/bar.txt');
 		$this->assertEquals($oldFolderId, $cachedData['parent']);
@@ -369,7 +369,7 @@ class ScannerTest extends TestCase {
 		$query = Server::get(IDBConnection::class)->getQueryBuilder();
 		$query->delete('filecache')
 			->where($query->expr()->eq('fileid', $query->createNamedParameter($oldFolderId)));
-		$query->execute();
+		$query->executeStatement();
 
 		$cachedData = $this->cache->get('folder/bar.txt');
 		$this->assertEquals($oldFolderId, $cachedData['parent']);

--- a/tests/lib/Files/Cache/SearchBuilderTest.php
+++ b/tests/lib/Files/Cache/SearchBuilderTest.php
@@ -84,7 +84,7 @@ class SearchBuilderTest extends TestCase {
 		$builder->delete('filecache')
 			->where($builder->expr()->eq('storage', $builder->createNamedParameter($this->numericStorageId, IQueryBuilder::PARAM_INT)));
 
-		$builder->execute();
+		$builder->executeStatement();
 	}
 
 	private function addCacheEntry(array $data) {
@@ -121,7 +121,7 @@ class SearchBuilderTest extends TestCase {
 
 		$builder->insert('filecache')
 			->values($values)
-			->execute();
+			->executeStatement();
 
 		return $builder->getLastInsertId();
 	}
@@ -130,7 +130,7 @@ class SearchBuilderTest extends TestCase {
 		$dbOperator = $this->searchBuilder->searchOperatorToDBExpr($this->builder, $operator);
 		$this->builder->andWhere($dbOperator);
 
-		$result = $this->builder->execute();
+		$result = $this->builder->executeQuery();
 		$rows = $result->fetchAll(\PDO::FETCH_COLUMN);
 		$result->closeCursor();
 

--- a/tests/lib/Files/Config/UserMountCacheTest.php
+++ b/tests/lib/Files/Config/UserMountCacheTest.php
@@ -81,14 +81,14 @@ class UserMountCacheTest extends TestCase {
 	protected function tearDown(): void {
 		$builder = $this->connection->getQueryBuilder();
 
-		$builder->delete('mounts')->execute();
+		$builder->delete('mounts')->executeStatement();
 
 		$builder = $this->connection->getQueryBuilder();
 
 		foreach ($this->fileIds as $fileId) {
 			$builder->delete('filecache')
 				->where($builder->expr()->eq('fileid', new Literal($fileId)))
-				->execute();
+				->executeStatement();
 		}
 	}
 
@@ -415,7 +415,7 @@ class UserMountCacheTest extends TestCase {
 					->from('filecache')
 					->where($query->expr()->eq('storage', $query->createNamedParameter($storageId)))
 					->andWhere($query->expr()->eq('path_hash', $query->createNamedParameter(md5($internalPath))));
-				$id = (int)$query->execute()->fetchColumn();
+				$id = (int)$query->executeQuery()->fetchColumn();
 			} else {
 				throw $e;
 			}

--- a/tests/lib/Files/Type/LoaderTest.php
+++ b/tests/lib/Files/Type/LoaderTest.php
@@ -28,7 +28,7 @@ class LoaderTest extends TestCase {
 			->where($deleteMimetypes->expr()->like(
 				'mimetype', $deleteMimetypes->createPositionalParameter('testing/%')
 			));
-		$deleteMimetypes->execute();
+		$deleteMimetypes->executeStatement();
 	}
 
 
@@ -38,7 +38,7 @@ class LoaderTest extends TestCase {
 			->values([
 				'mimetype' => $qb->createPositionalParameter('testing/mymimetype')
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$this->assertTrue($this->loader->exists('testing/mymimetype'));
 		$mimetypeId = $this->loader->getId('testing/mymimetype');
@@ -63,7 +63,7 @@ class LoaderTest extends TestCase {
 			->from('mimetypes')
 			->where($qb->expr()->eq('id', $qb->createPositionalParameter($mimetypeId)));
 
-		$result = $qb->execute();
+		$result = $qb->executeQuery();
 		$mimetype = $result->fetch();
 		$result->closeCursor();
 		$this->assertEquals('testing/mymimetype', $mimetype['mimetype']);

--- a/tests/lib/Repair/RepairDavSharesTest.php
+++ b/tests/lib/Repair/RepairDavSharesTest.php
@@ -131,7 +131,7 @@ class RepairDavSharesTest extends TestCase {
 			->method('where')
 			->willReturnSelf();
 		$selectMock->expects($this->once())
-			->method('execute')
+			->method('executeQuery')
 			->willReturn($shareResults);
 
 		$updateCalls = [];
@@ -155,7 +155,7 @@ class RepairDavSharesTest extends TestCase {
 				return $updateMock;
 			});
 		$updateMock->expects($this->exactly(2))
-			->method('execute');
+			->method('executeStatement');
 
 		$this->dbc->expects($this->atLeast(2))
 			->method('getQueryBuilder')

--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -103,7 +103,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$this->timeFactory->expects($this->any())->method('now')->willReturn(new \DateTimeImmutable('2023-05-04 00:00 Europe/Berlin'));
 
 		//Empty share table
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->provider = new DefaultShareProvider(
 			$this->dbConn,
@@ -122,9 +122,9 @@ class DefaultShareProviderTest extends \Test\TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
-		$this->dbConn->getQueryBuilder()->delete('filecache')->runAcrossAllShards()->execute();
-		$this->dbConn->getQueryBuilder()->delete('storages')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('filecache')->runAcrossAllShards()->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('storages')->executeStatement();
 	}
 
 	/**
@@ -180,8 +180,8 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			$qb->setValue('parent', $qb->expr()->literal($parent));
 		}
 
-		$this->assertEquals(1, $qb->execute());
-		return$qb->getLastInsertId();
+		$this->assertEquals(1, $qb->executeStatement());
+		return $qb->getLastInsertId();
 	}
 
 
@@ -207,7 +207,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -254,7 +254,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -289,7 +289,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -333,7 +333,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		// Get the id
 		$id = $qb->getLastInsertId();
@@ -419,7 +419,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'token' => $qb->expr()->literal('token'),
 				'expiration' => $qb->expr()->literal('2000-01-02 00:00:00'),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$id = $qb->getLastInsertId();
 
@@ -461,7 +461,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$id = $qb->getLastInsertId();
 
@@ -493,7 +493,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->select('*')
 			->from('share');
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$result = $cursor->fetchAll();
 		$cursor->closeCursor();
 
@@ -513,7 +513,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$id = $qb->getLastInsertId();
 
@@ -526,7 +526,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->select('*')
 			->from('share');
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$result = $cursor->fetchAll();
 		$cursor->closeCursor();
 
@@ -545,7 +545,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -560,7 +560,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(13),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$share = $this->createMock(IShare::class);
 		$share->method('getId')->willReturn($id);
@@ -591,7 +591,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->select('*')
 			->from('share');
 
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$result = $cursor->fetchAll();
 		$cursor->closeCursor();
 
@@ -611,7 +611,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		// Get the id
 		$id = $qb->getLastInsertId();
@@ -629,7 +629,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(2),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
@@ -644,7 +644,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(4),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$ownerPath = $this->createMock(Folder::class);
 		$ownerFolder = $this->createMock(Folder::class);
@@ -900,7 +900,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'token' => $qb->expr()->literal('secrettoken'),
 				'label' => $qb->expr()->literal('the label'),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 		$id = $qb->getLastInsertId();
 
 		$file = $this->createMock(File::class);
@@ -964,7 +964,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->values([
 				'id' => $qb->expr()->literal($storageStringId),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		return $qb->getLastInsertId();
 	}
 
@@ -977,7 +977,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'path_hash' => $qb->createNamedParameter(md5($path)),
 				'name' => $qb->createNamedParameter(basename($path)),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		return $qb->getLastInsertId();
 	}
 
@@ -1009,7 +1009,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1024,7 +1024,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget2'),
 				'permissions' => $qb->expr()->literal(14),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
@@ -1058,7 +1058,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget2'),
 				'permissions' => $qb->expr()->literal(14),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$qb = $this->dbConn->getQueryBuilder();
 		$qb->insert('share')
@@ -1072,7 +1072,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$groups = [];
@@ -1129,7 +1129,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		/*
@@ -1148,7 +1148,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(31),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		/*
 		 * Correct share. should be taken by code path.
@@ -1166,7 +1166,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(0),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$groups = ['sharedWith'];
 
@@ -1315,7 +1315,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
@@ -1361,7 +1361,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1377,7 +1377,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(0),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$this->rootFolder->method('getUserFolder')->with('shareOwner')->willReturnSelf();
@@ -1410,7 +1410,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1426,7 +1426,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'permissions' => $qb->expr()->literal(0),
 				'parent' => $qb->expr()->literal($id),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$file = $this->createMock(File::class);
 		$file->method('getId')->willReturn(42);
@@ -1460,7 +1460,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id1 = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -1475,7 +1475,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('userTarget'),
 				'permissions' => $qb->expr()->literal(0),
 			]);
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		$id2 = $qb->getLastInsertId();
 
 		$file = $this->createMock(File::class);
@@ -1518,7 +1518,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1551,7 +1551,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$stmt = $qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(2)))
-			->execute();
+			->executeQuery();
 
 		$shares = $stmt->fetchAll();
 		$stmt->closeCursor();
@@ -1575,7 +1575,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1591,7 +1591,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2),
 				'parent' => $qb->expr()->literal($id),
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 
 		$user1 = $this->createMock(IUser::class);
@@ -1623,7 +1623,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$stmt = $qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('share_type', $qb->createNamedParameter(2)))
-			->execute();
+			->executeQuery();
 
 		$shares = $stmt->fetchAll();
 		$stmt->closeCursor();
@@ -1648,7 +1648,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1694,7 +1694,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1732,7 +1732,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1761,7 +1761,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$stmt = $qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id)))
-			->execute();
+			->executeQuery();
 
 		$shares = $stmt->fetchAll();
 		$stmt->closeCursor();
@@ -1785,7 +1785,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_source' => $qb->expr()->literal(1),
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2)
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1828,7 +1828,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(2),
 				'token' => $qb->expr()->literal('token'),
-			])->execute();
+			])->executeStatement();
 		$this->assertEquals(1, $stmt);
 		$id = $qb->getLastInsertId();
 
@@ -1975,7 +1975,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->update('share');
 		$qb->where($qb->expr()->eq('id', $qb->createNamedParameter($id)));
 		$qb->set('password', $qb->createNamedParameter('password'));
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 
 		$users = [];
 		for ($i = 0; $i < 6; $i++) {
@@ -2186,7 +2186,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->from('share')
 			->where($qb->expr()->eq('parent', $qb->createNamedParameter($id)))
 			->orderBy('id')
-			->execute();
+			->executeQuery();
 
 		$shares = $stmt->fetchAll();
 
@@ -2316,7 +2316,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_type', $qb->createNamedParameter('file'))
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42))
-			->execute();
+			->executeStatement();
 
 		$id = $qb->getLastInsertId();
 
@@ -2328,7 +2328,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->where(
 				$qb->expr()->eq('id', $qb->createNamedParameter($id))
 			);
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetchAll();
 		$cursor->closeCursor();
 
@@ -2364,7 +2364,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_type', $qb->createNamedParameter('file'))
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42))
-			->execute();
+			->executeStatement();
 		$groupId = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -2376,7 +2376,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_type', $qb->createNamedParameter('file'))
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42))
-			->execute();
+			->executeStatement();
 		$userGroupId = $qb->getLastInsertId();
 
 		$this->provider->userDeleted($deletedUser, IShare::TYPE_GROUP);
@@ -2387,7 +2387,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->where(
 				$qb->expr()->eq('id', $qb->createNamedParameter($userGroupId))
 			);
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetchAll();
 		$cursor->closeCursor();
 		$this->assertCount($userGroupShareDeleted ? 0 : 1, $data);
@@ -2398,7 +2398,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->where(
 				$qb->expr()->eq('id', $qb->createNamedParameter($groupId))
 			);
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetchAll();
 		$cursor->closeCursor();
 		$this->assertCount($groupShareDeleted ? 0 : 1, $data);
@@ -2467,7 +2467,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_type', $qb->createNamedParameter('file'))
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42))
-			->execute();
+			->executeStatement();
 		$ids = [$qb->getLastInsertId()];
 
 		foreach ($shares['children'] as $child) {
@@ -2481,7 +2481,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				->setValue('item_source', $qb->createNamedParameter(42))
 				->setValue('file_source', $qb->createNamedParameter(42))
 				->setValue('parent', $qb->createNamedParameter($ids[0]))
-				->execute();
+				->executeStatement();
 			$ids[] = $qb->getLastInsertId();
 		}
 
@@ -2491,7 +2491,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$cursor = $qb->select('*')
 			->from('share')
 			->where($qb->expr()->in('id', $qb->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)))
-			->execute();
+			->executeQuery();
 		$data = $cursor->fetchAll();
 		$cursor->closeCursor();
 
@@ -2527,7 +2527,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_type', $qb->createNamedParameter('file'))
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42));
-		$qb->execute();
+		$qb->executeStatement();
 		$id1 = $qb->getLastInsertId();
 
 		$qb = $this->dbConn->getQueryBuilder();
@@ -2540,7 +2540,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			->setValue('item_source', $qb->createNamedParameter(42))
 			->setValue('file_source', $qb->createNamedParameter(42))
 			->setValue('parent', $qb->createNamedParameter($id1));
-		$qb->execute();
+		$qb->executeStatement();
 		$id2 = $qb->getLastInsertId();
 
 		$this->provider->userDeletedFromGroup($user, $group);
@@ -2549,7 +2549,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->select('*')
 			->from('share')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id2)));
-		$cursor = $qb->execute();
+		$cursor = $qb->executeQuery();
 		$data = $cursor->fetchAll();
 		$cursor->closeCursor();
 
@@ -2877,7 +2877,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget1'),
 				'permissions' => $qb->expr()->literal(13),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id1 = $qb->getLastInsertId();
 
@@ -2892,7 +2892,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget2'),
 				'permissions' => $qb->expr()->literal(14),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id2 = $qb->getLastInsertId();
 
@@ -2907,7 +2907,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget3'),
 				'permissions' => $qb->expr()->literal(15),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id3 = $qb->getLastInsertId();
 
@@ -2923,7 +2923,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget4'),
 				'permissions' => $qb->expr()->literal(16),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id4 = $qb->getLastInsertId();
 
@@ -2938,7 +2938,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'file_target' => $qb->expr()->literal('myTarget5'),
 				'permissions' => $qb->expr()->literal(17),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id5 = $qb->getLastInsertId();
 
@@ -3041,7 +3041,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'item_type' => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(1),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id1 = $qb->getLastInsertId();
 
@@ -3054,7 +3054,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'item_type' => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(1),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id2 = $qb->getLastInsertId();
 
@@ -3067,7 +3067,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 				'item_type' => $qb->expr()->literal('file'),
 				'file_source' => $qb->expr()->literal(1),
 			]);
-		$qb->execute();
+		$qb->executeStatement();
 
 		$id3 = $qb->getLastInsertId();
 

--- a/tests/lib/Share20/ShareByMailProviderTest.php
+++ b/tests/lib/Share20/ShareByMailProviderTest.php
@@ -103,7 +103,7 @@ class ShareByMailProviderTest extends TestCase {
 		$this->config = $this->createMock(IConfig::class);
 
 		// Empty share table
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
 
 		$this->provider = new ShareByMailProvider(
 			$this->config,
@@ -125,9 +125,9 @@ class ShareByMailProviderTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->dbConn->getQueryBuilder()->delete('share')->execute();
-		$this->dbConn->getQueryBuilder()->delete('filecache')->runAcrossAllShards()->execute();
-		$this->dbConn->getQueryBuilder()->delete('storages')->execute();
+		$this->dbConn->getQueryBuilder()->delete('share')->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('filecache')->runAcrossAllShards()->executeStatement();
+		$this->dbConn->getQueryBuilder()->delete('storages')->executeStatement();
 	}
 
 	/**
@@ -186,7 +186,7 @@ class ShareByMailProviderTest extends TestCase {
 			$qb->setValue('parent', $qb->expr()->literal($parent));
 		}
 
-		$this->assertEquals(1, $qb->execute());
+		$this->assertEquals(1, $qb->executeStatement());
 		return $qb->getLastInsertId();
 	}
 

--- a/tests/lib/SubAdminTest.php
+++ b/tests/lib/SubAdminTest.php
@@ -71,19 +71,19 @@ class SubAdminTest extends \Test\TestCase {
 				'gid' => $qb->createNamedParameter($this->groups[0]->getGID()),
 				'uid' => $qb->createNamedParameter('orphanedUser')
 			])
-			->execute();
+			->executeStatement();
 		$qb->insert('group_admin')
 			->values([
 				'gid' => $qb->createNamedParameter('orphanedGroup'),
 				'uid' => $qb->createNamedParameter('orphanedUser')
 			])
-			->execute();
+			->executeStatement();
 		$qb->insert('group_admin')
 			->values([
 				'gid' => $qb->createNamedParameter('orphanedGroup'),
 				'uid' => $qb->createNamedParameter($this->users[0]->getUID())
 			])
-			->execute();
+			->executeStatement();
 	}
 
 	protected function tearDown(): void {
@@ -99,7 +99,7 @@ class SubAdminTest extends \Test\TestCase {
 		$qb->delete('group_admin')
 			->where($qb->expr()->eq('uid', $qb->createNamedParameter('orphanedUser')))
 			->orWhere($qb->expr()->eq('gid', $qb->createNamedParameter('orphanedGroup')))
-			->execute();
+			->executeStatement();
 	}
 
 	public function testCreateSubAdmin(): void {
@@ -112,7 +112,7 @@ class SubAdminTest extends \Test\TestCase {
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
-			->execute()
+			->executeQuery()
 			->fetch();
 		$this->assertEquals(
 			[
@@ -121,10 +121,10 @@ class SubAdminTest extends \Test\TestCase {
 			], $result);
 
 		// Delete subadmin
-		$result = $qb->delete('*PREFIX*group_admin')
+		$qb->delete('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
-			->execute();
+			->executeStatement();
 	}
 
 	public function testDeleteSubAdmin(): void {
@@ -138,7 +138,7 @@ class SubAdminTest extends \Test\TestCase {
 			->from('group_admin')
 			->where($qb->expr()->eq('gid', $qb->createNamedParameter($this->groups[0]->getGID())))
 			->andWHere($qb->expr()->eq('uid', $qb->createNamedParameter($this->users[0]->getUID())))
-			->execute()
+			->executeQuery()
 			->fetch();
 		$this->assertEmpty($result);
 	}

--- a/tests/lib/SystemTag/SystemTagManagerTest.php
+++ b/tests/lib/SystemTag/SystemTagManagerTest.php
@@ -65,8 +65,8 @@ class SystemTagManagerTest extends TestCase {
 
 	protected function pruneTagsTables() {
 		$query = $this->connection->getQueryBuilder();
-		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->execute();
-		$query->delete(SystemTagManager::TAG_TABLE)->execute();
+		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->executeStatement();
+		$query->delete(SystemTagManager::TAG_TABLE)->executeStatement();
 	}
 
 	public static function getAllTagsDataProvider(): array {

--- a/tests/lib/SystemTag/SystemTagObjectMapperTest.php
+++ b/tests/lib/SystemTag/SystemTagObjectMapperTest.php
@@ -110,8 +110,8 @@ class SystemTagObjectMapperTest extends TestCase {
 
 	protected function pruneTagsTables() {
 		$query = $this->connection->getQueryBuilder();
-		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->execute();
-		$query->delete(SystemTagManager::TAG_TABLE)->execute();
+		$query->delete(SystemTagObjectMapper::RELATION_TABLE)->executeStatement();
+		$query->delete(SystemTagManager::TAG_TABLE)->executeStatement();
 	}
 
 	public function testGetTagIdsForObjects(): void {

--- a/tests/lib/TestCase.php
+++ b/tests/lib/TestCase.php
@@ -363,7 +363,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 */
 	protected static function tearDownAfterClassCleanShares(IQueryBuilder $queryBuilder) {
 		$queryBuilder->delete('share')
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -373,7 +373,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	 */
 	protected static function tearDownAfterClassCleanStorages(IQueryBuilder $queryBuilder) {
 		$queryBuilder->delete('storages')
-			->execute();
+			->executeStatement();
 	}
 
 	/**
@@ -384,7 +384,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase {
 	protected static function tearDownAfterClassCleanFileCache(IQueryBuilder $queryBuilder) {
 		$queryBuilder->delete('filecache')
 			->runAcrossAllShards()
-			->execute();
+			->executeStatement();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Commits best reviewed separately

- 1st and 3rd commit are about porting from IQueryBuilder::execute to IQueryBuilder::executeStatement and IQueryBuilder::executeQuery
- 2nd commit is about porting away from UniqueConstraintViolationException which is no longer throw directly by nextcloud but wrapped in a OCP\DB\Exception

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
