### PR TITLE
feat(theming): provide Nextcloud Assistant theming colors

### DIFF
--- a/apps/theming/css/default.css
+++ b/apps/theming/css/default.css
@@ -20,16 +20,15 @@
   --color-text-maxcontrast-background-blur: #595959;
   --color-text-error: #bf0000;
   --color-text-success: #066e03;
-  --color-element-error: #c90000;
-  --color-element-info: #0077C7;
-  --color-element-success: #099f05;
-  --color-element-warning: #BF7900;
   --color-border: #ededed;
   --color-border-dark: #dbdbdb;
   --color-border-maxcontrast: #7d7d7d;
   --color-border-error: var(--color-element-error);
   --color-border-success: var(--color-element-success);
-  --color-scrollbar: var(--color-border-maxcontrast) transparent;
+  --color-element-error: #c90000;
+  --color-element-info: #0077C7;
+  --color-element-success: #099f05;
+  --color-element-warning: #BF7900;
   --color-error: #FFE7E7;
   --color-error-hover: #ffc3c3;
   --color-error-text: #8A0000;
@@ -53,8 +52,18 @@
   --color-info-rgb: 213,241,250;
   --color-loading-light: #cccccc;
   --color-loading-dark: #444444;
+  --color-scrollbar: var(--color-border-maxcontrast) transparent;
   --color-box-shadow-rgb: 77,77,77;
   --color-box-shadow: rgba(var(--color-box-shadow-rgb), 0.5);
+  /* Assistant colors */
+  /* Background for AI generated content */
+  --color-background-assistant: #F6F5FF;
+  /* Border for AI generated content */
+  --color-border-assistant: linear-gradient(125deg, #7398FE 50%, #6104A4 125%);
+  /* Background for primary buttons to interact with the Assistant (e.g. generate content) */
+  --color-element-assistant: linear-gradient(238deg, #A569D3 12%, #00679E 39%, #422083 86%);
+  /* Icon color only to be used for the Assistant icon */
+  --color-element-assistant-icon: linear-gradient(285deg, #9669D3 15%, #00679E 40%, #492083 80%);
   --font-face: system-ui, -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
   --default-font-size: 15px;
   --font-size-small: 13px;

--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -87,14 +87,20 @@ class DarkTheme extends DefaultTheme implements ITheme {
 				'--color-text-error' => $this->util->lighten($colorErrorElement, 6),
 				'--color-text-success' => $this->util->lighten($colorSuccessElement, 6),
 
+				'--color-border' => $this->util->lighten($colorMainBackground, 7),
+				'--color-border-dark' => $this->util->lighten($colorMainBackground, 14),
+				'--color-border-maxcontrast' => $this->util->lighten($colorMainBackground, 40),
+
+				// Assistant colors (see default theme)
+				'--color-background-assistant' => '#221D2B',
+				'--color-border-assistant' => 'linear-gradient(125deg, #0C3A65 50%, #6204A5 125%)',
+
 				'--color-element-error' => $colorErrorElement,
 				'--color-element-info' => $colorInfoElement,
 				'--color-element-success' => $colorSuccessElement,
 				'--color-element-warning' => $colorWarningElement,
 
-				'--color-border' => $this->util->lighten($colorMainBackground, 7),
-				'--color-border-dark' => $this->util->lighten($colorMainBackground, 14),
-				'--color-border-maxcontrast' => $this->util->lighten($colorMainBackground, 40),
+
 
 				'--color-error' => $colorError,
 				'--color-error-hover' => $this->util->lighten($colorError, 10),

--- a/apps/theming/lib/Themes/DefaultTheme.php
+++ b/apps/theming/lib/Themes/DefaultTheme.php
@@ -138,12 +138,6 @@ class DefaultTheme implements ITheme {
 			'--color-text-error' => $this->util->darken($colorErrorElement, 2),
 			'--color-text-success' => $this->util->darken($colorSuccessElement, 10),
 
-			// special colors for elements (providing corresponding contrast) e.g. icons
-			'--color-element-error' => $colorErrorElement,
-			'--color-element-info' => $colorInfoElement,
-			'--color-element-success' => $colorSuccessElement,
-			'--color-element-warning' => $colorWarningElement,
-
 			// border colors
 			'--color-border' => $this->util->darken($colorMainBackground, 7),
 			'--color-border-dark' => $this->util->darken($colorMainBackground, 14),
@@ -151,7 +145,11 @@ class DefaultTheme implements ITheme {
 			'--color-border-error' => 'var(--color-element-error)',
 			'--color-border-success' => 'var(--color-element-success)',
 
-			'--color-scrollbar' => 'var(--color-border-maxcontrast) transparent',
+			// special colors for elements (providing corresponding contrast) e.g. icons
+			'--color-element-error' => $colorErrorElement,
+			'--color-element-info' => $colorInfoElement,
+			'--color-element-success' => $colorSuccessElement,
+			'--color-element-warning' => $colorWarningElement,
 
 			// error/warning/success/info feedback colors
 			'--color-error' => $colorError,
@@ -177,8 +175,18 @@ class DefaultTheme implements ITheme {
 			'--color-loading-light' => '#cccccc',
 			'--color-loading-dark' => '#444444',
 
+			// Scrollbar
+			'--color-scrollbar' => 'var(--color-border-maxcontrast) transparent',
+
+			// Box shadow of elements
 			'--color-box-shadow-rgb' => $colorBoxShadowRGB,
 			'--color-box-shadow' => 'rgba(var(--color-box-shadow-rgb), 0.5)',
+
+			// Assistant colors (marking AI generated content)
+			'--color-background-assistant' => '#F6F5FF', // Background for AI generated content
+			'--color-border-assistant' => 'linear-gradient(125deg, #7398FE 50%, #6104A4 125%)', // Border for AI generated content
+			'--color-element-assistant' => 'linear-gradient(238deg, #A569D3 12%, #00679E 39%, #422083 86%)', // Background of primary buttons to interact with the Assistant (e.g. generate content)
+			'--color-element-assistant-icon' => 'linear-gradient(285deg, #9669D3 15%, #00679E 40%, #492083 80%)', // The color used for the Assistant icon
 
 			'--font-face' => "system-ui, -apple-system, 'Segoe UI', Roboto, Oxygen-Sans, Cantarell, Ubuntu, 'Helvetica Neue', 'Noto Sans', 'Liberation Sans', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
 			'--default-font-size' => '15px',

--- a/apps/theming/tests/Themes/AccessibleThemeTestCase.php
+++ b/apps/theming/tests/Themes/AccessibleThemeTestCase.php
@@ -188,6 +188,16 @@ class AccessibleThemeTestCase extends TestCase {
 				],
 				$textContrast,
 			],
+			'text-on-assistant-background' => [
+				[
+					'--color-main-text',
+					'--color-text-maxcontrast',
+				],
+				[
+					'--color-background-assistant',
+				],
+				$textContrast,
+			],
 		];
 	}
 


### PR DESCRIPTION
* Resolves: https://github.com/nextcloud/server/issues/54665

## Summary

Provide the colors for the assistant, colors as defined in the feature request.
For the naming I adjusted the variable to match our naming schema:

* `--color-background-assistant`: Background for AI generated content
* `--color-border-assistant`: Border for AI generated content
* `--color-element-assistant`: Background of primary buttons to interact with the Assistant (e.g. generate content)
* `--color-element-assistant-icon`: The color used for the Assistant icon

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
