### PR TITLE
chore(Preview): Remove avconv support

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1429,7 +1429,7 @@ $CONFIG = [
 /**
  * Custom path for ffmpeg binary
  *
- * Defaults to ``null`` and falls back to searching ``avconv`` and ``ffmpeg``
+ * Defaults to ``null`` and falls back to searching ``ffmpeg``
  * in the configured ``PATH`` environment
  */
 'preview_ffmpeg_path' => '/usr/bin/ffmpeg',

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -135,12 +135,7 @@ class Movie extends ProviderV2 {
 
 		$binaryType = substr(strrchr($this->binary, '/'), 1);
 
-		if ($binaryType === 'avconv') {
-			$cmd = [$this->binary, '-y', '-ss', (string)$second,
-				'-i', $absPath,
-				'-an', '-f', 'mjpeg', '-vframes', '1', '-vsync', '1',
-				$tmpPath];
-		} elseif ($binaryType === 'ffmpeg') {
+		if ($binaryType === 'ffmpeg') {
 			if ($this->useHdr($absPath)) {
 				// Force colorspace to '2020_ncl' because some videos are
 				// tagged incorrectly as 'reserved' resulting in fail if not forced.

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -373,14 +373,11 @@ class PreviewManager implements IPreview {
 
 		$this->registerCoreProvidersOffice();
 
-		// Video requires avconv or ffmpeg
+		// Video requires ffmpeg
 		if (in_array(Preview\Movie::class, $this->getEnabledDefaultProvider())) {
 			$movieBinary = $this->config->getSystemValue('preview_ffmpeg_path', null);
 			if (!is_string($movieBinary)) {
-				$movieBinary = $this->binaryFinder->findBinaryPath('avconv');
-				if (!is_string($movieBinary)) {
-					$movieBinary = $this->binaryFinder->findBinaryPath('ffmpeg');
-				}
+				$movieBinary = $this->binaryFinder->findBinaryPath('ffmpeg');
 			}
 
 

--- a/tests/lib/Preview/MovieTest.php
+++ b/tests/lib/Preview/MovieTest.php
@@ -26,10 +26,7 @@ class MovieTest extends Provider {
 
 	protected function setUp(): void {
 		$binaryFinder = Server::get(IBinaryFinder::class);
-		$movieBinary = $binaryFinder->findBinaryPath('avconv');
-		if (!is_string($movieBinary)) {
-			$movieBinary = $binaryFinder->findBinaryPath('ffmpeg');
-		}
+		$movieBinary = $binaryFinder->findBinaryPath('ffmpeg');
 
 		if (is_string($movieBinary)) {
 			parent::setUp();


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

libav was a fork of ffmpeg, but hasn't seen any development since 2019: https://github.com/libav/libav. The only remaining thing seems to be the git mirror, the original git repo and none of the websites still exist.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
