### PR TITLE
fix(files_versions): Use helper function to get versions folder

### DIFF
--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -380,10 +380,7 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 			throw new Exception('Relative path not found for node with path: ' . $source->getPath());
 		}
 
-		$versionFolder = $this->rootFolder->get($userId . '/files_versions');
-		if (!$versionFolder instanceof Folder) {
-			throw new Exception('User versions folder does not exist');
-		}
+		$versionFolder = $this->getVersionFolder($user);
 
 		$versions = Storage::getVersions($userId, $relativePath);
 		foreach ($versions as $version) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Actually it throws a `OCP\\Files\\NotFoundException` if folder is not created/found.

Fixes:

```
{
  "reqId": "GN8O3iRfYZrIzBWcTFQR",
  "level": 3,
  "time": "2025-08-27T15:03:14+02:00",
  "remoteAddr": "83.13.22.4",
  "user": "user",
  "app": "no app in context",
  "method": "MOVE",
  "url": "/remote.php/dav/files/user/2024",
  "message": "Exception thrown: OCP\\Files\\NotFoundException",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
  "version": "30.0.14.1",
  "exception": {
    "Exception": "OCP\\Files\\NotFoundException",
    "Message": "/user/files_versions",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/private/Files/Node/LazyFolder.php",
        "line": 141,
        "function": "get",
        "class": "OC\\Files\\Node\\Root",
        "type": "->",
        "args": [
          "/user/files_versions"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Versions/LegacyVersionsBackend.php",
        "line": 373,
        "function": "get",
        "class": "OC\\Files\\Node\\LazyFolder",
        "type": "->",
        "args": [
          "user/files_versions"
        ]
      },
...
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
