### PR TITLE
fix(Accounts): Add back v2 scope migration

### DIFF
--- a/apps/provisioning_api/lib/ResponseDefinitions.php
+++ b/apps/provisioning_api/lib/ResponseDefinitions.php
@@ -18,7 +18,7 @@ namespace OCA\Provisioning_API;
  *     used?: float|int,
  * }
  *
- * @psalm-type Provisioning_APIUserDetailsScope = 'v2-private'|'v2-local'|'v2-federated'|'v2-published'|'private'|'contacts'|'public'
+ * @psalm-type Provisioning_APIUserDetailsScope = 'v2-private'|'v2-local'|'v2-federated'|'v2-published'
  *
  * @psalm-type Provisioning_APIUserDetails = array{
  *     additional_mail: list<string>,

--- a/apps/provisioning_api/openapi-administration.json
+++ b/apps/provisioning_api/openapi-administration.json
@@ -360,10 +360,7 @@
                     "v2-private",
                     "v2-local",
                     "v2-federated",
-                    "v2-published",
-                    "private",
-                    "contacts",
-                    "public"
+                    "v2-published"
                 ]
             }
         }

--- a/apps/provisioning_api/openapi-full.json
+++ b/apps/provisioning_api/openapi-full.json
@@ -407,10 +407,7 @@
                     "v2-private",
                     "v2-local",
                     "v2-federated",
-                    "v2-published",
-                    "private",
-                    "contacts",
-                    "public"
+                    "v2-published"
                 ]
             }
         }

--- a/apps/provisioning_api/openapi.json
+++ b/apps/provisioning_api/openapi.json
@@ -407,10 +407,7 @@
                     "v2-private",
                     "v2-local",
                     "v2-federated",
-                    "v2-published",
-                    "private",
-                    "contacts",
-                    "public"
+                    "v2-published"
                 ]
             }
         }

--- a/lib/private/Accounts/AccountManager.php
+++ b/lib/private/Accounts/AccountManager.php
@@ -132,7 +132,9 @@ class AccountManager implements IAccountManager {
 				$property->setScope(self::SCOPE_LOCAL);
 			}
 		} else {
-			$property->setScope($property->getScope());
+			// migrate scope values to the new format
+			// invalid scopes are mapped to a default value
+			$property->setScope(AccountProperty::mapScopeToV2($property->getScope()));
 		}
 	}
 

--- a/lib/private/Accounts/AccountProperty.php
+++ b/lib/private/Accounts/AccountProperty.php
@@ -55,11 +55,16 @@ class AccountProperty implements IAccountProperty {
 	 * @since 15.0.0
 	 */
 	public function setScope(string $scope): IAccountProperty {
-		if (!in_array($scope, IAccountManager::ALLOWED_SCOPES, )) {
+		$newScope = $this->mapScopeToV2($scope);
+		if (!in_array($newScope, [
+			IAccountManager::SCOPE_LOCAL,
+			IAccountManager::SCOPE_FEDERATED,
+			IAccountManager::SCOPE_PRIVATE,
+			IAccountManager::SCOPE_PUBLISHED
+		])) {
 			throw new InvalidArgumentException('Invalid scope');
 		}
-		/** @var IAccountManager::SCOPE_* $scope */
-		$this->scope = $scope;
+		$this->scope = $newScope;
 		return $this;
 	}
 
@@ -98,6 +103,19 @@ class AccountProperty implements IAccountProperty {
 	 */
 	public function getScope(): string {
 		return $this->scope;
+	}
+
+	public static function mapScopeToV2(string $scope): string {
+		if (str_starts_with($scope, 'v2-')) {
+			return $scope;
+		}
+
+		return match ($scope) {
+			'private', '' => IAccountManager::SCOPE_LOCAL,
+			'contacts' => IAccountManager::SCOPE_FEDERATED,
+			'public' => IAccountManager::SCOPE_PUBLISHED,
+			default => $scope,
+		};
 	}
 
 	/**

--- a/openapi.json
+++ b/openapi.json
@@ -3838,10 +3838,7 @@
                     "v2-private",
                     "v2-local",
                     "v2-federated",
-                    "v2-published",
-                    "private",
-                    "contacts",
-                    "public"
+                    "v2-published"
                 ]
             },
             "SettingsDeclarativeForm": {


### PR DESCRIPTION
Reverts part of https://github.com/nextcloud/server/pull/52544.
The database can still contain legacy scopes and when they are loaded, `setScope` will throw an error.
The migration needs to stay, as we don't save the migrated scopes back to the database.