### PR TITLE
refactor: implement reusable calendar factory

### DIFF
--- a/apps/dav/appinfo/v1/caldav.php
+++ b/apps/dav/appinfo/v1/caldav.php
@@ -8,6 +8,7 @@
 // Backends
 use OC\KnownUser\KnownUserService;
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCA\DAV\CalDAV\CalendarRoot;
 use OCA\DAV\CalDAV\DefaultCalendarValidator;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarFactory;
@@ -67,6 +68,7 @@ $config = Server::get(IConfig::class);
 $l10nFactory = Server::get(IL10NFactory::class);
 $davL10n = $l10nFactory->get('dav');
 $federatedCalendarFactory = Server::get(FederatedCalendarFactory::class);
+$calendarFactory = Server::get(CalendarFactory::class);
 
 $calDavBackend = new CalDavBackend(
 	$db,
@@ -88,7 +90,7 @@ $sendInvitations = Server::get(IConfig::class)->getAppValue('dav', 'sendInvitati
 $principalCollection = new \Sabre\CalDAV\Principal\Collection($principalBackend);
 $principalCollection->disableListing = !$debugging; // Disable listing
 
-$addressBookRoot = new CalendarRoot($principalBackend, $calDavBackend, 'principals', $logger, $davL10n, $config, $federatedCalendarFactory);
+$addressBookRoot = new CalendarRoot($principalBackend, $calDavBackend, 'principals', $federatedCalendarFactory, $calendarFactory);
 $addressBookRoot->disableListing = !$debugging; // Disable listing
 
 $nodes = [

--- a/apps/dav/composer/composer/autoload_classmap.php
+++ b/apps/dav/composer/composer/autoload_classmap.php
@@ -55,6 +55,7 @@ return array(
     'OCA\\DAV\\CalDAV\\CachedSubscriptionProvider' => $baseDir . '/../lib/CalDAV/CachedSubscriptionProvider.php',
     'OCA\\DAV\\CalDAV\\CalDavBackend' => $baseDir . '/../lib/CalDAV/CalDavBackend.php',
     'OCA\\DAV\\CalDAV\\Calendar' => $baseDir . '/../lib/CalDAV/Calendar.php',
+    'OCA\\DAV\\CalDAV\\CalendarFactory' => $baseDir . '/../lib/CalDAV/CalendarFactory.php',
     'OCA\\DAV\\CalDAV\\CalendarHome' => $baseDir . '/../lib/CalDAV/CalendarHome.php',
     'OCA\\DAV\\CalDAV\\CalendarImpl' => $baseDir . '/../lib/CalDAV/CalendarImpl.php',
     'OCA\\DAV\\CalDAV\\CalendarManager' => $baseDir . '/../lib/CalDAV/CalendarManager.php',

--- a/apps/dav/composer/composer/autoload_static.php
+++ b/apps/dav/composer/composer/autoload_static.php
@@ -70,6 +70,7 @@ class ComposerStaticInitDAV
         'OCA\\DAV\\CalDAV\\CachedSubscriptionProvider' => __DIR__ . '/..' . '/../lib/CalDAV/CachedSubscriptionProvider.php',
         'OCA\\DAV\\CalDAV\\CalDavBackend' => __DIR__ . '/..' . '/../lib/CalDAV/CalDavBackend.php',
         'OCA\\DAV\\CalDAV\\Calendar' => __DIR__ . '/..' . '/../lib/CalDAV/Calendar.php',
+        'OCA\\DAV\\CalDAV\\CalendarFactory' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarFactory.php',
         'OCA\\DAV\\CalDAV\\CalendarHome' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarHome.php',
         'OCA\\DAV\\CalDAV\\CalendarImpl' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarImpl.php',
         'OCA\\DAV\\CalDAV\\CalendarManager' => __DIR__ . '/..' . '/../lib/CalDAV/CalendarManager.php',

--- a/apps/dav/lib/CalDAV/CalendarFactory.php
+++ b/apps/dav/lib/CalDAV/CalendarFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\DAV\CalDAV;
+
+use OCA\DAV\AppInfo\Application;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\L10N\IFactory as IL10NFactory;
+use Psr\Log\LoggerInterface;
+
+class CalendarFactory {
+	private readonly IL10N $l10n;
+
+	public function __construct(
+		private readonly CalDavBackend $calDavBackend,
+		private readonly IConfig $config,
+		private readonly LoggerInterface $logger,
+		IL10NFactory $l10nFactory,
+	) {
+		$this->l10n = $l10nFactory->get(Application::APP_ID);
+	}
+
+	public function createCalendar(array $calendarInfo): Calendar {
+		return new Calendar(
+			$this->calDavBackend,
+			$calendarInfo,
+			$this->l10n,
+			$this->config,
+			$this->logger,
+		);
+	}
+
+	public function createPublicCalendar(array $calendarInfo): PublicCalendar {
+		return new PublicCalendar(
+			$this->calDavBackend,
+			$calendarInfo,
+			$this->l10n,
+			$this->config,
+			$this->logger,
+		);
+	}
+}

--- a/apps/dav/lib/CalDAV/CalendarManager.php
+++ b/apps/dav/lib/CalDAV/CalendarManager.php
@@ -7,9 +7,6 @@
 namespace OCA\DAV\CalDAV;
 
 use OCP\Calendar\IManager;
-use OCP\IConfig;
-use OCP\IL10N;
-use Psr\Log\LoggerInterface;
 
 class CalendarManager {
 
@@ -17,14 +14,10 @@ class CalendarManager {
 	 * CalendarManager constructor.
 	 *
 	 * @param CalDavBackend $backend
-	 * @param IL10N $l10n
-	 * @param IConfig $config
 	 */
 	public function __construct(
 		private CalDavBackend $backend,
-		private IL10N $l10n,
-		private IConfig $config,
-		private LoggerInterface $logger,
+		private readonly CalendarFactory $calendarFactory,
 	) {
 	}
 
@@ -43,7 +36,7 @@ class CalendarManager {
 	 */
 	private function register(IManager $cm, array $calendars) {
 		foreach ($calendars as $calendarInfo) {
-			$calendar = new Calendar($this->backend, $calendarInfo, $this->l10n, $this->config, $this->logger);
+			$calendar = $this->calendarFactory->createCalendar($calendarInfo);
 			$cm->registerCalendar(new CalendarImpl(
 				$calendar,
 				$calendarInfo,

--- a/apps/dav/lib/CalDAV/CalendarProvider.php
+++ b/apps/dav/lib/CalDAV/CalendarProvider.php
@@ -12,18 +12,13 @@ use OCA\DAV\CalDAV\Federation\FederatedCalendarImpl;
 use OCA\DAV\Db\Property;
 use OCA\DAV\Db\PropertyMapper;
 use OCP\Calendar\ICalendarProvider;
-use OCP\IConfig;
-use OCP\IL10N;
-use Psr\Log\LoggerInterface;
 
 class CalendarProvider implements ICalendarProvider {
 
 	public function __construct(
 		private CalDavBackend $calDavBackend,
-		private IL10N $l10n,
-		private IConfig $config,
-		private LoggerInterface $logger,
 		private PropertyMapper $propertyMapper,
+		private readonly CalendarFactory $calendarFactory,
 	) {
 	}
 
@@ -52,7 +47,7 @@ class CalendarProvider implements ICalendarProvider {
 
 			$calendarInfo = array_merge($calendarInfo, $additionalProperties[$path] ?? []);
 
-			$calendar = new Calendar($this->calDavBackend, $calendarInfo, $this->l10n, $this->config, $this->logger);
+			$calendar = $this->calendarFactory->createCalendar($calendarInfo);
 			$iCalendars[] = new CalendarImpl(
 				$calendar,
 				$calendarInfo,

--- a/apps/dav/lib/CalDAV/CalendarRoot.php
+++ b/apps/dav/lib/CalDAV/CalendarRoot.php
@@ -10,9 +10,6 @@ namespace OCA\DAV\CalDAV;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarFactory;
 use OCA\DAV\CalDAV\Federation\RemoteUserCalendarHome;
 use OCA\DAV\DAV\RemoteUserPrincipalBackend;
-use OCP\IConfig;
-use OCP\IL10N;
-use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Backend;
 use Sabre\DAVACL\PrincipalBackend;
 
@@ -23,10 +20,8 @@ class CalendarRoot extends \Sabre\CalDAV\CalendarRoot {
 		PrincipalBackend\BackendInterface $principalBackend,
 		Backend\BackendInterface $caldavBackend,
 		$principalPrefix,
-		private LoggerInterface $logger,
-		private IL10N $l10n,
-		private IConfig $config,
 		private FederatedCalendarFactory $federatedCalendarFactory,
+		private readonly CalendarFactory $calendarFactory,
 	) {
 		parent::__construct($principalBackend, $caldavBackend, $principalPrefix);
 	}
@@ -37,17 +32,15 @@ class CalendarRoot extends \Sabre\CalDAV\CalendarRoot {
 			return new RemoteUserCalendarHome(
 				$this->caldavBackend,
 				$principal,
-				$this->l10n,
-				$this->config,
-				$this->logger,
+				$this->calendarFactory,
 			);
 		}
 
 		return new CalendarHome(
 			$this->caldavBackend,
 			$principal,
-			$this->logger,
 			$this->federatedCalendarFactory,
+			$this->calendarFactory,
 			array_key_exists($principal['uri'], $this->returnCachedSubscriptions)
 		);
 	}

--- a/apps/dav/lib/CalDAV/PublicCalendarRoot.php
+++ b/apps/dav/lib/CalDAV/PublicCalendarRoot.php
@@ -7,9 +7,6 @@
  */
 namespace OCA\DAV\CalDAV;
 
-use OCP\IConfig;
-use OCP\IL10N;
-use Psr\Log\LoggerInterface;
 use Sabre\DAV\Collection;
 
 class PublicCalendarRoot extends Collection {
@@ -18,14 +15,10 @@ class PublicCalendarRoot extends Collection {
 	 * PublicCalendarRoot constructor.
 	 *
 	 * @param CalDavBackend $caldavBackend
-	 * @param IL10N $l10n
-	 * @param IConfig $config
 	 */
 	public function __construct(
 		protected CalDavBackend $caldavBackend,
-		protected IL10N $l10n,
-		protected IConfig $config,
-		private LoggerInterface $logger,
+		private readonly CalendarFactory $calendarFactory,
 	) {
 	}
 
@@ -41,7 +34,7 @@ class PublicCalendarRoot extends Collection {
 	 */
 	public function getChild($name) {
 		$calendar = $this->caldavBackend->getPublicCalendar($name);
-		return new PublicCalendar($this->caldavBackend, $calendar, $this->l10n, $this->config, $this->logger);
+		return $this->calendarFactory->createPublicCalendar($calendar);
 	}
 
 	/**

--- a/apps/dav/lib/Command/DeleteCalendar.php
+++ b/apps/dav/lib/Command/DeleteCalendar.php
@@ -10,11 +10,8 @@ namespace OCA\DAV\Command;
 
 use OCA\DAV\CalDAV\BirthdayService;
 use OCA\DAV\CalDAV\CalDavBackend;
-use OCA\DAV\CalDAV\Calendar;
-use OCP\IConfig;
-use OCP\IL10N;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCP\IUserManager;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,10 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 class DeleteCalendar extends Command {
 	public function __construct(
 		private CalDavBackend $calDav,
-		private IConfig $config,
-		private IL10N $l10n,
 		private IUserManager $userManager,
-		private LoggerInterface $logger,
+		private readonly CalendarFactory $calendarFactory,
 	) {
 		parent::__construct();
 	}
@@ -83,13 +78,7 @@ class DeleteCalendar extends Command {
 				'User <' . $user . '> has no calendar named <' . $name . '>. You can run occ dav:list-calendars to list calendars URIs for this user.');
 		}
 
-		$calendar = new Calendar(
-			$this->calDav,
-			$calendarInfo,
-			$this->l10n,
-			$this->config,
-			$this->logger
-		);
+		$calendar = $this->calendarFactory->createCalendar($calendarInfo);
 
 		$force = $input->getOption('force');
 		if ($force) {

--- a/apps/dav/lib/Command/MoveCalendar.php
+++ b/apps/dav/lib/Command/MoveCalendar.php
@@ -7,13 +7,10 @@
 namespace OCA\DAV\Command;
 
 use OCA\DAV\CalDAV\CalDavBackend;
-use OCA\DAV\CalDAV\Calendar;
-use OCP\IConfig;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCP\IGroupManager;
-use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\Share\IManager as IShareManager;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -30,10 +27,8 @@ class MoveCalendar extends Command {
 		private IUserManager $userManager,
 		private IGroupManager $groupManager,
 		private IShareManager $shareManager,
-		private IConfig $config,
-		private IL10N $l10n,
 		private CalDavBackend $calDav,
-		private LoggerInterface $logger,
+		private readonly CalendarFactory $calendarFactory,
 	) {
 		parent::__construct();
 	}
@@ -154,7 +149,7 @@ class MoveCalendar extends Command {
 			 */
 			if ($this->shareManager->shareWithGroupMembersOnly() === true && $prefix === 'groups' && !$this->groupManager->isInGroup($userDestination, $userOrGroup)) {
 				if ($force) {
-					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config, $this->logger), [], ['principal:principals/groups/' . $userOrGroup]);
+					$this->calDav->updateShares($this->calendarFactory->createCalendar($calendar), [], ['principal:principals/groups/' . $userOrGroup]);
 				} else {
 					throw new \InvalidArgumentException("User <$userDestination> is not part of the group <$userOrGroup> with whom the calendar <" . $calendar['uri'] . '> was shared. You may use -f to move the calendar while deleting this share.');
 				}
@@ -165,7 +160,7 @@ class MoveCalendar extends Command {
 			 */
 			if ($userOrGroup === $userDestination) {
 				if ($force) {
-					$this->calDav->updateShares(new Calendar($this->calDav, $calendar, $this->l10n, $this->config, $this->logger), [], ['principal:principals/users/' . $userOrGroup]);
+					$this->calDav->updateShares($this->calendarFactory->createCalendar($calendar), [], ['principal:principals/users/' . $userOrGroup]);
 				} else {
 					throw new \InvalidArgumentException('The calendar <' . $calendar['uri'] . "> is already shared to user <$userDestination>.You may use -f to move the calendar while deleting this share.");
 				}

--- a/apps/dav/lib/RootCollection.php
+++ b/apps/dav/lib/RootCollection.php
@@ -10,6 +10,7 @@ namespace OCA\DAV;
 use OC\KnownUser\KnownUserService;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCA\DAV\CalDAV\CalendarRoot;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarFactory;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarMapper;
@@ -63,6 +64,7 @@ class RootCollection extends SimpleCollection {
 		$proxyMapper = Server::get(ProxyMapper::class);
 		$rootFolder = Server::get(IRootFolder::class);
 		$federatedCalendarFactory = Server::get(FederatedCalendarFactory::class);
+		$calendarFactory = Server::get(CalendarFactory::class);
 
 		$userPrincipalBackend = new Principal(
 			$userManager,
@@ -110,18 +112,18 @@ class RootCollection extends SimpleCollection {
 			Server::get(FederatedCalendarMapper::class),
 			false,
 		);
-		$userCalendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users', $logger, $l10n, $config, $federatedCalendarFactory);
+		$userCalendarRoot = new CalendarRoot($userPrincipalBackend, $caldavBackend, 'principals/users', $federatedCalendarFactory, $calendarFactory);
 		$userCalendarRoot->disableListing = $disableListing;
 
-		$remoteUserCalendarRoot = new CalendarRoot($remoteUserPrincipalBackend, $caldavBackend, RemoteUserPrincipalBackend::PRINCIPAL_PREFIX, $logger, $l10n, $config, $federatedCalendarFactory);
+		$remoteUserCalendarRoot = new CalendarRoot($remoteUserPrincipalBackend, $caldavBackend, RemoteUserPrincipalBackend::PRINCIPAL_PREFIX, $federatedCalendarFactory, $calendarFactory);
 		$remoteUserCalendarRoot->disableListing = $disableListing;
 
-		$resourceCalendarRoot = new CalendarRoot($calendarResourcePrincipalBackend, $caldavBackend, 'principals/calendar-resources', $logger, $l10n, $config, $federatedCalendarFactory);
+		$resourceCalendarRoot = new CalendarRoot($calendarResourcePrincipalBackend, $caldavBackend, 'principals/calendar-resources', $federatedCalendarFactory, $calendarFactory);
 		$resourceCalendarRoot->disableListing = $disableListing;
-		$roomCalendarRoot = new CalendarRoot($calendarRoomPrincipalBackend, $caldavBackend, 'principals/calendar-rooms', $logger, $l10n, $config, $federatedCalendarFactory);
+		$roomCalendarRoot = new CalendarRoot($calendarRoomPrincipalBackend, $caldavBackend, 'principals/calendar-rooms', $federatedCalendarFactory, $calendarFactory);
 		$roomCalendarRoot->disableListing = $disableListing;
 
-		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend, $l10n, $config, $logger);
+		$publicCalendarRoot = new PublicCalendarRoot($caldavBackend, $calendarFactory);
 
 		$systemTagCollection = Server::get(SystemTagsByIdCollection::class);
 		$systemTagRelationsCollection = new SystemTagsRelationsCollection(

--- a/apps/dav/tests/unit/CalDAV/CalendarHomeTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarHomeTest.php
@@ -11,6 +11,7 @@ namespace OCA\DAV\Tests\unit\CalDAV;
 use OCA\DAV\AppInfo\PluginManager;
 use OCA\DAV\CalDAV\CachedSubscription;
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCA\DAV\CalDAV\CalendarHome;
 use OCA\DAV\CalDAV\Federation\FederatedCalendar;
 use OCA\DAV\CalDAV\Federation\FederatedCalendarFactory;
@@ -19,7 +20,6 @@ use OCA\DAV\CalDAV\Integration\ICalendarProvider;
 use OCA\DAV\CalDAV\Outbox;
 use OCA\DAV\CalDAV\Trashbin\TrashbinHome;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Schedule\Inbox;
 use Sabre\CalDAV\Subscriptions\Subscription;
 use Sabre\CalDAV\Xml\Property\SupportedCalendarComponentSet;
@@ -30,8 +30,8 @@ class CalendarHomeTest extends TestCase {
 	private CalDavBackend&MockObject $backend;
 	private array $principalInfo = [];
 	private PluginManager&MockObject $pluginManager;
-	private LoggerInterface&MockObject $logger;
 	private FederatedCalendarFactory&MockObject $federatedCalendarFactory;
+	private CalendarFactory&MockObject $calendarFactory;
 	private CalendarHome $calendarHome;
 
 	protected function setUp(): void {
@@ -42,14 +42,14 @@ class CalendarHomeTest extends TestCase {
 			'uri' => 'user-principal-123',
 		];
 		$this->pluginManager = $this->createMock(PluginManager::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->federatedCalendarFactory = $this->createMock(FederatedCalendarFactory::class);
+		$this->calendarFactory = $this->createMock(CalendarFactory::class);
 
 		$this->calendarHome = new CalendarHome(
 			$this->backend,
 			$this->principalInfo,
-			$this->logger,
 			$this->federatedCalendarFactory,
+			$this->calendarFactory,
 			false
 		);
 
@@ -293,8 +293,8 @@ class CalendarHomeTest extends TestCase {
 		$calendarHome = new CalendarHome(
 			$this->backend,
 			$this->principalInfo,
-			$this->logger,
 			$this->federatedCalendarFactory,
+			$this->calendarFactory,
 			false
 		);
 
@@ -360,8 +360,8 @@ class CalendarHomeTest extends TestCase {
 		$calendarHome = new CalendarHome(
 			$this->backend,
 			$this->principalInfo,
-			$this->logger,
 			$this->federatedCalendarFactory,
+			$this->calendarFactory,
 			true
 		);
 

--- a/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
+++ b/apps/dav/tests/unit/CalDAV/CalendarManagerTest.php
@@ -9,32 +9,24 @@ namespace OCA\DAV\Tests\unit\CalDAV;
 
 use OC\Calendar\Manager;
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCA\DAV\CalDAV\CalendarImpl;
 use OCA\DAV\CalDAV\CalendarManager;
 use OCP\Calendar\IManager;
-use OCP\IConfig;
-use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 
 class CalendarManagerTest extends \Test\TestCase {
 	private CalDavBackend&MockObject $backend;
-	private IL10N&MockObject $l10n;
-	private IConfig&MockObject $config;
-	private LoggerInterface&MockObject $logger;
+	private CalendarFactory&MockObject $calendarFactory;
 	private CalendarManager $manager;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->backend = $this->createMock(CalDavBackend::class);
-		$this->l10n = $this->createMock(IL10N::class);
-		$this->config = $this->createMock(IConfig::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->calendarFactory = $this->createMock(CalendarFactory::class);
 		$this->manager = new CalendarManager(
 			$this->backend,
-			$this->l10n,
-			$this->config,
-			$this->logger
+			$this->calendarFactory,
 		);
 	}
 

--- a/apps/dav/tests/unit/CalDAV/Federation/RemoteUserCalendarHomeTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/RemoteUserCalendarHomeTest.php
@@ -10,11 +10,9 @@ declare(strict_types=1);
 namespace OCA\DAV\Tests\unit\CalDAV\Federation;
 
 use OCA\DAV\CalDAV\Calendar;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCA\DAV\CalDAV\Federation\RemoteUserCalendarHome;
-use OCP\IConfig;
-use OCP\IL10N;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use Sabre\CalDAV\Backend\BackendInterface;
 use Sabre\DAV\Exception\NotFound;
 use Test\TestCase;
@@ -23,26 +21,20 @@ class RemoteUserCalendarHomeTest extends TestCase {
 	private RemoteUserCalendarHome $remoteUserCalendarHome;
 
 	private BackendInterface&MockObject $calDavBackend;
-	private IL10N&MockObject $l10n;
-	private IConfig&MockObject $config;
-	private LoggerInterface&MockObject $logger;
+	private CalendarFactory&MockObject $calendarFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->calDavBackend = $this->createMock(BackendInterface::class);
-		$this->l10n = $this->createMock(IL10N::class);
-		$this->config = $this->createMock(IConfig::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->calendarFactory = $this->createMock(CalendarFactory::class);
 
 		$this->remoteUserCalendarHome = new RemoteUserCalendarHome(
 			$this->calDavBackend,
 			[
 				'uri' => 'principals/remote-users/abcdef123',
 			],
-			$this->l10n,
-			$this->config,
-			$this->logger,
+			$this->calendarFactory,
 		);
 	}
 

--- a/apps/dav/tests/unit/Command/MoveCalendarTest.php
+++ b/apps/dav/tests/unit/Command/MoveCalendarTest.php
@@ -9,14 +9,12 @@ namespace OCA\DAV\Tests\unit\Command;
 
 use InvalidArgumentException;
 use OCA\DAV\CalDAV\CalDavBackend;
+use OCA\DAV\CalDAV\CalendarFactory;
 use OCA\DAV\Command\MoveCalendar;
-use OCP\IConfig;
 use OCP\IGroupManager;
-use OCP\IL10N;
 use OCP\IUserManager;
 use OCP\Share\IManager;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Tester\CommandTester;
 use Test\TestCase;
 
@@ -29,10 +27,8 @@ class MoveCalendarTest extends TestCase {
 	private IUserManager&MockObject $userManager;
 	private IGroupManager&MockObject $groupManager;
 	private \OCP\Share\IManager&MockObject $shareManager;
-	private IConfig&MockObject $config;
-	private IL10N&MockObject $l10n;
 	private CalDavBackend&MockObject $calDav;
-	private LoggerInterface&MockObject $logger;
+	private CalendarFactory&MockObject $calendarFactory;
 	private MoveCalendar $command;
 
 	protected function setUp(): void {
@@ -41,19 +37,15 @@ class MoveCalendarTest extends TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->groupManager = $this->createMock(IGroupManager::class);
 		$this->shareManager = $this->createMock(IManager::class);
-		$this->config = $this->createMock(IConfig::class);
-		$this->l10n = $this->createMock(IL10N::class);
 		$this->calDav = $this->createMock(CalDavBackend::class);
-		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->calendarFactory = $this->createMock(CalendarFactory::class);
 
 		$this->command = new MoveCalendar(
 			$this->userManager,
 			$this->groupManager,
 			$this->shareManager,
-			$this->config,
-			$this->l10n,
 			$this->calDav,
-			$this->logger
+			$this->calendarFactory,
 		);
 	}
 


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: _none_

## Summary

Apply the factory pattern to the `Calendar` and `PublicCalendar` classes as they only take a single varying argument (calendar info array). The rest is injected.

## TODO

- [ ] Fix integration tests (if broken)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
