### PR TITLE
fix(status.php): Fix samesite cookies

### DIFF
--- a/lib/base.php
+++ b/lib/base.php
@@ -384,13 +384,6 @@ class OC {
 		// prevents javascript from accessing php session cookies
 		ini_set('session.cookie_httponly', 'true');
 
-		// Do not initialize sessions for 'status.php' requests
-		// Monitoring endpoints can quickly flood session handlers
-		// and 'status.php' doesn't require sessions anyway
-		if (str_ends_with($request->getScriptName(), '/status.php')) {
-			return;
-		}
-
 		// set the cookie path to the Nextcloud directory
 		$cookie_path = OC::$WEBROOT ? : '/';
 		ini_set('session.cookie_path', $cookie_path);
@@ -399,6 +392,13 @@ class OC {
 		$cookie_domain = self::$config->getValue('cookie_domain', '');
 		if ($cookie_domain) {
 			ini_set('session.cookie_domain', $cookie_domain);
+		}
+
+		// Do not initialize sessions for 'status.php' requests
+		// Monitoring endpoints can quickly flood session handlers
+		// and 'status.php' doesn't require sessions anyway
+		if (str_ends_with($request->getScriptName(), '/status.php')) {
+			return;
 		}
 
 		// Let the session name be changed in the initSession Hook

--- a/lib/base.php
+++ b/lib/base.php
@@ -397,6 +397,7 @@ class OC {
 		// Do not initialize sessions for 'status.php' requests
 		// Monitoring endpoints can quickly flood session handlers
 		// and 'status.php' doesn't require sessions anyway
+		// We still need to run the ini_set above so that same-site cookies use the correct configuration.
 		if (str_ends_with($request->getScriptName(), '/status.php')) {
 			return;
 		}


### PR DESCRIPTION
* Resolves: #54227 
* Follow-up of https://github.com/nextcloud/server/pull/51184
* Alternative to https://github.com/nextcloud/server/pull/54528

## Summary

This skips less calls for status.php so that ini vars are correctly set and the code to set samesite cookies has the correct information when Nextcloud is installed in a subpath.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
