### PR TITLE
fix: make bucket mapper work with new multi-object-store config

### DIFF
--- a/lib/private/Files/ObjectStore/Mapper.php
+++ b/lib/private/Files/ObjectStore/Mapper.php
@@ -7,7 +7,6 @@
  */
 namespace OC\Files\ObjectStore;
 
-use OCP\IConfig;
 use OCP\IUser;
 
 /**
@@ -18,33 +17,17 @@ use OCP\IUser;
  * Map a user to a bucket.
  */
 class Mapper {
-	/** @var IUser */
-	private $user;
-
-	/** @var IConfig */
-	private $config;
-
-	/**
-	 * Mapper constructor.
-	 *
-	 * @param IUser $user
-	 * @param IConfig $config
-	 */
-	public function __construct(IUser $user, IConfig $config) {
-		$this->user = $user;
-		$this->config = $config;
+	public function __construct(
+		private readonly IUser $user,
+		private readonly array $config,
+	) {
 	}
 
-	/**
-	 * @param int $numBuckets
-	 * @return string
-	 */
-	public function getBucket($numBuckets = 64) {
+	public function getBucket(int $numBuckets = 64): string {
 		// Get the bucket config and shift if provided.
 		// Allow us to prevent writing in old filled buckets
-		$config = $this->config->getSystemValue('objectstore_multibucket');
-		$minBucket = is_array($config) && isset($config['arguments']['min_bucket'])
-			? (int)$config['arguments']['min_bucket']
+		$minBucket = isset($this->config['arguments']['min_bucket'])
+			? (int)$this->config['arguments']['min_bucket']
 			: 0;
 
 		$hash = md5($this->user->getUID());

--- a/lib/private/Files/ObjectStore/PrimaryObjectStoreConfig.php
+++ b/lib/private/Files/ObjectStore/PrimaryObjectStoreConfig.php
@@ -196,7 +196,7 @@ class PrimaryObjectStoreConfig {
 			if (!isset($config['arguments']['bucket'])) {
 				$config['arguments']['bucket'] = '';
 			}
-			$mapper = new Mapper($user, $this->config);
+			$mapper = new Mapper($user, $config);
 			$numBuckets = $config['arguments']['num_buckets'] ?? 64;
 			$bucket = $config['arguments']['bucket'] . $mapper->getBucket($numBuckets);
 

--- a/tests/lib/Files/ObjectStore/MapperTest.php
+++ b/tests/lib/Files/ObjectStore/MapperTest.php
@@ -9,25 +9,16 @@
 namespace Test\Files\ObjectStore;
 
 use OC\Files\ObjectStore\Mapper;
-use OCP\IConfig;
 use OCP\IUser;
 
 class MapperTest extends \Test\TestCase {
 	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
 	private $user;
 
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	private $config;
-
-	/** @var Mapper */
-	private $mapper;
-
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->user = $this->createMock(IUser::class);
-		$this->config = $this->createMock(IConfig::class);
-		$this->mapper = new Mapper($this->user, $this->config);
 	}
 
 	public static function dataGetBucket(): array {
@@ -49,16 +40,12 @@ class MapperTest extends \Test\TestCase {
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetBucket')]
 	public function testGetBucket($username, $numBuckets, $bucketShift, $expectedBucket): void {
+		$mapper = new Mapper($this->user, ['arguments' => ['min_bucket' => $bucketShift]]);
 		$this->user->expects($this->once())
 			->method('getUID')
 			->willReturn($username);
 
-		$this->config->expects($this->once())
-			->method('getSystemValue')
-			->with('objectstore_multibucket')
-			->willReturn(['arguments' => ['min_bucket' => $bucketShift]]);
-
-		$result = $this->mapper->getBucket($numBuckets);
+		$result = $mapper->getBucket($numBuckets);
 		$this->assertEquals($expectedBucket, $result);
 	}
 }


### PR DESCRIPTION
Forgot to adjust this with https://github.com/nextcloud/server/pull/52786 :see_no_evil: 