### PR TITLE
fix: always use english name for recently contacted category

### DIFF
--- a/apps/contactsinteraction/appinfo/info.xml
+++ b/apps/contactsinteraction/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Contacts Interaction</name>
 	<summary>Manages interaction between accounts and contacts</summary>
 	<description>Collect data about accounts and contacts interactions and provide an address book for the data</description>
-	<version>1.14.0</version>
+	<version>1.14.1</version>
 	<licence>agpl</licence>
 	<author>Christoph Wurst</author>
 	<author homepage="https://github.com/nextcloud/groupware">Nextcloud Groupware Team</author>
@@ -26,6 +26,11 @@
 	<background-jobs>
 		<job>OCA\ContactsInteraction\BackgroundJob\CleanupJob</job>
 	</background-jobs>
+	<repair-steps>
+		<live-migration>
+			<step>OCA\ContactsInteraction\Migration\FixVcardCategory</step>
+		</live-migration>
+	</repair-steps>
 	<sabre>
 		<address-book-plugins>
 			<plugin>OCA\ContactsInteraction\AddressBookProvider</plugin>

--- a/apps/contactsinteraction/composer/composer/autoload_classmap.php
+++ b/apps/contactsinteraction/composer/composer/autoload_classmap.php
@@ -17,5 +17,6 @@ return array(
     'OCA\\ContactsInteraction\\Db\\RecentContactMapper' => $baseDir . '/../lib/Db/RecentContactMapper.php',
     'OCA\\ContactsInteraction\\Listeners\\ContactInteractionListener' => $baseDir . '/../lib/Listeners/ContactInteractionListener.php',
     'OCA\\ContactsInteraction\\Listeners\\UserDeletedListener' => $baseDir . '/../lib/Listeners/UserDeletedListener.php',
+    'OCA\\ContactsInteraction\\Migration\\FixVcardCategory' => $baseDir . '/../lib/Migration/FixVcardCategory.php',
     'OCA\\ContactsInteraction\\Migration\\Version010000Date20200304152605' => $baseDir . '/../lib/Migration/Version010000Date20200304152605.php',
 );

--- a/apps/contactsinteraction/composer/composer/autoload_static.php
+++ b/apps/contactsinteraction/composer/composer/autoload_static.php
@@ -32,6 +32,7 @@ class ComposerStaticInitContactsInteraction
         'OCA\\ContactsInteraction\\Db\\RecentContactMapper' => __DIR__ . '/..' . '/../lib/Db/RecentContactMapper.php',
         'OCA\\ContactsInteraction\\Listeners\\ContactInteractionListener' => __DIR__ . '/..' . '/../lib/Listeners/ContactInteractionListener.php',
         'OCA\\ContactsInteraction\\Listeners\\UserDeletedListener' => __DIR__ . '/..' . '/../lib/Listeners/UserDeletedListener.php',
+        'OCA\\ContactsInteraction\\Migration\\FixVcardCategory' => __DIR__ . '/..' . '/../lib/Migration/FixVcardCategory.php',
         'OCA\\ContactsInteraction\\Migration\\Version010000Date20200304152605' => __DIR__ . '/..' . '/../lib/Migration/Version010000Date20200304152605.php',
     );
 

--- a/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
+++ b/apps/contactsinteraction/lib/Listeners/ContactInteractionListener.php
@@ -117,7 +117,8 @@ class ContactInteractionListener implements IEventListener {
 		$props = [
 			'URI' => UUIDUtil::getUUID(),
 			'FN' => $this->getDisplayName($contact->getUid()) ?? $contact->getEmail() ?? $contact->getFederatedCloudId(),
-			'CATEGORIES' => $this->l10n->t('Recently contacted'),
+			// Recently contacted not translated on purpose: https://github.com/nextcloud/contacts/issues/4663
+			'CATEGORIES' => 'Recently contacted',
 		];
 
 		if ($contact->getEmail() !== null) {

--- a/apps/contactsinteraction/lib/Migration/FixVcardCategory.php
+++ b/apps/contactsinteraction/lib/Migration/FixVcardCategory.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\ContactsInteraction\Migration;
+
+use OC\Migration\BackgroundRepair;
+use OCA\ContactsInteraction\AppInfo\Application;
+use OCP\BackgroundJob\IJobList;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+use Sabre\VObject\ParseException;
+use Sabre\VObject\Reader;
+
+class FixVcardCategory implements IRepairStep {
+
+	private const CARDS_PER_BATCH = 5000;
+
+	public function __construct(
+		private readonly IDBConnection $connection,
+		private readonly IJobList $jobList,
+	) {
+	}
+
+	public function getName(): string {
+		return 'Fix category of recent contacts vcards';
+	}
+
+	public function run(IOutput $output): void {
+		$query = $this->connection->getQueryBuilder();
+
+		$cardsWithTranslatedCategory = $query->select(['id', 'card'])
+			->from('recent_contact')
+			->where($query->expr()->notLike(
+				'card',
+				$query->createNamedParameter('%CATEGORIES:Recently contacted%')
+			))
+			->setMaxResults(self::CARDS_PER_BATCH)
+			->executeQuery();
+		$rowCount = $cardsWithTranslatedCategory->rowCount();
+
+		$output->startProgress($rowCount);
+
+		$this->connection->beginTransaction();
+
+		$updateQuery = $query->update('recent_contact')
+			->set('card', $query->createParameter('card'))
+			->where($query->expr()->eq('id', $query->createParameter('id')));
+
+		while ($card = $cardsWithTranslatedCategory->fetch()) {
+			$output->advance(1);
+
+			try {
+				$vcard = Reader::read($card['card']);
+			} catch (ParseException $e) {
+				$output->info('Could not parse vcard with id ' . $card['id']);
+				continue;
+			}
+
+			$vcard->remove('CATEGORIES');
+			$vcard->add('CATEGORIES', 'Recently contacted');
+
+			$updateQuery->setParameter('id', $card['id']);
+			$updateQuery->setParameter('card', $vcard->serialize());
+			$updateQuery->executeStatement();
+		}
+
+		$this->connection->commit();
+
+		$cardsWithTranslatedCategory->closeCursor();
+
+		$output->finishProgress();
+
+		if ($rowCount === self::CARDS_PER_BATCH) {
+			$this->jobList->add(BackgroundRepair::class, [
+				'app' => Application::APP_ID,
+				'step' => FixVcardCategory::class,
+				'reschedule' => time(), // Use a different argument to reschedule the job
+			]);
+		}
+	}
+}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/contacts/issues/4663

## Summary

Grouping in contacts is done by the categories property and therefore it's not ideal to translate it. 
See https://github.com/nextcloud/contacts/issues/4663 for additional context and steps to reproduce. 


## TODO

- [x] Review

## Helper script to generate recent contacts

```php
<?php

$pdo = new \PDO('pgsql:host=postgres;port=5432;dbname=server', 'postgres', 'postgres');
$pdo->beginTransaction();

$delete = $pdo->prepare("delete from oc_recent_contact where actor_uid = 'bob' and email ilike '%@example.org';");
$delete->execute();

$insert = $pdo->prepare('INSERT INTO oc_recent_contact (actor_uid, uid, email, federated_cloud_id, card, last_contact) VALUES (?,?,?,?,?,?)');
for ($i = 0; $i < 49000; $i++) {
	if ($i % 2 === 0) {
		$category = 'Zuletzt kontaktiert';
	} else {
		$category = 'Recently contacted';
	}

	$card = sprintf('BEGIN:VCARD
VERSION:4.0
PRODID:-//Blub Blub//EN
UID:recent-contact-%1$s
URI:recent-contact-%1$s
FN:test+%1$s@example.org
CATEGORIES:%2$s
EMAIL:test+%1$s@example.org
END:VCARD
', $i, $category);

	$insert->execute(['bob', null, 'test+' . $i . '@example.org', null, $card, time()]);
}

$pdo->commit();


```



## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
