### PR TITLE
fix: Make DefaultShareProvider getSharedWith test more robust

### DIFF
--- a/tests/lib/Share20/DefaultShareProviderTest.php
+++ b/tests/lib/Share20/DefaultShareProviderTest.php
@@ -1065,7 +1065,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 		$qb->insert('share')
 			->values([
 				'share_type' => $qb->expr()->literal(IShare::TYPE_GROUP),
-				'share_with' => $qb->expr()->literal('group3'),
+				'share_with' => $qb->expr()->literal('group103'),
 				'uid_owner' => $qb->expr()->literal('shareOwner3'),
 				'uid_initiator' => $qb->expr()->literal('sharedBy3'),
 				'item_type' => $qb->expr()->literal('file'),
@@ -1105,7 +1105,7 @@ class DefaultShareProviderTest extends \Test\TestCase {
 			]);
 		$this->assertEquals(1, $qb->execute());
 
-		// getSharedWith() returns a result ordered by id
+		// getSharedWith() returns a result ordered by id (we'll want this when checking the first share (aka $share[0]) later 
 		$id = $qb->getLastInsertId();
 
 		$groups = [];


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] Minor refactoring of getSharedWith so that TYPE_USER and TYPE_GROUP better match
- [ ] Note/test `count(shares2[])` fix for TYPE_GROUP

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
