### PR TITLE
[stable31] fix: cast fileid to string in getMountsForFileId

### DIFF
--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -353,6 +353,7 @@ class UserMountCache implements IUserMountCache {
 	 * @since 9.0.0
 	 */
 	public function getMountsForFileId($fileId, $user = null) {
+		$fileId = (int)$fileId;
 		try {
 			[$storageId, $internalPath] = $this->getCacheInfoFromFileId($fileId);
 		} catch (NotFoundException $e) {


### PR DESCRIPTION
Adding strict type hinting would be a breaking change so just do a cast for now.

Not a problem with master/32 because of https://github.com/nextcloud/server/pull/54197