### PR TITLE
fix(accountmanager): Delete email verification request on password change

### DIFF
--- a/core/Listener/PasswordUpdatedListener.php
+++ b/core/Listener/PasswordUpdatedListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace OC\Core\Listener;
 
+use OCP\Accounts\IAccountManager;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Security\VerificationToken\IVerificationToken;
@@ -20,13 +21,18 @@ use OCP\User\Events\PasswordUpdatedEvent;
 class PasswordUpdatedListener implements IEventListener {
 	public function __construct(
 		readonly private IVerificationToken $verificationToken,
+		readonly private IAccountManager $accountManager,
 	) {
-
 	}
 
 	public function handle(Event $event): void {
 		if ($event instanceof PasswordUpdatedEvent) {
+			// Delete lost password tokens
 			$this->verificationToken->delete('', $event->getUser(), 'lostpassword');
+
+			// Delete email verification token
+			$account = $this->accountManager->getAccount($event->getUser());
+			$this->accountManager->invalidEmailChangeVerificationRequests($account);
 		}
 	}
 }

--- a/lib/public/Accounts/IAccountManager.php
+++ b/lib/public/Accounts/IAccountManager.php
@@ -224,4 +224,11 @@ interface IAccountManager {
 	 * @since 21.0.0
 	 */
 	public function searchUsers(string $property, array $values): array;
+
+	/**
+	 * Invalid any previous email change verification emails.
+	 *
+	 * @since 32.0.0
+	 */
+	public function invalidEmailChangeVerificationRequests(IAccount $account): void;
 }


### PR DESCRIPTION
## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
