### PR TITLE
fix(theming): adjust assistant icon color on dark theme

### DIFF
--- a/apps/theming/lib/Themes/DarkTheme.php
+++ b/apps/theming/lib/Themes/DarkTheme.php
@@ -94,13 +94,12 @@ class DarkTheme extends DefaultTheme implements ITheme {
 				// Assistant colors (see default theme)
 				'--color-background-assistant' => '#221D2B',
 				'--color-border-assistant' => 'linear-gradient(125deg, #0C3A65 50%, #6204A5 125%)',
+				'--color-element-assistant-icon' => 'linear-gradient(285deg, #CDACE7 15.28%, #008FDB 39.98%, #A180E0 82.05%)',
 
 				'--color-element-error' => $colorErrorElement,
 				'--color-element-info' => $colorInfoElement,
 				'--color-element-success' => $colorSuccessElement,
 				'--color-element-warning' => $colorWarningElement,
-
-
 
 				'--color-error' => $colorError,
 				'--color-error-hover' => $this->util->lighten($colorError, 10),


### PR DESCRIPTION
* resolves https://github.com/nextcloud/server/issues/54782

## Summary

Override the icon color on dark theme.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
