### PR TITLE
fix(FileAccess): Make getByAncestorInStorage sharding ready

### DIFF
--- a/lib/private/Files/Cache/FileAccess.php
+++ b/lib/private/Files/Cache/FileAccess.php
@@ -152,8 +152,9 @@ class FileAccess implements IFileAccess {
 			$rows = [];
 			$i = 0;
 			do {
-				while (($rows[] = $files->fetch()) && $i < 1000) {
+				while ($i < 1000 && ($row = $files->fetch())) {
 					$i++;
+					$rows[] = $row;
 				}
 				$parents = array_map(function ($row) {
 					return $row['parent'];

--- a/tests/lib/Files/Cache/FileAccessTest.php
+++ b/tests/lib/Files/Cache/FileAccessTest.php
@@ -211,6 +211,7 @@ class FileAccessTest extends TestCase {
 				'name' => $queryBuilder->createNamedParameter('files'),
 				'mimetype' => 1,
 				'encrypted' => 0,
+				'size' => 1,
 			])
 			->executeStatement();
 
@@ -224,6 +225,7 @@ class FileAccessTest extends TestCase {
 				'name' => $queryBuilder->createNamedParameter('documents'),
 				'mimetype' => 2,
 				'encrypted' => 1,
+				'size' => 1,
 			])
 			->executeStatement();
 
@@ -237,6 +239,7 @@ class FileAccessTest extends TestCase {
 				'name' => $queryBuilder->createNamedParameter('photos'),
 				'mimetype' => 3,
 				'encrypted' => 1,
+				'size' => 1,
 			])
 			->executeStatement();
 
@@ -250,6 +253,7 @@ class FileAccessTest extends TestCase {
 				'name' => $queryBuilder->createNamedParameter('endtoendencrypted'),
 				'mimetype' => 4,
 				'encrypted' => 0,
+				'size' => 1,
 			])
 			->executeStatement();
 
@@ -263,6 +267,7 @@ class FileAccessTest extends TestCase {
 				'name' => $queryBuilder->createNamedParameter('serversideencrypted'),
 				'mimetype' => 4,
 				'encrypted' => 1,
+				'size' => 1,
 			])
 			->executeStatement();
 
@@ -276,6 +281,7 @@ class FileAccessTest extends TestCase {
 				'name' => $queryBuilder->createNamedParameter('storage2'),
 				'mimetype' => 5,
 				'encrypted' => 0,
+				'size' => 1,
 			])
 			->executeStatement();
 
@@ -289,6 +295,7 @@ class FileAccessTest extends TestCase {
 				'name' => $queryBuilder->createNamedParameter('file'),
 				'mimetype' => 6,
 				'encrypted' => 0,
+				'size' => 1,
 			])
 			->executeStatement();
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
