### PR TITLE
feat(ObjectStore): Add option to limit the total size

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1847,7 +1847,9 @@ $CONFIG = [
 			// if omitted
 			'serviceName' => 'swift',
 			// The Interface / URL Type, optional
-			'urlType' => 'internal'
+			'urlType' => 'internal',
+			// Maximum amount of data that can be uploaded
+			'totalSizeLimit' => 1024 * 1024 * 1024,
 		],
 	],
 


### PR DESCRIPTION
Some object stores might bill you more once the size is over a certain limits, so admins might want to prevent that case.