### PR TITLE
enh(avatars): use different colors for guests for the same name

### DIFF
--- a/lib/private/Avatar/GuestAvatar.php
+++ b/lib/private/Avatar/GuestAvatar.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 namespace OC\Avatar;
 
+use OCP\Color;
 use OCP\Files\SimpleFS\InMemoryFile;
 use OCP\Files\SimpleFS\ISimpleFile;
 use OCP\IConfig;
@@ -87,5 +88,14 @@ class GuestAvatar extends Avatar {
 	 */
 	public function isCustomAvatar(): bool {
 		return false;
+	}
+
+
+	/**
+	 * Different color than for authorized user with the same name
+	 * to make it harder to impersonate people.
+	 */
+	public function avatarBackgroundColor(string $hash): Color {
+		return parent::avatarBackgroundColor($hash . ' (guest)');
 	}
 }


### PR DESCRIPTION
Make it harder to impersonate users who have not set their avatar.

I'd like to use the generic guest name dialog that comes with Nextcloud 32 - but currently colors are the same for guests and authenticated users with the same name.

## Screenshots (using avatar colors in text)

:derelict_house: old | :house_with_garden: new
--- | ---
<img width="281" height="252" alt="Bildschirmfoto vom 2025-09-02 11-13-24" src="https://github.com/user-attachments/assets/70589bfe-e008-4c49-9aa8-ee4ca98ce87d" />  | <img width="281" height="252" alt="Bildschirmfoto vom 2025-09-02 11-10-54" src="https://github.com/user-attachments/assets/acdf7ee8-dd10-498d-bca9-52b43e22898a" />
<img width="596" height="252" alt="Bildschirmfoto vom 2025-09-02 11-13-56" src="https://github.com/user-attachments/assets/ef281532-f065-496e-b67a-83dfbd21fb99" />| <img width="605" height="270" alt="Bildschirmfoto vom 2025-09-02 11-10-35" src="https://github.com/user-attachments/assets/eda51da7-c33b-4567-a332-4f04ea9f6821" />


