### PR TITLE
fix: iMip reply from outlook.com does not contain organizer property

### DIFF
--- a/lib/private/Calendar/Manager.php
+++ b/lib/private/Calendar/Manager.php
@@ -261,8 +261,13 @@ class Manager implements IManager {
 		}
 
 		if (!isset($vEvent->ORGANIZER)) {
-			$this->logger->warning('iMip message event dose not contains an organizer');
-			return false;
+			// quirks mode: for Microsoft Exchange Servers use recipient as organizer if no organizer is set
+			if (isset($options['recipient']) && $options['recipient'] !== '') {
+				$vEvent->add('ORGANIZER', 'mailto:' . $options['recipient']);
+			} else {
+				$this->logger->warning('iMip message event does not contain an organizer and no recipient was provided');
+				return false;
+			}
 		}
 
 		if (!isset($vEvent->ATTENDEE)) {
@@ -335,7 +340,8 @@ class Manager implements IManager {
 			return false;
 		}
 		$userId = substr($principalUri, 17);
-		return $this->handleIMip($userId, $calendarData);
+		$options = ['recipient' => $recipient];
+		return $this->handleIMip($userId, $calendarData, $options);
 	}
 
 	/**
@@ -354,7 +360,8 @@ class Manager implements IManager {
 			return false;
 		}
 		$userId = substr($principalUri, 17);
-		return $this->handleIMip($userId, $calendarData);
+		$options = ['recipient' => $recipient];
+		return $this->handleIMip($userId, $calendarData, $options);
 	}
 
 	/**
@@ -374,7 +381,8 @@ class Manager implements IManager {
 			return false;
 		}
 		$userId = substr($principalUri, 17);
-		return $this->handleIMip($userId, $calendarData);
+		$options = ['recipient' => $recipient];
+		return $this->handleIMip($userId, $calendarData, $options);
 	}
 
 	public function createEventBuilder(): ICalendarEventBuilder {

--- a/lib/public/Calendar/IManager.php
+++ b/lib/public/Calendar/IManager.php
@@ -143,7 +143,7 @@ interface IManager {
 	/**
 	 * Handles a iMip message
 	 *
-	 * @param array{absent?: "create"} $options
+	 * @param array{absent?: "create", recipient?: string} $options
 	 *
 	 * @throws \OCP\DB\Exception
 	 *

--- a/tests/lib/Calendar/ManagerTest.php
+++ b/tests/lib/Calendar/ManagerTest.php
@@ -387,6 +387,82 @@ class ManagerTest extends TestCase {
 		$this->assertFalse($result);
 	}
 
+	public function testHandleImipMissingOrganizerWithRecipient(): void {
+		// construct mock user calendar
+		$userCalendar = $this->createMock(ITestCalendar::class);
+		$userCalendar->expects(self::once())
+			->method('isDeleted')
+			->willReturn(false);
+		$userCalendar->expects(self::once())
+			->method('isWritable')
+			->willReturn(true);
+		$userCalendar->expects(self::once())
+			->method('search')
+			->willReturn([['uri' => 'principals/user/attendee1/personal']]);
+		// construct mock calendar manager and returns
+		/** @var Manager&MockObject $manager */
+		$manager = $this->getMockBuilder(Manager::class)
+			->setConstructorArgs([
+				$this->coordinator,
+				$this->container,
+				$this->logger,
+				$this->time,
+				$this->secureRandom,
+				$this->userManager,
+				$this->serverFactory,
+				$this->propertyMapper,
+			])
+			->onlyMethods(['getCalendarsForPrincipal'])
+			->getMock();
+		$manager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->willReturn([$userCalendar]);
+		// construct parameters
+		$userId = 'attendee1';
+		$calendar = $this->vCalendar1a;
+		$calendar->add('METHOD', 'REQUEST');
+		$calendar->VEVENT->remove('ORGANIZER');
+		// construct user calendar returns
+		$userCalendar->expects(self::once())
+			->method('handleIMipMessage');
+		// test method
+		$result = $manager->handleIMip($userId, $calendar->serialize(), ['recipient' => 'organizer@testing.com']);
+	}
+
+	public function testHandleImipMissingOrganizerNoRecipient(): void {
+		// construct mock user calendar
+		$userCalendar = $this->createMock(ITestCalendar::class);
+		// construct mock calendar manager and returns
+		/** @var Manager&MockObject $manager */
+		$manager = $this->getMockBuilder(Manager::class)
+			->setConstructorArgs([
+				$this->coordinator,
+				$this->container,
+				$this->logger,
+				$this->time,
+				$this->secureRandom,
+				$this->userManager,
+				$this->serverFactory,
+				$this->propertyMapper,
+			])
+			->onlyMethods(['getCalendarsForPrincipal'])
+			->getMock();
+		$manager->expects(self::once())
+			->method('getCalendarsForPrincipal')
+			->willReturn([$userCalendar]);
+		// construct parameters
+		$userId = 'attendee1';
+		$calendar = $this->vCalendar1a;
+		$calendar->add('METHOD', 'REQUEST');
+		$calendar->VEVENT->remove('ORGANIZER');
+		// Logger expects warning
+		$this->logger->expects($this->once())
+			->method('warning')
+			->with('iMip message event does not contain an organizer and no recipient was provided');
+
+		$result = $manager->handleIMip($userId, $calendar->serialize(), []);
+	}
+
 	public function testHandleImipWithNoUid(): void {
 		// construct mock user calendar
 		$userCalendar = $this->createMock(ITestCalendar::class);


### PR DESCRIPTION
* Resolves: #53949

## Summary
- Fix Microsoft exchange 2010 reply issue

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
