### PR TITLE
fix(Filesystem): use FilenameValidator for `Filesystem::isFileBlacklisted`

### DIFF
--- a/lib/private/Files/Filesystem.php
+++ b/lib/private/Files/Filesystem.php
@@ -30,8 +30,7 @@ class Filesystem {
 
 	private static ?CappedMemoryCache $normalizedPathCache = null;
 
-	/** @var string[]|null */
-	private static ?array $blacklist = null;
+	private static ?FilenameValidator $validator = null;
 
 	/**
 	 * classname which used for hooks handling
@@ -434,16 +433,16 @@ class Filesystem {
 	/**
 	 * @param string $filename
 	 * @return bool
+	 *
+	 * @deprecated 30.0.0 - use \OC\Files\FilenameValidator::isForbidden
 	 */
 	public static function isFileBlacklisted($filename) {
-		$filename = self::normalizePath($filename);
-
-		if (self::$blacklist === null) {
-			self::$blacklist = \OC::$server->getConfig()->getSystemValue('blacklisted_files', ['.htaccess']);
+		if (self::$validator === null) {
+			self::$validator = \OCP\Server::get(FilenameValidator::class);
 		}
 
-		$filename = strtolower(basename($filename));
-		return in_array($filename, self::$blacklist);
+		$filename = self::normalizePath($filename);
+		return self::$validator->isForbidden($filename);
 	}
 
 	/**


### PR DESCRIPTION
* Resolves https://github.com/nextcloud/server/issues/49014

## Summary
This fixes the issue that some methods will not allow uploading files because they still require the deprecated config option to be used. So instead we need to use the validator introduced in v30.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
