### PR TITLE
fix(comments): use showFile route to reference files with a matching …

### DIFF
--- a/apps/comments/lib/Search/CommentsSearchProvider.php
+++ b/apps/comments/lib/Search/CommentsSearchProvider.php
@@ -17,7 +17,6 @@ use OCP\Search\ISearchQuery;
 use OCP\Search\SearchResult;
 use OCP\Search\SearchResultEntry;
 use function array_map;
-use function pathinfo;
 
 class CommentsSearchProvider implements IProvider {
 	public function __construct(
@@ -49,22 +48,25 @@ class CommentsSearchProvider implements IProvider {
 			$this->l10n->t('Comments'),
 			array_map(function (Result $result) {
 				$path = $result->path;
-				$pathInfo = pathinfo($path);
 				$isUser = $this->userManager->userExists($result->authorId);
 				$avatarUrl = $isUser
 					? $this->urlGenerator->linkToRouteAbsolute('core.avatar.getAvatar', ['userId' => $result->authorId, 'size' => 42])
 					: $this->urlGenerator->linkToRouteAbsolute('core.GuestAvatar.getAvatar', ['guestName' => $result->authorId, 'size' => 42]);
-				return new SearchResultEntry(
+				$link = $this->urlGenerator->linkToRoute(
+					'files.View.showFile',
+					['fileid' => $result->fileId]
+				);
+				$searchResultEntry = new SearchResultEntry(
 					$avatarUrl,
 					$result->name,
 					$path,
-					$this->urlGenerator->linkToRouteAbsolute('files.view.index', [
-						'dir' => $pathInfo['dirname'],
-						'scrollto' => $pathInfo['basename'],
-					]),
+					$link,
 					'',
 					true
 				);
+				$searchResultEntry->addAttribute('fileId', (string)$result->fileId);
+				$searchResultEntry->addAttribute('path', $path);
+				return $searchResultEntry;
 			}, $this->legacyProvider->search($query->getTerm()))
 		);
 	}

--- a/apps/comments/lib/Search/LegacyProvider.php
+++ b/apps/comments/lib/Search/LegacyProvider.php
@@ -11,6 +11,7 @@ namespace OCA\Comments\Search;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Files\Folder;
+use OCP\Files\InvalidPathException;
 use OCP\Files\Node;
 use OCP\Files\NotFoundException;
 use OCP\IUser;
@@ -61,9 +62,10 @@ class LegacyProvider extends Provider {
 					$result[] = new Result($query,
 						$comment,
 						$displayName,
-						$file->getPath()
+						$file->getPath(),
+						$file->getId(),
 					);
-				} catch (NotFoundException $e) {
+				} catch (NotFoundException|InvalidPathException $e) {
 					continue;
 				}
 			}

--- a/apps/comments/lib/Search/Result.php
+++ b/apps/comments/lib/Search/Result.php
@@ -34,6 +34,10 @@ class Result extends BaseResult {
 	 * @deprecated 20.0.0
 	 */
 	public $fileName;
+	/**
+	 * @deprecated 20.0.0
+	 */
+	public int $fileId;
 
 	/**
 	 * @throws NotFoundException
@@ -47,6 +51,7 @@ class Result extends BaseResult {
 		 */
 		public string $authorName,
 		string $path,
+		int $fileId,
 	) {
 		parent::__construct(
 			$comment->getId(),
@@ -58,6 +63,7 @@ class Result extends BaseResult {
 		$this->authorId = $comment->getActorId();
 		$this->fileName = basename($path);
 		$this->path = $this->getVisiblePath($path);
+		$this->fileId = $fileId;
 	}
 
 	/**

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -71,6 +71,8 @@
       <code><![CDATA[$result->authorId]]></code>
       <code><![CDATA[$result->authorId]]></code>
       <code><![CDATA[$result->authorId]]></code>
+      <code><![CDATA[$result->fileId]]></code>
+      <code><![CDATA[$result->fileId]]></code>
       <code><![CDATA[$result->name]]></code>
       <code><![CDATA[$result->path]]></code>
     </DeprecatedProperty>
@@ -81,7 +83,8 @@
       <code><![CDATA[new Result($query,
 						$comment,
 						$displayName,
-						$file->getPath()
+						$file->getPath(),
+						$file->getId(),
 					)]]></code>
     </DeprecatedClass>
     <DeprecatedMethod>
@@ -108,6 +111,7 @@
     <DeprecatedProperty>
       <code><![CDATA[$this->authorId]]></code>
       <code><![CDATA[$this->comment]]></code>
+      <code><![CDATA[$this->fileId]]></code>
       <code><![CDATA[$this->fileName]]></code>
       <code><![CDATA[$this->path]]></code>
     </DeprecatedProperty>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54378

## Summary

use showFile route to reference files with a matching comment

The files.view.index route with dir and scrollto is deprecated, and opening the actual does not work anymore.

I had in mind to replace the deprecated APIs right away, but I dislike making such a large number of changes. I also came across some oddities in how pagination is implemented. Because of that, this PR is a simplified version of https://github.com/nextcloud/server/pull/54379 and should be much easier to backport.

Steps to reproduce: https://github.com/nextcloud/server/issues/54378



## TODO

- [ ] CI
- [ ] Review

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
