### PR TITLE
fix(theming): Remove header-icon-mask in dark-mode high-contrast as well

### DIFF
--- a/apps/theming/lib/Themes/DarkHighContrastTheme.php
+++ b/apps/theming/lib/Themes/DarkHighContrastTheme.php
@@ -107,6 +107,9 @@ class DarkHighContrastTheme extends DarkTheme implements ITheme {
 
 				'--color-box-shadow-rgb' => $colorMainText,
 				'--color-box-shadow' => $colorMainText,
+
+				// remove the gradient from the app icons
+				'--header-menu-icon-mask' => 'none',
 			]
 		);
 	}


### PR DESCRIPTION
Before | After
---|---
<img width="693" height="148" alt="Bildschirmfoto vom 2025-09-03 12-56-07" src="https://github.com/user-attachments/assets/a56a5136-0a35-4cc7-93c3-34be225c410e" /> | <img width="693" height="148" alt="Bildschirmfoto vom 2025-09-03 13-00-23" src="https://github.com/user-attachments/assets/86148799-ac16-4fac-ae96-1e007cea2d09" />


## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
