### PR TITLE
feat(migration-attributes): add DataCleansing

### DIFF
--- a/apps/cloud_federation_api/lib/Migration/Version1016Date202502262004.php
+++ b/apps/cloud_federation_api/lib/Migration/Version1016Date202502262004.php
@@ -12,9 +12,11 @@ namespace OCA\CloudFederationAPI\Migration;
 use Closure;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
+use OCP\Migration\Attributes\CreateTable;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
+#[CreateTable(table: 'federated_invites', columns: ['id', 'user_id', 'recipient_provider', 'recipient_user_id', 'recipient_name', 'recipient_email', 'token', 'accepted', 'created_at', 'expired_at', 'accepted_at'], description: 'Supporting the OCM Invitation Flow feature')]
 class Version1016Date202502262004 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output

--- a/apps/dav/lib/Migration/Version1034Date20250605132605.php
+++ b/apps/dav/lib/Migration/Version1034Date20250605132605.php
@@ -12,9 +12,14 @@ namespace OCA\DAV\Migration;
 use Closure;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\Types;
+use OCP\Migration\Attributes\AddColumn;
+use OCP\Migration\Attributes\ColumnType;
+use OCP\Migration\Attributes\CreateTable;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 
+#[AddColumn(table: 'dav_shares', name: 'token', type: ColumnType::STRING)]
+#[CreateTable(table: 'calendars_federated', columns: ['id', 'display_name', 'color', 'uri', 'principaluri', 'remote_Url', 'token', 'sync_token', 'last_sync', 'shared_by', 'shared_by_display_name', 'components', 'permissions'], description: 'Supporting Federated Calender')]
 class Version1034Date20250605132605 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output

--- a/apps/dav/lib/Migration/Version1034Date20250813093701.php
+++ b/apps/dav/lib/Migration/Version1034Date20250813093701.php
@@ -13,10 +13,12 @@ use Closure;
 use OCP\DB\ISchemaWrapper;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
+use OCP\Migration\Attributes\DataCleansing;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use Override;
 
+#[DataCleansing(table: 'properties', description: 'remove commonly used custom properties set as default')]
 class Version1034Date20250813093701 extends SimpleMigrationStep {
 	public function __construct(
 		private IDBConnection $db,

--- a/build/psalm/OcpSinceChecker.php
+++ b/build/psalm/OcpSinceChecker.php
@@ -26,6 +26,7 @@ class OcpSinceChecker implements Psalm\Plugin\EventHandler\AfterClassLikeVisitIn
 
 		$isTesting = str_contains($statementsSource->getFilePath(), '/lib/public/Notification/')
 			|| str_contains($statementsSource->getFilePath(), '/lib/public/Config/')
+			|| str_contains($statementsSource->getFilePath(), '/lib/public/Migration/Attributes/')
 			|| str_contains($statementsSource->getFilePath(), 'CalendarEventStatus');
 
 		if ($isTesting) {

--- a/core/Migrations/Version32000Date20250620081925.php
+++ b/core/Migrations/Version32000Date20250620081925.php
@@ -9,8 +9,11 @@ declare(strict_types=1);
 
 namespace OC\Core\Migrations;
 
+use OCP\Migration\Attributes\DataCleansing;
+
 /**
  * Run the old migration Version24000Date20211210141942 again.
  */
+#[DataCleansing(table: 'preferences', description: 'lowercase accounts email address')]
 class Version32000Date20250620081925 extends Version24000Date20211210141942 {
 }

--- a/core/Migrations/Version32000Date20250731062008.php
+++ b/core/Migrations/Version32000Date20250731062008.php
@@ -12,6 +12,7 @@ namespace OC\Core\Migrations;
 use Closure;
 use OCP\DB\ISchemaWrapper;
 use OCP\IDBConnection;
+use OCP\Migration\Attributes\DataCleansing;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
 use Override;
@@ -21,6 +22,8 @@ use Override;
  * This migration will clean up existing duplicates.
  * The new unique constraint is added in @see \OC\Core\Listener\AddMissingIndicesListener
  */
+#[DataCleansing(table: 'vcategory', description: 'Cleanup of duplicate vcategory records')]
+#[DataCleansing(table: 'vcategory_to_object', description: 'Update object references')]
 class Version32000Date20250731062008 extends SimpleMigrationStep {
 	public function __construct(
 		private IDBConnection $connection,

--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -678,6 +678,8 @@ return array(
     'OCP\\Migration\\Attributes\\ColumnMigrationAttribute' => $baseDir . '/lib/public/Migration/Attributes/ColumnMigrationAttribute.php',
     'OCP\\Migration\\Attributes\\ColumnType' => $baseDir . '/lib/public/Migration/Attributes/ColumnType.php',
     'OCP\\Migration\\Attributes\\CreateTable' => $baseDir . '/lib/public/Migration/Attributes/CreateTable.php',
+    'OCP\\Migration\\Attributes\\DataCleansing' => $baseDir . '/lib/public/Migration/Attributes/DataCleansing.php',
+    'OCP\\Migration\\Attributes\\DataMigrationAttribute' => $baseDir . '/lib/public/Migration/Attributes/DataMigrationAttribute.php',
     'OCP\\Migration\\Attributes\\DropColumn' => $baseDir . '/lib/public/Migration/Attributes/DropColumn.php',
     'OCP\\Migration\\Attributes\\DropIndex' => $baseDir . '/lib/public/Migration/Attributes/DropIndex.php',
     'OCP\\Migration\\Attributes\\DropTable' => $baseDir . '/lib/public/Migration/Attributes/DropTable.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -719,6 +719,8 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OCP\\Migration\\Attributes\\ColumnMigrationAttribute' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/ColumnMigrationAttribute.php',
         'OCP\\Migration\\Attributes\\ColumnType' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/ColumnType.php',
         'OCP\\Migration\\Attributes\\CreateTable' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/CreateTable.php',
+        'OCP\\Migration\\Attributes\\DataCleansing' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/DataCleansing.php',
+        'OCP\\Migration\\Attributes\\DataMigrationAttribute' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/DataMigrationAttribute.php',
         'OCP\\Migration\\Attributes\\DropColumn' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/DropColumn.php',
         'OCP\\Migration\\Attributes\\DropIndex' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/DropIndex.php',
         'OCP\\Migration\\Attributes\\DropTable' => __DIR__ . '/../../..' . '/lib/public/Migration/Attributes/DropTable.php',

--- a/lib/public/Migration/Attributes/AddColumn.php
+++ b/lib/public/Migration/Attributes/AddColumn.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on new column creation
- *
- * @since 30.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '30.0.0')]
 class AddColumn extends ColumnMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/AddIndex.php
+++ b/lib/public/Migration/Attributes/AddIndex.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on index creation
- *
- * @since 30.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '30.0.0')]
 class AddIndex extends IndexMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/ColumnMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/ColumnMigrationAttribute.php
@@ -8,11 +8,12 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * generic class related to migration attribute about column changes
- *
- * @since 30.0.0
  */
+#[Consumable(since: '30.0.0')]
 class ColumnMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param string $table name of the database table

--- a/lib/public/Migration/Attributes/ColumnMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/ColumnMigrationAttribute.php
@@ -8,14 +8,12 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
-use JsonSerializable;
-
 /**
  * generic class related to migration attribute about column changes
  *
  * @since 30.0.0
  */
-class ColumnMigrationAttribute extends MigrationAttribute implements JsonSerializable {
+class ColumnMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param string $table name of the database table
 	 * @param string $name name of the column

--- a/lib/public/Migration/Attributes/ColumnType.php
+++ b/lib/public/Migration/Attributes/ColumnType.php
@@ -8,12 +8,14 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * enum ColumnType based on OCP\DB\Types
  *
  * @see \OCP\DB\Types
- * @since 30.0.0
  */
+#[Consumable(since: '30.0.0')]
 enum ColumnType : string {
 	/** @since 30.0.0 */
 	case BIGINT = 'bigint';

--- a/lib/public/Migration/Attributes/CreateTable.php
+++ b/lib/public/Migration/Attributes/CreateTable.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on table creation
- *
- * @since 30.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '30.0.0')]
 class CreateTable extends TableMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/DataCleansing.php
+++ b/lib/public/Migration/Attributes/DataCleansing.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Migration\Attributes;
+
+use Attribute;
+
+/**
+ * attribute on new column creation
+ *
+ * @since 32.0.0
+ */
+#[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+class DataCleansing extends DataMigrationAttribute {
+	/**
+	 * @return string
+	 * @since 32.0.0
+	 */
+	public function definition(): string {
+		return 'Cleansing data from table \'' . $this->getTable() . '\'';
+	}
+}

--- a/lib/public/Migration/Attributes/DataCleansing.php
+++ b/lib/public/Migration/Attributes/DataCleansing.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on new column creation
- *
- * @since 32.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '32.0.0')]
 class DataCleansing extends DataMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/DataMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/DataMigrationAttribute.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+namespace OCP\Migration\Attributes;
+
+/**
+ * generic class related to migration attribute about data migration
+ *
+ * @since 32.0.0
+ */
+class DataMigrationAttribute extends MigrationAttribute {
+}

--- a/lib/public/Migration/Attributes/DataMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/DataMigrationAttribute.php
@@ -8,10 +8,11 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * generic class related to migration attribute about data migration
- *
- * @since 32.0.0
  */
+#[Consumable(since: '32.0.0')]
 class DataMigrationAttribute extends MigrationAttribute {
 }

--- a/lib/public/Migration/Attributes/DropColumn.php
+++ b/lib/public/Migration/Attributes/DropColumn.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on column drop
- *
- * @since 30.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '30.0.0')]
 class DropColumn extends ColumnMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/DropIndex.php
+++ b/lib/public/Migration/Attributes/DropIndex.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on index drop
- *
- * @since 30.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '30.0.0')]
 class DropIndex extends IndexMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/DropTable.php
+++ b/lib/public/Migration/Attributes/DropTable.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on table drop
- *
- * @since 30.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '30.0.0')]
 class DropTable extends TableMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/GenericMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/GenericMigrationAttribute.php
@@ -8,15 +8,13 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
-use JsonSerializable;
-
 /**
  * generic entry, used to replace migration attribute not yet known in current version
  * but used in a future release
  *
  * @since 30.0.0
  */
-class GenericMigrationAttribute extends MigrationAttribute implements JsonSerializable {
+class GenericMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param array $details
 	 * @since 30.0.0

--- a/lib/public/Migration/Attributes/GenericMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/GenericMigrationAttribute.php
@@ -8,12 +8,13 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * generic entry, used to replace migration attribute not yet known in current version
  * but used in a future release
- *
- * @since 30.0.0
  */
+#[Consumable(since: '30.0.0')]
 class GenericMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param array $details

--- a/lib/public/Migration/Attributes/IndexMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/IndexMigrationAttribute.php
@@ -8,11 +8,12 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * generic class related to migration attribute about index changes
- *
- * @since 30.0.0
  */
+#[Consumable(since: '30.0.0')]
 class IndexMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param string $table name of the database table

--- a/lib/public/Migration/Attributes/IndexMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/IndexMigrationAttribute.php
@@ -8,14 +8,12 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
-use JsonSerializable;
-
 /**
  * generic class related to migration attribute about index changes
  *
  * @since 30.0.0
  */
-class IndexMigrationAttribute extends MigrationAttribute implements JsonSerializable {
+class IndexMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param string $table name of the database table
 	 * @param IndexType|null $type type of the index

--- a/lib/public/Migration/Attributes/IndexType.php
+++ b/lib/public/Migration/Attributes/IndexType.php
@@ -8,11 +8,12 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * type of index
- *
- * @since 30.0.0
  */
+#[Consumable(since: '30.0.0')]
 enum IndexType : string {
 	/** @since 30.0.0 */
 	case PRIMARY = 'primary';

--- a/lib/public/Migration/Attributes/MigrationAttribute.php
+++ b/lib/public/Migration/Attributes/MigrationAttribute.php
@@ -9,10 +9,9 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use JsonSerializable;
+use OCP\AppFramework\Attribute\Consumable;
 
-/**
- * @since 30.0.0
- */
+#[Consumable(since: '30.0.0')]
 class MigrationAttribute implements JsonSerializable {
 	/**
 	 * @param string $table name of the database table

--- a/lib/public/Migration/Attributes/ModifyColumn.php
+++ b/lib/public/Migration/Attributes/ModifyColumn.php
@@ -9,13 +9,13 @@ declare(strict_types=1);
 namespace OCP\Migration\Attributes;
 
 use Attribute;
+use OCP\AppFramework\Attribute\Consumable;
 
 /**
  * attribute on column modification
- *
- * @since 30.0.0
  */
 #[Attribute(Attribute::IS_REPEATABLE | Attribute::TARGET_CLASS)]
+#[Consumable(since: '30.0.0')]
 class ModifyColumn extends ColumnMigrationAttribute {
 	/**
 	 * @return string

--- a/lib/public/Migration/Attributes/TableMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/TableMigrationAttribute.php
@@ -8,11 +8,12 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
+use OCP\AppFramework\Attribute\Consumable;
+
 /**
  * generic class related to migration attribute about table changes
- *
- * @since 30.0.0
  */
+#[Consumable(since: '30.0.0')]
 class TableMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param string $table name of the database table

--- a/lib/public/Migration/Attributes/TableMigrationAttribute.php
+++ b/lib/public/Migration/Attributes/TableMigrationAttribute.php
@@ -8,14 +8,12 @@ declare(strict_types=1);
  */
 namespace OCP\Migration\Attributes;
 
-use JsonSerializable;
-
 /**
  * generic class related to migration attribute about table changes
  *
  * @since 30.0.0
  */
-class TableMigrationAttribute extends MigrationAttribute implements JsonSerializable {
+class TableMigrationAttribute extends MigrationAttribute {
 	/**
 	 * @param string $table name of the database table
 	 * @param array $columns list of columns


### PR DESCRIPTION
- removing redondants `implements JsonSerialize`
- new migration attribute `DataCleansing`

---
- generated metadata:
<img width="676" height="426" alt="image" src="https://github.com/user-attachments/assets/a2950090-c0bd-48d0-955a-d00c464b017e" />

- resulted on nc31, as `DataCleansing` is not there:
<img width="1596" height="198" alt="image" src="https://github.com/user-attachments/assets/f413d4eb-b0cd-45a9-8f3d-8aec3d42a01e" />
