### PR TITLE
Add task processing manager method to get the list of available task type IDs

### DIFF
--- a/lib/public/TaskProcessing/IManager.php
+++ b/lib/public/TaskProcessing/IManager.php
@@ -47,7 +47,7 @@ interface IManager {
 	public function getPreferredProvider(string $taskTypeId);
 
 	/**
-	 * @param bool $showDisabled if false, disabled task types will be filtered
+	 * @param bool $showDisabled if false, disabled task types will be filtered out
 	 * @param ?string $userId to check if the user is a guest. Will be obtained from session if left to default
 	 * @return array<string, array{name: string, description: string, inputShape: ShapeDescriptor[], inputShapeEnumValues: ShapeEnumValue[][], inputShapeDefaults: array<array-key, numeric|string>, optionalInputShape: ShapeDescriptor[], optionalInputShapeEnumValues: ShapeEnumValue[][], optionalInputShapeDefaults: array<array-key, numeric|string>, outputShape: ShapeDescriptor[], outputShapeEnumValues: ShapeEnumValue[][], optionalOutputShape: ShapeDescriptor[], optionalOutputShapeEnumValues: ShapeEnumValue[][]}>
 	 * @since 30.0.0
@@ -55,6 +55,14 @@ interface IManager {
 	 * @since 31.0.7 Added the `userId` argument
 	 */
 	public function getAvailableTaskTypes(bool $showDisabled = false, ?string $userId = null): array;
+
+	/**
+	 * @param bool $showDisabled if false, disabled task types will be filtered out
+	 * @param ?string $userId to check if the user is a guest. Will be obtained from session if left to default
+	 * @return list<string>
+	 * @since 32.0.0
+	 */
+	public function getAvailableTaskTypeIds(bool $showDisabled = false, ?string $userId = null): array;
 
 	/**
 	 * @param Task $task The task to run

--- a/tests/lib/TaskProcessing/TaskProcessingTest.php
+++ b/tests/lib/TaskProcessing/TaskProcessingTest.php
@@ -632,6 +632,7 @@ class TaskProcessingTest extends \Test\TestCase {
 	public function testShouldNotHaveAnyProviders(): void {
 		$this->registrationContext->expects($this->any())->method('getTaskProcessingProviders')->willReturn([]);
 		self::assertCount(0, $this->manager->getAvailableTaskTypes());
+		self::assertCount(0, $this->manager->getAvailableTaskTypeIds());
 		self::assertFalse($this->manager->hasProviders());
 		self::expectException(PreConditionNotMetException::class);
 		$this->manager->scheduleTask(new Task(TextToText::ID, ['input' => 'Hello'], 'test', null));
@@ -647,6 +648,8 @@ class TaskProcessingTest extends \Test\TestCase {
 		$this->appConfig->setValueString('core', 'ai.taskprocessing_type_preferences', json_encode($taskProcessingTypeSettings), lazy: true);
 		self::assertCount(0, $this->manager->getAvailableTaskTypes());
 		self::assertCount(1, $this->manager->getAvailableTaskTypes(true));
+		self::assertCount(0, $this->manager->getAvailableTaskTypeIds());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds(true));
 		self::assertTrue($this->manager->hasProviders());
 		self::expectException(PreConditionNotMetException::class);
 		$this->manager->scheduleTask(new Task(TextToText::ID, ['input' => 'Hello'], 'test', null));
@@ -659,6 +662,7 @@ class TaskProcessingTest extends \Test\TestCase {
 			new ServiceRegistration('test', BrokenSyncProvider::class)
 		]);
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToText::ID, ['wrongInputKey' => 'Hello'], 'test', null);
 		self::assertNull($task->getId());
@@ -680,6 +684,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		$this->userMountCache->expects($this->any())->method('getMountsForFileId')->willReturn([$mount]);
 
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue($this->manager->hasProviders());
 
 		$audioId = $this->getFile('audioInput', 'Hello')->getId();
@@ -695,6 +700,7 @@ class TaskProcessingTest extends \Test\TestCase {
 			new ServiceRegistration('test', FailingSyncProvider::class)
 		]);
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToText::ID, ['input' => 'Hello'], 'test', null);
 		self::assertNull($task->getId());
@@ -723,6 +729,7 @@ class TaskProcessingTest extends \Test\TestCase {
 			new ServiceRegistration('test', BrokenSyncProvider::class)
 		]);
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToText::ID, ['input' => 'Hello'], 'test', null);
 		self::assertNull($task->getId());
@@ -751,6 +758,7 @@ class TaskProcessingTest extends \Test\TestCase {
 			new ServiceRegistration('test', SuccessfulSyncProvider::class)
 		]);
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		$taskTypeStruct = $this->manager->getAvailableTaskTypes()[array_keys($this->manager->getAvailableTaskTypes())[0]];
 		self::assertTrue(isset($taskTypeStruct['inputShape']['input']));
 		self::assertEquals(EShapeType::Text, $taskTypeStruct['inputShape']['input']->getShapeType());
@@ -803,6 +811,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		$this->appConfig->setValueString('core', 'ai.taskprocessing_type_preferences', json_encode($taskProcessingTypeSettings), lazy: true);
 
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToText::ID, ['input' => 'Hello'], 'test', null);
@@ -843,6 +852,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		$this->userMountCache->expects($this->any())->method('getMountsForFileId')->willReturn([$mount]);
 
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 
 		self::assertTrue($this->manager->hasProviders());
 		$audioId = $this->getFile('audioInput', 'Hello')->getId();
@@ -893,6 +903,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		$mount->expects($this->any())->method('getUser')->willReturn($user);
 		$this->userMountCache->expects($this->any())->method('getMountsForFileId')->willReturn([$mount]);
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 
 		self::assertTrue($this->manager->hasProviders());
 		$audioId = $this->getFile('audioInput', 'Hello')->getId();
@@ -952,6 +963,7 @@ class TaskProcessingTest extends \Test\TestCase {
 			new ServiceRegistration('test', SuccessfulSyncProvider::class)
 		]);
 		self::assertCount(1, $this->manager->getAvailableTaskTypes());
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToText::ID, ['input' => 'Hello'], 'test', null);
 		$this->manager->scheduleTask($task);
@@ -992,6 +1004,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		]);
 		$taskTypes = $this->manager->getAvailableTaskTypes();
 		self::assertCount(1, $taskTypes);
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue(isset($taskTypes[TextToTextSummary::ID]));
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToTextSummary::ID, ['input' => 'Hello'], 'test', null);
@@ -1023,6 +1036,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		]);
 		$taskTypes = $this->manager->getAvailableTaskTypes();
 		self::assertCount(1, $taskTypes);
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue(isset($taskTypes[TextToTextSummary::ID]));
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToTextSummary::ID, ['input' => 'Hello'], 'test', null);
@@ -1053,6 +1067,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		]);
 		$taskTypes = $this->manager->getAvailableTaskTypes();
 		self::assertCount(1, $taskTypes);
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue(isset($taskTypes[TextToImage::ID]));
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToImage::ID, ['input' => 'Hello', 'numberOfImages' => 3], 'test', null);
@@ -1089,6 +1104,7 @@ class TaskProcessingTest extends \Test\TestCase {
 		]);
 		$taskTypes = $this->manager->getAvailableTaskTypes();
 		self::assertCount(1, $taskTypes);
+		self::assertCount(1, $this->manager->getAvailableTaskTypeIds());
 		self::assertTrue(isset($taskTypes[TextToImage::ID]));
 		self::assertTrue($this->manager->hasProviders());
 		$task = new Task(TextToImage::ID, ['input' => 'Hello', 'numberOfImages' => 3], 'test', null);
@@ -1178,6 +1194,7 @@ class TaskProcessingTest extends \Test\TestCase {
 
 		// Assert
 		self::assertArrayHasKey(ExternalTaskType::ID, $availableTypes);
+		self::assertContains(ExternalTaskType::ID, $this->manager->getAvailableTaskTypeIds());
 		self::assertEquals(ExternalTaskType::ID, $externalProvider->getTaskTypeId(), 'Test Sanity: Provider must handle the Task Type');
 		self::assertEquals('External Task Type via Event', $availableTypes[ExternalTaskType::ID]['name']);
 		// Check if shapes match the external type/provider
@@ -1230,11 +1247,14 @@ class TaskProcessingTest extends \Test\TestCase {
 
 		// Act
 		$availableTypes = $this->manager->getAvailableTaskTypes();
+		$availableTypeIds = $this->manager->getAvailableTaskTypeIds();
 
 		// Assert: Both task types should be available
+		self::assertContains(AudioToImage::ID, $availableTypeIds);
 		self::assertArrayHasKey(AudioToImage::ID, $availableTypes);
 		self::assertEquals(AudioToImage::class, $availableTypes[AudioToImage::ID]['name']);
 
+		self::assertContains(ExternalTaskType::ID, $availableTypeIds);
 		self::assertArrayHasKey(ExternalTaskType::ID, $availableTypes);
 		self::assertEquals('External Task Type via Event', $availableTypes[ExternalTaskType::ID]['name']);
 


### PR DESCRIPTION
Some consumers of this API get the list of available task types with `manager->getAvailableTaskTypes` which gives a full description of the task types, including the list of values for the enum input parameters. These values can be slow to compute, slowing down the process when they might not be needed.

This new method just get the list of available task type IDs.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) will be updated once the PR is merged https://github.com/nextcloud/documentation/pull/13596
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
