### PR TITLE
feat(occ): Add profiler link after occ output

### DIFF
--- a/console.php
+++ b/console.php
@@ -81,7 +81,8 @@ try {
 	/* base.php will have removed eventual debug options from argv in $_SERVER */
 	$argv = $_SERVER['argv'];
 	$input = new ArgvInput($argv);
-	$application->loadCommands($input, new ConsoleOutput());
+	$output = new ConsoleOutput();
+	$application->loadCommands($input, $output);
 
 	$eventLogger->end('console:build_application');
 	$eventLogger->start('console:run', 'Run the command');
@@ -98,6 +99,13 @@ try {
 		$profile->setMethod('occ');
 		$profile->setUrl(implode(' ', $argv));
 		$profiler->saveProfile($profile);
+
+		$urlGenerator = Server::get(\OCP\IURLGenerator::class);
+		$url = $urlGenerator->linkToRouteAbsolute('profiler.main.profiler', [
+			'profiler' => 'db',
+			'token' => $profile->getToken(),
+		]);
+		$output->writeln('Profiler output available at ' . $url);
 	}
 
 	if ($exitCode > 255) {


### PR DESCRIPTION
## Summary

Enable easy access to the profile when the profiler app is enabled.

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
