### PR TITLE
refactor: Commands and background jobs for the trashbin

### DIFF
--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -7,29 +7,36 @@
  */
 namespace OCA\Files_Trashbin\Command;
 
+use OC\Core\Command\Base;
+use OC\Files\SetupManager;
+use OC\User\LazyUser;
 use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\Files\NotPermittedException;
 use OCP\IDBConnection;
+use OCP\IUser;
 use OCP\IUserBackend;
 use OCP\IUserManager;
 use OCP\Util;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CleanUp extends Command {
+class CleanUp extends Base {
 
 	public function __construct(
 		protected IRootFolder $rootFolder,
 		protected IUserManager $userManager,
 		protected IDBConnection $dbConnection,
+		protected SetupManager $setupManager,
 	) {
 		parent::__construct();
 	}
 
-	protected function configure() {
+	protected function configure(): void {
+		parent::configure();
 		$this
 			->setName('trashbin:cleanup')
 			->setDescription('Remove deleted files')
@@ -47,17 +54,18 @@ class CleanUp extends Command {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
-		$users = $input->getArgument('user_id');
+		$userIds = $input->getArgument('user_id');
 		$verbose = $input->getOption('verbose');
-		if (!empty($users) && $input->getOption('all-users')) {
+		if (!empty($userIds) && $input->getOption('all-users')) {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
-		} elseif (!empty($users)) {
-			foreach ($users as $user) {
-				if ($this->userManager->userExists($user)) {
-					$output->writeln("Remove deleted files of   <info>$user</info>");
+		} elseif (!empty($userIds)) {
+			foreach ($userIds as $userId) {
+				$user = $this->userManager->get($userId);
+				if ($user) {
+					$output->writeln("Remove deleted files of   <info>$userId</info>");
 					$this->removeDeletedFiles($user, $output, $verbose);
 				} else {
-					$output->writeln("<error>Unknown user $user</error>");
+					$output->writeln("<error>Unknown user $userId</error>");
 					return 1;
 				}
 			}
@@ -72,13 +80,14 @@ class CleanUp extends Command {
 				$limit = 500;
 				$offset = 0;
 				do {
-					$users = $backend->getUsers('', $limit, $offset);
-					foreach ($users as $user) {
-						$output->writeln("   <info>$user</info>");
+					$userIds = $backend->getUsers('', $limit, $offset);
+					foreach ($userIds as $userId) {
+						$output->writeln("   <info>$userId</info>");
+						$user = new LazyUser($userId, $this->userManager, null, $backend);
 						$this->removeDeletedFiles($user, $output, $verbose);
 					}
 					$offset += $limit;
-				} while (count($users) >= $limit);
+				} while (count($userIds) >= $limit);
 			}
 		} else {
 			throw new InvalidOptionException('Either specify a user_id or --all-users');
@@ -87,32 +96,33 @@ class CleanUp extends Command {
 	}
 
 	/**
-	 * remove deleted files for the given user
+	 * Remove deleted files for the given user.
 	 */
-	protected function removeDeletedFiles(string $uid, OutputInterface $output, bool $verbose): void {
-		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($uid);
-		$path = '/' . $uid . '/files_trashbin';
-		if ($this->rootFolder->nodeExists($path)) {
+	protected function removeDeletedFiles(IUser $user, OutputInterface $output, bool $verbose): void {
+		$this->setupManager->tearDown();
+		$this->setupManager->setupForUser($user);
+		$path = '/' . $user->getUID() . '/files_trashbin';
+		try {
 			$node = $this->rootFolder->get($path);
-
+		} catch (NotFoundException|NotPermittedException) {
 			if ($verbose) {
-				$output->writeln('Deleting <info>' . Util::humanFileSize($node->getSize()) . "</info> in trash for <info>$uid</info>.");
+				$output->writeln("No trash found for <info>{$user->getUID()}</info>");
 			}
-			$node->delete();
-			if ($this->rootFolder->nodeExists($path)) {
-				$output->writeln('<error>Trash folder sill exists after attempting to delete it</error>');
-				return;
-			}
-			$query = $this->dbConnection->getQueryBuilder();
-			$query->delete('files_trash')
-				->where($query->expr()->eq('user', $query->createParameter('uid')))
-				->setParameter('uid', $uid);
-			$query->executeStatement();
-		} else {
-			if ($verbose) {
-				$output->writeln("No trash found for <info>$uid</info>");
-			}
+			return;
 		}
+
+		if ($verbose) {
+			$output->writeln('Deleting <info>' . Util::humanFileSize($node->getSize()) . "</info> in trash for <info>{$user->getUID()}</info>.");
+		}
+		$node->delete();
+		if ($this->rootFolder->nodeExists($path)) {
+			$output->writeln('<error>Trash folder sill exists after attempting to delete it</error>');
+			return;
+		}
+		$query = $this->dbConnection->getQueryBuilder();
+		$query->delete('files_trash')
+			->where($query->expr()->eq('user', $query->createParameter('uid')))
+			->setParameter('uid', $user->getUID());
+		$query->executeStatement();
 	}
 }

--- a/apps/files_trashbin/lib/Command/Expire.php
+++ b/apps/files_trashbin/lib/Command/Expire.php
@@ -8,32 +8,48 @@
 namespace OCA\Files_Trashbin\Command;
 
 use OC\Command\FileAccess;
+use OC\Files\SetupManager;
 use OCA\Files_Trashbin\Trashbin;
 use OCP\Command\ICommand;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
 use OCP\IUserManager;
 use OCP\Server;
+use Override;
+use Psr\Log\LoggerInterface;
 
 class Expire implements ICommand {
 	use FileAccess;
 
-	/**
-	 * @param string $user
-	 */
 	public function __construct(
-		private $user,
+		private readonly string $userId,
 	) {
 	}
 
-	public function handle() {
+	#[Override]
+	public function handle(): void {
+		// can't use DI because Expire needs to be serializable
 		$userManager = Server::get(IUserManager::class);
-		if (!$userManager->userExists($this->user)) {
+		$user = $userManager->get($this->userId);
+		if (!$user) {
 			// User has been deleted already
 			return;
 		}
 
-		\OC_Util::tearDownFS();
-		\OC_Util::setupFS($this->user);
-		Trashbin::expire($this->user);
-		\OC_Util::tearDownFS();
+		try {
+			$setupManager = Server::get(SetupManager::class);
+			$setupManager->tearDown();
+			$setupManager->setupForUser($user);
+
+			$trashRoot = Server::get(IRootFolder::class)->getUserFolder($user->getUID())->getParent()->get('files_trashbin');
+			if (!$trashRoot instanceof Folder) {
+				throw new \LogicException("Didn't expect files_trashbin to be a file instead of a folder");
+			}
+			Trashbin::expire($trashRoot, $user);
+		} catch (\Exception $e) {
+			Server::get(LoggerInterface::class)->error('Error while expiring trashbin for user ' . $user->getUID(), ['exception' => $e]);
+		} finally {
+			$setupManager->tearDown();
+		}
 	}
 }

--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -44,6 +44,7 @@ use OCP\IConfig;
 use OCP\IDBConnection;
 use OCP\IRequest;
 use OCP\IURLGenerator;
+use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Lock\ILockingProvider;
 use OCP\Lock\LockedException;
@@ -774,24 +775,19 @@ class Trashbin implements IEventListener {
 	}
 
 	/**
-	 * calculate remaining free space for trash bin
+	 * Calculate remaining free space for trash bin
 	 *
 	 * @param int|float $trashbinSize current size of the trash bin
-	 * @param string $user
 	 * @return int|float available free space for trash bin
 	 */
-	private static function calculateFreeSpace(int|float $trashbinSize, string $user): int|float {
-		$configuredTrashbinSize = static::getConfiguredTrashbinSize($user);
+	private static function calculateFreeSpace(Folder $userFolder, int|float $trashbinSize, IUser $user): int|float {
+		$configuredTrashbinSize = static::getConfiguredTrashbinSize($user->getUID());
 		if ($configuredTrashbinSize > -1) {
 			return $configuredTrashbinSize - $trashbinSize;
 		}
 
-		$userObject = Server::get(IUserManager::class)->get($user);
-		if (is_null($userObject)) {
-			return 0;
-		}
 		$softQuota = true;
-		$quota = $userObject->getQuota();
+		$quota = $user->getQuota();
 		if ($quota === null || $quota === 'none') {
 			$quota = Filesystem::free_space('/');
 			$softQuota = false;
@@ -810,10 +806,6 @@ class Trashbin implements IEventListener {
 		// calculate available space for trash bin
 		// subtract size of files and current trash bin size from quota
 		if ($softQuota) {
-			$userFolder = \OC::$server->getUserFolder($user);
-			if (is_null($userFolder)) {
-				return 0;
-			}
 			$free = $quota - $userFolder->getSize(false); // remaining free space for user
 			if ($free > 0) {
 				$availableSpace = ($free * self::DEFAULTMAXSIZE / 100) - $trashbinSize; // how much space can be used for versions
@@ -828,38 +820,34 @@ class Trashbin implements IEventListener {
 	}
 
 	/**
-	 * resize trash bin if necessary after a new file was added to Nextcloud
-	 *
-	 * @param string $user user id
+	 * Resize trash bin if necessary after a new file was added to Nextcloud
 	 */
-	public static function resizeTrash($user) {
-		$size = self::getTrashbinSize($user);
+	public static function resizeTrash(Folder $trashRoot, IUser $user): void {
+		$trashBinSize = $trashRoot->getSize();
 
-		$freeSpace = self::calculateFreeSpace($size, $user);
+		$freeSpace = self::calculateFreeSpace($trashRoot->getParent(), $trashBinSize, $user);
 
 		if ($freeSpace < 0) {
-			self::scheduleExpire($user);
+			self::scheduleExpire($user->getUID());
 		}
 	}
 
 	/**
-	 * clean up the trash bin
-	 *
-	 * @param string $user
+	 * Clean up the trash bin
 	 */
-	public static function expire($user) {
-		$trashBinSize = self::getTrashbinSize($user);
-		$availableSpace = self::calculateFreeSpace($trashBinSize, $user);
+	public static function expire(Folder $trashRoot, IUser $user): void {
+		$trashBinSize = $trashRoot->getSize();
+		$availableSpace = self::calculateFreeSpace($trashRoot->getParent(), $trashBinSize, $user);
 
-		$dirContent = Helper::getTrashFiles('/', $user, 'mtime');
+		$dirContent = Helper::getTrashFiles('/', $user->getUID(), 'mtime');
 
 		// delete all files older then $retention_obligation
-		[$delSize, $count] = self::deleteExpiredFiles($dirContent, $user);
+		[$delSize, $count] = self::deleteExpiredFiles($dirContent, $user->getUID());
 
 		$availableSpace += $delSize;
 
 		// delete files from trash until we meet the trash bin size limit again
-		self::deleteFiles(array_slice($dirContent, $count), $user, $availableSpace);
+		self::deleteFiles(array_slice($dirContent, $count), $user->getUID(), $availableSpace);
 	}
 
 	/**

--- a/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/BackgroundJob/ExpireTrashTest.php
@@ -14,6 +14,7 @@ use OCA\Files_Trashbin\BackgroundJob\ExpireTrash;
 use OCA\Files_Trashbin\Expiration;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
+use OCP\Files\IRootFolder;
 use OCP\Files\ISetupManager;
 use OCP\IAppConfig;
 use OCP\IUserManager;
@@ -31,6 +32,7 @@ class ExpireTrashTest extends TestCase {
 	private ITimeFactory&MockObject $time;
 	private ISetupManager&MockObject $setupManager;
 	private ILockingProvider&MockObject $lockingProvider;
+	private IRootFolder&MockObject $rootFolder;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -42,6 +44,7 @@ class ExpireTrashTest extends TestCase {
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->setupManager = $this->createMock(ISetupManager::class);
 		$this->lockingProvider = $this->createMock(ILockingProvider::class);
+		$this->rootFolder = $this->createMock(IRootFolder::class);
 
 		$this->time = $this->createMock(ITimeFactory::class);
 		$this->time->method('getTime')
@@ -68,6 +71,7 @@ class ExpireTrashTest extends TestCase {
 			$this->logger,
 			$this->setupManager,
 			$this->lockingProvider,
+			$this->rootFolder,
 			$this->time,
 		);
 		$job->start($this->jobList);
@@ -87,6 +91,7 @@ class ExpireTrashTest extends TestCase {
 			$this->logger,
 			$this->setupManager,
 			$this->lockingProvider,
+			$this->rootFolder,
 			$this->time,
 		);
 		$job->start($this->jobList);

--- a/apps/files_trashbin/tests/Command/ExpireTrashTest.php
+++ b/apps/files_trashbin/tests/Command/ExpireTrashTest.php
@@ -6,6 +6,7 @@
  */
 namespace OCA\Files_Trashbin\Tests\Command;
 
+use OC\Files\SetupManager;
 use OCA\Files_Trashbin\Command\ExpireTrash;
 use OCA\Files_Trashbin\Expiration;
 use OCA\Files_Trashbin\Helper;
@@ -16,9 +17,9 @@ use OCP\IConfig;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\Server;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
-use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Test\TestCase;
@@ -37,7 +38,6 @@ class ExpireTrashTest extends TestCase {
 	private IUserManager $userManager;
 	private IUser $user;
 	private ITimeFactory&MockObject $timeFactory;
-
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -66,7 +66,7 @@ class ExpireTrashTest extends TestCase {
 		parent::tearDown();
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider(methodName: 'retentionObligationProvider')]
+	#[DataProvider(methodName: 'retentionObligationProvider')]
 	public function testRetentionObligation(string $obligation, string $quota, int $elapsed, int $fileSize, bool $shouldExpire): void {
 		$this->config->setSystemValues(['trashbin_retention_obligation' => $obligation]);
 		$this->expiration->setRetentionObligation($obligation);
@@ -99,9 +99,10 @@ class ExpireTrashTest extends TestCase {
 			->willReturn([$userId]);
 
 		$command = new ExpireTrash(
-			Server::get(LoggerInterface::class),
 			Server::get(IUserManager::class),
-			$this->expiration
+			$this->expiration,
+			Server::get(SetupManager::class),
+			Server::get(IRootFolder::class),
 		);
 
 		$this->invokePrivate($command, 'execute', [$inputInterface, $outputInterface]);

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -1707,72 +1707,18 @@
       <code><![CDATA[moveMount]]></code>
     </UndefinedMethod>
   </file>
-  <file src="apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php">
-    <InternalClass>
-      <code><![CDATA[new View('/' . $user->getUID())]]></code>
-    </InternalClass>
-    <InternalMethod>
-      <code><![CDATA[is_dir]]></code>
-      <code><![CDATA[new View('/' . $user->getUID())]]></code>
-    </InternalMethod>
-  </file>
-  <file src="apps/files_trashbin/lib/Command/CleanUp.php">
-    <DeprecatedClass>
-      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedClass>
-    <DeprecatedMethod>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedMethod>
-  </file>
   <file src="apps/files_trashbin/lib/Command/Expire.php">
-    <DeprecatedClass>
-      <code><![CDATA[\OC_Util::setupFS($this->user)]]></code>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedClass>
     <DeprecatedInterface>
       <code><![CDATA[Expire]]></code>
     </DeprecatedInterface>
-    <DeprecatedMethod>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedMethod>
-  </file>
-  <file src="apps/files_trashbin/lib/Command/ExpireTrash.php">
-    <DeprecatedClass>
-      <code><![CDATA[\OC_Util::setupFS($user)]]></code>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedClass>
-    <DeprecatedMethod>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedMethod>
-    <InternalClass>
-      <code><![CDATA[new View('/' . $user)]]></code>
-    </InternalClass>
-    <InternalMethod>
-      <code><![CDATA[is_dir]]></code>
-      <code><![CDATA[new View('/' . $user)]]></code>
-    </InternalMethod>
-  </file>
-  <file src="apps/files_trashbin/lib/Command/RestoreAllFiles.php">
-    <DeprecatedClass>
-      <code><![CDATA[\OC_Util::setupFS($uid)]]></code>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedClass>
-    <DeprecatedMethod>
-      <code><![CDATA[\OC_Util::tearDownFS()]]></code>
-    </DeprecatedMethod>
   </file>
   <file src="apps/files_trashbin/lib/Command/Size.php">
     <DeprecatedInterface>
       <code><![CDATA[private]]></code>
     </DeprecatedInterface>
     <DeprecatedMethod>
-      <code><![CDATA[getAppValue]]></code>
       <code><![CDATA[getUserValue]]></code>
       <code><![CDATA[getUserValueForUsers]]></code>
-      <code><![CDATA[setAppValue]]></code>
       <code><![CDATA[setUserValue]]></code>
     </DeprecatedMethod>
   </file>
@@ -1848,7 +1794,6 @@
       <code><![CDATA[Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_moveToTrash', ['filePath' => Filesystem::normalizePath($file_path),
 				'trashPath' => Filesystem::normalizePath(static::getTrashFilename($filename, $timestamp))])]]></code>
       <code><![CDATA[Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'post_restore', ['filePath' => $targetPath, 'trashPath' => $sourcePath])]]></code>
-      <code><![CDATA[getUserFolder]]></code>
       <code><![CDATA[getUserFolder]]></code>
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>


### PR DESCRIPTION
## Summary

- Use modern node and SetupManager API
- Avoid passing the user by id and instead use IUser

Originally tried to optimize a bit the number of query but the new code is doing exactly as many DB request as before :( Still a nice cleanup

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
