### PR TITLE
feat(tests): Fail on PHPUnit warnings and risky tests, show deprecations

### DIFF
--- a/apps/dav/lib/CalDAV/Federation/CalendarFederationProvider.php
+++ b/apps/dav/lib/CalDAV/Federation/CalendarFederationProvider.php
@@ -63,6 +63,13 @@ class CalendarFederationProvider implements ICloudFederationProvider {
 		}
 
 		$rawProtocol = $share->getProtocol();
+		if (!isset($rawProtocol[ICalendarFederationProtocol::PROP_VERSION])) {
+			throw new ProviderCouldNotAddShareException(
+				'No protocol version',
+				'',
+				Http::STATUS_BAD_REQUEST,
+			);
+		}
 		switch ($rawProtocol[ICalendarFederationProtocol::PROP_VERSION]) {
 			case CalendarFederationProtocolV1::VERSION:
 				try {

--- a/apps/dav/lib/CalDAV/Federation/FederationSharingService.php
+++ b/apps/dav/lib/CalDAV/Federation/FederationSharingService.php
@@ -46,10 +46,10 @@ class FederationSharingService {
 	 */
 	private function decodeRemoteUserPrincipal(string $principal): ?string {
 		// Expected format: principals/remote-users/abcdef123
-		[$prefix, $collection, $encodedId] = explode('/', $principal);
-		if ($prefix !== 'principals' || $collection !== 'remote-users') {
+		if (!str_starts_with($principal, 'principals/remote-users/')) {
 			return null;
 		}
+		$encodedId = substr($principal, strlen('principals/remote-users/'));
 
 		$decodedId = base64_decode($encodedId);
 		if (!is_string($decodedId)) {

--- a/apps/dav/tests/unit/CalDAV/Federation/CalendarFederationProviderTest.php
+++ b/apps/dav/tests/unit/CalDAV/Federation/CalendarFederationProviderTest.php
@@ -175,7 +175,7 @@ class CalendarFederationProviderTest extends TestCase {
 			->method('add');
 
 		$this->expectException(ProviderCouldNotAddShareException::class);
-		$this->expectExceptionMessage('Unknown protocol version');
+		$this->expectExceptionMessage('No protocol version');
 		$this->expectExceptionCode(400);
 		$this->assertEquals(10, $this->calendarFederationProvider->shareReceived($share));
 	}

--- a/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
+++ b/apps/dav/tests/unit/DAV/Listener/UserEventsListenerTest.php
@@ -34,6 +34,7 @@ class UserEventsListenerTest extends TestCase {
 	private ExampleContactService&MockObject $exampleContactService;
 	private ExampleEventService&MockObject $exampleEventService;
 	private LoggerInterface&MockObject $logger;
+	private IJobList&MockObject $jobList;
 
 	private UserEventsListener $userEventsListener;
 

--- a/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
+++ b/apps/dav/tests/unit/Upload/UploadAutoMkcolPluginTest.php
@@ -20,10 +20,28 @@ use Sabre\HTTP\ResponseInterface;
 use Test\TestCase;
 
 class UploadAutoMkcolPluginTest extends TestCase {
-
 	private Tree&MockObject $tree;
 	private RequestInterface&MockObject $request;
 	private ResponseInterface&MockObject $response;
+
+	private UploadAutoMkcolPlugin $plugin;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$server = $this->createMock(Server::class);
+		$this->tree = $this->createMock(Tree::class);
+
+		$server->tree = $this->tree;
+		$this->plugin = new UploadAutoMkcolPlugin();
+
+		$this->request = $this->createMock(RequestInterface::class);
+		$this->response = $this->createMock(ResponseInterface::class);
+		$server->httpRequest = $this->request;
+		$server->httpResponse = $this->response;
+
+		$this->plugin->initialize($server);
+	}
 
 	public static function dataMissingHeaderShouldReturnTrue(): Generator {
 		yield 'missing X-NC-WebDAV-Auto-Mkcol header' => [null];
@@ -112,22 +130,5 @@ class UploadAutoMkcolPluginTest extends TestCase {
 
 		$return = $this->plugin->beforeMethod($this->request, $this->response);
 		self::assertTrue($return);
-	}
-
-	protected function setUp(): void {
-		parent::setUp();
-
-		$server = $this->createMock(Server::class);
-		$this->tree = $this->createMock(Tree::class);
-
-		$server->tree = $this->tree;
-		$this->plugin = new UploadAutoMkcolPlugin();
-
-		$this->request = $this->createMock(RequestInterface::class);
-		$this->response = $this->createMock(ResponseInterface::class);
-		$server->httpRequest = $this->request;
-		$server->httpResponse = $this->response;
-
-		$this->plugin->initialize($server);
 	}
 }

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -308,6 +308,12 @@ class ViewControllerTest extends TestCase {
 				}
 			});
 
+		$this->config
+			->method('getUserValue')
+			->willReturnMap([
+				[$this->user->getUID(), 'files', 'files_sorting_configs', '{}', '{}'],
+			]);
+
 		$this->viewController->index('', '', null);
 	}
 }

--- a/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
+++ b/apps/files_external/tests/Storage/Amazons3MultiPartTest.php
@@ -18,17 +18,15 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  * @package OCA\Files_External\Tests\Storage
  */
 class Amazons3MultiPartTest extends \Test\Files\Storage\Storage {
-	private $config;
+	use ConfigurableStorageTrait;
 	/** @var AmazonS3 */
 	protected $instance;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->config = include('files_external/tests/config.amazons3.php');
-		if (!is_array($this->config) || !$this->config['run']) {
-			$this->markTestSkipped('AmazonS3 backend not configured');
-		}
+		$this->loadConfig('files_external/tests/config.amazons3.php');
+
 		$this->instance = new AmazonS3($this->config + [
 			'putSizeLimit' => 1,
 			'copySizeLimit' => 1,

--- a/apps/files_external/tests/Storage/Amazons3Test.php
+++ b/apps/files_external/tests/Storage/Amazons3Test.php
@@ -19,17 +19,14 @@ use OCA\Files_External\Lib\Storage\AmazonS3;
  * @package OCA\Files_External\Tests\Storage
  */
 class Amazons3Test extends \Test\Files\Storage\Storage {
-	protected $config;
+	use ConfigurableStorageTrait;
 	/** @var AmazonS3 */
 	protected $instance;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->config = include('files_external/tests/config.amazons3.php');
-		if (!is_array($this->config) || !$this->config['run']) {
-			$this->markTestSkipped('AmazonS3 backend not configured');
-		}
+		$this->loadConfig('files_external/tests/config.amazons3.php');
 		$this->instance = new AmazonS3($this->config);
 	}
 

--- a/apps/files_external/tests/Storage/ConfigurableStorageTrait.php
+++ b/apps/files_external/tests/Storage/ConfigurableStorageTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Files_External\Tests\Storage;
+
+trait ConfigurableStorageTrait {
+	protected ?array $config = null;
+
+	protected function loadConfig(string $path): bool {
+		$this->config = null;
+		if (file_exists($path)) {
+			$this->config = include($path);
+		}
+		if (!$this->shouldRunConfig($this->config)) {
+			$this->markTestSkipped(__CLASS__ . ' Backend not configured');
+			return false;
+		}
+		return true;
+	}
+
+	protected function shouldRunConfig(mixed $config): bool {
+		return is_array($config) && ($config['run'] ?? false);
+	}
+}

--- a/apps/files_external/tests/Storage/FtpTest.php
+++ b/apps/files_external/tests/Storage/FtpTest.php
@@ -18,16 +18,14 @@ use OCA\Files_External\Lib\Storage\FTP;
  * @package OCA\Files_External\Tests\Storage
  */
 class FtpTest extends \Test\Files\Storage\Storage {
-	private $config;
+	use ConfigurableStorageTrait;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->config = include('files_external/tests/config.ftp.php');
-		if (! is_array($this->config) or ! $this->config['run']) {
-			$this->markTestSkipped('FTP backend not configured');
-		}
+		$this->loadConfig('files_external/tests/config.ftp.php');
+
 		$rootInstance = new FTP($this->config);
 		$rootInstance->mkdir($id);
 

--- a/apps/files_external/tests/Storage/OwncloudTest.php
+++ b/apps/files_external/tests/Storage/OwncloudTest.php
@@ -18,19 +18,20 @@ use OCA\Files_External\Lib\Storage\OwnCloud;
  * @package OCA\Files_External\Tests\Storage
  */
 class OwncloudTest extends \Test\Files\Storage\Storage {
-	private $config;
+	use ConfigurableStorageTrait;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->config = include('files_external/tests/config.php');
-		if (! is_array($this->config) or ! isset($this->config['owncloud']) or ! $this->config['owncloud']['run']) {
-			$this->markTestSkipped('Nextcloud backend not configured');
-		}
+		$this->loadConfig('files_external/tests/config.php');
 		$this->config['owncloud']['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new OwnCloud($this->config['owncloud']);
 		$this->instance->mkdir('/');
+	}
+
+	protected function shouldRunConfig(mixed $config): bool {
+		return is_array($config) && ($config['owncloud']['run'] ?? false);
 	}
 
 	protected function tearDown(): void {

--- a/apps/files_external/tests/Storage/SFTP_KeyTest.php
+++ b/apps/files_external/tests/Storage/SFTP_KeyTest.php
@@ -18,20 +18,21 @@ use OCA\Files_External\Lib\Storage\SFTP_Key;
  * @package OCA\Files_External\Tests\Storage
  */
 class SFTP_KeyTest extends \Test\Files\Storage\Storage {
-	private $config;
+	use ConfigurableStorageTrait;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->config = include('files_external/tests/config.php');
-		if (! is_array($this->config) or ! isset($this->config['sftp_key']) or ! $this->config['sftp_key']['run']) {
-			$this->markTestSkipped('SFTP with key backend not configured');
-		}
+		$this->loadConfig('files_external/tests/config.php');
 		// Make sure we have an new empty folder to work in
 		$this->config['sftp_key']['root'] .= '/' . $id;
 		$this->instance = new SFTP_Key($this->config['sftp_key']);
 		$this->instance->mkdir('/');
+	}
+
+	protected function shouldRunConfig(mixed $config): bool {
+		return is_array($config) && ($config['sftp_key']['run'] ?? false);
 	}
 
 	protected function tearDown(): void {

--- a/apps/files_external/tests/Storage/SftpTest.php
+++ b/apps/files_external/tests/Storage/SftpTest.php
@@ -18,21 +18,17 @@ use OCA\Files_External\Lib\Storage\SFTP;
  * @package OCA\Files_External\Tests\Storage
  */
 class SftpTest extends \Test\Files\Storage\Storage {
+	use ConfigurableStorageTrait;
 	/**
 	 * @var SFTP instance
 	 */
 	protected $instance;
 
-	private $config;
-
 	protected function setUp(): void {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$this->config = include('files_external/tests/config.sftp.php');
-		if (!is_array($this->config) or !$this->config['run']) {
-			$this->markTestSkipped('SFTP backend not configured');
-		}
+		$this->loadConfig('files_external/tests/config.sftp.php');
 		$this->config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
 		$this->instance = new SFTP($this->config);
 		$this->instance->mkdir('/');

--- a/apps/files_external/tests/Storage/SmbTest.php
+++ b/apps/files_external/tests/Storage/SmbTest.php
@@ -22,6 +22,7 @@ use PHPUnit\Framework\ExpectationFailedException;
  * @package OCA\Files_External\Tests\Storage
  */
 class SmbTest extends \Test\Files\Storage\Storage {
+	use ConfigurableStorageTrait;
 	/**
 	 * @var SMB instance
 	 */
@@ -31,15 +32,12 @@ class SmbTest extends \Test\Files\Storage\Storage {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$config = include('files_external/tests/config.smb.php');
-		if (!is_array($config) or !$config['run']) {
-			$this->markTestSkipped('Samba backend not configured');
+		$this->loadConfig('files_external/tests/config.smb.php');
+		if (substr($this->config['root'], -1, 1) != '/') {
+			$this->config['root'] .= '/';
 		}
-		if (substr($config['root'], -1, 1) != '/') {
-			$config['root'] .= '/';
-		}
-		$config['root'] .= $id; //make sure we have an new empty folder to work in
-		$this->instance = new SMB($config);
+		$this->config['root'] .= $id; //make sure we have an new empty folder to work in
+		$this->instance = new SMB($this->config);
 		$this->instance->mkdir('/');
 	}
 

--- a/apps/files_external/tests/Storage/SwiftTest.php
+++ b/apps/files_external/tests/Storage/SwiftTest.php
@@ -19,7 +19,7 @@ use OCA\Files_External\Lib\Storage\Swift;
  * @package OCA\Files_External\Tests\Storage
  */
 class SwiftTest extends \Test\Files\Storage\Storage {
-	private $config;
+	use ConfigurableStorageTrait;
 
 	/**
 	 * @var Swift instance
@@ -29,10 +29,7 @@ class SwiftTest extends \Test\Files\Storage\Storage {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->config = include('files_external/tests/config.swift.php');
-		if (!is_array($this->config) or !$this->config['run']) {
-			$this->markTestSkipped('OpenStack Object Storage backend not configured');
-		}
+		$this->loadConfig('files_external/tests/config.swift.php');
 		$this->instance = new Swift($this->config);
 	}
 

--- a/apps/files_external/tests/Storage/WebdavTest.php
+++ b/apps/files_external/tests/Storage/WebdavTest.php
@@ -21,19 +21,18 @@ use OCP\Server;
  * @package OCA\Files_External\Tests\Storage
  */
 class WebdavTest extends \Test\Files\Storage\Storage {
+	use ConfigurableStorageTrait;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$id = $this->getUniqueID();
-		$config = include('files_external/tests/config.webdav.php');
-		if (!is_array($config) or !$config['run']) {
-			$this->markTestSkipped('WebDAV backend not configured');
+		$this->loadConfig('files_external/tests/config.webdav.php');
+		if (isset($this->config['wait'])) {
+			$this->waitDelay = $this->config['wait'];
 		}
-		if (isset($config['wait'])) {
-			$this->waitDelay = $config['wait'];
-		}
-		$config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
-		$this->instance = new DAV($config);
+		$this->config['root'] .= '/' . $id; //make sure we have an new empty folder to work in
+		$this->instance = new DAV($this->config);
 		$this->instance->mkdir('/');
 	}
 

--- a/apps/files_sharing/tests/ApplicationTest.php
+++ b/apps/files_sharing/tests/ApplicationTest.php
@@ -1,9 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2022 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Files_Sharing\Tests;
 
 use OCA\Files_Sharing\AppInfo\Application;
@@ -20,17 +23,15 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IAttributes;
 use OCP\Share\IShare;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class ApplicationTest extends TestCase {
 	private Application $application;
 
-	/** @var IUserSession */
-	private $userSession;
-
-	/** @var IRootFolder */
-	private $rootFolder;
-
+	private IUserSession&MockObject $userSession;
+	private IRootFolder&MockObject $rootFolder;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -41,54 +42,45 @@ class ApplicationTest extends TestCase {
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 	}
 
-	public function providesDataForCanGet(): array {
-		// normal file (sender) - can download directly
-		$senderFileStorage = $this->createMock(IStorage::class);
-		$senderFileStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(false);
-		$senderFile = $this->createMock(File::class);
-		$senderFile->method('getStorage')->willReturn($senderFileStorage);
-		$senderUserFolder = $this->createMock(Folder::class);
-		$senderUserFolder->method('get')->willReturn($senderFile);
-
-		$result[] = [ '/bar.txt', $senderUserFolder, true ];
-
-		// shared file (receiver) with attribute secure-view-enabled set false -
-		// can download directly
-		$receiverFileShareAttributes = $this->createMock(IAttributes::class);
-		$receiverFileShareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(true);
-		$receiverFileShare = $this->createMock(IShare::class);
-		$receiverFileShare->method('getAttributes')->willReturn($receiverFileShareAttributes);
-		$receiverFileStorage = $this->createMock(SharedStorage::class);
-		$receiverFileStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(true);
-		$receiverFileStorage->method('getShare')->willReturn($receiverFileShare);
-		$receiverFile = $this->createMock(File::class);
-		$receiverFile->method('getStorage')->willReturn($receiverFileStorage);
-		$receiverUserFolder = $this->createMock(Folder::class);
-		$receiverUserFolder->method('get')->willReturn($receiverFile);
-
-		$result[] = [ '/share-bar.txt', $receiverUserFolder, true ];
-
-		// shared file (receiver) with attribute secure-view-enabled set true -
-		// cannot download directly
-		$secureReceiverFileShareAttributes = $this->createMock(IAttributes::class);
-		$secureReceiverFileShareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(false);
-		$secureReceiverFileShare = $this->createMock(IShare::class);
-		$secureReceiverFileShare->method('getAttributes')->willReturn($secureReceiverFileShareAttributes);
-		$secureReceiverFileStorage = $this->createMock(SharedStorage::class);
-		$secureReceiverFileStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(true);
-		$secureReceiverFileStorage->method('getShare')->willReturn($secureReceiverFileShare);
-		$secureReceiverFile = $this->createMock(File::class);
-		$secureReceiverFile->method('getStorage')->willReturn($secureReceiverFileStorage);
-		$secureReceiverUserFolder = $this->createMock(Folder::class);
-		$secureReceiverUserFolder->method('get')->willReturn($secureReceiverFile);
-
-		$result[] = [ '/secure-share-bar.txt', $secureReceiverUserFolder, false ];
-
-		return $result;
+	public static function providesDataForCanGet(): array {
+		return [
+			'normal file (sender)' => [
+				'/bar.txt', IStorage::class, false, null, true
+			],
+			'shared file (receiver) with attribute secure-view-enabled set false' => [
+				'/share-bar.txt', SharedStorage::class, true, true, true
+			],
+			'shared file (receiver) with attribute secure-view-enabled set true' => [
+				'/secure-share-bar.txt', SharedStorage::class, true, false, false
+			],
+		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesDataForCanGet')]
-	public function testCheckDirectCanBeDownloaded(string $path, Folder $userFolder, bool $run): void {
+	#[DataProvider('providesDataForCanGet')]
+	public function testCheckDirectCanBeDownloaded(
+		string $path,
+		string $storageClass,
+		bool $instanceOfSharedStorage,
+		?bool $storageShareDownloadPermission,
+		bool $canDownloadDirectly,
+	): void {
+		$fileStorage = $this->createMock($storageClass);
+		$fileStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn($instanceOfSharedStorage);
+		if ($storageShareDownloadPermission !== null) {
+			$fileShareAttributes = $this->createMock(IAttributes::class);
+			$fileShareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn($storageShareDownloadPermission);
+			$fileShare = $this->createMock(IShare::class);
+			$fileShare->method('getAttributes')->willReturn($fileShareAttributes);
+
+			$fileStorage->method('getShare')->willReturn($fileShare);
+		}
+
+		$file = $this->createMock(File::class);
+		$file->method('getStorage')->willReturn($fileStorage);
+
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($file);
+
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('test');
 		$this->userSession->method('getUser')->willReturn($user);
@@ -103,10 +95,34 @@ class ApplicationTest extends TestCase {
 		);
 		$listener->handle($event);
 
-		$this->assertEquals($run, $event->isSuccessful());
+		$this->assertEquals($canDownloadDirectly, $event->isSuccessful());
 	}
 
-	public function providesDataForCanZip(): array {
+	public static function providesDataForCanZip(): array {
+		return [
+			'can download zipped 2 non-shared files inside non-shared folder' => [
+				'/folder', ['bar1.txt', 'bar2.txt'], 'nonSharedStorage', ['nonSharedStorage','nonSharedStorage'], true
+			],
+			'can download zipped non-shared folder' => [
+				'/', ['folder'], 'nonSharedStorage', ['nonSharedStorage','nonSharedStorage'], true
+			],
+			'cannot download zipped 1 non-shared file and 1 secure-shared inside non-shared folder' => [
+				'/folder', ['secured-bar1.txt', 'bar2.txt'], 'nonSharedStorage', ['nonSharedStorage','secureSharedStorage'], false,
+			],
+			'cannot download zipped secure-shared folder' => [
+				'/', ['secured-folder'], 'secureSharedStorage', [], false,
+			],
+		];
+	}
+
+	#[DataProvider('providesDataForCanZip')]
+	public function testCheckZipCanBeDownloaded(
+		string $dir,
+		array $files,
+		string $folderStorage,
+		array $directoryListing,
+		bool $downloadSuccessful,
+	): void {
 		// Mock: Normal file/folder storage
 		$nonSharedStorage = $this->createMock(IStorage::class);
 		$nonSharedStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(false);
@@ -120,54 +136,39 @@ class ApplicationTest extends TestCase {
 		$secureSharedStorage->method('instanceOfStorage')->with(SharedStorage::class)->willReturn(true);
 		$secureSharedStorage->method('getShare')->willReturn($secureReceiverFileShare);
 
-		// 1. can download zipped 2 non-shared files inside non-shared folder
-		// 2. can download zipped non-shared folder
-		$sender1File = $this->createMock(File::class);
-		$sender1File->method('getStorage')->willReturn($nonSharedStorage);
-		$sender1Folder = $this->createMock(Folder::class);
-		$sender1Folder->method('getStorage')->willReturn($nonSharedStorage);
-		$sender1Folder->method('getDirectoryListing')->willReturn([$sender1File, $sender1File]);
-		$sender1RootFolder = $this->createMock(Folder::class);
-		$sender1RootFolder->method('getStorage')->willReturn($nonSharedStorage);
-		$sender1RootFolder->method('getDirectoryListing')->willReturn([$sender1Folder]);
-		$sender1UserFolder = $this->createMock(Folder::class);
-		$sender1UserFolder->method('get')->willReturn($sender1RootFolder);
+		$folder = $this->createMock(Folder::class);
+		if ($folderStorage === 'nonSharedStorage') {
+			$folder->method('getStorage')->willReturn($nonSharedStorage);
+		} elseif ($folderStorage === 'secureSharedStorage') {
+			$folder->method('getStorage')->willReturn($secureSharedStorage);
+		} else {
+			throw new \Exception('Unknown storage ' . $folderStorage);
+		}
+		if (count($directoryListing) > 0) {
+			$directoryListing = array_map(
+				function (string $fileStorage) use ($nonSharedStorage, $secureSharedStorage) {
+					$file = $this->createMock(File::class);
+					if ($fileStorage === 'nonSharedStorage') {
+						$file->method('getStorage')->willReturn($nonSharedStorage);
+					} elseif ($fileStorage === 'secureSharedStorage') {
+						$file->method('getStorage')->willReturn($secureSharedStorage);
+					} else {
+						throw new \Exception('Unknown storage ' . $fileStorage);
+					}
+					return $file;
+				},
+				$directoryListing
+			);
+			$folder->method('getDirectoryListing')->willReturn($directoryListing);
+		}
 
-		$return[] = [ '/folder', ['bar1.txt', 'bar2.txt'], $sender1UserFolder, true ];
-		$return[] = [ '/', ['folder'], $sender1UserFolder, true ];
+		$rootFolder = $this->createMock(Folder::class);
+		$rootFolder->method('getStorage')->willReturn($nonSharedStorage);
+		$rootFolder->method('getDirectoryListing')->willReturn([$folder]);
 
-		// 3. cannot download zipped 1 non-shared file and 1 secure-shared inside non-shared folder
-		$receiver1File = $this->createMock(File::class);
-		$receiver1File->method('getStorage')->willReturn($nonSharedStorage);
-		$receiver1SecureFile = $this->createMock(File::class);
-		$receiver1SecureFile->method('getStorage')->willReturn($secureSharedStorage);
-		$receiver1Folder = $this->createMock(Folder::class);
-		$receiver1Folder->method('getStorage')->willReturn($nonSharedStorage);
-		$receiver1Folder->method('getDirectoryListing')->willReturn([$receiver1File, $receiver1SecureFile]);
-		$receiver1RootFolder = $this->createMock(Folder::class);
-		$receiver1RootFolder->method('getStorage')->willReturn($nonSharedStorage);
-		$receiver1RootFolder->method('getDirectoryListing')->willReturn([$receiver1Folder]);
-		$receiver1UserFolder = $this->createMock(Folder::class);
-		$receiver1UserFolder->method('get')->willReturn($receiver1RootFolder);
+		$userFolder = $this->createMock(Folder::class);
+		$userFolder->method('get')->willReturn($rootFolder);
 
-		$return[] = [ '/folder', ['secured-bar1.txt', 'bar2.txt'], $receiver1UserFolder, false ];
-
-		// 4. cannot download zipped secure-shared folder
-		$receiver2Folder = $this->createMock(Folder::class);
-		$receiver2Folder->method('getStorage')->willReturn($secureSharedStorage);
-		$receiver2RootFolder = $this->createMock(Folder::class);
-		$receiver2RootFolder->method('getStorage')->willReturn($nonSharedStorage);
-		$receiver2RootFolder->method('getDirectoryListing')->willReturn([$receiver2Folder]);
-		$receiver2UserFolder = $this->createMock(Folder::class);
-		$receiver2UserFolder->method('get')->willReturn($receiver2RootFolder);
-
-		$return[] = [ '/', ['secured-folder'], $receiver2UserFolder, false ];
-
-		return $return;
-	}
-
-	#[\PHPUnit\Framework\Attributes\DataProvider('providesDataForCanZip')]
-	public function testCheckZipCanBeDownloaded(string $dir, array $files, Folder $userFolder, bool $run): void {
 		$user = $this->createMock(IUser::class);
 		$user->method('getUID')->willReturn('test');
 		$this->userSession->method('getUser')->willReturn($user);
@@ -183,9 +184,8 @@ class ApplicationTest extends TestCase {
 		);
 		$listener->handle($event);
 
-
-		$this->assertEquals($run, $event->isSuccessful());
-		$this->assertEquals($run, $event->getErrorMessage() === null);
+		$this->assertEquals($downloadSuccessful, $event->isSuccessful());
+		$this->assertEquals($downloadSuccessful, $event->getErrorMessage() === null);
 	}
 
 	public function testCheckFileUserNotFound(): void {

--- a/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
+++ b/apps/files_sharing/tests/Controller/ShareAPIControllerTest.php
@@ -5,6 +5,7 @@
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
  * SPDX-License-Identifier: AGPL-3.0-only
  */
+
 namespace OCA\Files_Sharing\Tests\Controller;
 
 use OCA\Federation\TrustedServers;
@@ -48,6 +49,7 @@ use OCP\Share\IManager;
 use OCP\Share\IProviderFactory;
 use OCP\Share\IShare;
 use OCP\UserStatus\IManager as IUserStatusManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
@@ -582,16 +584,32 @@ class ShareAPIControllerTest extends TestCase {
 	}
 	*/
 
-	public function createShare($id, $shareType, $sharedWith, $sharedBy, $shareOwner, $path, $permissions,
-		$shareTime, $expiration, $parent, $target, $mail_send, $note = '', $token = null,
-		$password = null, $label = '', $attributes = null) {
-		$share = $this->getMockBuilder(IShare::class)->getMock();
+	public function createShare(
+		int $id,
+		int $shareType,
+		?string $sharedWith,
+		string $sharedBy,
+		string $shareOwner,
+		File|Folder|null $node,
+		int $permissions,
+		int $shareTime,
+		?\DateTime $expiration,
+		int $parent,
+		string $target,
+		int $mail_send,
+		string $note = '',
+		?string $token = null,
+		?string $password = null,
+		string $label = '',
+		?IShareAttributes $attributes = null,
+	): MockObject {
+		$share = $this->createMock(IShare::class);
 		$share->method('getId')->willReturn($id);
 		$share->method('getShareType')->willReturn($shareType);
 		$share->method('getSharedWith')->willReturn($sharedWith);
 		$share->method('getSharedBy')->willReturn($sharedBy);
 		$share->method('getShareOwner')->willReturn($shareOwner);
-		$share->method('getNode')->willReturn($path);
+		$share->method('getNode')->willReturn($node);
 		$share->method('getPermissions')->willReturn($permissions);
 		$share->method('getNote')->willReturn($note);
 		$share->method('getLabel')->willReturn($label);
@@ -614,49 +632,25 @@ class ShareAPIControllerTest extends TestCase {
 		return $share;
 	}
 
-	public function dataGetShare() {
+	public static function dataGetShare(): array {
 		$data = [];
 
-		$cache = $this->getMockBuilder('OC\Files\Cache\Cache')
-			->disableOriginalConstructor()
-			->getMock();
-		$cache->method('getNumericStorageId')->willReturn(101);
+		$file = [
+			'class' => File::class,
+			'id' => 1,
+			'path' => 'file',
+			'mimeType' => 'myMimeType',
+		];
 
-		$storage = $this->getMockBuilder(IStorage::class)
-			->disableOriginalConstructor()
-			->getMock();
-		$storage->method('getId')->willReturn('STORAGE');
-		$storage->method('getCache')->willReturn($cache);
-
-		$parentFolder = $this->getMockBuilder(Folder::class)->getMock();
-		$parentFolder->method('getId')->willReturn(3);
-		$mountPoint = $this->createMock(IMountPoint::class);
-		$mountPoint->method('getMountType')->willReturn('');
-
-		$file = $this->getMockBuilder('OCP\Files\File')->getMock();
-		$file->method('getId')->willReturn(1);
-		$file->method('getPath')->willReturn('file');
-		$file->method('getStorage')->willReturn($storage);
-		$file->method('getParent')->willReturn($parentFolder);
-		$file->method('getSize')->willReturn(123465);
-		$file->method('getMTime')->willReturn(1234567890);
-		$file->method('getMimeType')->willReturn('myMimeType');
-		$file->method('getMountPoint')->willReturn($mountPoint);
-
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
-		$folder->method('getId')->willReturn(2);
-		$folder->method('getPath')->willReturn('folder');
-		$folder->method('getStorage')->willReturn($storage);
-		$folder->method('getParent')->willReturn($parentFolder);
-		$folder->method('getSize')->willReturn(123465);
-		$folder->method('getMTime')->willReturn(1234567890);
-		$folder->method('getMimeType')->willReturn('myFolderMimeType');
-		$folder->method('getMountPoint')->willReturn($mountPoint);
-
-		[$shareAttributes, $shareAttributesReturnJson] = $this->mockShareAttributes();
+		$folder = [
+			'class' => Folder::class,
+			'id' => 2,
+			'path' => 'folder',
+			'mimeType' => 'myFolderMimeType',
+		];
 
 		// File shared with user
-		$share = $this->createShare(
+		$share = [
 			100,
 			IShare::TYPE_USER,
 			'userId',
@@ -670,8 +664,11 @@ class ShareAPIControllerTest extends TestCase {
 			'target',
 			0,
 			'personal note',
-			$shareAttributes,
-		);
+			null,
+			null,
+			'',
+			[],
+		];
 		$expected = [
 			'id' => 100,
 			'share_type' => IShare::TYPE_USER,
@@ -688,7 +685,6 @@ class ShareAPIControllerTest extends TestCase {
 			'token' => null,
 			'expiration' => null,
 			'permissions' => 4,
-			'attributes' => $shareAttributesReturnJson,
 			'stime' => 5,
 			'parent' => null,
 			'storage_id' => 'STORAGE',
@@ -706,15 +702,14 @@ class ShareAPIControllerTest extends TestCase {
 			'can_delete' => false,
 			'item_size' => 123465,
 			'item_mtime' => 1234567890,
-			'attributes' => null,
 			'item_permissions' => 4,
 			'is-mount-root' => false,
 			'mount-type' => '',
 		];
-		$data[] = [$share, $expected];
+		$data['File shared with user'] = [$share, $expected, true];
 
 		// Folder shared with group
-		$share = $this->createShare(
+		$share = [
 			101,
 			IShare::TYPE_GROUP,
 			'groupId',
@@ -728,8 +723,11 @@ class ShareAPIControllerTest extends TestCase {
 			'target',
 			0,
 			'personal note',
-			$shareAttributes,
-		);
+			null,
+			null,
+			'',
+			[],
+		];
 		$expected = [
 			'id' => 101,
 			'share_type' => IShare::TYPE_GROUP,
@@ -745,7 +743,6 @@ class ShareAPIControllerTest extends TestCase {
 			'token' => null,
 			'expiration' => null,
 			'permissions' => 4,
-			'attributes' => $shareAttributesReturnJson,
 			'stime' => 5,
 			'parent' => null,
 			'storage_id' => 'STORAGE',
@@ -763,16 +760,15 @@ class ShareAPIControllerTest extends TestCase {
 			'can_delete' => false,
 			'item_size' => 123465,
 			'item_mtime' => 1234567890,
-			'attributes' => null,
 			'item_permissions' => 4,
 			'is-mount-root' => false,
 			'mount-type' => '',
 		];
-		$data[] = [$share, $expected];
+		$data['Folder shared with group'] = [$share, $expected, true];
 
 		// File shared by link with Expire
 		$expire = \DateTime::createFromFormat('Y-m-d h:i:s', '2000-01-02 01:02:03');
-		$share = $this->createShare(
+		$share = [
 			101,
 			IShare::TYPE_LINK,
 			null,
@@ -789,7 +785,7 @@ class ShareAPIControllerTest extends TestCase {
 			'token',
 			'password',
 			'first link share'
-		);
+		];
 		$expected = [
 			'id' => 101,
 			'share_type' => IShare::TYPE_LINK,
@@ -826,18 +822,51 @@ class ShareAPIControllerTest extends TestCase {
 			'can_delete' => false,
 			'item_size' => 123465,
 			'item_mtime' => 1234567890,
-			'attributes' => null,
 			'item_permissions' => 4,
 			'is-mount-root' => false,
 			'mount-type' => '',
 		];
-		$data[] = [$share, $expected];
+		$data['File shared by link with Expire'] = [$share, $expected, false];
 
 		return $data;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetShare')]
-	public function testGetShare(IShare $share, array $result): void {
+	#[DataProvider('dataGetShare')]
+	public function testGetShare(array $shareParams, array $result, bool $attributes): void {
+
+		$cache = $this->createMock(ICache::class);
+		$cache->method('getNumericStorageId')->willReturn(101);
+
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('getId')->willReturn('STORAGE');
+		$storage->method('getCache')->willReturn($cache);
+
+		$parentFolder = $this->createMock(Folder::class);
+		$parentFolder->method('getId')->willReturn(3);
+
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->method('getMountType')->willReturn('');
+
+		$nodeParams = $shareParams[5];
+		$node = $this->createMock($nodeParams['class']);
+		$node->method('getId')->willReturn($nodeParams['id']);
+		$node->method('getPath')->willReturn($nodeParams['path']);
+		$node->method('getStorage')->willReturn($storage);
+		$node->method('getParent')->willReturn($parentFolder);
+		$node->method('getSize')->willReturn(123465);
+		$node->method('getMTime')->willReturn(1234567890);
+		$node->method('getMimeType')->willReturn($nodeParams['mimeType']);
+		$node->method('getMountPoint')->willReturn($mountPoint);
+
+		$shareParams[5] = $node;
+
+		if ($attributes) {
+			[$shareAttributes, $shareAttributesReturnJson] = $this->mockShareAttributes();
+			$result['attributes'] = $shareAttributesReturnJson;
+			$shareParams[16] = $shareAttributes;
+		}
+
+		$share = $this->createShare(...$shareParams);
 		/** @var ShareAPIController&MockObject $ocs */
 		$ocs = $this->getMockBuilder(ShareAPIController::class)
 			->setConstructorArgs([
@@ -922,7 +951,7 @@ class ShareAPIControllerTest extends TestCase {
 		]);
 		$this->dateTimeZone->method('getTimezone')->willReturn(new \DateTimeZone('UTC'));
 
-		$data = $ocs->getShare($share->getId())->getData()[0];
+		$data = $ocs->getShare((string)$share->getId())->getData()[0];
 		$this->assertEquals($result, $data);
 	}
 
@@ -947,208 +976,217 @@ class ShareAPIControllerTest extends TestCase {
 			->with($this->currentUser)
 			->willReturn($userFolder);
 
-		$this->ocs->getShare(42);
+		$this->ocs->getShare('42');
 	}
 
-	public function dataGetShares() {
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
-		$file1 = $this->getMockBuilder(File::class)->getMock();
-		$file1->method('getName')
-			->willReturn('file1');
-		$file2 = $this->getMockBuilder(File::class)->getMock();
-		$file2->method('getName')
-			->willReturn('file2');
+	public static function dataGetShares(): array {
+		$file1 = [
+			'class' => File::class,
+			'methods' => [
+				'getName' => 'file1',
+			]
+		];
+		$file2 = [
+			'class' => File::class,
+			'methods' => [
+				'getName' => 'file2',
+			]
+		];
 
-		$folder->method('getDirectoryListing')
-			->willReturn([$file1, $file2]);
+		$folder = [
+			'class' => Folder::class,
+			'methods' => [
+				'getDirectoryListing' => [$file1, $file2]
+			]
+		];
 
-		$file1UserShareOwner = Server::get(IManager::class)->newShare();
-		$file1UserShareOwner->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(4);
+		$file1UserShareOwner = [
+			'type' => IShare::TYPE_USER,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'node' => $file1,
+			'id' => 4,
+		];
 
 		$file1UserShareOwnerExpected = [
 			'id' => 4,
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1UserShareInitiator = Server::get(IManager::class)->newShare();
-		$file1UserShareInitiator->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('currentUser')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(8);
+		$file1UserShareInitiator = [
+			'type' => IShare::TYPE_USER,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'currentUser',
+			'owner' => 'owner',
+			'node' => $file1,
+			'id' => 8,
+		];
 
 		$file1UserShareInitiatorExpected = [
 			'id' => 8,
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1UserShareRecipient = Server::get(IManager::class)->newShare();
-		$file1UserShareRecipient->setShareType(IShare::TYPE_USER)
-			->setSharedWith('currentUser')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(15);
+		$file1UserShareRecipient = [
+			'type' => IShare::TYPE_USER,
+			'sharedWith' => 'currentUser',
+			'sharedBy' => 'initiator',
+			'owner' => 'owner',
+			'node' => $file1,
+			'id' => 15,
+		];
 
 		$file1UserShareRecipientExpected = [
 			'id' => 15,
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1UserShareOther = Server::get(IManager::class)->newShare();
-		$file1UserShareOther->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(16);
+		$file1UserShareOther = [
+			'type' => IShare::TYPE_USER,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'owner',
+			'node' => $file1,
+			'id' => 16,
+		];
 
 		$file1UserShareOtherExpected = [
 			'id' => 16,
 			'share_type' => IShare::TYPE_USER,
 		];
 
-		$file1GroupShareOwner = Server::get(IManager::class)->newShare();
-		$file1GroupShareOwner->setShareType(IShare::TYPE_GROUP)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(23);
+		$file1GroupShareOwner = [
+			'type' => IShare::TYPE_GROUP,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'node' => $file1,
+			'id' => 23,
+		];
 
 		$file1GroupShareOwnerExpected = [
 			'id' => 23,
 			'share_type' => IShare::TYPE_GROUP,
 		];
 
-		$file1GroupShareRecipient = Server::get(IManager::class)->newShare();
-		$file1GroupShareRecipient->setShareType(IShare::TYPE_GROUP)
-			->setSharedWith('currentUserGroup')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(42);
+		$file1GroupShareRecipient = [
+			'type' => IShare::TYPE_GROUP,
+			'sharedWith' => 'currentUserGroup',
+			'sharedBy' => 'initiator',
+			'owner' => 'owner',
+			'node' => $file1,
+			'id' => 42,
+		];
 
 		$file1GroupShareRecipientExpected = [
 			'id' => 42,
 			'share_type' => IShare::TYPE_GROUP,
 		];
 
-		$file1GroupShareOther = Server::get(IManager::class)->newShare();
-		$file1GroupShareOther->setShareType(IShare::TYPE_GROUP)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(108);
+		$file1GroupShareOther = [
+			'type' => IShare::TYPE_GROUP,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'owner',
+			'node' => $file1,
+			'id' => 108,
+		];
 
-		$file1LinkShareOwner = Server::get(IManager::class)->newShare();
-		$file1LinkShareOwner->setShareType(IShare::TYPE_LINK)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(415);
+		$file1LinkShareOwner = [
+			'type' => IShare::TYPE_LINK,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'node' => $file1,
+			'id' => 415,
+		];
 
 		$file1LinkShareOwnerExpected = [
 			'id' => 415,
 			'share_type' => IShare::TYPE_LINK,
 		];
 
-		$file1EmailShareOwner = Server::get(IManager::class)->newShare();
-		$file1EmailShareOwner->setShareType(IShare::TYPE_EMAIL)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(416);
+		$file1EmailShareOwner = [
+			'type' => IShare::TYPE_EMAIL,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'node' => $file1,
+			'id' => 416,
+		];
 
 		$file1EmailShareOwnerExpected = [
 			'id' => 416,
 			'share_type' => IShare::TYPE_EMAIL,
 		];
 
-		$file1CircleShareOwner = Server::get(IManager::class)->newShare();
-		$file1CircleShareOwner->setShareType(IShare::TYPE_CIRCLE)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(423);
+		$file1CircleShareOwner = [
+			'type' => IShare::TYPE_CIRCLE,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'node' => $file1,
+			'id' => 423,
+		];
 
 		$file1CircleShareOwnerExpected = [
 			'id' => 423,
 			'share_type' => IShare::TYPE_CIRCLE,
 		];
 
-		$file1RoomShareOwner = Server::get(IManager::class)->newShare();
-		$file1RoomShareOwner->setShareType(IShare::TYPE_ROOM)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file1)
-			->setId(442);
+		$file1RoomShareOwner = [
+			'type' => IShare::TYPE_ROOM,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'node' => $file1,
+			'id' => 442,
+		];
 
 		$file1RoomShareOwnerExpected = [
 			'id' => 442,
 			'share_type' => IShare::TYPE_ROOM,
 		];
 
-		$file1RemoteShareOwner = Server::get(IManager::class)->newShare();
-		$file1RemoteShareOwner->setShareType(IShare::TYPE_REMOTE)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setExpirationDate(new \DateTime('2000-01-01T01:02:03'))
-			->setNode($file1)
-			->setId(815);
+		$file1RemoteShareOwner = [
+			'type' => IShare::TYPE_REMOTE,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'expirationDate' => new \DateTime('2000-01-01T01:02:03'),
+			'node' => $file1,
+			'id' => 815,
+		];
 
 		$file1RemoteShareOwnerExpected = [
 			'id' => 815,
 			'share_type' => IShare::TYPE_REMOTE,
 		];
 
-		$file1RemoteGroupShareOwner = Server::get(IManager::class)->newShare();
-		$file1RemoteGroupShareOwner->setShareType(IShare::TYPE_REMOTE_GROUP)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setExpirationDate(new \DateTime('2000-01-02T01:02:03'))
-			->setNode($file1)
-			->setId(816);
+		$file1RemoteGroupShareOwner = [
+			'type' => IShare::TYPE_REMOTE_GROUP,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'expirationDate' => new \DateTime('2000-01-01T01:02:03'),
+			'node' => $file1,
+			'id' => 816,
+		];
 
 		$file1RemoteGroupShareOwnerExpected = [
 			'id' => 816,
 			'share_type' => IShare::TYPE_REMOTE_GROUP,
 		];
 
-		$file2UserShareOwner = Server::get(IManager::class)->newShare();
-		$file2UserShareOwner->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file2)
-			->setId(823);
+		$file2UserShareOwner = [
+			'type' => IShare::TYPE_USER,
+			'sharedWith' => 'recipient',
+			'sharedBy' => 'initiator',
+			'owner' => 'currentUser',
+			'node' => $file2,
+			'id' => 823,
+		];
 
 		$file2UserShareOwnerExpected = [
 			'id' => 823,
@@ -1158,7 +1196,7 @@ class ShareAPIControllerTest extends TestCase {
 		$data = [
 			[
 				[
-					'path' => $file1,
+					'node' => $file1,
 				],
 				[
 					'file1' => [
@@ -1173,7 +1211,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $file1,
+					'node' => $file1,
 				],
 				[
 					'file1' => [
@@ -1188,7 +1226,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $file1,
+					'node' => $file1,
 				],
 				[
 					'file1' => [
@@ -1205,7 +1243,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $file1,
+					'node' => $file1,
 				],
 				[
 					'file1' => [
@@ -1220,7 +1258,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $file1,
+					'node' => $file1,
 				],
 				[
 					'file1' => [
@@ -1237,7 +1275,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $file1,
+					'node' => $file1,
 				],
 				[
 					'file1' => [
@@ -1264,7 +1302,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $file1,
+					'node' => $file1,
 				],
 				[
 					'file1' => [
@@ -1295,7 +1333,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1315,7 +1353,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1331,7 +1369,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1347,7 +1385,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1372,7 +1410,7 @@ class ShareAPIControllerTest extends TestCase {
 			// share with others would be included too in the results.
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1388,7 +1426,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1406,7 +1444,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1434,7 +1472,7 @@ class ShareAPIControllerTest extends TestCase {
 			],
 			[
 				[
-					'path' => $folder,
+					'node' => $folder,
 					'subfiles' => 'true',
 				],
 				[
@@ -1469,8 +1507,80 @@ class ShareAPIControllerTest extends TestCase {
 		return $data;
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetShares')]
+	private function mockSimpleNode(string $class, array $methods): MockObject {
+		$node = $this->createMock($class);
+		foreach ($methods as $method => $return) {
+			if ($method === 'getDirectoryListing') {
+				$return = array_map(
+					fn ($nodeParams) => $this->mockSimpleNode(...$nodeParams),
+					$return
+				);
+			}
+			$node->method($method)->willReturn($return);
+		}
+		return $node;
+	}
+
+	#[DataProvider('dataGetShares')]
 	public function testGetShares(array $getSharesParameters, array $shares, array $extraShareTypes, array $expected): void {
+		$shares = array_map(
+			fn ($sharesByType) => array_map(
+				fn ($shareList) => array_map(
+					function (array $shareParams): IShare {
+						$share = Server::get(IManager::class)->newShare();
+						$share->setShareType($shareParams['type'])
+							->setSharedBy($shareParams['sharedBy'])
+							->setShareOwner($shareParams['owner'])
+							->setPermissions(Constants::PERMISSION_READ)
+							->setId($shareParams['id']);
+						if (isset($shareParams['sharedWith'])) {
+							$share->setSharedWith($shareParams['sharedWith']);
+						}
+						if (isset($shareParams['sharedWithDisplayName'])) {
+							$share->setSharedWithDisplayName($shareParams['sharedWithDisplayName']);
+						}
+						if (isset($shareParams['sharedWithAvatar'])) {
+							$share->setSharedWithAvatar($shareParams['sharedWithAvatar']);
+						}
+						if (isset($shareParams['attributes'])) {
+							$shareAttributes = $this->createMock(IShareAttributes::class);
+							$shareAttributes->method('toArray')->willReturn($shareParams['attributes']);
+							$shareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(true);
+							$share->setAttributes($shareAttributes);
+
+							$expects['attributes'] = \json_encode($shareParams['attributes']);
+						}
+						if (isset($shareParams['node'])) {
+							$node = $this->mockSimpleNode(...$shareParams['node']);
+							$share->setNode($node);
+						}
+						if (isset($shareParams['note'])) {
+							$share->setNote($shareParams['note']);
+						}
+						if (isset($shareParams['expirationDate'])) {
+							$share->setExpirationDate($shareParams['expirationDate']);
+						}
+						if (isset($shareParams['token'])) {
+							$share->setToken($shareParams['token']);
+						}
+						if (isset($shareParams['label'])) {
+							$share->setLabel($shareParams['label']);
+						}
+						if (isset($shareParams['password'])) {
+							$share->setPassword($shareParams['password']);
+						}
+						if (isset($shareParams['sendPasswordByTalk'])) {
+							$share->setSendPasswordByTalk($shareParams['sendPasswordByTalk']);
+						}
+						return $share;
+					},
+					$shareList
+				),
+				$sharesByType
+			),
+			$shares
+		);
+
 		/** @var ShareAPIController&MockObject $ocs */
 		$ocs = $this->getMockBuilder(ShareAPIController::class)
 			->setConstructorArgs([
@@ -1512,7 +1622,7 @@ class ShareAPIControllerTest extends TestCase {
 		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$userFolder->method('get')
 			->with('path')
-			->willReturn($getSharesParameters['path']);
+			->willReturn($this->mockSimpleNode(...$getSharesParameters['node']));
 
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
@@ -1587,7 +1697,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertFalse($this->invokePrivate($this->ocs, 'canAccessShare', [$share]));
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCanAccessShareWithPermissions')]
+	#[DataProvider('dataCanAccessShareWithPermissions')]
 	public function testCanAccessShareWithPermissions(int $permissions, bool $expected): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_USER);
@@ -1625,7 +1735,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCanAccessShareAsGroupMember')]
+	#[DataProvider('dataCanAccessShareAsGroupMember')]
 	public function testCanAccessShareAsGroupMember(string $group, bool $expected): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_GROUP);
@@ -1676,41 +1786,25 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	public function dataCanAccessRoomShare() {
-		$result = [];
+	public static function dataCanAccessRoomShare(): array {
+		return [
+			[false, false, false],
+			[false, false, true],
+			[true, true, true],
+			[false, true, false],
+		];
+	}
 
+	#[DataProvider('dataCanAccessRoomShare')]
+	public function testCanAccessRoomShare(
+		bool $expected,
+		bool $helperAvailable,
+		bool $canAccessShareByHelper,
+	): void {
 		$share = $this->createMock(IShare::class);
 		$share->method('getShareType')->willReturn(IShare::TYPE_ROOM);
 		$share->method('getSharedWith')->willReturn('recipientRoom');
 
-		$result[] = [
-			false, $share, false, false
-		];
-
-		$result[] = [
-			false, $share, false, true
-		];
-
-		$result[] = [
-			true, $share, true, true
-		];
-
-		$result[] = [
-			false, $share, true, false
-		];
-
-		return $result;
-	}
-
-	/**
-	 *
-	 * @param bool $expects
-	 * @param IShare $share
-	 * @param bool helperAvailable
-	 * @param bool canAccessShareByHelper
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataCanAccessRoomShare')]
-	public function testCanAccessRoomShare(bool $expected, IShare $share, bool $helperAvailable, bool $canAccessShareByHelper): void {
 		$userFolder = $this->getMockBuilder(Folder::class)->getMock();
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
@@ -2953,7 +3047,7 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertEquals($expected->getData(), $result->getData());
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('publicUploadParamsProvider')]
+	#[DataProvider('publicUploadParamsProvider')]
 	public function testUpdateLinkShareEnablePublicUpload($permissions, $publicUpload, $expireDate, $password): void {
 		$ocs = $this->mockFormatShare();
 
@@ -3012,7 +3106,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('publicLinkValidPermissionsProvider')]
+	#[DataProvider('publicLinkValidPermissionsProvider')]
 	public function testUpdateLinkShareSetCRUDPermissions($permissions): void {
 		$ocs = $this->mockFormatShare();
 
@@ -3065,7 +3159,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('publicLinkInvalidPermissionsProvider1')]
+	#[DataProvider('publicLinkInvalidPermissionsProvider1')]
 	public function testUpdateLinkShareSetInvalidCRUDPermissions1($permissions): void {
 		$this->expectException(OCSBadRequestException::class);
 		$this->expectExceptionMessage('Share must at least have READ or CREATE permissions');
@@ -3080,7 +3174,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('publicLinkInvalidPermissionsProvider2')]
+	#[DataProvider('publicLinkInvalidPermissionsProvider2')]
 	public function testUpdateLinkShareSetInvalidCRUDPermissions2($permissions): void {
 		$this->expectException(OCSBadRequestException::class);
 		$this->expectExceptionMessage('Share must have READ permission if UPDATE or DELETE permission is set');
@@ -3132,7 +3226,7 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('publicUploadParamsProvider')]
+	#[DataProvider('publicUploadParamsProvider')]
 	public function testUpdateLinkSharePublicUploadNotAllowed($permissions, $publicUpload, $expireDate, $password): void {
 		$this->expectException(OCSForbiddenException::class);
 		$this->expectExceptionMessage('Public upload disabled by the administrator');
@@ -3958,81 +4052,47 @@ class ShareAPIControllerTest extends TestCase {
 		$this->assertInstanceOf(DataResponse::class, $result);
 	}
 
-	public function dataFormatShare() {
-		$file = $this->getMockBuilder(File::class)->getMock();
-		$folder = $this->getMockBuilder(Folder::class)->getMock();
-		$parent = $this->getMockBuilder(Folder::class)->getMock();
-		$fileWithPreview = $this->getMockBuilder(File::class)->getMock();
+	public static function dataFormatShare(): array {
+		$owner = ['getDisplayName' => 'ownerDN'];
+		$initiator = ['getDisplayName' => 'initiatorDN'];
+		$recipient = [
+			'getDisplayName' => 'recipientDN',
+			'getSystemEMailAddress' => 'recipient'
+		];
 
-		$file->method('getMimeType')->willReturn('myMimeType');
-		$folder->method('getMimeType')->willReturn('myFolderMimeType');
-		$fileWithPreview->method('getMimeType')->willReturn('mimeWithPreview');
-
-		$mountPoint = $this->createMock(IMountPoint::class);
-		$mountPoint->method('getMountType')->willReturn('');
-		$file->method('getMountPoint')->willReturn($mountPoint);
-		$folder->method('getMountPoint')->willReturn($mountPoint);
-		$fileWithPreview->method('getMountPoint')->willReturn($mountPoint);
-
-		$file->method('getPath')->willReturn('file');
-		$folder->method('getPath')->willReturn('folder');
-		$fileWithPreview->method('getPath')->willReturn('fileWithPreview');
-
-		$parent->method('getId')->willReturn(1);
-		$folder->method('getId')->willReturn(2);
-		$file->method('getId')->willReturn(3);
-		$fileWithPreview->method('getId')->willReturn(4);
-
-		$file->method('getParent')->willReturn($parent);
-		$folder->method('getParent')->willReturn($parent);
-		$fileWithPreview->method('getParent')->willReturn($parent);
-
-		$file->method('getSize')->willReturn(123456);
-		$folder->method('getSize')->willReturn(123456);
-		$fileWithPreview->method('getSize')->willReturn(123456);
-		$file->method('getMTime')->willReturn(1234567890);
-		$folder->method('getMTime')->willReturn(1234567890);
-		$fileWithPreview->method('getMTime')->willReturn(1234567890);
-
-		$cache = $this->getMockBuilder('OCP\Files\Cache\ICache')->getMock();
-		$cache->method('getNumericStorageId')->willReturn(100);
-		$storage = $this->createMock(IStorage::class);
-		$storage->method('getId')->willReturn('storageId');
-		$storage->method('getCache')->willReturn($cache);
-
-		$file->method('getStorage')->willReturn($storage);
-		$folder->method('getStorage')->willReturn($storage);
-		$fileWithPreview->method('getStorage')->willReturn($storage);
-
-
-		$mountPoint = $this->getMockBuilder(IMountPoint::class)->getMock();
-		$mountPoint->method('getMountType')->willReturn('');
-		$file->method('getMountPoint')->willReturn($mountPoint);
-		$folder->method('getMountPoint')->willReturn($mountPoint);
-
-		$owner = $this->getMockBuilder(IUser::class)->getMock();
-		$owner->method('getDisplayName')->willReturn('ownerDN');
-		$initiator = $this->getMockBuilder(IUser::class)->getMock();
-		$initiator->method('getDisplayName')->willReturn('initiatorDN');
-		$recipient = $this->getMockBuilder(IUser::class)->getMock();
-		$recipient->method('getDisplayName')->willReturn('recipientDN');
-		$recipient->method('getSystemEMailAddress')->willReturn('recipient');
-		[$shareAttributes, $shareAttributesReturnJson] = $this->mockShareAttributes();
+		$folder = [
+			'class' => Folder::class,
+			'mimeType' => 'myFolderMimeType',
+			'path' => 'folder',
+			'id' => 2,
+		];
+		$file = [
+			'class' => File::class,
+			'mimeType' => 'myMimeType',
+			'path' => 'file',
+			'id' => 3,
+		];
+		$fileWithPreview = [
+			'class' => File::class,
+			'mimeType' => 'mimeWithPreview',
+			'path' => 'fileWithPreview',
+			'id' => 4,
+		];
 
 		$result = [];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setAttributes($shareAttributes)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_USER,
+			'owner' => 'owner',
+			'sharedWith' => 'recipient',
+			'attributes' => [
+				'scope' => 'permissions',
+				'key' => 'download',
+				'value' => true
+			],
+			'node' => $file,
+			'note' => 'personal note',
+		];
 
 		// User backend down
 		$result[] = [
@@ -4042,7 +4102,6 @@ class ShareAPIControllerTest extends TestCase {
 				'uid_owner' => 'initiator',
 				'displayname_owner' => 'initiator',
 				'permissions' => 1,
-				'attributes' => $shareAttributesReturnJson,
 				'stime' => 946684862,
 				'parent' => null,
 				'expiration' => null,
@@ -4074,7 +4133,9 @@ class ShareAPIControllerTest extends TestCase {
 				'mount-type' => '',
 				'attributes' => '[{"scope":"permissions","key":"download","value":true}]',
 				'item_permissions' => 1,
-			], $share, [], false
+			],
+			$share,
+			[], false
 		];
 		// User backend up
 		$result[] = [
@@ -4084,7 +4145,6 @@ class ShareAPIControllerTest extends TestCase {
 				'uid_owner' => 'initiator',
 				'displayname_owner' => 'initiatorDN',
 				'permissions' => 1,
-				'attributes' => $shareAttributesReturnJson,
 				'stime' => 946684862,
 				'parent' => null,
 				'expiration' => null,
@@ -4123,17 +4183,15 @@ class ShareAPIControllerTest extends TestCase {
 			], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		// Same but no attributes
+		$share = [
+			'type' => IShare::TYPE_USER,
+			'owner' => 'owner',
+			'sharedWith' => 'recipient',
+			'node' => $file,
+			'note' => 'personal note',
+		];
+
 		// User backend down
 		$result[] = [
 			[
@@ -4177,17 +4235,8 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		$share['owner'] = 'currentUser';
+
 		// User backend down
 		$result[] = [
 			[
@@ -4232,18 +4281,13 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// with existing group
-
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_GROUP)
-			->setSharedWith('recipientGroup')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_GROUP,
+			'owner' => 'owner',
+			'sharedWith' => 'recipientGroup',
+			'node' => $file,
+			'note' => 'personal note',
+		];
 
 		$result[] = [
 			[
@@ -4287,17 +4331,8 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// with unknown group / no group backend
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_GROUP)
-			->setSharedWith('recipientGroup2')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		$share['sharedWith'] = 'recipientGroup2';
+
 		$result[] = [
 			[
 				'id' => '42',
@@ -4338,20 +4373,16 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_LINK)
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setPassword('mypassword')
-			->setExpirationDate(new \DateTime('2001-01-02T00:00:00'))
-			->setToken('myToken')
-			->setNote('personal note')
-			->setLabel('new link share')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_LINK,
+			'owner' => 'owner',
+			'node' => $file,
+			'note' => 'personal note',
+			'password' => 'mypassword',
+			'expirationDate' => new \DateTime('2001-01-02T00:00:00'),
+			'token' => 'myToken',
+			'label' => 'new link share',
+		];
 
 		$result[] = [
 			[
@@ -4397,21 +4428,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_LINK)
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setPassword('mypassword')
-			->setSendPasswordByTalk(true)
-			->setExpirationDate(new \DateTime('2001-01-02T00:00:00'))
-			->setToken('myToken')
-			->setNote('personal note')
-			->setLabel('new link share')
-			->setId(42);
+		$share['sendPasswordByTalk'] = true;
 
 		$result[] = [
 			[
@@ -4456,18 +4473,14 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_REMOTE)
-			->setSharedBy('initiator')
-			->setSharedWith('user@server.com')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setExpirationDate(new \DateTime('2001-02-03T04:05:06'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_REMOTE,
+			'owner' => 'owner',
+			'sharedWith' => 'user@server.com',
+			'node' => $folder,
+			'note' => 'personal note',
+			'expirationDate' => new \DateTime('2001-02-03T04:05:06'),
+		];
 
 		$result[] = [
 			[
@@ -4510,18 +4523,14 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_REMOTE_GROUP)
-			->setSharedBy('initiator')
-			->setSharedWith('user@server.com')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setExpirationDate(new \DateTime('2001-02-03T04:05:06'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_REMOTE_GROUP,
+			'owner' => 'owner',
+			'sharedWith' => 'user@server.com',
+			'node' => $folder,
+			'note' => 'personal note',
+			'expirationDate' => new \DateTime('2001-02-03T04:05:06'),
+		];
 
 		$result[] = [
 			[
@@ -4565,18 +4574,14 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Circle with id, display name and avatar set by the Circles app
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_CIRCLE)
-			->setSharedBy('initiator')
-			->setSharedWith('Circle (Public circle, circleOwner) [4815162342]')
-			->setSharedWithDisplayName('The display name')
-			->setSharedWithAvatar('path/to/the/avatar')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_CIRCLE,
+			'owner' => 'owner',
+			'sharedWith' => 'Circle (Public circle, circleOwner) [4815162342]',
+			'sharedWithDisplayName' => 'The display name',
+			'sharedWithAvatar' => 'path/to/the/avatar',
+			'node' => $folder,
+		];
 
 		$result[] = [
 			[
@@ -4621,16 +4626,12 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Circle with id set by the Circles app
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_CIRCLE)
-			->setSharedBy('initiator')
-			->setSharedWith('Circle (Public circle, circleOwner) [4815162342]')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_CIRCLE,
+			'owner' => 'owner',
+			'sharedWith' => 'Circle (Public circle, circleOwner) [4815162342]',
+			'node' => $folder,
+		];
 
 		$result[] = [
 			[
@@ -4674,16 +4675,12 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Circle with id not set by the Circles app
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_CIRCLE)
-			->setSharedBy('initiator')
-			->setSharedWith('Circle (Public circle, circleOwner)')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_CIRCLE,
+			'owner' => 'owner',
+			'sharedWith' => 'Circle (Public circle, circleOwner)',
+			'node' => $folder,
+		];
 
 		$result[] = [
 			[
@@ -4726,32 +4723,25 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_USER)
-			->setSharedBy('initiator')
-			->setSharedWith('recipient')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		// No node
+		$share = [
+			'type' => IShare::TYPE_USER,
+			'owner' => 'owner',
+			'sharedWith' => 'recipient',
+			'note' => 'personal note',
+		];
 
 		$result[] = [
 			[], $share, [], true
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_EMAIL)
-			->setSharedBy('initiator')
-			->setSharedWith('user@server.com')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setId(42)
-			->setPassword('password');
+		$share = [
+			'type' => IShare::TYPE_EMAIL,
+			'owner' => 'owner',
+			'sharedWith' => 'user@server.com',
+			'node' => $folder,
+			'password' => 'password',
+		];
 
 		$result[] = [
 			[
@@ -4796,18 +4786,7 @@ class ShareAPIControllerTest extends TestCase {
 			], $share, [], false
 		];
 
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_EMAIL)
-			->setSharedBy('initiator')
-			->setSharedWith('user@server.com')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($folder)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setId(42)
-			->setPassword('password')
-			->setSendPasswordByTalk(true);
+		$share['sendPasswordByTalk'] = true;
 
 		$result[] = [
 			[
@@ -4853,17 +4832,13 @@ class ShareAPIControllerTest extends TestCase {
 		];
 
 		// Preview is available
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_USER)
-			->setSharedWith('recipient')
-			->setSharedBy('initiator')
-			->setShareOwner('currentUser')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($fileWithPreview)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
+		$share = [
+			'type' => IShare::TYPE_USER,
+			'owner' => 'currentUser',
+			'sharedWith' => 'recipient',
+			'node' => $fileWithPreview,
+			'note' => 'personal note',
+		];
 
 		$result[] = [
 			[
@@ -4909,15 +4884,97 @@ class ShareAPIControllerTest extends TestCase {
 		return $result;
 	}
 
-	/**
-	 *
-	 * @param array $expects
-	 * @param IShare $share
-	 * @param array $users
-	 * @param $exception
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFormatShare')]
-	public function testFormatShare(array $expects, IShare $share, array $users, $exception): void {
+	#[DataProvider('dataFormatShare')]
+	public function testFormatShare(
+		array $expects,
+		array $shareParams,
+		array $users,
+		bool $exception,
+	): void {
+		$users = array_map(
+			function ($user) {
+				$mock = $this->createMock(IUser::class);
+				foreach ($user[1] as $method => $return) {
+					$mock->method($method)->willReturn($return);
+				}
+				return [$user[0],$mock];
+			},
+			$users
+		);
+
+		$share = Server::get(IManager::class)->newShare();
+		$share->setShareType($shareParams['type'])
+			->setSharedBy('initiator')
+			->setShareOwner($shareParams['owner'])
+			->setPermissions(Constants::PERMISSION_READ)
+			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
+			->setTarget('myTarget')
+			->setId(42);
+		if (isset($shareParams['sharedWith'])) {
+			$share->setSharedWith($shareParams['sharedWith']);
+		}
+		if (isset($shareParams['sharedWithDisplayName'])) {
+			$share->setSharedWithDisplayName($shareParams['sharedWithDisplayName']);
+		}
+		if (isset($shareParams['sharedWithAvatar'])) {
+			$share->setSharedWithAvatar($shareParams['sharedWithAvatar']);
+		}
+		if (isset($shareParams['attributes'])) {
+			$shareAttributes = $this->createMock(IShareAttributes::class);
+			$shareAttributes->method('toArray')->willReturn($shareParams['attributes']);
+			$shareAttributes->method('getAttribute')->with('permissions', 'download')->willReturn(true);
+			$share->setAttributes($shareAttributes);
+
+			$expects['attributes'] = \json_encode($shareParams['attributes']);
+		}
+		if (isset($shareParams['node'])) {
+			$node = $this->createMock($shareParams['node']['class']);
+
+			$node->method('getMimeType')->willReturn($shareParams['node']['mimeType']);
+
+			$mountPoint = $this->createMock(IMountPoint::class);
+			$mountPoint->method('getMountType')->willReturn('');
+			$node->method('getMountPoint')->willReturn($mountPoint);
+
+			$node->method('getPath')->willReturn($shareParams['node']['path']);
+			$node->method('getId')->willReturn($shareParams['node']['id']);
+
+			$parent = $this->createMock(Folder::class);
+			$parent->method('getId')->willReturn(1);
+			$node->method('getParent')->willReturn($parent);
+
+			$node->method('getSize')->willReturn(123456);
+			$node->method('getMTime')->willReturn(1234567890);
+
+			$cache = $this->createMock(ICache::class);
+			$cache->method('getNumericStorageId')->willReturn(100);
+			$storage = $this->createMock(IStorage::class);
+			$storage->method('getId')->willReturn('storageId');
+			$storage->method('getCache')->willReturn($cache);
+
+			$node->method('getStorage')->willReturn($storage);
+
+			$share->setNode($node);
+		}
+		if (isset($shareParams['note'])) {
+			$share->setNote($shareParams['note']);
+		}
+		if (isset($shareParams['expirationDate'])) {
+			$share->setExpirationDate($shareParams['expirationDate']);
+		}
+		if (isset($shareParams['token'])) {
+			$share->setToken($shareParams['token']);
+		}
+		if (isset($shareParams['label'])) {
+			$share->setLabel($shareParams['label']);
+		}
+		if (isset($shareParams['password'])) {
+			$share->setPassword($shareParams['password']);
+		}
+		if (isset($shareParams['sendPasswordByTalk'])) {
+			$share->setSendPasswordByTalk($shareParams['sendPasswordByTalk']);
+		}
+
 		$this->userManager->method('get')->willReturnMap($users);
 
 		$recipientGroup = $this->createMock(IGroup::class);
@@ -4989,47 +5046,8 @@ class ShareAPIControllerTest extends TestCase {
 		}
 	}
 
-	public function dataFormatRoomShare() {
-		$file = $this->getMockBuilder(File::class)->getMock();
-		$parent = $this->getMockBuilder(Folder::class)->getMock();
-
-		$file->method('getMimeType')->willReturn('myMimeType');
-
-		$file->method('getPath')->willReturn('file');
-
-		$parent->method('getId')->willReturn(1);
-		$file->method('getId')->willReturn(3);
-
-		$file->method('getParent')->willReturn($parent);
-
-		$file->method('getSize')->willReturn(123456);
-		$file->method('getMTime')->willReturn(1234567890);
-
-		$mountPoint = $this->getMockBuilder(IMountPoint::class)->getMock();
-		$mountPoint->method('getMountType')->willReturn('');
-		$file->method('getMountPoint')->willReturn($mountPoint);
-
-		$cache = $this->getMockBuilder('OCP\Files\Cache\ICache')->getMock();
-		$cache->method('getNumericStorageId')->willReturn(100);
-		$storage = $this->createMock(IStorage::class);
-		$storage->method('getId')->willReturn('storageId');
-		$storage->method('getCache')->willReturn($cache);
-
-		$file->method('getStorage')->willReturn($storage);
-
+	public static function dataFormatRoomShare(): array {
 		$result = [];
-
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_ROOM)
-			->setSharedWith('recipientRoom')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
 
 		$result[] = [
 			[
@@ -5068,20 +5086,8 @@ class ShareAPIControllerTest extends TestCase {
 				'mount-type' => '',
 				'attributes' => null,
 				'item_permissions' => 1,
-			], $share, false, []
+			], false, []
 		];
-
-		$share = Server::get(IManager::class)->newShare();
-		$share->setShareType(IShare::TYPE_ROOM)
-			->setSharedWith('recipientRoom')
-			->setSharedBy('initiator')
-			->setShareOwner('owner')
-			->setPermissions(Constants::PERMISSION_READ)
-			->setNode($file)
-			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
-			->setTarget('myTarget')
-			->setNote('personal note')
-			->setId(42);
 
 		$result[] = [
 			[
@@ -5120,7 +5126,7 @@ class ShareAPIControllerTest extends TestCase {
 				'mount-type' => '',
 				'attributes' => null,
 				'item_permissions' => 9,
-			], $share, true, [
+			], true, [
 				'share_with_displayname' => 'recipientRoomName'
 			]
 		];
@@ -5135,8 +5141,45 @@ class ShareAPIControllerTest extends TestCase {
 	 * @param bool $helperAvailable
 	 * @param array $formatShareByHelper
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataFormatRoomShare')]
-	public function testFormatRoomShare(array $expects, IShare $share, bool $helperAvailable, array $formatShareByHelper): void {
+	#[DataProvider('dataFormatRoomShare')]
+	public function testFormatRoomShare(array $expects, bool $helperAvailable, array $formatShareByHelper): void {
+		$file = $this->createMock(File::class);
+
+		$file->method('getMimeType')->willReturn('myMimeType');
+		$file->method('getPath')->willReturn('file');
+		$file->method('getId')->willReturn(3);
+
+		$parent = $this->createMock(Folder::class);
+		$parent->method('getId')->willReturn(1);
+		$file->method('getParent')->willReturn($parent);
+
+		$file->method('getSize')->willReturn(123456);
+		$file->method('getMTime')->willReturn(1234567890);
+
+		$mountPoint = $this->createMock(IMountPoint::class);
+		$mountPoint->method('getMountType')->willReturn('');
+		$file->method('getMountPoint')->willReturn($mountPoint);
+
+		$cache = $this->createMock(ICache::class);
+		$cache->method('getNumericStorageId')->willReturn(100);
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('getId')->willReturn('storageId');
+		$storage->method('getCache')->willReturn($cache);
+
+		$file->method('getStorage')->willReturn($storage);
+
+		$share = Server::get(IManager::class)->newShare();
+		$share->setShareType(IShare::TYPE_ROOM)
+			->setSharedWith('recipientRoom')
+			->setSharedBy('initiator')
+			->setShareOwner('owner')
+			->setPermissions(Constants::PERMISSION_READ)
+			->setNode($file)
+			->setShareTime(new \DateTime('2000-01-01T00:01:02'))
+			->setTarget('myTarget')
+			->setNote('personal note')
+			->setId(42);
+
 		$this->rootFolder->method('getUserFolder')
 			->with($this->currentUser)
 			->willReturnSelf();
@@ -5252,26 +5295,10 @@ class ShareAPIControllerTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider trustedServerProvider
-	 */
+	#[DataProvider('trustedServerProvider')]
 	public function testFormatShareWithFederatedShare(bool $isKnownServer, bool $isTrusted): void {
 		$nodeId = 12;
 		$nodePath = '/test.txt';
-		$share = $this->createShare(
-			1,
-			IShare::TYPE_REMOTE,
-			'recipient@remoteserver.com', // shared with
-			'sender@testserver.com',      // shared by
-			'shareOwner',                 // share owner
-			$nodePath,                  // path
-			Constants::PERMISSION_READ,
-			time(),
-			null,
-			null,
-			$nodePath,
-			$nodeId
-		);
 
 		$node = $this->createMock(File::class);
 		$node->method('getId')->willReturn($nodeId);
@@ -5292,6 +5319,21 @@ class ShareAPIControllerTest extends TestCase {
 		$node->method('getParent')->willReturn($parent);
 		$node->method('getSize')->willReturn(1234);
 		$node->method('getMTime')->willReturn(1234567890);
+
+		$share = $this->createShare(
+			1,
+			IShare::TYPE_REMOTE,
+			'recipient@remoteserver.com', // shared with
+			'sender@testserver.com',      // shared by
+			'shareOwner',                 // share owner
+			$node,
+			Constants::PERMISSION_READ,
+			time(),
+			null,
+			2,
+			$nodePath,
+			$nodeId
+		);
 
 		$this->previewManager->method('isAvailable')->with($node)->willReturn(false);
 
@@ -5320,20 +5362,6 @@ class ShareAPIControllerTest extends TestCase {
 	public function testFormatShareWithFederatedShareWithAtInUsername(): void {
 		$nodeId = 12;
 		$nodePath = '/test.txt';
-		$share = $this->createShare(
-			1,
-			IShare::TYPE_REMOTE,
-			'recipient@domain.com@remoteserver.com',
-			'sender@testserver.com',
-			'shareOwner',
-			$nodePath,
-			Constants::PERMISSION_READ,
-			time(),
-			null,
-			null,
-			$nodePath,
-			$nodeId
-		);
 
 		$node = $this->createMock(File::class);
 		$node->method('getId')->willReturn($nodeId);
@@ -5354,6 +5382,21 @@ class ShareAPIControllerTest extends TestCase {
 		$node->method('getParent')->willReturn($parent);
 		$node->method('getSize')->willReturn(1234);
 		$node->method('getMTime')->willReturn(1234567890);
+
+		$share = $this->createShare(
+			1,
+			IShare::TYPE_REMOTE,
+			'recipient@domain.com@remoteserver.com',
+			'sender@testserver.com',
+			'shareOwner',
+			$node,
+			Constants::PERMISSION_READ,
+			time(),
+			null,
+			2,
+			$nodePath,
+			$nodeId
+		);
 
 		$this->previewManager->method('isAvailable')->with($node)->willReturn(false);
 

--- a/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
@@ -4,6 +4,7 @@
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
+
 namespace OCA\Files_Sharing\Tests\Middleware;
 
 use OCA\Files_Sharing\Controller\ShareAPIController;
@@ -13,18 +14,16 @@ use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\IL10N;
 use OCP\Share\IManager;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * @package OCA\Files_Sharing\Middleware\SharingCheckMiddleware
  */
 class OCSShareAPIMiddlewareTest extends \Test\TestCase {
+	private IManager&MockObject $shareManager;
+	private IL10N&MockObject $l;
 
-	/** @var IManager|\PHPUnit\Framework\MockObject\MockObject */
-	private $shareManager;
-	/** @var IL10N */
-	private $l;
-	/** @var OCSShareAPIMiddleware */
-	private $middleware;
+	private OCSShareAPIMiddleware $middleware;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -37,49 +36,44 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 		$this->middleware = new OCSShareAPIMiddleware($this->shareManager, $this->l);
 	}
 
-	public function dataBeforeController() {
+	public static function dataBeforeController() {
 		return [
 			[
-				$this->createMock(Controller::class),
+				Controller::class,
 				false,
 				false
 			],
 			[
-				$this->createMock(Controller::class),
+				Controller::class,
 				true,
 				false
 			],
 			[
-				$this->createMock(OCSController::class),
+				OCSController::class,
 				false,
 				false
 			],
 			[
-				$this->createMock(OCSController::class),
+				OCSController::class,
 				true,
 				false
 			],
 			[
-				$this->createMock(ShareAPIController::class),
+				ShareAPIController::class,
 				false,
 				true
 			],
 			[
-				$this->createMock(ShareAPIController::class),
+				ShareAPIController::class,
 				true,
 				false
 			],
 		];
 	}
 
-	/**
-	 *
-	 * @param Controller $controller
-	 * @param bool $enabled
-	 * @param bool $exception
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataBeforeController')]
-	public function testBeforeController(Controller $controller, $enabled, $exception): void {
+	public function testBeforeController(string $controllerClass, bool $enabled, bool $exception): void {
+		$controller = $this->createMock($controllerClass);
 		$this->shareManager->method('shareApiEnabled')->willReturn($enabled);
 
 		try {
@@ -93,24 +87,20 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 	public function dataAfterController() {
 		return [
 			[
-				$this->createMock(Controller::class),
+				Controller::class,
 			],
 			[
-				$this->createMock(OCSController::class),
+				OCSController::class,
 			],
 			[
-				$this->createMock(ShareAPIController::class),
+				ShareAPIController::class,
 			],
 		];
 	}
 
-	/**
-	 *
-	 * @param Controller $controller
-	 * @param bool $called
-	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterController')]
-	public function testAfterController(Controller $controller): void {
+	public function testAfterController(string $controllerClass): void {
+		$controller = $this->createMock($controllerClass);
 		if ($controller instanceof ShareAPIController) {
 			$controller->expects($this->once())->method('cleanup');
 		}

--- a/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
+++ b/apps/files_sharing/tests/Middleware/OCSShareAPIMiddlewareTest.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\OCS\OCSNotFoundException;
 use OCP\AppFramework\OCSController;
 use OCP\IL10N;
 use OCP\Share\IManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -71,7 +72,7 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataBeforeController')]
+	#[DataProvider('dataBeforeController')]
 	public function testBeforeController(string $controllerClass, bool $enabled, bool $exception): void {
 		$controller = $this->createMock($controllerClass);
 		$this->shareManager->method('shareApiEnabled')->willReturn($enabled);
@@ -84,7 +85,7 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 		}
 	}
 
-	public function dataAfterController() {
+	public static function dataAfterController(): array {
 		return [
 			[
 				Controller::class,
@@ -98,7 +99,7 @@ class OCSShareAPIMiddlewareTest extends \Test\TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataAfterController')]
+	#[DataProvider('dataAfterController')]
 	public function testAfterController(string $controllerClass): void {
 		$controller = $this->createMock($controllerClass);
 		if ($controller instanceof ShareAPIController) {

--- a/apps/theming/tests/Settings/PersonalTest.php
+++ b/apps/theming/tests/Settings/PersonalTest.php
@@ -29,6 +29,7 @@ use OCP\IL10N;
 use OCP\INavigationManager;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -69,28 +70,30 @@ class PersonalTest extends TestCase {
 		);
 	}
 
-	public function dataTestGetForm(): array {
+	public static function dataTestGetForm(): array {
 		return [
 			['', [
-				$this->formatThemeForm('default'),
-				$this->formatThemeForm('light'),
-				$this->formatThemeForm('dark'),
-				$this->formatThemeForm('light-highcontrast'),
-				$this->formatThemeForm('dark-highcontrast'),
-				$this->formatThemeForm('opendyslexic'),
+				'default',
+				'light',
+				'dark',
+				'light-highcontrast',
+				'dark-highcontrast',
+				'opendyslexic',
 			]],
 			['dark', [
-				$this->formatThemeForm('dark'),
-				$this->formatThemeForm('opendyslexic'),
+				'dark',
+				'opendyslexic',
 			]],
 		];
 	}
 
-	/**
-	 * @param string[] $enabledThemes
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataTestGetForm')]
+	#[DataProvider('dataTestGetForm')]
 	public function testGetForm(string $enforcedTheme, array $themesState): void {
+		$themesState = array_map(
+			$this->formatThemeForm(...),
+			$themesState
+		);
+
 		$this->config->expects($this->once())
 			->method('getSystemValueString')
 			->with('enforce_theme', '')

--- a/autotest.sh
+++ b/autotest.sh
@@ -396,8 +396,8 @@ function execute_tests {
 		echo "No coverage"
 	fi
 
-	echo "$PHPUNIT" --fail-on-warning --fail-on-risky --display-deprecations --display-phpunit-deprecations --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-	"$PHPUNIT" --fail-on-warning --fail-on-risky --display-deprecations --display-phpunit-deprecations --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	echo "$PHPUNIT" --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	"$PHPUNIT" --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
 	RESULT=$?
 
 	if [ "$PRIMARY_STORAGE_CONFIG" == "swift" ] ; then

--- a/autotest.sh
+++ b/autotest.sh
@@ -396,8 +396,8 @@ function execute_tests {
 		echo "No coverage"
 	fi
 
-	echo "$PHPUNIT" --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
-	"$PHPUNIT" --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	echo "$PHPUNIT" --fail-on-warning --fail-on-risky --display-deprecations --display-phpunit-deprecations --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
+	"$PHPUNIT" --fail-on-warning --fail-on-risky --display-deprecations --display-phpunit-deprecations --colors=always --configuration phpunit-autotest.xml $GROUP $COVER --log-junit "autotest-results-$DB.xml" "$2" "$3"
 	RESULT=$?
 
 	if [ "$PRIMARY_STORAGE_CONFIG" == "swift" ] ; then

--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,9 @@
 			"Composer\\Config::disableProcessTimeout",
 			"PHP_CLI_SERVER_WORKERS=${NEXTCLOUD_WORKERS:=4} php -S ${NEXTCLOUD_HOST:=localhost}:${NEXTCLOUD_PORT:=8080} -t ./"
 		],
-		"test": "phpunit --colors=always --configuration tests/phpunit-autotest.xml",
+		"test": "phpunit --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration tests/phpunit-autotest.xml",
 		"test:db": "@composer run test -- --group DB,SLOWDB",
-		"test:files_external": "phpunit --colors=always --configuration tests/phpunit-autotest-external.xml",
+		"test:files_external": "phpunit --fail-on-warning --fail-on-risky --display-warnings --display-deprecations --display-phpunit-deprecations --colors=always --configuration tests/phpunit-autotest-external.xml",
 		"rector": "rector --config=build/rector.php && composer cs:fix",
 		"openapi": "./build/openapi-checker.sh"
 	},

--- a/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/GroupPluginTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -16,32 +18,23 @@ use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Share\IShare;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class GroupPluginTest extends TestCase {
-	/** @var IConfig|\PHPUnit\Framework\MockObject\MockObject */
-	protected $config;
+	private IConfig&MockObject $config;
+	private IGroupManager&MockObject $groupManager;
+	private IUserSession&MockObject $session;
+	private IUser&MockObject $user;
 
-	/** @var IGroupManager|\PHPUnit\Framework\MockObject\MockObject */
-	protected $groupManager;
-
-	/** @var IUserSession|\PHPUnit\Framework\MockObject\MockObject */
-	protected $session;
-
-	/** @var ISearchResult */
-	protected $searchResult;
+	protected ISearchResult $searchResult;
 
 	/** @var GroupPlugin */
 	protected $plugin;
 
-	/** @var int */
-	protected $limit = 2;
-
-	/** @var int */
-	protected $offset = 0;
-
-	/** @var IUser|\PHPUnit\Framework\MockObject\MockObject */
-	protected $user;
+	protected int $limit = 2;
+	protected int $offset = 0;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -57,7 +50,7 @@ class GroupPluginTest extends TestCase {
 		$this->user = $this->getUserMock('admin', 'Administrator');
 	}
 
-	public function instantiatePlugin() {
+	public function instantiatePlugin(): void {
 		// cannot be done within setUp, because dependent mocks needs to be set
 		// up with configuration etc. first
 		$this->plugin = new GroupPlugin(
@@ -67,7 +60,7 @@ class GroupPluginTest extends TestCase {
 		);
 	}
 
-	public function getUserMock($uid, $displayName) {
+	public function getUserMock(string $uid, string $displayName): IUser&MockObject {
 		$user = $this->createMock(IUser::class);
 
 		$user->expects($this->any())
@@ -81,13 +74,7 @@ class GroupPluginTest extends TestCase {
 		return $user;
 	}
 
-	/**
-	 * @param string $gid
-	 * @param null $displayName
-	 * @param bool $hide
-	 * @return IGroup|\PHPUnit\Framework\MockObject\MockObject
-	 */
-	protected function getGroupMock($gid, $displayName = null, $hide = false) {
+	protected function getGroupMock(string $gid, ?string $displayName = null, bool $hide = false): IGroup&MockObject {
 		$group = $this->createMock(IGroup::class);
 
 		$group->expects($this->any())
@@ -109,7 +96,7 @@ class GroupPluginTest extends TestCase {
 		return $group;
 	}
 
-	public function dataGetGroups(): array {
+	public static function dataGetGroups(): array {
 		return [
 			['test', false, true, false, [], [], [], [], true, false],
 			['test', false, false, false, [], [], [], [], true, false],
@@ -118,7 +105,7 @@ class GroupPluginTest extends TestCase {
 			// group without display name
 			[
 				'test', false, true, false,
-				[$this->getGroupMock('test1')],
+				[['test1']],
 				[],
 				[],
 				[['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']]],
@@ -128,7 +115,7 @@ class GroupPluginTest extends TestCase {
 			// group with display name, search by id
 			[
 				'test', false, true, false,
-				[$this->getGroupMock('test1', 'Test One')],
+				[['test1', 'Test One']],
 				[],
 				[],
 				[['label' => 'Test One', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']]],
@@ -138,7 +125,7 @@ class GroupPluginTest extends TestCase {
 			// group with display name, search by display name
 			[
 				'one', false, true, false,
-				[$this->getGroupMock('test1', 'Test One')],
+				[['test1', 'Test One']],
 				[],
 				[],
 				[['label' => 'Test One', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']]],
@@ -148,7 +135,7 @@ class GroupPluginTest extends TestCase {
 			// group with display name, search by display name, exact expected
 			[
 				'Test One', false, true, false,
-				[$this->getGroupMock('test1', 'Test One')],
+				[['test1', 'Test One']],
 				[],
 				[['label' => 'Test One', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']]],
 				[],
@@ -157,7 +144,7 @@ class GroupPluginTest extends TestCase {
 			],
 			[
 				'test', false, false, false,
-				[$this->getGroupMock('test1')],
+				[['test1']],
 				[],
 				[],
 				[],
@@ -167,8 +154,8 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', false, true, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
 				[],
 				[['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']]],
@@ -179,8 +166,8 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', false, false, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
 				[],
 				[['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']]],
@@ -191,8 +178,8 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', false, true, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
 				[],
 				[],
@@ -201,25 +188,25 @@ class GroupPluginTest extends TestCase {
 					['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']],
 				],
 				false,
-				null,
+				false,
 			],
 			[
 				'test', false, false, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
 				[],
 				[],
 				[],
 				true,
-				null,
+				false,
 			],
 			[
 				'test', false, true, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
 				[],
 				[
@@ -230,13 +217,13 @@ class GroupPluginTest extends TestCase {
 					['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']],
 				],
 				false,
-				$this->getGroupMock('test'),
+				['test'],
 			],
 			[
 				'test', false, false, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
 				[],
 				[
@@ -244,17 +231,17 @@ class GroupPluginTest extends TestCase {
 				],
 				[],
 				true,
-				$this->getGroupMock('test'),
+				['test'],
 			],
 			['test', true, true, false, [], [], [], [], true, false],
 			['test', true, false, false, [], [], [], [], true, false],
 			[
 				'test', true, true, false,
 				[
-					$this->getGroupMock('test1'),
-					$this->getGroupMock('test2'),
+					['test1'],
+					['test2'],
 				],
-				[$this->getGroupMock('test1')],
+				[['test1']],
 				[],
 				[['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']]],
 				false,
@@ -263,10 +250,10 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, false, false,
 				[
-					$this->getGroupMock('test1'),
-					$this->getGroupMock('test2'),
+					['test1'],
+					['test2'],
 				],
-				[$this->getGroupMock('test1')],
+				[['test1']],
 				[],
 				[],
 				true,
@@ -275,10 +262,10 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, true, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
-				[$this->getGroupMock('test')],
+				[['test']],
 				[['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']]],
 				[],
 				false,
@@ -287,10 +274,10 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, false, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
-				[$this->getGroupMock('test')],
+				[['test']],
 				[['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']]],
 				[],
 				true,
@@ -299,10 +286,10 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, true, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
-				[$this->getGroupMock('test1')],
+				[['test1']],
 				[],
 				[['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']]],
 				false,
@@ -311,10 +298,10 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, false, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
-				[$this->getGroupMock('test1')],
+				[['test1']],
 				[],
 				[],
 				true,
@@ -323,10 +310,10 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, true, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
-				[$this->getGroupMock('test'), $this->getGroupMock('test0'), $this->getGroupMock('test1')],
+				[['test'], ['test0'], ['test1']],
 				[['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']]],
 				[['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']]],
 				false,
@@ -335,10 +322,10 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, false, false,
 				[
-					$this->getGroupMock('test'),
-					$this->getGroupMock('test1'),
+					['test'],
+					['test1'],
 				],
-				[$this->getGroupMock('test'), $this->getGroupMock('test0'), $this->getGroupMock('test1')],
+				[['test'], ['test0'], ['test1']],
 				[['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']]],
 				[],
 				true,
@@ -347,37 +334,37 @@ class GroupPluginTest extends TestCase {
 			[
 				'test', true, true, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
-				[$this->getGroupMock('test'), $this->getGroupMock('test0'), $this->getGroupMock('test1')],
+				[['test'], ['test0'], ['test1']],
 				[],
 				[
 					['label' => 'test0', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test0']],
 					['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']],
 				],
 				false,
-				null,
+				false,
 			],
 			[
 				'test', true, false, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
-				[$this->getGroupMock('test'), $this->getGroupMock('test0'), $this->getGroupMock('test1')],
+				[['test'], ['test0'], ['test1']],
 				[],
 				[],
 				true,
-				null,
+				false,
 			],
 			[
 				'test', true, true, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
-				[$this->getGroupMock('test'), $this->getGroupMock('test0'), $this->getGroupMock('test1')],
+				[['test'], ['test0'], ['test1']],
 				[
 					['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']],
 				],
@@ -386,27 +373,27 @@ class GroupPluginTest extends TestCase {
 					['label' => 'test1', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test1']],
 				],
 				false,
-				$this->getGroupMock('test'),
+				['test'],
 			],
 			[
 				'test', true, false, false,
 				[
-					$this->getGroupMock('test0'),
-					$this->getGroupMock('test1'),
+					['test0'],
+					['test1'],
 				],
-				[$this->getGroupMock('test'), $this->getGroupMock('test0'), $this->getGroupMock('test1')],
+				[['test'], ['test0'], ['test1']],
 				[
 					['label' => 'test', 'value' => ['shareType' => IShare::TYPE_GROUP, 'shareWith' => 'test']],
 				],
 				[],
 				true,
-				$this->getGroupMock('test'),
+				['test'],
 			],
 			[
 				'test', false, false, false,
 				[
-					$this->getGroupMock('test', null, true),
-					$this->getGroupMock('test1'),
+					['test', null, true],
+					['test1'],
 				],
 				[],
 				[],
@@ -417,20 +404,7 @@ class GroupPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 *
-	 * @param string $searchTerm
-	 * @param bool $shareWithGroupOnly
-	 * @param bool $shareeEnumeration
-	 * @param bool $groupSharingDisabled
-	 * @param array $groupResponse
-	 * @param array $userGroupsResponse
-	 * @param array $exactExpected
-	 * @param array $expected
-	 * @param bool $reachedEnd
-	 * @param bool|IGroup $singleGroup
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetGroups')]
+	#[DataProvider('dataGetGroups')]
 	public function testSearch(
 		string $searchTerm,
 		bool $shareWithGroupOnly,
@@ -441,8 +415,19 @@ class GroupPluginTest extends TestCase {
 		array $exactExpected,
 		array $expected,
 		bool $reachedEnd,
-		$singleGroup,
+		array|false $singleGroup,
 	): void {
+		$groupResponse = array_map(
+			fn ($args) => $this->getGroupMock(...$args),
+			$groupResponse
+		);
+		if (is_array($singleGroup)) {
+			$singleGroup = $this->getGroupMock(...$singleGroup);
+		}
+		$userGroupsResponse = array_map(
+			fn ($args) => $this->getGroupMock(...$args),
+			$userGroupsResponse
+		);
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->willReturnCallback(

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -447,12 +447,11 @@ class UserPluginTest extends TestCase {
 						[$this->user->getUID(), 'test1', true],
 						[$this->user->getUID(), 'test2', true],
 					]);
-			} else {
-				$this->userManager->expects($this->once())
-					->method('searchDisplayName')
-					->with($searchTerm, $this->limit, $this->offset)
-					->willReturn($userResponse);
 			}
+			$this->userManager->expects($this->once())
+				->method('searchDisplayName')
+				->with($searchTerm, $this->limit, $this->offset)
+				->willReturn($userResponse);
 		} else {
 			$this->groupManager->method('getUserGroupIds')
 				->with($this->user)
@@ -690,7 +689,7 @@ class UserPluginTest extends TestCase {
 	}
 
 	#[DataProvider('dataSearchEnumeration')]
-	public function testSearchEnumerationLimit($search, $userGroups, $matchingUsers, $result, $mockedSettings): void {
+	public function testSearchEnumerationLimit(string $search, $userGroups, $matchingUsers, $result, $mockedSettings): void {
 		$this->mockConfig($mockedSettings);
 
 		$userResults = [];
@@ -737,10 +736,10 @@ class UserPluginTest extends TestCase {
 			->willReturnCallback(function ($search) use ($matchingUsers) {
 				$users = array_filter(
 					$matchingUsers,
-					fn ($user) => str_contains(strtolower($user['displayName']), strtolower($search))
+					fn ($user) => str_contains(strtolower($user['displayName'] ?? ''), strtolower($search))
 				);
 				return array_map(
-					fn ($user) => $this->getUserMock($user['uid'], $user['displayName']),
+					fn ($user) => $this->getUserMock($user['uid'], $user['displayName'] ?? ''),
 					$users);
 			});
 

--- a/tests/lib/Collaboration/Collaborators/UserPluginTest.php
+++ b/tests/lib/Collaboration/Collaborators/UserPluginTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
@@ -12,34 +14,24 @@ use OC\Collaboration\Collaborators\UserPlugin;
 use OC\KnownUser\KnownUserService;
 use OCP\Collaboration\Collaborators\ISearchResult;
 use OCP\IConfig;
-use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share\IShare;
 use OCP\UserStatus\IManager as IUserStatusManager;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
 class UserPluginTest extends TestCase {
-	/** @var IConfig|MockObject */
-	protected $config;
-
-	/** @var IUserManager|MockObject */
-	protected $userManager;
-
-	/** @var IGroupManager|MockObject */
-	protected $groupManager;
-
-	/** @var IUserSession|MockObject */
-	protected $session;
-
-	/** @var KnownUserService|MockObject */
-	protected $knownUserService;
-
-	/** @var IUserStatusManager|MockObject */
-	protected $userStatusManager;
+	private IConfig&MockObject $config;
+	private IUserManager&MockObject $userManager;
+	private IGroupManager&MockObject $groupManager;
+	private IUserSession&MockObject $session;
+	private KnownUserService&MockObject $knownUserService;
+	private IUserStatusManager&MockObject $userStatusManager;
+	private IUser&MockObject $user;
 
 	/** @var UserPlugin */
 	protected $plugin;
@@ -50,9 +42,6 @@ class UserPluginTest extends TestCase {
 	protected int $limit = 2;
 
 	protected int $offset = 0;
-
-	/** @var IUser|MockObject */
-	protected $user;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -74,7 +63,7 @@ class UserPluginTest extends TestCase {
 		$this->user = $this->getUserMock('admin', 'Administrator');
 	}
 
-	public function instantiatePlugin() {
+	public function instantiatePlugin(): void {
 		// cannot be done within setUp, because dependent mocks needs to be set
 		// up with configuration etc. first
 		$this->plugin = new UserPlugin(
@@ -87,7 +76,7 @@ class UserPluginTest extends TestCase {
 		);
 	}
 
-	public function mockConfig($mockedSettings) {
+	public function mockConfig($mockedSettings): void {
 		$this->config->expects($this->any())
 			->method('getAppValue')
 			->willReturnCallback(
@@ -97,7 +86,7 @@ class UserPluginTest extends TestCase {
 			);
 	}
 
-	public function getUserMock($uid, $displayName, $enabled = true, $groups = []) {
+	public function getUserMock(string $uid, string $displayName, bool $enabled = true, array $groups = []): IUser&MockObject {
 		$user = $this->createMock(IUser::class);
 
 		$user->expects($this->any())
@@ -115,17 +104,7 @@ class UserPluginTest extends TestCase {
 		return $user;
 	}
 
-	public function getGroupMock($gid) {
-		$group = $this->createMock(IGroup::class);
-
-		$group->expects($this->any())
-			->method('getGID')
-			->willReturn($gid);
-
-		return $group;
-	}
-
-	public function dataGetUsers(): array {
+	public static function dataGetUsers(): array {
 		return [
 			['test', false, true, [], [], [], [], true, false],
 			['test', false, false, [], [], [], [], true, false],
@@ -135,33 +114,33 @@ class UserPluginTest extends TestCase {
 				'test', false, true, [], [],
 				[
 					['label' => 'Test', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'], 'icon' => 'icon-user', 'subline' => null, 'status' => [], 'shareWithDisplayNameUnique' => 'test'],
-				], [], true, $this->getUserMock('test', 'Test'),
+				], [], true, ['test', 'Test'],
 			],
 			[
 				'test', false, false, [], [],
 				[
 					['label' => 'Test', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'], 'icon' => 'icon-user', 'subline' => null, 'status' => [], 'shareWithDisplayNameUnique' => 'test'],
-				], [], true, $this->getUserMock('test', 'Test'),
+				], [], true, ['test', 'Test'],
 			],
 			[
 				'test', true, true, [], [],
-				[], [], true, $this->getUserMock('test', 'Test'),
+				[], [], true, ['test', 'Test'],
 			],
 			[
 				'test', true, false, [], [],
-				[], [], true, $this->getUserMock('test', 'Test'),
+				[], [], true, ['test', 'Test'],
 			],
 			[
 				'test', true, true, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
 					['label' => 'Test', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'], 'icon' => 'icon-user', 'subline' => null, 'status' => [], 'shareWithDisplayNameUnique' => 'test'],
-				], [], true, $this->getUserMock('test', 'Test'),
+				], [], true, ['test', 'Test'],
 			],
 			[
 				'test', true, false, ['test-group'], [['test-group', 'test', 2, 0, []]],
 				[
 					['label' => 'Test', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test'], 'icon' => 'icon-user', 'subline' => null, 'status' => [], 'shareWithDisplayNameUnique' => 'test'],
-				], [], true, $this->getUserMock('test', 'Test'),
+				], [], true, ['test', 'Test'],
 			],
 			[
 				'test',
@@ -169,7 +148,7 @@ class UserPluginTest extends TestCase {
 				true,
 				[],
 				[
-					$this->getUserMock('test1', 'Test One'),
+					['test1', 'Test One'],
 				],
 				[],
 				[
@@ -184,7 +163,7 @@ class UserPluginTest extends TestCase {
 				false,
 				[],
 				[
-					$this->getUserMock('test1', 'Test One'),
+					['test1', 'Test One'],
 				],
 				[],
 				[],
@@ -197,8 +176,8 @@ class UserPluginTest extends TestCase {
 				true,
 				[],
 				[
-					$this->getUserMock('test1', 'Test One'),
-					$this->getUserMock('test2', 'Test Two'),
+					['test1', 'Test One'],
+					['test2', 'Test Two'],
 				],
 				[],
 				[
@@ -214,8 +193,8 @@ class UserPluginTest extends TestCase {
 				false,
 				[],
 				[
-					$this->getUserMock('test1', 'Test One'),
-					$this->getUserMock('test2', 'Test Two'),
+					['test1', 'Test One'],
+					['test2', 'Test Two'],
 				],
 				[],
 				[],
@@ -228,9 +207,9 @@ class UserPluginTest extends TestCase {
 				true,
 				[],
 				[
-					$this->getUserMock('test0', 'Test'),
-					$this->getUserMock('test1', 'Test One'),
-					$this->getUserMock('test2', 'Test Two'),
+					['test0', 'Test'],
+					['test1', 'Test One'],
+					['test2', 'Test Two'],
 				],
 				[
 					['label' => 'Test', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test0'], 'icon' => 'icon-user', 'subline' => null, 'status' => [], 'shareWithDisplayNameUnique' => 'test0'],
@@ -248,9 +227,9 @@ class UserPluginTest extends TestCase {
 				true,
 				[],
 				[
-					$this->getUserMock('test0', 'Test'),
-					$this->getUserMock('test1', 'Test One'),
-					$this->getUserMock('test2', 'Test Two'),
+					['test0', 'Test'],
+					['test1', 'Test One'],
+					['test2', 'Test Two'],
 				],
 				[
 					['label' => 'Test', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test0'], 'icon' => 'icon-user', 'subline' => null, 'status' => [], 'shareWithDisplayNameUnique' => 'test0'],
@@ -270,9 +249,9 @@ class UserPluginTest extends TestCase {
 				false,
 				[],
 				[
-					$this->getUserMock('test0', 'Test'),
-					$this->getUserMock('test1', 'Test One'),
-					$this->getUserMock('test2', 'Test Two'),
+					['test0', 'Test'],
+					['test1', 'Test One'],
+					['test2', 'Test Two'],
 				],
 				[
 					['label' => 'Test', 'value' => ['shareType' => IShare::TYPE_USER, 'shareWith' => 'test0'], 'icon' => 'icon-user', 'subline' => null, 'status' => [], 'shareWithDisplayNameUnique' => 'test0'],
@@ -296,7 +275,7 @@ class UserPluginTest extends TestCase {
 				],
 				true,
 				false,
-				[['test1', $this->getUserMock('test1', 'Test One')]],
+				[['test1', ['test1', 'Test One']]],
 			],
 			[
 				'test',
@@ -311,7 +290,7 @@ class UserPluginTest extends TestCase {
 				[],
 				true,
 				false,
-				[['test1', $this->getUserMock('test1', 'Test One')]],
+				[['test1', ['test1', 'Test One']]],
 			],
 			[
 				'test',
@@ -336,8 +315,8 @@ class UserPluginTest extends TestCase {
 				true,
 				false,
 				[
-					['test1', $this->getUserMock('test1', 'Test One')],
-					['test2', $this->getUserMock('test2', 'Test Two')],
+					['test1', ['test1', 'Test One']],
+					['test2', ['test2', 'Test Two']],
 				],
 			],
 			[
@@ -360,8 +339,8 @@ class UserPluginTest extends TestCase {
 				true,
 				false,
 				[
-					['test1', $this->getUserMock('test1', 'Test One')],
-					['test2', $this->getUserMock('test2', 'Test Two')],
+					['test1', ['test1', 'Test One']],
+					['test2', ['test2', 'Test Two']],
 				],
 			],
 			[
@@ -386,8 +365,8 @@ class UserPluginTest extends TestCase {
 				false,
 				false,
 				[
-					['test', $this->getUserMock('test', 'Test One')],
-					['test2', $this->getUserMock('test2', 'Test Two')],
+					['test', ['test', 'Test One']],
+					['test2', ['test2', 'Test Two']],
 				],
 			],
 			[
@@ -410,40 +389,34 @@ class UserPluginTest extends TestCase {
 				true,
 				false,
 				[
-					['test', $this->getUserMock('test', 'Test One')],
-					['test2', $this->getUserMock('test2', 'Test Two')],
+					['test', ['test', 'Test One']],
+					['test2', ['test2', 'Test Two']],
 				],
 			],
 		];
 	}
 
-	/**
-	 *
-	 * @param string $searchTerm
-	 * @param bool $shareWithGroupOnly
-	 * @param bool $shareeEnumeration
-	 * @param array $groupResponse
-	 * @param array $userResponse
-	 * @param array $exactExpected
-	 * @param array $expected
-	 * @param bool $reachedEnd
-	 * @param bool|IUser $singleUser
-	 * @param array $users
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetUsers')]
+	#[DataProvider('dataGetUsers')]
 	public function testSearch(
-		$searchTerm,
-		$shareWithGroupOnly,
-		$shareeEnumeration,
+		string $searchTerm,
+		bool $shareWithGroupOnly,
+		bool $shareeEnumeration,
 		array $groupResponse,
 		array $userResponse,
 		array $exactExpected,
 		array $expected,
-		$reachedEnd,
-		$singleUser,
+		bool $reachedEnd,
+		array|false $singleUser,
 		array $users = [],
-		$shareeEnumerationPhone = false,
+		bool $shareeEnumerationPhone = false,
 	): void {
+		if ($singleUser !== false) {
+			$singleUser = $this->getUserMock(...$singleUser);
+		}
+		$users = array_map(
+			fn ($args) => [$args[0], $this->getUserMock(...$args[1])],
+			$users
+		);
 		$this->mockConfig(['core' => [
 			'shareapi_only_share_with_group_members' => $shareWithGroupOnly ? 'yes' : 'no',
 			'shareapi_allow_share_dialog_user_enumeration' => $shareeEnumeration? 'yes' : 'no',
@@ -458,6 +431,10 @@ class UserPluginTest extends TestCase {
 			->willReturn($this->user);
 
 		if (!$shareWithGroupOnly) {
+			$userResponse = array_map(
+				fn ($args) => $this->getUserMock(...$args),
+				$userResponse
+			);
 			if ($shareeEnumerationPhone) {
 				$this->userManager->expects($this->once())
 					->method('searchKnownUsersByDisplayName')
@@ -534,13 +511,8 @@ class UserPluginTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @param array $users
-	 * @param array $expectedUIDs
-	 * @param $currentUserId
-	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('takeOutCurrentUserProvider')]
-	public function testTakeOutCurrentUser(array $users, array $expectedUIDs, $currentUserId): void {
+	#[DataProvider('takeOutCurrentUserProvider')]
+	public function testTakeOutCurrentUser(array $users, array $expectedUIDs, ?string $currentUserId): void {
 		$this->instantiatePlugin();
 
 		$this->session->expects($this->once())
@@ -717,7 +689,7 @@ class UserPluginTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataSearchEnumeration')]
+	#[DataProvider('dataSearchEnumeration')]
 	public function testSearchEnumerationLimit($search, $userGroups, $matchingUsers, $result, $mockedSettings): void {
 		$this->mockConfig($mockedSettings);
 

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -726,6 +726,8 @@ class MigrationsTest extends \Test\TestCase {
 		$table->expects($this->any())
 			->method('getName')
 			->willReturn(\str_repeat('a', 30));
+		$table->method('getIndexes')->willReturn([]);
+		$table->method('getForeignKeys')->willReturn([]);
 
 		$table->expects($this->once())
 			->method('getColumns')
@@ -735,6 +737,7 @@ class MigrationsTest extends \Test\TestCase {
 		$schema->expects($this->once())
 			->method('getTables')
 			->willReturn([$table]);
+		$schema->method('getSequences')->willReturn([]);
 
 		$sourceSchema = $this->createMock(Schema::class);
 		$sourceSchema->expects($this->any())

--- a/tests/lib/Files/ObjectStore/S3Test.php
+++ b/tests/lib/Files/ObjectStore/S3Test.php
@@ -110,6 +110,13 @@ class S3Test extends ObjectStoreTestCase {
 		$emptyStream = fopen('php://memory', 'r');
 		fwrite($emptyStream, '');
 
+		$warnings = [];
+		set_error_handler(
+			function (int $errno, string $errstr) use (&$warnings): void {
+				$warnings[] = $errstr;
+			},
+		);
+
 		$s3->writeObject('emptystream', $emptyStream);
 
 		$this->assertNoUpload('emptystream');
@@ -126,6 +133,8 @@ class S3Test extends ObjectStoreTestCase {
 		self::assertTrue($thrown, 'readObject with range requests are not expected to work on empty objects');
 
 		$s3->deleteObject('emptystream');
+		$this->assertOnlyExpectedWarnings($warnings);
+		restore_error_handler();
 	}
 
 	/** File size to upload in bytes */

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -831,183 +831,238 @@ class ManagerTest extends \Test\TestCase {
 		return $share;
 	}
 
-	public function dataGeneralChecks() {
+	public static function dataGeneralChecks(): array {
 		$user0 = 'user0';
 		$user2 = 'user1';
 		$group0 = 'group0';
-		$owner = $this->createMock(IUser::class);
-		$owner->method('getUID')
-			->willReturn($user0);
 
-		$file = $this->createMock(File::class);
-		$node = $this->createMock(Node::class);
-		$storage = $this->createMock(IStorage::class);
-		$storage->method('instanceOfStorage')
-			->with('\OCA\Files_Sharing\External\Storage')
-			->willReturn(false);
-		$file->method('getStorage')
-			->willReturn($storage);
-		$file->method('getId')->willReturn(108);
-		$node->method('getStorage')
-			->willReturn($storage);
-		$node->method('getId')->willReturn(108);
-
-		$data = [
-			[$this->createShare(null, IShare::TYPE_USER, $file, null, $user0, $user0, 31, null, null), 'Share recipient is not a valid user', true],
-			[$this->createShare(null, IShare::TYPE_USER, $file, $group0, $user0, $user0, 31, null, null), 'Share recipient is not a valid user', true],
-			[$this->createShare(null, IShare::TYPE_USER, $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'Share recipient is not a valid user', true],
-			[$this->createShare(null, IShare::TYPE_GROUP, $file, null, $user0, $user0, 31, null, null), 'Share recipient is not a valid group', true],
-			[$this->createShare(null, IShare::TYPE_GROUP, $file, $user2, $user0, $user0, 31, null, null), 'Share recipient is not a valid group', true],
-			[$this->createShare(null, IShare::TYPE_GROUP, $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'Share recipient is not a valid group', true],
-			[$this->createShare(null, IShare::TYPE_LINK, $file, $user2, $user0, $user0, 31, null, null), 'Share recipient should be empty', true],
-			[$this->createShare(null, IShare::TYPE_LINK, $file, $group0, $user0, $user0, 31, null, null), 'Share recipient should be empty', true],
-			[$this->createShare(null, IShare::TYPE_LINK, $file, 'foo@bar.com', $user0, $user0, 31, null, null), 'Share recipient should be empty', true],
-			[$this->createShare(null, -1, $file, null, $user0, $user0, 31, null, null), 'Unknown share type', true],
-
-			[$this->createShare(null, IShare::TYPE_USER, $file, $user2, null, $user0, 31, null, null), 'Share initiator must be set', true],
-			[$this->createShare(null, IShare::TYPE_GROUP, $file, $group0, null, $user0, 31, null, null), 'Share initiator must be set', true],
-			[$this->createShare(null, IShare::TYPE_LINK, $file, null, null, $user0, 31, null, null), 'Share initiator must be set', true],
-
-			[$this->createShare(null, IShare::TYPE_USER, $file, $user0, $user0, $user0, 31, null, null), 'Cannot share with yourself', true],
-
-			[$this->createShare(null, IShare::TYPE_USER, null, $user2, $user0, $user0, 31, null, null), 'Shared path must be set', true],
-			[$this->createShare(null, IShare::TYPE_GROUP, null, $group0, $user0, $user0, 31, null, null), 'Shared path must be set', true],
-			[$this->createShare(null, IShare::TYPE_LINK, null, null, $user0, $user0, 31, null, null), 'Shared path must be set', true],
-
-			[$this->createShare(null, IShare::TYPE_USER, $node, $user2, $user0, $user0, 31, null, null), 'Shared path must be either a file or a folder', true],
-			[$this->createShare(null, IShare::TYPE_GROUP, $node, $group0, $user0, $user0, 31, null, null), 'Shared path must be either a file or a folder', true],
-			[$this->createShare(null, IShare::TYPE_LINK, $node, null, $user0, $user0, 31, null, null), 'Shared path must be either a file or a folder', true],
+		$file = [
+			File::class,
+			[
+				'getId' => 108,
+			],
+			'default',
 		];
 
-		$nonShareAble = $this->createMock(Folder::class);
-		$nonShareAble->method('getId')->willReturn(108);
-		$nonShareAble->method('isShareable')->willReturn(false);
-		$nonShareAble->method('getPath')->willReturn('path');
-		$nonShareAble->method('getName')->willReturn('name');
-		$nonShareAble->method('getOwner')
-			->willReturn($owner);
-		$nonShareAble->method('getStorage')
-			->willReturn($storage);
+		$node = [
+			Node::class,
+			[
+				'getId' => 108,
+			],
+			'default',
+		];
 
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $nonShareAble, $user2, $user0, $user0, 31, null, null), 'You are not allowed to share name', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $nonShareAble, $group0, $user0, $user0, 31, null, null), 'You are not allowed to share name', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_LINK, $nonShareAble, null, $user0, $user0, 31, null, null), 'You are not allowed to share name', true];
+		$data = [
+			[[null, IShare::TYPE_USER, $file, null, $user0, $user0, 31, null, null], 'Share recipient is not a valid user', true],
+			[[null, IShare::TYPE_USER, $file, $group0, $user0, $user0, 31, null, null], 'Share recipient is not a valid user', true],
+			[[null, IShare::TYPE_USER, $file, 'foo@bar.com', $user0, $user0, 31, null, null], 'Share recipient is not a valid user', true],
+			[[null, IShare::TYPE_GROUP, $file, null, $user0, $user0, 31, null, null], 'Share recipient is not a valid group', true],
+			[[null, IShare::TYPE_GROUP, $file, $user2, $user0, $user0, 31, null, null], 'Share recipient is not a valid group', true],
+			[[null, IShare::TYPE_GROUP, $file, 'foo@bar.com', $user0, $user0, 31, null, null], 'Share recipient is not a valid group', true],
+			[[null, IShare::TYPE_LINK, $file, $user2, $user0, $user0, 31, null, null], 'Share recipient should be empty', true],
+			[[null, IShare::TYPE_LINK, $file, $group0, $user0, $user0, 31, null, null], 'Share recipient should be empty', true],
+			[[null, IShare::TYPE_LINK, $file, 'foo@bar.com', $user0, $user0, 31, null, null], 'Share recipient should be empty', true],
+			[[null, -1, $file, null, $user0, $user0, 31, null, null], 'Unknown share type', true],
 
-		$limitedPermssions = $this->createMock(File::class);
-		$limitedPermssions->method('isShareable')->willReturn(true);
-		$limitedPermssions->method('getPermissions')->willReturn(Constants::PERMISSION_READ);
-		$limitedPermssions->method('getId')->willReturn(108);
-		$limitedPermssions->method('getPath')->willReturn('path');
-		$limitedPermssions->method('getName')->willReturn('name');
-		$limitedPermssions->method('getOwner')
-			->willReturn($owner);
-		$limitedPermssions->method('getStorage')
-			->willReturn($storage);
+			[[null, IShare::TYPE_USER, $file, $user2, null, $user0, 31, null, null], 'Share initiator must be set', true],
+			[[null, IShare::TYPE_GROUP, $file, $group0, null, $user0, 31, null, null], 'Share initiator must be set', true],
+			[[null, IShare::TYPE_LINK, $file, null, null, $user0, 31, null, null], 'Share initiator must be set', true],
 
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $limitedPermssions, $user2, $user0, $user0, null, null, null), 'Valid permissions are required for sharing', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, null, null, null), 'Valid permissions are required for sharing', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_LINK, $limitedPermssions, null, $user0, $user0, null, null, null), 'Valid permissions are required for sharing', true];
+			[[null, IShare::TYPE_USER, $file, $user0, $user0, $user0, 31, null, null], 'Cannot share with yourself', true],
 
-		$mount = $this->createMock(MoveableMount::class);
-		$limitedPermssions->method('getMountPoint')->willReturn($mount);
+			[[null, IShare::TYPE_USER, null, $user2, $user0, $user0, 31, null, null], 'Shared path must be set', true],
+			[[null, IShare::TYPE_GROUP, null, $group0, $user0, $user0, 31, null, null], 'Shared path must be set', true],
+			[[null, IShare::TYPE_LINK, null, null, $user0, $user0, 31, null, null], 'Shared path must be set', true],
+
+			[[null, IShare::TYPE_USER, $node, $user2, $user0, $user0, 31, null, null], 'Shared path must be either a file or a folder', true],
+			[[null, IShare::TYPE_GROUP, $node, $group0, $user0, $user0, 31, null, null], 'Shared path must be either a file or a folder', true],
+			[[null, IShare::TYPE_LINK, $node, null, $user0, $user0, 31, null, null], 'Shared path must be either a file or a folder', true],
+		];
+
+		$nonShareAble = [
+			Folder::class,
+			[
+				'getId' => 108,
+				'isShareable' => false,
+				'getPath' => 'path',
+				'getName' => 'name',
+				'getOwner' => $user0,
+			],
+			'default',
+		];
+
+		$data[] = [[null, IShare::TYPE_USER, $nonShareAble, $user2, $user0, $user0, 31, null, null], 'You are not allowed to share name', true];
+		$data[] = [[null, IShare::TYPE_GROUP, $nonShareAble, $group0, $user0, $user0, 31, null, null], 'You are not allowed to share name', true];
+		$data[] = [[null, IShare::TYPE_LINK, $nonShareAble, null, $user0, $user0, 31, null, null], 'You are not allowed to share name', true];
+
+		$limitedPermssions = [
+			File::class,
+			[
+				'isShareable' => true,
+				'getPermissions' => Constants::PERMISSION_READ,
+				'getId' => 108,
+				'getPath' => 'path',
+				'getName' => 'name',
+				'getOwner' => $user0,
+			],
+			'default',
+		];
+
+		$data[] = [[null, IShare::TYPE_USER, $limitedPermssions, $user2, $user0, $user0, null, null, null], 'Valid permissions are required for sharing', true];
+		$data[] = [[null, IShare::TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, null, null, null], 'Valid permissions are required for sharing', true];
+		$data[] = [[null, IShare::TYPE_LINK, $limitedPermssions, null, $user0, $user0, null, null, null], 'Valid permissions are required for sharing', true];
+
+		$limitedPermssions[1]['getMountPoint'] = MoveableMount::class;
 
 		// increase permissions of a re-share
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, 17, null, null), 'Cannot increase permissions of path', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $limitedPermssions, $user2, $user0, $user0, 3, null, null), 'Cannot increase permissions of path', true];
+		$data[] = [[null, IShare::TYPE_GROUP, $limitedPermssions, $group0, $user0, $user0, 17, null, null], 'Cannot increase permissions of path', true];
+		$data[] = [[null, IShare::TYPE_USER, $limitedPermssions, $user2, $user0, $user0, 3, null, null], 'Cannot increase permissions of path', true];
 
-		$nonMovableStorage = $this->createMock(IStorage::class);
-		$nonMovableStorage->method('instanceOfStorage')
-			->with('\OCA\Files_Sharing\External\Storage')
-			->willReturn(false);
-		$nonMovableStorage->method('getPermissions')->willReturn(Constants::PERMISSION_ALL);
-		$nonMoveableMountPermssions = $this->createMock(Folder::class);
-		$nonMoveableMountPermssions->method('isShareable')->willReturn(true);
-		$nonMoveableMountPermssions->method('getPermissions')->willReturn(Constants::PERMISSION_READ);
-		$nonMoveableMountPermssions->method('getId')->willReturn(108);
-		$nonMoveableMountPermssions->method('getPath')->willReturn('path');
-		$nonMoveableMountPermssions->method('getName')->willReturn('name');
-		$nonMoveableMountPermssions->method('getInternalPath')->willReturn('');
-		$nonMoveableMountPermssions->method('getOwner')
-			->willReturn($owner);
-		$nonMoveableMountPermssions->method('getStorage')
-			->willReturn($nonMovableStorage);
+		$nonMoveableMountPermssions = [
+			Folder::class,
+			[
+				'isShareable' => true,
+				'getPermissions' => Constants::PERMISSION_READ,
+				'getId' => 108,
+				'getPath' => 'path',
+				'getName' => 'name',
+				'getInternalPath' => '',
+				'getOwner' => $user0,
+			],
+			'allPermssions',
+		];
 
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $nonMoveableMountPermssions, $user2, $user0, $user0, 11, null, null), 'Cannot increase permissions of path', false];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $nonMoveableMountPermssions, $group0, $user0, $user0, 11, null, null), 'Cannot increase permissions of path', false];
+		$data[] = [[null, IShare::TYPE_USER, $nonMoveableMountPermssions, $user2, $user0, $user0, 11, null, null], 'Cannot increase permissions of path', false];
+		$data[] = [[null, IShare::TYPE_GROUP, $nonMoveableMountPermssions, $group0, $user0, $user0, 11, null, null], 'Cannot increase permissions of path', false];
 
-		$rootFolder = $this->createMock(Folder::class);
-		$rootFolder->method('isShareable')->willReturn(true);
-		$rootFolder->method('getPermissions')->willReturn(Constants::PERMISSION_ALL);
-		$rootFolder->method('getId')->willReturn(42);
+		$rootFolder = [
+			Folder::class,
+			[
+				'isShareable' => true,
+				'getPermissions' => Constants::PERMISSION_ALL,
+				'getId' => 42,
+			],
+			'none',
+		];
 
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $rootFolder, $user2, $user0, $user0, 30, null, null), 'You cannot share your root folder', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $rootFolder, $group0, $user0, $user0, 2, null, null), 'You cannot share your root folder', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_LINK, $rootFolder, null, $user0, $user0, 16, null, null), 'You cannot share your root folder', true];
+		$data[] = [[null, IShare::TYPE_USER, $rootFolder, $user2, $user0, $user0, 30, null, null], 'You cannot share your root folder', true];
+		$data[] = [[null, IShare::TYPE_GROUP, $rootFolder, $group0, $user0, $user0, 2, null, null], 'You cannot share your root folder', true];
+		$data[] = [[null, IShare::TYPE_LINK, $rootFolder, null, $user0, $user0, 16, null, null], 'You cannot share your root folder', true];
 
-		$allPermssionsFiles = $this->createMock(File::class);
-		$allPermssionsFiles->method('isShareable')->willReturn(true);
-		$allPermssionsFiles->method('getPermissions')->willReturn(Constants::PERMISSION_ALL);
-		$allPermssionsFiles->method('getId')->willReturn(187);
-		$allPermssionsFiles->method('getOwner')
-			->willReturn($owner);
-		$allPermssionsFiles->method('getStorage')
-			->willReturn($storage);
+		$allPermssionsFiles = [
+			File::class,
+			[
+				'isShareable' => true,
+				'getPermissions' => Constants::PERMISSION_ALL,
+				'getId' => 187,
+				'getOwner' => $user0,
+			],
+			'default',
+		];
 
 		// test invalid CREATE or DELETE permissions
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $allPermssionsFiles, $user2, $user0, $user0, Constants::PERMISSION_ALL, null, null), 'File shares cannot have create or delete permissions', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $allPermssionsFiles, $group0, $user0, $user0, Constants::PERMISSION_READ | Constants::PERMISSION_CREATE, null, null), 'File shares cannot have create or delete permissions', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_LINK, $allPermssionsFiles, null, $user0, $user0, Constants::PERMISSION_READ | Constants::PERMISSION_DELETE, null, null), 'File shares cannot have create or delete permissions', true];
+		$data[] = [[null, IShare::TYPE_USER, $allPermssionsFiles, $user2, $user0, $user0, Constants::PERMISSION_ALL, null, null], 'File shares cannot have create or delete permissions', true];
+		$data[] = [[null, IShare::TYPE_GROUP, $allPermssionsFiles, $group0, $user0, $user0, Constants::PERMISSION_READ | Constants::PERMISSION_CREATE, null, null], 'File shares cannot have create or delete permissions', true];
+		$data[] = [[null, IShare::TYPE_LINK, $allPermssionsFiles, null, $user0, $user0, Constants::PERMISSION_READ | Constants::PERMISSION_DELETE, null, null], 'File shares cannot have create or delete permissions', true];
 
-		$allPermssions = $this->createMock(Folder::class);
-		$allPermssions->method('isShareable')->willReturn(true);
-		$allPermssions->method('getPermissions')->willReturn(Constants::PERMISSION_ALL);
-		$allPermssions->method('getId')->willReturn(108);
-		$allPermssions->method('getOwner')
-			->willReturn($owner);
-		$allPermssions->method('getStorage')
-			->willReturn($storage);
+		$allPermssions = [
+			Folder::class,
+			[
+				'isShareable' => true,
+				'getPermissions' => Constants::PERMISSION_ALL,
+				'getId' => 108,
+				'getOwner' => $user0,
+			],
+			'default',
+		];
 
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $allPermssions, $user2, $user0, $user0, 30, null, null), 'Shares need at least read permissions', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 2, null, null), 'Shares need at least read permissions', true];
+		$data[] = [[null, IShare::TYPE_USER, $allPermssions, $user2, $user0, $user0, 30, null, null], 'Shares need at least read permissions', true];
+		$data[] = [[null, IShare::TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 2, null, null], 'Shares need at least read permissions', true];
 
 		// test invalid permissions
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $allPermssions, $user2, $user0, $user0, 32, null, null), 'Valid permissions are required for sharing', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 63, null, null), 'Valid permissions are required for sharing', true];
-		$data[] = [$this->createShare(null, IShare::TYPE_LINK, $allPermssions, null, $user0, $user0, -1, null, null), 'Valid permissions are required for sharing', true];
+		$data[] = [[null, IShare::TYPE_USER, $allPermssions, $user2, $user0, $user0, 32, null, null], 'Valid permissions are required for sharing', true];
+		$data[] = [[null, IShare::TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 63, null, null], 'Valid permissions are required for sharing', true];
+		$data[] = [[null, IShare::TYPE_LINK, $allPermssions, null, $user0, $user0, -1, null, null], 'Valid permissions are required for sharing', true];
 
 		// working shares
-		$data[] = [$this->createShare(null, IShare::TYPE_USER, $allPermssions, $user2, $user0, $user0, 31, null, null), null, false];
-		$data[] = [$this->createShare(null, IShare::TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 3, null, null), null, false];
-		$data[] = [$this->createShare(null, IShare::TYPE_LINK, $allPermssions, null, $user0, $user0, 17, null, null), null, false];
+		$data[] = [[null, IShare::TYPE_USER, $allPermssions, $user2, $user0, $user0, 31, null, null], null, false];
+		$data[] = [[null, IShare::TYPE_GROUP, $allPermssions, $group0, $user0, $user0, 3, null, null], null, false];
+		$data[] = [[null, IShare::TYPE_LINK, $allPermssions, null, $user0, $user0, 17, null, null], null, false];
 
+		$remoteFile = [
+			Folder::class,
+			[
+				'isShareable' => true,
+				'getPermissions' => Constants::PERMISSION_READ ^ Constants::PERMISSION_UPDATE,
+				'getId' => 108,
+				'getOwner' => $user0,
+			],
+			'remote',
+		];
 
-		$remoteStorage = $this->createMock(IStorage::class);
-		$remoteStorage->method('instanceOfStorage')
-			->with('\OCA\Files_Sharing\External\Storage')
-			->willReturn(true);
-		$remoteFile = $this->createMock(Folder::class);
-		$remoteFile->method('isShareable')->willReturn(true);
-		$remoteFile->method('getPermissions')->willReturn(Constants::PERMISSION_READ ^ Constants::PERMISSION_UPDATE);
-		$remoteFile->method('getId')->willReturn(108);
-		$remoteFile->method('getOwner')
-			->willReturn($owner);
-		$remoteFile->method('getStorage')
-			->willReturn($storage);
-		$data[] = [$this->createShare(null, IShare::TYPE_REMOTE, $remoteFile, $user2, $user0, $user0, 1, null, null), null, false];
-		$data[] = [$this->createShare(null, IShare::TYPE_REMOTE, $remoteFile, $user2, $user0, $user0, 3, null, null), null, false];
-		$data[] = [$this->createShare(null, IShare::TYPE_REMOTE, $remoteFile, $user2, $user0, $user0, 31, null, null), 'Cannot increase permissions of ', true];
+		$data[] = [[null, IShare::TYPE_REMOTE, $remoteFile, $user2, $user0, $user0, 1, null, null], null, false];
+		$data[] = [[null, IShare::TYPE_REMOTE, $remoteFile, $user2, $user0, $user0, 3, null, null], null, false];
+		$data[] = [[null, IShare::TYPE_REMOTE, $remoteFile, $user2, $user0, $user0, 31, null, null], 'Cannot increase permissions of ', true];
 
 		return $data;
 	}
 
-	/**
-	 *
-	 * @param $share
-	 * @param $exceptionMessage
-	 * @param $exception
-	 */
+	private function createNodeMock(string $class, array $methods, string $storageType): MockObject {
+		$mock = $this->createMock($class);
+		foreach ($methods as $methodName => $return) {
+			if ($methodName === 'getOwner') {
+				$uid = $return;
+				$return = $this->createMock(IUser::class);
+				$return->method('getUID')
+					->willReturn($uid);
+			} elseif ($methodName === 'getMountPoint') {
+				$return = $this->createMock($return);
+			}
+			$mock->method($methodName)->willReturn($return);
+		}
+		switch ($storageType) {
+			case 'default':
+				$storage = $this->createMock(IStorage::class);
+				$storage->method('instanceOfStorage')
+					->with('\OCA\Files_Sharing\External\Storage')
+					->willReturn(false);
+				break;
+			case 'allPermssions':
+				$storage = $this->createMock(IStorage::class);
+				$storage->method('instanceOfStorage')
+					->with('\OCA\Files_Sharing\External\Storage')
+					->willReturn(false);
+				$storage->method('getPermissions')->willReturn(Constants::PERMISSION_ALL);
+				break;
+			case 'none':
+				$storage = false;
+				break;
+			case 'remote':
+				$storage = $this->createMock(IStorage::class);
+				$storage->method('instanceOfStorage')
+					->with('\OCA\Files_Sharing\External\Storage')
+					->willReturn(true);
+				break;
+			default:
+				throw new \Exception('Unknown storage type ' . $storageType);
+		}
+		if ($storage === false) {
+			$mock->expects(self::never())->method('getStorage');
+		} else {
+			$mock->method('getStorage')
+				->willReturn($storage);
+		}
+
+		return $mock;
+	}
+
 	#[\PHPUnit\Framework\Attributes\DataProvider('dataGeneralChecks')]
-	public function testGeneralChecks($share, $exceptionMessage, $exception): void {
+	public function testGeneralChecks(array $shareParams, ?string $exceptionMessage, bool $exception): void {
+		if ($shareParams[2] !== null) {
+			$shareParams[2] = $this->createNodeMock(...$shareParams[2]);
+		}
+		$share = $this->createShare(...$shareParams);
+
 		$thrown = null;
 
 		$this->userManager->method('userExists')->willReturnMap([


### PR DESCRIPTION
## Summary

Fail on PHPUnit warnings and risky tests, show deprecations.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
