### PR TITLE
feat: add setup check for request buffering on FPM

### DIFF
--- a/apps/settings/appinfo/routes.php
+++ b/apps/settings/appinfo/routes.php
@@ -44,10 +44,13 @@ return [
 		['name' => 'Users#usersListByGroup', 'url' => '/settings/users/{group}', 'verb' => 'GET', 'requirements' => ['group' => '.+'] , 'root' => ''],
 		['name' => 'Users#setPreference', 'url' => '/settings/users/preferences/{key}', 'verb' => 'POST' , 'root' => ''],
 		['name' => 'LogSettings#download', 'url' => '/settings/admin/log/download', 'verb' => 'GET' , 'root' => ''],
+
 		['name' => 'CheckSetup#setupCheckManager', 'url' => '/settings/setupcheck', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'CheckSetup#check', 'url' => '/settings/ajax/checksetup', 'verb' => 'GET' , 'root' => ''],
+		['name' => 'CheckSetup#checkContentLengthHeader', 'url' => '/settings/setupcheck/test-content-length', 'verb' => 'PUT' , 'root' => ''],
 		['name' => 'CheckSetup#getFailedIntegrityCheckFiles', 'url' => '/settings/integrity/failed', 'verb' => 'GET' , 'root' => ''],
 		['name' => 'CheckSetup#rescanFailedIntegrityCheck', 'url' => '/settings/integrity/rescan', 'verb' => 'GET' , 'root' => ''],
+
 		['name' => 'PersonalSettings#index', 'url' => '/settings/user/{section}', 'verb' => 'GET', 'defaults' => ['section' => 'personal-info'] , 'root' => ''],
 		['name' => 'AdminSettings#index', 'url' => '/settings/admin/{section}', 'verb' => 'GET', 'defaults' => ['section' => 'server'] , 'root' => ''],
 		['name' => 'AdminSettings#form', 'url' => '/settings/admin/{section}', 'verb' => 'GET' , 'root' => ''],

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -128,6 +128,7 @@ return array(
     'OCA\\Settings\\SetupChecks\\PushService' => $baseDir . '/../lib/SetupChecks/PushService.php',
     'OCA\\Settings\\SetupChecks\\RandomnessSecure' => $baseDir . '/../lib/SetupChecks/RandomnessSecure.php',
     'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => $baseDir . '/../lib/SetupChecks/ReadOnlyConfig.php',
+    'OCA\\Settings\\SetupChecks\\RequestBuffering' => $baseDir . '/../lib/SetupChecks/RequestBuffering.php',
     'OCA\\Settings\\SetupChecks\\SchedulingTableSize' => $baseDir . '/../lib/SetupChecks/SchedulingTableSize.php',
     'OCA\\Settings\\SetupChecks\\SecurityHeaders' => $baseDir . '/../lib/SetupChecks/SecurityHeaders.php',
     'OCA\\Settings\\SetupChecks\\SupportedDatabase' => $baseDir . '/../lib/SetupChecks/SupportedDatabase.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -143,6 +143,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\SetupChecks\\PushService' => __DIR__ . '/..' . '/../lib/SetupChecks/PushService.php',
         'OCA\\Settings\\SetupChecks\\RandomnessSecure' => __DIR__ . '/..' . '/../lib/SetupChecks/RandomnessSecure.php',
         'OCA\\Settings\\SetupChecks\\ReadOnlyConfig' => __DIR__ . '/..' . '/../lib/SetupChecks/ReadOnlyConfig.php',
+        'OCA\\Settings\\SetupChecks\\RequestBuffering' => __DIR__ . '/..' . '/../lib/SetupChecks/RequestBuffering.php',
         'OCA\\Settings\\SetupChecks\\SchedulingTableSize' => __DIR__ . '/..' . '/../lib/SetupChecks/SchedulingTableSize.php',
         'OCA\\Settings\\SetupChecks\\SecurityHeaders' => __DIR__ . '/..' . '/../lib/SetupChecks/SecurityHeaders.php',
         'OCA\\Settings\\SetupChecks\\SupportedDatabase' => __DIR__ . '/..' . '/../lib/SetupChecks/SupportedDatabase.php',

--- a/apps/settings/lib/AppInfo/Application.php
+++ b/apps/settings/lib/AppInfo/Application.php
@@ -66,6 +66,7 @@ use OCA\Settings\SetupChecks\PhpOutputBuffering;
 use OCA\Settings\SetupChecks\PushService;
 use OCA\Settings\SetupChecks\RandomnessSecure;
 use OCA\Settings\SetupChecks\ReadOnlyConfig;
+use OCA\Settings\SetupChecks\RequestBuffering;
 use OCA\Settings\SetupChecks\SchedulingTableSize;
 use OCA\Settings\SetupChecks\SecurityHeaders;
 use OCA\Settings\SetupChecks\SupportedDatabase;
@@ -203,6 +204,7 @@ class Application extends App implements IBootstrap {
 		$context->registerSetupCheck(PhpOutputBuffering::class);
 		$context->registerSetupCheck(RandomnessSecure::class);
 		$context->registerSetupCheck(ReadOnlyConfig::class);
+		$context->registerSetupCheck(RequestBuffering::class);
 		$context->registerSetupCheck(SecurityHeaders::class);
 		$context->registerSetupCheck(SchedulingTableSize::class);
 		$context->registerSetupCheck(SupportedDatabase::class);

--- a/apps/settings/lib/SetupChecks/RequestBuffering.php
+++ b/apps/settings/lib/SetupChecks/RequestBuffering.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\SetupChecks;
+
+use GuzzleHttp\Psr7;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\SetupCheck\CheckServerResponseTrait;
+use OCP\SetupCheck\ISetupCheck;
+use OCP\SetupCheck\SetupResult;
+use Psr\Log\LoggerInterface;
+
+class RequestBuffering implements ISetupCheck {
+
+	use CheckServerResponseTrait;
+
+	public function __construct(
+		protected IL10N $l10n,
+		protected IConfig $config,
+		protected IURLGenerator $urlGenerator,
+		protected IClientService $clientService,
+		protected LoggerInterface $logger,
+	) {
+	}
+
+	public function getCategory(): string {
+		return 'network';
+	}
+
+	public function getName(): string {
+		return $this->l10n->t('Request buffering');
+	}
+
+	public function run(): SetupResult {
+		$usingFPM = function_exists('fastcgi_finish_request');
+		if (!$usingFPM && !\OC::$CLI) {
+			return SetupResult::success(
+				$this->l10n->t('Not using PHP-FPM.')
+			);
+		}
+
+		$works = null;
+		$stream = Psr7\Utils::streamFor(str_repeat('x', 1337));
+		$options = [
+			'body' => $stream,
+			'headers' => [
+				'Transfer-Encoding' => 'chunked',
+			],
+		];
+		$url = $this->urlGenerator->linkToRoute('settings.CheckSetup.checkContentLengthHeader');
+		foreach ($this->runRequest('PUT', $url, ['ignoreSSL' => true, 'options' => $options]) as $response) {
+			$contentType = $response->getHeader('Content-Type');
+			if (!str_contains(strtolower($contentType), 'application/json')) {
+				continue;
+			}
+
+			$body = $response->getBody();
+			$body = is_resource($body) ? stream_get_contents($body) : $body;
+			$works = $works || $body === '"1337"';
+		}
+
+		if ($works === null) {
+			return SetupResult::info(
+				$this->l10n->t('Could not check that your web server has configured request buffering. Please check manually.'),
+			);
+		} elseif ($works === true) {
+			return SetupResult::success(
+				$this->l10n->t('Your web server seems to have request buffering configured correctly.'),
+			);
+		} else {
+			if ($usingFPM) {
+				return SetupResult::error(
+					$this->l10n->t('Your web server is not configured for request buffering, this will cause broken uploads with some clients.')
+					. ' '
+					. $this->l10n->t('Due to a limitation of PHP-FPM chunked requests will not be passed to Nextcloud if the server does not buffer such requests.'),
+				);
+			} else {
+				// Not using FPM but we are on CLI so we do not know if FPM is used
+				return SetupResult::warning(
+					$this->l10n->t('Your web server is not configured for request buffering, if you are running PHP-FPM this will cause broken uploads with some clients.')
+					. ' '
+					. $this->l10n->t('Due to a limitation of PHP-FPM chunked requests will not be passed to Nextcloud if the server does not buffer such requests.'),
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Context: Using `Transfer-Encoding: chunked` of HTTP 1.1

PHP-FPM has a bug[1] where the request body is not passed to PHP if the `Content-Length` header is missing, while FastCGI in general allows this (I could reproduce that FastCGI passed the request stream from NGinx) PHP-FPM does not forward this to the PHP application.

This means when using PHP-FPM we get an empty request body and thus every `PUT` will be an empty file.

I tested that `mod_php` is not affected, while it also has no `Content-Length` header, it correctly passed the stream and thus also works without buffering the request.

Only PHP-FPM needs buffering of the request so that a `Content-Length` header can be generated.

To enable this on Apache set: `SetEnvIfNoCase Transfer-Encoding "chunked" proxy-sendcl=1`
On NGinx: `fastcgi_request_buffering on;`.

[1]: https://bugs.php.net/bug.php?id=60826
ref: https://github.com/nextcloud/server/issues/7995

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
