### PR TITLE
fix: don't show object size warning if we can't determine the object size

### DIFF
--- a/core/Command/Info/File.php
+++ b/core/Command/Info/File.php
@@ -155,7 +155,7 @@ class File extends Command {
 					}
 					$stat = fstat($fh);
 					fclose($fh);
-					if ($stat['size'] !== $node->getSize()) {
+					if (isset($stat['size']) && $stat['size'] !== $node->getSize()) {
 						$output->writeln('  <error>warning: object had a size of ' . $stat['size'] . ' but cache entry has a size of ' . $node->getSize() . '</error>. This should have been automatically repaired');
 					}
 				} catch (\Exception $e) {


### PR DESCRIPTION
Fixes warnings like

```
warning: object had a size of  but cache entry has a size of 164
```