### PR TITLE
fix: ensure all object store configuration have distict bucket names

### DIFF
--- a/tests/lib/Files/ObjectStore/PrimaryObjectStoreConfigTest.php
+++ b/tests/lib/Files/ObjectStore/PrimaryObjectStoreConfigTest.php
@@ -91,12 +91,14 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 				'class' => StorageObjectStore::class,
 				'arguments' => [
 					'host' => 'server1',
+					'bucket' => '1',
 				],
 			],
 			'server2' => [
 				'class' => StorageObjectStore::class,
 				'arguments' => [
 					'host' => 'server2',
+					'bucket' => '2',
 				],
 			],
 		]);
@@ -119,6 +121,7 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 				'class' => StorageObjectStore::class,
 				'arguments' => [
 					'host' => 'server1',
+					'bucket' => '1',
 				],
 			],
 		]);
@@ -134,14 +137,14 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 					'host' => 'server1',
 					'multibucket' => true,
 					'num_buckets' => 8,
-					'bucket' => 'bucket-'
+					'bucket' => 'bucket1-'
 				],
 			],
 		]);
 
 		$result = $this->objectStoreConfig->getObjectStoreConfigForUser($this->getUser('test'));
 		$this->assertEquals('server1', $result['arguments']['host']);
-		$this->assertEquals('bucket-7', $result['arguments']['bucket']);
+		$this->assertEquals('bucket1-7', $result['arguments']['bucket']);
 
 		$this->setConfig('objectstore', [
 			'default' => 'server1',
@@ -151,18 +154,18 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 					'host' => 'server1',
 					'multibucket' => true,
 					'num_buckets' => 64,
-					'bucket' => 'bucket-'
+					'bucket' => 'bucket1-'
 				],
 			],
 		]);
 
 		$result = $this->objectStoreConfig->getObjectStoreConfigForUser($this->getUser('test'));
 		$this->assertEquals('server1', $result['arguments']['host']);
-		$this->assertEquals('bucket-7', $result['arguments']['bucket']);
+		$this->assertEquals('bucket1-7', $result['arguments']['bucket']);
 
 		$result = $this->objectStoreConfig->getObjectStoreConfigForUser($this->getUser('test-foo'));
 		$this->assertEquals('server1', $result['arguments']['host']);
-		$this->assertEquals('bucket-40', $result['arguments']['bucket']);
+		$this->assertEquals('bucket1-40', $result['arguments']['bucket']);
 
 		$this->setConfig('objectstore', [
 			'default' => 'server2',
@@ -172,7 +175,7 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 					'host' => 'server1',
 					'multibucket' => true,
 					'num_buckets' => 64,
-					'bucket' => 'bucket-'
+					'bucket' => 'bucket1-'
 				],
 			],
 			'server2' => [
@@ -181,18 +184,18 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 					'host' => 'server2',
 					'multibucket' => true,
 					'num_buckets' => 16,
-					'bucket' => 'bucket-'
+					'bucket' => 'bucket2-'
 				],
 			],
 		]);
 
 		$result = $this->objectStoreConfig->getObjectStoreConfigForUser($this->getUser('test'));
 		$this->assertEquals('server1', $result['arguments']['host']);
-		$this->assertEquals('bucket-7', $result['arguments']['bucket']);
+		$this->assertEquals('bucket1-7', $result['arguments']['bucket']);
 
 		$result = $this->objectStoreConfig->getObjectStoreConfigForUser($this->getUser('test-bar'));
 		$this->assertEquals('server2', $result['arguments']['host']);
-		$this->assertEquals('bucket-4', $result['arguments']['bucket']);
+		$this->assertEquals('bucket2-4', $result['arguments']['bucket']);
 	}
 
 	public function testMultibucketOldConfig() {
@@ -249,12 +252,14 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 				'class' => StorageObjectStore::class,
 				'arguments' => [
 					'host' => 'server1',
+					'bucket' => '1',
 				],
 			],
 			'server2' => [
 				'class' => StorageObjectStore::class,
 				'arguments' => [
 					'host' => 'server2',
+					'bucket' => '2',
 				],
 			],
 		]);
@@ -269,12 +274,14 @@ class PrimaryObjectStoreConfigTest extends TestCase {
 				'class' => StorageObjectStore::class,
 				'arguments' => [
 					'host' => 'server1',
+					'bucket' => '1',
 				],
 			],
 			'server2' => [
 				'class' => StorageObjectStore::class,
 				'arguments' => [
 					'host' => 'server2',
+					'bucket' => '2',
 				],
 			],
 		]);


### PR DESCRIPTION
Since the bucket name is used as the main determinant for the storage id (and changing this would be complicated). Having different object store configuration with the same bucket name would lead to complications.
So we just ensure that all configurations have a distinct bucket name.