### PR TITLE
[stable31] reuse check

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -111,10 +111,6 @@ Files: core/img/favicon*.* core/img/logo/logo*.* tests/data/testimage.webp tests
 Copyright: 2016-2024 Nextcloud GmbH
 License: LicenseRef-NextcloudTrademarks
 
-Files: apps/settings/data/Reasons to use Nextcloud.pdf
-Copyright: 2020 Nextcloud GmbH
-License: LicenseRef-NextcloudTrademarks
-
 Files: core/img/desktopapp.svg
 Copyright: 2016-2024 Nextcloud GmbH and Nextcloud contributors
 License: AGPL-3.0-or-later

--- a/apps/settings/data/Reasons to use Nextcloud.pdf.license
+++ b/apps/settings/data/Reasons to use Nextcloud.pdf.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 Nextcloud GmbH
+SPDX-License-Identifier: LicenseRef-NextcloudTrademarks


### PR DESCRIPTION
For unknown reasons, the reuse check is failing despite a definition being available in .reuse/dep5 :shrug: 

<img width="933" height="741" alt="image" src="https://github.com/user-attachments/assets/0c35e1b4-3358-4333-bfd8-ff21de13a14e" />



