### PR TITLE
fix(cache): Set default Redis port to `0` for UNIX sockets

### DIFF
--- a/lib/private/RedisFactory.php
+++ b/lib/private/RedisFactory.php
@@ -77,7 +77,7 @@ class RedisFactory {
 			$this->instance = new \Redis();
 
 			$host = $config['host'] ?? '127.0.0.1';
-			$port = $config['port'] ?? ($host[0] !== '/' ? 6379 : null);
+			$port = $config['port'] ?? ($host[0] !== '/' ? 6379 : 0);
 
 			$this->eventLogger->start('connect:redis', 'Connect to redis and send AUTH, SELECT');
 			// Support for older phpredis versions not supporting connectionParameters


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: #54813 <!-- related github issue -->

## Summary

When using phpredis with a UNIX socket, the port should either not be specified at all or be `<1`. 

https://github.com/phpredis/phpredis?tab=readme-ov-file#connect-open

https://github.com/phpredis/phpredis/blob/d0b0c5cfdde9d49a265ca4bf7184e3998863aed0/library.c#L3332-L3334

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
