### PR TITLE
fix(files_trashbin): Fix size propagation when moving file to trash

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -297,8 +297,9 @@ class Trashbin implements IEventListener {
 		try {
 			$moveSuccessful = true;
 
+			$inCache = $sourceStorage->getCache()->inCache($sourceInternalPath);
 			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
-			if ($sourceStorage->getCache()->inCache($sourceInternalPath)) {
+			if ($inCache) {
 				$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 			}
 		} catch (CopyRecursiveException $e) {

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -656,6 +656,28 @@ class TrashbinTest extends \Test\TestCase {
 		}
 	}
 
+	public function testTrashSizePropagation(): void {
+		$view = new View('/' . self::TEST_TRASHBIN_USER1 . '/files_trashbin/files');
+
+		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
+		$file1 = $userFolder->newFile('foo.txt');
+		$file1->putContent('1');
+
+		$this->assertTrue($userFolder->nodeExists('foo.txt'));
+		$file1->delete();
+		$this->assertFalse($userFolder->nodeExists('foo.txt'));
+		$this->assertEquals(1, $view->getFileInfo('')->getSize());
+
+		$folder = $userFolder->newFolder('bar');
+		$file2 = $folder->newFile('baz.txt');
+		$file2->putContent('22');
+
+		$this->assertTrue($userFolder->nodeExists('bar'));
+		$folder->delete();
+		$this->assertFalse($userFolder->nodeExists('bar'));
+		$this->assertEquals(3, $view->getFileInfo('')->getSize());
+	}
+
 	/**
 	 * @param string $user
 	 * @param bool $create


### PR DESCRIPTION
Broken since https://github.com/nextcloud/server/pull/48224.
Checking if the source path is in the cache always returns false, because the file was already moved to a different path.
So any file that was trashed, did not update the parent folder sizes.