### PR TITLE
fix: calculate node limit using MiB instead of MB

### DIFF
--- a/core/BackgroundJobs/GenerateMetadataJob.php
+++ b/core/BackgroundJobs/GenerateMetadataJob.php
@@ -98,7 +98,8 @@ class GenerateMetadataJob extends TimedJob {
 			// Files are loaded in memory so very big files can lead to an OOM on the server
 			$nodeSize = $node->getSize();
 			$nodeLimit = $this->config->getSystemValueInt('metadata_max_filesize', self::DEFAULT_MAX_FILESIZE);
-			if ($nodeSize > $nodeLimit * 1000000) {
+			$nodeLimitMib = $nodeLimit * 1024 * 1024;
+			if ($nodeSize > $nodeLimitMib) {
 				$this->logger->debug('Skipping generating metadata for fileid ' . $node->getId() . " as its size exceeds configured 'metadata_max_filesize'.");
 				continue;
 			}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: https://github.com/nextcloud/server/commit/2ea6713504aa49d1a8cb9a7efaad8706484986c1#commitcomment-148999016

## Summary

**Before:** Node limit is calculated using 1000 * 1000 Bytes (MB).
**After:** Node limit is calculated correctly using 1024 * 1024 Bytes (MiB).

See also: https://simple.wikipedia.org/wiki/Mebibyte

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
