### PR TITLE
fix(team-api): get all teams details in a single request

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4297,6 +4297,11 @@
       <code><![CDATA[$tag]]></code>
     </MoreSpecificImplementedParamType>
   </file>
+  <file src="lib/private/Teams/TeamManager.php">
+    <UndefinedDocblockClass>
+      <code><![CDATA[Circle]]></code>
+    </UndefinedDocblockClass>
+  </file>
   <file src="lib/private/URLGenerator.php">
     <InvalidReturnStatement>
       <code><![CDATA[$path]]></code>

--- a/core/ResponseDefinitions.php
+++ b/core/ResponseDefinitions.php
@@ -149,19 +149,28 @@ namespace OC\Core;
  *  }
  *
  * @psalm-type CoreTeam = array{
- *      id: string,
- *      name: string,
- *      icon: string,
+ *     teamId: string,
+ *     displayName: string,
+ *     link: ?string,
  * }
  *
  * @psalm-type CoreTeamResource = array{
- *       id: int,
- *       label: string,
- *       url: string,
- *       iconSvg: ?string,
- *       iconURL: ?string,
- *       iconEmoji: ?string,
- *   }
+ *     id: string,
+ *     label: string,
+ *     url: string,
+ *     iconSvg: ?string,
+ *     iconURL: ?string,
+ *     iconEmoji: ?string,
+ *     provider: array{
+ *         id: string,
+ *         name: string,
+ *         icon: string,
+ *     },
+ * }
+ *
+ * @psalm-type CoreTeamWithResources = CoreTeam&array{
+ *     resources: list<CoreTeamResource>,
+ * }
  *
  * @psalm-type CoreTaskProcessingShape = array{
  *     name: string,

--- a/core/openapi-full.json
+++ b/core/openapi-full.json
@@ -898,19 +898,20 @@
             "Team": {
                 "type": "object",
                 "required": [
-                    "id",
-                    "name",
-                    "icon"
+                    "teamId",
+                    "displayName",
+                    "link"
                 ],
                 "properties": {
-                    "id": {
+                    "teamId": {
                         "type": "string"
                     },
-                    "name": {
+                    "displayName": {
                         "type": "string"
                     },
-                    "icon": {
-                        "type": "string"
+                    "link": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },
@@ -922,12 +923,12 @@
                     "url",
                     "iconSvg",
                     "iconURL",
-                    "iconEmoji"
+                    "iconEmoji",
+                    "provider"
                 ],
                 "properties": {
                     "id": {
-                        "type": "integer",
-                        "format": "int64"
+                        "type": "string"
                     },
                     "label": {
                         "type": "string"
@@ -946,8 +947,48 @@
                     "iconEmoji": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "provider": {
+                        "type": "object",
+                        "required": [
+                            "id",
+                            "name",
+                            "icon"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "icon": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
+            },
+            "TeamWithResources": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Team"
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "resources"
+                        ],
+                        "properties": {
+                            "resources": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/TeamResource"
+                                }
+                            }
+                        }
+                    }
+                ]
             },
             "TextProcessingTask": {
                 "type": "object",
@@ -6306,7 +6347,7 @@
                                                         "teams": {
                                                             "type": "array",
                                                             "items": {
-                                                                "$ref": "#/components/schemas/Team"
+                                                                "$ref": "#/components/schemas/TeamWithResources"
                                                             }
                                                         }
                                                     }

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -898,19 +898,20 @@
             "Team": {
                 "type": "object",
                 "required": [
-                    "id",
-                    "name",
-                    "icon"
+                    "teamId",
+                    "displayName",
+                    "link"
                 ],
                 "properties": {
-                    "id": {
+                    "teamId": {
                         "type": "string"
                     },
-                    "name": {
+                    "displayName": {
                         "type": "string"
                     },
-                    "icon": {
-                        "type": "string"
+                    "link": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },
@@ -922,12 +923,12 @@
                     "url",
                     "iconSvg",
                     "iconURL",
-                    "iconEmoji"
+                    "iconEmoji",
+                    "provider"
                 ],
                 "properties": {
                     "id": {
-                        "type": "integer",
-                        "format": "int64"
+                        "type": "string"
                     },
                     "label": {
                         "type": "string"
@@ -946,8 +947,48 @@
                     "iconEmoji": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "provider": {
+                        "type": "object",
+                        "required": [
+                            "id",
+                            "name",
+                            "icon"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "icon": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
+            },
+            "TeamWithResources": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Team"
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "resources"
+                        ],
+                        "properties": {
+                            "resources": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/TeamResource"
+                                }
+                            }
+                        }
+                    }
+                ]
             },
             "TextProcessingTask": {
                 "type": "object",
@@ -6306,7 +6347,7 @@
                                                         "teams": {
                                                             "type": "array",
                                                             "items": {
-                                                                "$ref": "#/components/schemas/Team"
+                                                                "$ref": "#/components/schemas/TeamWithResources"
                                                             }
                                                         }
                                                     }

--- a/lib/public/Teams/ITeamManager.php
+++ b/lib/public/Teams/ITeamManager.php
@@ -40,4 +40,12 @@ interface ITeamManager {
 	 * @since 29.0.0
 	 */
 	public function getTeamsForResource(string $providerId, string $resourceId, string $userId): array;
+
+	/**
+	 * @param list<Team> $teams
+	 * @return array<string, list<TeamResource>>
+	 *
+	 * @since 33.0.0
+	 */
+	public function getSharedWithList(array $teams, string $userId): array;
 }

--- a/lib/public/Teams/Team.php
+++ b/lib/public/Teams/Team.php
@@ -50,6 +50,12 @@ class Team implements \JsonSerializable {
 	}
 
 	/**
+	 * @return array{
+	 *     teamId: string,
+	 *     displayName: string,
+	 *     link: ?string,
+	 * }
+	 *
 	 * @since 29.0.0
 	 */
 	public function jsonSerialize(): array {

--- a/lib/public/Teams/TeamResource.php
+++ b/lib/public/Teams/TeamResource.php
@@ -94,6 +94,20 @@ class TeamResource implements \JsonSerializable {
 	}
 
 	/**
+	 * @return array{
+	 *     id: string,
+	 *     label: string,
+	 *     url: string,
+	 *     iconSvg: ?string,
+	 *     iconURL: ?string,
+	 *     iconEmoji: ?string,
+	 *     provider: array{
+	 *         id: string,
+	 *         name: string,
+	 *         icon: string,
+	 *     },
+	 * }
+	 *
 	 * @since 29.0.0
 	 */
 	public function jsonSerialize(): array {

--- a/openapi.json
+++ b/openapi.json
@@ -940,19 +940,20 @@
             "CoreTeam": {
                 "type": "object",
                 "required": [
-                    "id",
-                    "name",
-                    "icon"
+                    "teamId",
+                    "displayName",
+                    "link"
                 ],
                 "properties": {
-                    "id": {
+                    "teamId": {
                         "type": "string"
                     },
-                    "name": {
+                    "displayName": {
                         "type": "string"
                     },
-                    "icon": {
-                        "type": "string"
+                    "link": {
+                        "type": "string",
+                        "nullable": true
                     }
                 }
             },
@@ -964,12 +965,12 @@
                     "url",
                     "iconSvg",
                     "iconURL",
-                    "iconEmoji"
+                    "iconEmoji",
+                    "provider"
                 ],
                 "properties": {
                     "id": {
-                        "type": "integer",
-                        "format": "int64"
+                        "type": "string"
                     },
                     "label": {
                         "type": "string"
@@ -988,8 +989,48 @@
                     "iconEmoji": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "provider": {
+                        "type": "object",
+                        "required": [
+                            "id",
+                            "name",
+                            "icon"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "icon": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
+            },
+            "CoreTeamWithResources": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/CoreTeam"
+                    },
+                    {
+                        "type": "object",
+                        "required": [
+                            "resources"
+                        ],
+                        "properties": {
+                            "resources": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/CoreTeamResource"
+                                }
+                            }
+                        }
+                    }
+                ]
             },
             "CoreTextProcessingTask": {
                 "type": "object",
@@ -9819,7 +9860,7 @@
                                                         "teams": {
                                                             "type": "array",
                                                             "items": {
-                                                                "$ref": "#/components/schemas/CoreTeam"
+                                                                "$ref": "#/components/schemas/CoreTeamWithResources"
                                                             }
                                                         }
                                                     }


### PR DESCRIPTION
The current use of the Team API to get all shares to all teams current user is a member does not scale well enough.
This is initialised when opening the right panel on a specific file. 

The fix is to get all details in a single request including all teams current user is a member of.

require https://github.com/nextcloud/circles/pull/2115