### PR TITLE
[stable32] chore(deps): update `doctrine/dbal` to v3.10.2

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -3529,10 +3529,6 @@
     <InvalidArgument>
       <code><![CDATA[$params]]></code>
     </InvalidArgument>
-    <InvalidArrayOffset>
-      <code><![CDATA[$params['adapter']]]></code>
-      <code><![CDATA[$params['tablePrefix']]]></code>
-    </InvalidArrayOffset>
   </file>
   <file src="lib/private/DB/Exceptions/DbalException.php">
     <RedundantCondition>


### PR DESCRIPTION
* [x] https://github.com/nextcloud/3rdparty/pull/2134

## Summary
* Fixes the problem with MariaDB 11 and `vector` keyword, see https://github.com/nextcloud/recognize/issues/1352

| Production Changes | From  | To      | Compare                                                        |
|--------------------|-------|---------|----------------------------------------------------------------|
| doctrine/cache     | 2.2.0 | REMOVED |                                                                |
| doctrine/dbal      | 3.9.4 | 3.10.2  | [...](https://github.com/doctrine/dbal/compare/3.9.4...3.10.2) |

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
