### PR TITLE
Refactor(APCu):  clarity, comments, & streamlining

### DIFF
--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -4039,14 +4039,6 @@
 			'MESSAGE=' . $this->logDetailsAsJSON($app, $message, $level))]]></code>
     </UndefinedFunction>
   </file>
-  <file src="lib/private/Memcache/APCu.php">
-    <InvalidReturnStatement>
-      <code><![CDATA[apcu_add($this->getPrefix() . $key, $value, $ttl)]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[bool]]></code>
-    </InvalidReturnType>
-  </file>
   <file src="lib/private/Memcache/Cache.php">
     <LessSpecificImplementedReturnType>
       <code><![CDATA[mixed]]></code>

--- a/lib/private/Memcache/APCu.php
+++ b/lib/private/Memcache/APCu.php
@@ -38,7 +38,7 @@ class APCu extends Cache implements IMemcache {
 		if ($ttl === 0) {
 			$ttl = self::DEFAULT_TTL;
 		}
-		return apcu_store($this->getPrefix() . $key, $value, $ttl);
+		return apcu_store($this->getPrefix() . $key, $value, $ttl) === true;
 	}
 
     /**
@@ -48,7 +48,7 @@ class APCu extends Cache implements IMemcache {
      * @return bool
      */
 	public function hasKey($key) {
-		return apcu_exists($this->getPrefix() . $key);
+		return apcu_exists($this->getPrefix() . $key) === true;
 	}
 	
     /**
@@ -58,14 +58,14 @@ class APCu extends Cache implements IMemcache {
      * @return bool
      */
 	public function remove($key) {
-		return apcu_delete($this->getPrefix() . $key);
+		return apcu_delete($this->getPrefix() . $key) !== false;
 	}
 
 	/**
      * Clears all cache entries that match the given prefix.
      *
      * @param string $prefix
-     * @return bool|int
+     * @return bool
      */
 	public function clear($prefix = '') {
 		/**
@@ -83,7 +83,7 @@ class APCu extends Cache implements IMemcache {
 			// only return the key names when interating
 			APC_ITER_KEY,
 		);
-		return apcu_delete($iterator);
+		return apcu_delete($iterator) !== false;
 	}
 
     /**
@@ -98,7 +98,7 @@ class APCu extends Cache implements IMemcache {
 		if ($ttl === 0) {
 			$ttl = self::DEFAULT_TTL;
 		}
-		return apcu_add($this->getPrefix() . $key, $value, $ttl);
+		return apcu_add($this->getPrefix() . $key, $value, $ttl) === true;
 	}
 
     /**

--- a/lib/private/Memcache/APCu.php
+++ b/lib/private/Memcache/APCu.php
@@ -7,24 +7,33 @@
  */
 namespace OC\Memcache;
 
-use bantu\IniGetWrapper\IniGetWrapper;
 use OCP\IMemcache;
 
 class APCu extends Cache implements IMemcache {
 	use CASTrait {
 		cas as casEmulated;
 	}
-
 	use CADTrait;
 
+    /**
+     * Fetches a value from the cache.
+     *
+     * @param string $key
+     * @return mixed|null Value if found, null otherwise
+     */
 	public function get($key) {
 		$result = apcu_fetch($this->getPrefix() . $key, $success);
-		if (!$success) {
-			return null;
-		}
-		return $result;
+		return $success ? $result : null;
 	}
 
+    /**
+     * Stores a value in the cache.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param int $ttl Time To Live in seconds. Defaults to 60*60*24 (24h)
+     * @return bool
+     */
 	public function set($key, $value, $ttl = 0) {
 		if ($ttl === 0) {
 			$ttl = self::DEFAULT_TTL;
@@ -32,33 +41,59 @@ class APCu extends Cache implements IMemcache {
 		return apcu_store($this->getPrefix() . $key, $value, $ttl);
 	}
 
+    /**
+     * Checks if a given key exists in the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
 	public function hasKey($key) {
 		return apcu_exists($this->getPrefix() . $key);
 	}
-
+	
+    /**
+     * Removes a value from the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
 	public function remove($key) {
 		return apcu_delete($this->getPrefix() . $key);
 	}
 
+	/**
+     * Clears all cache entries that match the given prefix.
+     *
+     * @param string $prefix
+     * @return bool|int
+     */
 	public function clear($prefix = '') {
-		$ns = $this->getPrefix() . $prefix;
-		$ns = preg_quote($ns, '/');
-		if (class_exists('\APCIterator')) {
-			$iter = new \APCIterator('user', '/^' . $ns . '/', APC_ITER_KEY);
-		} else {
-			$iter = new \APCUIterator('/^' . $ns . '/', APC_ITER_KEY);
-		}
-		return apcu_delete($iter);
+		/**
+ 		 * Note: Prefixes/namespaces in caching are currently inconsistent/confusing.
+ 		 * There are multiple levels (instance, user, app/use case) which may overlap.
+ 		 * Also, other implementations (e.g., MemCached) clear everything regardless 
+		 * of prefix.
+ 		 * TODO: Standardize prefix naming and document any differences across cache 
+		 * backends.
+ 		 */
+		$combinedNamespace = preg_quote($this->getPrefix() . $prefix, '/');
+		$iterator = new \APCUIterator(
+			// only care about keys that start with our $combinedNamespace
+			'/^' . $combinedNamespace . '/',
+			// only return the key names when interating
+			APC_ITER_KEY,
+		);
+		return apcu_delete($iterator);
 	}
 
-	/**
-	 * Set a value in the cache if it's not already stored
-	 *
-	 * @param string $key
-	 * @param mixed $value
-	 * @param int $ttl Time To Live in seconds. Defaults to 60*60*24
-	 * @return bool
-	 */
+    /**
+     * Adds a key to the cache only if it does not already exist.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param int $ttl Time To Live in seconds. Defaults to 60*60*24 (24h)
+     * @return bool False if key already exists (new value is ignored)
+     */
 	public function add($key, $value, $ttl = 0) {
 		if ($ttl === 0) {
 			$ttl = self::DEFAULT_TTL;
@@ -66,59 +101,67 @@ class APCu extends Cache implements IMemcache {
 		return apcu_add($this->getPrefix() . $key, $value, $ttl);
 	}
 
-	/**
-	 * Increase a stored number
-	 *
-	 * @param string $key
-	 * @param int $step
-	 * @return int | bool
-	 */
+    /**
+     * Increments a stored number.
+     *
+     * If the key does not exist, it is created and set to `0` before 
+	 * performing the increment (i.e. returning a value of `1`).
+  	 * 
+  	 * The TTL is left alone on preexisting keys, but newly created keys 
+	 * automatically get assigned a TTL of self::DEFAULT_TTL.
+     *
+     * @param string $key
+     * @param int $step
+     * @return int|bool New value on success, false on failure
+     */
 	public function inc($key, $step = 1) {
-		$success = null;
+		$success = null; // don't care
 		return apcu_inc($this->getPrefix() . $key, $step, $success, self::DEFAULT_TTL);
 	}
 
-	/**
-	 * Decrease a stored number
+    /**
+     * Decrements a stored number.
 	 *
-	 * @param string $key
-	 * @param int $step
-	 * @return int | bool
-	 */
+  	 * If the key does not exist, false is returned and the operation 
+	 * does not take place. This differs from `inc()` above for unknown reasons, 
+  	 * but it does match the interface and other implementations.
+     *
+     * @param string $key
+     * @param int $step
+     * @return int|bool New value on success, false if key does not exist
+     */
 	public function dec($key, $step = 1) {
-		return apcu_exists($this->getPrefix() . $key)
-			? apcu_dec($this->getPrefix() . $key, $step)
-			: false;
+		return $this->hasKey($key) ? apcu_dec($this->getPrefix() . $key, $step) : false;
 	}
 
 	/**
-	 * Compare and set
-	 *
-	 * @param string $key
-	 * @param mixed $old
-	 * @param mixed $new
-	 * @return bool
-	 */
+     * Compare and set operation (CAS).
+	 * 
+     * Sets $key's value to $new IF its current value matches $old.
+     * Uses APCu native CAS for integers, otherwise falls back to emulated CAS.
+     *
+     * @param string $key
+     * @param mixed $old
+     * @param mixed $new
+     * @return bool
+     */
 	public function cas($key, $old, $new) {
-		// apc only does cas for ints
-		if (is_int($old) and is_int($new)) {
+		// APCu only does cas for ints
+		if (is_int($old) && is_int($new)) {
 			return apcu_cas($this->getPrefix() . $key, $old, $new);
 		} else {
 			return $this->casEmulated($key, $old, $new);
 		}
 	}
 
+    /**
+     * Checks if APCu is usable.
+     *
+     * @return bool
+     */
 	public static function isAvailable(): bool {
-		if (!extension_loaded('apcu')) {
-			return false;
-		} elseif (!\OC::$server->get(IniGetWrapper::class)->getBool('apc.enabled')) {
-			return false;
-		} elseif (!\OC::$server->get(IniGetWrapper::class)->getBool('apc.enable_cli') && \OC::$CLI) {
-			return false;
-		} elseif (version_compare(phpversion('apcu') ?: '0.0.0', '5.1.0') === -1) {
-			return false;
-		} else {
-			return true;
-		}
+		return function_exists('apcu_enabled')
+			&& apcu_enabled()
+			&& version_compare(phpversion('apcu'), '5.1.19', '>=');
 	}
 }

--- a/lib/private/Memcache/APCu.php
+++ b/lib/private/Memcache/APCu.php
@@ -15,25 +15,25 @@ class APCu extends Cache implements IMemcache {
 	}
 	use CADTrait;
 
-    /**
-     * Fetches a value from the cache.
-     *
-     * @param string $key
-     * @return mixed|null Value if found, null otherwise
-     */
+	/**
+	 * Fetches a value from the cache.
+	 *
+	 * @param string $key
+	 * @return mixed|null Value if found, null otherwise
+	 */
 	public function get($key) {
 		$result = apcu_fetch($this->getPrefix() . $key, $success);
 		return $success ? $result : null;
 	}
 
-    /**
-     * Stores a value in the cache.
-     *
-     * @param string $key
-     * @param mixed $value
-     * @param int $ttl Time To Live in seconds. Defaults to 60*60*24 (24h)
-     * @return bool
-     */
+	/**
+	 * Stores a value in the cache.
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param int $ttl Time To Live in seconds. Defaults to 60*60*24 (24h)
+	 * @return bool
+	 */
 	public function set($key, $value, $ttl = 0) {
 		if ($ttl === 0) {
 			$ttl = self::DEFAULT_TTL;
@@ -41,41 +41,41 @@ class APCu extends Cache implements IMemcache {
 		return apcu_store($this->getPrefix() . $key, $value, $ttl) === true;
 	}
 
-    /**
-     * Checks if a given key exists in the cache.
-     *
-     * @param string $key
-     * @return bool
-     */
+	/**
+	 * Checks if a given key exists in the cache.
+	 *
+	 * @param string $key
+	 * @return bool
+	 */
 	public function hasKey($key) {
 		return apcu_exists($this->getPrefix() . $key) === true;
 	}
 	
-    /**
-     * Removes a value from the cache.
-     *
-     * @param string $key
-     * @return bool
-     */
+	/**
+	 * Removes a value from the cache.
+	 *
+	 * @param string $key
+	 * @return bool
+	 */
 	public function remove($key) {
 		return apcu_delete($this->getPrefix() . $key) !== false;
 	}
 
 	/**
-     * Clears all cache entries that match the given prefix.
-     *
-     * @param string $prefix
-     * @return bool
-     */
+	 * Clears all cache entries that match the given prefix.
+	 *
+	 * @param string $prefix
+	 * @return bool
+	 */
 	public function clear($prefix = '') {
 		/**
- 		 * Note: Prefixes/namespaces in caching are currently inconsistent/confusing.
- 		 * There are multiple levels (instance, user, app/use case) which may overlap.
- 		 * Also, other implementations (e.g., MemCached) clear everything regardless 
+		 * Note: Prefixes/namespaces in caching are currently inconsistent/confusing.
+		 * There are multiple levels (instance, user, app/use case) which may overlap.
+		 * Also, other implementations (e.g., MemCached) clear everything regardless 
 		 * of prefix.
- 		 * TODO: Standardize prefix naming and document any differences across cache 
+		 * TODO: Standardize prefix naming and document any differences across cache 
 		 * backends.
- 		 */
+		 */
 		$combinedNamespace = preg_quote($this->getPrefix() . $prefix, '/');
 		$iterator = new \APCUIterator(
 			// only care about keys that start with our $combinedNamespace
@@ -86,14 +86,14 @@ class APCu extends Cache implements IMemcache {
 		return apcu_delete($iterator) !== false;
 	}
 
-    /**
-     * Adds a key to the cache only if it does not already exist.
-     *
-     * @param string $key
-     * @param mixed $value
-     * @param int $ttl Time To Live in seconds. Defaults to 60*60*24 (24h)
-     * @return bool False if key already exists (new value is ignored)
-     */
+	/**
+	 * Adds a key to the cache only if it does not already exist.
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param int $ttl Time To Live in seconds. Defaults to 60*60*24 (24h)
+	 * @return bool False if key already exists (new value is ignored)
+	 */
 	public function add($key, $value, $ttl = 0) {
 		if ($ttl === 0) {
 			$ttl = self::DEFAULT_TTL;
@@ -101,50 +101,50 @@ class APCu extends Cache implements IMemcache {
 		return apcu_add($this->getPrefix() . $key, $value, $ttl) === true;
 	}
 
-    /**
-     * Increments a stored number.
-     *
-     * If the key does not exist, it is created and set to `0` before 
+	/**
+	 * Increments a stored number.
+	 *
+	 * If the key does not exist, it is created and set to `0` before 
 	 * performing the increment (i.e. returning a value of `1`).
-  	 * 
-  	 * The TTL is left alone on preexisting keys, but newly created keys 
+	 * 
+	 * The TTL is left alone on preexisting keys, but newly created keys 
 	 * automatically get assigned a TTL of self::DEFAULT_TTL.
-     *
-     * @param string $key
-     * @param int $step
-     * @return int|bool New value on success, false on failure
-     */
+	 *
+	 * @param string $key
+	 * @param int $step
+	 * @return int|bool New value on success, false on failure
+	 */
 	public function inc($key, $step = 1) {
 		$success = null; // don't care
 		return apcu_inc($this->getPrefix() . $key, $step, $success, self::DEFAULT_TTL);
 	}
 
-    /**
-     * Decrements a stored number.
+	/**
+	 * Decrements a stored number.
 	 *
-  	 * If the key does not exist, false is returned and the operation 
+	 * If the key does not exist, false is returned and the operation 
 	 * does not take place. This differs from `inc()` above for unknown reasons, 
-  	 * but it does match the interface and other implementations.
-     *
-     * @param string $key
-     * @param int $step
-     * @return int|bool New value on success, false if key does not exist
-     */
+	 * but it does match the interface and other implementations.
+	 *
+	 * @param string $key
+	 * @param int $step
+	 * @return int|bool New value on success, false if key does not exist
+	 */
 	public function dec($key, $step = 1) {
 		return $this->hasKey($key) ? apcu_dec($this->getPrefix() . $key, $step) : false;
 	}
 
 	/**
-     * Compare and set operation (CAS).
+	 * Compare and set operation (CAS).
 	 * 
-     * Sets $key's value to $new IF its current value matches $old.
-     * Uses APCu native CAS for integers, otherwise falls back to emulated CAS.
-     *
-     * @param string $key
-     * @param mixed $old
-     * @param mixed $new
-     * @return bool
-     */
+	 * Sets $key's value to $new IF its current value matches $old.
+	 * Uses APCu native CAS for integers, otherwise falls back to emulated CAS.
+	 *
+	 * @param string $key
+	 * @param mixed $old
+	 * @param mixed $new
+	 * @return bool
+	 */
 	public function cas($key, $old, $new) {
 		// APCu only does cas for ints
 		if (is_int($old) && is_int($new)) {
@@ -154,11 +154,11 @@ class APCu extends Cache implements IMemcache {
 		}
 	}
 
-    /**
-     * Checks if APCu is usable.
-     *
-     * @return bool
-     */
+	/**
+	 * Checks if APCu is usable.
+	 *
+	 * @return bool
+	 */
 	public static function isAvailable(): bool {
 		return function_exists('apcu_enabled')
 			&& apcu_enabled()

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -109,7 +109,7 @@ class Redis extends Cache implements IMemcacheTTL {
 		 */
 		$pattern = $this->getPrefix() . $prefix . '*';
 		/** @var array|false */
-		$keys = $self::$cache->keys($pattern);		
+		$keys = self::$cache->keys($pattern);		
 		if (!is_array($keys) || count($keys) === 0) { // no matching keys
 			return true; // nothing to do; consider operation done
 		}

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -175,15 +175,14 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	/**
-	 * Compare and set.
+	 * Compare and set if equal.
 	 * 
-	 * Sets $key's value to $new IF its current value matches $old.
-	 * Uses APCu native CAS for integers, otherwise falls back to emulated CAS.
+	 * Sets $key's value to $new if its current value matches $oldValue.
 	 *
 	 * @param string $key
 	 * @param mixed $oldValue
 	 * @param mixed $newValue
-	 * @return bool
+	 * @return bool True if successful, False if operation failed or no match found
 	 */
 	public function cas($key, $oldValue, $newValue) {
 		$oldValueEncoded = self::encodeValue($oldValue);
@@ -192,11 +191,15 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	/**
-	 * Compare and delete.
+	 * Compare and delete if equal.
+  	 * 
+	 * Deletes $key if it's current value matches $oldValue. 
+  	 * TODO: Compare against using built-in `GETDEL` (especially since we currently only
+	 * handle simple strings anyhow; though requires >=v6.2.0).
 	 *
 	 * @param string $key
-	 * @param mixed $old
-	 * @return bool
+	 * @param mixed $oldValue
+	 * @return bool True if successful, False if values not equal or operation failed
 	 */
 	public function cad($key, $oldValue) {
 		$oldValueEncoded = self::encodeValue($oldValue);
@@ -204,7 +207,13 @@ class Redis extends Cache implements IMemcacheTTL {
 	}
 
 	/**
-	 * Delete if current value is NOT $oldValue.
+ 	 * Compare and delete if not equal.
+   	 *
+	 * Delete $key if it's current value does not match $oldValue nor is `null`.
+  	 *
+	 * @param string $key
+	 * @param mixed $oldValue
+	 * @return bool True if successful, False if values equal or operation failed
 	 */
 	public function ncad(string $key, mixed $oldValue): bool {
 		$oldValueEncoded = self::encodeValue($oldValue);

--- a/lib/private/Memcache/Redis.php
+++ b/lib/private/Memcache/Redis.php
@@ -199,16 +199,16 @@ class Redis extends Cache implements IMemcacheTTL {
 	 * @return bool
 	 */
 	public function cad($key, $oldValue) {
-		$old = self::encodeValue($old);
-		return $this->evalLua('cad', [$key], [$oldValue]) > 0;
+		$oldValueEncoded = self::encodeValue($oldValue);
+		return $this->evalLua('cad', [$key], [$oldValueEncoded]) > 0;
 	}
 
 	/**
 	 * Delete if current value is NOT $oldValue.
 	 */
 	public function ncad(string $key, mixed $oldValue): bool {
-		$old = self::encodeValue($oldValue);
-		return $this->evalLua('ncad', [$key], [$oldValue]) > 0;
+		$oldValueEncoded = self::encodeValue($oldValue);
+		return $this->evalLua('ncad', [$key], [$oldValueEncoded]) > 0;
 	}
 
 	/**


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

- Simplifies availability check
- Comments including caveats/gotchas
- Minor code cosmetic refactoring 
- Bumped APCu version check to 5.1.19 (which has been required for use w/ PHP 8.0.0 for many years already anyhow)

## TODO

Planning to go through Redis & Memcached classes separately along with checking the associated interfaces. Might drop some of the shared/inherited comments across the board when I do so, but for now these are the most up-to-date ones. 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
