### PR TITLE
[stable31] Revert "fix(files_trashbin): Fix size propagation when moving file to trash

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -293,9 +293,8 @@ class Trashbin implements IEventListener {
 		try {
 			$moveSuccessful = true;
 
-			$inCache = $sourceStorage->getCache()->inCache($sourceInternalPath);
 			$trashStorage->moveFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
-			if ($inCache) {
+			if ($sourceStorage->getCache()->inCache($sourceInternalPath)) {
 				$trashStorage->getUpdater()->renameFromStorage($sourceStorage, $sourceInternalPath, $trashInternalPath);
 			}
 		} catch (CopyRecursiveException $e) {

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -19,9 +19,7 @@ use OCA\Files_Trashbin\Trashbin;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Constants;
 use OCP\Files\FileInfo;
-use OCP\Files\IRootFolder;
 use OCP\IConfig;
-use OCP\Server;
 use OCP\Share\IShare;
 
 /**
@@ -664,28 +662,6 @@ class TrashbinTest extends \Test\TestCase {
 
 			chmod($folderAbsPath, 0755);
 		}
-	}
-
-	public function testTrashSizePropagation(): void {
-		$view = new View('/' . self::TEST_TRASHBIN_USER1 . '/files_trashbin/files');
-
-		$userFolder = Server::get(IRootFolder::class)->getUserFolder(self::TEST_TRASHBIN_USER1);
-		$file1 = $userFolder->newFile('foo.txt');
-		$file1->putContent('1');
-
-		$this->assertTrue($userFolder->nodeExists('foo.txt'));
-		$file1->delete();
-		$this->assertFalse($userFolder->nodeExists('foo.txt'));
-		$this->assertEquals(1, $view->getFileInfo('')->getSize());
-
-		$folder = $userFolder->newFolder('bar');
-		$file2 = $folder->newFile('baz.txt');
-		$file2->putContent('22');
-
-		$this->assertTrue($userFolder->nodeExists('bar'));
-		$folder->delete();
-		$this->assertFalse($userFolder->nodeExists('bar'));
-		$this->assertEquals(3, $view->getFileInfo('')->getSize());
 	}
 
 	/**


### PR DESCRIPTION
This reverts commit b0a27e4dc4b3d96b6744ddb343d6deff4aa79197.

<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary


## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
