### PR TITLE
fix(ownCloud): ensure that `accounts.display_name` fits into `users.displayname`

### DIFF
--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -173,7 +173,8 @@ class SaveAccountsTableData implements IRepairStep {
 		}
 
 		if ($userdata['display_name'] !== null) {
-			$update->setParameter('displayname', $userdata['display_name'])
+			// user.displayname only allows 64 characters but old accounts.display_name allowed 255 characters
+			$update->setParameter('displayname', substr($userdata['display_name'], 0, 64))
 				->setParameter('userid', $userdata['user_id']);
 			$update->executeStatement();
 		}

--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -174,7 +174,7 @@ class SaveAccountsTableData implements IRepairStep {
 
 		if ($userdata['display_name'] !== null) {
 			// user.displayname only allows 64 characters but old accounts.display_name allowed 255 characters
-			$update->setParameter('displayname', substr($userdata['display_name'], 0, 64))
+			$update->setParameter('displayname', mb_substr($userdata['display_name'], 0, 64))
 				->setParameter('userid', $userdata['user_id']);
 			$update->executeStatement();
 		}


### PR DESCRIPTION
## Summary

`user.displayname` only allows 64 characters but old ownCloud `accounts.display_name` allowed 255 characters.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
