### PR TITLE
fix(auth): allow access to dynamic js files during 2FA

### DIFF
--- a/core/Controller/JsController.php
+++ b/core/Controller/JsController.php
@@ -42,6 +42,7 @@ class JsController extends Controller {
 
 	/**
 	 * @NoSameSiteCookieRequired
+	 * @NoTwoFactorRequired
 	 *
 	 * @param string $fileName js filename with extension
 	 * @param string $appName js folder name
@@ -75,6 +76,8 @@ class JsController extends Controller {
 	}
 
 	/**
+	 * @NoTwoFactorRequired
+	 *
 	 * @param ISimpleFolder $folder
 	 * @param string $fileName
 	 * @param bool $gzip is set to true if we use the gzip file


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

Nextcloud has some dynamically built js files like `js/merged-template-prepend.js`. These are not served by the web server but go through a controller. When the user has logged in but 2FA hasn't been passed yet, the resources are not loadable.

## TODO

- [x] Do

## How to test

1. Turn off debug mode (important, otherwise some of the logic seems to be turned off)
2. Set up 2FA
3. Log out
4. Open the browser console
5. Log in (no 2FA yet)

master: you see a request for `js/merged-template-prepend.js` and it gets redirected with a HTTP 303. The browser complains about a corrupted script.
here: the file can be accessed and the browser is happy.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
