### PR TITLE
feat(ZipFolderPlugin): always use the parent folder name as archive name

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/ZipFolderPlugin.php
@@ -157,14 +157,18 @@ class ZipFolderPlugin extends ServerPlugin {
 			$content[] = $child->getNode();
 		}
 
-		$archiveName = 'download';
+		$archiveName = $folder->getName();
+		if (count(explode('/', trim($folder->getPath(), '/'), 3)) === 2) {
+			// this is a download of the root folder
+			$archiveName = 'download';
+		}
+
 		$rootPath = $folder->getPath();
 		if (empty($files)) {
 			// We download the full folder so keep it in the tree
 			$rootPath = dirname($folder->getPath());
-			// Full folder is loaded to rename the archive to the folder name
-			$archiveName = $folder->getName();
 		}
+
 		$streamer = new Streamer($tarRequest, -1, count($content), $this->timezoneFactory);
 		$streamer->sendHeaders($archiveName);
 		// For full folder downloads we also add the folder itself to the archive

--- a/cypress/e2e/files_sharing/public-share/PublicShareUtils.ts
+++ b/cypress/e2e/files_sharing/public-share/PublicShareUtils.ts
@@ -158,7 +158,7 @@ function adjustSharePermission(): void {
  */
 export function setupPublicShare(shareName = 'shared'): Cypress.Chainable<string> {
 
-	return cy.task('getVariable', { key: 'public-share-data' })
+	return cy.task('getVariable', { key: `public-share-data--${shareName}` })
 		.then((data) => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const { dataSnapshot, shareUrl } = data as any || {}
@@ -183,7 +183,7 @@ export function setupPublicShare(shareName = 'shared'): Cypress.Chainable<string
 							shareData.dataSnapshot = snapshot
 						}),
 					)
-					.then(() => cy.task('setVariable', { key: 'public-share-data', value: shareData }))
+					.then(() => cy.task('setVariable', { key: `public-share-data--${shareName}`, value: shareData }))
 					.then(() => cy.log(`Public share setup, URL: ${shareData.shareUrl}`))
 					.then(() => cy.wrap(defaultShareContext.url))
 			}

--- a/cypress/e2e/files_sharing/public-share/download.cy.ts
+++ b/cypress/e2e/files_sharing/public-share/download.cy.ts
@@ -45,7 +45,9 @@ describe('files_sharing: Public share - downloading files', { testIsolation: tru
 	})
 
 	describe('folder share', () => {
-		before(() => setupPublicShare())
+		const shareName = 'a-folder-share'
+
+		before(() => setupPublicShare(shareName))
 
 		deleteDownloadsFolderBeforeEach()
 
@@ -72,7 +74,7 @@ describe('files_sharing: Public share - downloading files', { testIsolation: tru
 
 				// check a file is downloaded
 				const downloadsFolder = Cypress.config('downloadsFolder')
-				cy.readFile(`${downloadsFolder}/download.zip`, null, { timeout: 15000 })
+				cy.readFile(`${downloadsFolder}/${shareName}.zip`, null, { timeout: 15000 })
 					.should('exist')
 					.and('have.length.gt', 30)
 					// Check all files are included


### PR DESCRIPTION
## Summary

- for cfr#1476

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
