### PR TITLE
fix(files_versions): Return if version entity is not found

### DIFF
--- a/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
+++ b/apps/files_versions/lib/Versions/LegacyVersionsBackend.php
@@ -15,6 +15,7 @@ use OCA\DAV\Connector\Sabre\Exception\Forbidden;
 use OCA\Files_Versions\Db\VersionEntity;
 use OCA\Files_Versions\Db\VersionsMapper;
 use OCA\Files_Versions\Storage;
+use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\Constants;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
@@ -261,7 +262,12 @@ class LegacyVersionsBackend implements IVersionBackend, IDeletableVersionBackend
 	}
 
 	public function updateVersionEntity(File $sourceFile, int $revision, array $properties): void {
-		$versionEntity = $this->versionsMapper->findVersionForFileId($sourceFile->getId(), $revision);
+		try {
+			$versionEntity = $this->versionsMapper->findVersionForFileId($sourceFile->getId(), $revision);
+		} catch (DoesNotExistException $e) {
+			// no version found for fileId
+			return;
+		}
 
 		if (isset($properties['timestamp'])) {
 			$versionEntity->setTimestamp($properties['timestamp']);


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Fix for:

```
{
  "reqId": "iNwhE8uZnaFbKbyG6WFq",
  "level": 3,
  "time": "2025-09-11T09:48:09+02:00",
  "remoteAddr": "91.6.26.13",
  "user": "fzez",
  "app": "no app in context",
  "method": "COPY",
  "url": "/remote.php/dav/files/user/folder/file.md",
  "message": "Exception thrown: OCP\\AppFramework\\Db\\DoesNotExistException",
  "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
  "version": "30.0.14.1",
  "exception": {
    "Exception": "OCP\\AppFramework\\Db\\DoesNotExistException",
    "Message": "Did expect one result but found none when executing: query \"SELECT * FROM `*PREFIX*files_versions` WHERE (`file_id` = :dcValue1) AND (`timestamp` = :dcValue2)\"; ",
    "Code": 0,
    "Trace": [
      {
        "file": "/var/www/nextcloud/lib/public/AppFramework/Db/QBMapper.php",
        "line": 359,
        "function": "findOneQuery",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Db/VersionsMapper.php",
        "line": 60,
        "function": "findEntity",
        "class": "OCP\\AppFramework\\Db\\QBMapper",
        "type": "->",
        "args": [
          {
            "__class__": "OC\\DB\\QueryBuilder\\QueryBuilder"
          }
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Versions/LegacyVersionsBackend.php",
        "line": 254,
        "function": "findVersionForFileId",
        "class": "OCA\\Files_Versions\\Db\\VersionsMapper",
        "type": "->",
        "args": [
          204706,
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Versions/VersionManager.php",
        "line": 129,
        "function": "updateVersionEntity",
        "class": "OCA\\Files_Versions\\Versions\\LegacyVersionsBackend",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 254,
        "function": "updateVersionEntity",
        "class": "OCA\\Files_Versions\\Versions\\VersionManager",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/nextcloud/apps/files_versions/lib/Listener/FileEventsListener.php",
        "line": 85,
        "function": "post_write_hook",
        "class": "OCA\\Files_Versions\\Listener\\FileEventsListener",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      ...
}
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
