### PR TITLE
chore(settings): Drop unneeded 'json' PHP module check (since PHP 8.0.0)

### DIFF
--- a/apps/settings/lib/SetupChecks/PhpModules.php
+++ b/apps/settings/lib/SetupChecks/PhpModules.php
@@ -20,7 +20,6 @@ class PhpModules implements ISetupCheck {
 		'dom',
 		'fileinfo',
 		'gd',
-		'json',
 		'mbstring',
 		'openssl',
 		'posix',


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Removed `json` module from the list of required PHP modules.

It's built-in and not possible to disable at compile time since PHP 8.0.0.

Refs:
- https://www.php.net/manual/en/json.installation.php
- https://wiki.php.net/rfc/always_enable_json
- https://www.php.net/ChangeLog-8.php#8.0.0

Related: nextcloud/documentation#13660

## TODO

- [ ] ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
