### PR TITLE
[stable30] fix(Apps): fix install command check on existing apps

### DIFF
--- a/core/Command/App/Install.php
+++ b/core/Command/App/Install.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OC\Core\Command\App;
 
 use OC\Installer;
+use OCP\App\AppPathNotFoundException;
 use OCP\App\IAppManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -58,9 +59,11 @@ class Install extends Command {
 		$appId = $input->getArgument('app-id');
 		$forceEnable = (bool) $input->getOption('force');
 
-		if ($this->appManager->isInstalled($appId)) {
+		try {
+			$this->appManager->getAppPath($appId);
 			$output->writeln($appId . ' already installed');
 			return 1;
+		} catch (AppPathNotFoundException) {
 		}
 
 		try {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

Currently, enabled apps are returned, whether they are installed or not. This is a behavioral breaking change compared to 29.

Based this now on 30 for https://github.com/nextcloud/univention-app/pull/208, and I am not sure this is what we really want in server (cf. my comment at https://github.com/nextcloud/server/pull/49648/files#r2341962849).  

If so, I'd do a new PR based on master, which has diverges further.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
