### PR TITLE
fix: check if reported size is numeric in file info command

### DIFF
--- a/core/Command/Info/File.php
+++ b/core/Command/Info/File.php
@@ -176,7 +176,7 @@ class File extends Command {
 					}
 					$stat = fstat($fh);
 					fclose($fh);
-					if (isset($stat['size']) && $stat['size'] !== $node->getSize()) {
+					if (isset($stat['size']) && is_numeric($stat['size']) && $stat['size'] !== $node->getSize()) {
 						$output->writeln('  <error>warning: object had a size of ' . $stat['size'] . ' but cache entry has a size of ' . $node->getSize() . '</error>. This should have been automatically repaired');
 					}
 				} catch (\Exception $e) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Resolves: # <!-- related github issue -->

## Summary

The stat array will contain a 'size' member if S3 is used as primary storage. However, it will be empty leading to confusing error messages: `warning: object had a size of  but cache entry has a size of 59. This should have been automatically repaired`

(See how there is no actual size mentioned after `size of`.)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
