### PR TITLE
fix(settings): rename "Settings presets" to "Quick presets"

### DIFF
--- a/apps/settings/lib/Sections/Admin/Presets.php
+++ b/apps/settings/lib/Sections/Admin/Presets.php
@@ -29,7 +29,7 @@ class Presets implements IIconSection {
 	}
 
 	public function getName(): string {
-		return $this->l->t('Settings presets');
+		return $this->l->t('Quick presets');
 	}
 
 	public function getPriority(): int {


### PR DESCRIPTION
## Summary

As discussed with @jancborchardt and @jospoortvliet 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
