### PR TITLE
[stable25] fix(ownCloud): ensure that `accounts.display_name` fits into `users.displayname`

### DIFF
--- a/lib/private/Repair/Owncloud/SaveAccountsTableData.php
+++ b/lib/private/Repair/Owncloud/SaveAccountsTableData.php
@@ -191,7 +191,8 @@ class SaveAccountsTableData implements IRepairStep {
 		}
 
 		if ($userdata['display_name'] !== null) {
-			$update->setParameter('displayname', $userdata['display_name'])
+			// user.displayname only allows 64 characters but old accounts.display_name allowed 255 characters
+			$update->setParameter('displayname', mb_substr($userdata['display_name'], 0, 64))
 				->setParameter('userid', $userdata['user_id']);
 			$update->execute();
 		}


### PR DESCRIPTION
- manual backport of https://github.com/nextcloud/server/pull/55006

Needed because we recommend to do migrations from OC 10.x to NC 25 ...

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
