### PR TITLE
feat(updater): Allow to define locked apps to (not) be updated

### DIFF
--- a/apps/settings/lib/Controller/AppSettingsController.php
+++ b/apps/settings/lib/Controller/AppSettingsController.php
@@ -650,6 +650,12 @@ class AppSettingsController extends Controller {
 	public function updateApp(string $appId): JSONResponse {
 		$appId = $this->appManager->cleanAppId($appId);
 
+		// Don't try to update locked apps
+		$appsLocked = $this->config->getSystemValue('apps_locked', []);
+		if (in_array($appId, $appsLocked, true)) {
+			return new JSONResponse(['data' => ['message' => $this->l10n->t('App is locked, update skipped.')]], Http::STATUS_FORBIDDEN);
+		}
+
 		$this->config->setSystemValue('maintenance', true);
 		try {
 			$result = $this->installer->updateAppstoreApp($appId);

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -373,7 +373,14 @@ class Updater extends BasicEmitter {
 	 * @throws \Exception
 	 */
 	private function upgradeAppStoreApps(array $apps, array $previousEnableStates = []): void {
+		$appsLocked = $this->config->getSystemValue('apps_locked', []);
+
 		foreach ($apps as $app) {
+			// Don't try to update locked apps
+			if (in_array($app, $appsLocked, true)) {
+				$this->log->info('Update skipped for locked app' . $app, ['app' => 'updater']);
+				continue;
+			}
 			try {
 				$this->emit('\OC\Updater', 'checkAppStoreAppBefore', [$app]);
 				if ($this->installer->isUpdateAvailable($app)) {


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

## Summary

In some environnements, it can be useful to "lock" apps to disallow updates by administrators for many reasons; control when updates are made, deny updates from the Web while manually forcing them on the CLI (after disable the switch), forcing an app to remain on a specific version, etc.

Actually, to accomplish a similar behavior, one must render the `/apps/<app>` folder unwritable by the webserver (ex.: `cd /var/www/nextcloud/apps/; chmod 0750 <app>; chown -R root:www-data <app>`) because if webserver can't write on the app folder, app can't be updated.

**With this PR**, an Administrator could publish an array of apps on `config.php` like:

`'apps_locked' => ['user_saml', 'groupfolders', 'onlyoffice'];`

And such apps couldn't be updated unless the app name is removed from the array.
We could also implement a `--force` switch on the CLI, but i believe that removing the app from the array could be more effective.

**One question remains**; if, while upgrading server to a major version (32>33) apps need update for compatibility reasons, how to handle this case effectively:

1. Deny server upgrade and ask administrator to empty the array?
2. Bypass that switch and upgrade apps nevertheless?

Please review and comment.

## ToDo

- [ ] Documentation

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
