### PR TITLE
fix(TagsTest): Declare `rootFolder` property

### DIFF
--- a/tests/lib/TagsTest.php
+++ b/tests/lib/TagsTest.php
@@ -38,6 +38,7 @@ class TagsTest extends \Test\TestCase {
 	protected $tagMapper;
 	/** @var ITagManager */
 	protected $tagMgr;
+	protected IRootFolder $rootFolder;
 
 	protected function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
It was not caught by the CI on master, but is blocking in the backports.

Follow-up of https://github.com/nextcloud/server/pull/55122