### PR TITLE
[stable30] fix(auth): Fix invalid unique constraint violation catch

### DIFF
--- a/tests/lib/Authentication/Token/ManagerTest.php
+++ b/tests/lib/Authentication/Token/ManagerTest.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 
 namespace Test\Authentication\Token;
 
-use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IToken;
 use OC\Authentication\Token\Manager;
 use OC\Authentication\Token\PublicKeyToken;
 use OC\Authentication\Token\PublicKeyTokenProvider;
+use OCP\DB\Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -61,9 +61,10 @@ class ManagerTest extends TestCase {
 		$this->assertSame($token, $actual);
 	}
 
-	public function testGenerateConflictingToken() {
-		/** @var MockObject|UniqueConstraintViolationException $exception */
-		$exception = $this->createMock(UniqueConstraintViolationException::class);
+	public function testGenerateConflictingToken(): void {
+		/** @var MockObject&Exception $exception */
+		$exception = $this->createMock(Exception::class);
+		$exception->method('getReason')->willReturn(Exception::REASON_UNIQUE_CONSTRAINT_VIOLATION);
 
 		$token = new PublicKeyToken();
 		$token->setUid('uid');


### PR DESCRIPTION
UniqueConstraintViolationException is no longer throw but instead a OCP\DB\Exception is.

Backport of https://github.com/nextcloud/server/pull/55123

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
