### PR TITLE
test(integration): Check ocs share permission for correct folder

### DIFF
--- a/build/integration/sharing_features/sharing-v1-part3.feature
+++ b/build/integration/sharing_features/sharing-v1-part3.feature
@@ -46,7 +46,7 @@ Feature: sharing
   Scenario: Correct webdav share-permissions for owned folder
     Given user "user0" exists
     And user "user0" created a folder "/tmp"
-    When as "user0" gets properties of folder "/" with
+    When as "user0" gets properties of folder "/tmp" with
       |{http://open-collaboration-services.org/ns}share-permissions |
     Then the single response should contain a property "{http://open-collaboration-services.org/ns}share-permissions" with value "31"
 


### PR DESCRIPTION
Extracted from https://github.com/nextcloud/server/pull/54803

The intention of the test is to check the permissions of the newly created folder, but it wasn't actually doing that.