### PR TITLE
fix(Updater): Lower deadlock log level from warning to info

### DIFF
--- a/lib/private/Files/Cache/Updater.php
+++ b/lib/private/Files/Cache/Updater.php
@@ -284,7 +284,7 @@ class Updater implements IUpdater {
 					// ignore the failure.
 					// with failures concurrent updates, someone else would have already done it.
 					// in the worst case the `storage_mtime` isn't updated, which should at most only trigger an extra rescan
-					$this->logger->warning('Error while updating parent storage_mtime, should be safe to ignore', ['exception' => $e]);
+					$this->logger->info('Error while updating parent storage_mtime, should be safe to ignore', ['exception' => $e]);
 				}
 			}
 		}


### PR DESCRIPTION
If this is safe to ignore, then it does not make sense to keep warning the admins.

