### PR TITLE
fix: Allow hyphen in appid

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -1021,7 +1021,7 @@ class AppManager implements IAppManager {
 	 */
 	public function cleanAppId(string $app): string {
 		/* Only lowercase alphanumeric is allowed */
-		return preg_replace('/(^[0-9_]|[^a-z0-9_]+|_$)/', '', $app);
+		return preg_replace('/(^[0-9_-]+|[^a-z0-9_-]+|[_-]+$)/', '', $app);
 	}
 
 	/**

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -28,6 +28,7 @@ use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\ServerVersion;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use Test\TestCase;
@@ -143,7 +144,7 @@ class AppManagerTest extends TestCase {
 		);
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataGetAppIcon')]
+	#[DataProvider('dataGetAppIcon')]
 	public function testGetAppIcon($callback, ?bool $dark, ?string $expected): void {
 		$this->urlGenerator->expects($this->atLeastOnce())
 			->method('imagePath')
@@ -314,7 +315,7 @@ class AppManagerTest extends TestCase {
 	/**
 	 * @param array $appInfo
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataEnableAppForGroupsAllowedTypes')]
+	#[DataProvider('dataEnableAppForGroupsAllowedTypes')]
 	public function testEnableAppForGroupsAllowedTypes(array $appInfo): void {
 		$group1 = $this->createMock(IGroup::class);
 		$group1->method('getGID')
@@ -375,7 +376,7 @@ class AppManagerTest extends TestCase {
 	 * @param string $type
 	 *
 	 */
-	#[\PHPUnit\Framework\Attributes\DataProvider('dataEnableAppForGroupsForbiddenTypes')]
+	#[DataProvider('dataEnableAppForGroupsForbiddenTypes')]
 	public function testEnableAppForGroupsForbiddenTypes($type): void {
 		$this->expectException(\Exception::class);
 		$this->expectExceptionMessage('test can\'t be enabled for groups.');
@@ -781,7 +782,7 @@ class AppManagerTest extends TestCase {
 		];
 	}
 
-	#[\PHPUnit\Framework\Attributes\DataProvider('isBackendRequiredDataProvider')]
+	#[DataProvider('isBackendRequiredDataProvider')]
 	public function testIsBackendRequired(
 		string $backend,
 		array $appBackends,
@@ -895,5 +896,26 @@ class AppManagerTest extends TestCase {
 			'0',
 			$manager->getAppVersion('unknown'),
 		);
+	}
+
+	public static function dataCleanAppId(): array {
+		return [
+			['simple', 'simple'],
+			['UPPERCASEa', 'a'],
+			['MixEdCaSe', 'ixdae'],
+			['007startwithdigit', 'startwithdigit'],
+			['0-numb3rs-4ll0w3d-1n-m1ddle-0', 'numb3rs-4ll0w3d-1n-m1ddle-0'],
+			['hyphen-and_underscore_allowed', 'hyphen-and_underscore_allowed'],
+			['_but-not-at-the-end_', 'but-not-at-the-end'],
+			['-but-not-at-the-end-', 'but-not-at-the-end'],
+			['--_but-not-at-the-end___', 'but-not-at-the-end'],
+			[' also remove all spaces', 'alsoremoveallspaces'],
+			['a«"«»()@+-/*=%\{}…~|&œ—<>[]^±_−÷×≠‰A', 'a-_'],
+		];
+	}
+
+	#[DataProvider('dataCleanAppId')]
+	public function testCleanAppId(string $inputString, string $appid): void {
+		$this->assertEquals($appid, $this->manager->cleanAppId($inputString));
 	}
 }


### PR DESCRIPTION
* Follow-up of https://github.com/nextcloud/server/commit/7ed583cb8ee64f77696b0e23f79d8d1b4038bcbc

## Summary

It’s rare but exists for some apps not in the appstore. 
Also added unit tests for cleanAppId and fixed small issues with it.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
