### PR TITLE
Reflect public shares in `isPublic` flag and fix permission check

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -68,7 +68,16 @@ $requestUri = Server::get(IRequest::class)->getRequestUri();
 $linkCheckPlugin = new PublicLinkCheckPlugin();
 $filesDropPlugin = new FilesDropPlugin();
 
-$server = $serverFactory->createServer(false, $baseuri, $requestUri, $authPlugin, function (\Sabre\DAV\Server $server) use ($authBackend, $linkCheckPlugin, $filesDropPlugin) {
+$server = $serverFactory->createServer(
+	true,
+	$baseuri,
+	$requestUri,
+	$authPlugin,
+	function (\Sabre\DAV\Server $server) use (
+		$authBackend,
+		$linkCheckPlugin,
+		$filesDropPlugin
+	) {
 	$isAjax = in_array('XMLHttpRequest', explode(',', $_SERVER['HTTP_X_REQUESTED_WITH'] ?? ''));
 	/** @var FederatedShareProvider $shareProvider */
 	$federatedShareProvider = Server::get(FederatedShareProvider::class);

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -181,7 +181,7 @@ class Directory extends Node implements \Sabre\DAV\ICollection, \Sabre\DAV\IQuot
 		// If we are, then only PUT and MKCOL are allowed (see plugin)
 		// so we are safe to return the directory without a risk of
 		// leaking files and folders structure.
-		if ($storage instanceof PublicShareWrapper) {
+		if ($storage->instanceOfStorage(PublicShareWrapper::class)) {
 			$share = $storage->getShare();
 			$allowDirectory = ($share->getPermissions() & Constants::PERMISSION_READ) !== Constants::PERMISSION_READ;
 		}

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -37,6 +37,7 @@ use OCP\IRequest;
 use OCP\ITagManager;
 use OCP\IUserManager;
 use OCP\IUserSession;
+use OCP\L10N\IFactory;
 use OCP\SabrePluginEvent;
 use OCP\SystemTag\ISystemTagManager;
 use OCP\SystemTag\ISystemTagObjectMapper;
@@ -71,14 +72,7 @@ class ServerFactory {
 		callable $viewCallBack,
 	): Server {
 		$debugEnabled = $this->config->getSystemValue('debug', false);
-		// Fire up server
-		if ($isPublicShare) {
-			$rootCollection = new SimpleCollection('root');
-			$tree = new CachingTree($rootCollection);
-		} else {
-			$rootCollection = null;
-			$tree = new ObjectTree();
-		}
+		[$tree, $rootCollection] = $this->getTree($isPublicShare);
 		$server = new Server($tree);
 		// Set URL explicitly due to reverse-proxy situations
 		$server->httpRequest->setUrl($requestUri);
@@ -128,7 +122,7 @@ class ServerFactory {
 
 		// wait with registering these until auth is handled and the filesystem is setup
 		$server->on('beforeMethod:*', function () use ($server, $tree,
-			$viewCallBack, $isPublicShare, $rootCollection, $debugEnabled): void {
+			$viewCallBack, $rootCollection, $debugEnabled): void {
 			// ensure the skeleton is copied
 			$userFolder = \OC::$server->getUserFolder();
 
@@ -147,36 +141,8 @@ class ServerFactory {
 				$root = new File($view, $rootInfo);
 			}
 
-			if ($isPublicShare) {
-				$userPrincipalBackend = new Principal(
-					\OCP\Server::get(IUserManager::class),
-					\OCP\Server::get(IGroupManager::class),
-					\OCP\Server::get(IAccountManager::class),
-					\OCP\Server::get(\OCP\Share\IManager::class),
-					\OCP\Server::get(IUserSession::class),
-					\OCP\Server::get(IAppManager::class),
-					\OCP\Server::get(ProxyMapper::class),
-					\OCP\Server::get(KnownUserService::class),
-					\OCP\Server::get(IConfig::class),
-					\OC::$server->getL10NFactory(),
-				);
-
-				// Mount the share collection at /public.php/dav/shares/<share token>
-				$rootCollection->addChild(new RootCollection(
-					$root,
-					$userPrincipalBackend,
-					'principals/shares',
-				));
-
-				// Mount the upload collection at /public.php/dav/uploads/<share token>
-				$rootCollection->addChild(new \OCA\DAV\Upload\RootCollection(
-					$userPrincipalBackend,
-					'principals/shares',
-					\OCP\Server::get(CleanupService::class),
-					\OCP\Server::get(IRootFolder::class),
-					\OCP\Server::get(IUserSession::class),
-					\OCP\Server::get(\OCP\Share\IManager::class),
-				));
+			if ($rootCollection !== null) {
+				$this->initRootCollection($rootCollection, $root);
 			} else {
 				/** @var ObjectTree $tree */
 				$tree->init($root, $view, $this->mountManager);
@@ -251,5 +217,62 @@ class ServerFactory {
 			}
 		}, 30); // priority 30: after auth (10) and acl(20), before lock(50) and handling the request
 		return $server;
+	}
+
+	/**
+	 * Returns a Tree object and, if $useCollection is true, the collection used
+	 * as root.
+	 *
+	 * @param bool $useCollection Whether to use a collection or the legacy
+	 *               ObjectTree, which doesn't use collections.
+	 * @return array{0: CachingTree|ObjectTree, 1: SimpleCollection|null}
+	 */
+	public function getTree(bool $useCollection): array {
+		if ($useCollection) {
+			$rootCollection = new SimpleCollection('root');
+			$tree = new CachingTree($rootCollection);
+			return [$tree, $rootCollection];
+		}
+
+		return [new ObjectTree(), null];
+	}
+
+	/**
+	 * Adds the user's principal backend to $rootCollection.
+	 */
+	private function initRootCollection(SimpleCollection $rootCollection, Directory|File $root): void {
+		$userPrincipalBackend = new Principal(
+			\OCP\Server::get(IUserManager::class),
+			\OCP\Server::get(IGroupManager::class),
+			\OCP\Server::get(IAccountManager::class),
+			\OCP\Server::get(\OCP\Share\IManager::class),
+			\OCP\Server::get(IUserSession::class),
+			\OCP\Server::get(IAppManager::class),
+			\OCP\Server::get(ProxyMapper::class),
+			\OCP\Server::get(KnownUserService::class),
+			\OCP\Server::get(IConfig::class),
+			\OCP\Server::get(IFactory::class),
+		);
+
+		// Mount the share collection at /public.php/dav/files/<share token>
+		$rootCollection->addChild(
+			new RootCollection(
+				$root,
+				$userPrincipalBackend,
+				'principals/shares',
+			)
+		);
+
+		// Mount the upload collection at /public.php/dav/uploads/<share token>
+		$rootCollection->addChild(
+			new \OCA\DAV\Upload\RootCollection(
+				$userPrincipalBackend,
+				'principals/shares',
+				\OCP\Server::get(CleanupService::class),
+				\OCP\Server::get(IRootFolder::class),
+				\OCP\Server::get(IUserSession::class),
+				\OCP\Server::get(\OCP\Share\IManager::class),
+			)
+		);
 	}
 }

--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -229,7 +229,7 @@ class ServerFactory {
 	 * as root.
 	 *
 	 * @param bool $useCollection Whether to use a collection or the legacy
-	 *               ObjectTree, which doesn't use collections.
+	 *                            ObjectTree, which doesn't use collections.
 	 * @return array{0: CachingTree|ObjectTree, 1: SimpleCollection|null}
 	 */
 	public function getTree(bool $useCollection): array {

--- a/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/DirectoryTest.php
@@ -21,6 +21,7 @@ use OCP\Constants;
 use OCP\Files\ForbiddenException;
 use OCP\Files\InvalidPathException;
 use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Storage\IStorage;
 use OCP\Files\StorageNotAvailableException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\Traits\UserTrait;
@@ -61,12 +62,16 @@ class DirectoryTest extends \Test\TestCase {
 
 	private View&MockObject $view;
 	private FileInfo&MockObject $info;
+	private IStorage&MockObject $storage;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->view = $this->createMock(View::class);
 		$this->info = $this->createMock(FileInfo::class);
+		$this->storage = $this->createMock(IStorage::class);
+		$this->info->method('getStorage')
+			->willReturn($this->storage);
 		$this->info->method('isReadable')
 			->willReturn(true);
 		$this->info->method('getType')

--- a/build/psalm-baseline.xml
+++ b/build/psalm-baseline.xml
@@ -736,7 +736,6 @@
   </file>
   <file src="apps/dav/lib/Connector/Sabre/ServerFactory.php">
     <DeprecatedMethod>
-      <code><![CDATA[getL10NFactory]]></code>
       <code><![CDATA[getUserFolder]]></code>
     </DeprecatedMethod>
     <InternalMethod>


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* Follow-up of: #52182
* Needed to hide share and mount information in `/public.php/webdav` in  https://github.com/nextcloud/server/pull/54542

## Summary

Fixes some issues introduced in the PR above, namely:

  1. The boolean flag `isPublicShare` was `false` in an instance where it should have been set to true. Flipping it to reflect the publicity of the share would break a compatibility functionality (read more below)
  3. Creating a collection using nicknames in a public share failed due to using instanceof on a storage wrapped by the `files_accesscontrol` app, instead of the function `instanceOfStorage` which checks if the instance itself or any wrapped storages (or wrappers) are instance of the passed class.

### Compatibility Issue

For compatibility reasons the API call `PROPFIND http://nextcloud.local/public.php/webdav` should return the properties of the files in a public share. The share is identified through its ID, sent through the authorization header as username. In the master code, flipping the bool `isPublicShare` to true would break this functionality by changing the way the DAV tree is set up.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
