### PR TITLE
feat(db): Restaure support for non-nullable boolean column

### DIFF
--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -7,6 +7,7 @@
  */
 namespace OC\DB;
 
+use Doctrine\DBAL\Platforms\OraclePlatform;
 use Doctrine\DBAL\Schema\Index;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;
@@ -576,8 +577,11 @@ class MigrationService {
 						throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is NotNull, but has empty string or null as default.');
 					}
 
-					if ($thing->getNotnull() && $thing->getType()->getName() === Types::BOOLEAN) {
-						throw new \InvalidArgumentException('Column "' . $table->getName() . '"."' . $thing->getName() . '" is type Bool and also NotNull, so it can not store "false".');
+					if ($this->connection->getDatabasePlatform() instanceof OraclePlatform) {
+						// Oracle doesn't support boolean column with non-null value
+						if ($thing->getNotnull() && $thing->getType()->getName() === Types::BOOLEAN) {
+							$thing->setNotnull(false);
+						}
 					}
 
 					$sourceColumn = null;


### PR DESCRIPTION
## Summary

We disabled them because they are not supported on Oracle DB and it is still the case for OCI < 23. But instead of disabling the support completely for every database types, mark non-nullable boolean column as actually nullable when using Oracle.

This allow to use some slighly lighter schema on normal databases who support natively booleans wheen we don't need to store 3 states true|false|null.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
