### PR TITLE
[stable32] fix(lexicon): trigger email indexing

### DIFF
--- a/apps/settings/appinfo/info.xml
+++ b/apps/settings/appinfo/info.xml
@@ -9,7 +9,7 @@
 	<name>Nextcloud settings</name>
 	<summary>Nextcloud settings</summary>
 	<description>Nextcloud settings</description>
-	<version>1.15.0</version>
+	<version>1.15.1</version>
 	<licence>agpl</licence>
 	<author>Nextcloud</author>
 	<namespace>Settings</namespace>


### PR DESCRIPTION
needed to trigger migration implemented in #55159