### PR TITLE
feat(db): add SSL/TLS support for PostgreSQL

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -2119,6 +2119,17 @@ $CONFIG = [
 	'mysql.collation' => null,
 
 	/**
+	 * PostgreSQL SSL connection
+	 */
+	'pgsql_ssl' => [
+		'mode' => '',
+		'cert' => '',
+		'rootcert' => '',
+		'key' => '',
+		'crl' => '',
+	],
+
+	/**
 	 * Database types supported for installation.
 	 *
 	 * Available:

--- a/lib/private/DB/ConnectionFactory.php
+++ b/lib/private/DB/ConnectionFactory.php
@@ -198,6 +198,17 @@ class ConnectionFactory {
 			'tablePrefix' => $connectionParams['tablePrefix']
 		];
 
+		if ($type === 'pgsql') {
+			$pgsqlSsl = $this->config->getValue('pgsql_ssl', false);
+			if (is_array($pgsqlSsl)) {
+				$connectionParams['sslmode'] = $pgsqlSsl['mode'] ?? '';
+				$connectionParams['sslrootcert'] = $pgsqlSsl['rootcert'] ?? '';
+				$connectionParams['sslcert'] = $pgsqlSsl['cert'] ?? '';
+				$connectionParams['sslkey'] = $pgsqlSsl['key'] ?? '';
+				$connectionParams['sslcrl'] = $pgsqlSsl['crl'] ?? '';
+			}
+		}
+
 		if ($type === 'mysql' && $this->config->getValue('mysql.utf8mb4', false)) {
 			$connectionParams['defaultTableOptions'] = [
 				'collate' => 'utf8mb4_bin',

--- a/tests/lib/DB/ConnectionFactoryTest.php
+++ b/tests/lib/DB/ConnectionFactoryTest.php
@@ -40,4 +40,33 @@ class ConnectionFactoryTest extends TestCase {
 
 		$this->assertEquals($expected, self::invokePrivate($factory, 'splitHostFromPortAndSocket', [$host]));
 	}
+
+	public function testPgsqlSslConnection(): void {
+		/** @var SystemConfig|\PHPUnit\Framework\MockObject\MockObject $config */
+		$config = $this->createMock(SystemConfig::class);
+		$config->method('getValue')
+			->willReturnCallback(function ($key, $default) {
+				return match ($key) {
+					'dbtype' => 'pgsql',
+					'pgsql_ssl' => [
+						'mode' => 'verify-full',
+						'cert' => 'client.crt',
+						'key' => 'client.key',
+						'crl' => 'client.crl',
+						'rootcert' => 'rootCA.crt',
+					],
+					default => $default,
+				};
+			});
+		$factory = new ConnectionFactory($config);
+
+		$params = $factory->createConnectionParams();
+
+		$this->assertEquals('pdo_pgsql', $params['driver']);
+		$this->assertEquals('verify-full', $params['sslmode']);
+		$this->assertEquals('rootCA.crt', $params['sslrootcert']);
+		$this->assertEquals('client.crt', $params['sslcert']);
+		$this->assertEquals('client.key', $params['sslkey']);
+		$this->assertEquals('client.crl', $params['sslcrl']);
+	}
 }


### PR DESCRIPTION
## Summary

Add SSL/TLS support for PostgreSQL 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
