### PR TITLE
feat: add header with user id in response

### DIFF
--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -11,6 +11,8 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
+use OCP\Server;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -228,7 +230,7 @@ class Response {
 		/**
 		 * @psalm-suppress UndefinedClass
 		 */
-		$request = \OCP\Server::get(IRequest::class);
+		$request = Server::get(IRequest::class);
 		$mergeWith = [
 			'X-Request-Id' => $request->getId(),
 			'Cache-Control' => 'no-cache, no-store, must-revalidate',
@@ -243,6 +245,11 @@ class Response {
 
 		if ($this->ETag) {
 			$mergeWith['ETag'] = '"' . $this->ETag . '"';
+		}
+
+		$userSession = Server::get(IUserSession::class);
+		if ($user = $userSession->getUser()) {
+			$mergeWith['X-User-Id'] = $user->getUID();
 		}
 
 		return array_merge($mergeWith, $this->headers);


### PR DESCRIPTION
This is intended to allow admin to setup the webserver to include the user id in the access logs.