### PR TITLE
fix(systemtags): Provide initial state for admin restriction setting

### DIFF
--- a/apps/systemtags/lib/Settings/Admin.php
+++ b/apps/systemtags/lib/Settings/Admin.php
@@ -6,16 +6,28 @@
  */
 namespace OCA\SystemTags\Settings;
 
+use OCA\SystemTags\AppInfo\Application;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
 use OCP\Settings\ISettings;
 use OCP\Util;
 
 class Admin implements ISettings {
 
+	public function __construct(
+		private IAppConfig $appConfig,
+		private IInitialState $initialStateService,
+	) {
+	}
+
 	/**
 	 * @return TemplateResponse
 	 */
 	public function getForm() {
+		$restrictSystemTagsCreationToAdmin = $this->appConfig->getValueBool(Application::APP_ID, 'restrict_creation_to_admin', false);
+		$this->initialStateService->provideInitialState('restrictSystemTagsCreationToAdmin', $restrictSystemTagsCreationToAdmin);
+
 		Util::addScript('systemtags', 'admin');
 		return new TemplateResponse('systemtags', 'admin', [], '');
 	}

--- a/apps/systemtags/tests/Settings/AdminTest.php
+++ b/apps/systemtags/tests/Settings/AdminTest.php
@@ -8,19 +8,54 @@ namespace OCA\SystemTags\Tests\Settings;
 
 use OCA\SystemTags\Settings\Admin;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IAppConfig;
 use Test\TestCase;
 
 class AdminTest extends TestCase {
 	/** @var Admin */
 	private $admin;
+	/** @var IAppConfig|\PHPUnit\Framework\MockObject\MockObject */
+	private $appConfig;
+	/** @var IInitialState|\PHPUnit\Framework\MockObject\MockObject */
+	private $initialState;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->admin = new Admin();
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->initialState = $this->createMock(IInitialState::class);
+
+		$this->admin = new Admin(
+			$this->appConfig,
+			$this->initialState
+		);
 	}
 
 	public function testGetForm(): void {
+		$this->appConfig->expects($this->once())
+			->method('getValueBool')
+			->with('systemtags', 'restrict_creation_to_admin', false)
+			->willReturn(false);
+
+		$this->initialState->expects($this->once())
+			->method('provideInitialState')
+			->with('restrictSystemTagsCreationToAdmin', false);
+
+		$expected = new TemplateResponse('systemtags', 'admin', [], '');
+		$this->assertEquals($expected, $this->admin->getForm());
+	}
+
+	public function testGetFormWithRestrictedCreation(): void {
+		$this->appConfig->expects($this->once())
+			->method('getValueBool')
+			->with('systemtags', 'restrict_creation_to_admin', false)
+			->willReturn(true);
+
+		$this->initialState->expects($this->once())
+			->method('provideInitialState')
+			->with('restrictSystemTagsCreationToAdmin', true);
+
 		$expected = new TemplateResponse('systemtags', 'admin', [], '');
 		$this->assertEquals($expected, $this->admin->getForm());
 	}


### PR DESCRIPTION
The “Restrict tag creation and editing to administrators” switch in the SystemTags admin settings was not reflecting the correct database value on page load. This happened because no initial state was being provided.

Fix
This change ensures the correct initial state is set by:

- Injecting IAppConfig and IInitialState dependencies.
- Following the same initial state provisioning pattern used by other admin settings in Nextcloud.
