### PR TITLE
feat(OCM-Invites): Enable the invitesAcceptedDialog

### DIFF
--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -151,6 +151,12 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 		$provider->setApiVersion(self::API_VERSION);
 		$provider->setEndPoint(substr($url, 0, $pos));
 		$provider->setCapabilities(['/invite-accepted', '/notifications', '/shares']);
+		// The inviteAcceptDialog is available from the contacts app, if this config value is set
+		$ocmInvitesEnabled = $this->appConfig->getValueBool('contacts', 'ocm_invites_enabled');
+		if ($ocmInvitesEnabled) {
+			$inviteAcceptDialog = $this->urlGenerator->getAbsoluteURL('/apps/contacts/ocm/invite-accept-dialog');
+			$provider->setInviteAcceptDialog($inviteAcceptDialog);
+		}
 
 		$resource = $provider->createNewResourceType();
 		$resource->setName('file')


### PR DESCRIPTION
In a previous pr: #51113 the necessary plumbing for OCM Invites was introduced.

Now the companion PR for the contacts is coming along nicely: https://github.com/nextcloud/contacts/pull/4417 and that means that we should now display the inviteAcceptDialog that is provided from the contacts app according to the specification: https://www.ietf.org/archive/id/draft-lopresti-open-cloud-mesh-05.html#name-fields

We can only do that in core, since that is where OCM discovery lives, so here is a PR for that.

TL;DR; If the contacts app has enabled OCM invites, we need to show that in the discovery.

