### PR TITLE
fix(metadata): properly handle casting non-numeric values in search operations with custom metadata

### DIFF
--- a/apps/dav/lib/Files/FileSearchBackend.php
+++ b/apps/dav/lib/Files/FileSearchBackend.php
@@ -482,7 +482,10 @@ class FileSearchBackend implements ISearchBackend {
 			case SearchPropertyDefinition::DATATYPE_DECIMAL:
 			case SearchPropertyDefinition::DATATYPE_INTEGER:
 			case SearchPropertyDefinition::DATATYPE_NONNEGATIVE_INTEGER:
-				return 0 + $value;
+				if (is_numeric($value)) {
+					return 0 + $value;
+				}
+				throw new \Error('Value for numeric datatype is not numeric');
 			case SearchPropertyDefinition::DATATYPE_DATETIME:
 				if (is_numeric($value)) {
 					return max(0, 0 + $value);


### PR DESCRIPTION
If a metadata property is declared with a number type but the value provided are not numeric, it just logs "A non-numeric value encountered at `apps/dav/lib/Files/FileSearchBackend.php#486`" instead of throwing a proper error.

Now with a proper error here we have the proper exception being thrown later: `InvalidArgumentException Invalid property value for {http://nextcloud.org/ns}metadata-photos-original_date_time`.

See https://github.com/nextcloud/photos/pull/3187 for the actual issue in photos.

(I'm too lazy to add a specific test for this, but feel free to)

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
