### PR TITLE
bug(OCM-Provider): We did not set inviteAcceptDialog

### DIFF
--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -226,6 +226,9 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 			$resources[] = $resource->import($resourceData);
 		}
 		$this->setResourceTypes($resources);
+		if (isset($data['inviteAcceptDialog'])) {
+			$this->setInviteAcceptDialog($data['inviteAcceptDialog']);
+		}
 
 		if (isset($data['publicKey'])) {
 			// import details about the remote request signing public key, if available


### PR DESCRIPTION
The OCM Provider would always return an empty inviteAcceptDialog, that is fixed now.