### PR TITLE
fix(ocm-invites): add route to invite accept dialog

### DIFF
--- a/core/AppInfo/ConfigLexicon.php
+++ b/core/AppInfo/ConfigLexicon.php
@@ -28,6 +28,8 @@ class ConfigLexicon implements ILexicon {
 	public const SHARE_LINK_EXPIRE_DATE_ENFORCED = 'shareapi_enforce_expire_date';
 	public const USER_LANGUAGE = 'lang';
 	public const OCM_DISCOVERY_ENABLED = 'ocm_discovery_enabled';
+	public const OCM_INVITE_ACCEPT_DIALOG = 'ocm_invite_accept_dialog';
+
 	public const USER_LOCALE = 'locale';
 	public const USER_TIMEZONE = 'timezone';
 
@@ -87,6 +89,7 @@ class ConfigLexicon implements ILexicon {
 			),
 			new Entry(self::LASTCRON_TIMESTAMP, ValueType::INT, 0, 'timestamp of last cron execution'),
 			new Entry(self::OCM_DISCOVERY_ENABLED, ValueType::BOOL, true, 'enable/disable OCM', lazy: true),
+			new Entry(self::OCM_INVITE_ACCEPT_DIALOG, ValueType::STRING, '', 'route to local invite accept dialog', lazy: true, note: 'set as empty string to disable feature'),
 		];
 	}
 

--- a/lib/private/OCM/Model/OCMProvider.php
+++ b/lib/private/OCM/Model/OCMProvider.php
@@ -226,6 +226,7 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 			$resources[] = $resource->import($resourceData);
 		}
 		$this->setResourceTypes($resources);
+		$this->setInviteAcceptDialog($data['inviteAcceptDialog'] ?? '');
 
 		if (isset($data['publicKey'])) {
 			// import details about the remote request signing public key, if available
@@ -271,11 +272,11 @@ class OCMProvider implements ICapabilityAwareOCMProvider {
 		];
 
 		$capabilities = $this->getCapabilities();
-		$inviteAcceptDialog = $this->getInviteAcceptDialog();
 		if ($capabilities) {
 			$response['capabilities'] = $capabilities;
 		}
-		if ($inviteAcceptDialog) {
+		$inviteAcceptDialog = $this->getInviteAcceptDialog();
+		if ($inviteAcceptDialog !== '') {
 			$response['inviteAcceptDialog'] = $inviteAcceptDialog;
 		}
 		return $response;

--- a/lib/private/OCM/OCMDiscoveryService.php
+++ b/lib/private/OCM/OCMDiscoveryService.php
@@ -152,6 +152,12 @@ class OCMDiscoveryService implements IOCMDiscoveryService {
 		$provider->setEndPoint(substr($url, 0, $pos));
 		$provider->setCapabilities(['/invite-accepted', '/notifications', '/shares']);
 
+		// The inviteAcceptDialog is available from the contacts app, if this config value is set
+		$inviteAcceptDialog = $this->appConfig->getValueString('core', ConfigLexicon::OCM_INVITE_ACCEPT_DIALOG);
+		if ($inviteAcceptDialog !== '') {
+			$provider->setInviteAcceptDialog($this->urlGenerator->linkToRouteAbsolute($inviteAcceptDialog));
+		}
+
 		$resource = $provider->createNewResourceType();
 		$resource->setName('file')
 			->setShareTypes(['user', 'group'])


### PR DESCRIPTION
- get remote details about the _invite accept dialog_ feature
- add details about _invite accept dialog_ to local ocm discovery
- link to accept dialog is configured via appconfig:

>     ./occ config:app:set core ocm_invite_accept_dialog --value 'contacts.federated_invites.invite_accept_dialog'

if empty, feature disabled (disabled by default)