### PR TITLE
fix(http): handle getHttpProtocol being unset in $_SERVER['SERVER_PROTOCOL'] if called from occ

### DIFF
--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -676,7 +676,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 	 * @return string HTTP protocol. HTTP/2, HTTP/1.1 or HTTP/1.0.
 	 */
 	public function getHttpProtocol(): string {
-		$claimedProtocol = $this->server['SERVER_PROTOCOL'];
+		$claimedProtocol = $this->server['SERVER_PROTOCOL'] ?? '';
 
 		if (\is_string($claimedProtocol)) {
 			$claimedProtocol = strtoupper($claimedProtocol);


### PR DESCRIPTION
Due to the profiler app loading HttpDataCollector when running occ.

This won't change behavior, fallback value is still `'HTTP/1.1'` (but the error of missing `SERVER_PROTOCOL` won't be shown though).

Similar issue at https://github.com/nextcloud/profiler/pull/637

```
An unhandled exception has been thrown:
ErrorException: Undefined array key "SERVER_PROTOCOL" in server/lib/private/AppFramework/Http/Request.php:679
Stack trace:
#0 server/lib/private/AppFramework/Http/Request.php(679): OCA\Files\Command\ScanAppData->exceptionErrorHandler()
#1 server/apps/profiler/lib/DataCollector/HttpDataCollector.php(30): OC\AppFramework\Http\Request->getHttpProtocol()
#2 server/lib/private/Profiler/Profiler.php(69): OCA\Profiler\DataCollector\HttpDataCollector->collect()
#3 server/console.php(98): OC\Profiler\Profiler->collect()
#4 server/occ(33): require_once('...')
#5 {main}%        
```

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
