### PR TITLE
[stable31] fix: Allow hyphen in appid

### DIFF
--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
  * SPDX-FileCopyrightText: 2016 ownCloud, Inc.
@@ -175,9 +176,9 @@ class AppManager implements IAppManager {
 			if (is_resource($dh)) {
 				while (($file = readdir($dh)) !== false) {
 					if (
-						$file[0] != '.' &&
-						is_dir($apps_dir['path'] . '/' . $file) &&
-						is_file($apps_dir['path'] . '/' . $file . '/appinfo/info.xml')
+						$file[0] != '.'
+						&& is_dir($apps_dir['path'] . '/' . $file)
+						&& is_file($apps_dir['path'] . '/' . $file . '/appinfo/info.xml')
 					) {
 						$apps[] = $file;
 					}
@@ -525,8 +526,8 @@ class AppManager implements IAppManager {
 
 		if (!empty($info['collaboration']['plugins'])) {
 			// deal with one or many plugin entries
-			$plugins = isset($info['collaboration']['plugins']['plugin']['@value']) ?
-				[$info['collaboration']['plugins']['plugin']] : $info['collaboration']['plugins']['plugin'];
+			$plugins = isset($info['collaboration']['plugins']['plugin']['@value'])
+				? [$info['collaboration']['plugins']['plugin']] : $info['collaboration']['plugins']['plugin'];
 			$collaboratorSearch = null;
 			$autoCompleteManager = null;
 			foreach ($plugins as $plugin) {
@@ -945,6 +946,6 @@ class AppManager implements IAppManager {
 	 */
 	public function cleanAppId(string $app): string {
 		/* Only lowercase alphanumeric is allowed */
-		return preg_replace('/(^[0-9_]|[^a-z0-9_]+|_$)/', '', $app);
+		return preg_replace('/(^[0-9_-]+|[^a-z0-9_-]+|[_-]+$)/', '', $app);
 	}
 }

--- a/tests/lib/App/AppManagerTest.php
+++ b/tests/lib/App/AppManagerTest.php
@@ -888,4 +888,26 @@ class AppManagerTest extends TestCase {
 		);
 	}
 
+	public static function dataCleanAppId(): array {
+		return [
+			['simple', 'simple'],
+			['UPPERCASEa', 'a'],
+			['MixEdCaSe', 'ixdae'],
+			['007startwithdigit', 'startwithdigit'],
+			['0-numb3rs-4ll0w3d-1n-m1ddle-0', 'numb3rs-4ll0w3d-1n-m1ddle-0'],
+			['hyphen-and_underscore_allowed', 'hyphen-and_underscore_allowed'],
+			['_but-not-at-the-end_', 'but-not-at-the-end'],
+			['-but-not-at-the-end-', 'but-not-at-the-end'],
+			['--_but-not-at-the-end___', 'but-not-at-the-end'],
+			[' also remove all spaces', 'alsoremoveallspaces'],
+			['a«"«»()@+-/*=%\{}…~|&œ—<>[]^±_−÷×≠‰A', 'a-_'],
+		];
+	}
+
+	/**
+	 * @dataProvider dataCleanAppId
+	 */
+	public function testCleanAppId(string $inputString, string $appid): void {
+		$this->assertEquals($appid, $this->manager->cleanAppId($inputString));
+	}
 }


### PR DESCRIPTION
## Summary

Manual backport of #55142 

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
