### PR TITLE
chore: add chunked queries on `occ sharing:delete-orphan-shares`

### DIFF
--- a/apps/files_sharing/lib/OrphanHelper.php
+++ b/apps/files_sharing/lib/OrphanHelper.php
@@ -39,8 +39,13 @@ class OrphanHelper {
 	public function deleteShares(array $ids): void {
 		$query = $this->connection->getQueryBuilder();
 		$query->delete('share')
-			->where($query->expr()->in('id', $query->createNamedParameter($ids, IQueryBuilder::PARAM_INT_ARRAY)));
-		$query->executeStatement();
+			->where($query->expr()->in('id', $query->createParameter('ids')));
+
+		$idsChunks = array_chunk($ids, 500);
+		foreach ($idsChunks as $idsChunk) {
+			$query->setParameter('ids', $idsChunk, IQueryBuilder::PARAM_INT_ARRAY)
+				->executeStatement();
+		}
 	}
 
 	public function fileExists(int $fileId): bool {


### PR DESCRIPTION
* Resolves: #53570

## Summary

Add chunked delete on `occ sharing:delete-orphan-shares`

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
