### PR TITLE
admin-delegation occ - add output option for show command to support JSON formats

### DIFF
--- a/apps/settings/lib/Command/AdminDelegation/Show.php
+++ b/apps/settings/lib/Command/AdminDelegation/Show.php
@@ -37,7 +37,6 @@ class Show extends Base {
 		$io->title('Current delegations');
 
 		$sections = $this->settingManager->getAdminSections();
-		$settings = [];
 		$headers = ['Name', 'SettingId', 'Delegated to groups'];
 		foreach ($sections as $sectionPriority) {
 			foreach ($sectionPriority as $section) {

--- a/apps/settings/lib/Command/AdminDelegation/Show.php
+++ b/apps/settings/lib/Command/AdminDelegation/Show.php
@@ -34,6 +34,16 @@ class Show extends Base {
 
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
+
+		$this->outputPlainFormat($io);
+
+		return 0;
+	}
+
+	/**
+	 * Output data in plain table format
+	 */
+	private function outputPlainFormat(SymfonyStyle $io): void {
 		$io->title('Current delegations');
 
 		$sections = $this->settingManager->getAdminSections();
@@ -62,8 +72,6 @@ class Show extends Base {
 				}, $sectionSettings));
 			}
 		}
-
-		return 0;
 	}
 
 	/**


### PR DESCRIPTION
## Overview
This PR enhances the `occ admin-delegation:show` command by adding support for JSON output formats, providing a more programmatic way to access delegation information.

## Changes Made
- **Enhanced Command Options**: Added `--output` option to the `admin-delegation:show` command with support for:
  - `plain` (default) - existing table format
  - `json` - compact JSON output
  - `json_pretty` - formatted JSON output

- **New Import**: Added `Symfony\Component\Console\Input\InputOption` import to support the new option parameter

- **Improved Data Structure**: Implemented structured JSON output that includes:
  - Section ID and metadata
  - Setting names and class names
  - Authorized groups for each delegated setting
  - Proper nesting of sections and their associated settings

## Usage
```bash
# Default table output (unchanged)
occ admin-delegation:show

# JSON output
occ admin-delegation:show --output=json

# Pretty-printed JSON output  
occ admin-delegation:show --output=json_pretty
```
<details>
<summary>JSON Output</summary>

```json
[
    {
        "id": "overview",
        "name": "Overview",
        "settings": [
            {
                "name": "Security & setup checks",
                "className": "OCA\\Settings\\Settings\\Admin\\Overview",
                "delegatedGroups": []
            }
        ]
    },
    {
        "id": "server",
        "name": "Basic settings",
        "settings": [
            {
                "name": "Background jobs",
                "className": "OCA\\Settings\\Settings\\Admin\\Server",
                "delegatedGroups": []
            }
        ]
    },
    {
        "id": "sharing",
        "name": "Sharing",
        "settings": [
            {
                "name": "Global",
                "className": "OCA\\Settings\\Settings\\Admin\\Sharing",
                "delegatedGroups": []
            }
        ]
    },
    {
        "id": "theming",
        "name": "Theming",
        "settings": [
            {
                "name": "Global",
                "className": "OCA\\Theming\\Settings\\Admin",
                "delegatedGroups": []
            }
        ]
    },
    {
        "id": "ai",
        "name": "Assistant",
        "settings": [
            {
                "name": "Artificial Intelligence",
                "className": "OCA\\Settings\\Settings\\Admin\\ArtificialIntelligence",
                "delegatedGroups": []
            }
        ]
    },
    {
        "id": "admindelegation",
        "name": "Administration privileges",
        "settings": [
            {
                "name": "Users",
                "className": "OCA\\Settings\\Settings\\Admin\\Users",
                "delegatedGroups": []
            },
            {
                "name": "Webhooks",
                "className": "OCA\\WebhookListeners\\Settings\\Admin",
                "delegatedGroups": []
            }
        ]
    }
]
```

</details>



## Benefits
- **API Integration**: Enables easier integration with external tools and scripts
- **Automation**: Facilitates automated processing of delegation configurations
- **Backward Compatibility**: Maintains existing table output as the default behavior
- **Structured Data**: Provides consistently formatted delegation data for programmatic consumption

## Technical Details
- Leverages the existing `Base` class output formatting methods
- Maintains the same data collection logic for consistency
- Proper error handling and fallback to default plain output

## Files Changed
- `apps/settings/lib/Command/AdminDelegation/Show.php`

This enhancement improves the usability of the admin delegation system for both interactive use and automation scenarios.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
