### PR TITLE
fix(admin): Hide empty section for users admin delegation

### DIFF
--- a/apps/settings/appinfo/info.xml
+++ b/apps/settings/appinfo/info.xml
@@ -35,7 +35,6 @@
 		<admin>OCA\Settings\Settings\Admin\Sharing</admin>
 		<admin>OCA\Settings\Settings\Admin\Security</admin>
 		<admin>OCA\Settings\Settings\Admin\Delegation</admin>
-		<delegation>OCA\Settings\Settings\Admin\Users</delegation>
 		<admin-section>OCA\Settings\Sections\Admin\Additional</admin-section>
 		<admin-section>OCA\Settings\Sections\Admin\Delegation</admin-section>
 		<admin-section>OCA\Settings\Sections\Admin\Groupware</admin-section>
@@ -45,6 +44,8 @@
 		<admin-section>OCA\Settings\Sections\Admin\Security</admin-section>
 		<admin-section>OCA\Settings\Sections\Admin\Server</admin-section>
 		<admin-section>OCA\Settings\Sections\Admin\Sharing</admin-section>
+		<admin-delegation>OCA\Settings\Settings\Admin\Users</admin-delegation>
+		<admin-delegation-section>OCA\Settings\Sections\Admin\Users</admin-delegation-section>
 		<personal>OCA\Settings\Settings\Personal\Additional</personal>
 		<personal>OCA\Settings\Settings\Personal\PersonalInfo</personal>
 		<personal>OCA\Settings\Settings\Personal\ServerDevNotice</personal>

--- a/apps/settings/appinfo/info.xml
+++ b/apps/settings/appinfo/info.xml
@@ -35,7 +35,7 @@
 		<admin>OCA\Settings\Settings\Admin\Sharing</admin>
 		<admin>OCA\Settings\Settings\Admin\Security</admin>
 		<admin>OCA\Settings\Settings\Admin\Delegation</admin>
-		<admin>OCA\Settings\Settings\Admin\Users</admin>
+		<delegation>OCA\Settings\Settings\Admin\Users</delegation>
 		<admin-section>OCA\Settings\Sections\Admin\Additional</admin-section>
 		<admin-section>OCA\Settings\Sections\Admin\Delegation</admin-section>
 		<admin-section>OCA\Settings\Sections\Admin\Groupware</admin-section>

--- a/apps/settings/composer/composer/autoload_classmap.php
+++ b/apps/settings/composer/composer/autoload_classmap.php
@@ -60,6 +60,7 @@ return array(
     'OCA\\Settings\\Sections\\Admin\\Security' => $baseDir . '/../lib/Sections/Admin/Security.php',
     'OCA\\Settings\\Sections\\Admin\\Server' => $baseDir . '/../lib/Sections/Admin/Server.php',
     'OCA\\Settings\\Sections\\Admin\\Sharing' => $baseDir . '/../lib/Sections/Admin/Sharing.php',
+    'OCA\\Settings\\Sections\\Admin\\Users' => $baseDir . '/../lib/Sections/Admin/Users.php',
     'OCA\\Settings\\Sections\\Personal\\Availability' => $baseDir . '/../lib/Sections/Personal/Availability.php',
     'OCA\\Settings\\Sections\\Personal\\Calendar' => $baseDir . '/../lib/Sections/Personal/Calendar.php',
     'OCA\\Settings\\Sections\\Personal\\PersonalInfo' => $baseDir . '/../lib/Sections/Personal/PersonalInfo.php',

--- a/apps/settings/composer/composer/autoload_static.php
+++ b/apps/settings/composer/composer/autoload_static.php
@@ -75,6 +75,7 @@ class ComposerStaticInitSettings
         'OCA\\Settings\\Sections\\Admin\\Security' => __DIR__ . '/..' . '/../lib/Sections/Admin/Security.php',
         'OCA\\Settings\\Sections\\Admin\\Server' => __DIR__ . '/..' . '/../lib/Sections/Admin/Server.php',
         'OCA\\Settings\\Sections\\Admin\\Sharing' => __DIR__ . '/..' . '/../lib/Sections/Admin/Sharing.php',
+        'OCA\\Settings\\Sections\\Admin\\Users' => __DIR__ . '/..' . '/../lib/Sections/Admin/Users.php',
         'OCA\\Settings\\Sections\\Personal\\Availability' => __DIR__ . '/..' . '/../lib/Sections/Personal/Availability.php',
         'OCA\\Settings\\Sections\\Personal\\Calendar' => __DIR__ . '/..' . '/../lib/Sections/Personal/Calendar.php',
         'OCA\\Settings\\Sections\\Personal\\PersonalInfo' => __DIR__ . '/..' . '/../lib/Sections/Personal/PersonalInfo.php',

--- a/apps/settings/lib/Sections/Admin/Users.php
+++ b/apps/settings/lib/Sections/Admin/Users.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Settings\Sections\Admin;
+
+use OCP\IL10N;
+use OCP\Settings\IIconSection;
+
+class Users implements IIconSection {
+	public function __construct(
+		private IL10N $l,
+	) {
+	}
+
+	public function getID(): string {
+		return 'usersdelegation';
+	}
+
+	public function getName(): string {
+		return $this->l->t('Users');
+	}
+
+	public function getPriority(): int {
+		return 55;
+	}
+
+	public function getIcon(): string {
+		return '';
+	}
+}

--- a/apps/settings/lib/Settings/Admin/Delegation.php
+++ b/apps/settings/lib/Settings/Admin/Delegation.php
@@ -45,32 +45,19 @@ class Delegation implements ISettings {
 
 	private function initSettingState(): void {
 		// Available settings page initialization
-		$sections = $this->settingManager->getAdminSections();
+		$delegatedSettings = $this->settingManager->getAdminDelegatedSettings();
 		$settings = [];
-		foreach ($sections as $sectionPriority) {
-			foreach ($sectionPriority as $section) {
-				$sectionSettings = $this->settingManager->getAdminSettings($section->getId());
-				$sectionSettings = array_reduce($sectionSettings, [$this, 'getDelegatedSettings'], []);
-				$settings = array_merge(
-					$settings,
-					array_map(function (IDelegatedSettings $setting) use ($section) {
-						$sectionName = $section->getName() . ($setting->getName() !== null ? ' - ' . $setting->getName() : '');
-						return [
-							'class' => get_class($setting),
-							'sectionName' => $sectionName,
-							'id' => mb_strtolower(str_replace(' ', '-', $sectionName)),
-							'priority' => $section->getPriority(),
-						];
-					}, $sectionSettings)
-				);
+		foreach ($delegatedSettings as ['section' => $section, 'settings' => $sectionSettings]) {
+			foreach ($sectionSettings as $setting) {
+				$sectionName = $section->getName() . ($setting->getName() !== null ? ' - ' . $setting->getName() : '');
+				$settings[] = [
+					'class' => get_class($setting),
+					'sectionName' => $sectionName,
+					'id' => mb_strtolower(str_replace(' ', '-', $sectionName)),
+					'priority' => $section->getPriority(),
+				];
 			}
 		}
-		usort($settings, function (array $a, array $b) {
-			if ($a['priority'] == $b['priority']) {
-				return 0;
-			}
-			return ($a['priority'] < $b['priority']) ? -1 : 1;
-		});
 		$this->initialStateService->provideInitialState('available-settings', $settings);
 	}
 

--- a/apps/settings/lib/Settings/Admin/Users.php
+++ b/apps/settings/lib/Settings/Admin/Users.php
@@ -10,49 +10,27 @@ declare(strict_types=1);
 namespace OCA\Settings\Settings\Admin;
 
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IL10N;
 use OCP\Settings\IDelegatedSettings;
 
 /**
  * Empty settings class, used only for admin delegation.
  */
 class Users implements IDelegatedSettings {
-
-	public function __construct(
-		protected string $appName,
-		private IL10N $l10n,
-	) {
-	}
-
-	/**
-	 * Empty template response
-	 */
 	public function getForm(): TemplateResponse {
-
-		return new /** @template-extends TemplateResponse<\OCP\AppFramework\Http::STATUS_OK, array{}> */ class($this->appName, '') extends TemplateResponse {
-			public function render(): string {
-				return '';
-			}
-		};
+		throw new \Exception('Admin delegation settings should never be rendered');
 	}
 
 	public function getSection(): ?string {
-		return 'admindelegation';
+		return 'usersdelegation';
 	}
 
-	/**
-	 * @return int whether the form should be rather on the top or bottom of
-	 *             the admin section. The forms are arranged in ascending order of the
-	 *             priority values. It is required to return a value between 0 and 100.
-	 *
-	 * E.g.: 70
-	 */
 	public function getPriority(): int {
 		return 0;
 	}
 
-	public function getName(): string {
-		return $this->l10n->t('Users');
+	public function getName(): ?string {
+		/* Use section name alone */
+		return null;
 	}
 
 	public function getAuthorizedAppConfig(): array {

--- a/apps/settings/lib/Settings/Admin/Users.php
+++ b/apps/settings/lib/Settings/Admin/Users.php
@@ -37,7 +37,7 @@ class Users implements IDelegatedSettings {
 	}
 
 	public function getSection(): ?string {
-		return null;
+		return 'admindelegation';
 	}
 
 	/**

--- a/apps/settings/lib/Settings/Admin/Users.php
+++ b/apps/settings/lib/Settings/Admin/Users.php
@@ -37,7 +37,7 @@ class Users implements IDelegatedSettings {
 	}
 
 	public function getSection(): ?string {
-		return 'admindelegation';
+		return null;
 	}
 
 	/**

--- a/apps/webhook_listeners/appinfo/info.xml
+++ b/apps/webhook_listeners/appinfo/info.xml
@@ -32,6 +32,7 @@
 	</commands>
 
 	<settings>
-		<delegation>OCA\WebhookListeners\Settings\Admin</delegation>
+		<admin-delegation>OCA\WebhookListeners\Settings\Admin</admin-delegation>
+		<admin-delegation-section>OCA\WebhookListeners\Settings\AdminSection</admin-delegation-section>
 	</settings>
 </info>

--- a/apps/webhook_listeners/appinfo/info.xml
+++ b/apps/webhook_listeners/appinfo/info.xml
@@ -32,6 +32,6 @@
 	</commands>
 
 	<settings>
-		<admin>OCA\WebhookListeners\Settings\Admin</admin>
+		<delegation>OCA\WebhookListeners\Settings\Admin</delegation>
 	</settings>
 </info>

--- a/apps/webhook_listeners/composer/composer/autoload_classmap.php
+++ b/apps/webhook_listeners/composer/composer/autoload_classmap.php
@@ -20,4 +20,5 @@ return array(
     'OCA\\WebhookListeners\\ResponseDefinitions' => $baseDir . '/../lib/ResponseDefinitions.php',
     'OCA\\WebhookListeners\\Service\\PHPMongoQuery' => $baseDir . '/../lib/Service/PHPMongoQuery.php',
     'OCA\\WebhookListeners\\Settings\\Admin' => $baseDir . '/../lib/Settings/Admin.php',
+    'OCA\\WebhookListeners\\Settings\\AdminSection' => $baseDir . '/../lib/Settings/AdminSection.php',
 );

--- a/apps/webhook_listeners/composer/composer/autoload_static.php
+++ b/apps/webhook_listeners/composer/composer/autoload_static.php
@@ -35,6 +35,7 @@ class ComposerStaticInitWebhookListeners
         'OCA\\WebhookListeners\\ResponseDefinitions' => __DIR__ . '/..' . '/../lib/ResponseDefinitions.php',
         'OCA\\WebhookListeners\\Service\\PHPMongoQuery' => __DIR__ . '/..' . '/../lib/Service/PHPMongoQuery.php',
         'OCA\\WebhookListeners\\Settings\\Admin' => __DIR__ . '/..' . '/../lib/Settings/Admin.php',
+        'OCA\\WebhookListeners\\Settings\\AdminSection' => __DIR__ . '/..' . '/../lib/Settings/AdminSection.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/apps/webhook_listeners/lib/Settings/Admin.php
+++ b/apps/webhook_listeners/lib/Settings/Admin.php
@@ -9,51 +9,32 @@ declare(strict_types=1);
 
 namespace OCA\WebhookListeners\Settings;
 
-use OCP\AppFramework\Http;
+use OCA\WebhookListeners\AppInfo\Application;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\IL10N;
 use OCP\Settings\IDelegatedSettings;
 
 /**
  * Empty settings class, used only for admin delegation for now as there is no UI
  */
 class Admin implements IDelegatedSettings {
-
-	public function __construct(
-		protected string $appName,
-		private IL10N $l10n,
-	) {
-	}
-
 	/**
 	 * Empty template response
 	 */
 	public function getForm(): TemplateResponse {
-
-		return new /** @template-extends TemplateResponse<Http::STATUS_OK, array{}> */ class($this->appName, '') extends TemplateResponse {
-			public function render(): string {
-				return '';
-			}
-		};
+		throw new \Exception('Admin delegation settings should never be rendered');
 	}
 
-	public function getSection(): ?string {
-		return 'admindelegation';
+	public function getSection(): string {
+		return Application::APP_ID . '-admin';
 	}
 
-	/**
-	 * @return int whether the form should be rather on the top or bottom of
-	 *             the admin section. The forms are arranged in ascending order of the
-	 *             priority values. It is required to return a value between 0 and 100.
-	 *
-	 * E.g.: 70
-	 */
 	public function getPriority(): int {
 		return 0;
 	}
 
-	public function getName(): string {
-		return $this->l10n->t('Webhooks');
+	public function getName(): ?string {
+		/* Use section name alone */
+		return null;
 	}
 
 	public function getAuthorizedAppConfig(): array {

--- a/apps/webhook_listeners/lib/Settings/AdminSection.php
+++ b/apps/webhook_listeners/lib/Settings/AdminSection.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\WebhookListeners\Settings;
+
+use OCA\WebhookListeners\AppInfo\Application;
+use OCP\IL10N;
+use OCP\Settings\IIconSection;
+
+class AdminSection implements IIconSection {
+	public function __construct(
+		private IL10N $l,
+	) {
+	}
+
+	public function getID(): string {
+		return Application::APP_ID . '-admin';
+	}
+
+	public function getName(): string {
+		return $this->l->t('Webhooks');
+	}
+
+	public function getPriority(): int {
+		return 56;
+	}
+
+	public function getIcon(): string {
+		return '';
+	}
+}

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -502,7 +502,7 @@ class AppManager implements IAppManager {
 		}
 
 		if (!empty($info['settings'])) {
-			$settingsManager = \OC::$server->get(ISettingsManager::class);
+			$settingsManager = \OCP\Server::get(ISettingsManager::class);
 			if (!empty($info['settings']['admin'])) {
 				foreach ($info['settings']['admin'] as $setting) {
 					$settingsManager->registerSetting('admin', $setting);
@@ -521,6 +521,11 @@ class AppManager implements IAppManager {
 			if (!empty($info['settings']['personal-section'])) {
 				foreach ($info['settings']['personal-section'] as $section) {
 					$settingsManager->registerSection('personal', $section);
+				}
+			}
+			if (!empty($info['settings']['delegation'])) {
+				foreach ($info['settings']['delegation'] as $setting) {
+					$settingsManager->registerSetting(ISettingsManager::SETTINGS_DELEGATION, $setting);
 				}
 			}
 		}

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -523,9 +523,14 @@ class AppManager implements IAppManager {
 					$settingsManager->registerSection('personal', $section);
 				}
 			}
-			if (!empty($info['settings']['delegation'])) {
-				foreach ($info['settings']['delegation'] as $setting) {
+			if (!empty($info['settings']['admin-delegation'])) {
+				foreach ($info['settings']['admin-delegation'] as $setting) {
 					$settingsManager->registerSetting(ISettingsManager::SETTINGS_DELEGATION, $setting);
+				}
+			}
+			if (!empty($info['settings']['admin-delegation-section'])) {
+				foreach ($info['settings']['admin-delegation-section'] as $section) {
+					$settingsManager->registerSection(ISettingsManager::SETTINGS_DELEGATION, $section);
 				}
 			}
 		}

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -184,6 +184,9 @@ class InfoParser {
 		if (isset($array['settings']['personal-section']) && !is_array($array['settings']['personal-section'])) {
 			$array['settings']['personal-section'] = [$array['settings']['personal-section']];
 		}
+		if (isset($array['settings']['delegation']) && !is_array($array['settings']['delegation'])) {
+			$array['settings']['delegation'] = [$array['settings']['delegation']];
+		}
 		if (isset($array['navigations']['navigation']) && $this->isNavigationItem($array['navigations']['navigation'])) {
 			$array['navigations']['navigation'] = [$array['navigations']['navigation']];
 		}

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -184,8 +184,11 @@ class InfoParser {
 		if (isset($array['settings']['personal-section']) && !is_array($array['settings']['personal-section'])) {
 			$array['settings']['personal-section'] = [$array['settings']['personal-section']];
 		}
-		if (isset($array['settings']['delegation']) && !is_array($array['settings']['delegation'])) {
-			$array['settings']['delegation'] = [$array['settings']['delegation']];
+		if (isset($array['settings']['admin-delegation']) && !is_array($array['settings']['admin-delegation'])) {
+			$array['settings']['admin-delegation'] = [$array['settings']['admin-delegation']];
+		}
+		if (isset($array['settings']['admin-delegation-section']) && !is_array($array['settings']['admin-delegation-section'])) {
+			$array['settings']['admin-delegation-section'] = [$array['settings']['admin-delegation-section']];
 		}
 		if (isset($array['navigations']['navigation']) && $this->isNavigationItem($array['navigations']['navigation'])) {
 			$array['navigations']['navigation'] = [$array['navigations']['navigation']];

--- a/lib/private/Settings/Manager.php
+++ b/lib/private/Settings/Manager.php
@@ -23,53 +23,30 @@ use OCP\Settings\ISubAdminSettings;
 use Psr\Log\LoggerInterface;
 
 class Manager implements IManager {
-	/** @var LoggerInterface */
-	private $log;
-
-	/** @var IL10N */
-	private $l;
-
-	/** @var IFactory */
-	private $l10nFactory;
-
-	/** @var IURLGenerator */
-	private $url;
-
-	/** @var IServerContainer */
-	private $container;
-
-	/** @var AuthorizedGroupMapper $mapper */
-	private $mapper;
-
-	/** @var IGroupManager $groupManager */
-	private $groupManager;
-
-	/** @var ISubAdmin $subAdmin */
-	private $subAdmin;
-
-	public function __construct(
-		LoggerInterface $log,
-		IFactory $l10nFactory,
-		IURLGenerator $url,
-		IServerContainer $container,
-		AuthorizedGroupMapper $mapper,
-		IGroupManager $groupManager,
-		ISubAdmin $subAdmin,
-	) {
-		$this->log = $log;
-		$this->l10nFactory = $l10nFactory;
-		$this->url = $url;
-		$this->container = $container;
-		$this->mapper = $mapper;
-		$this->groupManager = $groupManager;
-		$this->subAdmin = $subAdmin;
-	}
+	private ?IL10N $l = null;
 
 	/** @var array<self::SETTINGS_*, list<class-string<IIconSection>>> */
-	protected $sectionClasses = [];
+	protected array $sectionClasses = [];
 
 	/** @var array<self::SETTINGS_*, array<string, IIconSection>> */
-	protected $sections = [];
+	protected array $sections = [];
+
+	/** @var array<class-string<ISettings>, self::SETTINGS_*> */
+	protected array $settingClasses = [];
+
+	/** @var array<self::SETTINGS_*, array<string, list<ISettings>>> */
+	protected array $settings = [];
+
+	public function __construct(
+		private LoggerInterface $log,
+		private IFactory $l10nFactory,
+		private IURLGenerator $url,
+		private IServerContainer $container,
+		private AuthorizedGroupMapper $mapper,
+		private IGroupManager $groupManager,
+		private ISubAdmin $subAdmin,
+	) {
+	}
 
 	/**
 	 * @inheritdoc
@@ -138,12 +115,6 @@ class Manager implements IManager {
 		], true);
 	}
 
-	/** @var array<class-string<ISettings>, self::SETTINGS_*> */
-	protected $settingClasses = [];
-
-	/** @var array<self::SETTINGS_*, array<string, list<ISettings>>> */
-	protected $settings = [];
-
 	/**
 	 * @inheritdoc
 	 */
@@ -188,14 +159,15 @@ class Manager implements IManager {
 			if ($filter !== null && !$filter($setting)) {
 				continue;
 			}
-			if ($setting->getSection() === null) {
+			$settingSection = $setting->getSection();
+			if ($settingSection === null) {
 				continue;
 			}
 
-			if (!isset($this->settings[$settingsType][$setting->getSection()])) {
-				$this->settings[$settingsType][$setting->getSection()] = [];
+			if (!isset($this->settings[$settingsType][$settingSection])) {
+				$this->settings[$settingsType][$settingSection] = [];
 			}
-			$this->settings[$settingsType][$setting->getSection()][] = $setting;
+			$this->settings[$settingsType][$settingSection][] = $setting;
 
 			unset($this->settingClasses[$class]);
 		}

--- a/lib/public/Settings/IManager.php
+++ b/lib/public/Settings/IManager.php
@@ -48,6 +48,12 @@ interface IManager {
 	public const SETTINGS_PERSONAL = 'personal';
 
 	/**
+	 * @since 33.0.0
+	 * For settings only used for delegation but not appearing in settings menu
+	 */
+	public const SETTINGS_DELEGATION = 'delegation';
+
+	/**
 	 * @psalm-param self::SETTINGS_* $type
 	 * @param class-string<IIconSection> $section
 	 * @since 14.0.0
@@ -118,4 +124,11 @@ interface IManager {
 	 * @since 25.0.0
 	 */
 	public function getSection(string $type, string $sectionId): ?IIconSection;
+
+	/**
+	 * Return admin delegated settings, sorted by priority and grouped by section
+	 * @return array<string, array{section:IIconSection,settings:list<IDelegatedSettings>}>
+	 * @since 33.0.0
+	 */
+	public function getAdminDelegatedSettings(): array;
 }

--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -415,7 +415,10 @@
                         maxOccurs="unbounded"/>
             <xs:element name="personal-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
-			<xs:element name="delegation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="admin-delegation" type="php-class" minOccurs="0"
+						maxOccurs="unbounded"/>
+			<xs:element name="admin-delegation-section" type="php-class" minOccurs="0"
+                        maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/resources/app-info-shipped.xsd
+++ b/resources/app-info-shipped.xsd
@@ -415,6 +415,7 @@
                         maxOccurs="unbounded"/>
             <xs:element name="personal-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
+			<xs:element name="delegation" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -411,7 +411,10 @@
                         maxOccurs="unbounded"/>
             <xs:element name="personal-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
-			<xs:element name="delegation" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="admin-delegation" type="php-class" minOccurs="0"
+						maxOccurs="unbounded"/>
+			<xs:element name="admin-delegation-section" type="php-class" minOccurs="0"
+                        maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/resources/app-info.xsd
+++ b/resources/app-info.xsd
@@ -411,6 +411,7 @@
                         maxOccurs="unbounded"/>
             <xs:element name="personal-section" type="php-class" minOccurs="0"
                         maxOccurs="unbounded"/>
+			<xs:element name="delegation" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
## Summary

When delegating users to a group, these delegated admins see an empty "Admin delegation" section in the settings.
To fix this, I had to add a new type of settings, `delegation`. Unlike `admin` and `personal`, these settings do not appear in any menu but can still be used for admin delegation.
I did not add a new section type, because it works just fine to reuse admin sections for delegated settings. It can be added later if needed.

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [ ] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [ ] Screenshots before/after for front-end changes
- [ ] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [ ] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [ ] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [ ] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
