### PR TITLE
perf: log slow DNS operations

### DIFF
--- a/lib/composer/composer/autoload_classmap.php
+++ b/lib/composer/composer/autoload_classmap.php
@@ -1633,6 +1633,7 @@ return array(
     'OC\\Diagnostics\\EventLogger' => $baseDir . '/lib/private/Diagnostics/EventLogger.php',
     'OC\\Diagnostics\\Query' => $baseDir . '/lib/private/Diagnostics/Query.php',
     'OC\\Diagnostics\\QueryLogger' => $baseDir . '/lib/private/Diagnostics/QueryLogger.php',
+    'OC\\Diagnostics\\TLogSlowOperation' => $baseDir . '/lib/private/Diagnostics/TLogSlowOperation.php',
     'OC\\DirectEditing\\Manager' => $baseDir . '/lib/private/DirectEditing/Manager.php',
     'OC\\DirectEditing\\Token' => $baseDir . '/lib/private/DirectEditing/Token.php',
     'OC\\EmojiHelper' => $baseDir . '/lib/private/EmojiHelper.php',

--- a/lib/composer/composer/autoload_static.php
+++ b/lib/composer/composer/autoload_static.php
@@ -1674,6 +1674,7 @@ class ComposerStaticInit749170dad3f5e7f9ca158f5a9f04f6a2
         'OC\\Diagnostics\\EventLogger' => __DIR__ . '/../../..' . '/lib/private/Diagnostics/EventLogger.php',
         'OC\\Diagnostics\\Query' => __DIR__ . '/../../..' . '/lib/private/Diagnostics/Query.php',
         'OC\\Diagnostics\\QueryLogger' => __DIR__ . '/../../..' . '/lib/private/Diagnostics/QueryLogger.php',
+        'OC\\Diagnostics\\TLogSlowOperation' => __DIR__ . '/../../..' . '/lib/private/Diagnostics/TLogSlowOperation.php',
         'OC\\DirectEditing\\Manager' => __DIR__ . '/../../..' . '/lib/private/DirectEditing/Manager.php',
         'OC\\DirectEditing\\Token' => __DIR__ . '/../../..' . '/lib/private/DirectEditing/Token.php',
         'OC\\EmojiHelper' => __DIR__ . '/../../..' . '/lib/private/EmojiHelper.php',

--- a/lib/private/Diagnostics/TLogSlowOperation.php
+++ b/lib/private/Diagnostics/TLogSlowOperation.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OC\Diagnostics;
+
+use OCP\ILogger;
+use Psr\Log\LoggerInterface;
+use function microtime;
+
+trait TLogSlowOperation {
+
+	/**
+	 * @template R
+	 * @param LoggerInterface $logger
+	 * @param string $operation
+	 * @param callable $fn
+	 * @psalm-param callable(): R $fn
+	 *
+	 * @return mixed
+	 */
+	public function monitorAndLog(LoggerInterface $logger, string $operation, callable $fn): mixed {
+		$timeBefore = microtime(true);
+		$result = $fn();
+		$timeAfter = microtime(true);
+		$timeSpent = $timeAfter - $timeBefore;
+		if ($timeSpent > 0.1) {
+			$logLevel = match (true) {
+				$timeSpent > 25 => ILogger::ERROR,
+				$timeSpent > 10 => ILogger::WARN,
+				$timeSpent > 0.5 => ILogger::INFO,
+				default => ILogger::DEBUG,
+			};
+			$logger->log(
+				$logLevel,
+				"Slow $operation detected",
+				[
+					'timeSpent' => $timeSpent,
+				],
+			);
+		}
+		return $result;
+	}
+
+}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -12,11 +12,9 @@ namespace OC\Session;
 use OC\Authentication\Token\IProvider;
 use OC\Diagnostics\TLogSlowOperation;
 use OCP\Authentication\Exceptions\InvalidTokenException;
-use OCP\ILogger;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use Psr\Log\LoggerInterface;
 use function call_user_func_array;
-use function microtime;
 
 /**
  * Class Internal
@@ -198,7 +196,7 @@ class Internal extends Session {
 			return $this->monitorAndLog(
 				$this->logger,
 				$functionName,
-				function () use ($silence, $functionName, $parameters){
+				function () use ($silence, $functionName, $parameters) {
 					if ($silence) {
 						return @call_user_func_array($functionName, $parameters);
 					} else {

--- a/tests/lib/Http/Client/DnsPinMiddlewareTest.php
+++ b/tests/lib/Http/Client/DnsPinMiddlewareTest.php
@@ -20,6 +20,7 @@ use OC\Net\IpAddressClassifier;
 use OCP\Http\Client\LocalServerException;
 use OCP\ICacheFactory;
 use Psr\Http\Message\RequestInterface;
+use Psr\Log\NullLogger;
 use Test\TestCase;
 
 class DnsPinMiddlewareTest extends TestCase {
@@ -35,9 +36,10 @@ class DnsPinMiddlewareTest extends TestCase {
 
 		$ipAddressClassifier = new IpAddressClassifier();
 		$negativeDnsCache = new NegativeDnsCache($cacheFactory);
+		$logger = new NullLogger();
 
 		$this->dnsPinMiddleware = $this->getMockBuilder(DnsPinMiddleware::class)
-			->setConstructorArgs([$negativeDnsCache, $ipAddressClassifier])
+			->setConstructorArgs([$negativeDnsCache, $ipAddressClassifier, $logger])
 			->onlyMethods(['dnsGetRecord'])
 			->getMock();
 	}


### PR DESCRIPTION
<!--
  - 🚨 SECURITY INFO
  -
  - Before sending a pull request that fixes a security issue please report it via our HackerOne page (https://hackerone.com/nextcloud) following our security policy (https://nextcloud.com/security/). This allows us to coordinate the fix and release without potentially exposing all Nextcloud servers and users in the meantime.
-->

* For https://github.com/nextcloud/mail/issues/10384

## Summary

DNS can be a bottleneck. This makes the problem visible in the log when the DNS pinning middleware is slowing things down.

## TODO

- [x] Refactor session monitoring into generic trait
- [x] Wrap dns operation in middleware

## Checklist

- Code is [properly formatted](https://docs.nextcloud.com/server/latest/developer_manual/digging_deeper/continuous_integration.html#linting)
- [Sign-off message](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) is added to all commits
- [x] Tests ([unit](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#unit-tests), [integration](https://docs.nextcloud.com/server/latest/developer_manual/app_development/tutorial.html#integration-tests), api and/or acceptance) are included
- [x] Screenshots before/after for front-end changes
- [x] Documentation ([manuals](https://github.com/nextcloud/documentation/) or wiki) has been updated or is not required
- [x] [Backports requested](https://github.com/nextcloud/backportbot/#usage) where applicable (ex: critical bugfixes)
- [x] [Labels added](https://github.com/nextcloud/server/labels) where applicable (ex: bug/enhancement, `3. to review`, feature component)
- [x] [Milestone added](https://github.com/nextcloud/server/milestones) for target branch/version (ex: 32.x for `stable32`)
